### PR TITLE
Update glslang to `219b025` and use preinstalled `glslangValidator` if available

### DIFF
--- a/glsl-to-spirv/build/build.rs
+++ b/glsl-to-spirv/build/build.rs
@@ -15,6 +15,12 @@ fn main() {
         // TODO: check the hash of the file to make sure that it is not altered
         Path::new("build/glslangValidator.exe").to_owned()
 
+    } else if let Ok(true) = Command::new("glslangValidator").arg("-version").status().map(|s| s.success()) {
+        // we found `glslangValidator` in $PATH and we know that we are not on Windows
+        // the crates `which`/`quale` would do the job, but why add a new dependency?
+        let which = Command::new("which").arg("glslangValidator").output().unwrap();
+        Path::new(&String::from_utf8_lossy(&which.stdout).into_owned().trim()).to_owned()
+
     } else {
         // Try to initialize submodules. Don't care if it fails, since this code also runs for
         // the crates.io package.


### PR DESCRIPTION
This updates `glslang` to https://github.com/KhronosGroup/glslang/commit/219b025d7eae1383770c89247e6c5eb1909ac188 to fix a compile error.

In addition the `build.rs` will use a preinstalled `glslangValidator` if found. This part might not be portable to android? I unfortunately have no experience there.
