### PR TITLE
Fix CpuBufferPool capacity

### DIFF
--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -757,4 +757,14 @@ mod tests {
 
         assert_eq!(pool.capacity(), 5);
     }
+
+    #[test]
+    fn chunk_0_elems_doesnt_pollute() {
+        let (device, _) = gfx_dev_and_queue!();
+
+        let pool = CpuBufferPool::<u8>::upload(device);
+
+        let _ = pool.chunk(vec![]);
+        let _ = pool.chunk(vec![0, 0]);
+    }
 }

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -282,7 +282,7 @@ impl<T, A> CpuBufferPool<T, A>
         };
 
         // TODO: choose the capacity better?
-        let next_capacity = data.len() * match *mutex {
+        let next_capacity = cmp::max(data.len(), 1) * match *mutex {
             Some(ref b) => b.capacity * 2,
             None => 3,
         };


### PR DESCRIPTION
If you call `chunk()` with an empty iterator, the code will allocate a buffer of `iter_len * 3` elements, ie. 0 elements.

Then later when you called `chunk()` again with a non-empty iterator, the code will allocate a buffer of `iter_len * existing_capacity * 2` elements, ie. 0 again. Then it will detect that the buffer is still not large enough and enter an `unreachable!` code.

This fixes this problem.
