### PR TITLE
Finish implementing dedicated allocation

### DIFF
--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -44,18 +44,20 @@ use device::Queue;
 use instance::QueueFamily;
 use memory::Content;
 use memory::CpuAccess as MemCpuAccess;
+use memory::DedicatedAlloc;
 use memory::DeviceMemoryAllocError;
 use memory::pool::AllocLayout;
 use memory::pool::MappingRequirement;
 use memory::pool::MemoryPool;
 use memory::pool::MemoryPoolAlloc;
+use memory::pool::PotentialDedicatedAllocation;
 use memory::pool::StdMemoryPoolAlloc;
 use sync::AccessError;
 use sync::Sharing;
 
 /// Buffer whose content is accessible by the CPU.
 #[derive(Debug)]
-pub struct CpuAccessibleBuffer<T: ?Sized, A = StdMemoryPoolAlloc> {
+pub struct CpuAccessibleBuffer<T: ?Sized, A = PotentialDedicatedAllocation<StdMemoryPoolAlloc>> {
     // Inner content.
     inner: UnsafeBuffer,
 
@@ -207,7 +209,8 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
                                     mem_reqs.size,
                                     mem_reqs.alignment,
                                     AllocLayout::Linear,
-                                    MappingRequirement::Map)?;
+                                    MappingRequirement::Map,
+                                    DedicatedAlloc::Buffer(&buffer))?;
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         debug_assert!(mem.mapped_memory().is_some());
         buffer.bind_memory(mem.memory(), mem.offset())?;

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -30,10 +30,12 @@ use device::Device;
 use device::DeviceOwned;
 use device::Queue;
 use instance::QueueFamily;
+use memory::DedicatedAlloc;
 use memory::pool::AllocLayout;
 use memory::pool::MappingRequirement;
 use memory::pool::MemoryPool;
 use memory::pool::MemoryPoolAlloc;
+use memory::pool::PotentialDedicatedAllocation;
 use memory::pool::StdMemoryPoolAlloc;
 use memory::DeviceMemoryAllocError;
 use sync::AccessError;
@@ -48,7 +50,7 @@ use sync::Sharing;
 /// The `DeviceLocalBuffer` will be in device-local memory, unless the device doesn't provide any
 /// device-local memory.
 #[derive(Debug)]
-pub struct DeviceLocalBuffer<T: ?Sized, A = StdMemoryPoolAlloc> {
+pub struct DeviceLocalBuffer<T: ?Sized, A = PotentialDedicatedAllocation<StdMemoryPoolAlloc>> {
     // Inner content.
     inner: UnsafeBuffer,
 
@@ -146,7 +148,8 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
                                     mem_reqs.size,
                                     mem_reqs.alignment,
                                     AllocLayout::Linear,
-                                    MappingRequirement::DoNotMap)?;
+                                    MappingRequirement::DoNotMap,
+                                    DedicatedAlloc::Buffer(&buffer))?;
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         buffer.bind_memory(mem.memory(), mem.offset())?;
 

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -32,6 +32,7 @@ use device::Queue;
 use instance::QueueFamily;
 use memory::DedicatedAlloc;
 use memory::pool::AllocLayout;
+use memory::pool::AllocFromRequirementsFilter;
 use memory::pool::MappingRequirement;
 use memory::pool::MemoryPool;
 use memory::pool::MemoryPoolAlloc;
@@ -130,26 +131,16 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
             }
         };
 
-        let mem_ty = {
-            let device_local = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0)
-                .filter(|t| t.is_device_local());
-            let any = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0);
-            device_local.chain(any).next().unwrap()
-        };
-
-        let mem = MemoryPool::alloc(&Device::standard_pool(&device),
-                                    mem_ty,
-                                    mem_reqs.size,
-                                    mem_reqs.alignment,
+        let mem = MemoryPool::alloc_from_requirements(&Device::standard_pool(&device),
+                                    &mem_reqs,
                                     AllocLayout::Linear,
                                     MappingRequirement::DoNotMap,
-                                    DedicatedAlloc::Buffer(&buffer))?;
+                                    DedicatedAlloc::Buffer(&buffer),
+                                    |t| if t.is_device_local() {
+                                        AllocFromRequirementsFilter::Preferred
+                                    } else {
+                                        AllocFromRequirementsFilter::Allowed
+                                    })?;
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         buffer.bind_memory(mem.memory(), mem.offset())?;
 

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -42,6 +42,7 @@ use device::Device;
 use device::DeviceOwned;
 use device::Queue;
 use instance::QueueFamily;
+use memory::pool::AllocFromRequirementsFilter;
 use memory::pool::AllocLayout;
 use memory::pool::MappingRequirement;
 use memory::pool::MemoryPool;
@@ -254,26 +255,16 @@ impl<T: ?Sized> ImmutableBuffer<T> {
             }
         };
 
-        let mem_ty = {
-            let device_local = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0)
-                .filter(|t| t.is_device_local());
-            let any = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0);
-            device_local.chain(any).next().unwrap()
-        };
-
-        let mem = MemoryPool::alloc(&Device::standard_pool(&device),
-                                    mem_ty,
-                                    mem_reqs.size,
-                                    mem_reqs.alignment,
-                                    AllocLayout::Linear,
-                                    MappingRequirement::DoNotMap,
-                                    DedicatedAlloc::Buffer(&buffer))?;
+        let mem = MemoryPool::alloc_from_requirements(&Device::standard_pool(&device),
+                                                      &mem_reqs,
+                                                      AllocLayout::Linear,
+                                                      MappingRequirement::DoNotMap,
+                                                      DedicatedAlloc::Buffer(&buffer),
+                                                      |t| if t.is_device_local() {
+                                                          AllocFromRequirementsFilter::Preferred
+                                                      } else {
+                                                          AllocFromRequirementsFilter::Allowed
+                                                      })?;
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         buffer.bind_memory(mem.memory(), mem.offset())?;
 

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -32,6 +32,7 @@ use image::traits::ImageClearValue;
 use image::traits::ImageContent;
 use image::traits::ImageViewAccess;
 use memory::DedicatedAlloc;
+use memory::pool::AllocFromRequirementsFilter;
 use memory::pool::AllocLayout;
 use memory::pool::MappingRequirement;
 use memory::pool::MemoryPool;
@@ -214,26 +215,16 @@ impl<F> AttachmentImage<F> {
                              false)?
         };
 
-        let mem_ty = {
-            let device_local = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0)
-                .filter(|t| t.is_device_local());
-            let any = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0);
-            device_local.chain(any).next().unwrap()
-        };
-
-        let mem = MemoryPool::alloc(&Device::standard_pool(&device),
-                                    mem_ty,
-                                    mem_reqs.size,
-                                    mem_reqs.alignment,
+        let mem = MemoryPool::alloc_from_requirements(&Device::standard_pool(&device),
+                                    &mem_reqs,
                                     AllocLayout::Optimal,
                                     MappingRequirement::DoNotMap,
-                                    DedicatedAlloc::Image(&image))?;
+                                    DedicatedAlloc::Image(&image),
+                                    |t| if t.is_device_local() {
+                                        AllocFromRequirementsFilter::Preferred
+                                    } else {
+                                        AllocFromRequirementsFilter::Allowed
+                                    })?;
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         unsafe {
             image.bind_memory(mem.memory(), mem.offset())?;

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -31,10 +31,12 @@ use image::traits::ImageAccess;
 use image::traits::ImageClearValue;
 use image::traits::ImageContent;
 use image::traits::ImageViewAccess;
+use memory::DedicatedAlloc;
 use memory::pool::AllocLayout;
 use memory::pool::MappingRequirement;
 use memory::pool::MemoryPool;
 use memory::pool::MemoryPoolAlloc;
+use memory::pool::PotentialDedicatedAllocation;
 use memory::pool::StdMemoryPoolAlloc;
 use sync::AccessError;
 use sync::Sharing;
@@ -69,7 +71,7 @@ use sync::Sharing;
 ///
 // TODO: forbid reading transient images outside render passes?
 #[derive(Debug)]
-pub struct AttachmentImage<F = Format, A = StdMemoryPoolAlloc> {
+pub struct AttachmentImage<F = Format, A = PotentialDedicatedAllocation<StdMemoryPoolAlloc>> {
     // Inner implementation.
     image: UnsafeImage,
 
@@ -230,7 +232,8 @@ impl<F> AttachmentImage<F> {
                                     mem_reqs.size,
                                     mem_reqs.alignment,
                                     AllocLayout::Optimal,
-                                    MappingRequirement::DoNotMap)?;
+                                    MappingRequirement::DoNotMap,
+                                    DedicatedAlloc::Image(&image))?;
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         unsafe {
             image.bind_memory(mem.memory(), mem.offset())?;

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -39,6 +39,7 @@ use image::traits::ImageContent;
 use image::traits::ImageViewAccess;
 use instance::QueueFamily;
 use memory::DedicatedAlloc;
+use memory::pool::AllocFromRequirementsFilter;
 use memory::pool::AllocLayout;
 use memory::pool::MappingRequirement;
 use memory::pool::MemoryPool;
@@ -139,26 +140,16 @@ impl<F> ImmutableImage<F> {
                              false)?
         };
 
-        let mem_ty = {
-            let device_local = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0)
-                .filter(|t| t.is_device_local());
-            let any = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0);
-            device_local.chain(any).next().unwrap()
-        };
-
-        let mem = MemoryPool::alloc(&Device::standard_pool(&device),
-                                    mem_ty,
-                                    mem_reqs.size,
-                                    mem_reqs.alignment,
+        let mem = MemoryPool::alloc_from_requirements(&Device::standard_pool(&device),
+                                    &mem_reqs,
                                     AllocLayout::Optimal,
                                     MappingRequirement::DoNotMap,
-                                    DedicatedAlloc::Image(&image))?;
+                                    DedicatedAlloc::Image(&image),
+                                    |t| if t.is_device_local() {
+                                        AllocFromRequirementsFilter::Preferred
+                                    } else {
+                                        AllocFromRequirementsFilter::Allowed
+                                    })?;
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         unsafe {
             image.bind_memory(mem.memory(), mem.offset())?;

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -32,6 +32,7 @@ use image::traits::ImageViewAccess;
 use instance::QueueFamily;
 use memory::DedicatedAlloc;
 use memory::pool::AllocLayout;
+use memory::pool::AllocFromRequirementsFilter;
 use memory::pool::MappingRequirement;
 use memory::pool::MemoryPool;
 use memory::pool::MemoryPoolAlloc;
@@ -128,26 +129,16 @@ impl<F> StorageImage<F> {
                              false)?
         };
 
-        let mem_ty = {
-            let device_local = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0)
-                .filter(|t| t.is_device_local());
-            let any = device
-                .physical_device()
-                .memory_types()
-                .filter(|t| (mem_reqs.memory_type_bits & (1 << t.id())) != 0);
-            device_local.chain(any).next().unwrap()
-        };
-
-        let mem = MemoryPool::alloc(&Device::standard_pool(&device),
-                                    mem_ty,
-                                    mem_reqs.size,
-                                    mem_reqs.alignment,
+        let mem = MemoryPool::alloc_from_requirements(&Device::standard_pool(&device),
+                                    &mem_reqs,
                                     AllocLayout::Optimal,
                                     MappingRequirement::DoNotMap,
-                                    DedicatedAlloc::Image(&image))?;
+                                    DedicatedAlloc::Image(&image),
+                                    |t| if t.is_device_local() {
+                                        AllocFromRequirementsFilter::Preferred
+                                    } else {
+                                        AllocFromRequirementsFilter::Allowed
+                                    })?;
         debug_assert!((mem.offset() % mem_reqs.alignment) == 0);
         unsafe {
             image.bind_memory(mem.memory(), mem.offset())?;

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -118,8 +118,8 @@ pub struct MemoryRequirements {
     pub memory_type_bits: u32,
 
     /// True if the implementation prefers to use dedicated allocations (in other words, allocate
-    /// a whole block of memory dedicated to this resource alone). If the implementation doesn't
-    /// support dedicated allocations, this will be false.
+    /// a whole block of memory dedicated to this resource alone). If the
+    /// `khr_get_memory_requirements2` extension isn't enabled, then this will be false.
     ///
     /// > **Note**: As its name says, using a dedicated allocation is an optimization and not a
     /// > requirement.

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -138,10 +138,20 @@ impl MemoryRequirements {
     }
 }
 
+/// Indicates whether we want to allocate memory for a specific resource, or in a generic way.
+///
+/// Using dedicated allocations can yield faster performances, but requires the
+/// `VK_KHR_dedicated_allocation` extension to be enabled on the device.
+///
+/// If a dedicated allocation is performed, it must only be bound to any resource other than the
+/// one that was passed with the enumeration.
 #[derive(Debug, Copy, Clone)]
 pub enum DedicatedAlloc<'a> {
+    /// Generic allocation.
     None,
+    /// Allocation dedicated to a buffer.
     Buffer(&'a UnsafeBuffer),
+    /// Allocation dedicated to an image.
     Image(&'a UnsafeImage),
 }
 

--- a/vulkano/src/memory/pool/mod.rs
+++ b/vulkano/src/memory/pool/mod.rs
@@ -109,14 +109,14 @@ pub unsafe trait MemoryPool: DeviceOwned {
 
         match map {
             MappingRequirement::Map => {
-                let mem = DeviceMemory::dedicated_alloc(self.device().clone(), ty, size,
-                                                        dedicated)?;
-                Ok(PotentialDedicatedAllocation::Dedicated(mem))
-            },
-            MappingRequirement::DoNotMap => {
                 let mem = DeviceMemory::dedicated_alloc_and_map(self.device().clone(), ty, size,
                                                                 dedicated)?;
                 Ok(PotentialDedicatedAllocation::DedicatedMapped(mem))
+            },
+            MappingRequirement::DoNotMap => {
+                let mem = DeviceMemory::dedicated_alloc(self.device().clone(), ty, size,
+                                                        dedicated)?;
+                Ok(PotentialDedicatedAllocation::Dedicated(mem))
             },
         }
     }

--- a/vulkano/src/memory/pool/mod.rs
+++ b/vulkano/src/memory/pool/mod.rs
@@ -91,16 +91,7 @@ pub unsafe trait MemoryPool: DeviceOwned {
             return Ok(alloc.into());
         }
 
-        let use_dedicated = match dedicated {
-            DedicatedAlloc::None => false,
-            DedicatedAlloc::Buffer(ref buf) => size >= 20 * 1024 * 1024,
-            DedicatedAlloc::Image(ref img) => {
-                size >= 20 * 1024 * 1024 || img.usage_color_attachment() ||
-                    img.usage_depth_stencil_attachment()
-            },
-        };
-
-        if !use_dedicated {
+        if let DedicatedAlloc::None = dedicated {
             let alloc = self.alloc_generic(ty, size, alignment, layout, map)?;
             return Ok(alloc.into());
         }

--- a/vulkano/src/memory/pool/mod.rs
+++ b/vulkano/src/memory/pool/mod.rs
@@ -7,7 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use device::DeviceOwned;
 use instance::MemoryType;
+use memory::DedicatedAlloc;
 use memory::DeviceMemory;
 use memory::MappedDeviceMemory;
 use memory::DeviceMemoryAllocError;
@@ -24,7 +26,7 @@ mod non_host_visible;
 mod pool;
 
 /// Pool of GPU-visible memory that can be allocated from.
-pub unsafe trait MemoryPool {
+pub unsafe trait MemoryPool: DeviceOwned {
     /// Object that represents a single allocation. Its destructor should free the chunk.
     type Alloc: MemoryPoolAlloc;
 
@@ -32,9 +34,45 @@ pub unsafe trait MemoryPool {
     ///
     /// # Safety
     ///
+    /// Implementation safety:
+    ///
     /// - The returned object must match the requirements.
     /// - When a linear object is allocated next to an optimal object, it is mandatory that
     ///   the boundary is aligned to the value of the `buffer_image_granularity` limit.
+    ///
+    /// Note that it is not unsafe to *call* this function, but it is unsafe to bind the memory
+    /// returned by this function to a resource.
+    ///
+    /// # Panic
+    ///
+    /// - Panics if `memory_type` doesn't belong to the same physical device as the device which
+    ///   was used to create this pool.
+    /// - Panics if the memory type is not host-visible and `map` is `MappingRequirement::Map`.
+    /// - Panics if `size` is 0.
+    /// - Panics if `alignment` is 0.
+    ///
+    fn alloc_generic(&self, ty: MemoryType, size: usize, alignment: usize, layout: AllocLayout,
+                     map: MappingRequirement) -> Result<Self::Alloc, DeviceMemoryAllocError>;
+
+    /// Allocates memory from the pool.
+    ///
+    /// Contrary to `alloc_generic`, this function may allocate a whole new block of memory
+    /// dedicated to a resource. The default provided implementation will do so for allocations
+    /// of more than 20MB and for images that have the color_attachment or depth_stencil_attachment
+    /// usages enabled.
+    ///
+    /// # Safety
+    ///
+    /// Implementation safety:
+    ///
+    /// - The returned object must match the requirements.
+    /// - When a linear object is allocated next to an optimal object, it is mandatory that
+    ///   the boundary is aligned to the value of the `buffer_image_granularity` limit.
+    /// - If `dedicated` is not `None`, the returned memory must either not be dedicated or be
+    ///   dedicated to the resource that was passed.
+    ///
+    /// Note that it is not unsafe to *call* this function, but it is unsafe to bind the memory
+    /// returned by this function to a resource.
     ///
     /// # Panic
     ///
@@ -45,7 +83,43 @@ pub unsafe trait MemoryPool {
     /// - Panics if `alignment` is 0.
     ///
     fn alloc(&self, ty: MemoryType, size: usize, alignment: usize, layout: AllocLayout,
-             map: MappingRequirement) -> Result<Self::Alloc, DeviceMemoryAllocError>;
+             map: MappingRequirement, dedicated: DedicatedAlloc)
+             -> Result<PotentialDedicatedAllocation<Self::Alloc>, DeviceMemoryAllocError>
+    {
+        if !self.device().loaded_extensions().khr_dedicated_allocation {
+            let alloc = self.alloc_generic(ty, size, alignment, layout, map)?;
+            return Ok(alloc.into());
+        }
+
+        let use_dedicated = match dedicated {
+            DedicatedAlloc::None => false,
+            DedicatedAlloc::Buffer(ref buf) => size >= 20 * 1024 * 1024,
+            DedicatedAlloc::Image(ref img) => {
+                size >= 20 * 1024 * 1024 || img.usage_color_attachment() ||
+                    img.usage_depth_stencil_attachment()
+            },
+        };
+
+        if !use_dedicated {
+            let alloc = self.alloc_generic(ty, size, alignment, layout, map)?;
+            return Ok(alloc.into());
+        }
+
+        // If we reach here, then we perform a dedicated alloc.
+
+        match map {
+            MappingRequirement::Map => {
+                let mem = DeviceMemory::dedicated_alloc(self.device().clone(), ty, size,
+                                                        dedicated)?;
+                Ok(PotentialDedicatedAllocation::Dedicated(mem))
+            },
+            MappingRequirement::DoNotMap => {
+                let mem = DeviceMemory::dedicated_alloc_and_map(self.device().clone(), ty, size,
+                                                                dedicated)?;
+                Ok(PotentialDedicatedAllocation::DedicatedMapped(mem))
+            },
+        }
+    }
 }
 
 /// Object that represents a single allocation. Its destructor should free the chunk.
@@ -78,4 +152,51 @@ pub enum AllocLayout {
     Linear,
     /// The object has an optimal layout.
     Optimal,
+}
+
+/// Enumeration that can contain either a generic allocation coming from a pool, or a dedicated
+/// allocation for one specific resource.
+#[derive(Debug)]
+pub enum PotentialDedicatedAllocation<A> {
+    Generic(A),
+    Dedicated(DeviceMemory),
+    DedicatedMapped(MappedDeviceMemory),
+}
+
+unsafe impl<A> MemoryPoolAlloc for PotentialDedicatedAllocation<A>
+    where A: MemoryPoolAlloc
+{
+    #[inline]
+    fn mapped_memory(&self) -> Option<&MappedDeviceMemory> {
+        match *self {
+            PotentialDedicatedAllocation::Generic(ref alloc) => alloc.mapped_memory(),
+            PotentialDedicatedAllocation::Dedicated(ref mem) => None,
+            PotentialDedicatedAllocation::DedicatedMapped(ref mem) => Some(mem),
+        }
+    }
+
+    #[inline]
+    fn memory(&self) -> &DeviceMemory {
+        match *self {
+            PotentialDedicatedAllocation::Generic(ref alloc) => alloc.memory(),
+            PotentialDedicatedAllocation::Dedicated(ref mem) => mem,
+            PotentialDedicatedAllocation::DedicatedMapped(ref mem) => mem.as_ref(),
+        }
+    }
+
+    #[inline]
+    fn offset(&self) -> usize {
+        match *self {
+            PotentialDedicatedAllocation::Generic(ref alloc) => alloc.offset(),
+            PotentialDedicatedAllocation::Dedicated(_) => 0,
+            PotentialDedicatedAllocation::DedicatedMapped(_) => 0,
+        }
+    }
+}
+
+impl<A> From<A> for PotentialDedicatedAllocation<A> {
+    #[inline]
+    fn from(alloc: A) -> PotentialDedicatedAllocation<A> {
+        PotentialDedicatedAllocation::Generic(alloc)
+    }
 }

--- a/vulkano/src/memory/pool/pool.rs
+++ b/vulkano/src/memory/pool/pool.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use device::Device;
+use device::DeviceOwned;
 use instance::MemoryType;
 use memory::DeviceMemory;
 use memory::MappedDeviceMemory;
@@ -53,8 +54,9 @@ impl StdMemoryPool {
 unsafe impl MemoryPool for Arc<StdMemoryPool> {
     type Alloc = StdMemoryPoolAlloc;
 
-    fn alloc(&self, memory_type: MemoryType, size: usize, alignment: usize, layout: AllocLayout,
-             map: MappingRequirement) -> Result<StdMemoryPoolAlloc, DeviceMemoryAllocError> {
+    fn alloc_generic(&self, memory_type: MemoryType, size: usize, alignment: usize,
+                     layout: AllocLayout, map: MappingRequirement)
+                     -> Result<StdMemoryPoolAlloc, DeviceMemoryAllocError> {
         let mut pools = self.pools.lock().unwrap();
 
         let memory_type_host_visible = memory_type.is_host_visible();
@@ -106,6 +108,13 @@ unsafe impl MemoryPool for Arc<StdMemoryPool> {
                 }
             },
         }
+    }
+}
+
+unsafe impl DeviceOwned for StdMemoryPool {
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        &self.device
     }
 }
 


### PR DESCRIPTION
Close #640 

Breaking change.

Modifies the API of `MemoryPool`. Its sole required method is renamed to `alloc_generic`, while `alloc` is turned into a provided method and takes an additional parameter which is the dedicated allocation.

`alloc` now also returns a `PotentialDedicatedAllocation<A>` instead of a `A`.
