### PR TITLE
Remove the list of queue families in most places when creating a buffer or image

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -112,7 +112,7 @@ void main() {
         // Iterator that produces the data.
         let data_iter = (0 .. 65536u32).map(|n| n);
         // Builds the buffer and fills it with this iterator.
-        CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), Some(queue.family()),
+        CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
                                        data_iter).expect("failed to create buffer")
     };
 

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -101,7 +101,7 @@ fn main() {
     let dimensions = Dimensions::Dim2d { width: 4096, height: 4096 };
     const data: [[u8; 4]; 4096*4096] = [[0; 4]; 4096 * 4096];
     let (image, _) = ImmutableImage::from_iter(data.iter().cloned(), dimensions, pixel_format,
-                                               Some(queue.family()), queue.clone()).unwrap();
+                                               queue.clone()).unwrap();
 
     // (At this point you should see a bunch of messages printed to the terminal window - have fun debugging!)
 }

--- a/examples/src/bin/guide-compute-operations.rs
+++ b/examples/src/bin/guide-compute-operations.rs
@@ -51,7 +51,6 @@ fn main() {
     // Introduction to compute operations
     let data_iter = 0 .. 65536;
     let data_buffer = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
-                                                    Some(queue.family()),
                                                     data_iter).expect("failed to create buffer");
 
     // Compute pipelines

--- a/examples/src/bin/guide-example-operation.rs
+++ b/examples/src/bin/guide-example-operation.rs
@@ -46,11 +46,11 @@ fn main() {
 
     // Example operation
     let source_content = 0 .. 64;
-    let source = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), Some(queue.family()),
+    let source = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
                                                 source_content).expect("failed to create buffer");
 
     let dest_content = (0 .. 64).map(|_| 0);
-    let dest = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), Some(queue.family()),
+    let dest = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
                                               dest_content).expect("failed to create buffer");
 
     let command_buffer = AutoCommandBufferBuilder::new(device.clone(), queue.family()).unwrap()

--- a/examples/src/bin/guide-image-clear.rs
+++ b/examples/src/bin/guide-image-clear.rs
@@ -55,7 +55,6 @@ fn main() {
 
     // Clearing an image
     let buf = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
-                                             Some(queue.family()),
                                              (0 .. 1024 * 1024 * 4).map(|_| 0u8))
                                              .expect("failed to create buffer");
 

--- a/examples/src/bin/guide-mandelbrot.rs
+++ b/examples/src/bin/guide-mandelbrot.rs
@@ -103,7 +103,6 @@ void main() {
     );
 
     let buf = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
-                                             Some(queue.family()),
                                              (0 .. 1024 * 1024 * 4).map(|_| 0u8))
                                              .expect("failed to create buffer");
 

--- a/examples/src/bin/guide-triangle.rs
+++ b/examples/src/bin/guide-triangle.rs
@@ -61,7 +61,6 @@ fn main() {
                                   Format::R8G8B8A8Unorm, Some(queue.family())).unwrap();
 
     let buf = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
-                                             Some(queue.family()),
                                              (0 .. 1024 * 1024 * 4).map(|_| 0u8))
                                              .expect("failed to create buffer");
 
@@ -74,7 +73,6 @@ fn main() {
     let vertex2 = Vertex { position: [ 0.0,  0.5] };
     let vertex3 = Vertex { position: [ 0.5, -0.25] };
     let vertex_buffer = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(),
-                                                    Some(queue.family()),
                                                     vec![vertex1, vertex2, vertex3].into_iter()).unwrap();
                                                     
     let render_pass = Arc::new(single_pass_renderpass!(device.clone(),

--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -79,7 +79,7 @@ fn main() {
 
     let vertex_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer::<[Vertex]>
                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(),
-                                       Some(queue.family()), [
+                                       [
                                            Vertex { position: [-0.5, -0.5 ] },
                                            Vertex { position: [-0.5,  0.5 ] },
                                            Vertex { position: [ 0.5, -0.5 ] },
@@ -115,7 +115,6 @@ fn main() {
             image_data.iter().cloned(),
             vulkano::image::Dimensions::Dim2d { width: 93, height: 93 },
             vulkano::format::R8G8B8A8Srgb,
-            Some(queue.family()),
             queue.clone()).unwrap()
     };
 

--- a/examples/src/bin/runtime-shader.rs
+++ b/examples/src/bin/runtime-shader.rs
@@ -405,7 +405,6 @@ fn main() {
     let vertex_buffer = CpuAccessibleBuffer::from_iter(
         graphics_device.clone(),
         BufferUsage::all(),
-        Some(graphics_queue.family()),
         [
             Vertex { position: [-1.0,  1.0], color: [1.0, 0.0, 0.0] },
             Vertex { position: [ 0.0, -1.0], color: [0.0, 1.0, 0.0] },

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -76,15 +76,15 @@ fn main() {
     let mut depth_buffer = vulkano::image::attachment::AttachmentImage::transient(device.clone(), dimensions, vulkano::format::D16Unorm).unwrap();
 
     let vertex_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::VERTICES.iter().cloned())
+                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), examples::VERTICES.iter().cloned())
                                 .expect("failed to create buffer");
 
     let normals_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::NORMALS.iter().cloned())
+                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), examples::NORMALS.iter().cloned())
                                 .expect("failed to create buffer");
 
     let index_buffer = vulkano::buffer::cpu_access::CpuAccessibleBuffer
-                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), Some(queue.family()), examples::INDICES.iter().cloned())
+                                ::from_iter(device.clone(), vulkano::buffer::BufferUsage::all(), examples::INDICES.iter().cloned())
                                 .expect("failed to create buffer");
 
     // note: this teapot was meant for OpenGL where the origin is at the lower left
@@ -94,7 +94,7 @@ fn main() {
     let scale = cgmath::Matrix4::from_scale(0.01);
 
     let uniform_buffer = vulkano::buffer::cpu_pool::CpuBufferPool::<vs::ty::Data>
-                               ::new(device.clone(), vulkano::buffer::BufferUsage::all(), Some(queue.family()));
+                               ::new(device.clone(), vulkano::buffer::BufferUsage::all());
 
     let vs = vs::Shader::load(device.clone()).expect("failed to create shader module");
     let fs = fs::Shader::load(device.clone()).expect("failed to create shader module");

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -197,7 +197,7 @@ fn main() {
         struct Vertex { position: [f32; 2] }
         impl_vertex!(Vertex, position);
 
-        CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), Some(queue.family()), [
+        CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), [
             Vertex { position: [-0.5, -0.25] },
             Vertex { position: [0.0, 0.5] },
             Vertex { position: [0.25, -0.1] }

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -19,7 +19,6 @@
 //!
 
 use smallvec::SmallVec;
-use std::iter;
 use std::marker::PhantomData;
 use std::mem;
 use std::sync::Arc;
@@ -96,7 +95,6 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     {
         let source = CpuAccessibleBuffer::from_data(queue.device().clone(),
                                                     BufferUsage::transfer_source(),
-                                                    iter::once(queue.family()),
                                                     data)?;
         ImmutableBuffer::from_buffer(source, usage, queue)
     }
@@ -176,7 +174,6 @@ impl<T> ImmutableBuffer<[T]> {
     {
         let source = CpuAccessibleBuffer::from_iter(queue.device().clone(),
                                                     BufferUsage::transfer_source(),
-                                                    iter::once(queue.family()),
                                                     data)?;
         ImmutableBuffer::from_buffer(source, usage, queue)
     }
@@ -433,7 +430,6 @@ mod tests {
     use buffer::immutable::ImmutableBuffer;
     use command_buffer::AutoCommandBufferBuilder;
     use command_buffer::CommandBuffer;
-    use std::iter;
     use sync::GpuFuture;
 
     #[test]
@@ -447,7 +443,6 @@ mod tests {
 
         let destination = CpuAccessibleBuffer::from_data(device.clone(),
                                                   BufferUsage::all(),
-                                                  iter::once(queue.family()),
                                                   0)
             .unwrap();
 
@@ -477,7 +472,6 @@ mod tests {
 
         let destination = CpuAccessibleBuffer::from_iter(device.clone(),
                                                   BufferUsage::all(),
-                                                  iter::once(queue.family()),
                                                   (0 .. 512).map(|_| 0u32))
             .unwrap();
 
@@ -533,7 +527,6 @@ mod tests {
 
         let source = CpuAccessibleBuffer::from_data(device.clone(),
                                                  BufferUsage::all(),
-                                                 iter::once(queue.family()),
                                                  0)
             .unwrap();
 
@@ -563,7 +556,6 @@ mod tests {
 
         let source = CpuAccessibleBuffer::from_data(device.clone(),
                                                  BufferUsage::all(),
-                                                 iter::once(queue.family()),
                                                  0)
             .unwrap();
 
@@ -594,7 +586,6 @@ mod tests {
 
         let source = CpuAccessibleBuffer::from_data(device.clone(),
                                                  BufferUsage::all(),
-                                                 iter::once(queue.family()),
                                                  0)
             .unwrap();
 

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -89,17 +89,16 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     /// the initial upload operation. In order to be allowed to use the `ImmutableBuffer`, you must
     /// either submit your operation after this future, or execute this future and wait for it to
     /// be finished before submitting your own operation.
-    pub fn from_data<'a, I>(
-        data: T, usage: BufferUsage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_data(
+        data: T, usage: BufferUsage, queue: Arc<Queue>)
         -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferFromBufferFuture), DeviceMemoryAllocError>
-        where I: IntoIterator<Item = QueueFamily<'a>>,
-              T: 'static + Send + Sync + Sized
+        where T: 'static + Send + Sync + Sized
     {
         let source = CpuAccessibleBuffer::from_data(queue.device().clone(),
                                                     BufferUsage::transfer_source(),
                                                     iter::once(queue.family()),
                                                     data)?;
-        ImmutableBuffer::from_buffer(source, usage, queue_families, queue)
+        ImmutableBuffer::from_buffer(source, usage, queue)
     }
 
     /// Builds an `ImmutableBuffer` that copies its data from another buffer.
@@ -108,11 +107,10 @@ impl<T: ?Sized> ImmutableBuffer<T> {
     /// the initial upload operation. In order to be allowed to use the `ImmutableBuffer`, you must
     /// either submit your operation after this future, or execute this future and wait for it to
     /// be finished before submitting your own operation.
-    pub fn from_buffer<'a, B, I>(
-        source: B, usage: BufferUsage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_buffer<B>(
+        source: B, usage: BufferUsage, queue: Arc<Queue>)
         -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferFromBufferFuture), DeviceMemoryAllocError>
         where B: BufferAccess + TypedBufferAccess<Content = T> + 'static + Clone + Send + Sync,
-              I: IntoIterator<Item = QueueFamily<'a>>,
               T: 'static + Send + Sync
     {
         unsafe {
@@ -125,9 +123,10 @@ impl<T: ?Sized> ImmutableBuffer<T> {
             let (buffer, init) = ImmutableBuffer::raw(source.device().clone(),
                                                       source.size(),
                                                       actual_usage,
-                                                      queue_families)?;
+                                                      source.device().active_queue_families())?;
 
-            let cb = AutoCommandBufferBuilder::new(source.device().clone(), queue.family())?
+            let cb = AutoCommandBufferBuilder::new(source.device().clone(),
+                                                   queue.family())?
                 .copy_buffer(source, init).unwrap()     // TODO: return error?
                 .build().unwrap();                      // TODO: return OomError
 
@@ -159,28 +158,27 @@ impl<T> ImmutableBuffer<T> {
     ///   data, otherwise the content is undefined.
     ///
     #[inline]
-    pub unsafe fn uninitialized<'a, I>(
-        device: Arc<Device>, usage: BufferUsage, queue_families: I)
+    pub unsafe fn uninitialized(
+        device: Arc<Device>, usage: BufferUsage)
         -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferInitialization<T>), DeviceMemoryAllocError>
-        where I: IntoIterator<Item = QueueFamily<'a>>
     {
-        ImmutableBuffer::raw(device, mem::size_of::<T>(), usage, queue_families)
+        ImmutableBuffer::raw(device.clone(), mem::size_of::<T>(), usage,
+                             device.active_queue_families())
     }
 }
 
 impl<T> ImmutableBuffer<[T]> {
-    pub fn from_iter<'a, D, I>(
-        data: D, usage: BufferUsage, queue_families: I, queue: Arc<Queue>)
+    pub fn from_iter<D>(
+        data: D, usage: BufferUsage, queue: Arc<Queue>)
         -> Result<(Arc<ImmutableBuffer<[T]>>, ImmutableBufferFromBufferFuture), DeviceMemoryAllocError>
-        where I: IntoIterator<Item = QueueFamily<'a>>,
-              D: ExactSizeIterator<Item = T>,
+        where D: ExactSizeIterator<Item = T>,
               T: 'static + Send + Sync + Sized
     {
         let source = CpuAccessibleBuffer::from_iter(queue.device().clone(),
                                                     BufferUsage::transfer_source(),
                                                     iter::once(queue.family()),
                                                     data)?;
-        ImmutableBuffer::from_buffer(source, usage, queue_families, queue)
+        ImmutableBuffer::from_buffer(source, usage, queue)
     }
 
     /// Builds a new buffer with uninitialized data. Can be used for arrays.
@@ -200,12 +198,12 @@ impl<T> ImmutableBuffer<[T]> {
     ///   data, otherwise the content is undefined.
     ///
     #[inline]
-    pub unsafe fn uninitialized_array<'a, I>(
-        device: Arc<Device>, len: usize, usage: BufferUsage, queue_families: I)
+    pub unsafe fn uninitialized_array(
+        device: Arc<Device>, len: usize, usage: BufferUsage)
         -> Result<(Arc<ImmutableBuffer<[T]>>, ImmutableBufferInitialization<[T]>), DeviceMemoryAllocError>
-        where I: IntoIterator<Item = QueueFamily<'a>>
     {
-        ImmutableBuffer::raw(device, len * mem::size_of::<T>(), usage, queue_families)
+        ImmutableBuffer::raw(device.clone(), len * mem::size_of::<T>(),
+                             usage, device.active_queue_families())
     }
 }
 
@@ -444,7 +442,6 @@ mod tests {
 
         let (buffer, _) = ImmutableBuffer::from_data(12u32,
                                                      BufferUsage::all(),
-                                                     iter::once(queue.family()),
                                                      queue.clone())
             .unwrap();
 
@@ -475,7 +472,6 @@ mod tests {
 
         let (buffer, _) = ImmutableBuffer::from_iter((0 .. 512u32).map(|n| n * 2),
                                                      BufferUsage::all(),
-                                                     iter::once(queue.family()),
                                                      queue.clone())
             .unwrap();
 
@@ -508,7 +504,6 @@ mod tests {
 
         let (buffer, _) = ImmutableBuffer::from_data(12u32,
                                                      BufferUsage::all(),
-                                                     iter::once(queue.family()),
                                                      queue.clone())
             .unwrap();
 
@@ -532,8 +527,7 @@ mod tests {
 
         let (buffer, _) = unsafe {
             ImmutableBuffer::<u32>::uninitialized(device.clone(),
-                                                  BufferUsage::all(),
-                                                  iter::once(queue.family()))
+                                                  BufferUsage::all())
                 .unwrap()
         };
 
@@ -563,8 +557,7 @@ mod tests {
 
         let (buffer, init) = unsafe {
             ImmutableBuffer::<u32>::uninitialized(device.clone(),
-                                                  BufferUsage::all(),
-                                                  iter::once(queue.family()))
+                                                  BufferUsage::all())
                 .unwrap()
         };
 
@@ -595,8 +588,7 @@ mod tests {
 
         let (buffer, init) = unsafe {
             ImmutableBuffer::<u32>::uninitialized(device.clone(),
-                                                  BufferUsage::all(),
-                                                  iter::once(queue.family()))
+                                                  BufferUsage::all())
                 .unwrap()
         };
 
@@ -633,7 +625,7 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let _ =
-            ImmutableBuffer::from_data((), BufferUsage::all(), Some(queue.family()), queue.clone());
+            ImmutableBuffer::from_data((), BufferUsage::all(), queue.clone());
     }
 
     // TODO: write tons of tests that try to exploit loopholes

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -32,7 +32,6 @@
 //! };
 //!
 //! let (buffer, _future) = ImmutableBuffer::<[u32]>::from_iter((0..128).map(|n| n), usage,
-//!                                                             Some(queue.family()),
 //!                                                             queue.clone()).unwrap();
 //! let _view = BufferView::new(buffer, format::R32Uint).unwrap();
 //! ```
@@ -349,7 +348,6 @@ mod tests {
 
         let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0 .. 128).map(|_| [0; 4]),
                                                                   usage,
-                                                                  Some(queue.family()),
                                                                   queue.clone())
             .unwrap();
         let view = BufferView::new(buffer, format::R8G8B8A8Unorm).unwrap();
@@ -369,7 +367,6 @@ mod tests {
 
         let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0 .. 128).map(|_| [0; 4]),
                                                                   usage,
-                                                                  Some(queue.family()),
                                                                   queue.clone())
             .unwrap();
         let view = BufferView::new(buffer, format::R8G8B8A8Unorm).unwrap();
@@ -389,7 +386,6 @@ mod tests {
 
         let (buffer, _) = ImmutableBuffer::<[u32]>::from_iter((0 .. 128).map(|_| 0),
                                                               usage,
-                                                              Some(queue.family()),
                                                               queue.clone())
             .unwrap();
         let view = BufferView::new(buffer, format::R32Uint).unwrap();
@@ -405,7 +401,6 @@ mod tests {
 
         let (buffer, _) = ImmutableBuffer::<[[u8; 4]]>::from_iter((0 .. 128).map(|_| [0; 4]),
                                                                   BufferUsage::none(),
-                                                                  Some(queue.family()),
                                                                   queue.clone())
             .unwrap();
 
@@ -427,7 +422,6 @@ mod tests {
 
         let (buffer, _) = ImmutableBuffer::<[[f64; 4]]>::from_iter((0 .. 128).map(|_| [0.0; 4]),
                                                                    usage,
-                                                                   Some(queue.family()),
                                                                    queue.clone())
             .unwrap();
 

--- a/vulkano/src/command_buffer/state_cacher.rs
+++ b/vulkano/src/command_buffer/state_cacher.rs
@@ -373,7 +373,6 @@ mod tests {
         const EMPTY: [i32; 0] = [];
         let buf = CpuAccessibleBuffer::from_data(device,
                                                  BufferUsage::vertex_buffer(),
-                                                 Some(queue.family()),
                                                  EMPTY.iter()).unwrap();
         
         let mut cacher = StateCacher::new();
@@ -398,7 +397,6 @@ mod tests {
         const EMPTY: [i32; 0] = [];
         let buf = CpuAccessibleBuffer::from_data(device,
                                                  BufferUsage::vertex_buffer(),
-                                                 Some(queue.family()),
                                                  EMPTY.iter()).unwrap();
         
         let mut cacher = StateCacher::new();
@@ -431,15 +429,12 @@ mod tests {
         const EMPTY: [i32; 0] = [];
         let buf1 = CpuAccessibleBuffer::from_data(device.clone(),
                                                   BufferUsage::vertex_buffer(),
-                                                  Some(queue.family()),
                                                   EMPTY.iter()).unwrap();
         let buf2 = CpuAccessibleBuffer::from_data(device.clone(),
                                                   BufferUsage::vertex_buffer(),
-                                                  Some(queue.family()),
                                                   EMPTY.iter()).unwrap();
         let buf3 = CpuAccessibleBuffer::from_data(device,
                                                   BufferUsage::vertex_buffer(),
-                                                  Some(queue.family()),
                                                   EMPTY.iter()).unwrap();
         
         let mut cacher = StateCacher::new();

--- a/vulkano/src/command_buffer/synced/tests.rs
+++ b/vulkano/src/command_buffer/synced/tests.rs
@@ -36,7 +36,6 @@ fn basic_conflict() {
 
         let buf = CpuAccessibleBuffer::from_data(device,
                                                  BufferUsage::all(),
-                                                 Some(queue.family()),
                                                  0u32).unwrap();
 
         match sync.copy_buffer(buf.clone(), buf.clone(), iter::once((0, 0, 4))) {

--- a/vulkano/src/command_buffer/validity/fill_buffer.rs
+++ b/vulkano/src/command_buffer/validity/fill_buffer.rs
@@ -70,7 +70,6 @@ impl fmt::Display for CheckFillBufferError {
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
     use buffer::BufferUsage;
     use buffer::CpuAccessibleBuffer;
     use super::*;
@@ -79,7 +78,7 @@ mod tests {
     fn missing_usage() {
         let (device, queue) = gfx_dev_and_queue!();
         let buffer = CpuAccessibleBuffer::from_data(device.clone(), BufferUsage::vertex_buffer(),
-                                                    iter::once(queue.family()), 0u32).unwrap();
+                                                    0u32).unwrap();
 
         match check_fill_buffer(&device, &buffer) {
             Err(CheckFillBufferError::BufferMissingUsage) => (),
@@ -91,8 +90,7 @@ mod tests {
     fn wrong_device() {
         let (dev1, queue) = gfx_dev_and_queue!();
         let (dev2, _) = gfx_dev_and_queue!();
-        let buffer = CpuAccessibleBuffer::from_data(dev1, BufferUsage::all(),
-                                                    iter::once(queue.family()), 0u32).unwrap();
+        let buffer = CpuAccessibleBuffer::from_data(dev1, BufferUsage::all(), 0u32).unwrap();
 
         assert_should_panic!({
             let _ = check_fill_buffer(&dev2, &buffer);

--- a/vulkano/src/command_buffer/validity/index_buffer.rs
+++ b/vulkano/src/command_buffer/validity/index_buffer.rs
@@ -89,7 +89,6 @@ impl fmt::Display for CheckIndexBufferError {
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
     use buffer::BufferUsage;
     use buffer::CpuAccessibleBuffer;
     use super::*;
@@ -98,7 +97,6 @@ mod tests {
     fn num_indices() {
         let (device, queue) = gfx_dev_and_queue!();
         let buffer = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::index_buffer(),
-                                                    iter::once(queue.family()),
                                                     0 .. 500u32).unwrap();
 
         match check_index_buffer(&device, &buffer) {
@@ -113,7 +111,6 @@ mod tests {
     fn missing_usage() {
         let (device, queue) = gfx_dev_and_queue!();
         let buffer = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::vertex_buffer(),
-                                                    iter::once(queue.family()),
                                                     0 .. 500u32).unwrap();
 
         match check_index_buffer(&device, &buffer) {
@@ -128,7 +125,6 @@ mod tests {
         let (dev2, _) = gfx_dev_and_queue!();
 
         let buffer = CpuAccessibleBuffer::from_iter(dev1, BufferUsage::all(),
-                                                    iter::once(queue.family()),
                                                     0 .. 500u32).unwrap();
 
         assert_should_panic!({

--- a/vulkano/src/command_buffer/validity/update_buffer.rs
+++ b/vulkano/src/command_buffer/validity/update_buffer.rs
@@ -87,7 +87,6 @@ impl fmt::Display for CheckUpdateBufferError {
 
 #[cfg(test)]
 mod tests {
-    use std::iter;
     use buffer::BufferAccess;
     use buffer::BufferUsage;
     use buffer::CpuAccessibleBuffer;
@@ -97,7 +96,7 @@ mod tests {
     fn missing_usage() {
         let (device, queue) = gfx_dev_and_queue!();
         let buffer = CpuAccessibleBuffer::from_data(device.clone(), BufferUsage::vertex_buffer(),
-                                                    iter::once(queue.family()), 0u32).unwrap();
+                                                    0u32).unwrap();
 
         match check_update_buffer(&device, &buffer, &0) {
             Err(CheckUpdateBufferError::BufferMissingUsage) => (),
@@ -109,7 +108,6 @@ mod tests {
     fn data_too_large() {
         let (device, queue) = gfx_dev_and_queue!();
         let buffer = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::transfer_destination(),
-                                                    iter::once(queue.family()),
                                                     0 .. 65536).unwrap();
         let data = (0 .. 65536).collect::<Vec<u32>>();
 
@@ -123,7 +121,6 @@ mod tests {
     fn data_just_large_enough() {
         let (device, queue) = gfx_dev_and_queue!();
         let buffer = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::transfer_destination(),
-                                                    iter::once(queue.family()),
                                                     (0 .. 100000).map(|_| 0)).unwrap();
         let data = (0 .. 65536).map(|_| 0).collect::<Vec<u8>>();
 
@@ -137,7 +134,6 @@ mod tests {
     fn wrong_alignment() {
         let (device, queue) = gfx_dev_and_queue!();
         let buffer = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::transfer_destination(),
-                                                    iter::once(queue.family()),
                                                     0 .. 100).unwrap();
         let data = (0 .. 30).collect::<Vec<u8>>();
 
@@ -152,7 +148,7 @@ mod tests {
         let (dev1, queue) = gfx_dev_and_queue!();
         let (dev2, _) = gfx_dev_and_queue!();
         let buffer = CpuAccessibleBuffer::from_data(dev1, BufferUsage::all(),
-                                                    iter::once(queue.family()), 0u32).unwrap();
+                                                    0u32).unwrap();
 
         assert_should_panic!({
             let _ = check_update_buffer(&dev2, &buffer, &0);

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -11,7 +11,6 @@ use smallvec::SmallVec;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::iter;
 
 use buffer::BufferAccess;
 use buffer::BufferUsage;
@@ -194,7 +193,6 @@ impl<F> ImmutableImage<F> {
     {
         let source = CpuAccessibleBuffer::from_iter(queue.device().clone(),
                                                     BufferUsage::transfer_source(),
-                                                    iter::once(queue.family()),
                                                     iter)?;
         ImmutableImage::from_buffer(source, dimensions, format, queue)
     }

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -184,32 +184,30 @@ impl<F> ImmutableImage<F> {
     ///
     /// TODO: Support mipmaps
     #[inline]
-    pub fn from_iter<'a, P, I, J>(iter: I, dimensions: Dimensions, format: F, queue_families: J, queue: Arc<Queue>)
-                                  -> Result<(Arc<Self>, CommandBufferExecFuture<NowFuture, AutoCommandBuffer>),
-                                            ImageCreationError>
+    pub fn from_iter<P, I>(iter: I, dimensions: Dimensions, format: F, queue: Arc<Queue>)
+                           -> Result<(Arc<Self>, CommandBufferExecFuture<NowFuture, AutoCommandBuffer>),
+                                     ImageCreationError>
         where P: Send + Sync + Clone + 'static,
               F: FormatDesc + AcceptsPixels<P> + 'static + Send + Sync,
               I: ExactSizeIterator<Item = P>,
-              J: IntoIterator<Item = QueueFamily<'a>>,
               Format: AcceptsPixels<P>,
     {
         let source = CpuAccessibleBuffer::from_iter(queue.device().clone(),
                                                     BufferUsage::transfer_source(),
                                                     iter::once(queue.family()),
                                                     iter)?;
-        ImmutableImage::from_buffer(source, dimensions, format, queue_families, queue)
+        ImmutableImage::from_buffer(source, dimensions, format, queue)
     }
 
     /// Construct an ImmutableImage containing a copy of the data in `source`.
     ///
     /// TODO: Support mipmaps
-    pub fn from_buffer<'a, B, P, I>(source: B, dimensions: Dimensions, format: F, queue_families: I, queue: Arc<Queue>)
-                                    -> Result<(Arc<Self>, CommandBufferExecFuture<NowFuture, AutoCommandBuffer>),
-                                              ImageCreationError>
+    pub fn from_buffer<B, P>(source: B, dimensions: Dimensions, format: F, queue: Arc<Queue>)
+                             -> Result<(Arc<Self>, CommandBufferExecFuture<NowFuture, AutoCommandBuffer>),
+                                       ImageCreationError>
         where B: BufferAccess + TypedBufferAccess<Content = [P]> + 'static + Clone + Send + Sync,
               P: Send + Sync + Clone + 'static,
               F: FormatDesc + AcceptsPixels<P> + 'static + Send + Sync,
-              I: IntoIterator<Item = QueueFamily<'a>>,
               Format: AcceptsPixels<P>,
     {
         let usage = ImageUsage { transfer_destination: true, sampled: true, ..ImageUsage::none() };
@@ -218,7 +216,7 @@ impl<F> ImmutableImage<F> {
         let (buffer, init) = ImmutableImage::uninitialized(source.device().clone(),
                                                            dimensions, format,
                                                            MipmapsCount::One, usage, layout,
-                                                           queue_families)?;
+                                                           source.device().active_queue_families())?;
 
         let cb = AutoCommandBufferBuilder::new(source.device().clone(), queue.family())?
             .copy_buffer_to_image_dimensions(source, init, [0, 0, 0], dimensions.width_height_depth(), 0, dimensions.array_layers_with_cube(), 0).unwrap()


### PR DESCRIPTION
Fix #577 

Makes the API much less cumbersome to use.

Obviously a breaking change. In theory we could deprecate existing functions and introduce new ones instead, but we'd run out of names pretty quickly if doing so.
