### PR TITLE
Add Surface::new()

### DIFF
--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -49,9 +49,9 @@ impl Surface {
     ///
     /// Be careful when using it
     ///
-    pub unsafe fn new(instance: Arc<Instance>, surface: vk::SurfaceKHR) -> Surface {
+    pub unsafe fn from_raw_surface(instance: Arc<Instance>, surface: vk::SurfaceKHR) -> Surface {
         Surface {
-            instance: instance.clone(),
+            instance: instance,
             surface: surface,
             has_swapchain: AtomicBool::new(false),
         }

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -45,6 +45,18 @@ pub struct Surface {
 }
 
 impl Surface {
+    /// Creates a `Surface` given the raw handler.
+    ///
+    /// Be careful when using it
+    ///
+    pub unsafe fn new(instance: Arc<Instance>, surface: vk::SurfaceKHR) -> Surface {
+        Surface {
+            instance: instance.clone(),
+            surface: surface,
+            has_swapchain: AtomicBool::new(false),
+        }
+    }
+
     /// Creates a `Surface` that covers a display mode.
     ///
     /// # Panic


### PR DESCRIPTION
Creates a `Surface` given the raw handler

This is needed for me, since I want to use the [glfw](https://crates.io/crates/glfw) crate with the `glfw::ffi::glfwCreateWindowSurface` function. After creating the Surface with this function, I had no way to integrate it into the framework: creating a `vulkano::swapchain::Surface` object seemed out of the question because there is no public method/way to do it.

It's probably not the best solution. I'm open to better ones.

I propose it unsafe because it is very unsafe to use if you don't know what you are doing, I suppose.