### PR TITLE
Prevent creating a new swapchain from a stale one

### DIFF
--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -212,10 +212,6 @@ impl Swapchain {
     /// swapchain. The order in which the images are returned is important for the
     /// `acquire_next_image` and `present` functions.
     ///
-    /// According to the specification, if the `old_swapchain` is not `None`,
-    /// > any images not acquired by the application may be freed by the implementation,
-    /// > which may occur even if creation of the new swapchain fails.
-    ///
     /// # Panic
     ///
     /// - Panics if the device and the surface don't belong to the same instance.

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -213,8 +213,8 @@ impl Swapchain {
     /// `acquire_next_image` and `present` functions.
     ///
     /// According to the specification, if the `old_swapchain` is not `None`,
-    /// > "any images not acquired by the application may be freed by the implementation,
-    /// > which may occur even if creation of the new swapchain fails."
+    /// > any images not acquired by the application may be freed by the implementation,
+    /// > which may occur even if creation of the new swapchain fails.
     ///
     /// # Panic
     ///
@@ -356,9 +356,9 @@ impl Swapchain {
             } else {
                 // According to the documentation of VkSwapchainCreateInfoKHR:
                 //
-                // > "Upon calling vkCreateSwapchainKHR with a oldSwapchain that is not VK_NULL_HANDLE,
+                // > Upon calling vkCreateSwapchainKHR with a oldSwapchain that is not VK_NULL_HANDLE,
                 // > any images not acquired by the application may be freed by the implementation,
-                // > which may occur even if creation of the new swapchain fails."
+                // > which may occur even if creation of the new swapchain fails.
                 //
                 // Therefore, we set stale to true and keep it to true even if the call to `vkCreateSwapchainKHR` below fails.
                 *stale = true;

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -212,9 +212,9 @@ impl Swapchain {
     /// swapchain. The order in which the images are returned is important for the
     /// `acquire_next_image` and `present` functions.
     ///
-    /// If the `old_swapchain` is not `None`, the old swapchain **cannot** be used after the call,
-    /// except for presenting already acquired images. Even if the call fails, the implementation
-    /// is allowed to free the old swapchain.
+    /// According to the specification, if the `old_swapchain` is not `None`,
+    /// > "any images not acquired by the application may be freed by the implementation,
+    /// > which may occur even if creation of the new swapchain fails."
     ///
     /// # Panic
     ///
@@ -356,9 +356,9 @@ impl Swapchain {
             } else {
                 // According to the documentation of VkSwapchainCreateInfoKHR:
                 //
-                //  "Upon calling vkCreateSwapchainKHR with a oldSwapchain that is not VK_NULL_HANDLE,
-                //  any images not acquired by the application may be freed by the implementation,
-                //  which may occur even if creation of the new swapchain fails."
+                // > "Upon calling vkCreateSwapchainKHR with a oldSwapchain that is not VK_NULL_HANDLE,
+                // > any images not acquired by the application may be freed by the implementation,
+                // > which may occur even if creation of the new swapchain fails."
                 //
                 // Therefore, we set stale to true and keep it to true even if the call to `vkCreateSwapchainKHR` below fails.
                 *stale = true;


### PR DESCRIPTION
This pull request prevents creating a swapchain from an old one, if the old one has already been used to recreate another one.

It does so by checking the `swapchain.stale` property, and sets it correctly. Also added a new `SwapchainCreationError::OldSwapchainAlreadyUsed` error to report this situation.

Fixes #735.