### PR TITLE
More limits check fixes

### DIFF
--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -124,11 +124,11 @@ pub fn write_descriptor_sets(doc: &parse::Spirv) -> String {
     let num_bindings_in_set_body = {
         (0 .. num_sets)
             .map(|set| {
-                     let num = 1 +
-                         descriptors
+                     let num =
+                        descriptors
                              .iter()
                              .filter(|d| d.set == set)
-                             .fold(0, |s, d| cmp::max(s, d.binding));
+                             .fold(0, |s, d| cmp::max(s, 1 + d.binding));
                      format!("{set} => Some({num}),", set = set, num = num)
                  })
             .collect::<Vec<_>>()

--- a/vulkano/src/descriptor/pipeline_layout/limits_check.rs
+++ b/vulkano/src/descriptor/pipeline_layout/limits_check.rs
@@ -34,11 +34,17 @@ pub fn check_desc_against_limits<D>(device: &Device, desc: &D)
     let mut num_input_attachments = Counter::default();
 
     for set in 0 .. desc.num_sets() {
-        let num_bindings_in_set = desc.num_bindings_in_set(set)
-                                      .expect("Wrong implementation of PipelineLayoutDesc");
+        let num_bindings_in_set = match desc.num_bindings_in_set(set) {
+            None => continue,
+            Some(n) => n,
+        };
+
         for binding in 0 .. num_bindings_in_set {
-            let descriptor = desc.descriptor(set, binding)
-                                 .expect("Wrong implementation of PipelineLayoutDesc");
+            let descriptor = match desc.descriptor(set, binding) {
+                None => continue,
+                Some(n) => n,
+            };
+
             num_resources.increment(descriptor.array_count, &descriptor.stages);
 
             match descriptor.ty.ty().expect("Not implemented yet") {        // TODO:


### PR DESCRIPTION
Actually we want to ignore the situation where the trait returns `None`, as it is perfectly valid to have empty sets.