### PR TITLE
Fix `ApplicationInfo::from_cargo_toml`

### DIFF
--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -507,6 +507,33 @@ pub struct ApplicationInfo<'a> {
     pub engine_version: Option<Version>,
 }
 
+impl<'a> ApplicationInfo<'a> {
+    /// Builds an `ApplicationInfo` from the information gathered by Cargo.
+    ///
+    /// # Panic
+    ///
+    /// - Panics if the required environment variables are missing, which happens if the project
+    ///   wasn't built by Cargo.
+    ///
+    #[deprecated(note="Please use the `from_cargo_toml!` macro instead")]
+    pub fn from_cargo_toml() -> ApplicationInfo<'a> {
+        let version = Version {
+            major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
+            minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
+            patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
+        };
+
+        let name = env!("CARGO_PKG_NAME");
+
+        ApplicationInfo {
+            application_name: Some(name.into()),
+            application_version: Some(version),
+            engine_name: None,
+            engine_version: None,
+        }
+    }
+}
+
 /// Builds an `ApplicationInfo` from the information gathered by Cargo.
 ///
 /// # Panic

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -538,8 +538,12 @@ macro_rules! from_cargo_toml {
 
 impl<'a> Default for ApplicationInfo<'a> {
     fn default() -> ApplicationInfo<'a> {
-        // Use vulkano's version and name as default.
-        from_cargo_toml!()
+        ApplicationInfo {
+            application_name: None,
+            application_version: None,
+            engine_name: None,
+            engine_version: None,
+        }
     }
 }
 

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -542,7 +542,7 @@ impl<'a> ApplicationInfo<'a> {
 ///   wasn't built by Cargo.
 ///
 #[macro_export]
-macro_rules! from_cargo_toml {
+macro_rules! app_info_from_cargo_toml {
     () => {
         {
             let version = Version {

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -507,35 +507,39 @@ pub struct ApplicationInfo<'a> {
     pub engine_version: Option<Version>,
 }
 
-impl<'a> ApplicationInfo<'a> {
-    /// Builds an `ApplicationInfo` from the information gathered by Cargo.
-    ///
-    /// # Panic
-    ///
-    /// - Panics if the required environment variables are missing, which happens if the project
-    ///   wasn't built by Cargo.
-    ///
-    pub fn from_cargo_toml() -> ApplicationInfo<'a> {
-        let version = Version {
-            major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
-            minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
-            patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
-        };
+/// Builds an `ApplicationInfo` from the information gathered by Cargo.
+///
+/// # Panic
+///
+/// - Panics if the required environment variables are missing, which happens if the project
+///   wasn't built by Cargo.
+///
+#[macro_export]
+macro_rules! from_cargo_toml {
+    () => {
+        {
+            let version = Version {
+                major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
+                minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
+                patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
+            };
 
-        let name = env!("CARGO_PKG_NAME");
+            let name = env!("CARGO_PKG_NAME");
 
-        ApplicationInfo {
-            application_name: Some(name.into()),
-            application_version: Some(version),
-            engine_name: None,
-            engine_version: None,
+            ApplicationInfo {
+                application_name: Some(name.into()),
+                application_version: Some(version),
+                engine_name: None,
+                engine_version: None,
+            }
         }
     }
 }
 
 impl<'a> Default for ApplicationInfo<'a> {
     fn default() -> ApplicationInfo<'a> {
-        ApplicationInfo::from_cargo_toml()
+        // Use vulkano's version and name as default.
+        from_cargo_toml!()
     }
 }
 

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -515,7 +515,7 @@ impl<'a> ApplicationInfo<'a> {
     /// - Panics if the required environment variables are missing, which happens if the project
     ///   wasn't built by Cargo.
     ///
-    #[deprecated(note="Please use the `from_cargo_toml!` macro instead")]
+    #[deprecated(note="Please use the `app_info_from_cargo_toml!` macro instead")]
     pub fn from_cargo_toml() -> ApplicationInfo<'a> {
         let version = Version {
             major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -543,24 +543,22 @@ impl<'a> ApplicationInfo<'a> {
 ///
 #[macro_export]
 macro_rules! app_info_from_cargo_toml {
-    () => {
-        {
-            let version = Version {
-                major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
-                minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
-                patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
-            };
+    () => {{
+        let version = $crate::instance::Version {
+            major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
+            minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
+            patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
+        };
 
-            let name = env!("CARGO_PKG_NAME");
+        let name = env!("CARGO_PKG_NAME");
 
-            ApplicationInfo {
-                application_name: Some(name.into()),
-                application_version: Some(version),
-                engine_name: None,
-                engine_version: None,
-            }
+        $crate::instance::ApplicationInfo {
+            application_name: Some(name.into()),
+            application_version: Some(version),
+            engine_name: None,
+            engine_version: None,
         }
-    }
+    }}
 }
 
 impl<'a> Default for ApplicationInfo<'a> {

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -81,13 +81,14 @@
 //! behavior for your application alone through a control panel.
 //!
 //! ```no_run
+//! # #[macro_use] extern crate vulkano;
 //! use vulkano::instance::ApplicationInfo;
 //! use vulkano::instance::Instance;
 //! use vulkano::instance::InstanceExtensions;
 //!
 //! // Builds an `ApplicationInfo` by looking at the content of the `Cargo.toml` file at
 //! // compile-time.
-//! let app_infos = ApplicationInfo::from_cargo_toml();
+//! let app_infos = from_cargo_toml!();
 //!
 //! let _instance = Instance::new(Some(&app_infos), &InstanceExtensions::none(), None).unwrap();
 //! ```

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -83,9 +83,7 @@
 //! ```no_run
 //! # #[macro_use] extern crate vulkano;
 //! # fn main() {
-//! use vulkano::instance::ApplicationInfo;
-//! use vulkano::instance::Instance;
-//! use vulkano::instance::InstanceExtensions;
+//! use vulkano::instance::{Instance, InstanceExtensions};
 //!
 //! // Builds an `ApplicationInfo` by looking at the content of the `Cargo.toml` file at
 //! // compile-time.

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -89,7 +89,7 @@
 //!
 //! // Builds an `ApplicationInfo` by looking at the content of the `Cargo.toml` file at
 //! // compile-time.
-//! let app_infos = from_cargo_toml!();
+//! let app_infos = app_info_from_cargo_toml!();
 //!
 //! let _instance = Instance::new(Some(&app_infos), &InstanceExtensions::none(), None).unwrap();
 //! # }

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -82,6 +82,7 @@
 //!
 //! ```no_run
 //! # #[macro_use] extern crate vulkano;
+//! # fn main() {
 //! use vulkano::instance::ApplicationInfo;
 //! use vulkano::instance::Instance;
 //! use vulkano::instance::InstanceExtensions;
@@ -91,6 +92,7 @@
 //! let app_infos = from_cargo_toml!();
 //!
 //! let _instance = Instance::new(Some(&app_infos), &InstanceExtensions::none(), None).unwrap();
+//! # }
 //! ```
 //!
 //! # Enumerating physical devices and creating a device


### PR DESCRIPTION
This pull request fixes #500.

Until now, `from_cargo_toml` always filled the `ApplicationInfo` structure with the name and version of the `vulkano` crate, instead of the calling crate.

To fix this, `from_cargo_toml` is now a macro, which becomes an expression which gathers the required environment variables. It is meant to be invoked when the user's crate is built, not when `vulkano` is built.