### PR TITLE
Implement `device::QueuesIter::device(&self)`.

### DIFF
--- a/vulkano/src/device.rs
+++ b/vulkano/src/device.rs
@@ -527,6 +527,13 @@ pub struct QueuesIter {
     families_and_ids: SmallVec<[(u32, u32); 8]>,
 }
 
+impl QueuesIter {
+    /// Returns the device the queues were produced for.
+    pub fn device(&self) -> &Arc<Device> {
+        &self.device
+    }
+}
+
 impl Iterator for QueuesIter {
     type Item = Arc<Queue>;
 

--- a/vulkano/src/device.rs
+++ b/vulkano/src/device.rs
@@ -527,9 +527,8 @@ pub struct QueuesIter {
     families_and_ids: SmallVec<[(u32, u32); 8]>,
 }
 
-impl QueuesIter {
-    /// Returns the device the queues were produced for.
-    pub fn device(&self) -> &Arc<Device> {
+unsafe impl DeviceOwned for QueuesIter {
+    fn device(&self) -> &Arc<Device> {
         &self.device
     }
 }
@@ -701,6 +700,13 @@ impl Queue {
             check_errors(vk.QueueWaitIdle(*queue))?;
             Ok(())
         }
+    }
+}
+
+
+unsafe impl DeviceOwned for Queue {
+    fn device(&self) -> &Arc<Device> {
+        &self.device
     }
 }
 


### PR DESCRIPTION
This way people can get access to the device without first popping a queue from the iterator. 

To me it seems silly now that `Device::new` returns a device and a `QueuesIter`, even though the former is easily accessible through the latter. This might be a point of future refactoring? 