### PR TITLE
Improvements for the StandardCommandPool

### DIFF
--- a/vulkano/src/command_buffer/pool/standard.rs
+++ b/vulkano/src/command_buffer/pool/standard.rs
@@ -92,20 +92,8 @@ unsafe impl CommandPool for Arc<StandardCommandPool> {
         // Get an appropriate `Arc<StandardCommandPoolPerThread>`.
         let per_thread = match hashmap.entry(thread::current().id()) {
             Entry::Occupied(mut entry) => {
-                if let Some(entry) = entry.get().upgrade() {
-                    entry
-                } else {
-                    let new_pool =
-                        UnsafeCommandPool::new(self.device.clone(), self.queue_family(), false, true)?;
-                    let pt = Arc::new(StandardCommandPoolPerThread {
-                                          pool: Mutex::new(new_pool),
-                                          available_primary_command_buffers: MsQueue::new(),
-                                          available_secondary_command_buffers: MsQueue::new(),
-                                      });
-
-                    entry.insert(Arc::downgrade(&pt));
-                    pt
-                }
+                // The `unwrap()` can't fail, since we retained only valid members earlier.
+                entry.get().upgrade().unwrap()
             },
             Entry::Vacant(entry) => {
                 let new_pool =

--- a/vulkano/src/command_buffer/pool/standard.rs
+++ b/vulkano/src/command_buffer/pool/standard.rs
@@ -138,6 +138,7 @@ unsafe impl CommandPool for Arc<StandardCommandPool> {
                         inner: StandardCommandPoolAlloc {
                             cmd: Some(cmd),
                             pool: per_thread.clone(),
+                            pool_parent: self.clone(),
                             secondary: secondary,
                             device: self.device.clone(),
                         },
@@ -159,6 +160,7 @@ unsafe impl CommandPool for Arc<StandardCommandPool> {
                     inner: StandardCommandPoolAlloc {
                         cmd: Some(cmd),
                         pool: per_thread.clone(),
+                        pool_parent: self.clone(),
                         secondary: secondary,
                         device: self.device.clone(),
                     },
@@ -228,6 +230,8 @@ pub struct StandardCommandPoolAlloc {
     cmd: Option<UnsafeCommandPoolAlloc>,
     // We hold a reference to the command pool for our destructor.
     pool: Arc<StandardCommandPoolPerThread>,
+    // Keep alive the `StandardCommandPool`, otherwise it would be destroyed.
+    pool_parent: Arc<StandardCommandPool>,
     // True if secondary command buffer.
     secondary: bool,
     // The device we belong to. Necessary because of the `DeviceOwned` trait implementation.


### PR DESCRIPTION
Right now a new command pool is created every time you create a command buffer. Ouch. That's due to a bug fixed in this PR.