### PR TITLE
Propagate allocation errors to CpuBufferPool::next() and chunk()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Unreleased
+# Unreleased (major)
+
+- Changed `CpuBufferPool::next()` and `chunk()` to return a `Result` in case of an error when
+  allocating or mapping memory.
 
 # Version 0.6.2 (2017-09-06)
 

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -190,7 +190,7 @@ fn main() {
                 proj : proj.into(),
             };
 
-            uniform_buffer.next(uniform_data)
+            uniform_buffer.next(uniform_data).unwrap()
         };
 
         let set = Arc::new(vulkano::descriptor::descriptor_set::PersistentDescriptorSet::start(pipeline.clone(), 0)


### PR DESCRIPTION
Breaking change.