### PR TITLE
Simplify BufferAccess and ImageAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Unreleased
+# Unreleased (major)
+
+- Changed `BufferAccess::conflict_*` and `ImageAccess::conflict_*` to forbid querying a specific
+  range of the resource.
 
 # Version 0.6.2 (2017-09-06)
 

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -42,6 +42,7 @@ use buffer::traits::TypedBufferAccess;
 use device::Device;
 use device::DeviceOwned;
 use device::Queue;
+use image::ImageAccess;
 use instance::QueueFamily;
 use memory::Content;
 use memory::CpuAccess as MemCpuAccess;
@@ -317,7 +318,17 @@ unsafe impl<T: ?Sized, A> BufferAccess for CpuAccessibleBuffer<T, A>
     }
 
     #[inline]
-    fn conflict_key(&self, _: usize, _: usize) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.inner.key()
     }
 

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -28,6 +28,7 @@ use buffer::traits::TypedBufferAccess;
 use device::Device;
 use device::DeviceOwned;
 use device::Queue;
+use image::ImageAccess;
 use memory::DedicatedAlloc;
 use memory::DeviceMemoryAllocError;
 use memory::pool::AllocFromRequirementsFilter;
@@ -609,7 +610,17 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
     }
 
     #[inline]
-    fn conflict_key(&self, _: usize, _: usize) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.buffer.inner.key() + self.index as u64
     }
 
@@ -730,8 +741,18 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolSubbuffer<T, A>
     }
 
     #[inline]
-    fn conflict_key(&self, a: usize, b: usize) -> u64 {
-        self.chunk.conflict_key(a, b)
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
+        self.chunk.conflict_key()
     }
 
     #[inline]

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -29,6 +29,7 @@ use buffer::traits::TypedBufferAccess;
 use device::Device;
 use device::DeviceOwned;
 use device::Queue;
+use image::ImageAccess;
 use instance::QueueFamily;
 use memory::DedicatedAlloc;
 use memory::DeviceMemoryAllocError;
@@ -195,7 +196,17 @@ unsafe impl<T: ?Sized, A> BufferAccess for DeviceLocalBuffer<T, A>
     }
 
     #[inline]
-    fn conflict_key(&self, _: usize, _: usize) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.inner.key()
     }
 

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -40,6 +40,7 @@ use command_buffer::CommandBufferExecFuture;
 use device::Device;
 use device::DeviceOwned;
 use device::Queue;
+use image::ImageAccess;
 use instance::QueueFamily;
 use memory::DedicatedAlloc;
 use memory::DeviceMemoryAllocError;
@@ -327,7 +328,17 @@ unsafe impl<T: ?Sized, A> BufferAccess for ImmutableBuffer<T, A> {
     }
 
     #[inline]
-    fn conflict_key(&self, _: usize, _: usize) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.inner.key()
     }
 
@@ -383,7 +394,17 @@ unsafe impl<T: ?Sized, A> BufferAccess for ImmutableBufferInitialization<T, A> {
     }
 
     #[inline]
-    fn conflict_key(&self, _: usize, _: usize) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.buffer.inner.key()
     }
 

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -18,6 +18,7 @@ use buffer::traits::TypedBufferAccess;
 use device::Device;
 use device::DeviceOwned;
 use device::Queue;
+use image::ImageAccess;
 use sync::AccessError;
 
 /// A subpart of a buffer.
@@ -194,22 +195,18 @@ unsafe impl<T: ?Sized, B> BufferAccess for BufferSlice<T, B>
     }
 
     #[inline]
-    fn conflicts_buffer(&self, self_offset: usize, self_size: usize, other: &BufferAccess,
-                        other_offset: usize, other_size: usize)
-                        -> bool {
-        let self_offset = self.offset + self_offset;
-        // FIXME: spurious failures ; needs investigation
-        //debug_assert!(self_size + self_offset <= self.size);
-        self.resource
-            .conflicts_buffer(self_offset, self_size, other, other_offset, other_size)
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        self.resource.conflicts_buffer(other)
     }
 
     #[inline]
-    fn conflict_key(&self, self_offset: usize, self_size: usize) -> u64 {
-        let self_offset = self.offset + self_offset;
-        // FIXME: spurious failures ; needs investigation
-        //debug_assert!(self_size + self_offset <= self.size);
-        self.resource.conflict_key(self_offset, self_size)
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        self.resource.conflicts_image(other)
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
+        self.resource.conflict_key()
     }
 
     #[inline]

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -18,7 +18,6 @@ use memory::Content;
 use sync::AccessError;
 
 use SafeDeref;
-use VulkanObject;
 
 /// Trait for objects that represent a way for the GPU to have access to a buffer or a slice of a
 /// buffer.
@@ -88,52 +87,30 @@ pub unsafe trait BufferAccess: DeviceOwned {
         self.slice(index .. (index + 1))
     }
 
-    /// Returns true if an access to `self` (as defined by `self_offset` and `self_size`)
-    /// potentially overlaps the same memory as an access to `other` (as defined by `other_offset`
-    /// and `other_size`).
+    /// Returns true if an access to `self` potentially overlaps the same memory as an access to
+    /// `other`.
     ///
-    /// If this function returns `false`, this means that we are allowed to access the offset/size
-    /// of `self` at the same time as the offset/size of `other` without causing a data race.
-    ///
-    /// Note that the function must be transitive. In other words if `conflicts(a, b)` is true and
-    /// `conflicts(b, c)` is true, then `conflicts(a, c)` must be true as well.
-    fn conflicts_buffer(&self, _self_offset: usize, self_size: usize, other: &BufferAccess,
-                        _other_offset: usize, _other_size: usize)
-                        -> bool {
-        // TODO: should we really provide a default implementation?
-
-        debug_assert!(self_size <= self.size());
-
-        if self.inner().buffer.internal_object() != other.inner().buffer.internal_object() {
-            return false;
-        }
-
-        true
-    }
-
-    /// Returns true if an access to `self` (as defined by `self_offset` and `self_size`)
-    /// potentially overlaps the same memory as an access to `other` (as defined by
-    /// `other_first_layer`, `other_num_layers`, `other_first_mipmap` and `other_num_mipmaps`).
-    ///
-    /// If this function returns `false`, this means that we are allowed to access the offset/size
-    /// of `self` at the same time as the offset/size of `other` without causing a data race.
+    /// If this function returns `false`, this means that we are allowed to mutably access the
+    /// content of `self` at the same time as the content of `other` without causing a data
+    /// race.
     ///
     /// Note that the function must be transitive. In other words if `conflicts(a, b)` is true and
     /// `conflicts(b, c)` is true, then `conflicts(a, c)` must be true as well.
-    fn conflicts_image(&self, self_offset: usize, self_size: usize, other: &ImageAccess,
-                       other_first_layer: u32, other_num_layers: u32, other_first_mipmap: u32,
-                       other_num_mipmaps: u32)
-                       -> bool {
-        let other_key = other.conflict_key(other_first_layer,
-                                           other_num_layers,
-                                           other_first_mipmap,
-                                           other_num_mipmaps);
-        self.conflict_key(self_offset, self_size) == other_key
-    }
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool;
 
-    /// Returns a key that uniquely identifies the range given by offset/size.
+    /// Returns true if an access to `self` potentially overlaps the same memory as an access to
+    /// `other`.
     ///
-    /// Two ranges that potentially overlap in memory should return the same key.
+    /// If this function returns `false`, this means that we are allowed to mutably access the
+    /// content of `self` at the same time as the content of `other` without causing a data
+    /// race.
+    ///
+    /// Note that the function must be transitive. In other words if `conflicts(a, b)` is true and
+    /// `conflicts(b, c)` is true, then `conflicts(a, c)` must be true as well.
+    fn conflicts_image(&self, other: &ImageAccess) -> bool;
+
+    /// Returns a key that uniquely identifies the buffer. Two buffers or images that potentially
+    /// overlap in memory must return the same key.
     ///
     /// The key is shared amongst all buffers and images, which means that you can make several
     /// different buffer objects share the same memory, or make some buffer objects share memory
@@ -142,34 +119,7 @@ pub unsafe trait BufferAccess: DeviceOwned {
     /// Since it is possible to accidentally return the same key for memory ranges that don't
     /// overlap, the `conflicts_buffer` or `conflicts_image` function should always be called to
     /// verify whether they actually overlap.
-    fn conflict_key(&self, _self_offset: usize, _self_size: usize) -> u64 {
-        // FIXME: remove implementation
-        unimplemented!()
-    }
-
-    /// Shortcut for `conflicts_buffer` that compares the whole buffer to another.
-    #[inline]
-    fn conflicts_buffer_all(&self, other: &BufferAccess) -> bool {
-        self.conflicts_buffer(0, self.size(), other, 0, other.size())
-    }
-
-    /// Shortcut for `conflicts_image` that compares the whole buffer to a whole image.
-    #[inline]
-    fn conflicts_image_all(&self, other: &ImageAccess) -> bool {
-        self.conflicts_image(0,
-                             self.size(),
-                             other,
-                             0,
-                             other.dimensions().array_layers(),
-                             0,
-                             other.mipmap_levels())
-    }
-
-    /// Shortcut for `conflict_key` that grabs the key of the whole buffer.
-    #[inline]
-    fn conflict_key_all(&self) -> u64 {
-        self.conflict_key(0, self.size())
-    }
+    fn conflict_key(&self) -> u64;
 
     /// Locks the resource for usage on the GPU. Returns an error if the lock can't be acquired.
     ///
@@ -224,15 +174,18 @@ unsafe impl<T> BufferAccess for T
     }
 
     #[inline]
-    fn conflicts_buffer(&self, self_offset: usize, self_size: usize, other: &BufferAccess,
-                        other_offset: usize, other_size: usize)
-                        -> bool {
-        (**self).conflicts_buffer(self_offset, self_size, other, other_offset, other_size)
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        (**self).conflicts_buffer(other)
     }
 
     #[inline]
-    fn conflict_key(&self, self_offset: usize, self_size: usize) -> u64 {
-        (**self).conflict_key(self_offset, self_size)
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        (**self).conflicts_image(other)
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
+        (**self).conflict_key()
     }
 
     #[inline]

--- a/vulkano/src/command_buffer/validity/copy_buffer.rs
+++ b/vulkano/src/command_buffer/validity/copy_buffer.rs
@@ -43,10 +43,10 @@ pub fn check_copy_buffer<S, D, T>(device: &Device, source: &S, destination: &D)
 
     let copy_size = cmp::min(source.size(), destination.size());
 
-    if source.conflicts_buffer(0, copy_size, &destination, 0, copy_size) {
+    if source.conflicts_buffer(&destination) {
         return Err(CheckCopyBufferError::OverlappingRanges);
     } else {
-        debug_assert!(!destination.conflicts_buffer(0, copy_size, &source, 0, copy_size));
+        debug_assert!(!destination.conflicts_buffer(&source));
     }
 
     Ok(CheckCopyBuffer { copy_size })

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use buffer::BufferAccess;
 use device::Device;
 use device::Queue;
 use format::ClearValue;
@@ -432,7 +433,17 @@ unsafe impl<F, A> ImageAccess for AttachmentImage<F, A>
     }
 
     #[inline]
-    fn conflict_key(&self, _: u32, _: u32, _: u32, _: u32) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        self.conflict_key() == other.conflict_key()
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.image.key()
     }
 

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -293,7 +293,17 @@ unsafe impl<F, A> ImageAccess for ImmutableImage<F, A>
     }
 
     #[inline]
-    fn conflict_key(&self, _: u32, _: u32, _: u32, _: u32) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.image.key()
     }
 
@@ -391,7 +401,17 @@ unsafe impl<F, A> ImageAccess for ImmutableImageInitialization<F, A>
     }
 
     #[inline]
-    fn conflict_key(&self, _: u32, _: u32, _: u32, _: u32) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.image.image.key()
     }
 

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use buffer::BufferAccess;
 use device::Device;
 use device::Queue;
 use format::ClearValue;
@@ -198,7 +199,17 @@ unsafe impl<F, A> ImageAccess for StorageImage<F, A>
     }
 
     #[inline]
-    fn conflict_key(&self, _: u32, _: u32, _: u32, _: u32) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        self.conflict_key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.image.key()
     }
 

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+use buffer::BufferAccess;
 use device::Queue;
 use format::ClearValue;
 use format::Format;
@@ -101,7 +102,17 @@ unsafe impl ImageAccess for SwapchainImage {
     }
 
     #[inline]
-    fn conflict_key(&self, _: u32, _: u32, _: u32, _: u32) -> u64 {
+    fn conflicts_buffer(&self, other: &BufferAccess) -> bool {
+        false
+    }
+
+    #[inline]
+    fn conflicts_image(&self, other: &ImageAccess) -> bool {
+        self.my_image().image.key() == other.conflict_key() // TODO:
+    }
+
+    #[inline]
+    fn conflict_key(&self) -> u64 {
         self.my_image().image.key()
     }
 


### PR DESCRIPTION
Breaking change.

This PR fixes a problem with vulkano right now.
Because of the implementation of the synchronization layer, all the `conflict_*` methods must be transitive. In other words, if `conflict(a, b)` is true and `conflict(b, c)` is true, then `conflict(a, c)` must be true as well. This is already explained in comments on the `conflict` methods.

But this poses a problem. For example, since `buf.conflict(0 .. 1024, buf, 512 .. 1536)` must return true and `buf.conflict(512 .. 1536, buf, 1024 .. 2048)` must return true as well, then `buf.conflict(0 .. 1024, buf, 1024 .. 2048)` must also return true. The method must return true even though the two ranges don't overlap.
It doesn't make sense to allow specifying a range at all, as this constraint will always get in the way.

This PR simply removes passing a range to the `conflict` methods.
