### PR TITLE
Remove some TODOs

### DIFF
--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -53,7 +53,6 @@ pub unsafe trait CommandBuffer: DeviceOwned {
     /// the given queue, and if so locks it.
     ///
     /// If you call this function, then you should call `unlock` afterwards.
-    // TODO: require `&mut self` instead, but this has some consequences on other parts of the lib
     fn lock_submit(&self, future: &GpuFuture, queue: &Queue) -> Result<(), CommandBufferExecError>;
 
     /// Unlocks the command buffer. Should be called once for each call to `lock_submit`.
@@ -61,7 +60,6 @@ pub unsafe trait CommandBuffer: DeviceOwned {
     /// # Safety
     ///
     /// Must not be called if you haven't called `lock_submit` before.
-    // TODO: require `&mut self` instead, but this has some consequences on other parts of the lib
     unsafe fn unlock(&self);
 
     /// Executes this command buffer on a queue.


### PR DESCRIPTION
Since a command buffer can be created with the simultaneous_use flag, it makes sense to require shared access in order to lock the command buffer.