### PR TITLE
Remove the unused CommandBufferBuild trait

### DIFF
--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -92,7 +92,6 @@ pub use self::auto::UpdateBufferError;
 pub use self::state_cacher::StateCacher;
 pub use self::state_cacher::StateCacherOutcome;
 pub use self::traits::CommandBuffer;
-pub use self::traits::CommandBufferBuild;
 pub use self::traits::CommandBufferExecError;
 pub use self::traits::CommandBufferExecFuture;
 

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -147,17 +147,6 @@ pub unsafe trait CommandBuffer: DeviceOwned {
     // FIXME: lots of other methods
 }
 
-/// Turns a command buffer builder into a real command buffer.
-pub unsafe trait CommandBufferBuild {
-    /// The type of the built command buffer.
-    type Out;
-    /// Error that can be returned when building.
-    type Err;
-
-    /// Builds the command buffer.
-    fn build(self) -> Result<Self::Out, Self::Err>;
-}
-
 unsafe impl<T> CommandBuffer for T
     where T: SafeDeref,
           T::Target: CommandBuffer


### PR DESCRIPTION
Not worth putting the changelog.
This trait is something I forgot to remove when reworking command buffers.