### PR TITLE
Fix layer count check in swapchain constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   range of the resource.
 - Changed `CpuBufferPool::next()` and `chunk()` to return a `Result` in case of an error when
   allocating or mapping memory.
+- Fixed `layers` argument validation in `Swapchain::new_inner`.
 
 # Version 0.6.2 (2017-09-06)
 

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -303,7 +303,7 @@ impl Swapchain {
         if dimensions[1] > capabilities.max_image_extent[1] {
             return Err(SwapchainCreationError::UnsupportedDimensions);
         }
-        if layers < 1 && layers > capabilities.max_image_array_layers {
+        if layers < 1 || layers > capabilities.max_image_array_layers {
             return Err(SwapchainCreationError::UnsupportedArrayLayers);
         }
         if (usage.to_usage_bits() & capabilities.supported_usage_flags.to_usage_bits()) !=


### PR DESCRIPTION
I assume this is the correct behavior since the existing check is impossible to trigger.