### PR TITLE
Provide 32-bit word constructor for ShaderModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Changed `CpuBufferPool::next()` and `chunk()` to return a `Result` in case of an error when
   allocating or mapping memory.
 - Fixed `layers` argument validation in `Swapchain::new_inner`.
+- Provide 32-bit word constructor for `ShaderModule` (`ShaderModule::from_words`).
 
 # Version 0.6.2 (2017-09-06)
 


### PR DESCRIPTION
This provides the alternative constructor `ShaderModule::from_words(..)`, which uses `&[u32]` for the SPIR-V code.

`ShaderModule` currently uses an argument of type `&[u8]`, which causes interoperability issues with libraries like [shaderc][shaderc] and [rspirv][rspirv].

This is spec-compliant since the byte-code of the shader module is defined as `[..] a series of 32-bit words in host endianness.`

[shaderc]: https://docs.rs/shaderc/0.2.0/shaderc/struct.CompilationArtifact.html
[rspirv]: https://docs.rs/rspirv/0.4.0/rspirv/binary/trait.Assemble.html#tymethod.assemble