### PR TITLE
Bufferless vertex definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Changed `CpuBufferPool::next()` and `chunk()` to return a `Result` in case of an error when
   allocating or mapping memory.
 - Fixed `layers` argument validation in `Swapchain::new_inner`.
+- Added `vulkano::pipeline::vertex::BufferlessDefinition` and `BufferlessVertices` to enable
+  bufferless drawing, which is useful when drawing with shaders that compute their vertices
+  internally.
 
 # Version 0.6.2 (2017-09-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
   allocating or mapping memory.
 - Fixed `layers` argument validation in `Swapchain::new_inner`.
 - Added `vulkano::pipeline::vertex::BufferlessDefinition` and `BufferlessVertices` to enable
-  bufferless drawing, which is useful when drawing with shaders that compute their vertices
-  internally.
+  bufferless drawing.
 
 # Version 0.6.2 (2017-09-06)
 

--- a/vulkano/src/pipeline/vertex/bufferless.rs
+++ b/vulkano/src/pipeline/vertex/bufferless.rs
@@ -22,9 +22,18 @@ use buffer::BufferAccess;
 /// `gl_VertexIndex`
 pub struct BufferlessDefinition;
 
-unsafe impl VertexSource<usize> for BufferlessDefinition {
-    fn decode(&self, n: usize) -> (Vec<Box<BufferAccess + Sync + Send + 'static>>, usize, usize) {
-        (Vec::new(), n, 1)
+/// Value to be passed as the vertex source for bufferless draw commands.
+///
+/// Note that the concrete type of the graphics pipeline using `BufferlessDefinition` must be
+/// visible to the command buffer builder for this to be usable.
+pub struct BufferlessVertices {
+    vertices: usize,
+    instances: usize,
+}
+
+unsafe impl VertexSource<BufferlessVertices> for BufferlessDefinition {
+    fn decode(&self, n: BufferlessVertices) -> (Vec<Box<BufferAccess + Sync + Send + 'static>>, usize, usize) {
+        (Vec::new(), n.vertices, n.instances)
     }
 }
 

--- a/vulkano/src/pipeline/vertex/bufferless.rs
+++ b/vulkano/src/pipeline/vertex/bufferless.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2017 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::iter;
+
+use pipeline::vertex::AttributeInfo;
+use pipeline::vertex::IncompatibleVertexDefinitionError;
+use pipeline::vertex::InputRate;
+use pipeline::vertex::VertexDefinition;
+use pipeline::vertex::VertexSource;
+use buffer::BufferAccess;
+
+/// Implementation of `VertexDefinition` for drawing with no buffers at all.
+///
+/// This is only useful if your shaders come up with vertex data on their own, e.g. by inspecting
+/// `gl_VertexIndex`
+pub struct BufferlessDefinition;
+
+unsafe impl VertexSource<usize> for BufferlessDefinition {
+    fn decode(&self, n: usize) -> (Vec<Box<BufferAccess + Sync + Send + 'static>>, usize, usize) {
+        (Vec::new(), n, 1)
+    }
+}
+
+unsafe impl<T> VertexSource<Vec<T>> for BufferlessDefinition {
+    fn decode<'l>(&self, _: Vec<T>) -> (Vec<Box<BufferAccess + Sync + Send + 'static>>, usize, usize) {
+        panic!("bufferless drawing should not be supplied with buffers")
+    }
+}
+
+unsafe impl<I> VertexDefinition<I> for BufferlessDefinition {
+    type BuffersIter = iter::Empty<(u32, usize, InputRate)>;
+    type AttribsIter = iter::Empty<(u32, u32, AttributeInfo)>;
+    fn definition(&self, _: &I) -> Result<(Self::BuffersIter, Self::AttribsIter), IncompatibleVertexDefinitionError> {
+        Ok((iter::empty(), iter::empty()))
+    }
+}

--- a/vulkano/src/pipeline/vertex/bufferless.rs
+++ b/vulkano/src/pipeline/vertex/bufferless.rs
@@ -27,8 +27,8 @@ pub struct BufferlessDefinition;
 /// Note that the concrete type of the graphics pipeline using `BufferlessDefinition` must be
 /// visible to the command buffer builder for this to be usable.
 pub struct BufferlessVertices {
-    vertices: usize,
-    instances: usize,
+    pub vertices: usize,
+    pub instances: usize,
 }
 
 unsafe impl VertexSource<BufferlessVertices> for BufferlessDefinition {

--- a/vulkano/src/pipeline/vertex/mod.rs
+++ b/vulkano/src/pipeline/vertex/mod.rs
@@ -76,6 +76,7 @@ pub use self::vertex::Vertex;
 pub use self::vertex::VertexMemberInfo;
 pub use self::vertex::VertexMemberTy;
 pub use self::bufferless::BufferlessDefinition;
+pub use self::bufferless::BufferlessVertices;
 
 mod definition;
 mod impl_vertex;

--- a/vulkano/src/pipeline/vertex/mod.rs
+++ b/vulkano/src/pipeline/vertex/mod.rs
@@ -75,6 +75,7 @@ pub use self::two::TwoBuffersDefinition;
 pub use self::vertex::Vertex;
 pub use self::vertex::VertexMemberInfo;
 pub use self::vertex::VertexMemberTy;
+pub use self::bufferless::BufferlessDefinition;
 
 mod definition;
 mod impl_vertex;
@@ -82,3 +83,4 @@ mod one_one;
 mod single;
 mod two;
 mod vertex;
+mod bufferless;


### PR DESCRIPTION
This makes it convenient to perform a draw without any buffers at all, which is useful when you have a pipeline that comes up with vertex data on its own by some mechanism. For example, this can be used to [simplify full-screen passes](https://www.saschawillems.de/?page_id=2122).

It seems to unfortunately be necessary to implement the inappropriate trait `VertexSource<Vec<T>>` for this to be usable in a graphics pipeline, and it is probably not currently usable through a boxed abstract pipeline for related reasons.