### PR TITLE
Fixed the layer scaling issue on macOS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed an HiDPI scaling issue on macOS in vulkano-win.
+
 # Version 0.7.0 (2017-09-21)
 
 - Added `RuntimePipelineDesc`, an implementation of `PipelineLayoutDesc` that makes creating custom

--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -39,10 +39,7 @@ fn main() {
     let mut events_loop = winit::EventsLoop::new();
     let window = winit::WindowBuilder::new().build_vk_surface(&events_loop, instance.clone()).unwrap();
 
-    let mut dimensions = {
-        let (width, height) = window.window().get_inner_size_pixels().unwrap();
-        [width, height]
-    };
+    let mut dimensions;
 
     let queue = physical.queue_families().find(|&q| q.supports_graphics() &&
                                                    window.surface().is_supported(q).unwrap_or(false))
@@ -60,7 +57,7 @@ fn main() {
     let (mut swapchain, mut images) = {
         let caps = window.surface().capabilities(physical).expect("failed to get surface capabilities");
 
-        //let dimensions = caps.current_extent.unwrap_or([width, height]);
+        dimensions = caps.current_extent.unwrap_or([1024, 768]);
         let usage = caps.supported_usage_flags;
         let alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
@@ -151,10 +148,10 @@ fn main() {
     loop {
         previous_frame_end.cleanup_finished();
         if recreate_swapchain {
-            dimensions = {
-                let (new_width, new_height) = window.window().get_inner_size_pixels().unwrap();
-                [new_width, new_height]
-            };
+
+            dimensions = window.surface().capabilities(physical)
+                .expect("failed to get surface capabilities")
+                .current_extent.unwrap_or([1024, 768]);
             
             let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
                 Ok(r) => r,

--- a/examples/src/bin/runtime-shader.rs
+++ b/examples/src/bin/runtime-shader.rs
@@ -140,7 +140,8 @@ fn main() {
     );
 
     let vs = {
-        let mut f = File::open("src/bin/runtime-shader.vert.spv").unwrap();
+        let mut f = File::open("src/bin/runtime-shader.vert.spv")
+            .expect("Can't find file src/bin/runtime-shader.vert.spv");
         let mut v = vec![];
         f.read_to_end(&mut v).unwrap();
         // Create a ShaderModule on a device the same Shader::load does it.
@@ -149,7 +150,8 @@ fn main() {
     };
 
     let fs = {
-        let mut f = File::open("src/bin/runtime-shader.frag.spv").unwrap();
+        let mut f = File::open("src/bin/runtime-shader.frag.spv")
+            .expect("Can't find file src/bin/runtime-shader.frag.spv");
         let mut v = vec![];
         f.read_to_end(&mut v).unwrap();
         unsafe { ShaderModule::new(graphics_device.clone(), &v) }.unwrap()

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -40,10 +40,7 @@ fn main() {
     let mut events_loop = winit::EventsLoop::new();
     let window = winit::WindowBuilder::new().build_vk_surface(&events_loop, instance.clone()).unwrap();
 
-    let mut dimensions = {
-        let (width, height) = window.window().get_inner_size_pixels().unwrap();
-        [width, height]
-    };
+    let mut dimensions;
 
     let queue = physical.queue_families().find(|&q| q.supports_graphics() &&
                                                    window.surface().is_supported(q).unwrap_or(false))
@@ -61,6 +58,8 @@ fn main() {
 
     let (mut swapchain, mut images) = {
         let caps = window.surface().capabilities(physical).expect("failed to get surface capabilities");
+
+        dimensions = caps.current_extent.unwrap_or([1024, 768]);
 
         let usage = caps.supported_usage_flags;
         let format = caps.supported_formats[0].0;
@@ -143,10 +142,10 @@ fn main() {
         previous_frame.cleanup_finished();
 
         if recreate_swapchain {
-            dimensions = {
-                let (new_width, new_height) = window.window().get_inner_size_pixels().unwrap();
-                [new_width, new_height]
-            };
+
+        dimensions = window.surface().capabilities(physical)
+            .expect("failed to get surface capabilities")
+            .current_extent.unwrap_or([1024, 768]);
             
             let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
                 Ok(r) => r,

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -106,14 +106,7 @@ fn main() {
     // window and a cross-platform Vulkan surface that represents the surface of the window.
     let mut events_loop = winit::EventsLoop::new();
     let window = winit::WindowBuilder::new().build_vk_surface(&events_loop, instance.clone()).unwrap();
-
-    // Get the dimensions of the viewport. These variables need to be mutable since the viewport
-    // can change size.
-    let mut dimensions = {
-        let (width, height) = window.window().get_inner_size_pixels().unwrap();
-        [width, height]
-    };
-
+    
     // The next step is to choose which GPU queue will execute our draw commands.
     //
     // Devices can provide multiple queues to run commands in parallel (for example a draw queue
@@ -163,6 +156,10 @@ fn main() {
     // iterator and throw it away.
     let queue = queues.next().unwrap();
 
+    // The dimensions of the surface.
+    // This variable needs to be mutable since the viewport can change size.
+    let mut dimensions;
+
     // Before we can draw on the surface, we have to create what is called a swapchain. Creating
     // a swapchain allocates the color buffers that will contain the image that will ultimately
     // be visible on the screen. These images are returned alongside with the swapchain.
@@ -171,11 +168,12 @@ fn main() {
         // pass values that are allowed by the capabilities.
         let caps = window.surface().capabilities(physical)
                          .expect("failed to get surface capabilities");
+        
+        dimensions = caps.current_extent.unwrap();
 
-        // We choose the dimensions of the swapchain to match the current dimensions of the window.
+        // We choose the dimensions of the swapchain to match the current extent of the surface.
         // If `caps.current_extent` is `None`, this means that the window size will be determined
         // by the dimensions of the swapchain, in which case we just use the width and height defined above.
-        //let dimensions = caps.current_extent.unwrap_or([width, height]);
 
         // The alpha mode indicates how the alpha value of the final image will behave. For example
         // you can choose whether the window will be opaque or transparent.
@@ -339,10 +337,9 @@ void main() {
         // If the swapchain needs to be recreated, recreate it
         if recreate_swapchain {
             // Get the new dimensions for the viewport/framebuffers.
-            dimensions = {
-                let (new_width, new_height) = window.window().get_inner_size_pixels().unwrap();
-                [new_width, new_height]
-            };
+            dimensions = window.surface().capabilities(physical)
+                        .expect("failed to get surface capabilities")
+                        .current_extent.unwrap();
             
             let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
                 Ok(r) => r,

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -12,6 +12,6 @@ vulkano = { version = "0.7.0", path = "../vulkano" }
 winit = "0.7.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal-rs = "0.4"
+metal-rs = "0.4.3"
 cocoa = "0.9"
 objc = "0.2"

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -188,8 +188,10 @@ unsafe fn winit_to_surface(instance: Arc<Instance>, win: &winit::Window)
     layer.remove_all_animations();
 
     let view = wnd.contentView();
-    view.setWantsLayer(YES);
+
+    layer.set_contents_scale(view.backingScaleFactor());
     view.setLayer(mem::transmute(layer.0)); // Bombs here with out of memory
+    view.setWantsLayer(YES);
 
     Surface::from_macos_moltenvk(instance, win.get_nsview() as *const ())
 }


### PR DESCRIPTION
Fixed the layer scaling issue on macOS, as `metal-rs` published the needed API.

Also changed the triangle example to use the surface extents instead of window dimensions, as that seems to be a more robust source of correct information. (At least one user reported that on their X.org-based system the surface was created according to the outer dimensions of the window, not inner, which is contrary to macOS. I don't know about Windows.)

The triangle example now runs straight out of the box on my macOS-based system, if the MoltenVK dynamic library is installed. Also, according to the MoltenVK support forums, the next version is going to fix the excessive logging.

Fixes https://github.com/vulkano-rs/vulkano/issues/738