### PR TITLE
Fixed le() and ge() for DescriptorsCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Fixed `le()` and `ge()` for `DescriptorsCount`, which also fixes a potential memory leak when
+  allocating descriptor sets.
+
 # Version 0.7.0 (2017-09-21)
 
 - Added `RuntimePipelineDesc`, an implementation of `PipelineLayoutDesc` that makes creating custom

--- a/vulkano/src/descriptor/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor/descriptor_set/sys.rs
@@ -130,6 +130,14 @@ macro_rules! descriptors_count {
                     None
                 }
             }
+
+            fn le(&self, other: &DescriptorsCount) -> bool {
+                $(self.$name <= other.$name)&&+
+            }
+
+            fn ge(&self, other: &DescriptorsCount) -> bool {
+                $(self.$name >= other.$name)&&+
+            }
         }
 
         impl ops::Sub for DescriptorsCount {


### PR DESCRIPTION
Also fixes #808, because checking for space in a descriptor pool uses `ge()` at [descriptor/descriptor_set/std_pool.rs:80](https://github.com/vulkano-rs/vulkano/blob/089d0879f7460b89c68de84c37671467ec359c76/vulkano/src/descriptor/descriptor_set/std_pool.rs#L80).

It may be better to scrap the PartialOrd trait entirely and implement comparison functions that must be called explicitly, but this is the easy solution and it's less of a breaking change.