### PR TITLE
Minimal command buffer debug marker support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Allow `impl_vertex!` to support generic structs.
 - Fixed creating a buffer view not checking the `min_texel_buffer_offset_alignment` limit.
+- Added support for loading the `VK_EXT_debug_marker` extension and adding debug markers to
+  `UnsafeCommandBufferBuilder`
 
 # Version 0.7.1 (2017-09-28)
 

--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -189,6 +189,9 @@ pub const STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR: u32 = 1000146001;
 pub const STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2_KHR: u32 = 1000146002;
 pub const STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR: u32 = 1000146003;
 pub const STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2_KHR: u32 = 1000146004;
+pub const STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT: u32 = 1000022000;
+pub const STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT: u32 = 1000022001;
+pub const STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT: u32 = 1000022002;
 
 pub type SystemAllocationScope = u32;
 pub const SYSTEM_ALLOCATION_SCOPE_COMMAND: u32 = 0;
@@ -2642,6 +2645,34 @@ pub struct PresentRegionsKHR {
     pub pRegions: *const PresentRegionKHR,
 }
 
+#[repr(C)]
+pub struct DebugMarkerObjectNameInfoEXT {
+    pub sType: StructureType,
+    pub pNext: *const c_void,
+    pub objectType: DebugReportObjectTypeEXT,
+    pub object: u64,
+    pub name: *const c_char,
+}
+
+#[repr(C)]
+pub struct DebugMarkerObjectTagInfoEXT {
+    pub sType: StructureType,
+    pub pNext: *const c_void,
+    pub objectType: DebugReportObjectTypeEXT,
+    pub object: u64,
+    pub tagName: u64,
+    pub tagSize: usize,
+    pub tag: *const c_void,
+}
+
+#[repr(C)]
+pub struct DebugMarkerMarkerInfoEXT {
+    pub sType: StructureType,
+    pub pNext: *const c_void,
+    pub pMarkerName: *const c_char,
+    pub color: [f32; 4],
+}
+
 macro_rules! ptrs {
     ($struct_name:ident, { $($name:ident => ($($param_n:ident: $param_ty:ty),*) -> $ret:ty,)+ }) => (
         pub struct $struct_name {
@@ -2890,4 +2921,9 @@ ptrs!(DevicePointers, {
     CmdPushDescriptorSetWithTemplateKHR => (commandBuffer: CommandBuffer, descriptorUpdateTemplate: DescriptorUpdateTemplateKHR, layout: PipelineLayout, set: u32, pData: *const c_void) -> (),
     GetImageMemoryRequirements2KHR => (device: Device, pInfo: *const ImageMemoryRequirementsInfo2KHR, pMemoryRequirements: *mut MemoryRequirements2KHR) -> (),
     GetBufferMemoryRequirements2KHR => (device: Device, pInfo: *const BufferMemoryRequirementsInfo2KHR, pMemoryRequirements: *mut MemoryRequirements2KHR) -> (),
+    DebugMarkerSetObjectNameEXT => (device: Device, pNameInfo: *const DebugMarkerObjectNameInfoEXT) -> Result,
+    DebugMarkerSetObjectTagEXT => (device: Device, pTagInfo: *const DebugMarkerObjectTagInfoEXT) -> Result,
+    CmdDebugMarkerBeginEXT => (commandBuffer: CommandBuffer, pMarkerInfo: *const DebugMarkerMarkerInfoEXT) -> (),
+    CmdDebugMarkerEndEXT => (commandBuffer: CommandBuffer) -> (),
+    CmdDebugMarkerInsertEXT => (commandBuffer: CommandBuffer, pMarkerInfo: *const DebugMarkerMarkerInfoEXT) -> (),
 });

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1378,8 +1378,11 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     }
 
     /// Calls `vkCmdDebugMarkerBeginEXT` on the builder.
+    ///
+    /// Does nothing if the `VK_EXT_debug_marker` device extension is not loaded.
     #[inline]
     pub unsafe fn debug_marker_begin(&mut self, name: &CStr, color: [f32; 4]) {
+        if !self.device().loaded_extensions().ext_debug_marker { return; }
         let vk = self.device().pointers();
         let cmd = self.internal_object();
         let info = vk::DebugMarkerMarkerInfoEXT {
@@ -1392,16 +1395,22 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     }
 
     /// Calls `vkCmdDebugMarkerEndEXT` on the builder.
+    ///
+    /// Does nothing if the `VK_EXT_debug_marker` device extension is not loaded.
     #[inline]
     pub unsafe fn debug_marker_end(&mut self) {
+        if !self.device().loaded_extensions().ext_debug_marker { return; }
         let vk = self.device().pointers();
         let cmd = self.internal_object();
         vk.CmdDebugMarkerEndEXT(cmd);
     }
 
     /// Calls `vkCmdDebugMarkerInsertEXT` on the builder.
+    ///
+    /// Does nothing if the `VK_EXT_debug_marker` device extension is not loaded.
     #[inline]
     pub unsafe fn debug_marker_insert(&mut self, name: &CStr, color: [f32; 4]) {
+        if !self.device().loaded_extensions().ext_debug_marker { return; }
         let vk = self.device().pointers();
         let cmd = self.internal_object();
         let info = vk::DebugMarkerMarkerInfoEXT {

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -13,6 +13,7 @@ use std::mem;
 use std::ops::Range;
 use std::ptr;
 use std::sync::Arc;
+use std::ffi::CStr;
 
 use OomError;
 use VulkanObject;
@@ -1374,6 +1375,42 @@ impl<P> UnsafeCommandBufferBuilder<P> {
                              stages.into_vulkan_bits(),
                              query.pool().internal_object(),
                              query.index());
+    }
+
+    /// Calls `vkCmdDebugMarkerBeginEXT` on the builder.
+    #[inline]
+    pub unsafe fn debug_marker_begin(&mut self, name: &CStr, color: [f32; 4]) {
+        let vk = self.device().pointers();
+        let cmd = self.internal_object();
+        let info = vk::DebugMarkerMarkerInfoEXT {
+            sType: vk::STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT,
+            pNext: ptr::null(),
+            pMarkerName: name.as_ptr(),
+            color: color,
+        };
+        vk.CmdDebugMarkerBeginEXT(cmd, &info);
+    }
+
+    /// Calls `vkCmdDebugMarkerEndEXT` on the builder.
+    #[inline]
+    pub unsafe fn debug_marker_end(&mut self) {
+        let vk = self.device().pointers();
+        let cmd = self.internal_object();
+        vk.CmdDebugMarkerEndEXT(cmd);
+    }
+
+    /// Calls `vkCmdDebugMarkerInsertEXT` on the builder.
+    #[inline]
+    pub unsafe fn debug_marker_insert(&mut self, name: &CStr, color: [f32; 4]) {
+        let vk = self.device().pointers();
+        let cmd = self.internal_object();
+        let info = vk::DebugMarkerMarkerInfoEXT {
+            sType: vk::STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT,
+            pNext: ptr::null(),
+            pMarkerName: name.as_ptr(),
+            color: color,
+        };
+        vk.CmdDebugMarkerInsertEXT(cmd, &info);
     }
 }
 

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1378,11 +1378,8 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     }
 
     /// Calls `vkCmdDebugMarkerBeginEXT` on the builder.
-    ///
-    /// Does nothing if the `VK_EXT_debug_marker` device extension is not loaded.
     #[inline]
     pub unsafe fn debug_marker_begin(&mut self, name: &CStr, color: [f32; 4]) {
-        if !self.device().loaded_extensions().ext_debug_marker { return; }
         let vk = self.device().pointers();
         let cmd = self.internal_object();
         let info = vk::DebugMarkerMarkerInfoEXT {
@@ -1395,22 +1392,16 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     }
 
     /// Calls `vkCmdDebugMarkerEndEXT` on the builder.
-    ///
-    /// Does nothing if the `VK_EXT_debug_marker` device extension is not loaded.
     #[inline]
     pub unsafe fn debug_marker_end(&mut self) {
-        if !self.device().loaded_extensions().ext_debug_marker { return; }
         let vk = self.device().pointers();
         let cmd = self.internal_object();
         vk.CmdDebugMarkerEndEXT(cmd);
     }
 
     /// Calls `vkCmdDebugMarkerInsertEXT` on the builder.
-    ///
-    /// Does nothing if the `VK_EXT_debug_marker` device extension is not loaded.
     #[inline]
     pub unsafe fn debug_marker_insert(&mut self, name: &CStr, color: [f32; 4]) {
-        if !self.device().loaded_extensions().ext_debug_marker { return; }
         let vk = self.device().pointers();
         let cmd = self.internal_object();
         let info = vk::DebugMarkerMarkerInfoEXT {

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1381,6 +1381,10 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     ///
     /// # Panics
     /// Requires the `VK_EXT_debug_marker` device extension to be loaded.
+    ///
+    /// # Safety
+    /// The command pool that this command buffer was allocated from must support graphics or
+    /// compute operations
     #[inline]
     pub unsafe fn debug_marker_begin(&mut self, name: &CStr, color: [f32; 4]) {
         let vk = self.device().pointers();
@@ -1398,6 +1402,12 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     ///
     /// # Panics
     /// Requires the `VK_EXT_debug_marker` device extension to be loaded.
+    ///
+    /// # Safety
+    /// There must be an outstanding `vkCmdDebugMarkerBeginEXT` command prior to the
+    /// `vkCmdDebugMarkerEndEXT` on the queue that this command buffer is submitted to. If the
+    /// matching `vkCmdDebugMarkerBeginEXT` command was in a secondary command buffer, the
+    /// `vkCmdDebugMarkerEndEXT` must be in the same command buffer.
     #[inline]
     pub unsafe fn debug_marker_end(&mut self) {
         let vk = self.device().pointers();
@@ -1409,6 +1419,10 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     ///
     /// # Panics
     /// Requires the `VK_EXT_debug_marker` device extension to be loaded.
+    ///
+    /// # Safety
+    /// The command pool that this command buffer was allocated from must support graphics or
+    /// compute operations
     #[inline]
     pub unsafe fn debug_marker_insert(&mut self, name: &CStr, color: [f32; 4]) {
         let vk = self.device().pointers();

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1378,6 +1378,9 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     }
 
     /// Calls `vkCmdDebugMarkerBeginEXT` on the builder.
+    ///
+    /// # Panics
+    /// Requires the `VK_EXT_debug_marker` device extension to be loaded.
     #[inline]
     pub unsafe fn debug_marker_begin(&mut self, name: &CStr, color: [f32; 4]) {
         let vk = self.device().pointers();
@@ -1392,6 +1395,9 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     }
 
     /// Calls `vkCmdDebugMarkerEndEXT` on the builder.
+    ///
+    /// # Panics
+    /// Requires the `VK_EXT_debug_marker` device extension to be loaded.
     #[inline]
     pub unsafe fn debug_marker_end(&mut self) {
         let vk = self.device().pointers();
@@ -1400,6 +1406,9 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     }
 
     /// Calls `vkCmdDebugMarkerInsertEXT` on the builder.
+    ///
+    /// # Panics
+    /// Requires the `VK_EXT_debug_marker` device extension to be loaded.
     #[inline]
     pub unsafe fn debug_marker_insert(&mut self, name: &CStr, color: [f32; 4]) {
         let vk = self.device().pointers();

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -399,6 +399,7 @@ device_extensions! {
     khr_get_memory_requirements2 => b"VK_KHR_get_memory_requirements2",
     khr_dedicated_allocation => b"VK_KHR_dedicated_allocation",
     khr_incremental_present => b"VK_KHR_incremental_present",
+    ext_debug_marker => b"VK_EXT_debug_marker",
 }
 
 /// Error that can happen when loading the list of layers.


### PR DESCRIPTION
Not yet tested.

Exposes debug markers for unsafe command buffers only. Extension to auto command buffers should be straightforward future work. No attempt was made to provide a good interface for setting object names/tags. That could be done well through a trait; perhaps new methods on `VulkanObject`?

This is needed to support a good experience for debugging with tools like renderdoc.