### PR TITLE
Debug object names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix occasional truncation of glslang_validator when glsl-to-spirv is rebuilt
 - Fix linking against MoltenVK >= 0.19.0 
 - Added `AutoCommandBufferBuilder::copy_image`
+- Refactored vk-sys to use strongly typed handles
+- Added `Device::set_object_name` using `VK_EXT_debug_marker`
 
 # Version 0.7.2 (2017-10-09)
 

--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -25,7 +25,7 @@ pub type DeviceSize = u64;
 pub type SampleMask = u32;
 
 /// Handles yielded by the Vulkan implementation
-pub trait Handle: Into<u64> {
+pub trait Handle: Into<u64> + Copy {
     const TYPE: DebugReportObjectTypeEXT;
     const NULL: Self;
     fn is_null(&self) -> bool;

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -291,7 +291,7 @@ impl UnsafeBuffer {
     /// Returns a key unique to each `UnsafeBuffer`. Can be used for the `conflicts_key` method.
     #[inline]
     pub fn key(&self) -> u64 {
-        self.buffer
+        self.buffer.into()
     }
 }
 

--- a/vulkano/src/command_buffer/state_cacher.rs
+++ b/vulkano/src/command_buffer/state_cacher.rs
@@ -62,8 +62,8 @@ impl StateCacher {
     pub fn new() -> StateCacher {
         StateCacher {
             dynamic_state: DynamicState::none(),
-            compute_pipeline: 0,
-            graphics_pipeline: 0,
+            compute_pipeline: vk::Pipeline::NULL,
+            graphics_pipeline: vk::Pipeline::NULL,
             compute_descriptor_sets: SmallVec::new(),
             graphics_descriptor_sets: SmallVec::new(),
             poisonned_descriptor_sets: false,
@@ -78,8 +78,8 @@ impl StateCacher {
     #[inline]
     pub fn invalidate(&mut self) {
         self.dynamic_state = DynamicState::none();
-        self.compute_pipeline = 0;
-        self.graphics_pipeline = 0;
+        self.compute_pipeline = vk::Pipeline::NULL;
+        self.graphics_pipeline = vk::Pipeline::NULL;
         self.compute_descriptor_sets = SmallVec::new();
         self.graphics_descriptor_sets = SmallVec::new();
         self.vertex_buffers = SmallVec::new();

--- a/vulkano/src/command_buffer/submit/bind_sparse.rs
+++ b/vulkano/src/command_buffer/submit/bind_sparse.rs
@@ -42,7 +42,7 @@ impl<'a> SubmitBindSparseBuilder<'a> {
     pub fn new() -> SubmitBindSparseBuilder<'a> {
         SubmitBindSparseBuilder {
             infos: SmallVec::new(),
-            fence: 0,
+            fence: vk::Fence::NULL,
         }
     }
 
@@ -76,7 +76,7 @@ impl<'a> SubmitBindSparseBuilder<'a> {
     /// ```
     #[inline]
     pub fn has_fence(&self) -> bool {
-        self.fence != 0
+        !self.fence.is_null()
     }
 
     /// Adds an operation that signals a fence after this submission ends.
@@ -128,7 +128,7 @@ impl<'a> SubmitBindSparseBuilder<'a> {
     #[inline]
     pub fn merge(&mut self, other: SubmitBindSparseBuilder<'a>)
                  -> Result<(), SubmitBindSparseBuilder<'a>> {
-        if self.fence != 0 && other.fence != 0 {
+        if !self.fence.is_null() && !other.fence.is_null() {
             return Err(other);
         }
 
@@ -378,7 +378,7 @@ impl<'a> SubmitBindSparseBufferBindBuilder<'a> {
         self.binds.push(vk::SparseMemoryBind {
                             resourceOffset: offset as vk::DeviceSize,
                             size: size as vk::DeviceSize,
-                            memory: 0,
+                            memory: vk::DeviceMemory::NULL,
                             memoryOffset: 0,
                             flags: 0,
                         });
@@ -423,7 +423,7 @@ impl<'a> SubmitBindSparseImageOpaqueBindBuilder<'a> {
         self.binds.push(vk::SparseMemoryBind {
                             resourceOffset: offset as vk::DeviceSize,
                             size: size as vk::DeviceSize,
-                            memory: 0,
+                            memory: vk::DeviceMemory::NULL,
                             memoryOffset: 0,
                             flags: 0, // TODO: is that relevant?
                         });

--- a/vulkano/src/command_buffer/submit/queue_submit.rs
+++ b/vulkano/src/command_buffer/submit/queue_submit.rs
@@ -47,7 +47,7 @@ impl<'a> SubmitCommandBufferBuilder<'a> {
             destination_stages: SmallVec::new(),
             signal_semaphores: SmallVec::new(),
             command_buffers: SmallVec::new(),
-            fence: 0,
+            fence: vk::Fence::NULL,
             marker: PhantomData,
         }
     }
@@ -72,7 +72,7 @@ impl<'a> SubmitCommandBufferBuilder<'a> {
     /// ```
     #[inline]
     pub fn has_fence(&self) -> bool {
-        self.fence != 0
+        !self.fence.is_null()
     }
 
     /// Adds an operation that signals a fence after this submission ends.
@@ -231,7 +231,7 @@ impl<'a> SubmitCommandBufferBuilder<'a> {
     /// Panics if both builders have a fence already set.
     // TODO: create multiple batches instead
     pub fn merge(mut self, other: Self) -> Self {
-        assert!(self.fence == 0 || other.fence == 0,
+        assert!(self.fence.is_null() || other.fence.is_null(),
                 "Can't merge two queue submits that both have a fence");
 
         self.wait_semaphores.extend(other.wait_semaphores);
@@ -239,7 +239,7 @@ impl<'a> SubmitCommandBufferBuilder<'a> {
         self.signal_semaphores.extend(other.signal_semaphores);
         self.command_buffers.extend(other.command_buffers);
 
-        if self.fence == 0 {
+        if self.fence.is_null() {
             self.fence = other.fence;
         }
 

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -264,11 +264,11 @@ impl<P> UnsafeCommandBufferBuilder<P> {
                         //       the render pass?
                         FramebufferAbstract::inner(fb).internal_object()
                     },
-                    None => 0,
+                    None => vk::Framebuffer::NULL,
                 };
                 (rp, sp, fb)
             },
-            _ => (0, 0, 0),
+            _ => (vk::RenderPass::NULL, 0, vk::Framebuffer::NULL),
         };
 
         let (oqe, qf, ps) = match kind {

--- a/vulkano/src/descriptor/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor/descriptor_set/sys.rs
@@ -658,7 +658,7 @@ impl UnsafeDescriptorSet {
                     DescriptorWriteInner::Sampler(sampler) => {
                         image_descriptors.push(vk::DescriptorImageInfo {
                                                    sampler: sampler,
-                                                   imageView: 0,
+                                                   imageView: vk::ImageView::NULL,
                                                    imageLayout: 0,
                                                });
                     },
@@ -671,21 +671,21 @@ impl UnsafeDescriptorSet {
                     },
                     DescriptorWriteInner::StorageImage(view, layout) => {
                         image_descriptors.push(vk::DescriptorImageInfo {
-                                                   sampler: 0,
+                                                   sampler: vk::Sampler::NULL,
                                                    imageView: view,
                                                    imageLayout: layout,
                                                });
                     },
                     DescriptorWriteInner::SampledImage(view, layout) => {
                         image_descriptors.push(vk::DescriptorImageInfo {
-                                                   sampler: 0,
+                                                   sampler: vk::Sampler::NULL,
                                                    imageView: view,
                                                    imageLayout: layout,
                                                });
                     },
                     DescriptorWriteInner::InputAttachment(view, layout) => {
                         image_descriptors.push(vk::DescriptorImageInfo {
-                                                   sampler: 0,
+                                                   sampler: vk::Sampler::NULL,
                                                    imageView: view,
                                                    imageLayout: layout,
                                                });

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -559,7 +559,7 @@ impl UnsafeImage {
     /// Creates an image from a raw handle. The image won't be destroyed.
     ///
     /// This function is for example used at the swapchain's initialization.
-    pub unsafe fn from_raw(device: Arc<Device>, handle: u64, usage: u32, format: Format,
+    pub unsafe fn from_raw(device: Arc<Device>, handle: vk::Image, usage: u32, format: Format,
                            dimensions: ImageDimensions, samples: u32, mipmaps: u32)
                            -> UnsafeImage {
         let vk_i = device.instance().pointers();
@@ -632,7 +632,7 @@ impl UnsafeImage {
     /// Returns a key unique to each `UnsafeImage`. Can be used for the `conflicts_key` method.
     #[inline]
     pub fn key(&self) -> u64 {
-        self.image
+        self.image.into()
     }
 
     /// Queries the layout of an image in memory. Only valid for images with linear tiling.

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -110,7 +110,7 @@ impl<L> FunctionPointers<L> {
     pub fn new(loader: L) -> FunctionPointers<L>
         where L: Loader
     {
-        let entry_points = vk::EntryPoints::load(|name| unsafe { mem::transmute(loader.get_instance_proc_addr(0, name.as_ptr())) });
+        let entry_points = vk::EntryPoints::load(|name| unsafe { mem::transmute(loader.get_instance_proc_addr(vk::Instance::NULL, name.as_ptr())) });
 
         FunctionPointers {
             loader,

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -110,7 +110,7 @@ unsafe impl<T: ?Sized> SafeDeref for Box<T> {
 /// Gives access to the internal identifier of an object.
 pub unsafe trait VulkanObject {
     /// The type of the object.
-    type Object;
+    type Object: vk::Handle;
 
     /// Returns a reference to the object.
     fn internal_object(&self) -> Self::Object;

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -104,7 +104,7 @@ impl DeviceMemory {
                         Some(vk::MemoryDedicatedAllocateInfoKHR {
                                  sType: vk::STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
                                  pNext: ptr::null(),
-                                 image: 0,
+                                 image: vk::Image::NULL,
                                  buffer: buffer.internal_object(),
                              })
                     },
@@ -113,7 +113,7 @@ impl DeviceMemory {
                                  sType: vk::STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_KHR,
                                  pNext: ptr::null(),
                                  image: image.internal_object(),
-                                 buffer: 0,
+                                 buffer: vk::Buffer::NULL,
                              })
                     },
                     DedicatedAlloc::None => {

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -134,13 +134,13 @@ impl<Pl> ComputePipeline<Pl> {
                 flags: 0,
                 stage: stage,
                 layout: PipelineLayoutAbstract::sys(&pipeline_layout).internal_object(),
-                basePipelineHandle: 0,
+                basePipelineHandle: vk::Pipeline::NULL,
                 basePipelineIndex: 0,
             };
 
             let mut output = mem::uninitialized();
             check_errors(vk.CreateComputePipelines(device.internal_object(),
-                                                   0,
+                                                   vk::PipelineCache::NULL,
                                                    1,
                                                    &infos,
                                                    ptr::null(),

--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -1049,13 +1049,13 @@ impl<Vdef, Vs, Vss, Tcs, Tcss, Tes, Tess, Gs, Gss, Fs, Fss, Rp>
                     .inner()
                     .internal_object(),
                 subpass: self.render_pass.as_ref().unwrap().index(),
-                basePipelineHandle: 0, // TODO:
+                basePipelineHandle: vk::Pipeline::NULL, // TODO:
                 basePipelineIndex: -1, // TODO:
             };
 
             let mut output = mem::uninitialized();
             check_errors(vk.CreateGraphicsPipelines(device.internal_object(),
-                                                    0,
+                                                    vk::PipelineCache::NULL,
                                                     1,
                                                     &infos,
                                                     ptr::null(),

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -395,7 +395,7 @@ impl Swapchain {
                 oldSwapchain: if let Some(ref old_swapchain) = old_swapchain {
                     old_swapchain.swapchain
                 } else {
-                    0
+                    vk::SwapchainKHR::NULL
                 },
             };
 
@@ -1167,8 +1167,8 @@ pub unsafe fn acquire_next_image_raw(swapchain: &Swapchain, timeout: Option<Dura
         check_errors(vk.AcquireNextImageKHR(swapchain.device.internal_object(),
                                             swapchain.swapchain,
                                             timeout_ns,
-                                            semaphore.map(|s| s.internal_object()).unwrap_or(0),
-                                            fence.map(|f| f.internal_object()).unwrap_or(0),
+                                            semaphore.map(|s| s.internal_object()).unwrap_or(vk::Semaphore::NULL),
+                                            fence.map(|f| f.internal_object()).unwrap_or(vk::Fence::NULL),
                                             &mut out))?;
 
     let (id, suboptimal) = match r {


### PR DESCRIPTION
Depends on #847.

This commit makes all vk-sys handle types strong, which is a breaking change. I'd like to get some comments on the design of the new `Handle` trait in vk-sys before this is merged.

This use of associated constants triggers a panic bug in rustc 1.20.0. The bug appears to be fixed (tests pass) as of 1.21.0-beta.3 or earlier.