### PR TITLE
Allow depth/stencil images to be used with AutoCommandBufferBuilder::copy_image_to_buffer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Changed `ShaderInterfaceMismatchError` to be more verbose.
+- Allow depth/stencil images to be used with `AutoCommandBufferBuilder::copy_image_to_buffer()`
 
 # Version 0.7.2 (2017-10-09)
 

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -730,10 +730,14 @@ impl<P> AutoCommandBufferBuilder<P> {
                 buffer_offset: 0,
                 buffer_row_length: 0,
                 buffer_image_height: 0,
-                image_aspect: UnsafeCommandBufferBuilderImageAspect {
-                    color: source.has_color(),
-                    depth: source.has_depth(),
-                    stencil: source.has_stencil()
+                image_aspect: if destination.has_color() {
+                    UnsafeCommandBufferBuilderImageAspect {
+                        color: true,
+                        depth: false,
+                        stencil: false,
+                    }
+                } else {
+                    unimplemented!()
                 },
                 image_mip_level: mipmap,
                 image_base_array_layer: first_layer,
@@ -790,14 +794,10 @@ impl<P> AutoCommandBufferBuilder<P> {
                 buffer_offset: 0,
                 buffer_row_length: 0,
                 buffer_image_height: 0,
-                image_aspect: if source.has_color() {
-                    UnsafeCommandBufferBuilderImageAspect {
-                        color: true,
-                        depth: false,
-                        stencil: false,
-                    }
-                } else {
-                    unimplemented!()
+                image_aspect: UnsafeCommandBufferBuilderImageAspect {
+                    color: source.has_color(),
+                    depth: source.has_depth(),
+                    stencil: source.has_stencil()
                 },
                 image_mip_level: mipmap,
                 image_base_array_layer: first_layer,

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -730,14 +730,10 @@ impl<P> AutoCommandBufferBuilder<P> {
                 buffer_offset: 0,
                 buffer_row_length: 0,
                 buffer_image_height: 0,
-                image_aspect: if destination.has_color() {
-                    UnsafeCommandBufferBuilderImageAspect {
-                        color: true,
-                        depth: false,
-                        stencil: false,
-                    }
-                } else {
-                    unimplemented!()
+                image_aspect: UnsafeCommandBufferBuilderImageAspect {
+                    color: source.has_color(),
+                    depth: source.has_depth(),
+                    stencil: source.has_stencil()
                 },
                 image_mip_level: mipmap,
                 image_base_array_layer: first_layer,


### PR DESCRIPTION
As I suggested here: https://github.com/vulkano-rs/vulkano/issues/866
