### PR TITLE
Do not try to hardlink glslangValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Changed `ShaderInterfaceMismatchError` to be more verbose.
 - Allow depth/stencil images to be used with `AutoCommandBufferBuilder::copy_image_to_buffer()`
 - Clear value validation for `AutoCommandBufferBuilder::begin_render_pass()`
+- Fix occasional truncation of glslang_validator when glsl-to-spirv is rebuilt
 
 # Version 0.7.2 (2017-10-09)
 

--- a/glsl-to-spirv/build/build.rs
+++ b/glsl-to-spirv/build/build.rs
@@ -29,7 +29,5 @@ fn main() {
             .join("glslangValidator")
     };
 
-    if let Err(_) = fs::hard_link(&path, &out_file) {
-        fs::copy(&path, &out_file).expect("failed to copy executable");
-    }
+    fs::copy(&path, &out_file).expect("failed to copy executable");
 }


### PR DESCRIPTION
Previously, it was possible for the hardlinked glslangValidator to become truncated when the glsl-to-spirv crate was rebuilt. The file would be successfully hardlinked the first time, but on subsequent builds the hardlink attempt would fail becasue the target already exists. This would cause the build script to fall back to a copy, which truncates when source and dest are the same file.

This removes the hardlinking entirely, meaning that we always just copy our built glslangValidator to where we want it. While it would be possible to try to make the hardlinking/copying logic idempotent, the complexity (and potential fragility to similar bugs in the future) doesn't seem worth it to avoid one copy.

This fixes #95