### PR TITLE
Expose vkCmdCopyImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Clear value validation for `AutoCommandBufferBuilder::begin_render_pass()`
 - Fix occasional truncation of glslang_validator when glsl-to-spirv is rebuilt
 - Fix linking against MoltenVK >= 0.19.0 
+- Added `AutoCommandBufferBuilder::copy_image`
 
 # Version 0.7.2 (2017-10-09)
 

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -40,6 +40,7 @@ use command_buffer::sys::UnsafeCommandBufferBuilderBufferImageCopy;
 use command_buffer::sys::UnsafeCommandBufferBuilderColorImageClear;
 use command_buffer::sys::UnsafeCommandBufferBuilderImageAspect;
 use command_buffer::sys::UnsafeCommandBufferBuilderImageBlit;
+use command_buffer::sys::UnsafeCommandBufferBuilderImageCopy;
 use command_buffer::validity::*;
 use descriptor::descriptor_set::DescriptorSetsCollection;
 use descriptor::pipeline_layout::PipelineLayoutAbstract;
@@ -544,6 +545,82 @@ impl<P> AutoCommandBufferBuilder<P> {
                 .begin_render_pass(framebuffer.clone(), contents, clear_values)?;
             self.render_pass = Some((Box::new(framebuffer) as Box<_>, 0));
             self.subpass_secondary = secondary;
+            Ok(self)
+        }
+    }
+
+    /// Adds a command that copies an image to another.
+    ///
+    /// Copy operations have several restrictions:
+    ///
+    /// - Copy operations are only allowed on queue families that support transfer, graphics, or
+    ///   compute operations.
+    /// - The number of samples in the source and destination images must be equal.
+    /// - The size of the uncompressed element format of the source image must be equal to the
+    ///   compressed element format of the destination.
+    /// - If you copy between depth, stencil or depth-stencil images, the format of both images
+    ///   must match exactly.
+    /// - For two-dimensional images, the Z coordinate must be 0 for the image offsets and 1 for
+    ///   the extent. Same for the Y coordinate for one-dimensional images.
+    /// - For non-array images, the base array layer must be 0 and the number of layers must be 1.
+    ///
+    /// If `layer_count` is superior to 1, the copy will happen between each individual layer as
+    /// if they were separate images.
+    ///
+    /// # Panic
+    ///
+    /// - Panics if the source or the destination was not created with `device`.
+    ///
+    pub fn copy_image<S, D>(mut self, source: S, source_offset: [i32; 3],
+                            source_base_array_layer: u32, source_mip_level: u32,
+                            destination: D, destination_offset: [i32; 3],
+                            destination_base_array_layer: u32, destination_mip_level: u32,
+                            extent: [u32; 3], layer_count: u32)
+                            -> Result<Self, CopyImageError>
+        where S: ImageAccess + Send + Sync + 'static,
+              D: ImageAccess + Send + Sync + 'static
+    {
+        unsafe {
+            self.ensure_outside_render_pass()?;
+
+            check_copy_image(self.device(),
+                             &source,
+                             source_offset,
+                             source_base_array_layer,
+                             source_mip_level,
+                             &destination,
+                             destination_offset,
+                             destination_base_array_layer,
+                             destination_mip_level,
+                             extent,
+                             layer_count)?;
+
+            let copy = UnsafeCommandBufferBuilderImageCopy {
+                // TODO: Allowing choosing a subset of the image aspects, but note that if color
+                // is included, neither depth nor stencil may.
+                aspect: UnsafeCommandBufferBuilderImageAspect {
+                    color: source.has_color(),
+                    depth: !source.has_color() &&
+                           source.has_depth() && destination.has_depth(),
+                    stencil: !source.has_color() &&
+                             source.has_stencil() && destination.has_stencil(),
+                },
+                source_mip_level,
+                destination_mip_level,
+                source_base_array_layer,
+                destination_base_array_layer,
+                layer_count,
+                source_offset,
+                destination_offset,
+                extent,
+            };
+
+            // TODO: Allow choosing layouts, but note that only Transfer*Optimal and General are
+            // valid.
+            self.inner
+                .copy_image(source, ImageLayout::TransferSrcOptimal,
+                            destination, ImageLayout::TransferDstOptimal,
+                            iter::once(copy))?;
             Ok(self)
         }
     }
@@ -1454,6 +1531,12 @@ err_gen!(BuildError {
 
 err_gen!(BeginRenderPassError {
              AutoCommandBufferBuilderContextError,
+             SyncCommandBufferBuilderError,
+         });
+
+err_gen!(CopyImageError {
+             AutoCommandBufferBuilderContextError,
+             CheckCopyImageError,
              SyncCommandBufferBuilderError,
          });
 

--- a/vulkano/src/command_buffer/validity/copy_image.rs
+++ b/vulkano/src/command_buffer/validity/copy_image.rs
@@ -1,0 +1,230 @@
+// Copyright (c) 2017 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::error;
+use std::fmt;
+
+use VulkanObject;
+use device::Device;
+use format::FormatTy;
+use format::PossibleCompressedFormatDesc;
+use image::ImageAccess;
+use image::ImageDimensions;
+
+/// Checks whether a copy image command is valid.
+///
+/// Note that this doesn't check whether `layer_count` is equal to 0. TODO: change that?
+///
+/// # Panic
+///
+/// - Panics if the source or the destination was not created with `device`.
+///
+pub fn check_copy_image<S, D>(device: &Device, source: &S, source_offset: [i32; 3],
+                              source_base_array_layer: u32, source_mip_level: u32,
+                              destination: &D, destination_offset: [i32; 3],
+                              destination_base_array_layer: u32, destination_mip_level: u32,
+                              extent: [u32; 3], layer_count: u32)
+                              -> Result<(), CheckCopyImageError>
+    where S: ?Sized + ImageAccess,
+          D: ?Sized + ImageAccess
+{
+    let source_inner = source.inner();
+    let destination_inner = destination.inner();
+
+    assert_eq!(source_inner.image.device().internal_object(),
+               device.internal_object());
+    assert_eq!(destination_inner.image.device().internal_object(),
+               device.internal_object());
+
+    if !source_inner.image.usage_transfer_source() {
+        return Err(CheckCopyImageError::MissingTransferSourceUsage);
+    }
+
+    if !destination_inner.image.usage_transfer_destination() {
+        return Err(CheckCopyImageError::MissingTransferDestinationUsage);
+    }
+
+    if source.samples() != destination.samples() {
+        return Err(CheckCopyImageError::SampleCountMismatch);
+    }
+
+    let source_format_ty = source.format().ty();
+    let destination_format_ty = destination.format().ty();
+
+    if source_format_ty.is_depth_and_or_stencil() {
+        if source.format() != destination.format() {
+            return Err(CheckCopyImageError::DepthStencilFormatMismatch);
+        }
+    }
+
+    // TODO: The correct check here is that the uncompressed element size of the source is
+    // equal to the compressed element size of the destination.  However, format doesn't
+    // currently expose this information, so to be safe, we simply disallow compressed formats.
+    if source.format().is_compressed() || destination.format().is_compressed() ||
+            (source.format().size() != destination.format().size()) {
+        return Err(CheckCopyImageError::SizeIncompatibleFormatsTypes {
+                       source_format_ty: source.format().ty(),
+                       destination_format_ty: destination.format().ty(),
+                   });
+    }
+
+    let source_dimensions = match source
+        .dimensions()
+        .mipmap_dimensions(source_mip_level) {
+        Some(d) => d,
+        None => return Err(CheckCopyImageError::SourceCoordinatesOutOfRange),
+    };
+
+    let destination_dimensions = match destination
+        .dimensions()
+        .mipmap_dimensions(destination_mip_level) {
+        Some(d) => d,
+        None => return Err(CheckCopyImageError::DestinationCoordinatesOutOfRange),
+    };
+
+    if source_base_array_layer + layer_count > source_dimensions.array_layers() {
+        return Err(CheckCopyImageError::SourceCoordinatesOutOfRange);
+    }
+
+    if destination_base_array_layer + layer_count > destination_dimensions.array_layers() {
+        return Err(CheckCopyImageError::DestinationCoordinatesOutOfRange);
+    }
+
+    if source_offset[0] < 0 ||
+            source_offset[0] as u32 + extent[0] > source_dimensions.width() {
+        return Err(CheckCopyImageError::SourceCoordinatesOutOfRange);
+    }
+
+    if source_offset[1] < 0 ||
+            source_offset[1] as u32 + extent[1] > source_dimensions.height() {
+        return Err(CheckCopyImageError::SourceCoordinatesOutOfRange);
+    }
+
+    if source_offset[2] < 0 ||
+            source_offset[2] as u32 + extent[2] > source_dimensions.depth() {
+        return Err(CheckCopyImageError::SourceCoordinatesOutOfRange);
+    }
+
+    if destination_offset[0] < 0 ||
+            destination_offset[0] as u32 + extent[0] > destination_dimensions.width() {
+        return Err(CheckCopyImageError::DestinationCoordinatesOutOfRange);
+    }
+
+    if destination_offset[1] < 0 ||
+            destination_offset[1] as u32 + extent[1] > destination_dimensions.height() {
+        return Err(CheckCopyImageError::DestinationCoordinatesOutOfRange);
+    }
+
+    if destination_offset[2] < 0 ||
+            destination_offset[2] as u32 + extent[2] > destination_dimensions.depth() {
+        return Err(CheckCopyImageError::DestinationCoordinatesOutOfRange);
+    }
+
+    match source_dimensions {
+        ImageDimensions::Dim1d { .. } => {
+            if source_offset[1] != 0 || extent[1] != 1 {
+                return Err(CheckCopyImageError::IncompatibleRangeForImageType);
+            }
+            if source_offset[2] != 0 || extent[2] != 1 {
+                return Err(CheckCopyImageError::IncompatibleRangeForImageType);
+            }
+        },
+        ImageDimensions::Dim2d { .. } => {
+            if source_offset[2] != 0 || extent[2] != 1 {
+                return Err(CheckCopyImageError::IncompatibleRangeForImageType);
+            }
+        },
+        ImageDimensions::Dim3d { .. } => {},
+    }
+
+    match destination_dimensions {
+        ImageDimensions::Dim1d { .. } => {
+            if destination_offset[1] != 0 || extent[1] != 1 {
+                return Err(CheckCopyImageError::IncompatibleRangeForImageType);
+            }
+            if destination_offset[2] != 0 || extent[2] != 1 {
+                return Err(CheckCopyImageError::IncompatibleRangeForImageType);
+            }
+        },
+        ImageDimensions::Dim2d { .. } => {
+            if destination_offset[2] != 0 || extent[2] != 1 {
+                return Err(CheckCopyImageError::IncompatibleRangeForImageType);
+            }
+        },
+        ImageDimensions::Dim3d { .. } => {},
+    }
+
+    Ok(())
+}
+
+/// Error that can happen from `check_copy_image`.
+#[derive(Debug, Copy, Clone)]
+pub enum CheckCopyImageError {
+    /// The source is missing the transfer source usage.
+    MissingTransferSourceUsage,
+    /// The destination is missing the transfer destination usage.
+    MissingTransferDestinationUsage,
+    /// The number of samples in the source and destination do not match.
+    SampleCountMismatch,
+    /// The format of the source and destination must be equal when copying depth/stencil images.
+    DepthStencilFormatMismatch,
+    /// The types of the source format and the destination format aren't size-compatible.
+    SizeIncompatibleFormatsTypes {
+        source_format_ty: FormatTy,
+        destination_format_ty: FormatTy,
+    },
+    /// The offsets, array layers and/or mipmap levels are out of range in the source image.
+    SourceCoordinatesOutOfRange,
+    /// The offsets, array layers and/or mipmap levels are out of range in the destination image.
+    DestinationCoordinatesOutOfRange,
+    /// The offsets or extent are incompatible with the image type.
+    IncompatibleRangeForImageType,
+}
+
+impl error::Error for CheckCopyImageError {
+    #[inline]
+    fn description(&self) -> &str {
+        match *self {
+            CheckCopyImageError::MissingTransferSourceUsage => {
+                "the source is missing the transfer source usage"
+            },
+            CheckCopyImageError::MissingTransferDestinationUsage => {
+                "the destination is missing the transfer destination usage"
+            },
+            CheckCopyImageError::SampleCountMismatch => {
+                "the number of samples in the source and destination do not match"
+            }
+            CheckCopyImageError::DepthStencilFormatMismatch => {
+                "the format of the source and destination must be equal when copying \
+                 depth/stencil images"
+            },
+            CheckCopyImageError::SizeIncompatibleFormatsTypes { .. } => {
+                "the types of the source format and the destination format aren't size-compatible"
+            },
+            CheckCopyImageError::SourceCoordinatesOutOfRange => {
+                "the offsets, array layers and/or mipmap levels are out of range in the source \
+                 image"
+            },
+            CheckCopyImageError::DestinationCoordinatesOutOfRange => {
+                "the offsets, array layers and/or mipmap levels are out of range in the \
+                 destination image"
+            },
+            CheckCopyImageError::IncompatibleRangeForImageType => {
+                "the offsets or extent are incompatible with the image type"
+            },
+        }
+    }
+}
+
+impl fmt::Display for CheckCopyImageError {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(fmt, "{}", error::Error::description(self))
+    }
+}

--- a/vulkano/src/command_buffer/validity/mod.rs
+++ b/vulkano/src/command_buffer/validity/mod.rs
@@ -12,6 +12,7 @@
 pub use self::blit_image::{CheckBlitImageError, check_blit_image};
 pub use self::clear_color_image::{CheckClearColorImageError, check_clear_color_image};
 pub use self::copy_buffer::{CheckCopyBuffer, CheckCopyBufferError, check_copy_buffer};
+pub use self::copy_image::{CheckCopyImageError, check_copy_image};
 pub use self::copy_image_buffer::{CheckCopyBufferImageError, CheckCopyBufferImageTy,
                                   check_copy_buffer_image};
 pub use self::descriptor_sets::{CheckDescriptorSetsValidityError, check_descriptor_sets_validity};
@@ -26,6 +27,7 @@ pub use self::vertex_buffers::{CheckVertexBuffer, CheckVertexBufferError, check_
 mod blit_image;
 mod clear_color_image;
 mod copy_buffer;
+mod copy_image;
 mod copy_image_buffer;
 mod descriptor_sets;
 mod dispatch;


### PR DESCRIPTION
Exposes vkCmdCopyImage as requested in #883 through copy_image methods on AutoCommandBufferBuilder and UnsafeCommandBufferBuilder.