### PR TITLE
Enforce one ClearValue per Attachment

### DIFF
--- a/vulkano/src/framebuffer/traits.rs
+++ b/vulkano/src/framebuffer/traits.rs
@@ -128,12 +128,6 @@ pub unsafe trait RenderPassDescClearValues<C> {
     /// The format of the clear value **must** match the format of the attachment. Attachments
     /// that are not loaded with `LoadOp::Clear` must have an entry equal to `ClearValue::None`.
     ///
-    /// Only the attachments whose `LoadOp` is `Clear` should appear in the list returned by the
-    /// method. Other attachments simply should not appear. TODO: check that this is correct.
-    /// For example if attachments 1, 2 and 4 are `Clear` and attachments 0 and 3 are `Load`, then
-    /// the list returned by the function must have three elements which are the clear values of
-    /// attachments 1, 2 and 4.
-    ///
     /// # Safety
     ///
     /// This trait is unsafe because vulkano doesn't check whether the clear value is in a format


### PR DESCRIPTION
Breaking change.

The vulkan spec says:
```
clearValueCount must be greater than the largest attachment index in renderPass that
specifies a loadOp (or stencilLoadOp, if the attachment has a depth/stencil format)
of VK_ATTACHMENT_LOAD_OP_CLEAR
```

The easiest way to enforce this is to ensure there is one clear value per attachment.

No need to update the changelog as it already mentions the addition of the (unreleased) clear value validation that I am modifying.
  