### PR TITLE
Fixed issue #857 / swapchain resize causes panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Clear value validation for `AutoCommandBufferBuilder::begin_render_pass()`
 - Fix occasional truncation of glslang_validator when glsl-to-spirv is rebuilt
 - Fix linking against MoltenVK >= 0.19.0 
+- Fix panic on DeviceLost error after resizing swapchain on nvidia/amd hardware
 - Added `AutoCommandBufferBuilder::copy_image`
 - Added `VulkanObject::TYPE` to look up the `DebugReportObjectTypeEXT` of an object
 - Added `Device::set_object_name` and `Device::set_object_name_raw`

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -1017,7 +1017,10 @@ unsafe impl<P> GpuFuture for PresentFuture<P>
                    SubmitAnyBuilder::QueuePresent(builder)
                },
                SubmitAnyBuilder::CommandBuffer(cb) => {
-                   cb.submit(&queue.unwrap())?; // FIXME: wrong because build_submission can be called multiple times
+                   // submit the command buffer by flushing previous.
+                   // Since the implementation should remember being flushed it's safe to call build_submission multiple times
+                   self.previous.flush()?;
+                   
                    let mut builder = SubmitPresentBuilder::new();
                    builder.add_swapchain(&self.swapchain,
                                          self.image_id as u32,
@@ -1025,7 +1028,10 @@ unsafe impl<P> GpuFuture for PresentFuture<P>
                    SubmitAnyBuilder::QueuePresent(builder)
                },
                SubmitAnyBuilder::BindSparse(cb) => {
-                   cb.submit(&queue.unwrap())?; // FIXME: wrong because build_submission can be called multiple times
+                   // submit the command buffer by flushing previous.
+                   // Since the implementation should remember being flushed it's safe to call build_submission multiple times
+                   self.previous.flush()?;
+
                    let mut builder = SubmitPresentBuilder::new();
                    builder.add_swapchain(&self.swapchain,
                                          self.image_id as u32,


### PR DESCRIPTION
This pull reqeust contains a fix for issue #857: the device can be lost while trying to resize the swapchain.
After enabling validation layers the cause for this issue seems to be that one time submit buffers can be submitted by vulkano up to 4 times!

This is because the PresentFuture submits the commandbuffer of the CommandBufferExecFuture before it all by itself, without notifying the CommandBufferExecFuture of this. Replacing the submit call by a flush() fixes the problem.
This is what happens if you resize the swapchain and get an OutOfDate error:

`FenceSignalFuture::flush()` => build submissions for underlying futures
`PresentFuture::build_submission()` => submits command buffer (first time), then fails to swap because `OutOfDate`
FenceSignalFuture::flush() now returns an error, but the future is still pending. What to do? we could drop it:
`FenceSignalFuture::drop()` => submission is built again, including command buffer submit (second time), but fails (technically still because of `OutOfDate`)=> VALIDATION ERROR
`PresentFuture::drop()` => submission is built again but fails (third time) => VALIDATION ERROR
`ExecCommandBufferFuture::drop()` => submission is built again, succeeds (fourth time)   => VALIDATION ERROR



  
  