### PR TITLE
Fixed resizing bug in examples (#303)

### DIFF
--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -211,8 +211,21 @@ fn main() {
         let future = previous_frame_end.join(future)
             .then_execute(queue.clone(), cb).unwrap()
             .then_swapchain_present(queue.clone(), swapchain.clone(), image_num)
-            .then_signal_fence_and_flush().unwrap();
-        previous_frame_end = Box::new(future) as Box<_>;
+            .then_signal_fence_and_flush();
+
+        match future {
+            Ok(future) => {
+                previous_frame_end = Box::new(future) as Box<_>;
+            }
+            Err(vulkano::sync::FlushError::OutOfDate) => {
+                recreate_swapchain = true;
+                previous_frame_end = Box::new(vulkano::sync::now(device.clone())) as Box<_>;
+            }
+            Err(e) => {
+                println!("{:?}", e);
+                previous_frame_end = Box::new(vulkano::sync::now(device.clone())) as Box<_>;
+            }
+        }
 
         let mut done = false;
         events_loop.poll_events(|ev| {


### PR DESCRIPTION
Fixed the OutOfDate error in the examples by match unwrapping

By match unwrapping the future returned from `then_signal_fence_and_flush` and recreating the swapchain; The examples are now able to be resized without crashing on unwrapping the err value on my GTX 1050 and GTX 970.

This fixes issue #303 when dealing with unwrapping `Err(OutOfDate)`