### PR TITLE
Link IOKit to fix compilation on macOS against open-source MoltenVK

### DIFF
--- a/vulkano/build.rs
+++ b/vulkano/build.rs
@@ -14,6 +14,7 @@ fn main() {
     if target.contains("apple-darwin") {
         println!("cargo:rustc-link-lib=c++");
         println!("cargo:rustc-link-lib=framework=MoltenVK");
+        println!("cargo:rustc-link-lib=framework=IOKit");
         println!("cargo:rustc-link-lib=framework=IOSurface");
         println!("cargo:rustc-link-lib=framework=QuartzCore");
         println!("cargo:rustc-link-lib=framework=Metal");


### PR DESCRIPTION
Required by the following imports: https://github.com/KhronosGroup/MoltenVK/blob/93c524d2f05d7a7f983354b8e53cd4e6812708c7/MoltenVK/MoltenVK/Utility/MVKOSExtensions.mm#L31-L32