### PR TITLE
Fix macos compilation

### DIFF
--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -12,6 +12,6 @@ vulkano = { version = "0.7.0", path = "../vulkano" }
 winit = "0.7.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal-rs = "0.5.2"
+metal-rs = "0.6.6"
 cocoa = "0.11"
 objc = "0.2.2"

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -165,7 +165,7 @@ unsafe fn winit_to_surface(instance: Arc<Instance>, win: winit::Window)
 
     let wnd: cocoa_id = mem::transmute(win.get_nswindow());
 
-    let layer = CAMetalLayer::new();
+    let layer = CoreAnimationLayer::new();
 
     layer.set_edge_antialiasing_mask(0);
     layer.set_presents_with_transaction(false);
@@ -174,7 +174,7 @@ unsafe fn winit_to_surface(instance: Arc<Instance>, win: winit::Window)
     let view = wnd.contentView();
 
     layer.set_contents_scale(view.backingScaleFactor());
-    view.setLayer(mem::transmute(layer.0)); // Bombs here with out of memory
+    view.setLayer(mem::transmute(layer.as_ref())); // Bombs here with out of memory
     view.setWantsLayer(YES);
 
     Surface::from_macos_moltenvk(instance, win.get_nsview() as *const (), win)


### PR DESCRIPTION
This implements a trivial fix to reflect breaking changes in `metal-rs`. `vulkano-win` should compile on macOS once again. While I at it, it also updates `metal-rs` to the latest version.