### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/glsl-to-spirv/Cargo.toml
+++ b/glsl-to-spirv/Cargo.toml
@@ -9,7 +9,7 @@ build = "build/build.rs"
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-tempdir = "0.3.5"
+tempfile = "3"
 
 [build-dependencies]
 cmake = "0.1.27"

--- a/glsl-to-spirv/src/lib.rs
+++ b/glsl-to-spirv/src/lib.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate tempdir;
+extern crate tempfile;
 
 use std::fs::File;
 use std::io::Write;
@@ -24,7 +24,7 @@ pub fn compile(code: &str, ty: ShaderType) -> Result<SpirvOutput, String> {
 fn compile_inner<'a, I>(shaders: I) -> Result<SpirvOutput, String>
     where I: IntoIterator<Item = (&'a str, ShaderType)>
 {
-    let temp_dir = tempdir::TempDir::new("glslang-compile").unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
     let output_file = temp_dir.path().join("compilation_output.spv");
 
     let mut command = Command::new(concat!(env!("OUT_DIR"), "/glslang_validator"));


### PR DESCRIPTION
`tempdir` is [deprecated](https://github.com/rust-lang-nursery/tempdir/issues/45) in favor of `tempfile`. As a bonus vulkano will not depend on `winapi` crate for linux and macos builds.