### PR TITLE
Remove pritnln from parse::test::test

### DIFF
--- a/vulkano-shaders/src/parse.rs
+++ b/vulkano-shaders/src/parse.rs
@@ -399,6 +399,6 @@ mod test {
     #[test]
     fn test() {
         let data = include_bytes!("../tests/frag.spv");
-        println!("{:#?}", parse::parse_spirv(data).unwrap());
+        parse::parse_spirv(data).unwrap();
     }
 }


### PR DESCRIPTION
I'm adding tests and sometime run them with `cargo test -- --nocapture`, so I can see any debug output. I removed the println here because it prints a lot of extra text and makes it hard to see debug output.