### PR TITLE
Use libvulkan.dylib instead of MoltenVK by default on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Use dynamically loaded `libvulkan` like on other platforms instead of linking to MoltenVK on macOS
+
 # Version 0.9.0 (2018-03-13)
 
 - Updated winit to version 0.11.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ What does vulkano do?
 - Tries to be convenient to use. Nobody is going to use a library that requires you to browse
   the documentation for hours for every single operation.
 
-Note that vulkano does **not** require you to install the official Vulkan SDK. This is not
-something specific to vulkano (you don't need the SDK to write programs that use Vulkan, even
+Note that in general vulkano does **not** require you to install the official Vulkan SDK. This is
+not something specific to vulkano (you don't need the SDK to write programs that use Vulkan, even
 without vulkano), but many people are unaware of that and install the SDK thinking that it is
-required.
+required. However, macOS and iOS platforms do require a little more Vulkan setup since it is not
+natively supported. See below for more details.
 
 ## Development status
 
@@ -45,6 +46,22 @@ will likely be straight-forward to fix in user code.
 To get started you are encouraged to read the examples in
 [the `vulkano-examples` repository](https://github.com/vulkano-rs/vulkano-examples), starting with
 [the `triangle` example](https://github.com/vulkano-rs/vulkano-examples/blob/master/triangle/main.rs).
+
+## macOS and iOS Setup
+
+Vulkan is not natively supported by macOS and iOS. However, there exists [MoltenVK](https://github.com/KhronosGroup/MoltenVK)
+a Vulkan implementation on top of Apple's Metal API. This allows vulkano to build and run on macOS
+and iOS platforms.
+
+The easiest way to get vulkano up and running on macOS is to install the 
+[Vulkan SDK for macOS](https://vulkan.lunarg.com/sdk/home). Vulkano will by default, as it does on
+other platforms, look for `libvulkan.1.dylib` (included as part of the SDK). Note that it is still
+possible to link with the MoltenVK framework (as vulkano did in previous versions) by adding the
+appropriate cargo output lines to your build script and implementing your own
+`vulkano::instance::loader::Loader` that calls the MoltenVK `vkGetInstanceProcAddr` implementation.
+
+On iOS vulkano links directly to the MoltenVK framework. There is nothing else to do besides
+installing it. Note that the Vulkan SDK for macOS also comes with the iOS framework.
 
 ## Donate
 

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -26,7 +26,7 @@ use cocoa::appkit::{NSView, NSWindow};
 #[cfg(target_os = "macos")]
 use cocoa::base::id as cocoa_id;
 #[cfg(target_os = "macos")]
-use metal::*;
+use metal::CoreAnimationLayer;
 #[cfg(target_os = "macos")]
 use objc::runtime::YES;
 

--- a/vulkano/build.rs
+++ b/vulkano/build.rs
@@ -11,14 +11,14 @@ use std::env;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
-    if target.contains("apple-darwin") {
+    if target.contains("apple-ios") {
         println!("cargo:rustc-link-search=framework=/Library/Frameworks/");
         println!("cargo:rustc-link-lib=c++");
         println!("cargo:rustc-link-lib=framework=MoltenVK");
-        println!("cargo:rustc-link-lib=framework=IOKit");
+        println!("cargo:rustc-link-lib=framework=Metal");
         println!("cargo:rustc-link-lib=framework=IOSurface");
         println!("cargo:rustc-link-lib=framework=QuartzCore");
-        println!("cargo:rustc-link-lib=framework=Metal");
+        println!("cargo:rustc-link-lib=framework=UIKit");
         println!("cargo:rustc-link-lib=framework=Foundation");
     }
 }

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -168,18 +168,17 @@ macro_rules! statically_linked_vulkan_loader {
 /// This function tries to auto-guess where to find the Vulkan implementation, and loads it in a
 /// `lazy_static!`. The content of the lazy_static is then returned, or an error if we failed to
 /// load Vulkan.
-pub fn auto_loader(
-    )
+pub fn auto_loader()
     -> Result<&'static FunctionPointers<Box<Loader + Send + Sync>>, LoadingError>
 {
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_os = "ios")]
     #[allow(non_snake_case)]
     fn def_loader_impl() -> Result<Box<Loader + Send + Sync>, LoadingError> {
         let loader = statically_linked_vulkan_loader!();
         Ok(Box::new(loader))
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(target_os = "ios"))]
     fn def_loader_impl() -> Result<Box<Loader + Send + Sync>, LoadingError> {
         #[cfg(windows)]
         fn get_path() -> &'static Path {
@@ -188,6 +187,10 @@ pub fn auto_loader(
         #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
         fn get_path() -> &'static Path {
             Path::new("libvulkan.so.1")
+        }
+        #[cfg(target_os = "macos")]
+        fn get_path() -> &'static Path {
+            Path::new("libvulkan.1.dylib")
         }
         #[cfg(target_os = "android")]
         fn get_path() -> &'static Path {


### PR DESCRIPTION
Note that this is a breaking change. I added some more docs to the README.md but would be willing to create an example that uses MoltenVK instead of the default libvulkan on macOS. This PR is for issue #928 