### PR TITLE
Expose SPIR-V binary in generated shader code and add unsafe function to load arbitrary new binary

### DIFF
--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -130,6 +130,8 @@ pub struct {name} {{
     shader: ::std::sync::Arc<::vulkano::pipeline::shader::ShaderModule>,
 }}
 
+pub const SPIRV_BINARY: &[u8] = &[{spirv_data}];
+
 impl {name} {{
     /// Loads the shader in Vulkan as a `ShaderModule`.
     #[inline]
@@ -139,7 +141,8 @@ impl {name} {{
     {{
 
         "#,
-            name = name
+            name = name,
+            spirv_data = spirv_data,
         ));
 
         // checking whether each required capability is enabled in the vulkan device
@@ -162,10 +165,8 @@ impl {name} {{
         output.push_str(&format!(
             r#"
         unsafe {{
-            let data = [{spirv_data}];
-
             Ok({name} {{
-                shader: try!(::vulkano::pipeline::shader::ShaderModule::new(device, &data))
+                shader: try!(::vulkano::pipeline::shader::ShaderModule::new(device, SPIRV_BINARY))
             }})
         }}
     }}
@@ -178,7 +179,6 @@ impl {name} {{
     }}
         "#,
             name = name,
-            spirv_data = spirv_data
         ));
 
         // writing one method for each entry point of this module

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -136,7 +136,19 @@ impl {name} {{
     /// Loads the shader in Vulkan as a `ShaderModule`.
     #[inline]
     #[allow(unsafe_code)]
+    #[allow(dead_code)]
     pub fn load(device: ::std::sync::Arc<::vulkano::device::Device>)
+                -> Result<{name}, ::vulkano::OomError>
+    {{
+        unsafe {{
+            Self::load_binary(device, SPIRV_BINARY)
+        }}
+    }}
+
+    /// Loads the shader in Vulkan as a `ShaderModule`.
+    #[inline]
+    #[allow(unsafe_code)]
+    pub unsafe fn load_binary(device: ::std::sync::Arc<::vulkano::device::Device>, spirv_binary: &[u8])
                 -> Result<{name}, ::vulkano::OomError>
     {{
 
@@ -164,11 +176,9 @@ impl {name} {{
         // follow-up of the header
         output.push_str(&format!(
             r#"
-        unsafe {{
-            Ok({name} {{
-                shader: try!(::vulkano::pipeline::shader::ShaderModule::new(device, SPIRV_BINARY))
-            }})
-        }}
+        Ok({name} {{
+            shader: try!(::vulkano::pipeline::shader::ShaderModule::new(device, spirv_binary))
+        }})
     }}
 
     /// Returns the module that was created.


### PR DESCRIPTION
To support safe shader hot reloading, we'll need to analyze the shader modules original SPIR-V binary and the new shader module SPIR-V binary to ensure that the new SPIR-V binary is compatible with the old interface and can be safely substituted.

As a first step, this change exposes the old SPIR-V module binary so that it can be analyzed for compatibility, as well as adding the ability to load a new binary. The function to load a new binary is marked as unsafe, since loading a new binary with a different interface may crash the program.

Edit: Added binary loading functionality.