### PR TITLE
Allow subpass dependencies on VK_SUBPASS_EXTERNAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Use dynamically loaded `libvulkan` like on other platforms instead of linking to MoltenVK on macOS
+- Allow custom implementations of `RenderPassDesc` to specify `VK_SUBPASS_EXTERNAL` as a dependency source or destination
 
 # Version 0.9.0 (2018-03-13)
 

--- a/vulkano/src/framebuffer/sys.rs
+++ b/vulkano/src/framebuffer/sys.rs
@@ -299,8 +299,8 @@ impl<D> RenderPass<D>
         let dependencies = description
             .dependency_descs()
             .map(|dependency| {
-                debug_assert!(dependency.source_subpass < passes.len());
-                debug_assert!(dependency.destination_subpass < passes.len());
+                debug_assert!(dependency.source_subpass as u32 == vk::SUBPASS_EXTERNAL || dependency.source_subpass < passes.len());
+                debug_assert!(dependency.destination_subpass as u32 == vk::SUBPASS_EXTERNAL || dependency.destination_subpass < passes.len());
 
                 vk::SubpassDependency {
                     srcSubpass: dependency.source_subpass as u32,


### PR DESCRIPTION
This updates the asserts in `RenderPass` creation to allow `VK_SUBPASS_EXTERNAL` as a special value in addition to any value less than the total number of subpasses. This enables custom unsafe implementations of `RenderPassDesc` to define their external dependencies.