### PR TITLE
Update winit to 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Use dynamically loaded `libvulkan` like on other platforms instead of linking to MoltenVK on macOS
+- Updated winit to version 0.13.
 
 # Version 0.9.0 (2018-03-13)
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,5 +10,5 @@ vulkano-shader-derive = { path = "../vulkano-shader-derive" }
 vulkano-win = { path = "../vulkano-win" }
 cgmath = "0.15.0"
 image = "0.18.0"
-winit = "0.11.0"
+winit = "0.13.1"
 time = "0.1.38"

--- a/examples/src/bin/image.rs
+++ b/examples/src/bin/image.rs
@@ -230,7 +230,7 @@ fn main() {
         let mut done = false;
         events_loop.poll_events(|ev| {
             match ev {
-                winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => done = true,
+                winit::Event::WindowEvent { event: winit::WindowEvent::CloseRequested, .. } => done = true,
                 _ => ()
             }
         });

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -252,7 +252,7 @@ fn main() {
         let mut done = false;
         events_loop.poll_events(|ev| {
             match ev {
-                winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => done = true,
+                winit::Event::WindowEvent { event: winit::WindowEvent::CloseRequested, .. } => done = true,
                 _ => ()
             }
         });

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -473,7 +473,7 @@ void main() {
         let mut done = false;
         events_loop.poll_events(|ev| {
             match ev {
-                winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => done = true,
+                winit::Event::WindowEvent { event: winit::WindowEvent::CloseRequested, .. } => done = true,
                 _ => ()
             }
         });

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 vulkano = { version = "0.9.0", path = "../vulkano" }
-winit = "0.11.0"
+winit = "0.13.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal-rs = "0.6"


### PR DESCRIPTION
Winit 0.13.0 has some fixes for window management on X11 that avoid some messy behavior with Vulkan surfaces (see tomaka/winit#434).