### PR TITLE
Add name in DescriptorDesc

### DIFF
--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -23,6 +23,7 @@ pub fn write_descriptor_sets(doc: &parse::Spirv) -> String {
         desc_ty: String,
         array_count: u64,
         readonly: bool,
+        name: String
     }
 
     // Looping to find all the elements that have the `DescriptorSet` decoration.
@@ -74,6 +75,7 @@ pub fn write_descriptor_sets(doc: &parse::Spirv) -> String {
                              binding: binding,
                              array_count: array_count,
                              readonly: readonly,
+                             name: name
                          });
     }
 
@@ -106,12 +108,14 @@ pub fn write_descriptor_sets(doc: &parse::Spirv) -> String {
             array_count: {array_count},
             stages: self.0.clone(),
             readonly: {readonly},
+            name: String::from(\"{name}\")
         }}),",
                 set = d.set,
                 binding = d.binding,
                 desc_ty = d.desc_ty,
                 array_count = d.array_count,
-                readonly = if d.readonly { "true" } else { "false" }
+                readonly = if d.readonly { "true" } else { "false" },
+                name = d.name
             )
 
         })

--- a/vulkano/src/descriptor/descriptor.rs
+++ b/vulkano/src/descriptor/descriptor.rs
@@ -71,6 +71,9 @@ pub struct DescriptorDesc {
 
     /// True if the attachment is only ever read by the shader. False if it is also written.
     pub readonly: bool,
+
+    /// Name of the uniform in the shader
+    pub name: String
 }
 
 impl DescriptorDesc {
@@ -115,6 +118,7 @@ impl DescriptorDesc {
                  array_count: cmp::max(self.array_count, other.array_count),
                  stages: self.stages | other.stages,
                  readonly: self.readonly && other.readonly,
+                 name: self.name.clone()
              })
     }
 

--- a/vulkano/src/descriptor/descriptor_set/std_pool.rs
+++ b/vulkano/src/descriptor/descriptor_set/std_pool.rs
@@ -199,6 +199,7 @@ mod tests {
             array_count: 1,
             stages: ShaderStages::all(),
             readonly: false,
+            name: String::from("test")
         };
         let layout = UnsafeDescriptorSetLayout::new(device.clone(), iter::once(Some(desc)))
             .unwrap();

--- a/vulkano/src/descriptor/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor/descriptor_set/sys.rs
@@ -1091,6 +1091,7 @@ mod tests {
             array_count: 1,
             stages: ShaderStages::all_graphics(),
             readonly: true,
+            name: String::from("test")
         };
 
         let set_layout = UnsafeDescriptorSetLayout::new(device.clone(), iter::once(Some(layout)))
@@ -1121,6 +1122,7 @@ mod tests {
             array_count: 1,
             stages: ShaderStages::all_graphics(),
             readonly: true,
+            name: String::from("test")
         };
 
         let set_layout = UnsafeDescriptorSetLayout::new(device1, iter::once(Some(layout))).unwrap();

--- a/vulkano/src/descriptor/descriptor_set/unsafe_layout.rs
+++ b/vulkano/src/descriptor/descriptor_set/unsafe_layout.rs
@@ -173,6 +173,7 @@ mod tests {
             array_count: 1,
             stages: ShaderStages::all_graphics(),
             readonly: true,
+            name: String::from("test")
         };
 
         let sl = UnsafeDescriptorSetLayout::new(device.clone(), iter::once(Some(layout))).unwrap();

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -927,6 +927,7 @@ mod tests {
                                                ..ShaderStages::none()
                                            },
                                            readonly: true,
+                                           name: String::from("test")
                                        }),
                         _ => None,
                     }


### PR DESCRIPTION
This commit add the uniform name in `DescriptoDesc`.
Using the `vulkano-shaders::reflect` function, it allows to increase
code introspection on shaders.

Fix the #963 issue