### PR TITLE
Fix future object safety of BufferAccess

### DIFF
--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -30,17 +30,6 @@ pub unsafe trait BufferAccess: DeviceOwned {
     /// Returns the size of the buffer in bytes.
     fn size(&self) -> usize;
 
-    /// Returns the length of the buffer in number of elements.
-    ///
-    /// This method can only be called for buffers whose type is known to be an array.
-    #[inline]
-    fn len(&self) -> usize
-        where Self: TypedBufferAccess,
-              Self::Content: Content
-    {
-        self.size() / <Self::Content as Content>::indiv_size()
-    }
-
     /// Builds a `BufferSlice` object holding the buffer by reference.
     #[inline]
     fn as_buffer_slice(&self) -> BufferSlice<Self::Content, &Self>
@@ -208,6 +197,14 @@ unsafe impl<T> BufferAccess for T
 pub unsafe trait TypedBufferAccess: BufferAccess {
     /// The type of the content.
     type Content: ?Sized;
+
+    /// Returns the length of the buffer in number of elements.
+    ///
+    /// This method can only be called for buffers whose type is known to be an array.
+    #[inline]
+    fn len(&self) -> usize where Self::Content: Content {
+        self.size() / <Self::Content as Content>::indiv_size()
+    }
 }
 
 unsafe impl<T> TypedBufferAccess for T


### PR DESCRIPTION
It was recently discovered in rust-lang/rust#50781 that `Self: Trait` bounds in trait methods are not really object-safe. This will be made into a warning by rust-lang/rust#50966, and vulkano will be affected by the warning.

There is no actual unsafety in the affected code in vulkano, making this unsafe would require some weird impls in vulkano itself.

The fix looks simple, to move `fn len` from `BufferAccess` to being directly in `TypedBufferAccess`.