### PR TITLE
Fix clear values in runtime-shader example

### DIFF
--- a/examples/src/bin/runtime-shader.rs
+++ b/examples/src/bin/runtime-shader.rs
@@ -444,7 +444,7 @@ fn main() {
             .begin_render_pass(
                 framebuffers[image_num].clone(),
                 false,
-                vec![[0.0, 0.0, 0.0, 1.0].into(), 1.0.into()],
+                vec![[0.0, 0.0, 0.0, 1.0].into()],
             ).unwrap()
             .draw(
                 graphics_pipeline.clone(),


### PR DESCRIPTION
Fixes: https://github.com/vulkano-rs/vulkano/issues/967
The issue was introduced by the clear value validation added in: https://github.com/vulkano-rs/vulkano/commit/36d74eab9f6987110b6041a4e342c0e3aee3649e
I'm assuming the code was like this due to being copy pasted from the teapot example or similar.