### PR TITLE
Remove incorrect assertions

### DIFF
--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -375,7 +375,6 @@ unsafe impl<T: ?Sized, A> BufferAccess for CpuAccessibleBuffer<T, A>
             let read_lock = self.access.read().unwrap();
             if let CurrentGpuAccess::NonExclusive { ref num } = *read_lock {
                 let prev = num.fetch_add(1, Ordering::SeqCst);
-                debug_assert!(prev >= 1);
                 return;
             }
         }

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -656,7 +656,6 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
             .find(|c| c.index == self.index)
             .unwrap();
 
-        debug_assert!(chunk.num_gpu_accesses >= 1);
         chunk.num_gpu_accesses = chunk
             .num_gpu_accesses
             .checked_add(1)


### PR DESCRIPTION
Fixes: https://github.com/vulkano-rs/vulkano/issues/758 and https://github.com/vulkano-rs/vulkano/issues/907
I could be completely misunderstanding this but it looks like these assertions are incorrect?
Given the name of the function `increase_gpu_lock` and the lock state is a usize, it looks like this is a non exclusive lock, so this should be fine.
