### PR TITLE
Remove incorrect assertions

### DIFF
--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -375,7 +375,6 @@ unsafe impl<T: ?Sized, A> BufferAccess for CpuAccessibleBuffer<T, A>
             let read_lock = self.access.read().unwrap();
             if let CurrentGpuAccess::NonExclusive { ref num } = *read_lock {
                 let prev = num.fetch_add(1, Ordering::SeqCst);
-                debug_assert!(prev >= 1);
                 return;
             }
         }

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -656,7 +656,6 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
             .find(|c| c.index == self.index)
             .unwrap();
 
-        debug_assert!(chunk.num_gpu_accesses >= 1);
         chunk.num_gpu_accesses = chunk
             .num_gpu_accesses
             .checked_add(1)


### PR DESCRIPTION
I'm reopening this as the comment you linked to was for CurrentGpuAccess::Exclusive and my change is for the handling of CurrentGpuAccess::NonExclusive.
I mentioned this on the old PR but I dont know if you get notifications for closed PR's...
Link to the old one: https://github.com/vulkano-rs/vulkano/pull/970