### PR TITLE
Upgrade deps + fix warnings in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased (major)
 
 - Use dynamically loaded `libvulkan` like on other platforms instead of linking to MoltenVK on macOS
-- Updated winit to version 0.13.
+- Updated winit to version 0.16.
 - Allow custom implementations of `RenderPassDesc` to specify `VK_SUBPASS_EXTERNAL` as a dependency source or destination
 
 # Version 0.9.0 (2018-03-13)

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 vulkano = { path = "../vulkano" }
 vulkano-shader-derive = { path = "../vulkano-shader-derive" }
 vulkano-win = { path = "../vulkano-win" }
-cgmath = "0.15.0"
-image = "0.18.0"
-winit = "0.13.1"
+cgmath = "0.16.1"
+image = "0.19.0"
+winit = "0.16.0"
 time = "0.1.38"

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -14,7 +14,6 @@
 // GPU", or *GPGPU*. This is what this example demonstrates.
 
 // Note that since we don't create any window, fewer imports are needed.
-#[macro_use]
 extern crate vulkano;
 #[macro_use]
 extern crate vulkano_shader_derive;
@@ -81,6 +80,7 @@ fn main() {
     // pipelines are much more simple to create.
     let pipeline = Arc::new({
         // TODO: explain
+        #[allow(dead_code)]
         mod cs {
             #[derive(VulkanoShader)]
             #[ty = "compute"]

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -11,7 +11,7 @@ extern crate vulkano;
 
 use vulkano::device::{Device, DeviceExtensions};
 use vulkano::format::Format;
-use vulkano::image::{ImmutableImage, ImageUsage, ImageLayout};
+use vulkano::image::ImmutableImage;
 use vulkano::image::Dimensions;
 use vulkano::instance;
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
@@ -93,14 +93,14 @@ fn main() {
 
     let physical = PhysicalDevice::enumerate(&instance).next().expect("no device available");
     let queue = physical.queue_families().next().expect("couldn't find a queue family");
-    let (device, mut queues) = Device::new(physical, physical.supported_features(), &DeviceExtensions::none(), vec![(queue, 0.5)]).expect("failed to create device");
+    let (_, mut queues) = Device::new(physical, physical.supported_features(), &DeviceExtensions::none(), vec![(queue, 0.5)]).expect("failed to create device");
     let queue = queues.next().unwrap();
 
     // Create an image in order to generate some additional logging:
     let pixel_format = Format::R8G8B8A8Uint;
     let dimensions = Dimensions::Dim2d { width: 4096, height: 4096 };
-    const data: [[u8; 4]; 4096*4096] = [[0; 4]; 4096 * 4096];
-    let (image, _) = ImmutableImage::from_iter(data.iter().cloned(), dimensions, pixel_format,
+    const DATA: [[u8; 4]; 4096*4096] = [[0; 4]; 4096 * 4096];
+    ImmutableImage::from_iter(DATA.iter().cloned(), dimensions, pixel_format,
                                                queue.clone()).unwrap();
 
     // (At this point you should see a bunch of messages printed to the terminal window - have fun debugging!)

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 vulkano = { version = "0.9.0", path = "../vulkano" }
-winit = "0.13.1"
+winit = "0.16.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal-rs = "0.6"


### PR DESCRIPTION
I upgraded all dependencies to their latest versions.
When I tested each example I noticed there were multiple warnings so I fixed those as well.

Somewhat unrelated:
We should really do a vulkano 0.10.0 release to prevent the new object safety warnings from occurring for people who use crates.io
e.g. https://github.com/vulkano-rs/vulkano/issues/981
I propose doing such a release after reviewing + merging the current waiting PR's (including this one ^.^)