### PR TITLE
Fix CpuBufferPool allocation strategy

### DIFF
--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -315,12 +315,10 @@ impl<T, A> CpuBufferPool<T, A>
             Err(d) => d,
         };
 
-        // TODO: choose the capacity better?
-        let next_capacity = cmp::max(data.len(), 1) *
-            match *mutex {
-                Some(ref b) => b.capacity * 2,
-                None => 3,
-            };
+        let next_capacity = match *mutex {
+            Some(ref b) if data.len() < b.capacity => 2 * b.capacity,
+            _ => 2 * data.len(),
+        };
 
         self.reset_buf(&mut mutex, next_capacity)?;
 


### PR DESCRIPTION
The previous strategy was quite sub-optimal and was failing hard with OOM when `chunk` was used for allocating big buffers, e.g. textures, due to the multiplication of `data.len()` with current capacity.

Fixes: #984