### PR TITLE
Don't force the surface to take ownership of the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Use dynamically loaded `libvulkan` like on other platforms instead of linking to MoltenVK on macOS
 - Updated winit to version 0.16.
 - Allow custom implementations of `RenderPassDesc` to specify `VK_SUBPASS_EXTERNAL` as a dependency source or destination
+- Added `vulkano_win::create_vk_surface` which allows creating a surface safely without taking ownership of
+  the window.
 
 # Version 0.9.0 (2018-03-13)
 


### PR DESCRIPTION
This PR adds a new method `create_vk_surface` which allows creating a surface from anything outlived by a window. This is enforced by the `SafeBorrow` trait which is essentially the equivalent of `SafeDeref` for `Borrow`.

Closes #920