### PR TITLE
Docs: Fix swapchain image count computation.

### DIFF
--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -144,7 +144,10 @@
 //! let dimensions = caps.current_extent.unwrap_or([640, 480]);
 //!
 //! // Try to use double-buffering.
-//! let buffers_count = max(min(2, caps.min_image_count), caps.max_image_count.unwrap_or(2));
+//! let buffers_count = match caps.max_image_count {
+//!     None => max(2, caps.min_image_count),
+//!     Some(limit) => min(max(2, caps.min_image_count), limit)
+//! };
 //!
 //! // Preserve the current surface transform.
 //! let transform = caps.current_transform;


### PR DESCRIPTION
The previous expression gives unreasonable answers for some combinations of
`swapchain::Capabilities`' `min_image_count` and `max_image_count` values. For
example, for `3` and `None`, the expression evaluates to 2, which isn't a
permitted image count.

I looked for a terser expression (using `Option` methods, say), but the `match`
expression ended up being the most legible I came up with.