### PR TITLE
Avoid gratuitous use of std::mem::replace.

### DIFF
--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -155,8 +155,8 @@ fn main() {
                 Err(err) => panic!("{:?}", err)
             };
 
-            std::mem::replace(&mut swapchain, new_swapchain);
-            std::mem::replace(&mut images, new_images);
+            swapchain = new_swapchain;
+            images = new_images;
 
             let new_depth_buffer = vulkano::image::attachment::AttachmentImage::transient(device.clone(), dimensions, vulkano::format::D16Unorm).unwrap();
             std::mem::replace(&mut depth_buffer, new_depth_buffer);


### PR DESCRIPTION
Either these calls to `replace` are unnecessary, or I'm going to learn something
I really need to know.

The only way difference I can see between `replace` and a simple assignment is
that `replace` returns ownership of the value to the caller, so the old value is
dropped after the new value has been put in place. But if Rust lets us assign to
or move from a variable, that means that no other alias can observe that
happening --- which I think means that the drop can't possibly care whether it
occurs before or after the move.