### PR TITLE
PersistentDescriptorSetError: Expand missing usage errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Unreleased
+# Unreleased (Breaking)
+
+- Split 'PersistentDescriptorSetError::MissingUsage' into 'MissingImageUsage' and 'MissingBufferUsage'
+  each with a matching enum indicating the usage that was missing.
 
 # Version 0.10.0 (2018-08-10)
 


### PR DESCRIPTION
Expand MissingUsage into MissingUsageBuffer and MissingUsageImage
each with the usage bitmaps so that the usage that is missing is obvious
in the error, e.g.:

thread 'main' panicked at 'add curimage: MissingUsageImage(ImageUsage { transfer_source: false, transfer_destination: false, sampled: false, storage: true, color_attachment: false, depth_stencil_attachment: false, transient_attachment: false, input_attachment: false })', libcore/result.rs:945:5

Signed-off-by: Dr. David Alan Gilbert <dave@treblig.org>
