### PR TITLE
Fix instance_count when using draw_index with instance buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Split 'PersistentDescriptorSetError::MissingUsage' into 'MissingImageUsage' and 'MissingBufferUsage'
   each with a matching enum indicating the usage that was missing.
+- Fix instance_count when using draw_index with instance buffers
 
 # Version 0.10.0 (2018-08-10)
 

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -1073,7 +1073,11 @@ impl<P> AutoCommandBufferBuilder<P> {
             debug_assert!(self.graphics_allowed);
 
             self.inner
-                .draw_indexed(ib_infos.num_indices as u32, 1, 0, 0, 0);
+                .draw_indexed(ib_infos.num_indices as u32,
+                              vb_infos.instance_count as u32,
+                              0,
+                              0,
+                              0);
             Ok(self)
         }
     }


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Currently, AutoCommandBufferBuilder.draw_indexed() hard codes the value of instance_count to 1.
https://github.com/vulkano-rs/vulkano/blob/67ace6b1c5e7506dbf623741a7d940d4a77d2298/vulkano/src/command_buffer/auto.rs#L1076

This is different from the behavior of the draw() method which uses the size of the instance buffer used as a vertex input source.
This PR harmonizes both methods.