### PR TITLE
Spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,15 @@ Vulkano is still in heavy development and doesn't yet meet its goals of being ve
 the general structure of the library is most likely definitive, and all future breaking changes
 will likely be straight-forward to fix in user code.
 
-## [Documentation](https://docs.rs/vulkano)
+## Documentation
 
-To get started you are encouraged to read the examples in
-[the `vulkano-examples` repository](https://github.com/vulkano-rs/vulkano-examples), starting with
-[the `triangle` example](https://github.com/vulkano-rs/vulkano-examples/blob/master/triangle/main.rs).
+To get started you are encouraged to use the following resources:
+
+*   The guide on [vulkano.rs](http://vulkano.rs/guide/introduction) - Starts with trivial compute
+    examples (~50 lines of code) then works up to rendering triangles and mandelbrots.
+*   [The `vulkano-examples` repository](https://github.com/vulkano-rs/vulkano-examples) - Includes
+    examples in the repo and also a list of projects that use vulkano.
+*   [docs.rs](https://docs.rs/vulkano) - Full Vulkano API documentation
 
 ## macOS and iOS Setup
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To get started you are encouraged to use the following resources:
 
 *   The guide on [vulkano.rs](http://vulkano.rs/guide/introduction) - Starts with trivial compute
     examples (~50 lines of code) then works up to rendering triangles and mandelbrots.
-*   [The `vulkano-examples` repository](https://github.com/vulkano-rs/vulkano-examples) - Includes
+*   The [vulkano-examples](https://github.com/vulkano-rs/vulkano-examples) repository - Includes
     examples in the repo and also a list of projects that use vulkano.
 *   [docs.rs](https://docs.rs/vulkano) - Full Vulkano API documentation
 

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -54,7 +54,7 @@ fn main() {
     };
 
     // Since we can request multiple queues, the `queues` variable is in fact an iterator. In this
-    // example we use only one queue, so we just retreive the first and only element of the
+    // example we use only one queue, so we just retrieve the first and only element of the
     // iterator and throw it away.
     let queue = queues.next().unwrap();
 
@@ -70,7 +70,7 @@ fn main() {
     // or four by four, a GPU will do it by groups of 32 or 64.
     //
     // Note however that in a real-life situation for such a simple operation the cost of
-    // accessing memory usually outweights the benefits of a faster calculation. Since both the CPU
+    // accessing memory usually outweighs the benefits of a faster calculation. Since both the CPU
     // and the GPU will need to access data, there is no other choice but to transfer the data
     // through the slow PCI express bus.
 
@@ -136,14 +136,14 @@ void main() {
         //
         // Note that we clone the pipeline and the set. Since they are both wrapped around an
         // `Arc`, this only clones the `Arc` and not the whole pipeline or set (which aren't
-        // clonable anyway). In this example we would avoid cloning them since this is the last
+        // cloneable anyway). In this example we would avoid cloning them since this is the last
         // time we use them, but in a real code you would probably need to clone them.
         .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), ()).unwrap()
         // Finish building the command buffer by calling `build`.
         .build().unwrap();
 
     // Let's execute this command buffer now.
-    // To do so, we TODO: this is a bit clumsby, probably needs a shortcut
+    // To do so, we TODO: this is a bit clumsy, probably needs a shortcut
     let future = now(device.clone())
         .then_execute(queue.clone(), command_buffer).unwrap()
 

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -20,7 +20,7 @@ use vulkano::instance::debug::{DebugCallback, MessageTypes};
 fn main() {
     // Vulkano Debugging Example Code
     //
-    // This example code will demonstrate using the debug functions of the Vulkano api.
+    // This example code will demonstrate using the debug functions of the Vulkano API.
     //
     // There is documentation here about how to setup debugging:
     // https://vulkan.lunarg.com/doc/view/1.0.13.0/windows/layers.html
@@ -39,8 +39,8 @@ fn main() {
     // The main layer you might want is: VK_LAYER_LUNARG_standard_validation
     // This includes a number of the other layers for you and is quite detailed.
     //
-    // Additional layers can be installed (gpu vendor provided, something you found on github, etc)
-    // and you should verify that list for safety - Volkano will return an error if you specify
+    // Additional layers can be installed (gpu vendor provided, something you found on GitHub, etc)
+    // and you should verify that list for safety - Vulkano will return an error if you specify
     // any layers that are not installed on this system. That code to do could look like this:
     println!("List of Vulkan debugging layers available to use:");
     let mut layers = instance::layers_list().unwrap();
@@ -88,7 +88,7 @@ fn main() {
     }).ok();
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Create vulkan objects in the same way as the other examples                                               //
+    // Create Vulkan objects in the same way as the other examples                                               //
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     let physical = PhysicalDevice::enumerate(&instance).next().expect("no device available");

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -27,7 +27,7 @@ use cgmath::Vector3;
 
 use std::sync::Arc;
 
-/// Allows applying a directional ligh source to a scene.
+/// Allows applying a directional light source to a scene.
 pub struct DirectionalLightingSystem {
     gfx_queue: Arc<Queue>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -110,7 +110,7 @@ impl PointLightingSystem {
     ///   the result of the deferred pass.
     /// - `screen_to_world` is a matrix that turns coordinates from framebuffer space into world
     ///   space. This matrix is used alongside with `depth_input` to determine the world
-    ///   coorindates of each pixel being processed.
+    ///   coordinates of each pixel being processed.
     /// - `position` is the position of the spot light in world coordinates.
     /// - `color` is the color of the light.
     ///

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -46,7 +46,7 @@ pub struct FrameSystem {
     // The normal vector is the vector perpendicular to the surface of the object at this point.
     normals_buffer: Arc<AttachmentImage>,
     // Intermediate render target that will contain the depth of each pixel of the scene.
-    // This is a traditionnal depth buffer. `0.0` means "near", and `1.0` means "far".
+    // This is a traditional depth buffer. `0.0` means "near", and `1.0` means "far".
     depth_buffer: Arc<AttachmentImage>,
 
     // Will allow us to add an ambient lighting to a scene during the second subpass.

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 //
-// This example demostrates one way of preparing data structures and loading
+// This example demonstrates one way of preparing data structures and loading
 // SPIRV shaders from external source (file system).
 //
 // Note that you will need to do all correctness checking by yourself.

--- a/examples/src/bin/teapot.rs
+++ b/examples/src/bin/teapot.rs
@@ -84,7 +84,7 @@ fn main() {
                                 .expect("failed to create buffer");
 
     // note: this teapot was meant for OpenGL where the origin is at the lower left
-    //       instead the origin is at the upper left in vulkan, so we reverse the Y axis
+    //       instead the origin is at the upper left in Vulkan, so we reverse the Y axis
     let mut proj = cgmath::perspective(cgmath::Rad(std::f32::consts::FRAC_PI_2), { dimensions[0] as f32 / dimensions[1] as f32 }, 0.01, 100.0);
     let view = cgmath::Matrix4::look_at(cgmath::Point3::new(0.3, 0.3, 1.0), cgmath::Point3::new(0.0, 0.0, 0.0), cgmath::Vector3::new(0.0, -1.0, 0.0));
     let scale = cgmath::Matrix4::from_scale(0.01);

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -174,7 +174,7 @@ layout(triangles, equal_spacing, cw) in;
 
 void main(void)
 {
-    // retreive the vertex positions set by the tcs
+    // retrieve the vertex positions set by the tcs
     vec4 vert_x = gl_in[0].gl_Position;
     vec4 vert_y = gl_in[1].gl_Position;
     vec4 vert_z = gl_in[2].gl_Position;

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -56,7 +56,7 @@ use vulkano::sync::GpuFuture;
 use std::sync::Arc;
 
 fn main() {
-    // The first step of any vulkan program is to create an instance.
+    // The first step of any Vulkan program is to create an instance.
     let instance = {
         // When we create an instance, we have to pass a list of extensions that we want to enable.
         //
@@ -147,7 +147,7 @@ fn main() {
     };
 
     // Since we can request multiple queues, the `queues` variable is in fact an iterator. In this
-    // example we use only one queue, so we just retreive the first and only element of the
+    // example we use only one queue, so we just retrieve the first and only element of the
     // iterator and throw it away.
     let queue = queues.next().unwrap();
 
@@ -242,7 +242,7 @@ void main() {
     let fs = fs::Shader::load(device.clone()).expect("failed to create shader module");
 
     // At this point, OpenGL initialization would be finished. However in Vulkan it is not. OpenGL
-    // implicitely does a lot of computation whenever you draw. In Vulkan, you have to do all this
+    // implicitly does a lot of computation whenever you draw. In Vulkan, you have to do all this
     // manually.
 
     // The next step is to create a *render pass*, which is an object that describes where the

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -142,7 +142,7 @@ impl {name} {{
             name = name
         ));
 
-        // checking whether each required capability is enabled in the vulkan device
+        // checking whether each required capability is enabled in the Vulkan device
         for i in doc.instructions.iter() {
             if let &parse::Instruction::Capability(ref cap) = i {
                 if let Some(cap) = capability_name(cap) {

--- a/vulkano-shaders/src/parse.rs
+++ b/vulkano-shaders/src/parse.rs
@@ -44,7 +44,7 @@ pub fn parse_spirv(data: &[u8]) -> Result<Spirv, ParseError> {
 
 /// Parses a SPIR-V document from a list of u32s.
 ///
-/// Endianess has already been handled.
+/// Endianness has already been handled.
 fn parse_u32s(i: &[u32]) -> Result<Spirv, ParseError> {
     if i.len() < 5 {
         return Err(ParseError::MissingHeader);

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -242,7 +242,7 @@ impl<T: ?Sized, A> CpuAccessibleBuffer<T, A>
     /// this function will return an error as well.
     ///
     /// After this function successfully locks the buffer, any attempt to submit a command buffer
-    /// that uses it in exclusive mode will fail. You can still submit this buffer for non-exlusive
+    /// that uses it in exclusive mode will fail. You can still submit this buffer for non-exclusive
     /// accesses (ie. reads).
     #[inline]
     pub fn read(&self) -> Result<ReadLock<T>, ReadLockError> {

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -300,7 +300,7 @@ impl<T, A> CpuBufferPool<T, A>
     ///
     /// # Panic
     ///
-    /// Panicks if the length of the iterator didn't match the actual number of element.
+    /// Panics if the length of the iterator didn't match the actual number of element.
     ///
     pub fn chunk<I>(&self, data: I) -> Result<CpuBufferPoolChunk<T, A>, DeviceMemoryAllocError>
         where I: IntoIterator<Item = T>,
@@ -398,7 +398,7 @@ impl<T, A> CpuBufferPool<T, A>
     //
     // # Panic
     //
-    // Panicks if the length of the iterator didn't match the actual number of element.
+    // Panics if the length of the iterator didn't match the actual number of element.
     //
     fn try_next_impl<I>(&self, cur_buf_mutex: &mut MutexGuard<Option<Arc<ActualBuffer<A>>>>,
                         mut data: I)
@@ -621,7 +621,7 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
     fn conflict_key(&self) -> (u64, usize) {
         (
             self.buffer.inner.key(),
-            // ensure the special cased empty buffers dont collide with a regular buffer starting at 0
+            // ensure the special cased empty buffers don't collide with a regular buffer starting at 0
             if self.requested_len == 0 { usize::max_value() } else { self.index }
         )
     }

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -70,7 +70,7 @@
 //! - As a storage buffer. Storage buffers can be read and written.
 //! - As a uniform texel buffer. Contrary to a uniform buffer, the data is interpreted by the
 //!   GPU and can be for example normalized.
-//! - As a storage texel buffer. Additionnally, some data formats can be modified with atomic
+//! - As a storage texel buffer. Additionally, some data formats can be modified with atomic
 //!   operations.
 //!
 //! Using uniform/storage texel buffers requires creating a *buffer view*. See the `view` module

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -1189,7 +1189,7 @@ impl<P> AutoCommandBufferBuilder<P> {
     /// Adds a command that writes the content of a buffer.
     ///
     /// This function is similar to the `memset` function in C. The `data` parameter is a number
-    /// that will be repeatidely written through the entire buffer.
+    /// that will be repeatedly written through the entire buffer.
     ///
     /// > **Note**: This function is technically safe because buffers can only contain integers or
     /// > floating point numbers, which are always valid whatever their memory representation is.

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -29,7 +29,7 @@ use vk;
 /// Low-level implementation of a command pool.
 ///
 /// A command pool is always tied to a specific queue family. Command buffers allocated from a pool
-/// can only be executed on the corresponding queue familiy.
+/// can only be executed on the corresponding queue family.
 ///
 /// This struct doesn't implement the `Sync` trait because Vulkan command pools are not thread
 /// safe. In other words, you can only use a pool from one thread at a time.

--- a/vulkano/src/command_buffer/state_cacher.rs
+++ b/vulkano/src/command_buffer/state_cacher.rs
@@ -38,11 +38,11 @@ pub struct StateCacher {
     // the processing then we will end up in a weird state. This bool is true when we start
     // comparing sets, and is set to false when we end up comparing. If it was true when we start
     // comparing, we know that something bad happened and we flush the cache.
-    poisonned_descriptor_sets: bool,
+    poisoned_descriptor_sets: bool,
     // The vertex buffers currently bound.
     vertex_buffers: SmallVec<[(vk::Buffer, vk::DeviceSize); 12]>,
-    // Same as `poisonned_descriptor_sets` but for vertex buffers.
-    poisonned_vertex_buffers: bool,
+    // Same as `poisoned_descriptor_sets` but for vertex buffers.
+    poisoned_vertex_buffers: bool,
     // The index buffer, offset, and index type currently bound. `None` if nothing bound.
     index_buffer: Option<(vk::Buffer, usize, IndexType)>,
 }
@@ -66,9 +66,9 @@ impl StateCacher {
             graphics_pipeline: 0,
             compute_descriptor_sets: SmallVec::new(),
             graphics_descriptor_sets: SmallVec::new(),
-            poisonned_descriptor_sets: false,
+            poisoned_descriptor_sets: false,
             vertex_buffers: SmallVec::new(),
-            poisonned_vertex_buffers: false,
+            poisoned_vertex_buffers: false,
             index_buffer: None,
         }
     }
@@ -123,15 +123,15 @@ impl StateCacher {
     /// changes are going to be performed after the `compare` function returns.
     #[inline]
     pub fn bind_descriptor_sets(&mut self, graphics: bool) -> StateCacherDescriptorSets {
-        if self.poisonned_descriptor_sets {
+        if self.poisoned_descriptor_sets {
             self.compute_descriptor_sets = SmallVec::new();
             self.graphics_descriptor_sets = SmallVec::new();
         }
 
-        self.poisonned_descriptor_sets = true;
+        self.poisoned_descriptor_sets = true;
 
         StateCacherDescriptorSets {
-            poisonned: &mut self.poisonned_descriptor_sets,
+            poisoned: &mut self.poisoned_descriptor_sets,
             state: if graphics {
                 &mut self.graphics_descriptor_sets
             } else {
@@ -189,14 +189,14 @@ impl StateCacher {
     /// changes are going to be performed after the `compare` function returns.
     #[inline]
     pub fn bind_vertex_buffers(&mut self) -> StateCacherVertexBuffers {
-        if self.poisonned_vertex_buffers {
+        if self.poisoned_vertex_buffers {
             self.vertex_buffers = SmallVec::new();
         }
 
-        self.poisonned_vertex_buffers = true;
+        self.poisoned_vertex_buffers = true;
 
         StateCacherVertexBuffers {
-            poisonned: &mut self.poisonned_vertex_buffers,
+            poisoned: &mut self.poisoned_vertex_buffers,
             state: &mut self.vertex_buffers,
             offset: 0,
             first_diff: None,
@@ -232,8 +232,8 @@ impl StateCacher {
 /// > **Note**: For reliability reasons, if you drop/leak this struct before calling `compare` then
 /// > the cache of the currently bound descriptor sets will be reset.
 pub struct StateCacherDescriptorSets<'s> {
-    // Reference to the parent's `poisonned_descriptor_sets`.
-    poisonned: &'s mut bool,
+    // Reference to the parent's `poisoned_descriptor_sets`.
+    poisoned: &'s mut bool,
     // Reference to the descriptor sets list to compare to.
     state: &'s mut SmallVec<[vk::DescriptorSet; 12]>,
     // Next offset within the list to compare to.
@@ -274,7 +274,7 @@ impl<'s> StateCacherDescriptorSets<'s> {
     /// After this function returns, the cache will be updated to match your list.
     #[inline]
     pub fn compare(self) -> Option<u32> {
-        *self.poisonned = false;
+        *self.poisoned = false;
         // Removing from the cache any set that wasn't added with `add`.
         self.state.truncate(self.offset);
         self.found_diff
@@ -286,13 +286,13 @@ impl<'s> StateCacherDescriptorSets<'s> {
 /// > **Note**: For reliability reasons, if you drop/leak this struct before calling `compare` then
 /// > the cache of the currently bound vertex buffers will be reset.
 pub struct StateCacherVertexBuffers<'s> {
-    // Reference to the parent's `poisonned_vertex_buffers`.
-    poisonned: &'s mut bool,
+    // Reference to the parent's `poisoned_vertex_buffers`.
+    poisoned: &'s mut bool,
     // Reference to the vertex buffers list to compare to.
     state: &'s mut SmallVec<[(vk::Buffer, vk::DeviceSize); 12]>,
     // Next offset within the list to compare to.
     offset: usize,
-    // Contains the offet of the first vertex buffer that differs.
+    // Contains the offset of the first vertex buffer that differs.
     first_diff: Option<u32>,
     // Offset of the last vertex buffer that differs.
     last_diff: u32,
@@ -339,7 +339,7 @@ impl<'s> StateCacherVertexBuffers<'s> {
     /// > range `1 .. 2` only contains one element.
     #[inline]
     pub fn compare(self) -> Option<Range<u32>> {
-        *self.poisonned = false;
+        *self.poisoned = false;
 
         // Removing from the cache any set that wasn't added with `add`.
         self.state.truncate(self.offset);

--- a/vulkano/src/command_buffer/synced/base.rs
+++ b/vulkano/src/command_buffer/synced/base.rs
@@ -53,7 +53,7 @@ use sync::PipelineStages;
 /// trying to copy from a buffer to an image which share the same memory), then an error is
 /// returned.
 /// Note that all methods are still unsafe, because this builder doesn't check the validity of
-/// the commands except for synchronization purposes. The builder may panic if you pass unvalid
+/// the commands except for synchronization purposes. The builder may panic if you pass invalid
 /// commands.
 ///
 /// The `P` generic is the same as `UnsafeCommandBufferBuilder`.

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1798,7 +1798,7 @@ impl UnsafeCommandBufferBuilderPipelineBarrier {
     ///
     /// Also adds an execution dependency similar to `add_execution_dependency`.
     ///
-    /// Also allows transfering buffer ownership between queues.
+    /// Also allows transferring buffer ownership between queues.
     ///
     /// # Safety
     ///
@@ -1849,7 +1849,7 @@ impl UnsafeCommandBufferBuilderPipelineBarrier {
     /// Adds an image memory barrier. This is the equivalent of `add_buffer_memory_barrier` but
     /// for images.
     ///
-    /// In addition to transfering image ownership between queues, it also allows changing the
+    /// In addition to transferring image ownership between queues, it also allows changing the
     /// layout of images.
     ///
     /// Also adds an execution dependency similar to `add_execution_dependency`.

--- a/vulkano/src/descriptor/descriptor.rs
+++ b/vulkano/src/descriptor/descriptor.rs
@@ -122,7 +122,7 @@ impl DescriptorDesc {
     ///
     /// # Panic
     ///
-    /// Panicks if the type is `Sampler`.
+    /// Panics if the type is `Sampler`.
     ///
     pub fn pipeline_stages_and_access(&self) -> (PipelineStages, AccessFlagBits) {
         let stages: PipelineStages = self.stages.into();

--- a/vulkano/src/descriptor/descriptor.rs
+++ b/vulkano/src/descriptor/descriptor.rs
@@ -122,7 +122,7 @@ impl DescriptorDesc {
     ///
     /// # Panic
     ///
-    /// Panicks if the type if `Sampler`.
+    /// Panicks if the type is `Sampler`.
     ///
     pub fn pipeline_stages_and_access(&self) -> (PipelineStages, AccessFlagBits) {
         let stages: PipelineStages = self.stages.into();

--- a/vulkano/src/descriptor/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor/descriptor_set/persistent.rs
@@ -48,7 +48,7 @@ use sampler::Sampler;
 /// > descriptor set in performance-critical paths..
 ///
 /// The template parameter of the `PersistentDescriptorSet` is complex, and you shouldn't try to
-/// express it explicitely. If you want to store your descriptor set in a struct or in a `Vec` for
+/// express it explicitly. If you want to store your descriptor set in a struct or in a `Vec` for
 /// example, you are encouraged to turn the `PersistentDescriptorSet` into a `Box<DescriptorSet>`
 /// or a `Arc<DescriptorSet>`.
 ///
@@ -990,14 +990,14 @@ unsafe impl<R> PersistentDescriptorSetResources for (R, PersistentDescriptorSetS
     }
 }
 
-// Part of the PersisitentDescriptorSetError for the case
+// Part of the PersistentDescriptorSetError for the case
 // of missing usage on a buffer.
 #[derive(Debug, Clone)]
 pub enum MissingBufferUsage {
     StorageBuffer, UniformBuffer, StorageTexelBuffer, UniformTexelBuffer
 }
 
-// Part of the PersisitentDescriptorSetError for the case
+// Part of the PersistentDescriptorSetError for the case
 // of missing usage on an image.
 #[derive(Debug, Clone)]
 pub enum MissingImageUsage {

--- a/vulkano/src/descriptor/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor/descriptor_set/sys.rs
@@ -596,7 +596,7 @@ impl UnsafeDescriptorSet {
             // sure that it's impossible to have an empty descriptor write.
             debug_assert!(!indiv_write.inner.is_empty());
 
-            // The whole struct that wr write here is valid, except for pImageInfo, pBufferInfo
+            // The whole struct thats written here is valid, except for pImageInfo, pBufferInfo
             // and pTexelBufferView which are placeholder values.
             raw_writes.push(vk::WriteDescriptorSet {
                                 sType: vk::STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,

--- a/vulkano/src/descriptor/pipeline_layout/union.rs
+++ b/vulkano/src/descriptor/pipeline_layout/union.rs
@@ -74,7 +74,7 @@ unsafe impl<A, B> PipelineLayoutDesc for PipelineLayoutDescUnion<A, B>
 
     #[inline]
     fn num_push_constants_ranges(&self) -> usize {
-        // We simply call `push_constants_range` repeatidely to determine when it is over.
+        // We simply call `push_constants_range` repeatedly to determine when it is over.
         // TODO: consider caching this
         (self.a.num_push_constants_ranges() ..)
             .filter(|&n| self.push_constants_range(n).is_none())

--- a/vulkano/src/device.rs
+++ b/vulkano/src/device.rs
@@ -344,7 +344,7 @@ impl Device {
     /// # Safety
     ///
     /// This function is not thread-safe. You must not submit anything to any of the queue
-    /// of the device (either explicitely or implicitely, for example with a future's destructor)
+    /// of the device (either explicitly or implicitly, for example with a future's destructor)
     /// while this function is waiting.
     ///
     pub unsafe fn wait(&self) -> Result<(), OomError> {
@@ -447,8 +447,8 @@ impl Device {
 
     /// Used to track the number of allocations on this device.
     ///
-    /// To ensure valid usage of the vulkan API, we cannot call `vkAllocateMemory` when
-    /// `maxMemoryAllocationCount` has been exceeded. See the vulkan specs:
+    /// To ensure valid usage of the Vulkan API, we cannot call `vkAllocateMemory` when
+    /// `maxMemoryAllocationCount` has been exceeded. See the Vulkan specs:
     /// https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#vkAllocateMemory
     ///
     /// Warning: You should never modify this value, except in `device_memory` module

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -39,7 +39,7 @@
 //! - `Sint` means that the values are signed integers. No conversion is performed.
 //!
 //! - `Ufloat` means that the values are unsigned floating points. No conversion is performed. This
-//!   format is very unsual.
+//!   format is very unusual.
 //!
 //! - `Sfloat` means that the values are regular floating points. No conversion is performed.
 //!

--- a/vulkano/src/framebuffer/compat_atch.rs
+++ b/vulkano/src/framebuffer/compat_atch.rs
@@ -21,7 +21,7 @@ use std::fmt;
 ///
 /// # Panic
 ///
-/// Panicks if the attachment number is out of range.
+/// Panics if the attachment number is out of range.
 // TODO: add a specializable trait instead, that uses this function
 // TODO: ImageView instead of ImageViewAccess?
 pub fn ensure_image_view_compatible<Rp, I>(render_pass: &Rp, attachment_num: usize, image: &I)

--- a/vulkano/src/framebuffer/desc.rs
+++ b/vulkano/src/framebuffer/desc.rs
@@ -39,7 +39,7 @@ use vk;
 ///   access it through the `RenderPass::desc()` method that returns a shared borrow to the
 ///   description. It must not be possible for a shared borrow to modify the description in such a
 ///   way that the description changes.
-/// - The provided methods shouldn't be overriden with fancy implementations. For example
+/// - The provided methods shouldn't be overridden with fancy implementations. For example
 ///   `build_render_pass` must build a render pass from the description and not a different one.
 ///
 pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> {
@@ -423,9 +423,9 @@ impl<'a, R: ?Sized + 'a> Iterator for RenderPassDescDependencies<'a, R>
 /// Describes an attachment that will be used in a render pass.
 #[derive(Debug, Clone)]
 pub struct LayoutAttachmentDescription {
-    /// Format of the image that is going to be binded.
+    /// Format of the image that is going to be bound.
     pub format: Format,
-    /// Number of samples of the image that is going to be binded.
+    /// Number of samples of the image that is going to be bound.
     pub samples: u32,
 
     /// What the implementation should do with that attachment at the start of the render pass.
@@ -536,7 +536,7 @@ pub struct LayoutPassDependencyDescription {
     /// subpass is finished for these given pixels.
     ///
     /// In other words, if the previous subpass has some side effects on other parts of an
-    /// attachment, then you sould set it to false.
+    /// attachment, then you should set it to false.
     ///
     /// Passing `false` is always safer than passing `true`, but in practice you rarely need to
     /// pass `false`.

--- a/vulkano/src/framebuffer/macros.rs
+++ b/vulkano/src/framebuffer/macros.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-/// Builds a `RenderPass` object whose template parameter is of undeterminate type.
+/// Builds a `RenderPass` object whose template parameter is of indeterminate type.
 #[macro_export]
 macro_rules! single_pass_renderpass {
     (
@@ -34,7 +34,7 @@ macro_rules! single_pass_renderpass {
     )
 }
 
-/// Builds a `RenderPass` object whose template parameter is of undeterminate type.
+/// Builds a `RenderPass` object whose template parameter is of indeterminate type.
 #[macro_export]
 macro_rules! ordered_passes_renderpass {
     (

--- a/vulkano/src/framebuffer/mod.rs
+++ b/vulkano/src/framebuffer/mod.rs
@@ -34,7 +34,7 @@
 //! In vulkano a render pass is represented by the `RenderPass` struct. This struct has a template
 //! parameter that contains the description of the render pass. The `RenderPassAbstract` trait is
 //! implemented on all instances of `RenderPass<_>` and makes it easier to store render passes
-//! without having to explicitely write its type.
+//! without having to explicitly write its type.
 //!
 //! The template parameter of the `RenderPass` struct must implement the `RenderPassDesc` trait.
 //! In order to create a render pass, you can create an object that implements this trait, then

--- a/vulkano/src/framebuffer/sys.rs
+++ b/vulkano/src/framebuffer/sys.rs
@@ -59,7 +59,7 @@ impl<D> RenderPass<D>
     ///
     /// # Panic
     ///
-    /// - Can panic if it detects some violations in the restrictions. Only unexpensive checks are
+    /// - Can panic if it detects some violations in the restrictions. Only inexpensive checks are
     /// performed. `debug_assert!` is used, so some restrictions are only checked in debug
     /// mode.
     ///

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -469,7 +469,7 @@ impl ImageDimensions {
     ///
     /// # Panic
     ///
-    /// In debug mode, panicks if `width`, `height` or `depth` is equal to 0. In release, returns
+    /// In debug mode, Panics if `width`, `height` or `depth` is equal to 0. In release, returns
     /// an unspecified value.
     ///
     pub fn mipmap_dimensions(&self, level: u32) -> Option<ImageDimensions> {

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -662,7 +662,7 @@ impl UnsafeImage {
         self.linear_layout_impl(mip_level, vk::IMAGE_ASPECT_COLOR_BIT)
     }
 
-    /// Same as `color_linear_layout`, except that it retreives the depth component of the image.
+    /// Same as `color_linear_layout`, except that it retrieves the depth component of the image.
     ///
     /// # Panic
     ///
@@ -678,7 +678,7 @@ impl UnsafeImage {
         self.linear_layout_impl(mip_level, vk::IMAGE_ASPECT_DEPTH_BIT)
     }
 
-    /// Same as `color_linear_layout`, except that it retreives the stencil component of the image.
+    /// Same as `color_linear_layout`, except that it retrieves the stencil component of the image.
     ///
     /// # Panic
     ///
@@ -822,7 +822,7 @@ pub enum ImageCreationError {
         obtained: u32,
         valid_range: Range<u32>,
     },
-    /// The requeted number of samples is not supported, or is 0.
+    /// The requested number of samples is not supported, or is 0.
     UnsupportedSamplesCount { obtained: u32 },
     /// The dimensions are too large, or one of the dimensions is 0.
     UnsupportedDimensions { dimensions: ImageDimensions },
@@ -842,7 +842,7 @@ impl error::Error for ImageCreationError {
             ImageCreationError::InvalidMipmapsCount { .. } =>
                 "a wrong number of mipmaps was provided",
             ImageCreationError::UnsupportedSamplesCount { .. } =>
-                "the requeted number of samples is not supported, or is 0",
+                "the requested number of samples is not supported, or is 0",
             ImageCreationError::UnsupportedDimensions { .. } =>
                 "the dimensions are too large, or one of the dimensions is 0",
             ImageCreationError::FormatNotSupported =>

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -161,7 +161,7 @@ pub unsafe trait ImageAccess {
     ///
     /// After this function returns `Ok`, you are authorized to use the image on the GPU. If the
     /// GPU operation requires an exclusive access to the image (which includes image layout
-    /// transitions) then `exlusive_access` should be true.
+    /// transitions) then `exclusive_access` should be true.
     ///
     /// The `expected_layout` is the layout we expect the image to be in when we lock it. If the
     /// actual layout doesn't match this expected layout, then an error should be returned. If

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -77,7 +77,7 @@ impl DebugCallback {
         }
 
         // Note that we need to double-box the callback, because a `*const Fn()` is a fat pointer
-        // that can't be casted to a `*const c_void`.
+        // that can't be cast to a `*const c_void`.
         let user_callback = Box::new(Box::new(user_callback) as Box<_>);
 
         extern "system" fn callback(ty: vk::DebugReportFlagsEXT, _: vk::DebugReportObjectTypeEXT,

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -426,7 +426,7 @@ impl Instance {
     /*/// Same as `new`, but provides an allocator that will be used by the Vulkan library whenever
     /// it needs to allocate memory on the host.
     ///
-    /// Note that this allocator can be overriden when you create a `Device`, a `MemoryPool`, etc.
+    /// Note that this allocator can be overridden when you create a `Device`, a `MemoryPool`, etc.
     pub fn with_alloc(app_infos: Option<&ApplicationInfo>, alloc: Box<Alloc + Send + Sync>) -> Arc<Instance> {
         unimplemented!()
     }*/

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! - Once you have chosen a physical device to use, you can create a
 //!   [`Device`](device/index.html) object from it. The `Device` is the most important
-//!   object of Vulkan, as it represents an open channel of communicaton with a physical device.
+//!   object of Vulkan, as it represents an open channel of communication with a physical device.
 //!   You always need to have one before you can do interesting things with Vulkan.
 //!
 //! - [*Buffers*](buffer/index.html) and [*images*](image/index.html) can be used to store data on
@@ -195,7 +195,7 @@ enum Success {
 /// All possible errors returned by any Vulkan function.
 ///
 /// This type is not public. Instead all public error types should implement `From<Error>` and
-/// panic for error code that arent supposed to happen.
+/// panic for error code that aren't supposed to happen.
 #[derive(Debug, Copy, Clone)]
 #[repr(u32)]
 // TODO: being pub is necessary because of the weird visibility rules in rustc

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -40,7 +40,7 @@ use vk;
 /// # let device: std::sync::Arc<vulkano::device::Device> = return;
 /// let mem_ty = device.physical_device().memory_types().next().unwrap();
 ///
-/// // Allocates 1kB of memory.
+/// // Allocates 1KB of memory.
 /// let memory = DeviceMemory::alloc(device.clone(), mem_ty, 1024).unwrap();
 /// ```
 pub struct DeviceMemory {
@@ -83,7 +83,7 @@ impl DeviceMemory {
                    memory_type.physical_device().internal_object());
 
         // Note: This check is disabled because MoltenVK doesn't report correct heap sizes yet.
-        // More generally, whether or not this check is useful is questionnable.
+        // More generally, whether or not this check is useful is questionable.
         // TODO: ^
         /*if size > memory_type.heap().size() {
             return Err(OomError::OutOfDeviceMemory);
@@ -271,7 +271,7 @@ impl Drop for DeviceMemory {
 ///                     .filter(|t| t.is_host_visible())
 ///                     .next().unwrap();    // Vk specs guarantee that this can't fail
 ///
-/// // Allocates 1kB of memory.
+/// // Allocates 1KB of memory.
 /// let memory = DeviceMemory::alloc_and_map(device.clone(), mem_ty, 1024).unwrap();
 ///
 /// // Get access to the content. Note that this is very unsafe for two reasons: 1) the content is

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -10,7 +10,7 @@
 //! Device memory allocation and memory pools.
 //!
 //! By default, memory allocation is automatically handled by the vulkano library when you create
-//! a buffer or an image. But if you want more control, you have the possibility to costumize the
+//! a buffer or an image. But if you want more control, you have the possibility to customise the
 //! memory allocation strategy.
 //!
 //! # Memory types and heaps
@@ -47,7 +47,7 @@
 //!
 //! Memory types are order from "best" to "worse". In other words, the implementation prefers that
 //! you use the memory types that are earlier in the list. This means that selecting a memory type
-//! should always be done by enumerating them and taking the first one that matches our criterias.
+//! should always be done by enumerating them and taking the first one that matches our criteria.
 //!
 //! ## In practice
 //!

--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -1141,7 +1141,7 @@ impl<Vdef, Vs, Vss, Tcs, Tcss, Tes, Tess, Gs, Gss, Fs, Fss, Rp>
 
     /// Sets the vertex input to a single vertex buffer.
     ///
-    /// You will most likely need to explicitely specify the template parameter to the type of a
+    /// You will most likely need to explicitly specify the template parameter to the type of a
     /// vertex.
     #[inline]
     pub fn vertex_input_single_buffer<V>(self)
@@ -1458,7 +1458,7 @@ impl<Vdef, Vs, Vss, Tcs, Tcss, Tes, Tess, Gs, Gss, Fs, Fss, Rp>
         self
     }*/
 
-    /// Sets the front-facing faces to couner-clockwise faces. This is the default.
+    /// Sets the front-facing faces to counter-clockwise faces. This is the default.
     ///
     /// Triangles whose vertices are oriented counter-clockwise on the screen will be considered
     /// as facing their front. Otherwise they will be considered as facing their back.

--- a/vulkano/src/pipeline/input_assembly.rs
+++ b/vulkano/src/pipeline/input_assembly.rs
@@ -20,13 +20,13 @@ use vk;
 pub struct InputAssembly {
     /// The type of primitives.
     ///
-    /// Note that some tologies don't support primitive restart.
+    /// Note that some topologies don't support primitive restart.
     pub topology: PrimitiveTopology,
 
     /// If true, then the special index value `0xffff` or `0xffffffff` will tell the GPU that it is
     /// the end of the current primitive. A new primitive will restart at the next index.
     ///
-    /// Note that some tologies don't support primitive restart.
+    /// Note that some topologies don't support primitive restart.
     pub primitive_restart_enable: bool,
 }
 

--- a/vulkano/src/pipeline/multisample.rs
+++ b/vulkano/src/pipeline/multisample.rs
@@ -27,7 +27,7 @@
 //! an implementation-defined way to determine which samples get disabled or not. For example if
 //! the alpha value is 0.5, then about half of the samples will be discarded. If you render to a
 //! multisample image, this means that the color will end up being mixed with whatever color was
-//! undernearth, which gives the same effect as alpha blending.
+//! underneath, which gives the same effect as alpha blending.
 //!
 //! If `alpha_to_one` is true, the alpha value of all the samples will be forced to 1.0 (or the
 //! maximum possible value) after the effects of `alpha_to_coverage` have been applied.

--- a/vulkano/src/pipeline/shader.rs
+++ b/vulkano/src/pipeline/shader.rs
@@ -13,7 +13,7 @@
 //! code and can contain one or more entry points. Note that for the moment the official
 //! GLSL-to-SPIR-V compiler does not support multiple entry points.
 //!
-//! The vulkano library does not provide any functionnality that checks and introspects the SPIR-V
+//! The vulkano library does not provide any functionality that checks and introspects the SPIR-V
 //! code, therefore the whole shader-related API is unsafe. You are encouraged to use the
 //! `vulkano-shaders` crate that will generate Rust code that wraps around vulkano's shaders API.
 
@@ -628,7 +628,7 @@ unsafe impl SpecializationConstants for () {
     }
 }
 
-/// Describes an indiviual constant to set in the shader. Also a field in the struct.
+/// Describes an individual constant to set in the shader. Also a field in the struct.
 // Implementation note: has the same memory representation as a `VkSpecializationMapEntry`.
 #[repr(C)]
 pub struct SpecializationMapEntry {

--- a/vulkano/src/pipeline/vertex/vertex.rs
+++ b/vulkano/src/pipeline/vertex/vertex.rs
@@ -13,7 +13,7 @@ use format::Format;
 /// from a vertex shader.
 ///
 /// At this stage, the vertex is in a "raw" format. For example a `[f32; 4]` can match both a
-/// `vec4` or a `float[4]`. The way the things are binded depends on the shader.
+/// `vec4` or a `float[4]`. The way the things are bound depends on the shader.
 pub unsafe trait Vertex: 'static + Send + Sync {
     /// Returns the characteristics of a vertex member by its name.
     fn member(name: &str) -> Option<VertexMemberInfo>;

--- a/vulkano/src/query/mod.rs
+++ b/vulkano/src/query/mod.rs
@@ -94,7 +94,7 @@ impl UnsafeQueryPool {
     ///
     /// # Panic
     ///
-    /// Panicks if `count` is 0.
+    /// Panics if `count` is 0.
     #[inline]
     pub fn queries_range(&self, first_index: u32, count: u32) -> Option<UnsafeQueriesRange> {
         assert!(count >= 1);

--- a/vulkano/src/swapchain/capabilities.rs
+++ b/vulkano/src/swapchain/capabilities.rs
@@ -70,7 +70,7 @@ pub enum PresentMode {
     Mailbox = vk::PRESENT_MODE_MAILBOX_KHR,
 
     /// The action of presenting an image adds it to a queue of images. At each vertical blanking
-    /// period, the queue is poped and an image is presented.
+    /// period, the queue is popped and an image is presented.
     ///
     /// Guaranteed to be always supported.
     ///
@@ -535,7 +535,7 @@ impl Default for SurfaceTransform {
 ///
 /// > **Note**: Lots of developers are confused by color spaces. You can sometimes find articles
 /// > talking about gamma correction and suggestion to put your colors to the power 2.2 for
-/// > example. These are all hacks and you should use the sRGB pixel formats intead.
+/// > example. These are all hacks and you should use the sRGB pixel formats instead.
 ///
 /// If you follow these three rules, then everything should render the same way on all platforms.
 ///

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -510,7 +510,7 @@ impl<W> Surface<W> {
         }
     }
 
-    /// Retreives the capabilities of a surface when used by a certain device.
+    /// Retrieves the capabilities of a surface when used by a certain device.
     ///
     /// # Panic
     ///
@@ -704,7 +704,7 @@ impl From<Error> for SurfaceCreationError {
     }
 }
 
-/// Error that can happen when retreiving a surface's capabilities.
+/// Error that can happen when retrieving a surface's capabilities.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum CapabilitiesError {

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -126,9 +126,9 @@ pub fn present<F, W>(swapchain: Arc<Swapchain<W>>, before: F, queue: Arc<Queue>,
 }
 
 /// Same as `swapchain::present`, except it allows specifying a present region.
-/// Areas outside the present region may be ignored by vulkan in order to optimize presentation.
+/// Areas outside the present region may be ignored by Vulkan in order to optimize presentation.
 ///
-/// This is just an optimizaion hint, as the vulkan driver is free to ignore the given present region.
+/// This is just an optimization hint, as the Vulkan driver is free to ignore the given present region.
 ///
 /// If `VK_KHR_incremental_present` is not enabled on the device, the parameter will be ignored.
 pub fn present_incremental<F, W>(swapchain: Arc<Swapchain<W>>, before: F, queue: Arc<Queue>,

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -29,9 +29,9 @@ use vk;
 
 /// A fence is used to know when a command buffer submission has finished its execution.
 ///
-/// When a command buffer accesses a ressource, you have to ensure that the CPU doesn't access
-/// the same ressource simultaneously (except for concurrent reads). Therefore in order to know
-/// when the CPU can access a ressource again, a fence has to be used.
+/// When a command buffer accesses a resource, you have to ensure that the CPU doesn't access
+/// the same resource simultaneously (except for concurrent reads). Therefore in order to know
+/// when the CPU can access a resource again, a fence has to be used.
 #[derive(Debug)]
 pub struct Fence<D = Arc<Device>>
     where D: SafeDeref<Target = Device>

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -120,7 +120,7 @@ enum FenceSignalFutureState<F> {
     Cleaned,
 
     // A function panicked while the state was being modified. Should never happen.
-    Poisonned,
+    Poisoned,
 }
 
 impl<F> FenceSignalFuture<F>
@@ -194,10 +194,10 @@ impl<F> FenceSignalFuture<F>
     fn flush_impl(&self, state: &mut MutexGuard<FenceSignalFutureState<F>>)
                   -> Result<(), FlushError> {
         unsafe {
-            // In this function we temporarily replace the current state with `Poisonned` at the
+            // In this function we temporarily replace the current state with `Poisoned` at the
             // beginning, and we take care to always put back a value into `state` before
             // returning (even in case of error).
-            let old_state = mem::replace(&mut **state, FenceSignalFutureState::Poisonned);
+            let old_state = mem::replace(&mut **state, FenceSignalFutureState::Poisoned);
 
             let (previous, fence, partially_flushed) = match old_state {
                 FenceSignalFutureState::Pending(prev, fence) => {
@@ -207,7 +207,7 @@ impl<F> FenceSignalFuture<F>
                     (prev, fence, true)
                 },
                 other => {
-                    // We were already flushed in the past, or we're already poisonned. Don't do
+                    // We were already flushed in the past, or we're already poisoned. Don't do
                     // anything.
                     **state = other;
                     return Ok(());
@@ -305,7 +305,7 @@ impl<F> FenceSignalFutureState<F> {
             FenceSignalFutureState::PartiallyFlushed(ref prev, _) => Some(prev),
             FenceSignalFutureState::Flushed(ref prev, _) => Some(prev),
             FenceSignalFutureState::Cleaned => None,
-            FenceSignalFutureState::Poisonned => None,
+            FenceSignalFutureState::Poisoned => None,
         }
     }
 }
@@ -333,7 +333,7 @@ unsafe impl<F> GpuFuture for FenceSignalFuture<F>
                 }
             },
             FenceSignalFutureState::Cleaned |
-            FenceSignalFutureState::Poisonned => (),
+            FenceSignalFutureState::Poisoned => (),
             FenceSignalFutureState::Pending(_, _) => unreachable!(),
             FenceSignalFutureState::PartiallyFlushed(_, _) => unreachable!(),
         }
@@ -355,7 +355,7 @@ unsafe impl<F> GpuFuture for FenceSignalFuture<F>
                 prev.signal_finished();
             },
             FenceSignalFutureState::Cleaned |
-            FenceSignalFutureState::Poisonned => (),
+            FenceSignalFutureState::Poisoned => (),
             _ => unreachable!(),
         }
     }
@@ -442,7 +442,7 @@ impl<F> Drop for FenceSignalFuture<F>
             FenceSignalFutureState::Cleaned => {
                 // Also a normal situation. The user called `cleanup_finished()` before dropping.
             },
-            FenceSignalFutureState::Poisonned => {
+            FenceSignalFutureState::Poisoned => {
                 // The previous future was already dropped and blocked the current queue.
             },
             FenceSignalFutureState::Pending(_, _) |

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -53,7 +53,7 @@
 //! Respecting the order of operations on the GPU is important, as it is what *proves* vulkano that
 //! what you are doing is indeed safe. For example if you submit two operations that modify the
 //! same buffer, then you need to execute one after the other instead of submitting them
-//! independantly. Failing to do so would mean that these two operations could potentially execute
+//! independently. Failing to do so would mean that these two operations could potentially execute
 //! simultaneously on the GPU, which would be unsafe.
 //!
 //! This is done by calling one of the methods of the `GpuFuture` trait. For example calling
@@ -131,7 +131,7 @@ mod semaphore;
 /// Declares in which queue(s) a resource can be used.
 ///
 /// When you create a buffer or an image, you have to tell the Vulkan library in which queue
-/// families it will be used. The vulkano library requires you to tell in which queue famiily
+/// families it will be used. The vulkano library requires you to tell in which queue family
 /// the resource will be used, even for exclusive mode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 // TODO: remove


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

I ran `LANG=en_us aspell --mode ccpp check $filename` on every rust file.

There are some changes to field names but none of them are public.