### PR TITLE
Add a `reinterpret` function to `BufferSlice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Unreleased (Breaking)
 
-- Split 'PersistentDescriptorSetError::MissingUsage' into 'MissingImageUsage' and 'MissingBufferUsage'
+- Split `PersistentDescriptorSetError::MissingUsage` into `MissingImageUsage` and `MissingBufferUsage`
   each with a matching enum indicating the usage that was missing.
 - Fix instance_count when using draw_index with instance buffers
+- Added a `reinterpret` function to `BufferSlice`
 
 # Version 0.10.0 (2018-08-10)
 

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -132,6 +132,17 @@ impl<T: ?Sized, B> BufferSlice<T, B> {
             size: size,
         }
     }
+
+    #[inline]
+    pub unsafe fn reinterpret<R: ?Sized>(self) -> BufferSlice<R, B>
+    {
+        BufferSlice {
+            marker: PhantomData,
+            resource: self.resource,
+            offset: self.offset,
+            size: self.size,
+        }
+    }
 }
 
 impl<T, B> BufferSlice<[T], B> {

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -133,6 +133,27 @@ impl<T: ?Sized, B> BufferSlice<T, B> {
         }
     }
 
+    /// Changes the `T` generic parameter of the `BufferSlice` to the desired type. This can be
+    /// useful when you have a buffer with various types of data and want to create a typed slice
+    /// of a region that contains a single type of data.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use vulkano::buffer::BufferSlice;
+    /// # use vulkano::buffer::immutable::ImmutableBuffer;
+    /// # struct VertexImpl;
+    /// let blob_slice: BufferSlice<[u8], Arc<ImmutableBuffer<[u8]>>> = return;
+    /// let vertex_slice: BufferSlice<[VertexImpl], Arc<ImmutableBuffer<[u8]>>> = unsafe {
+    ///     blob_slice.reinterpret::<[VertexImpl]>()
+    /// };
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// Correct `offset` and `size` must be ensured before using this `BufferSlice` on the device.
+    /// See `BufferSlice::slice` for adjusting these properties.
     #[inline]
     pub unsafe fn reinterpret<R: ?Sized>(self) -> BufferSlice<R, B>
     {


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

This function allows the user to "view" the buffer as containing data of a different type. It can be useful when a buffer contains multiple types of data.