### PR TITLE
Deprecate glsl-to-spirv

### DIFF
--- a/glsl-to-spirv/Cargo.toml
+++ b/glsl-to-spirv/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "glsl-to-spirv"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
-description = "Wrapper around the official GLSL to SPIR-V compiler"
+description = "Deprecated. Use shaderc-rs instead."
 license = "MIT/Apache-2.0"
 build = "build/build.rs"
 categories = ["rendering::graphics-api"]

--- a/glsl-to-spirv/readme.md
+++ b/glsl-to-spirv/readme.md
@@ -1,0 +1,1 @@
+This crate is deprecated please use [shaderc-rs](https://github.com/google/shaderc-rs) instead.


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.


This PR is needed before merging https://github.com/vulkano-rs/vulkano/pull/947 so that people can see on crates.io that it is deprecated.