### PR TITLE
Made `AttributeInfo` derive `Copy`, `Clone` and `Debug`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   each with a matching enum indicating the usage that was missing.
 - Fix instance_count when using draw_index with instance buffers
 - Added a `reinterpret` function to `BufferSlice`
+- Made `AttributeInfo` derive `Copy`, `Clone` and `Debug`
 
 # Version 0.10.0 (2018-08-10)
 

--- a/vulkano/src/pipeline/vertex/definition.rs
+++ b/vulkano/src/pipeline/vertex/definition.rs
@@ -59,6 +59,7 @@ pub enum InputRate {
 
 /// Information about a single attribute within a vertex.
 /// TODO: change that API
+#[derive(Copy, Clone, Debug)]
 pub struct AttributeInfo {
     /// Number of bytes between the start of a vertex and the location of attribute.
     pub offset: usize,


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Made `AttributeInfo` derive `Copy`, `Clone` and `Debug`. The `Copy` trait is not necessary, but I thought the struct was small enough to warrant deriving it. This addition makes it easier to create custom implementations of `VertexDefinition`, where an iterator over a tuple containing `AttributeInfo` is created.