### PR TITLE
remove build_glsl_shaders from vulkano_shaders crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased (Breaking)
 
+- Remove vulkano_shaders::build_glsl_shaders
 - Split `PersistentDescriptorSetError::MissingUsage` into `MissingImageUsage` and `MissingBufferUsage`
   each with a matching enum indicating the usage that was missing.
 - Fix instance_count when using draw_index with instance buffers


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

I'm fairly certain this function is just a left over from before proc macros.
Now that we have proc macros, writing rust code to a file during build.rs then reading it again during compilation is not a great solution.
If someone is really determined they can still use the `reflect(..)` method to manually generate the rust code, but I wouldn't recommend that as I would consider the generated code implementation details.

I will leave this PR open for a while to let anyone comment if they are using this function for anything, or can see a valid use for it.