### PR TITLE
Reject spirv arrays that have incorrect stride in rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Fix instance_count when using draw_index with instance buffers
 - Added a `reinterpret` function to `BufferSlice`
 - Made `AttributeInfo` derive `Copy`, `Clone` and `Debug`
-
 - Use [google/shaderc](https://github.com/google/shaderc-rs) for shader compilation
+- Reject generation of rust types for SPIR-V arrays that would have incorrect array stride.
 
 # Version 0.10.0 (2018-08-10)
 


### PR DESCRIPTION
SPIR-V allows the array stride and size of a type to differ, but rust defines them to be the same. Thus
certain types when represented in rust will have the wrong layout. E.g. an array of vec3 can have an array
stride of 16 in SPIR-V, but an array of [f32;3] in rust would have a stride of 12. Thus using one for the
other would cause corruption.

This suggests a workaround by using a wrapping struct or upgrading the size of the type to one where the size is the array stride.

I considered generating the wrapping struct for the user, but that seems very confusing for the user. We could generate wrapping structs for all vec and mat types in arrays, but that would be a large API change.

See #298.

* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
  I did this because people affected by this bug will now get compile errors. This could be surprising, but their code was incorrect all along.
* [ ] Updated documentation to reflect any user-facing changes - in this repository
  I didn't see anything relevant to update.
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
  I didn't find anything relevant to update there.