### PR TITLE
Add Clone/Debug to QueuesIter.

### DIFF
--- a/vulkano/src/device.rs
+++ b/vulkano/src/device.rs
@@ -556,6 +556,7 @@ unsafe impl<T> DeviceOwned for T
 }
 
 /// Iterator that returns the queues produced when creating a device.
+#[derive(Clone, Debug)]
 pub struct QueuesIter {
     next_queue: usize,
     device: Arc<Device>,


### PR DESCRIPTION
This is primarily to allow debugging, e.g:

    println!("Queues: {:?}", queues.clone().count());
    let queue = queues.next().ok_or(VkError::NoAvailableQueue)?;
