### PR TITLE
Remove the layout prefix from render pass related structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Made `AttributeInfo` derive `Copy`, `Clone` and `Debug`
 - Use [google/shaderc](https://github.com/google/shaderc-rs) for shader compilation
 - Reject generation of rust types for SPIR-V arrays that would have incorrect array stride.
+- Removed `Layout` prefix from renderpass related structures (AttachmentDescription, PassDescription, PassDependencyDescription)
 
 # Version 0.10.0 (2018-08-10)
 

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -565,6 +565,18 @@ impl<P> AutoCommandBufferBuilder<P> {
         }
     }
 
+    /// Starts a debug marker group
+    pub fn debug_marker_begin(mut self, name: &str, color : [f32;4]) -> Result<Self, ()> {
+        self.inner.debug_marker_begin(name, color);
+        Ok(self)
+    }
+
+    /// Ends a debug marker group
+    pub fn debug_marker_end(mut self) -> Result<Self, ()> {
+        self.inner.debug_marker_end();
+        Ok(self)
+    }
+
     /// Adds a command that copies an image to another.
     ///
     /// Copy operations have several restrictions:

--- a/vulkano/src/framebuffer/desc.rs
+++ b/vulkano/src/framebuffer/desc.rs
@@ -49,7 +49,7 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> {
     /// Returns the description of an attachment.
     ///
     /// Returns `None` if `num` is greater than or equal to `num_attachments()`.
-    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription>;
+    fn attachment_desc(&self, num: usize) -> Option<AttachmentDescription>;
 
     /// Returns an iterator to the list of attachments.
     #[inline]
@@ -68,7 +68,7 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> {
     /// Returns the description of a subpass.
     ///
     /// Returns `None` if `num` is greater than or equal to `num_subpasses()`.
-    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription>;
+    fn subpass_desc(&self, num: usize) -> Option<PassDescription>;
 
     /// Returns an iterator to the list of subpasses.
     #[inline]
@@ -87,7 +87,7 @@ pub unsafe trait RenderPassDesc: RenderPassDescClearValues<Vec<ClearValue>> {
     /// Returns the description of a dependency.
     ///
     /// Returns `None` if `num` is greater than or equal to `num_dependencies()`.
-    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription>;
+    fn dependency_desc(&self, num: usize) -> Option<PassDependencyDescription>;
 
     /// Returns an iterator to the list of dependencies.
     #[inline]
@@ -320,7 +320,7 @@ unsafe impl<T> RenderPassDesc for T
     }
 
     #[inline]
-    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+    fn attachment_desc(&self, num: usize) -> Option<AttachmentDescription> {
         (**self).attachment_desc(num)
     }
 
@@ -330,7 +330,7 @@ unsafe impl<T> RenderPassDesc for T
     }
 
     #[inline]
-    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+    fn subpass_desc(&self, num: usize) -> Option<PassDescription> {
         (**self).subpass_desc(num)
     }
 
@@ -340,7 +340,7 @@ unsafe impl<T> RenderPassDesc for T
     }
 
     #[inline]
-    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+    fn dependency_desc(&self, num: usize) -> Option<PassDependencyDescription> {
         (**self).dependency_desc(num)
     }
 }
@@ -355,9 +355,9 @@ pub struct RenderPassDescAttachments<'a, R: ?Sized + 'a> {
 impl<'a, R: ?Sized + 'a> Iterator for RenderPassDescAttachments<'a, R>
     where R: RenderPassDesc
 {
-    type Item = LayoutAttachmentDescription;
+    type Item = AttachmentDescription;
 
-    fn next(&mut self) -> Option<LayoutAttachmentDescription> {
+    fn next(&mut self) -> Option<AttachmentDescription> {
         if self.num < self.render_pass.num_attachments() {
             let n = self.num;
             self.num += 1;
@@ -380,9 +380,9 @@ pub struct RenderPassDescSubpasses<'a, R: ?Sized + 'a> {
 impl<'a, R: ?Sized + 'a> Iterator for RenderPassDescSubpasses<'a, R>
     where R: RenderPassDesc
 {
-    type Item = LayoutPassDescription;
+    type Item = PassDescription;
 
-    fn next(&mut self) -> Option<LayoutPassDescription> {
+    fn next(&mut self) -> Option<PassDescription> {
         if self.num < self.render_pass.num_subpasses() {
             let n = self.num;
             self.num += 1;
@@ -405,9 +405,9 @@ pub struct RenderPassDescDependencies<'a, R: ?Sized + 'a> {
 impl<'a, R: ?Sized + 'a> Iterator for RenderPassDescDependencies<'a, R>
     where R: RenderPassDesc
 {
-    type Item = LayoutPassDependencyDescription;
+    type Item = PassDependencyDescription;
 
-    fn next(&mut self) -> Option<LayoutPassDependencyDescription> {
+    fn next(&mut self) -> Option<PassDependencyDescription> {
         if self.num < self.render_pass.num_dependencies() {
             let n = self.num;
             self.num += 1;
@@ -422,7 +422,7 @@ impl<'a, R: ?Sized + 'a> Iterator for RenderPassDescDependencies<'a, R>
 
 /// Describes an attachment that will be used in a render pass.
 #[derive(Debug, Clone)]
-pub struct LayoutAttachmentDescription {
+pub struct AttachmentDescription {
     /// Format of the image that is going to be bound.
     pub format: Format,
     /// Number of samples of the image that is going to be bound.
@@ -450,11 +450,11 @@ pub struct LayoutAttachmentDescription {
     pub final_layout: ImageLayout,
 }
 
-impl LayoutAttachmentDescription {
+impl AttachmentDescription {
     /// Returns true if this attachment is compatible with another attachment, as defined in the
     /// `Render Pass Compatibility` section of the Vulkan specs.
     #[inline]
-    pub fn is_compatible_with(&self, other: &LayoutAttachmentDescription) -> bool {
+    pub fn is_compatible_with(&self, other: &AttachmentDescription) -> bool {
         self.format == other.format && self.samples == other.samples
     }
 }
@@ -483,7 +483,7 @@ impl LayoutAttachmentDescription {
 // TODO: add tests for all these restrictions
 // TODO: allow unused attachments (for example attachment 0 and 2 are used, 1 is unused)
 #[derive(Debug, Clone)]
-pub struct LayoutPassDescription {
+pub struct PassDescription {
     /// Indices and layouts of attachments to use as color attachments.
     pub color_attachments: Vec<(usize, ImageLayout)>, // TODO: Vec is slow
 
@@ -509,7 +509,7 @@ pub struct LayoutPassDescription {
 /// you specify that there exists a dependency between two passes (ie. the result of one will be
 /// used as the input of another one).
 #[derive(Debug, Clone)]
-pub struct LayoutPassDependencyDescription {
+pub struct PassDependencyDescription {
     /// Index of the subpass that writes the data that `destination_subpass` is going to use.
     pub source_subpass: usize,
 

--- a/vulkano/src/framebuffer/empty.rs
+++ b/vulkano/src/framebuffer/empty.rs
@@ -8,9 +8,9 @@
 // according to those terms.
 
 use format::ClearValue;
-use framebuffer::LayoutAttachmentDescription;
-use framebuffer::LayoutPassDependencyDescription;
-use framebuffer::LayoutPassDescription;
+use framebuffer::AttachmentDescription;
+use framebuffer::PassDependencyDescription;
+use framebuffer::PassDescription;
 use framebuffer::RenderPassDesc;
 use framebuffer::RenderPassDescClearValues;
 use std::iter;
@@ -39,7 +39,7 @@ unsafe impl RenderPassDesc for EmptySinglePassRenderPassDesc {
     }
 
     #[inline]
-    fn attachment_desc(&self, _: usize) -> Option<LayoutAttachmentDescription> {
+    fn attachment_desc(&self, _: usize) -> Option<AttachmentDescription> {
         None
     }
 
@@ -49,9 +49,9 @@ unsafe impl RenderPassDesc for EmptySinglePassRenderPassDesc {
     }
 
     #[inline]
-    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+    fn subpass_desc(&self, num: usize) -> Option<PassDescription> {
         if num == 0 {
-            Some(LayoutPassDescription {
+            Some(PassDescription {
                      color_attachments: vec![],
                      depth_stencil: None,
                      input_attachments: vec![],
@@ -69,7 +69,7 @@ unsafe impl RenderPassDesc for EmptySinglePassRenderPassDesc {
     }
 
     #[inline]
-    fn dependency_desc(&self, _: usize) -> Option<LayoutPassDependencyDescription> {
+    fn dependency_desc(&self, _: usize) -> Option<PassDependencyDescription> {
         None
     }
 

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -22,9 +22,9 @@ use format::ClearValue;
 use framebuffer::AttachmentsList;
 use framebuffer::FramebufferAbstract;
 use framebuffer::IncompatibleRenderPassAttachmentError;
-use framebuffer::LayoutAttachmentDescription;
-use framebuffer::LayoutPassDependencyDescription;
-use framebuffer::LayoutPassDescription;
+use framebuffer::AttachmentDescription;
+use framebuffer::PassDependencyDescription;
+use framebuffer::PassDescription;
 use framebuffer::RenderPassAbstract;
 use framebuffer::RenderPassDesc;
 use framebuffer::RenderPassDescClearValues;
@@ -390,7 +390,7 @@ unsafe impl<Rp, A> RenderPassDesc for Framebuffer<Rp, A>
     }
 
     #[inline]
-    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+    fn attachment_desc(&self, num: usize) -> Option<AttachmentDescription> {
         self.render_pass.attachment_desc(num)
     }
 
@@ -400,7 +400,7 @@ unsafe impl<Rp, A> RenderPassDesc for Framebuffer<Rp, A>
     }
 
     #[inline]
-    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+    fn subpass_desc(&self, num: usize) -> Option<PassDescription> {
         self.render_pass.subpass_desc(num)
     }
 
@@ -410,7 +410,7 @@ unsafe impl<Rp, A> RenderPassDesc for Framebuffer<Rp, A>
     }
 
     #[inline]
-    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+    fn dependency_desc(&self, num: usize) -> Option<PassDependencyDescription> {
         self.render_pass.dependency_desc(num)
     }
 }

--- a/vulkano/src/framebuffer/macros.rs
+++ b/vulkano/src/framebuffer/macros.rs
@@ -72,9 +72,9 @@ macro_rules! ordered_passes_renderpass {
             use $crate::format::Format;
             use $crate::framebuffer::RenderPassDesc;
             use $crate::framebuffer::RenderPassDescClearValues;
-            use $crate::framebuffer::LayoutAttachmentDescription;
-            use $crate::framebuffer::LayoutPassDescription;
-            use $crate::framebuffer::LayoutPassDependencyDescription;
+            use $crate::framebuffer::AttachmentDescription;
+            use $crate::framebuffer::PassDescription;
+            use $crate::framebuffer::PassDependencyDescription;
             use $crate::image::ImageLayout;
             use $crate::sync::AccessFlagBits;
             use $crate::sync::PipelineStages;
@@ -93,7 +93,7 @@ macro_rules! ordered_passes_renderpass {
                 }
 
                 #[inline]
-                fn attachment_desc(&self, id: usize) -> Option<LayoutAttachmentDescription> {
+                fn attachment_desc(&self, id: usize) -> Option<AttachmentDescription> {
                     attachment(self, id)
                 }
 
@@ -103,7 +103,7 @@ macro_rules! ordered_passes_renderpass {
                 }
 
                 #[inline]
-                fn subpass_desc(&self, id: usize) -> Option<LayoutPassDescription> {
+                fn subpass_desc(&self, id: usize) -> Option<PassDescription> {
                     subpass(id)
                 }
 
@@ -113,7 +113,7 @@ macro_rules! ordered_passes_renderpass {
                 }
 
                 #[inline]
-                fn dependency_desc(&self, id: usize) -> Option<LayoutPassDependencyDescription> {
+                fn dependency_desc(&self, id: usize) -> Option<PassDependencyDescription> {
                     dependency(id)
                 }
             }
@@ -136,7 +136,7 @@ macro_rules! ordered_passes_renderpass {
             }
 
             #[inline]
-            fn attachment(desc: &CustomRenderPassDesc, id: usize) -> Option<LayoutAttachmentDescription> {
+            fn attachment(desc: &CustomRenderPassDesc, id: usize) -> Option<AttachmentDescription> {
                 #![allow(unused_assignments)]
                 #![allow(unused_mut)]
 
@@ -146,7 +146,7 @@ macro_rules! ordered_passes_renderpass {
                     if id == num {
                         let (initial_layout, final_layout) = attachment_layouts(num);
 
-                        return Some($crate::framebuffer::LayoutAttachmentDescription {
+                        return Some($crate::framebuffer::AttachmentDescription {
                             format: desc.$atch_name.0,
                             samples: desc.$atch_name.1,
                             load: $crate::framebuffer::LoadOp::$load,
@@ -175,7 +175,7 @@ macro_rules! ordered_passes_renderpass {
             }
 
             #[inline]
-            fn subpass(id: usize) -> Option<LayoutPassDescription> {
+            fn subpass(id: usize) -> Option<PassDescription> {
                 #![allow(unused_assignments)]
                 #![allow(unused_mut)]
                 #![allow(unused_variables)]
@@ -195,7 +195,7 @@ macro_rules! ordered_passes_renderpass {
                             depth = Some(($depth_atch, ImageLayout::DepthStencilAttachmentOptimal));
                         )*
 
-                        let mut desc = LayoutPassDescription {
+                        let mut desc = PassDescription {
                             color_attachments: vec![
                                 $(
                                     ($color_atch, ImageLayout::ColorAttachmentOptimal)
@@ -238,14 +238,14 @@ macro_rules! ordered_passes_renderpass {
             }
 
             #[inline]
-            fn dependency(id: usize) -> Option<LayoutPassDependencyDescription> {
+            fn dependency(id: usize) -> Option<PassDependencyDescription> {
                 let num_passes = num_subpasses();
 
                 if id + 1 >= num_passes {
                     return None;
                 }
 
-                Some(LayoutPassDependencyDescription {
+                Some(PassDependencyDescription {
                     source_subpass: id,
                     destination_subpass: id + 1,
                     source_stages: PipelineStages { all_graphics: true, .. PipelineStages::none() },         // TODO: correct values

--- a/vulkano/src/framebuffer/mod.rs
+++ b/vulkano/src/framebuffer/mod.rs
@@ -93,9 +93,9 @@
 pub use self::attachments_list::AttachmentsList;
 pub use self::compat_atch::IncompatibleRenderPassAttachmentError;
 pub use self::compat_atch::ensure_image_view_compatible;
-pub use self::desc::LayoutAttachmentDescription;
-pub use self::desc::LayoutPassDependencyDescription;
-pub use self::desc::LayoutPassDescription;
+pub use self::desc::AttachmentDescription;
+pub use self::desc::PassDependencyDescription;
+pub use self::desc::PassDescription;
 pub use self::desc::LoadOp;
 pub use self::desc::RenderPassDesc;
 pub use self::desc::RenderPassDescAttachments;

--- a/vulkano/src/framebuffer/sys.rs
+++ b/vulkano/src/framebuffer/sys.rs
@@ -20,9 +20,9 @@ use device::Device;
 use device::DeviceOwned;
 use format::ClearValue;
 use framebuffer::EmptySinglePassRenderPassDesc;
-use framebuffer::LayoutAttachmentDescription;
-use framebuffer::LayoutPassDependencyDescription;
-use framebuffer::LayoutPassDescription;
+use framebuffer::AttachmentDescription;
+use framebuffer::PassDependencyDescription;
+use framebuffer::PassDescription;
 use framebuffer::LoadOp;
 use framebuffer::RenderPassAbstract;
 use framebuffer::RenderPassDesc;
@@ -417,7 +417,7 @@ unsafe impl<D> RenderPassDesc for RenderPass<D>
     }
 
     #[inline]
-    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+    fn attachment_desc(&self, num: usize) -> Option<AttachmentDescription> {
         self.desc.attachment_desc(num)
     }
 
@@ -427,7 +427,7 @@ unsafe impl<D> RenderPassDesc for RenderPass<D>
     }
 
     #[inline]
-    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+    fn subpass_desc(&self, num: usize) -> Option<PassDescription> {
         self.desc.subpass_desc(num)
     }
 
@@ -437,7 +437,7 @@ unsafe impl<D> RenderPassDesc for RenderPass<D>
     }
 
     #[inline]
-    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+    fn dependency_desc(&self, num: usize) -> Option<PassDependencyDescription> {
         self.desc.dependency_desc(num)
     }
 }

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -25,9 +25,9 @@ use descriptor::pipeline_layout::PipelineLayoutSys;
 use device::Device;
 use device::DeviceOwned;
 use format::ClearValue;
-use framebuffer::LayoutAttachmentDescription;
-use framebuffer::LayoutPassDependencyDescription;
-use framebuffer::LayoutPassDescription;
+use framebuffer::AttachmentDescription;
+use framebuffer::PassDependencyDescription;
+use framebuffer::PassDescription;
 use framebuffer::RenderPassAbstract;
 use framebuffer::RenderPassDesc;
 use framebuffer::RenderPassDescClearValues;
@@ -265,7 +265,7 @@ unsafe impl<Mv, L, Rp> RenderPassDesc for GraphicsPipeline<Mv, L, Rp>
     }
 
     #[inline]
-    fn attachment_desc(&self, num: usize) -> Option<LayoutAttachmentDescription> {
+    fn attachment_desc(&self, num: usize) -> Option<AttachmentDescription> {
         self.render_pass.attachment_desc(num)
     }
 
@@ -275,7 +275,7 @@ unsafe impl<Mv, L, Rp> RenderPassDesc for GraphicsPipeline<Mv, L, Rp>
     }
 
     #[inline]
-    fn subpass_desc(&self, num: usize) -> Option<LayoutPassDescription> {
+    fn subpass_desc(&self, num: usize) -> Option<PassDescription> {
         self.render_pass.subpass_desc(num)
     }
 
@@ -285,7 +285,7 @@ unsafe impl<Mv, L, Rp> RenderPassDesc for GraphicsPipeline<Mv, L, Rp>
     }
 
     #[inline]
-    fn dependency_desc(&self, num: usize) -> Option<LayoutPassDependencyDescription> {
+    fn dependency_desc(&self, num: usize) -> Option<PassDependencyDescription> {
         self.render_pass.dependency_desc(num)
     }
 }


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

This PR removes the `Layout` prefix of the structures defined for a render pass.
@rukai 
