### PR TITLE
Add ranges for GPU locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@
 - Use [google/shaderc](https://github.com/google/shaderc-rs) for shader compilation
 - Reject generation of rust types for SPIR-V arrays that would have incorrect array stride.
 - Removed the `Layout` prefix of the descriptions used for a render pass.
-- Added the ability to lock a range of `DeviceLocalBuffer` with `try_gpu_lock`
-- Changed the GPU to lock a range of `DeviceLocalBuffer` instead of the entire buffer when `BufferSlice`s are used
+- Added the ability to lock a range of a buffer with `try_gpu_lock`
+    +   Applicable to `DeviceLocalBuffer` and `CpuAccessibleBuffer`
+    +   `CpuBufferPool` still locks the entire buffer chunk
+- Changed the GPU to lock a range of the buffer instead of the entire buffer when `BufferSlice`s are used
 
 # Version 0.10.0 (2018-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Use [google/shaderc](https://github.com/google/shaderc-rs) for shader compilation
 - Reject generation of rust types for SPIR-V arrays that would have incorrect array stride.
 - Removed the `Layout` prefix of the descriptions used for a render pass.
+- Added the ability to lock a range of `DeviceLocalBuffer` with `try_gpu_lock`
+- Changed the GPU to lock a range of `DeviceLocalBuffer` instead of the entire buffer when `BufferSlice`s are used
 
 # Version 0.10.0 (2018-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added the ability to lock a range of a buffer with `try_gpu_lock`
     +   Applicable to `DeviceLocalBuffer` and `CpuAccessibleBuffer`
     +   `CpuBufferPool` still locks the entire buffer chunk
+- Removed unused `&Queue` parameter from `BufferAccess::try_gpu_lock()`
 - Changed the GPU to lock a range of the buffer instead of the entire buffer when `BufferSlice`s are used
 
 # Version 0.10.0 (2018-08-10)

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -18,3 +18,13 @@ smallvec = "0.6.0"
 lazy_static = "1"
 vk-sys = { version = "0.3.3", path = "../vk-sys" }
 half = "1"
+
+[dev-dependencies]
+criterion = "0.2"
+
+[lib]
+bench = false
+
+[[bench]]
+name = "gpu_access"
+harness = false

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -18,6 +18,7 @@ smallvec = "0.6.0"
 lazy_static = "1"
 vk-sys = { version = "0.3.3", path = "../vk-sys" }
 half = "1"
+bio = "0.22.0"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/vulkano/benches/gpu_access.rs
+++ b/vulkano/benches/gpu_access.rs
@@ -4,6 +4,7 @@ extern crate vulkano;
 
 use criterion::Criterion;
 use vulkano::buffer::GpuAccess;
+use vulkano::buffer::GpuAccessType::Exclusive;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function_over_inputs("lock and unlock", |b, &&size| {
@@ -12,16 +13,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             for i in 1..size {
                 let range = (i - 1) * 100..i * 100;
-                gpu_access.try_lock(true, range.clone()).unwrap();
+                gpu_access.try_gpu_lock(0, Exclusive, range.clone()).unwrap();
             }
 
-            for i in 1..size {
-                let range = (i - 1) * 100..i * 100;
-
-                unsafe {
-                    gpu_access.unlock(range);
-                }
-            }
+            gpu_access.gpu_unlock(0);
         })
     }, &[100, 1000, 5000, 10000]);
 }

--- a/vulkano/benches/gpu_access.rs
+++ b/vulkano/benches/gpu_access.rs
@@ -1,0 +1,30 @@
+#[macro_use]
+extern crate criterion;
+extern crate vulkano;
+
+use criterion::Criterion;
+use vulkano::buffer::GpuAccess;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function_over_inputs("lock and unlock", |b, &&size| {
+        let mut gpu_access = GpuAccess::new();
+
+        b.iter(|| {
+            for i in 1..size {
+                let range = (i - 1) * 100..i * 100;
+                gpu_access.try_lock(true, range.clone()).unwrap();
+            }
+
+            for i in 1..size {
+                let range = (i - 1) * 100..i * 100;
+
+                unsafe {
+                    gpu_access.unlock(range);
+                }
+            }
+        })
+    }, &[100, 1000, 5000, 10000]);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -24,6 +24,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use std::ops::Range;
 use std::ptr;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -333,7 +334,10 @@ unsafe impl<T: ?Sized, A> BufferAccess for CpuAccessibleBuffer<T, A>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, exclusive_access: bool, _: &Queue) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, exclusive_access: bool, _: &Queue, range: Range<usize>) -> Result<(), AccessError> {
+        // TODO: ranges
+        assert_eq!(range, 0..self.size());
+
         if exclusive_access {
             let mut lock = match self.access.try_write() {
                 Ok(lock) => lock,
@@ -366,7 +370,10 @@ unsafe impl<T: ?Sized, A> BufferAccess for CpuAccessibleBuffer<T, A>
     }
 
     #[inline]
-    unsafe fn increase_gpu_lock(&self) {
+    unsafe fn increase_gpu_lock(&self, range: Range<usize>) {
+        // TODO: ranges
+        assert_eq!(range, 0..self.size());
+
         // First, handle if we have a non-exclusive access.
         {
             // Since the buffer is in use by the GPU, it is invalid to hold a write-lock to
@@ -393,7 +400,10 @@ unsafe impl<T: ?Sized, A> BufferAccess for CpuAccessibleBuffer<T, A>
     }
 
     #[inline]
-    unsafe fn unlock(&self) {
+    unsafe fn unlock(&self, range: Range<usize>) {
+        // TODO: ranges
+        assert_eq!(range, 0..self.size());
+
         // First, handle if we had a non-exclusive access.
         {
             // Since the buffer is in use by the GPU, it is invalid to hold a write-lock to

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -42,7 +42,6 @@ use buffer::traits::BufferInner;
 use buffer::traits::TypedBufferAccess;
 use device::Device;
 use device::DeviceOwned;
-use device::Queue;
 use image::ImageAccess;
 use instance::QueueFamily;
 use memory::Content;
@@ -319,7 +318,7 @@ unsafe impl<T: ?Sized, A> BufferAccess for CpuAccessibleBuffer<T, A>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, exclusive: bool, _: &Queue, range: Range<usize>) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, exclusive: bool, range: Range<usize>) -> Result<(), AccessError> {
         match self.access.try_write() {
             Ok(mut gpu_lock) => gpu_lock.try_lock(exclusive, range),
             Err(_) => Err(AccessError::AlreadyInUse),

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -28,7 +28,6 @@ use buffer::traits::BufferInner;
 use buffer::traits::TypedBufferAccess;
 use device::Device;
 use device::DeviceOwned;
-use device::Queue;
 use image::ImageAccess;
 use memory::DedicatedAlloc;
 use memory::DeviceMemoryAllocError;
@@ -628,7 +627,7 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, _: &Queue, range: Range<usize>) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, _: bool, range: Range<usize>) -> Result<(), AccessError> {
         // TODO: ranges
         // assert_eq!(range, 0..self.size());
 
@@ -768,8 +767,8 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolSubbuffer<T, A>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, e: bool, q: &Queue, r: Range<usize>) -> Result<(), AccessError> {
-        self.chunk.try_gpu_lock(e, q, r)
+    fn try_gpu_lock(&self, e: bool, r: Range<usize>) -> Result<(), AccessError> {
+        self.chunk.try_gpu_lock(e, r)
     }
 
     #[inline]

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -11,6 +11,7 @@ use std::cmp;
 use std::iter;
 use std::marker::PhantomData;
 use std::mem;
+use std::ops::Range;
 use std::ptr;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -627,7 +628,10 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, _: &Queue) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, _: bool, _: &Queue, range: Range<usize>) -> Result<(), AccessError> {
+        // TODO: ranges
+        // assert_eq!(range, 0..self.size());
+
         if self.requested_len == 0 {
             return Ok(());
         }
@@ -647,7 +651,10 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
     }
 
     #[inline]
-    unsafe fn increase_gpu_lock(&self) {
+    unsafe fn increase_gpu_lock(&self, range: Range<usize>) {
+        // TODO: ranges
+        // assert_eq!(range, 0..self.size());
+
         if self.requested_len == 0 {
             return;
         }
@@ -666,7 +673,10 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
     }
 
     #[inline]
-    unsafe fn unlock(&self) {
+    unsafe fn unlock(&self, range: Range<usize>) {
+        // TODO: ranges
+        // assert_eq!(range, 0..self.size());
+
         if self.requested_len == 0 {
             return;
         }
@@ -758,18 +768,18 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolSubbuffer<T, A>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, e: bool, q: &Queue) -> Result<(), AccessError> {
-        self.chunk.try_gpu_lock(e, q)
+    fn try_gpu_lock(&self, e: bool, q: &Queue, r: Range<usize>) -> Result<(), AccessError> {
+        self.chunk.try_gpu_lock(e, q, r)
     }
 
     #[inline]
-    unsafe fn increase_gpu_lock(&self) {
-        self.chunk.increase_gpu_lock()
+    unsafe fn increase_gpu_lock(&self, r: Range<usize>) {
+        self.chunk.increase_gpu_lock(r)
     }
 
     #[inline]
-    unsafe fn unlock(&self) {
-        self.chunk.unlock()
+    unsafe fn unlock(&self, r: Range<usize>) {
+        self.chunk.unlock(r)
     }
 }
 

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -30,7 +30,6 @@ use buffer::traits::BufferInner;
 use buffer::traits::TypedBufferAccess;
 use device::Device;
 use device::DeviceOwned;
-use device::Queue;
 use image::ImageAccess;
 use instance::QueueFamily;
 use memory::DedicatedAlloc;
@@ -208,7 +207,7 @@ unsafe impl<T: ?Sized, A> BufferAccess for DeviceLocalBuffer<T, A>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, e: bool, _: &Queue, r: Range<usize>) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, e: bool, r: Range<usize>) -> Result<(), AccessError> {
         let mut gpu_access = self.gpu_access.lock().unwrap();
         gpu_access.try_lock(e, r)
     }

--- a/vulkano/src/buffer/gpu_access.rs
+++ b/vulkano/src/buffer/gpu_access.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use smallvec::SmallVec;
+use std::ops::Range;
+
+use sync::AccessError;
+
+#[derive(Debug)]
+pub struct GpuAccessRange {
+    range: Range<usize>,
+    locks: u32,
+    exclusive: bool
+}
+
+#[derive(Debug)]
+pub struct GpuAccess {
+    ranges: SmallVec<[GpuAccessRange; 4]>
+}
+
+impl GpuAccess {
+    pub fn new() -> Self {
+        GpuAccess {
+            ranges: smallvec![]
+        }
+    }
+
+    #[inline]
+    pub fn can_lock(&self, exclusive: bool, range: Range<usize>) -> bool {
+        // Find all ranges that intersect with the range we're looking to lock
+        // TODO: if we need to make this loop faster, we can use an interval
+        // tree to do so, which is a data structure for efficiently finding
+        // overlapping ranges
+        for access in self.ranges
+            .iter()
+            .take_while(|x| x.range.start <= range.end && x.range.end <= range.start) {
+            // Can't exclusively lock the range if it's already locked by
+            // someone else
+            if exclusive {
+                return false;
+            }
+
+            // Can't lock the range if it's exclusively locked by someone else
+            if access.exclusive {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    #[inline]
+    pub fn try_lock(&mut self, exclusive: bool, range: Range<usize>) -> Result<(), AccessError> {
+        // If there are no other locks yet, we can go ahead and lock
+        if self.ranges.is_empty() {
+            self.ranges.push(GpuAccessRange {
+                range,
+                locks: 1,
+                exclusive
+            });
+
+            return Ok(());
+        }
+
+        let mut range_already_locked = false;
+
+        // Find all ranges that intersect with the range we're looking to lock
+        // TODO: if we need to make this loop faster, we can use an interval
+        // tree to do so, which is a data structure for efficiently finding
+        // overlapping ranges
+        for access in self.ranges
+            .iter_mut()
+            .take_while(|x| x.range.start <= range.end && x.range.end <= range.start) {
+            // Can't exclusively lock the range if it's already locked by
+            // someone else
+            if exclusive {
+                return Err(AccessError::AlreadyInUse);
+            }
+
+            // Can't lock the range if it's exclusively locked by someone else
+            if access.exclusive {
+                return Err(AccessError::AlreadyInUse);
+            }
+
+            // If this is the same range we're trying to lock, increase the lock
+            // count
+            if access.range == range {
+                debug_assert!(!range_already_locked);
+                range_already_locked = true;
+
+                access.locks += 1;
+            }
+        }
+
+        // Didn't find this range already locked, so go ahead and lock
+        if !range_already_locked {
+            self.ranges.push(GpuAccessRange {
+                range,
+                locks: 1,
+                exclusive
+            });
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub unsafe fn increase_lock(&mut self, range: Range<usize>) {
+        let access = self.ranges
+            .iter_mut()
+            .find(|x| x.range == range)
+            .expect("Tried to increase lock for a buffer range that is not locked");
+
+        debug_assert!(access.locks >= 1);
+        access.locks += 1;
+    }
+
+    #[inline]
+    pub unsafe fn unlock(&mut self, range: Range<usize>) {
+        let (i, _) = self.ranges
+            .iter_mut()
+            .enumerate()
+            .find(|(_, x)| x.range == range)
+            .expect("Tried to unlock a buffer range that isn't locked");
+
+        assert!(self.ranges[i].locks >= 1);
+        self.ranges[i].locks -= 1;
+
+        if self.ranges[i].locks == 0 {
+            self.ranges.remove(i);
+        }
+    }
+}

--- a/vulkano/src/buffer/gpu_access.rs
+++ b/vulkano/src/buffer/gpu_access.rs
@@ -112,28 +112,59 @@ impl GpuAccess {
 
     #[inline]
     pub unsafe fn increase_lock(&mut self, range: Range<usize>) {
-        let access = self.ranges
-            .iter_mut()
-            .find(|x| x.range == range)
-            .expect("Tried to increase lock for a buffer range that is not locked");
+        // When a lock is increased, it's possible that the range is not exactly
+        // the same that was used to create the lock. This can happen, for
+        // example when using a single copy_buffer command to copy both vertex
+        // and index data into the buffer. This will result in a single lock
+        // containing the both vertex and index buffer ranges.
 
-        debug_assert!(access.locks >= 1);
-        access.locks += 1;
+        // Later, when draw_indexed is invoked, bind_index_buffer is called, and
+        // it will try to increase the lock with its range, but that range is in
+        // fact a subrange of the range that was used to create the lock.
+
+        // Hence, we will look for an intersecting range and increase the lock
+        // for that instead.
+
+        let mut intersecting_ranges = 0;
+
+        for access in self.ranges
+            .iter_mut()
+            .filter(|x| ranges_intersect(&x.range, &range)) {
+            debug_assert!(access.locks >= 1);
+            access.locks += 1;
+
+            intersecting_ranges += 1;
+        }
+
+        assert!(intersecting_ranges > 0, "Tried to increase lock for a buffer range that is not locked");
+
+        // If multiple intersecting ranges are found, I think that means that an
+        // invalid range was provided here?
+
+        assert!(intersecting_ranges == 1);
     }
 
     #[inline]
     pub unsafe fn unlock(&mut self, range: Range<usize>) {
-        let (i, _) = self.ranges
+        let mut intersecting_ranges = 0;
+
+        for (i, access) in self.ranges
             .iter_mut()
             .enumerate()
-            .find(|(_, x)| x.range == range)
-            .expect("Tried to unlock a buffer range that isn't locked");
+            .filter(|(_, x)| ranges_intersect(&x.range, &range)) {
+            assert!(access.locks >= 1);
+            access.locks -= 1;
 
-        assert!(self.ranges[i].locks >= 1);
-        self.ranges[i].locks -= 1;
-
-        if self.ranges[i].locks == 0 {
-            self.ranges.remove(i);
+            intersecting_ranges += 1;
         }
+
+        assert!(intersecting_ranges > 0, "Tried to unlock a buffer range that isn't locked");
+
+        // If multiple intersecting ranges are found, I think that means that an
+        // invalid range was provided here?
+
+        assert!(intersecting_ranges == 1);
+
+        self.ranges.retain(|x| x.locks > 0);
     }
 }

--- a/vulkano/src/buffer/gpu_access.rs
+++ b/vulkano/src/buffer/gpu_access.rs
@@ -7,51 +7,49 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use smallvec::SmallVec;
 use std::ops::Range;
+use std::collections::HashMap;
 
+use bio::data_structures::interval_tree::IntervalTree;
+use bio::utils::Interval;
 use sync::AccessError;
+use vk::CommandBuffer;
 
 #[derive(Debug)]
-pub struct GpuAccessRange {
-    range: Range<usize>,
-    locks: u32,
-    exclusive: bool
+pub enum GpuAccessType {
+    Exclusive,
+    NonExclusive
 }
+
+use self::GpuAccessType::Exclusive;
 
 #[derive(Debug)]
 pub struct GpuAccess {
-    ranges: SmallVec<[GpuAccessRange; 4]>
+    trees: HashMap<CommandBuffer, IntervalTree<usize, GpuAccessType>>
 }
 
-fn ranges_intersect(a: &Range<usize>, b: &Range<usize>) -> bool {
-    a.start < b.end && a.end > b.start
-}
-
-// TODO: to make loops here faster, we could use an interval tree to do so,
-// which is a data structure for efficiently finding overlapping ranges
 impl GpuAccess {
     pub fn new() -> Self {
         GpuAccess {
-            ranges: smallvec![]
+            trees: HashMap::new()
         }
     }
 
     #[inline]
-    pub fn can_lock(&self, exclusive: bool, range: Range<usize>) -> bool {
-        // Find all ranges that intersect with the range we're looking to lock
-        for access in self.ranges
-            .iter()
-            .filter(|x| ranges_intersect(&x.range, &range)) {
-            // Can't exclusively lock the range if it's already locked by
-            // someone else
-            if exclusive {
-                return false;
-            }
+    pub fn can_cpu_lock(&self, access: GpuAccessType, range: Range<usize>) -> bool {
+        // Find all ranges that overlap with the range we're looking to lock
+        for (_, tree) in &self.trees {
+            for entry in tree.find(range.clone()) {
+                // Can't exclusively lock the range if it's already locked by
+                // someone else
+                if let Exclusive = access {
+                    return false;
+                }
 
-            // Can't lock the range if it's exclusively locked by someone else
-            if access.exclusive {
-                return false;
+                // Can't lock the range if it's exclusively locked by someone else
+                if let Exclusive = entry.data() {
+                    return false;
+                }
             }
         }
 
@@ -59,113 +57,48 @@ impl GpuAccess {
     }
 
     #[inline]
-    pub fn try_lock(&mut self, exclusive: bool, range: Range<usize>) -> Result<(), AccessError> {
-        // If there are no other locks yet, we can go ahead and lock
-        if self.ranges.is_empty() {
-            self.ranges.push(GpuAccessRange {
-                range,
-                locks: 1,
-                exclusive
-            });
-
-            return Ok(());
-        }
-
+    pub fn try_gpu_lock(&mut self, command_buffer: CommandBuffer, access: GpuAccessType, range: Range<usize>) -> Result<(), AccessError> {
         let mut range_already_locked = false;
 
-        // Find all ranges that intersect with the range we're looking to lock
-        for access in self.ranges
-            .iter_mut()
-            .filter(|x| ranges_intersect(&x.range, &range)) {
-            // Can't exclusively lock the range if it's already locked by
-            // someone else
-            if exclusive {
-                return Err(AccessError::AlreadyInUse);
-            }
+        // Find all ranges that overlap with the range we're looking to lock
+        for (_, tree) in &self.trees {
+            for entry in tree.find(range.clone()) {
+                // Can't exclusively lock the range if it's already locked by
+                // someone else
+                if let Exclusive = access {
+                    return Err(AccessError::AlreadyInUse);
+                }
 
-            // Can't lock the range if it's exclusively locked by someone else
-            if access.exclusive {
-                return Err(AccessError::AlreadyInUse);
-            }
+                let interval = entry.interval();
 
-            // If this is the same range we're trying to lock, increase the lock
-            // count
-            if access.range == range {
-                debug_assert!(!range_already_locked);
-                range_already_locked = true;
+                // Can't lock the range if it's exclusively locked by someone
+                // else
+                if let Exclusive = entry.data() {
+                    return Err(AccessError::AlreadyInUse);
+                }
 
-                access.locks += 1;
+                // Check to see if we've already non-exclusively locked this
+                // exact range so we don't insert the same range to the tree
+                // twice
+                if interval == &Interval::from(&range) {
+                    debug_assert!(!range_already_locked);
+                    range_already_locked = true;
+                }
             }
         }
 
         // Didn't find this range already locked, so go ahead and lock
         if !range_already_locked {
-            self.ranges.push(GpuAccessRange {
-                range,
-                locks: 1,
-                exclusive
-            });
+            let tree = self.trees.entry(command_buffer).or_insert(IntervalTree::new());
+            tree.insert(range, access);
         }
 
         Ok(())
     }
 
     #[inline]
-    pub unsafe fn increase_lock(&mut self, range: Range<usize>) {
-        // When a lock is increased, it's possible that the range is not exactly
-        // the same that was used to create the lock. This can happen, for
-        // example when using a single copy_buffer command to copy both vertex
-        // and index data into the buffer. This will result in a single lock
-        // containing the both vertex and index buffer ranges.
-
-        // Later, when draw_indexed is invoked, bind_index_buffer is called, and
-        // it will try to increase the lock with its range, but that range is in
-        // fact a subrange of the range that was used to create the lock.
-
-        // Hence, we will look for an intersecting range and increase the lock
-        // for that instead.
-
-        let mut intersecting_ranges = 0;
-
-        for access in self.ranges
-            .iter_mut()
-            .filter(|x| ranges_intersect(&x.range, &range)) {
-            debug_assert!(access.locks >= 1);
-            access.locks += 1;
-
-            intersecting_ranges += 1;
-        }
-
-        assert!(intersecting_ranges > 0, "Tried to increase lock for a buffer range that is not locked");
-
-        // If multiple intersecting ranges are found, I think that means that an
-        // invalid range was provided here?
-
-        assert!(intersecting_ranges == 1);
-    }
-
-    #[inline]
-    pub unsafe fn unlock(&mut self, range: Range<usize>) {
-        let mut intersecting_ranges = 0;
-
-        for (i, access) in self.ranges
-            .iter_mut()
-            .enumerate()
-            .filter(|(_, x)| ranges_intersect(&x.range, &range)) {
-            assert!(access.locks >= 1);
-            access.locks -= 1;
-
-            intersecting_ranges += 1;
-        }
-
-        assert!(intersecting_ranges > 0, "Tried to unlock a buffer range that isn't locked");
-
-        // If multiple intersecting ranges are found, I think that means that an
-        // invalid range was provided here?
-
-        assert!(intersecting_ranges == 1);
-
-        self.ranges.retain(|x| x.locks > 0);
+    pub fn gpu_unlock(&mut self, command_buffer: CommandBuffer) {
+        self.trees.remove(&command_buffer);
     }
 }
 

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -344,7 +344,7 @@ unsafe impl<T: ?Sized, A> BufferAccess for ImmutableBuffer<T, A> {
     }
 
     #[inline]
-    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue, range: Range<usize>) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, exclusive_access: bool, range: Range<usize>) -> Result<(), AccessError> {
         if exclusive_access {
             return Err(AccessError::ExclusiveDenied);
         }
@@ -410,7 +410,7 @@ unsafe impl<T: ?Sized, A> BufferAccess for ImmutableBufferInitialization<T, A> {
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, _: &Queue, range: Range<usize>) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, _: bool, range: Range<usize>) -> Result<(), AccessError> {
         if self.buffer.initialized.load(Ordering::Relaxed) {
             return Err(AccessError::AlreadyInUse);
         }

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -90,6 +90,7 @@ pub use self::usage::BufferUsage;
 pub use self::view::BufferView;
 pub use self::view::BufferViewRef;
 pub use self::gpu_access::GpuAccess;
+pub use self::gpu_access::GpuAccessType;
 
 pub mod cpu_access;
 pub mod cpu_pool;

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -89,6 +89,7 @@ pub use self::traits::TypedBufferAccess;
 pub use self::usage::BufferUsage;
 pub use self::view::BufferView;
 pub use self::view::BufferViewRef;
+pub use self::gpu_access::GpuAccess;
 
 pub mod cpu_access;
 pub mod cpu_pool;
@@ -100,3 +101,4 @@ pub mod view;
 mod slice;
 mod traits;
 mod usage;
+mod gpu_access;

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -242,18 +242,39 @@ unsafe impl<T: ?Sized, B> BufferAccess for BufferSlice<T, B>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue) -> Result<(), AccessError> {
-        self.resource.try_gpu_lock(exclusive_access, queue)
+    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue, range: Range<usize>) -> Result<(), AccessError> {
+        // TODO: subranges. at the time of writing we should never hit this
+        // assert because the only place calling this function is
+        // SyncCommandBuffer and it's always locking the entire BufferAccess (so
+        // the entire slice in this case)
+        assert_eq!(range, 0..self.size());
+
+        let offset = self.inner().offset;
+        self.resource.try_gpu_lock(exclusive_access, queue, offset..offset + self.size())
     }
 
     #[inline]
-    unsafe fn increase_gpu_lock(&self) {
-        self.resource.increase_gpu_lock()
+    unsafe fn increase_gpu_lock(&self, range: Range<usize>) {
+        // TODO: subranges. at the time of writing we should never hit this
+        // assert because the only place calling this function is
+        // SyncCommandBuffer and it's always locking the entire BufferAccess (so
+        // the entire slice in this case)
+        assert_eq!(range, 0..self.size());
+
+        let offset = self.inner().offset;
+        self.resource.increase_gpu_lock(offset..offset + self.size())
     }
 
     #[inline]
-    unsafe fn unlock(&self) {
-        self.resource.unlock()
+    unsafe fn unlock(&self, range: Range<usize>) {
+        // TODO: subranges. at the time of writing we should never hit this
+        // assert because the only place calling this function is
+        // SyncCommandBuffer and it's always locking the entire BufferAccess (so
+        // the entire slice in this case)
+        assert_eq!(range, 0..self.size());
+
+        let offset = self.inner().offset;
+        self.resource.unlock(offset..offset + self.size())
     }
 }
 

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -17,7 +17,6 @@ use buffer::traits::BufferInner;
 use buffer::traits::TypedBufferAccess;
 use device::Device;
 use device::DeviceOwned;
-use device::Queue;
 use image::ImageAccess;
 use sync::AccessError;
 
@@ -242,7 +241,7 @@ unsafe impl<T: ?Sized, B> BufferAccess for BufferSlice<T, B>
     }
 
     #[inline]
-    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue, range: Range<usize>) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, exclusive_access: bool, range: Range<usize>) -> Result<(), AccessError> {
         // TODO: subranges. at the time of writing we should never hit this
         // assert because the only place calling this function is
         // SyncCommandBuffer and it's always locking the entire BufferAccess (so
@@ -250,7 +249,7 @@ unsafe impl<T: ?Sized, B> BufferAccess for BufferSlice<T, B>
         assert_eq!(range, 0..self.size());
 
         let offset = self.inner().offset;
-        self.resource.try_gpu_lock(exclusive_access, queue, offset..offset + self.size())
+        self.resource.try_gpu_lock(exclusive_access, offset..offset + self.size())
     }
 
     #[inline]

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -12,7 +12,6 @@ use std::ops::Range;
 use buffer::BufferSlice;
 use buffer::sys::UnsafeBuffer;
 use device::DeviceOwned;
-use device::Queue;
 use image::ImageAccess;
 use memory::Content;
 use sync::AccessError;
@@ -120,7 +119,7 @@ pub unsafe trait BufferAccess: DeviceOwned {
     /// no longer in use by the GPU. The implementation is not expected to
     /// automatically perform any unlocking and can rely on the fact that
     /// `unlock()` is going to be called.
-    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue, range: Range<usize>) -> Result<(), AccessError>;
+    fn try_gpu_lock(&self, exclusive_access: bool, range: Range<usize>) -> Result<(), AccessError>;
 
     /// Locks a range of the resource for usage on the GPU. Supposes that the
     /// range is already locked, and simply increases the lock by one.
@@ -182,8 +181,8 @@ unsafe impl<T> BufferAccess for T
     }
 
     #[inline]
-    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue, range: Range<usize>) -> Result<(), AccessError> {
-        (**self).try_gpu_lock(exclusive_access, queue, range)
+    fn try_gpu_lock(&self, exclusive_access: bool, range: Range<usize>) -> Result<(), AccessError> {
+        (**self).try_gpu_lock(exclusive_access, range)
     }
 
     #[inline]

--- a/vulkano/src/command_buffer/synced/base.rs
+++ b/vulkano/src/command_buffer/synced/base.rs
@@ -1077,7 +1077,7 @@ impl<P> SyncCommandBuffer<P> {
                         Err(err) => err,
                     };
 
-                    match (buf.try_gpu_lock(entry.exclusive, queue, 0..buf.size()), prev_err) {
+                    match (buf.try_gpu_lock(entry.exclusive, 0..buf.size()), prev_err) {
                         (Ok(_), _) => (),
                         (Err(err), AccessCheckError::Unknown) |
                         (_, AccessCheckError::Denied(err)) => {

--- a/vulkano/src/command_buffer/synced/base.rs
+++ b/vulkano/src/command_buffer/synced/base.rs
@@ -1069,7 +1069,7 @@ impl<P> SyncCommandBuffer<P> {
                     let prev_err = match future.check_buffer_access(&buf, entry.exclusive, queue) {
                         Ok(_) => {
                             unsafe {
-                                buf.increase_gpu_lock();
+                                buf.increase_gpu_lock(0..buf.size());
                             }
                             locked_resources += 1;
                             continue;
@@ -1077,7 +1077,7 @@ impl<P> SyncCommandBuffer<P> {
                         Err(err) => err,
                     };
 
-                    match (buf.try_gpu_lock(entry.exclusive, queue), prev_err) {
+                    match (buf.try_gpu_lock(entry.exclusive, queue, 0..buf.size()), prev_err) {
                         (Ok(_), _) => (),
                         (Err(err), AccessCheckError::Unknown) |
                         (_, AccessCheckError::Denied(err)) => {
@@ -1148,7 +1148,7 @@ impl<P> SyncCommandBuffer<P> {
                         let cmd = &commands_lock[command_id];
                         let buf = cmd.buffer(resource_index);
                         unsafe {
-                            buf.unlock();
+                            buf.unlock(0..buf.size());
                         }
                     },
 
@@ -1196,7 +1196,7 @@ impl<P> SyncCommandBuffer<P> {
                 KeyTy::Buffer => {
                     let cmd = &commands_lock[command_id];
                     let buf = cmd.buffer(resource_index);
-                    buf.unlock();
+                    buf.unlock(0..buf.size());
                 },
                 KeyTy::Image => {
                     let cmd = &commands_lock[command_id];

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -66,6 +66,7 @@ extern crate fnv;
 #[macro_use]
 extern crate lazy_static;
 extern crate shared_library;
+#[macro_use]
 extern crate smallvec;
 extern crate vk_sys as vk;
 pub extern crate half;

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -66,10 +66,10 @@ extern crate fnv;
 #[macro_use]
 extern crate lazy_static;
 extern crate shared_library;
-#[macro_use]
 extern crate smallvec;
 extern crate vk_sys as vk;
 pub extern crate half;
+extern crate bio;
 
 #[macro_use]
 mod tests;


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Fixes #1070.

Would like to request feedback. There's some more work to be done before this should be merged, e.g. `try_gpu_lock` and related functions could be refactored into a `GpuAccess` struct which is then added as a field to all the different buffers.

Only the `DeviceLocalBuffer` currently supports the locking of subranges. Would it also be desirable to implement this for other types of buffers? For `ImmutableBuffer` I think locking the buffer is a no-op anyway, but what about `CpuAccessibleBuffer` and `CpuBufferPool`?

I think it would make sense to also support this for `CpuAccessibleBuffer`, but I'm not sure about `CpuBufferPool`. Considering how `CpuBufferPool` is generally used (a chunk of the buffer is filled with data, sent to the GPU, and then another chunk of the buffer is used the next frame), does it even make sense to support this?