### PR TITLE
Add documentation for GraphicsPipelineAbstract

### DIFF
--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -322,42 +322,44 @@ impl Drop for Inner {
 
 /// Trait implemented on objects that reference a graphics pipeline. Can be made into a trait
 /// object.
+/// When using this trait `AutoCommandBufferBuilder::draw*` calls will need the buffers to be
+/// wrapped in a `vec!()`.
 pub unsafe trait GraphicsPipelineAbstract: PipelineLayoutAbstract + RenderPassAbstract + VertexSource<Vec<Arc<BufferAccess + Send + Sync>>> {
-/// Returns an opaque object that represents the inside of the graphics pipeline.
+    /// Returns an opaque object that represents the inside of the graphics pipeline.
     fn inner(&self) -> GraphicsPipelineSys;
 
-/// Returns the index of the subpass this graphics pipeline is rendering to.
+    /// Returns the index of the subpass this graphics pipeline is rendering to.
     fn subpass_index(&self) -> u32;
 
-/// Returns the subpass this graphics pipeline is rendering to.
+    /// Returns the subpass this graphics pipeline is rendering to.
     #[inline]
     fn subpass(self) -> Subpass<Self> where Self: Sized {
         let index = self.subpass_index();
         Subpass::from(self, index).expect("Wrong subpass index in GraphicsPipelineAbstract::subpass")
     }
 
-/// Returns true if the line width used by this pipeline is dynamic.
+    /// Returns true if the line width used by this pipeline is dynamic.
     fn has_dynamic_line_width(&self) -> bool;
 
-/// Returns the number of viewports and scissors of this pipeline.
+    /// Returns the number of viewports and scissors of this pipeline.
     fn num_viewports(&self) -> u32;
 
-/// Returns true if the viewports used by this pipeline are dynamic.
+    /// Returns true if the viewports used by this pipeline are dynamic.
     fn has_dynamic_viewports(&self) -> bool;
 
-/// Returns true if the scissors used by this pipeline are dynamic.
+    /// Returns true if the scissors used by this pipeline are dynamic.
     fn has_dynamic_scissors(&self) -> bool;
 
-/// Returns true if the depth bounds used by this pipeline are dynamic.
+    /// Returns true if the depth bounds used by this pipeline are dynamic.
     fn has_dynamic_depth_bounds(&self) -> bool;
 
-/// Returns true if the stencil compare masks used by this pipeline are dynamic.
+    /// Returns true if the stencil compare masks used by this pipeline are dynamic.
     fn has_dynamic_stencil_compare_mask(&self) -> bool;
 
-/// Returns true if the stencil write masks used by this pipeline are dynamic.
+    /// Returns true if the stencil write masks used by this pipeline are dynamic.
     fn has_dynamic_stencil_write_mask(&self) -> bool;
 
-/// Returns true if the stencil references used by this pipeline are dynamic.
+    /// Returns true if the stencil references used by this pipeline are dynamic.
     fn has_dynamic_stencil_reference(&self) -> bool;
 }
 


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

This PR better documents GraphicsPipelineAbstract by mentioning that your draw calls will now need the buffer to be wrapped in a vec.

I'm not convinced this is the best solution though, the ideal solution would be for GraphicsPipeline and GraphicsPipelineAbstract to function in the same way here. That is, both should allow a CpuAccessibleBuffer to be passed directly in the draw call.

I have no idea how to implement that though, the generics is doing my head in.
The code that handles it for GraphicsPipeline is here: https://github.com/vulkano-rs/vulkano/blob/7a1112035022407ba36e0a4082bda8c3e455cf2f/vulkano/src/pipeline/graphics_pipeline/mod.rs#L504
We need to find a way to implement this for GraphicsPipelineAbstract.
If such a thing is impossible then I will merge this PR instead.

The commit to add the linked code is https://github.com/vulkano-rs/vulkano/commit/4c0a0933b183baf91437b79cb41481102d0f7e6a
The commit to add `VertexSource<Vec<Arc<BufferAccess + Send + Sync>>>` is https://github.com/vulkano-rs/vulkano/commit/64459fc6afc09df489f7d1dbafd241086c4a219c#diff-1f6ce30b101af55aab9d8ea160fee761

As mentioned in the issue, it looks like this will be resolved by later rust features, so I'll merge this as is and keep the issue open. https://github.com/vulkano-rs/vulkano/issues/1082