### PR TITLE
Remove vulkano-shader-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ members = [
     "vk-sys",
     "vulkano",
     "vulkano-shaders",
-    "vulkano-shader-derive",
     "vulkano-win"
 ]
 

--- a/README.md
+++ b/README.md
@@ -150,15 +150,10 @@ If your change adds, removes or modifies a trait or a function, please add an en
 This repository contains six libraries:
 
 - `vulkano` is the main one.
-- `vulkano-shaders` can analyse SPIR-V shaders at compile-time.
-- `vulkano-shader-derive` provides a custom derive that invokes `vulkano-shaders`. It lets you
-  easily integrate your GLSL shaders within the rest of your source code.
+- `vulkano-shaders` Provides the `vulkano_shader!` macro for compiling glsl shaders.
 - `vulkano-win` provides a safe link between vulkano and the `winit` library which can create
   a window to render to.
 - `vk-sys` contains raw bindings for Vulkan. You can use it even if you don't care about vulkano.
-
-Once procedural macros are stabilized in Rust, the `vulkano-shaders` and `vulkano-shader-derive`
-crates will be merged with the `vulkano` crate.
 
 In order to run tests, run `cargo test --all` at the root of the repository. Make sure your Vulkan
 driver is up to date before doing so.

--- a/vulkano-shader-derive/Cargo.toml
+++ b/vulkano-shader-derive/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "vulkano-shader-derive"
-version = "0.11.0"
-authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
-repository = "https://github.com/vulkano-rs/vulkano"
-description = "Deprecated"
-license = "MIT/Apache-2.0"
-documentation = "https://docs.rs/vulkano"
-categories = []


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Deleting the crate had to be done in a second PR so the vulkano-shader-derive deprecated version 0.11 would publish. I dont have the crates.io credentials to do it manually.