### PR TITLE
Reenable per swapchain check_errors in SubmitPresentBuilder::submit

### DIFF
--- a/vulkano/src/command_buffer/submit/queue_present.rs
+++ b/vulkano/src/command_buffer/submit/queue_present.rs
@@ -11,7 +11,6 @@ use smallvec::SmallVec;
 use std::error;
 use std::fmt;
 use std::marker::PhantomData;
-use std::mem;
 use std::ptr;
 
 use device::DeviceOwned;
@@ -158,7 +157,7 @@ impl<'a> SubmitPresentBuilder<'a> {
                 }
             };
 
-            let mut results = vec![mem::uninitialized(); self.swapchains.len()]; // TODO: alloca
+            let mut results = vec![vk::SUCCESS; self.swapchains.len()];
 
             let vk = queue.device().pointers();
             let queue = queue.internal_object_guard();
@@ -179,10 +178,9 @@ impl<'a> SubmitPresentBuilder<'a> {
 
             check_errors(vk.QueuePresentKHR(*queue, &infos))?;
 
-            // TODO: AMD driver initially didn't write the results ; check that it's been fixed
-            //for result in results {
-            //try!(check_errors(result));
-            //}
+            for result in results {
+                check_errors(result)?;
+            }
 
             Ok(())
         }


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

There was a comment complaining that an AMD driver (which one? there are three) was not setting the pResults.
I made this a non issue by replacing mem::uninitialized() with vk::SUCESS.