### PR TITLE
Descriptor set collection vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Use [google/shaderc](https://github.com/google/shaderc-rs) for shader compilation
 - Reject generation of rust types for SPIR-V arrays that would have incorrect array stride.
 - Removed the `Layout` prefix of the descriptions used for a render pass.
+- Implemented DescriptorSetCollection for `Vec<T>` which allows easier use of construction them for usage when drawing.
 
 # Version 0.10.0 (2018-08-10)
 

--- a/vulkano/src/descriptor/descriptor_set/collection.rs
+++ b/vulkano/src/descriptor/descriptor_set/collection.rs
@@ -84,14 +84,18 @@ unsafe impl<T> DescriptorSetsCollection for Vec<T>
 
     #[inline]
     fn num_bindings_in_set(&self, set: usize) -> Option<usize> {
-        let set  = &self[set];
-        Some(set.num_bindings())
+        match self.get(set) {
+            Some(set) => Some(set.num_bindings()),
+            None => None,
+        }
     }
 
     #[inline]
     fn descriptor(&self, set: usize, binding: usize) -> Option<DescriptorDesc> {
-        let set = &self[set];
-        set.descriptor(binding)
+        match self.get(set) {
+            Some(set) => set.descriptor(binding),
+            None => None,
+        }
     }
 }
 

--- a/vulkano/src/descriptor/descriptor_set/collection.rs
+++ b/vulkano/src/descriptor/descriptor_set/collection.rs
@@ -84,12 +84,8 @@ unsafe impl<T> DescriptorSetsCollection for Vec<T>
 
     #[inline]
     fn num_bindings_in_set(&self, set: usize) -> Option<usize> {
-        match self.get(set) {
-            Some(set) => Some(set.num_bindings()),
-            None => None,
-        }
+        self.get(set).map(|x| x.num_bindings())
     }
-
     #[inline]
     fn descriptor(&self, set: usize, binding: usize) -> Option<DescriptorDesc> {
         match self.get(set) {

--- a/vulkano/src/descriptor/descriptor_set/collection.rs
+++ b/vulkano/src/descriptor/descriptor_set/collection.rs
@@ -88,10 +88,7 @@ unsafe impl<T> DescriptorSetsCollection for Vec<T>
     }
     #[inline]
     fn descriptor(&self, set: usize, binding: usize) -> Option<DescriptorDesc> {
-        match self.get(set) {
-            Some(set) => set.descriptor(binding),
-            None => None,
-        }
+        self.get(set).and_then(|x| x.descriptor(binding))
     }
 }
 

--- a/vulkano/src/descriptor/descriptor_set/collection.rs
+++ b/vulkano/src/descriptor/descriptor_set/collection.rs
@@ -70,6 +70,31 @@ unsafe impl<T> DescriptorSetsCollection for T
     }
 }
 
+unsafe impl<T> DescriptorSetsCollection for Vec<T>
+    where T: DescriptorSet + Send + Sync + 'static
+{
+    #[inline]
+    fn into_vec(self) -> Vec<Box<DescriptorSet + Send + Sync>> {
+        let mut v = Vec::new();
+        for o in self {
+            v.push(Box::new(o) as Box<_>);
+        }
+        return v;
+    }
+
+    #[inline]
+    fn num_bindings_in_set(&self, set: usize) -> Option<usize> {
+        let set  = &self[set];
+        Some(set.num_bindings())
+    }
+
+    #[inline]
+    fn descriptor(&self, set: usize, binding: usize) -> Option<DescriptorDesc> {
+        let set = &self[set];
+        set.descriptor(binding)
+    }
+}
+
 macro_rules! impl_collection {
     ($first:ident $(, $others:ident)+) => (
         unsafe impl<$first$(, $others)+> DescriptorSetsCollection for ($first, $($others),+)


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

This PR implements `DescriptorSetsCollection` for `Vec<T>` so you can construct a list of descriptor sets more easily for use with `draw` and `draw_indexed`

```
let sets = vec![
    set0.clone(),
    set1.clone()
];

command_buffer = command_buffer.draw_indexed( pipeline.clone(), &dynamic_states, vec![obj.vertices().clone()],indices.clone(), sets, *matrix).unwrap();
```

Not sure if this was left out on purpose or not, but I found myself needing this to easily send descriptor sets around, I combine a uniform and per material set for textures etc.