### PR TITLE
Move shaders back that were supposed to be defined in the middle of `main() { }`

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -28,25 +28,6 @@ use vulkano::sync;
 
 use std::sync::Arc;
 
-mod cs {
-    vulkano_shaders::shader!{
-        ty: "compute",
-        src: "
-#version 450
-
-layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
-
-layout(set = 0, binding = 0) buffer Data {
-    uint data[];
-} data;
-
-void main() {
-    uint idx = gl_GlobalInvocationID.x;
-    data.data[idx] *= 12;
-}"
-    }
-}
-
 fn main() {
     // As with other examples, the first step is to create an instance.
     let instance = Instance::new(None, &InstanceExtensions::none(), None).unwrap();
@@ -90,6 +71,24 @@ fn main() {
     // If you are familiar with graphics pipeline, the principle is the same except that compute
     // pipelines are much simpler to create.
     let pipeline = Arc::new({
+        mod cs {
+            vulkano_shaders::shader!{
+                ty: "compute",
+                src: "
+#version 450
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) buffer Data {
+    uint data[];
+} data;
+
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+    data.data[idx] *= 12;
+}"
+            }
+        }
         let shader = cs::Shader::load(device.clone()).unwrap();
         ComputePipeline::new(device.clone(), &shader.main_entry_point(), &()).unwrap()
     });

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -84,34 +84,6 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::sync::GpuFuture;
 use vulkano::format::ClearValue;
 
-mod vs {
-    vulkano_shaders::shader!{
-        ty: "vertex",
-        src: "
-#version 450
-
-layout(location = 0) in vec2 position;
-
-void main() {
-    gl_Position = vec4(position, 0.0, 1.0);
-}"
-    }
-}
-
-mod fs {
-    vulkano_shaders::shader!{
-        ty: "fragment",
-        src: "
-#version 450
-
-layout(location = 0) out vec4 f_color;
-
-void main() {
-    f_color = vec4(1.0, 0.0, 0.0, 1.0);
-}"
-    }
-}
-
 fn main() {
     // The usual Vulkan initialization.
     let instance = Instance::new(None, &InstanceExtensions::none(), None).unwrap();
@@ -179,6 +151,34 @@ fn main() {
     // without multisampling.
     // At the end of the example, we copy the content of `image` (ie. the final image) to a buffer,
     // then read the content of that buffer and save it to a PNG file.
+
+    mod vs {
+        vulkano_shaders::shader!{
+            ty: "vertex",
+            src: "
+#version 450
+
+layout(location = 0) in vec2 position;
+
+void main() {
+    gl_Position = vec4(position, 0.0, 1.0);
+}"
+        }
+    }
+
+    mod fs {
+        vulkano_shaders::shader!{
+            ty: "fragment",
+            src: "
+#version 450
+
+layout(location = 0) out vec4 f_color;
+
+void main() {
+    f_color = vec4(1.0, 0.0, 0.0, 1.0);
+}"
+        }
+    }
 
     let vs = vs::Shader::load(device.clone()).unwrap();
     let fs = fs::Shader::load(device.clone()).unwrap();

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -22,10 +22,18 @@ use vulkano::sync;
 
 use std::sync::Arc;
 
-mod cs {
-    vulkano_shaders::shader!{
-        ty: "compute",
-        src: "
+fn main() {
+    let instance = Instance::new(None, &InstanceExtensions::none(), None).unwrap();
+    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
+    let queue_family = physical.queue_families().find(|&q| q.supports_compute()).unwrap();
+    let (device, mut queues) = Device::new(physical, physical.supported_features(),
+        &DeviceExtensions::none(), [(queue_family, 0.5)].iter().cloned()).unwrap();
+    let queue = queues.next().unwrap();
+
+    mod cs {
+        vulkano_shaders::shader!{
+            ty: "compute",
+            src: "
 #version 450
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
@@ -47,17 +55,11 @@ void main() {
         data.data[idx] += uint(pc.addend);
     }
 }"
+        }
     }
-}
 
-fn main() {
-    let instance = Instance::new(None, &InstanceExtensions::none(), None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    let queue_family = physical.queue_families().find(|&q| q.supports_compute()).unwrap();
-    let (device, mut queues) = Device::new(physical, physical.supported_features(),
-        &DeviceExtensions::none(), [(queue_family, 0.5)].iter().cloned()).unwrap();
-    let queue = queues.next().unwrap();
     let shader = cs::Shader::load(device.clone()).unwrap();
+
     let pipeline = Arc::new(ComputePipeline::new(device.clone(), &shader.main_entry_point(), &()).unwrap());
 
     let data_buffer = {

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -49,42 +49,6 @@ use winit::{EventsLoop, Window, WindowBuilder, Event, WindowEvent};
 
 use std::sync::Arc;
 
-// TODO: Move this back to the middle of the example, it makes for a more coherent sequential explanation (check git history)
-// The raw shader creation API provided by the vulkano library is unsafe, for various reasons.
-//
-// An overview of what the `shader!` macro generates can be found in the
-// `vulkano-shaders` crate docs. You can view them at https://docs.rs/vulkano-shaders/
-//
-// TODO: explain this in details
-mod vs {
-    vulkano_shaders::shader!{
-        ty: "vertex",
-        src: "
-#version 450
-
-layout(location = 0) in vec2 position;
-
-void main() {
-gl_Position = vec4(position, 0.0, 1.0);
-}"
-    }
-}
-
-mod fs {
-    vulkano_shaders::shader!{
-        ty: "fragment",
-        src: "
-#version 450
-
-layout(location = 0) out vec4 f_color;
-
-void main() {
-    f_color = vec4(1.0, 0.0, 0.0, 1.0);
-}
-"
-    }
-}
-
 fn main() {
     // The first step of any Vulkan program is to create an instance.
     let instance = {
@@ -230,6 +194,43 @@ fn main() {
             Vertex { position: [0.25, -0.1] }
         ].iter().cloned()).unwrap()
     };
+
+    // The next step is to create the shaders.
+    //
+    // The raw shader creation API provided by the vulkano library is unsafe, for various reasons.
+    //
+    // An overview of what the `vulkano_shaders::shader!` macro generates can be found in the
+    // `vulkano-shaders` crate docs. You can view them at https://docs.rs/vulkano-shaders/
+    //
+    // TODO: explain this in details
+    mod vs {
+        vulkano_shaders::shader!{
+            ty: "vertex",
+            src: "
+#version 450
+
+layout(location = 0) in vec2 position;
+
+void main() {
+    gl_Position = vec4(position, 0.0, 1.0);
+}"
+        }
+    }
+
+    mod fs {
+        vulkano_shaders::shader!{
+            ty: "fragment",
+            src: "
+#version 450
+
+layout(location = 0) out vec4 f_color;
+
+void main() {
+    f_color = vec4(1.0, 0.0, 0.0, 1.0);
+}
+"
+        }
+    }
 
     let vs = vs::Shader::load(device.clone()).unwrap();
     let fs = fs::Shader::load(device.clone()).unwrap();


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

They were initially moved because rust currently doesnt support
function-like proc macros in a function, but now they are wrapped in a
mod anyway.
