### PR TITLE
Allow single_pass_renderpass! to work without also using ordered_passes_renderpass in rust 2018

### DIFF
--- a/vulkano/src/framebuffer/macros.rs
+++ b/vulkano/src/framebuffer/macros.rs
@@ -19,7 +19,7 @@ macro_rules! single_pass_renderpass {
             $(resolve: [$($resolve_atch:ident),*])*$(,)*
         }
     ) => (
-        ordered_passes_renderpass!(
+        $crate::ordered_passes_renderpass!(
             $device,
             attachments: { $($a)* },
             passes: [


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
