### PR TITLE
Release vulkano 0.11.1

### DIFF
--- a/CHANGELOG_VK_SYS.md
+++ b/CHANGELOG_VK_SYS.md
@@ -1,3 +1,7 @@
-# Version 0.3.4 (2018-11-08)
+# Version 0.4.0 (2018-11-16)
+
+- Removed MIR support
+
+# Version 0.3.4 (2018-11-08) **yanked**
 
 - Accidentally released with breaking change with the removal of MIR support.

--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+# Version 0.11.1 (2018-11-16)
+
 - Expose `CopyImageError` and `DrawIndexedIndirectError`.
 
-# Version 0.11.0 (2018-11-08)
+# Version 0.11.0 (2018-11-08) (**yanked** because vk-sys 0.3.4 was accidentally breaking vulkano 0.10)
 
 - Update to winit 0.18
 - Export features and device extensions from the device module instead of the instance module

--- a/vk-sys/Cargo.toml
+++ b/vk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vk-sys"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Bindings for the Vulkan graphics API"

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Safe wrapper for the Vulkan graphics API"
@@ -18,5 +18,5 @@ fnv = "1.0.6"
 shared_library = "0.1.7"
 smallvec = "0.6.0"
 lazy_static = "1"
-vk-sys = { version = "0.3.3", path = "../vk-sys" }
+vk-sys = { version = "0.4.0", path = "../vk-sys" }
 half = "1"


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Because I did a minor release of vk-sys that broke vulkano 0.10, that minor release had to be yanked.
This then broke vulkano 0.11, so I'm doing another release of vulkano and vk-sys.