### PR TITLE
Add a `union` method to the extensions types.

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -2,6 +2,7 @@
 
 - Add support for `#include "..."` and `#include <...>` directives within source
   files.
+- Add a `union` method for the extensions types.
 
 # Version 0.11.1 (2018-11-16)
 

--- a/vulkano/src/extensions.rs
+++ b/vulkano/src/extensions.rs
@@ -42,6 +42,16 @@ macro_rules! extensions {
                 }
             }
 
+            /// Returns the union of this list and another list.
+            pub fn union(&self, other: &$sname) -> $sname {
+                $sname {
+                    $(
+                        $ext: self.$ext || other.$ext,
+                    )*
+                    _unbuildable: Unbuildable(())
+                }
+            }
+
             /// Returns the intersection of this list and another list.
             #[inline]
             pub fn intersection(&self, other: &$sname) -> $sname {

--- a/vulkano/src/extensions.rs
+++ b/vulkano/src/extensions.rs
@@ -43,6 +43,7 @@ macro_rules! extensions {
             }
 
             /// Returns the union of this list and another list.
+            #[inline]
             pub fn union(&self, other: &$sname) -> $sname {
                 $sname {
                     $(


### PR DESCRIPTION
Currently the extensions types implement `intersection` and `difference` methods but provide no simple way to produce a `union`. This PR addresses this by adding a `union` method.

* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* ~Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.~
