### PR TITLE
handle spirv group decorations

### DIFF
--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -10,7 +10,7 @@
 use syn::Ident;
 use proc_macro2::{Span, TokenStream};
 
-use enums::{StorageClass, ExecutionModel, ExecutionMode};
+use enums::{StorageClass, ExecutionModel, ExecutionMode, Decoration};
 use parse::{Instruction, Spirv};
 use spirv_search;
 
@@ -221,11 +221,9 @@ fn write_interface_structs(doc: &Spirv, capitalized_ep_name: &str, interface: &[
                         continue;
                     } // FIXME: hack
 
-                    let location = match spirv_search::location_decoration(doc, result_id) {
-                        Some(l) => l,
-                        None => panic!("Attribute `{}` (id {}) is missing a location",
-                                       name,
-                                       result_id),
+                    let location = match doc.get_decoration_params(result_id, Decoration::DecorationLocation) {
+                        Some(l) => l[0],
+                        None => panic!("Attribute `{}` (id {}) is missing a location", name, result_id),
                     };
 
                     let (format, location_len) = spirv_search::format_from_id(doc, result_type_id, ignore_first_array);

--- a/vulkano-shaders/src/enums.rs
+++ b/vulkano-shaders/src/enums.rs
@@ -15,7 +15,7 @@ use parse::ParseError;
 macro_rules! enumeration {
     ($(typedef enum $unused:ident { $($elem:ident = $value:expr,)+ } $name:ident;)+) => (
         $(
-            #[derive(Debug, Clone)]
+            #[derive(Debug, Clone, PartialEq)]
             pub enum $name {
                 $($elem),+
             }

--- a/vulkano-shaders/src/parse.rs
+++ b/vulkano-shaders/src/parse.rs
@@ -161,6 +161,17 @@ pub enum Instruction {
         decoration: Decoration,
         params: Vec<u32>,
     },
+    DecorationGroup {
+        result_id: u32,
+    },
+    GroupDecorate {
+        decoration_group: u32,
+        targets: Vec<u32>,
+    },
+    GroupMemberDecorate {
+        decoration_group: u32,
+        targets: Vec<(u32, u32)>,
+    },
     Label { result_id: u32 },
     Branch { result_id: u32 },
     Kill,
@@ -331,6 +342,17 @@ fn decode_instruction(opcode: u16, operands: &[u32]) -> Result<Instruction, Pars
                decoration: Decoration::from_num(operands[2])?,
                params: operands[3 ..].to_owned(),
            },
+           73 => Instruction::DecorationGroup {
+                result_id: operands[0],
+           },
+           74 => Instruction::GroupDecorate {
+               decoration_group: operands[0],
+               targets: operands[1 ..].to_owned(),
+           },
+           75 => Instruction::GroupMemberDecorate {
+               decoration_group: operands[0],
+               targets: operands.chunks(2).map(|x| (x[0], x[1])).collect(),
+           },
            248 => Instruction::Label { result_id: operands[0] },
            249 => Instruction::Branch { result_id: operands[0] },
            252 => Instruction::Kill,
@@ -355,6 +377,151 @@ fn parse_string(data: &[u32]) -> (String, &[u32]) {
     let s = String::from_utf8(bytes).expect("Shader content is not UTF-8");
 
     (s, &data[r ..])
+}
+
+pub(crate) struct FoundDecoration {
+    pub target_id: u32,
+    pub params: Vec<u32>
+}
+
+impl Spirv {
+    /// Returns the params and the id of all decorations that match the passed Decoration type
+    ///
+    /// for each matching OpDecorate:
+    ///     if it points at a regular target:
+    ///         creates a FoundDecoration with its params and target_id
+    ///     if it points at a group:
+    ///         the OpDecorate's target_id is ignored and a seperate FoundDecoration is created only for each target_id given in matching OpGroupDecorate instructions.
+    pub(crate) fn get_decorations(&self, find_decoration: Decoration) -> Vec<FoundDecoration> {
+        let mut decorations = vec!();
+        for instruction in &self.instructions {
+            if let Instruction::Decorate { target_id, ref decoration, ref params } = instruction {
+                if *decoration == find_decoration {
+                    // assume by default it is just pointing at the target_id
+                    let mut target_ids = vec!(*target_id);
+
+                    // however it might be pointing at a group, which can have multiple target_ids
+                    for inner_instruction in &self.instructions {
+                        if let Instruction::DecorationGroup { result_id } = inner_instruction {
+                            if *result_id == *target_id {
+                                target_ids.clear();
+
+                                for inner_instruction in &self.instructions {
+                                    if let Instruction::GroupDecorate { decoration_group, targets } = inner_instruction {
+                                        if *decoration_group == *target_id {
+                                            target_ids.extend(targets);
+                                        }
+                                    }
+                                }
+
+                                // result_id must be unique so we can safely break here
+                                break
+                            }
+                        }
+                    }
+
+                    // create for all target_ids found
+                    for target_id in target_ids {
+                        decorations.push(FoundDecoration {
+                            target_id,
+                            params: params.clone()
+                        });
+                    }
+                }
+            }
+        }
+        decorations
+    }
+
+    /// Returns the params held by the decoration for the specified id and type
+    /// Searches OpDecorate and OpGroupMemberDecorate
+    /// Returns None if such a decoration does not exist
+    pub(crate) fn get_decoration_params(&self, id: u32, find_decoration: Decoration) -> Option<Vec<u32>> {
+        for instruction in &self.instructions {
+            match instruction {
+                Instruction::Decorate { target_id, ref decoration, ref params }
+                if *target_id == id && *decoration == find_decoration => {
+                    return Some(params.clone());
+                }
+                Instruction::GroupDecorate { decoration_group, ref targets } => {
+                    for group_target_id in targets {
+                        if *group_target_id == id {
+                            for instruction in &self.instructions {
+                                if let Instruction::Decorate { target_id, ref decoration, ref params } = instruction {
+                                    if target_id == decoration_group && *decoration == find_decoration {
+                                        return Some(params.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => (),
+            };
+        }
+        None
+    }
+
+    /// Returns the params held by the decoration for the member specified by id, member and type
+    /// Searches OpMemberDecorate and OpGroupMemberDecorate
+    /// Returns None if such a decoration does not exist
+    pub(crate) fn get_member_decoration_params(&self, struct_id: u32, member_literal: u32, find_decoration: Decoration) -> Option<Vec<u32>> {
+        for instruction in &self.instructions {
+            match instruction {
+                Instruction::MemberDecorate { target_id, member, ref decoration, ref params }
+                if *target_id == struct_id && *member == member_literal && *decoration == find_decoration => {
+                    return Some(params.clone());
+                }
+                Instruction::GroupMemberDecorate { decoration_group, ref targets } => {
+                    for (group_target_struct_id, group_target_member_literal) in targets {
+                        if *group_target_struct_id == struct_id && *group_target_member_literal == member_literal {
+                            for instruction in &self.instructions {
+                                if let Instruction::Decorate { target_id, ref decoration, ref params } = instruction {
+                                    if target_id == decoration_group && *decoration == find_decoration {
+                                        return Some(params.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => (),
+            };
+        }
+        None
+    }
+
+    /// Returns the params held by the Decoration::DecorationBuiltIn for the specified struct id
+    /// Searches OpMemberDecorate and OpGroupMemberDecorate
+    /// Returns None if such a decoration does not exist
+    ///
+    /// This function does not need a member_literal argument because the spirv spec requires that a
+    /// struct must contain either all builtin or all non-builtin members.
+    pub(crate) fn get_member_decoration_builtin_params(&self, struct_id: u32) -> Option<Vec<u32>> {
+        for instruction in &self.instructions {
+            match instruction {
+                Instruction::MemberDecorate { target_id, decoration: Decoration::DecorationBuiltIn, ref params, .. }
+                if *target_id == struct_id => {
+                    return Some(params.clone());
+                }
+                Instruction::GroupMemberDecorate { decoration_group, ref targets } => {
+                    for (group_target_struct_id, _) in targets {
+                        if *group_target_struct_id == struct_id {
+                            for instruction in &self.instructions {
+                                if let Instruction::Decorate { target_id, decoration: Decoration::DecorationBuiltIn, ref params } = instruction {
+                                    if target_id == decoration_group {
+                                        return Some(params.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => (),
+            };
+        }
+        None
+    }
 }
 
 #[cfg(test)]

--- a/vulkano-shaders/src/spec_consts.rs
+++ b/vulkano-shaders/src/spec_consts.rs
@@ -72,15 +72,8 @@ pub fn write_specialization_constants(doc: &Spirv) -> TokenStream {
         let (rust_ty, rust_size, rust_alignment) = spec_const_type_from_id(doc, type_id);
         let rust_size = rust_size.expect("Found runtime-sized specialization constant");
 
-        let constant_id = doc.instructions
-            .iter()
-            .filter_map(|i| match i {
-                &Instruction::Decorate { target_id, decoration: Decoration::DecorationSpecId, ref params }
-                    if target_id == result_id => Some(params[0]),
-                _ => None,
-            })
-            .next()
-            .expect("Found a specialization constant with no SpecId decoration");
+        let constant_id = doc.get_decoration_params(result_id, Decoration::DecorationSpecId)
+            .unwrap()[0];
 
         spec_consts.push(SpecConst {
             name: spirv_search::name_from_id(doc, result_id),

--- a/vulkano-shaders/src/spirv_search.rs
+++ b/vulkano-shaders/src/spirv_search.rs
@@ -130,28 +130,13 @@ pub fn member_name_from_id(doc: &Spirv, searched: u32, searched_member: u32) -> 
     String::from("__unnamed")
 }
 
-pub fn location_decoration(doc: &Spirv, searched: u32) -> Option<u32> {
-    for instruction in &doc.instructions {
-        if let &Instruction::Decorate { target_id, decoration: Decoration::DecorationLocation, ref params } = instruction {
-            if target_id == searched {
-                return Some(params[0])
-            }
-        }
-    }
-
-    None
-}
-
 /// Returns true if a `BuiltIn` decorator is applied on an id.
 pub fn is_builtin(doc: &Spirv, id: u32) -> bool {
-    for instruction in &doc.instructions {
-        match *instruction {
-            Instruction::Decorate { target_id, decoration: Decoration::DecorationBuiltIn, .. }
-                if target_id == id => { return true }
-            Instruction::MemberDecorate { target_id, decoration: Decoration::DecorationBuiltIn, .. }
-                if target_id == id => { return true }
-            _ => (),
-        }
+    if doc.get_decoration_params(id, Decoration::DecorationBuiltIn).is_some() {
+        return true
+    }
+    if doc.get_member_decoration_builtin_params(id).is_some() {
+        return true
     }
 
     for instruction in &doc.instructions {


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

While this is an important robustness fix, I have never seen shaderc generate decoration group instructions
Most of this will be replaced if we move to rspirv but at least we know what functionality it needs to provide us.

closes https://github.com/vulkano-rs/vulkano/issues/1053