### PR TITLE
Mac install

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -3,6 +3,7 @@
 - Add support for `#include "..."` and `#include <...>` directives within source
   files.
 - Add a `union` method for the extensions types.
+- Add MoltenVK auto installer for macOS
 
 # Version 0.11.1 (2018-11-16)
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The easiest way to get vulkano up and running on macOS is to install the
 Vulkano will find it and dynamically link with `libvulkan.dylib`:
 
 Vulkano will attempt to automatically download and install the latest Vulkan SDK for macOS.
+The sdk will be installed at `$HOME/.vulkan_sdk`.
 If you would prefer a manual installation complete the following instructions before
 building vulkano.
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ Vulkano will find it and dynamically link with `libvulkan.dylib`:
 Vulkano will attempt to automatically download and install the latest Vulkan SDK for macOS.
 The sdk will be installed at `$HOME/.vulkan_sdk`.
 If you get an error the first time you run vulkano then
-you will need to source your `source ~/.profile` or `source ~/.bash_profile`
+you will need to source your `source ~/.bash_profile`
 or simply reopen your terminal.
+If you are not using bash as your shell you will need to manually add
+the following environment variables.
 If you would prefer a manual installation complete the following instructions before
 building vulkano.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Vulkano will find it and dynamically link with `libvulkan.dylib`:
 
 Vulkano will attempt to automatically download and install the latest Vulkan SDK for macOS.
 The sdk will be installed at `$HOME/.vulkan_sdk`.
+If you get an error the first time you run vulkano then
+you will need to source your `source ~/.profile` or `source ~/.bash_profile` 
+or simply reopen your terminal.
 If you would prefer a manual installation complete the following instructions before
 building vulkano.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Vulkano will find it and dynamically link with `libvulkan.dylib`:
 Vulkano will attempt to automatically download and install the latest Vulkan SDK for macOS.
 The sdk will be installed at `$HOME/.vulkan_sdk`.
 If you get an error the first time you run vulkano then
-you will need to source your `source ~/.profile` or `source ~/.bash_profile` 
+you will need to source your `source ~/.profile` or `source ~/.bash_profile`
 or simply reopen your terminal.
 If you would prefer a manual installation complete the following instructions before
 building vulkano.

--- a/README.md
+++ b/README.md
@@ -96,23 +96,29 @@ sudo apt-get install build-essential git python cmake libvulkan-dev vulkan-utils
 
 ### macOS and iOS Specific Setup
 
+TLDR; In the best case, vulkano should work on macOS without having to take any further action, read on if you need more information or something goes wrong.
+
 Vulkan is not natively supported by macOS and iOS. However, there exists [MoltenVK](https://github.com/KhronosGroup/MoltenVK)
 a Vulkan implementation on top of Apple's Metal API. This allows vulkano to build and run on macOS
 and iOS platforms.
 
-The easiest way to get vulkano up and running on macOS is to install the
-[Vulkan SDK for macOS](https://vulkan.lunarg.com/sdk/home). To install the SDK so that
-Vulkano will find it and dynamically link with `libvulkan.dylib`:
+The Vulkan SDK for macOS also comes with the iOS framework.
+
+Note that as of writing, MoltenVK has some bugs that show up in the examples.
+Some minor modifications may be required as workarounds: see https://github.com/vulkano-rs/vulkano/pull/1027.
+The examples also do not work properly on macOS 10.11 and lower without workarounds due to MoltenVK's Metal backend not getting
+the required features until macOS 10.12. See https://github.com/vulkano-rs/vulkano/issues/1075 for workarounds.
+
+#### macOS and iOS Automatic Setup
 
 Vulkano will attempt to automatically download and install the latest Vulkan SDK for macOS.
-The sdk will be installed at `$HOME/.vulkan_sdk`.
-If you get an error the first time you run vulkano then
-you will need to source your `source ~/.bash_profile`
-or simply reopen your terminal.
-If you are not using bash as your shell you will need to manually add
-the following environment variables.
-If you would prefer a manual installation complete the following instructions before
-building vulkano.
+The SDK will be installed at `$HOME/.vulkan_sdk`.
+If you are not using bash as your shell you will need to manually add the environment variables listed in step 2 of "macOS and iOS Manual Setup".
+
+#### macOS and iOS Manual Setup
+
+Follow these steps to manually install the [Vulkan SDK for macOS](https://vulkan.lunarg.com/sdk/home) so that
+Vulkano will find it and dynamically link with `libvulkan.dylib`.
 
 1. Download the latest macOS release and unpack it somewhere, for the next step
 we'll assume that's `~/vulkan_sdk`.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The easiest way to get vulkano up and running on macOS is to install the
 [Vulkan SDK for macOS](https://vulkan.lunarg.com/sdk/home). To install the SDK so that
 Vulkano will find it and dynamically link with `libvulkan.dylib`:
 
+Vulkano will attempt to automatically download and install the latest Vulkan SDK for macOS.
+If you would prefer a manual installation complete the following instructions before
+building vulkano.
+
 1. Download the latest macOS release and unpack it somewhere, for the next step
 we'll assume that's `~/vulkan_sdk`.
 2. Modify your environment to contain the SDK bin directory in PATH and the SDK lib directory in

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -20,3 +20,6 @@ smallvec = "0.6.0"
 lazy_static = "1"
 vk-sys = { version = "0.4.0", path = "../vk-sys" }
 half = "1"
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+moltenvk_deps = "0.1"

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -21,5 +21,6 @@ lazy_static = "1"
 vk-sys = { version = "0.4.0", path = "../vk-sys" }
 half = "1"
 
-[target.'cfg(target_os = "macos")'.build-dependencies]
-moltenvk_deps = "0.1"
+[target.'cfg(target_os = "macos")'.dependencies]
+#moltenvk_deps = "0.1"
+moltenvk_deps = { path = "../../moltenvk_deps" } 

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -22,5 +22,4 @@ vk-sys = { version = "0.4.0", path = "../vk-sys" }
 half = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-#moltenvk_deps = "0.1"
-moltenvk_deps = { path = "../../moltenvk_deps" } 
+moltenvk_deps = "0.1"

--- a/vulkano/build.rs
+++ b/vulkano/build.rs
@@ -25,6 +25,7 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=Foundation");
     }
     if target.contains("apple-darwin") {
+        #[cfg(target_os = "macos")]
         moltenvk_deps::check_or_install();
     }
 }

--- a/vulkano/build.rs
+++ b/vulkano/build.rs
@@ -7,6 +7,8 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+extern crate moltenvk_deps;
+
 use std::env;
 
 fn main() {
@@ -20,5 +22,8 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=QuartzCore");
         println!("cargo:rustc-link-lib=framework=UIKit");
         println!("cargo:rustc-link-lib=framework=Foundation");
+    }
+    if target.contains("apple-darwin") {
+        moltenvk_deps::check_or_install();
     }
 }

--- a/vulkano/build.rs
+++ b/vulkano/build.rs
@@ -7,9 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-#[cfg(target_os = "macos")]
-extern crate moltenvk_deps;
-
 use std::env;
 
 fn main() {
@@ -23,9 +20,5 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=QuartzCore");
         println!("cargo:rustc-link-lib=framework=UIKit");
         println!("cargo:rustc-link-lib=framework=Foundation");
-    }
-    if target.contains("apple-darwin") {
-        #[cfg(target_os = "macos")]
-        moltenvk_deps::check_or_install();
     }
 }

--- a/vulkano/build.rs
+++ b/vulkano/build.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+#[cfg(target_os = "macos")]
 extern crate moltenvk_deps;
 
 use std::env;

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -191,6 +191,11 @@ pub fn auto_loader()
         }
         #[cfg(target_os = "macos")]
         fn get_path() -> PathBuf {
+            // Checks if the mac dependencies are install
+            // and offers to autmatically install them.
+            // VULKAN_LIB_PATH needs to be passed because
+            // shared_library cannot detect temporary 
+            // environment variables on macOS.
             moltenvk_deps::check_or_install();
             let lib_name = "libvulkan.1.dylib";
             match env::var_os("VULKAN_LIB_PATH") {

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -28,7 +28,8 @@ use std::mem;
 use std::ops::Deref;
 use std::os::raw::c_char;
 use std::os::raw::c_void;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::env;
 
 use SafeDeref;
 use vk;
@@ -189,8 +190,17 @@ pub fn auto_loader()
             Path::new("libvulkan.so.1")
         }
         #[cfg(target_os = "macos")]
-        fn get_path() -> &'static Path {
-            Path::new("libvulkan.1.dylib")
+        fn get_path() -> PathBuf {
+            moltenvk_deps::check_or_install();
+            let lib_name = "libvulkan.1.dylib";
+            match env::var_os("VULKAN_LIB_PATH") {
+                Some(p) => {
+                    let p = p.into_string().expect("Failed to receive temporary vulkan sdk path");
+                    let temp_path = format!("{}/{}", p, lib_name);
+                    PathBuf::from(temp_path)
+                },
+                None => PathBuf::from(lib_name),
+            }
         }
         #[cfg(target_os = "android")]
         fn get_path() -> &'static Path {

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -194,7 +194,7 @@ pub fn auto_loader()
             // Checks if the mac dependencies are install
             // and offers to autmatically install them.
             // VULKAN_LIB_PATH needs to be passed because
-            // shared_library cannot detect temporary 
+            // shared_library cannot detect temporary
             // environment variables on macOS.
             moltenvk_deps::check_or_install();
             let lib_name = "libvulkan.1.dylib";

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -196,6 +196,7 @@ pub fn auto_loader()
             // VULKAN_LIB_PATH needs to be passed because
             // shared_library cannot detect temporary
             // environment variables on macOS.
+            #[cfg(not(test))]
             moltenvk_deps::check_or_install();
             let lib_name = "libvulkan.1.dylib";
             match env::var_os("VULKAN_LIB_PATH") {

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -70,6 +70,8 @@ extern crate shared_library;
 extern crate smallvec;
 extern crate vk_sys as vk;
 pub extern crate half;
+#[cfg(target_os = "macos")]
+extern crate moltenvk_deps;
 
 #[macro_use]
 mod tests;


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository

This PR automatically downloads and installs the latest Vulkan SDK from lunarg.
It will only do this if `VULKAN_SDK` is not set.
The sdk will be installed at `$HOME/.vulkan_sdk`
 and the following environment variables will be set in the users `.profile` or `.bash_profile`
```sh
export VULKAN_SDK=$HOME/.vulkan_sdk/macOS
export PATH=$VULKAN_SDK/bin:$PATH
export DYLD_LIBRARY_PATH=$VULKAN_SDK/lib:$DYLD_LIBRARY_PATH
export VK_ICD_FILENAMES=$VULKAN_SDK/etc/vulkan/icd.d/MoltenVK_icd.json
export VK_LAYER_PATH=$VULKAN_SDK/etc/vulkan/explicit_layer.d
```
The only thing that isn't automated is the user will get a error about failing to link the vulkan libs. This is because the changes to their profile are not automatically refreshed.
They will need to either `source ~/.profile` or `source ~/.bash_profile` or reopen their terminal after the first time they build vulkano.

If anyone knows how to automate this that would be super useful.
So far I have tried to pass the env var settings along from the build script to the lib using `cargo:rustc_env` but that only works if you are directly using Vulkano and not if it's a dependency.

One thing we could do is assume that if the env vars are not set when Vulkano is run then they must just be set to the defaults and but the user has not sourced their profile. Then just `std::env::set_var` to set them temporarily.
