### PR TITLE
Revert adding windows to CI, its not ready yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 os:
   - linux
   - osx
-  - windows
+  #- windows # Waiting on https://travis-ci.community/t/timeout-before-install-step/1502/3
 language: rust
 rust:
   - nightly


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Issue explained here: https://travis-ci.community/t/timeout-before-install-step/1502/3

CI passed for the PR because PRs don't get secrets.
But when building the master branch the existence of secrets makes travis explode :(
So I'm reverting it. 