### PR TITLE
Make buffer::sys::UnsafeBuffer::new panic if the usage parameter is empty

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -60,8 +60,8 @@ impl UnsafeBuffer {
     ///
     /// # Panic
     ///
-    /// Panics if `sparse.sparse` is false and `sparse.sparse_residency` or
-    /// `sparse.sparse_aliased` is true.
+    /// - Panics if `sparse.sparse` is false and `sparse.sparse_residency` or `sparse.sparse_aliased` is true.
+    /// - Panics if `usage` is empty.
     ///
     pub unsafe fn new<'a, I>(device: Arc<Device>, size: usize, usage: BufferUsage,
                              sharing: Sharing<I>, sparse: SparseLevel)
@@ -79,6 +79,10 @@ impl UnsafeBuffer {
         };
 
         let usage_bits = usage.to_vulkan_bits();
+
+        // Checking for empty BufferUsage.
+        assert!(usage_bits != 0,
+                "Can't create buffer with empty BufferUsage");
 
         // Checking sparse features.
         assert!(sparse.sparse || !sparse.sparse_residency,


### PR DESCRIPTION
This PR adds an assertion in buffer::sys::UnsafeBuffer::new to catch invalid usage of the Vulkan API.
It's a small addition, but it could still cause new errors so I have added a line to the changelog.
Changing the guide shouldn't be necessary.

* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
