### PR TITLE
Change AutoCommandBufferBuilder::execute_commands to accept vector of secondary command buffers 

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -1244,13 +1244,15 @@ impl<P> AutoCommandBufferBuilder<P> {
     /// **This function is unsafe for now because safety checks and synchronization are not
     /// implemented.**
     // TODO: implement correctly
-    pub unsafe fn execute_commands<C>(mut self, command_buffer: C)
+    pub unsafe fn execute_commands<C>(mut self, command_buffers: Vec<C>)
                                       -> Result<Self, ExecuteCommandsError>
         where C: CommandBuffer + Send + Sync + 'static
     {
         {
             let mut builder = self.inner.execute_commands();
-            builder.add(command_buffer);
+            for cmd_buffer in command_buffers {
+                builder.add(cmd_buffer);
+            }
             builder.submit()?;
         }
 

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -1239,7 +1239,7 @@ impl<P> AutoCommandBufferBuilder<P> {
         }
     }
 
-    /// Adds a command that executes a secondary command buffer.
+    /// Adds a command that executes anumber of secondary command buffers.
     ///
     /// **This function is unsafe for now because safety checks and synchronization are not
     /// implemented.**


### PR DESCRIPTION
* Updated documentation to reflect any user-facing changes - in this repository

This works ok, but I'd like to know what would have to be done to make this function safe.