### PR TITLE
Add .gitattributes to automatically resolve merge conflicts on changelogs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+CHANGELOG_VK_SYS.md=union
+CHANGELOG_VULKANO.md=union

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
-* [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
+* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
 * [ ] Updated documentation to reflect any user-facing changes - in this repository
 * [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.


### PR DESCRIPTION
Woah, so I just found out about this thing and it looks super useful.

http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/

Edit: ahhhh, turns out that merging via the github UI doesnt support this anyway, which explains why noone else bothers with it.
I'll still merge the PR in case thats fixed in the future and it will still help with local merges.

* [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
