### PR TITLE
Fix shader include for virtual workspaces

### DIFF
--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -290,40 +290,40 @@ pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let (path, source_code) = match input.source_kind {
         SourceKind::Src(source) => (None, source),
-		SourceKind::Path(path) => {
-			let crate_root_string = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
-			let crate_root = Path::new(&crate_root_string);
-			let source = {
-				let full_path = crate_root.join(&path);
+        SourceKind::Path(path) => {
+            let crate_root_string = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
+            let crate_root = Path::new(&crate_root_string);
+            let source = {
+                let full_path = crate_root.join(&path);
 
-				if full_path.is_file() {
-					read_file_to_string(&full_path)
-						.expect(&format!("Error reading source from {:?}", path))
-				} else {
-					panic!("File {:?} was not found; note that the path must be relative to your Cargo.toml", path);
-				}
-			};
+                if full_path.is_file() {
+                    read_file_to_string(&full_path)
+                        .expect(&format!("Error reading source from {:?}", path))
+                } else {
+                    panic!("File {:?} was not found; note that the path must be relative to your Cargo.toml", path);
+                }
+            };
 
-			// We need to take into account that `path` has to be crate-relative, but this proc macro
-			// works with paths relative to workspace, which in case of virtual workspaces
-			// is not the same as CARGO_MANIFEST_DIR
-			let path = {
-				// If this fails we have bigger problems
-				let workspace_root = Path::new(".").canonicalize().unwrap();
-				let workspace_prefix = match crate_root.strip_prefix(workspace_root) {
-					Err(_) => Path::new(""),
-					Ok(prefix) => prefix
-				};
+            // We need to take into account that `path` has to be crate-relative, but this proc macro
+            // works with paths relative to workspace, which in case of virtual workspaces
+            // is not the same as CARGO_MANIFEST_DIR
+            let path = {
+                // If this fails we have bigger problems
+                let workspace_root = Path::new(".").canonicalize().unwrap();
+                let workspace_prefix = match crate_root.strip_prefix(workspace_root) {
+                    Err(_) => Path::new(""),
+                    Ok(prefix) => prefix
+                };
 
-				let prefixed_path = workspace_prefix.join(&path);
-				match prefixed_path.to_str() {
-					None => path.clone(),
-					Some(s) => s.to_string()
-				}
-			};
+                let prefixed_path = workspace_prefix.join(&path);
+                match prefixed_path.to_str() {
+                    None => path.clone(),
+                    Some(s) => s.to_string()
+                }
+            };
 
-			(Some(path), source)
-		}
+            (Some(path), source)
+        }
     };
 
     let content = codegen::compile(path, &source_code, input.shader_kind, &input.include_directories).unwrap();

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -290,17 +290,40 @@ pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let (path, source_code) = match input.source_kind {
         SourceKind::Src(source) => (None, source),
-        SourceKind::Path(path) => (Some(path.clone()), {
-            let root = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".into());
-            let full_path = Path::new(&root).join(&path);
+		SourceKind::Path(path) => {
+			let crate_root_string = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
+			let crate_root = Path::new(&crate_root_string);
+			let source = {
+				let full_path = crate_root.join(&path);
 
-            if full_path.is_file() {
-                read_file_to_string(&full_path)
-                    .expect(&format!("Error reading source from {:?}", path))
-            } else {
-                panic!("File {:?} was not found ; note that the path must be relative to your Cargo.toml", path);
-            }
-        })
+				if full_path.is_file() {
+					read_file_to_string(&full_path)
+						.expect(&format!("Error reading source from {:?}", path))
+				} else {
+					panic!("File {:?} was not found; note that the path must be relative to your Cargo.toml", path);
+				}
+			};
+
+			// We need to take into account that `path` has to be crate-relative, but this proc macro
+			// works with paths relative to workspace, which in case of virtual workspaces
+			// is not the same as CARGO_MANIFEST_DIR
+			let path = {
+				// If this fails we have bigger problems
+				let workspace_root = Path::new(".").canonicalize().unwrap();
+				let workspace_prefix = match crate_root.strip_prefix(workspace_root) {
+					Err(_) => Path::new(""),
+					Ok(prefix) => prefix
+				};
+
+				let prefixed_path = workspace_prefix.join(&path);
+				match prefixed_path.to_str() {
+					None => path.clone(),
+					Some(s) => s.to_string()
+				}
+			};
+
+			(Some(path), source)
+		}
     };
 
     let content = codegen::compile(path, &source_code, input.shader_kind, &input.include_directories).unwrap();


### PR DESCRIPTION
Fixed proc macro `shader!` to correctly handle cases where crate root != proc macro root.

In `include_callback` function in `codegen.rs` variable `contained_within_path_raw` is used to calculate paths for relative includes. This variable is a RELATIVE path passed from the `shader` proc macro and it is relative to the crate root (as passed by the user from the `path` attribute of the macro). However, in cases where virtual workspaces are used, crate root is not the same as workspace root. This is a problem because proc macros resolve relative paths against workspace root.

I've added a fix to the `shader` macro to correctly prefix the user-passed crate-relative path into workspace-relative path for correct resolution in `include_callback`.

Also I tested this on the shader-include example (uncommented, on linux) and it didn't break anything.

Additionally, while researching this I've noticed that shader include directories (for includes with `#include <path>`) also require paths relative to the workspace root, not crate root. I don't want to make any breaking decisions but I think we should consider prefixing those as well so they are always crate-root relative, same as shader paths.

* [ ] ~~Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users~~
* [ ] ~~Updated documentation to reflect any user-facing changes - in this repository~~
* [ ] ~~Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.~~
