### PR TITLE
Shader include workspaces includes

### DIFF
--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -40,7 +40,7 @@ fn main() {
 //                ty: "compute",
 //                // We declare what directories to search for when using the `#include <...>`
 //                // syntax. Specified directories have descending priorities based on their order.
-//                include: [ "examples/src/bin/shader-include/standard-shaders" ],
+//                include: [ "src/bin/shader-include/standard-shaders" ],
 //                src: "
 //#version 450
 //// Substitutes this line with the contents of the file `common.glsl` found in one of the standard

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -290,40 +290,40 @@ pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let (path, source_code) = match input.source_kind {
         SourceKind::Src(source) => (None, source),
-		SourceKind::Path(path) => {
-			let crate_root_string = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
-			let crate_root = Path::new(&crate_root_string);
-			let source = {
-				let full_path = crate_root.join(&path);
+        SourceKind::Path(path) => {
+            let crate_root_string = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
+            let crate_root = Path::new(&crate_root_string);
+            let source = {
+                let full_path = crate_root.join(&path);
 
-				if full_path.is_file() {
-					read_file_to_string(&full_path)
-						.expect(&format!("Error reading source from {:?}", path))
-				} else {
-					panic!("File {:?} was not found; note that the path must be relative to your Cargo.toml", path);
-				}
-			};
+                if full_path.is_file() {
+                    read_file_to_string(&full_path)
+                        .expect(&format!("Error reading source from {:?}", path))
+                } else {
+                    panic!("File {:?} was not found; note that the path must be relative to your Cargo.toml", path);
+                }
+            };
 
-			// We need to take into account that `path` has to be crate-relative, but this proc macro
-			// works with paths relative to workspace, which in case of virtual workspaces
-			// is not the same as CARGO_MANIFEST_DIR
-			let path = {
-				// If this fails we have bigger problems
-				let workspace_root = Path::new(".").canonicalize().unwrap();
-				let workspace_prefix = match crate_root.strip_prefix(workspace_root) {
-					Err(_) => Path::new(""),
-					Ok(prefix) => prefix
-				};
+            // We need to take into account that `path` has to be crate-relative, but this proc macro
+            // works with paths relative to workspace, which in case of virtual workspaces
+            // is not the same as CARGO_MANIFEST_DIR
+            let path = {
+                // If this fails we have bigger problems
+                let workspace_root = Path::new(".").canonicalize().unwrap();
+                let workspace_prefix = match crate_root.strip_prefix(workspace_root) {
+                    Err(_) => Path::new(""),
+                    Ok(prefix) => prefix
+                };
 
-				let prefixed_path = workspace_prefix.join(&path);
-				match prefixed_path.to_str() {
-					None => path.clone(),
-					Some(s) => s.to_string()
-				}
-			};
+                let prefixed_path = workspace_prefix.join(&path);
+                match prefixed_path.to_str() {
+                    None => path.clone(),
+                    Some(s) => s.to_string()
+                }
+            };
 
-			(Some(path), source)
-		}
+            (Some(path), source)
+        }
     };
 
     let content = codegen::compile(path, &source_code, input.shader_kind, &input.include_directories).unwrap();

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -288,21 +288,21 @@ pub(self) fn read_file_to_string(full_path: &Path) -> IoResult<String> {
 
 /// Obtains the prefix needed for crate-relative path to become workspace-relative.
 fn get_workspace_prefix() -> PathBuf {
-	let crate_root_string = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
-	let crate_root = Path::new(&crate_root_string);
+    let crate_root_string = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
+    let crate_root = Path::new(&crate_root_string);
 
-	let workspace_root = Path::new(".").canonicalize().unwrap();
-	match crate_root.strip_prefix(workspace_root) {
-		Err(_) => Path::new("").to_path_buf(),
-		Ok(prefix) => prefix.to_path_buf()
-	}
+    let workspace_root = Path::new(".").canonicalize().unwrap();
+    match crate_root.strip_prefix(workspace_root) {
+        Err(_) => Path::new("").to_path_buf(),
+        Ok(prefix) => prefix.to_path_buf()
+    }
 }
 
 #[proc_macro]
 pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as MacroInput);
 
-	let workspace_prefix = get_workspace_prefix();
+    let workspace_prefix = get_workspace_prefix();
 
     let (path, source_code) = match input.source_kind {
         SourceKind::Src(source) => (None, source),
@@ -335,14 +335,14 @@ pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         }
     };
 
-	let mut include_directories = Vec::with_capacity(input.include_directories.len());
-	for include_directory in input.include_directories {
-		let prefixed_path = workspace_prefix.join(Path::new(&include_directory));
-		match prefixed_path.to_str() {
-			None => include_directories.push(include_directory),
-			Some(new_path) => include_directories.push(new_path.to_string())
-		};
-	}
+    let mut include_directories = Vec::with_capacity(input.include_directories.len());
+    for include_directory in input.include_directories {
+        let prefixed_path = workspace_prefix.join(Path::new(&include_directory));
+        match prefixed_path.to_str() {
+            None => include_directories.push(include_directory),
+            Some(new_path) => include_directories.push(new_path.to_string())
+        };
+    }
 
     let content = codegen::compile(path, &source_code, input.shader_kind, &include_directories).unwrap();
     codegen::reflect("Shader", content.as_binary(), input.dump).unwrap().into()

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -125,11 +125,13 @@
 //!
 //! Provides the path to the GLSL source to be compiled, relative to `Cargo.toml`.
 //! Cannot be used in conjunction with the `src` field.
+//! This path is always crate root-relative, even in virtual workspaces.
 //!
 //! ## `include: ["...", "...", ..., "..."]`
 //!
 //! Specifies the standard include directories to be searched through when using the
 //! `#include <...>` directive within a shader source.
+//! These paths are always crate root-relative, even in virtual workspaces.
 //! If `path` was specified, relative paths can also be used (`#include "..."`), without the need
 //! to specify one or more standard include directories. Relative paths are relative to the
 //! directory, which contains the source file the `#include "..."` directive is declared in.

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -290,17 +290,40 @@ pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let (path, source_code) = match input.source_kind {
         SourceKind::Src(source) => (None, source),
-        SourceKind::Path(path) => (Some(path.clone()), {
-            let root = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".into());
-            let full_path = Path::new(&root).join(&path);
+		SourceKind::Path(path) => {
+			let crate_root_string = env::var("CARGO_MANIFEST_DIR").unwrap_or(".".to_string());
+			let crate_root = Path::new(&crate_root_string);
+			let source = {
+				let full_path = crate_root.join(&path);
 
-            if full_path.is_file() {
-                read_file_to_string(&full_path)
-                    .expect(&format!("Error reading source from {:?}", path))
-            } else {
-                panic!("File {:?} was not found ; note that the path must be relative to your Cargo.toml", path);
-            }
-        })
+				if full_path.is_file() {
+					read_file_to_string(&full_path)
+						.expect(&format!("Error reading source from {:?}", path))
+				} else {
+					panic!("File {:?} was not found; note that the path must be relative to your Cargo.toml", path);
+				}
+			};
+
+			// We need to take into account that `path` has to be crate-relative, but this proc macro
+			// works with paths relative to workspace, which in case of virtual workspaces
+			// is not the same as CARGO_MANIFEST_DIR
+			let path = {
+				// If this fails we have bigger problems
+				let workspace_root = Path::new(".").canonicalize().unwrap();
+				let workspace_prefix = match crate_root.strip_prefix(workspace_root) {
+					Err(_) => Path::new(""),
+					Ok(prefix) => prefix
+				};
+
+				let prefixed_path = workspace_prefix.join(&path);
+				match prefixed_path.to_str() {
+					None => path.clone(),
+					Some(s) => s.to_string()
+				}
+			};
+
+			(Some(path), source)
+		}
     };
 
     let content = codegen::compile(path, &source_code, input.shader_kind, &input.include_directories).unwrap();


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Implemented include directories prefixing as discussed in https://github.com/vulkano-rs/vulkano/pull/1179. This PR also supersedes the mentioned PR.

This is a draft because I want to propose to also merge [this branch](https://github.com/TheEdward162/vulkano/tree/shader-include-examples/virtual-examples) (edited to work with these changes, of course) into this PR. I'm still unsure if a separate `virtual-examples` directory is a good way to go or if we maybe want to move all examples into a virtual workspace.

I think we should replace the current `shader-include` examples with my version because I think my version is cleaner, better demostrates the separation between standard and relative includes and also properly tests both cases.
