### PR TITLE
supports_transfer tell the truth

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,5 +1,6 @@
 # Unreleased (breaking)
 
+- `QueueFamily::explicitly_supports_tranfers` only returns true if `vk::QUEUE_TRANSFER_BIT` is set instead of also always returning true.  Removed `supports_transfers`.
 - Update to winit 0.19
 - Add support for `#include "..."` and `#include <...>` directives within source
   files.

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -1073,15 +1073,13 @@ impl<'a> QueueFamily<'a> {
     }
 
     /// Returns true if queues of this family can execute transfer operations.
-    ///
-    /// > **Note**: Queues that support graphics or compute operations also always support transfer
-    /// > operations. As of writing this, this function will always return true. The purpose of
-    /// > this function is to be future-proofed in case queues that don't support transfer
-    /// > operations are ever added to Vulkan.
+    /// > **Note**: While all queues that can perform graphics or compute operations can implicitly perform
+    /// > transfer operations, graphics & compute queues only optionally indicate support for tranfers.
+    /// > Many discrete cards will have one queue family that exclusively sets the VK_QUEUE_TRANSFER_BIT
+    /// > to indicate a special relationship with the DMA module and more efficient transfers.
     #[inline]
-    pub fn supports_transfers(&self) -> bool {
-        (self.flags() & vk::QUEUE_TRANSFER_BIT) != 0 || self.supports_graphics() ||
-            self.supports_compute()
+    pub fn explicitly_supports_transfers(&self) -> bool {
+        (self.flags() & vk::QUEUE_TRANSFER_BIT) != 0
     }
 
     /// Returns true if queues of this family can execute sparse resources binding operations.


### PR DESCRIPTION
The future is here.  Some graphics cards are now only setting the transfer bit on queues with some special DMA controller relationship that can perform higher speed transfers.  Let's tell the truth.

* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

https://github.com/vulkano-rs/vulkano/issues/1174