### PR TITLE
Ensure Device::active_queue_families contain no duplicates

### DIFF
--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -300,6 +300,13 @@ impl Device {
                                                   *const _
                                           });
 
+        let mut active_queue_families: SmallVec<[u32; 8]> = SmallVec::new();
+        for (queue_family, _) in output_queues.iter() {
+            if let None = active_queue_families.iter().find(|&&qf| qf == *queue_family) {
+                active_queue_families.push(*queue_family);
+            }
+        }
+
         let device =
             Arc::new(Device {
                          instance: phys.instance().clone(),
@@ -315,7 +322,7 @@ impl Device {
                              ..requested_features.clone()
                          },
                          extensions: (&extensions).into(),
-                         active_queue_families: output_queues.iter().map(|&(q, _)| q).collect(),
+                         active_queue_families,
                          allocation_count: Mutex::new(0),
                          fence_pool: Mutex::new(Vec::new()),
                          semaphore_pool: Mutex::new(Vec::new()),


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Each entry in Device::active_queue_families should be unique (as I've understood it). See for example the creation of ImmutableBuffer in Immutable::raw_impl, which will set the sharing mode to Concurrent if we have more than one (used) queue family on the device.