### PR TITLE
Shaderc version bump

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,5 +1,5 @@
 # Unreleased (breaking)
-
+- Update shaderc to 0.5.  New shaderc has improved pre-built options for libshaderc that significantly reduce package build time and are appropriate for use in CI
 - `QueueFamily::explicitly_supports_tranfers` only returns true if `vk::QUEUE_TRANSFER_BIT` is set instead of also always returning true.  Removed `supports_transfers`.
 - Update to winit 0.19
 - Add support for `#include "..."` and `#include <...>` directives within source

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Vulkano uses [shaderc-rs](https://github.com/google/shaderc-rs) for shader compi
 
 Unless you provide libshaderc, in order to build libshaderc with the shaderc-sys crate, the following tools must be installed and available on `PATH`:
 - [CMake](https://cmake.org/)
+- [Ninja](https://ninja-build.org/) Is optional except when building with MSVC.  It may speed up build time for libshaderc.
 - [Python](https://www.python.org/) (works with both Python 2.x and 3.x, on windows the executable must be named `python.exe`)
 
 These requirements can be either installed with your favourite package manager or with installers

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ To get started you are encouraged to use the following resources:
 
 ## Setup
 
-Vulkano uses [shaderc-rs](https://github.com/google/shaderc-rs) for shader compilation. In order to
-build the shaderc-rs crate the following tools must be installed and available on `PATH`:
+Vulkano uses [shaderc-rs](https://github.com/google/shaderc-rs) for shader compilation.  Refer to shaderc-rs documentation to provide a pre-built libshaderc for faster build times.
+
+Unless you provide libshaderc, in order to build libshaderc with the shaderc-sys crate, the following tools must be installed and available on `PATH`:
 - [CMake](https://cmake.org/)
 - [Python](https://www.python.org/) (works with both Python 2.x and 3.x, on windows the executable must be named `python.exe`)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ from the projects' websites. Below are some example ways to get setup.
 1. `rustup default stable-x86_64-pc-windows-msvc`
 2. Install [Build Tools for Visual Studio 2017](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017). If you have already been using this toolchain then its probably already installed.
 3.  Install [msys2](http://www.msys2.org/), following ALL of the instructions.
-4.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw-w64-x86_64-cmake mingw-w64-x86_64-python2`
+4.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw-w64-x86_64-cmake mingw-w64-x86_64-python2 mingw-w64-x86_64-ninja`
 5.  Add the msys2 mingw64 binary path to the PATH environment variable.
 
 ### Windows-gnu Specific Setup
@@ -83,7 +83,7 @@ Steps 1 and 2 are to workaround https://github.com/rust-lang/rust/issues/49078 b
 4.  Run the command: `rustup target install x86_64-pc-windows-gnu`
 5.  Install [Build Tools for Visual Studio 2017](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017). If you have already been using this toolchain then its probably already installed.
 6.  Install [msys2](http://www.msys2.org/), following ALL of the instructions.
-7.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw64/mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make mingw-w64-x86_64-python2`
+7.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw64/mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make mingw-w64-x86_64-python2 mingw-w64-x86_64-ninja`
 8.  Add the msys2 mingw64 binary path to the PATH environment variable.
 9.  Any cargo command that builds the project needs to include `--target x86_64-pc-windows-gnu` e.g. to run: `cargo run --target x86_64-pc-windows-gnu`
 

--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["rendering::graphics-api"]
 proc-macro = true
 
 [dependencies]
-shaderc = "0.3"
+shaderc = "0.5"
 syn = "0.15"
 quote = "0.6"
 proc-macro2 = "0.4"


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

```
01:59 < knappador> Can I pass a file path into a dependency via features?
02:00 < knappador> Trying to figure out how to give downstream consumers a way to configure 
                 the location of a pre-build library that's slow to compile
02:00 < viny> not really
```
Sad.

I took a look at the CI files but I think it's opaque from the perspective of Vulkano maintainers.

To enable this on a CI build:
```
cargo build SHADERC_LIB_DIR=/path/to/the/glslang/SPIRV/and/libshaderc/unless/monolithically/built/
```

I'm also waiting for [a valid pc file](https://github.com/google/shaderc/pull/581) to start hitting maintained packages to use pkg-config to pick up the system libraries more reliably.  Ubuntu has no ppa, so basically we're limited to setting `SHADERC_LIB_DIR` or building from source in CI on Ubuntu.

The API from 0.3.X was not bumped to 0.5 for any reason other than punching crates.io, so there are no anticipated breaking changes (and I will support on shaderc-sys related issues)

#1183  related, not fixed due to CI