### PR TITLE
rustc is now making use of the fact that derefencing a null pointer is UB. Remove all null dereferences

### DIFF
--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -136,7 +136,7 @@ impl AmbientLightingSystem {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2]
 }

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -148,7 +148,7 @@ impl DirectionalLightingSystem {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2]
 }

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -162,7 +162,7 @@ impl PointLightingSystem {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2]
 }

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -88,7 +88,7 @@ impl TriangleDrawSystem {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2]
 }

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -76,7 +76,7 @@ fn main() {
     };
 
 
-    #[derive(Debug, Clone)]
+    #[derive(Default, Debug, Clone)]
     struct Vertex { position: [f32; 2] }
     vulkano::impl_vertex!(Vertex, position);
 

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -44,14 +44,14 @@ use std::sync::Arc;
 // graphics pipeline, we need to define two vertex types:
 //
 // 1. `Vertex` is the vertex type that we will use to describe the triangle's geometry.
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2],
 }
 impl_vertex!(Vertex, position);
 
 // 2. `InstanceData` is the vertex type that describes the unique data per instance.
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 struct InstanceData {
     position_offset: [f32; 2],
     scale: f32,

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -178,7 +178,7 @@ void main() {
     let vs = vs::Shader::load(device.clone()).unwrap();
     let fs = fs::Shader::load(device.clone()).unwrap();
 
-    #[derive(Copy, Clone)]
+    #[derive(Default, Copy, Clone)]
     struct Vertex {
         position: [f32; 2],
     }

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -52,7 +52,7 @@ use std::fs::File;
 use std::io::Read;
 use std::sync::Arc;
 
-#[derive(Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 pub struct Vertex {
     pub position: [f32; 2],
     pub color: [f32; 3],

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -167,7 +167,7 @@ fn main() {
     };
 
     let vertex_buffer = {
-        #[derive(Debug, Clone)]
+        #[derive(Default, Debug, Clone)]
         struct Vertex { position: [f32; 2] }
         vulkano::impl_vertex!(Vertex, position);
 

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -170,7 +170,7 @@ fn main() {
 
     // We now create a buffer that will store the shape of our triangle.
     let vertex_buffer = {
-        #[derive(Debug, Clone)]
+        #[derive(Default, Debug, Clone)]
         struct Vertex { position: [f32; 2] }
         vulkano::impl_vertex!(Vertex, position);
 

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-#[derive(Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 pub struct Vertex {
     position: (f32, f32, f32)
 }
@@ -549,7 +549,7 @@ pub const VERTICES: [Vertex; 531] = [
     Vertex { position: (34.9202, 28.3457, -15.6121) }
 ];
 
-#[derive(Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 pub struct Normal {
     normal: (f32, f32, f32)
 }

--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -202,8 +202,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: i8,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{i8}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{i8}, Some(std::mem::size_of::<i8>()), mem::align_of::<Foo>());
                     },
                     (8, false) => {
                         #[repr(C)]
@@ -211,8 +210,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: u8,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{u8}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{u8}, Some(std::mem::size_of::<u8>()), mem::align_of::<Foo>());
                     },
                     (16, true) => {
                         #[repr(C)]
@@ -220,8 +218,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: i16,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{i16}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{i16}, Some(std::mem::size_of::<i16>()), mem::align_of::<Foo>());
                     },
                     (16, false) => {
                         #[repr(C)]
@@ -229,8 +226,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: u16,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{u16}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{u16}, Some(std::mem::size_of::<u16>()), mem::align_of::<Foo>());
                     },
                     (32, true) => {
                         #[repr(C)]
@@ -238,8 +234,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: i32,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{i32}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{i32}, Some(std::mem::size_of::<i32>()), mem::align_of::<Foo>());
                     },
                     (32, false) => {
                         #[repr(C)]
@@ -247,8 +242,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: u32,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{u32}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{u32}, Some(std::mem::size_of::<u32>()), mem::align_of::<Foo>());
                     },
                     (64, true) => {
                         #[repr(C)]
@@ -256,8 +250,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: i64,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{i64}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{i64}, Some(std::mem::size_of::<i64>()), mem::align_of::<Foo>());
                     },
                     (64, false) => {
                         #[repr(C)]
@@ -265,8 +258,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: u64,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{u64}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{u64}, Some(std::mem::size_of::<u64>()), mem::align_of::<Foo>());
                     },
                     _ => panic!("No Rust equivalent for an integer of width {}", width),
                 }
@@ -279,8 +271,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: f32,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{f32}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{f32}, Some(std::mem::size_of::<f32>()), mem::align_of::<Foo>());
                     },
                     64 => {
                         #[repr(C)]
@@ -288,8 +279,7 @@ pub fn type_from_id(doc: &Spirv, searched: u32) -> (TokenStream, Option<usize>, 
                             data: f64,
                             after: u8,
                         }
-                        let size = unsafe { (&(&*(0 as *const Foo)).after) as *const u8 as usize };
-                        return (quote!{f64}, Some(size), mem::align_of::<Foo>());
+                        return (quote!{f64}, Some(std::mem::size_of::<f64>()), mem::align_of::<Foo>());
                     },
                     _ => panic!("No Rust equivalent for a floating-point of width {}", width),
                 }

--- a/vulkano/src/pipeline/vertex/impl_vertex.rs
+++ b/vulkano/src/pipeline/vertex/impl_vertex.rs
@@ -27,20 +27,15 @@ macro_rules! impl_vertex {
 
                 $(
                     if name == stringify!($member) {
-                        let (ty, array_size) = unsafe {
-                            #[inline] fn f<T: VertexMember>(_: &T) -> (VertexMemberTy, usize)
-                                      { T::format() }
-                            let dummy: *const $out = ptr::null();
-                            f(&(&*dummy).$member)
-                        };
+                        let dummy = <$out>::default();
+                        #[inline] fn f<T: VertexMember>(_: &T) -> (VertexMemberTy, usize) { T::format() }
+                        let (ty, array_size) = f(&dummy.$member);
+
+                        let dummy_ptr = (&dummy) as *const _;
+                        let member_ptr = (&dummy.$member) as *const _;
 
                         return Some(VertexMemberInfo {
-                            offset: unsafe {
-                                let dummy: *const $out = ptr::null();
-                                let member = (&(&*dummy).$member) as *const _;
-                                member as usize
-                            },
-
+                            offset: member_ptr as usize - dummy_ptr as usize,
                             ty: ty,
                             array_size: array_size,
                         });


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Uh oh..
rustc is now making use of the fact that derefencing a null pointer is UB.
So we need to remove all null dereferences, of which there are surprisingly large amount of. In order to get vulkano working AT ALL on nightly and presumably soon beta + stable.

@tomaka You have a pretty good idea what is and isnt UB. Why did you write these null dereferences, is there something you needed from them that I am missing?

Fixes https://github.com/vulkano-rs/vulkano/issues/1207