### PR TITLE
Release vulkano 0.13

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -2,6 +2,12 @@
 
 *No changes as of yet.*
 
+# Version 0.13.0 (2019-07-02)
+
+This is an emergency breaking breaking change. It fixes Undefined Behaviour that was preventing the compilation of Vulkano on the latest rust nightlies.
+
+- Structs that have the `impl_struct` macro applied to them, now also need to `#[derive(Default)]`.
+
 # Version 0.12.0 (2019-05-24)
 
 - Update shaderc to 0.5.  New shaderc has improved pre-built options for libshaderc that significantly reduce package build time and are appropriate for use in CI

--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano-shaders"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2018"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
@@ -21,4 +21,4 @@ quote = "0.6"
 proc-macro2 = "0.4"
 
 [dev-dependencies]
-vulkano = { version = "0.12", path = "../vulkano" }
+vulkano = { version = "0.13", path = "../vulkano" }

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano-win"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2018"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
@@ -13,7 +13,7 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 winit = "0.19"
-vulkano = { version = "0.12.0", path = "../vulkano" }
+vulkano = { version = "0.13.0", path = "../vulkano" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = "0.13"

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Safe wrapper for the Vulkan graphics API"


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

I'll merge this tonight.
I might do a quick PR beforehand, to fix all the new `dyn` warnings that appear on nightly now.