### PR TITLE
Update crate count in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ If your change adds, removes or modifies a trait or a function, please add an en
 
 ## Structure
 
-This repository contains six libraries:
+This repository contains four libraries:
 
 - `vulkano` is the main one.
 - `vulkano-shaders` Provides the `shader!` macro for compiling glsl shaders.


### PR DESCRIPTION
I did a bit of a double take while reading the README. Last time I checked four != six ;)

Looks like commits 23709fb0117b569a8c7e35b36b929938361f1dba and b507034df7a922b52b7e63d8900e0b3df472a5ff forgot to update the total # of libraries in this repo after removing `vulkano-shader-derive` and `glsl-to-spirv`.