### PR TITLE
Remove assert that was based on bad assumption

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-*No changes as of yet.*
+- Removed faulty debug_assert in `SwapchainAcquireFuture::drop`.
 
 # Version 0.13.0 (2019-07-02)
 

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -872,24 +872,10 @@ unsafe impl<W> DeviceOwned for SwapchainAcquireFuture<W> {
 
 impl<W> Drop for SwapchainAcquireFuture<W> {
     fn drop(&mut self) {
-        if !*self.finished.get_mut() {
             if let Some(ref fence) = self.fence {
                 fence.wait(None).unwrap(); // TODO: handle error?
                 self.semaphore = None;
             }
-
-        } else {
-            // We make sure that the fence is signalled. This also silences an error from the
-            // validation layers about using a fence whose state hasn't been checked (even though
-            // we know for sure that it must've been signalled).
-            debug_assert!({
-                              let dur = Some(Duration::new(0, 0));
-                              self.fence
-                                  .as_ref()
-                                  .map(|f| f.wait(dur).is_ok())
-                                  .unwrap_or(true)
-                          });
-        }
 
         // TODO: if this future is destroyed without being presented, then eventually acquiring
         // a new image will block forever ; difficulty: hard


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* ~[ ] Updated documentation to reflect any user-facing changes - in this repository~
* ~[ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR~

This pull request addresses issue #960 

The assumption that the fence must already be signalled is incorrect. There is nothing in the Vulkan spec regarding `VkAcquireNextImageInfoKHR` that says what order the fence and semaphore are signalled in, or that they are signalled at exactly the same time from the API users perspective. 