### PR TITLE
Publish version 0.14.0.

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Version 0.14.0 (2019-08-17)
+
 - Update shaderc to 0.6. This again allows to use locally installed libraries which reduces the build-time significantly on Arch/Voidlinux (see https://github.com/google/shaderc-rs/issues/58)
 - Removed faulty debug_assert in `SwapchainAcquireFuture::drop`.
 - Compressed texture formats can now be uploaded using `ImmutableImage::from_iter`, `ImmutableImage::from_buffer`, `AutoCommandBuilder::copy_buffer_to_image_dimensions`,

--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano-shaders"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2018"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
@@ -21,7 +21,7 @@ quote = "0.6"
 proc-macro2 = "0.4"
 
 [dev-dependencies]
-vulkano = { version = "0.13", path = "../vulkano" }
+vulkano = { version = "0.14", path = "../vulkano" }
 
 [features]
 shaderc-build-from-source = ["shaderc/build-from-source"]

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano-win"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2018"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
@@ -13,7 +13,7 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 winit = "0.19"
-vulkano = { version = "0.13.0", path = "../vulkano" }
+vulkano = { version = "0.14.0", path = "../vulkano" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = "0.13"

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Safe wrapper for the Vulkan graphics API"


### PR DESCRIPTION
This is kind of a delayed emergency release to address an issue where
some Linux distributions (Arch, Void and perhaps others) are unable to
build any projects depending on vulkano-shaders due to
google/shaderc-rs#58. This is resolved in shaderc 0.6 and in turn will
be resolved in vulkano 0.14 thanks to #1226.