### PR TITLE
Replaced immediate dimensions variable to dynamic

### DIFF
--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -114,11 +114,12 @@ fn main() {
     let (texture, tex_future) = {
         let image = image::load_from_memory_with_format(include_bytes!("image_img.png"),
             ImageFormat::PNG).unwrap().to_rgba();
+        let dimensions = Dimensions::Dim2d { width: image.width(), height: image.height() };
         let image_data = image.into_raw().clone();
 
         ImmutableImage::from_iter(
             image_data.iter().cloned(),
-            Dimensions::Dim2d { width: 93, height: 93 },
+            dimensions,
             Format::R8G8B8A8Srgb,
             queue.clone()
         ).unwrap()


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

[examples/src/bin/image/main.rs#L121](https://github.com/vulkano-rs/vulkano/blob/master/examples/src/bin/image/main.rs#L121)
Dimensions::Dim2d made with immediate variables.
But I think those variables can be copied from image.
If image_img.png has modified, there is some possibility of need to changing that immediate variables.


Sorry for the ugly English. Thank you.