### PR TITLE
Prevent building a GraphicsPipeline with a NULL handle.

### DIFF
--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -73,6 +73,7 @@ pub const MAX_MEMORY_TYPES: u32 = 32;
 pub const MAX_MEMORY_HEAPS: u32 = 16;
 pub const MAX_EXTENSION_NAME_SIZE: u32 = 256;
 pub const MAX_DESCRIPTION_SIZE: u32 = 256;
+pub const NULL_HANDLE: u64 = 0;
 
 pub type PipelineCacheHeaderVersion = u32;
 pub const PIPELINE_CACHE_HEADER_VERSION_ONE: u32 = 1;

--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -1083,6 +1083,13 @@ impl<Vdef, Vs, Vss, Tcs, Tcss, Tes, Tess, Gs, Gss, Fs, Fss, Rp>
             output.assume_init()
         };
 
+        // Some drivers return `VK_SUCCESS` but provide a null handle if they
+        // fail to create the pipeline (due to invalid shaders, etc)
+        // This check ensures that we don't create an invalid `GraphicsPipeline` instance
+        if (pipeline == vk::NULL_HANDLE) {
+            panic!("vkCreateGraphicsPipelines provided a NULL handle");
+        }
+
         let (render_pass, render_pass_subpass) = self.render_pass.take().unwrap().into();
 
         Ok(GraphicsPipeline {


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

I've found that the Adreno driver on Android returns a NULL handle from `vkCreateGraphicsPipelines` if invalid shaders are passed to a pipeline (for example, shaders that exceed the limits of GPU). The current behavior of Vulkano is to ignore this and create a Vulkano `GraphicsPipeline` instance with a NULL handle, this causes lots of weird and hard to debug issues later on in the application including crashes inside the graphics driver.

This change simply adds a panic if this case is detected, so the rest of the program cannot proceed with an invalid `GraphicsPipeline`.