### PR TITLE
Make Runtime-Shader Example work for the Version 0.16

### DIFF
--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -37,7 +37,7 @@ use vulkano::pipeline::GraphicsPipeline;
 use vulkano::pipeline::shader::{GraphicsShaderType, ShaderInterfaceDef, ShaderInterfaceDefEntry, ShaderModule};
 use vulkano::pipeline::vertex::SingleBufferDefinition;
 use vulkano::pipeline::viewport::Viewport;
-use vulkano::swapchain::{AcquireError, PresentMode, SurfaceTransform, Swapchain, SwapchainCreationError, ColorSpace};
+use vulkano::swapchain::{AcquireError, PresentMode, SurfaceTransform, Swapchain, SwapchainCreationError};
 use vulkano::swapchain;
 use vulkano::sync::GpuFuture;
 use vulkano::sync;
@@ -92,7 +92,7 @@ fn main() {
         let format = caps.supported_formats[0].0;
 
         Swapchain::new(device.clone(), surface.clone(), caps.min_image_count, format, initial_dimensions,
-            1, usage, &queue, SurfaceTransform::Identity, alpha, PresentMode::Fifo, true, ColorSpace::SrgbNonLinear).unwrap()
+            1, usage, &queue, SurfaceTransform::Identity, alpha, PresentMode::Fifo, true, None).unwrap()
     };
 
     let render_pass = Arc::new(vulkano::single_pass_renderpass!(


### PR DESCRIPTION
I was testing the example and saw that the Swapchain Constructor dont need a Colorspace as an Parameter only an old Swapchain so i fixed that
