### PR TITLE
I added a from_cstrings method on RawInstanceExtensions to...

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Added RawInstanceExtensions::from_cstrings(Vec<CString>) - which allows for easier integration with windowing api's like glfw
 - Added Swapchain::surface() - which returns the saved surface
 - Added Swapchain::with_old_swapchain() - same as previous Swapchain::new(), if an oldswapchain needs to be used
 - Swapchain::new() now doesnt need to have the old_swapchain parameter anymore but requires the ColorSpace

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -160,7 +160,7 @@ instance_extensions! {
     ext_swapchain_colorspace => b"VK_EXT_swapchain_colorspace",
     khr_get_physical_device_properties2 => b"VK_KHR_get_physical_device_properties2",
 }
-
+/*
 impl RawInstanceExtensions{
 
     /*
@@ -178,7 +178,7 @@ impl RawInstanceExtensions{
         let x: HashSet<CString> = victim.drain(..).collect();
         return x;
     }
-}
+}*/
 
 /// This helper type can only be instantiated inside this module.
 /// See `*Extensions::_unbuildable`.

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -161,6 +161,25 @@ instance_extensions! {
     khr_get_physical_device_properties2 => b"VK_KHR_get_physical_device_properties2",
 }
 
+impl RawInstanceExtensions{
+
+    /*
+    Takes a Vector of CStrings and converts it into a RawInstanceExtensions object that represents all of the instance extensions in the Vector.
+    Notice, this function is unsafe because passing in non valid Vulkan Extension names will result in undefined behaviour.
+
+    This function should be use for easier integration with windowing api's such as glfw that provide required extensions based on platform through a function.
+    */
+    pub unsafe fn from_cstrings(strs:Vec<CString>) -> RawInstanceExtensions{
+        RawInstanceExtensions{0:RawInstanceExtensions::vec_to_set(strs)}
+    }
+
+    fn vec_to_set(vec: Vec<CString>) -> HashSet<CString> {
+        let mut victim = vec.clone();
+        let x: HashSet<CString> = victim.drain(..).collect();
+        return x;
+    }
+}
+
 /// This helper type can only be instantiated inside this module.
 /// See `*Extensions::_unbuildable`.
 #[doc(hidden)]

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -160,7 +160,7 @@ instance_extensions! {
     ext_swapchain_colorspace => b"VK_EXT_swapchain_colorspace",
     khr_get_physical_device_properties2 => b"VK_KHR_get_physical_device_properties2",
 }
-/*
+
 impl RawInstanceExtensions{
 
     /*
@@ -178,7 +178,7 @@ impl RawInstanceExtensions{
         let x: HashSet<CString> = victim.drain(..).collect();
         return x;
     }
-}*/
+}
 
 /// This helper type can only be instantiated inside this module.
 /// See `*Extensions::_unbuildable`.


### PR DESCRIPTION
...ease integration with windowing api's. My current solution to integrate glfw in my project has been to create my own RawInstanceExtensions struct and transmuting it to a vulkano RawInstanceExtensions. This solution is very ugly so I added the helper function and some documentation in the code. 

The function is unsafe to make it clear to the user that they need to be careful while using it. I know Vulkano is about creating a safe api but this should be unsafe since misuse could cause odd behaviour.