### PR TITLE
Stop Join Future from doing the same submit multiple times.

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -14,6 +14,7 @@
 - Added Swapchain::surface() - which returns the saved surface
 - Propogate new lines correctly in shader compile errors.
 - `Queue` and `QueueFamily` now implement `PartialEq` and `Eq`
+- Fixed Join Future implementation to not submit joined command buffers twice.
 
 # Version 0.16.0 (2019-11-01)
 


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

The implementation of `build_submission `in JoinFuture called queue submits of joined futures directly. Since the `build_submission` contract allows it to be called mutiple times that could lead to submits being duplicated. Amongst others this leads to vulkan validation layer errors as seen in #1294, which should be fixed with this.

This fix replaces the direct submit calls by a flush of the appropriate joined futures. This is similar to the approach taken in `PresentFuture` and as far as I can tell is in line with the contracts of `build_submission` and `flush`. I ran all tests and examples to do some basic validation and saw no issues.