### PR TITLE
Add 's' to dimension in Swapchain::recreate_with_dimension

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,5 +1,6 @@
 # Version 0.17.0 (TBA)
 
+- **Breaking** Swapchain::recreate_with_dimension() is now Swapchain::recreate_with_dimensions()
 - **Breaking** Sync::SharingMode::Exclusive(queue_family: u32) is now Sync::SharingMode::Exclusive.
 - **Breaking** Added Swapchain::with_old_swapchain() - same as previous Swapchain::new(), if an oldswapchain needs to be used
 - **Breaking** Swapchain::new() now doesnt need to have the old_swapchain parameter anymore but requires the ColorSpace

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -101,7 +101,7 @@ fn main() {
 
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e)

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -162,7 +162,7 @@ fn main() {
 
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e)

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -219,7 +219,7 @@ fn main() {
 
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e)

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -208,7 +208,7 @@ fn main() {
 
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e)

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -216,7 +216,7 @@ fn main() {
 
                 if *recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e)

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -396,7 +396,7 @@ fn main() {
 
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e)

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -130,7 +130,7 @@ fn main() {
 
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e)

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -238,7 +238,7 @@ fn main() {
 
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e)

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -324,7 +324,7 @@ fn main() {
                 if recreate_swapchain {
                     // Get the new dimensions of the window.
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
-                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimension(dimensions) {
+                    let (new_swapchain, new_images) = match swapchain.recreate_with_dimensions(dimensions) {
                         Ok(r) => r,
                         // This error tends to happen when the user is manually resizing the window.
                         // Simply restarting the loop is the easiest way to fix this issue.

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -276,7 +276,7 @@
 //!
 //! loop {
 //!     if recreate_swapchain {
-//!         swapchain = swapchain.0.recreate_with_dimension([1024, 768]).unwrap();
+//!         swapchain = swapchain.0.recreate_with_dimensions([1024, 768]).unwrap();
 //!         recreate_swapchain = false;
 //!     }
 //!

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -295,7 +295,7 @@ impl <W> Swapchain<W> {
     }
 
     /// Recreates the swapchain with new dimensions.
-    pub fn recreate_with_dimension(
+    pub fn recreate_with_dimensions(
         &self, dimensions: [u32; 2])
         -> Result<(Arc<Swapchain<W>>, Vec<Arc<SwapchainImage<W>>>), SwapchainCreationError> {
         Swapchain::new_inner(self.device.clone(),


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Little nitpick, but the best place to fix typos like these is in major releases which are already going to break code by themselves.
