### PR TITLE
Add VertexMember implementations for cgmath types

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -5,6 +5,8 @@
 - **Breaking** Update dependency `winit` 0.21 -> 0.22
 - Update dependency `half` 1.4 -> 1.5
 - Update dependency `smallvec` 0.6 -> 1.2
+- Add an optional feature, `cgmath-vertex` (which requires cgmath 0.17), which allows common cgmath types to be used inside vertex data definitions
+    + Types supported: `Basis`, `Deg`, `Point`, `Quaternion`, `Rad`, `Vector`, `Matrix`
 
 # Version 0.17.0 (2020-02-09)
 

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -14,9 +14,13 @@ build = "build.rs"
 
 [dependencies]
 crossbeam = "0.7"
+cgmath = { version = "0.17", optional = true }
 fnv = "1.0"
 shared_library = "0.1"
 smallvec = "1.2"
 lazy_static = "1.4"
 vk-sys = { version = "0.5.1", path = "../vk-sys" }
 half = "1.5"
+
+[features]
+cgmath-vertex = ["cgmath"]

--- a/vulkano/src/pipeline/vertex/impl_vertex.rs
+++ b/vulkano/src/pipeline/vertex/impl_vertex.rs
@@ -192,3 +192,166 @@ impl_vm_array!(15);
 impl_vm_array!(16);
 impl_vm_array!(32);
 impl_vm_array!(64);
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Basis2<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        <cgmath::Matrix2<T> as VertexMember>::format()
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Basis3<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        <cgmath::Matrix3<T> as VertexMember>::format()
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Deg<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Matrix2<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <cgmath::Vector2<T> as VertexMember>::format();
+        (ty, sz * 2)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Matrix3<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <cgmath::Vector3<T> as VertexMember>::format();
+        (ty, sz * 3)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Matrix4<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <cgmath::Vector4<T> as VertexMember>::format();
+        (ty, sz * 4)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Point1<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Point2<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 2)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Point3<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 3)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Quaternion<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 4)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Rad<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Vector1<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Vector2<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 2)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Vector3<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 3)
+    }
+}
+
+#[cfg(feature = "cgmath-vertex")]
+unsafe impl<T> VertexMember for cgmath::Vector4<T>
+    where T: VertexMember
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 4)
+    }
+}


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

Still very WIP, it fulfills the same needs of #1133. I've implemented it only for cgmath because it's what I'm using currently, but I'd have no problem extending this to, for example, nalgebra types.

The former PR replaces vertex members of the examples with types from cgmath. I think they should be self-contained, and should run without more external dependencies, so I kept them as-is.
