### PR TITLE
Add vulkano-derive with custom derive for Vertex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "examples",
     "vk-sys",
     "vulkano",
+    "vulkano-derive",
     "vulkano-shaders",
     "vulkano-win"
 ]

--- a/vulkano-derive/Cargo.toml
+++ b/vulkano-derive/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "vulkano-derive"
+version = "0.17.0"
+edition = "2018"
+authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
+repository = "https://github.com/vulkano-rs/vulkano"
+description = "Custom derive for vulkano traits"
+license = "MIT/Apache-2.0"
+documentation = "https://docs.rs/vulkano"
+homepage = "https://vulkano.rs"
+keywords = ["vulkan", "bindings", "graphics", "gpu", "rendering"]
+categories = ["rendering::graphics-api"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+syn = "1.0"

--- a/vulkano-derive/src/lib.rs
+++ b/vulkano-derive/src/lib.rs
@@ -17,6 +17,7 @@ pub fn vertex_macro_derive(input: TokenStream) -> TokenStream {
     };
 
     let member = fields.iter().map(|field| &field.ident);
+    let ty = fields.iter().map(|field| &field.ty);
     let name = &ast.ident;
 
     let output = quote! {
@@ -36,12 +37,7 @@ pub fn vertex_macro_derive(input: TokenStream) -> TokenStream {
                 #(
                     if name == stringify!(#member) {
                         let dummy = <#name>::default();
-                        #[inline] fn f<T: VertexMember>(_: &T)
-                        -> (VertexMemberTy, usize) {
-                            T::format()
-                        }
-
-                        let (ty, array_size) = f(&dummy.#member);
+                        let (ty, array_size) = <#ty>::format();
                         let dummy_ptr = (&dummy) as *const _;
                         let member_ptr = (&dummy.#member) as *const _;
 

--- a/vulkano-derive/src/lib.rs
+++ b/vulkano-derive/src/lib.rs
@@ -1,0 +1,62 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DataStruct, DeriveInput, Fields};
+
+#[proc_macro_derive(Vertex)]
+pub fn vertex_macro_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse_macro_input!(input as DeriveInput);
+
+    let fields = match &ast.data {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(fields),
+            ..
+        }) => &fields.named,
+        _ => panic!("expected struct with named fields"),
+    };
+
+    let member = fields.iter().map(|field| &field.ident);
+    let name = &ast.ident;
+
+    let output = quote! {
+        #[allow(unsafe_code)]
+        unsafe impl ::vulkano::pipeline::vertex::Vertex for #name {
+            #[inline(always)]
+            fn member(name: &str)
+            -> Option<::vulkano::pipeline::vertex::VertexMemberInfo> {
+                use std::ptr;
+
+                #[allow(unused_imports)]
+                use ::vulkano::format::Format;
+                use ::vulkano::pipeline::vertex::VertexMemberInfo;
+                use ::vulkano::pipeline::vertex::VertexMemberTy;
+                use ::vulkano::pipeline::vertex::VertexMember;
+
+                #(
+                    if name == stringify!(#member) {
+                        let dummy = <#name>::default();
+                        #[inline] fn f<T: VertexMember>(_: &T)
+                        -> (VertexMemberTy, usize) {
+                            T::format()
+                        }
+
+                        let (ty, array_size) = f(&dummy.#member);
+                        let dummy_ptr = (&dummy) as *const _;
+                        let member_ptr = (&dummy.#member) as *const _;
+
+                        return Some(VertexMemberInfo {
+                            offset: member_ptr as usize - dummy_ptr as usize,
+                            ty: ty,
+                            array_size: array_size,
+                        })
+                    }
+                )*
+
+                None
+            }
+        }
+    };
+
+    output.into()
+}


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

WIP. Currently it does the same as `impl_vertex!` but as a derive macro. There is a lot of room left to improve the code, and even use features only available to procedural macros.