### PR TITLE
Fix an `abort()` in the tests.

### DIFF
--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -867,14 +867,12 @@ impl<'a> PhysicalDevice<'a> {
 
     /// Returns the human-readable name of the device.
     #[inline]
-    pub fn name(&self) -> String {
-        // FIXME: for some reason this panics if you use a `&str`
+    pub fn name(&self) -> &str {
         unsafe {
-            let val = self.infos().properties.deviceName;
+            let val = &self.infos().properties.deviceName;
             let val = CStr::from_ptr(val.as_ptr());
             val.to_str()
                 .expect("physical device name contained non-UTF8 characters")
-                .to_owned()
         }
     }
 

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -91,11 +91,11 @@ impl DeviceMemory {
         );
 
         // Note: This check is disabled because MoltenVK doesn't report correct heap sizes yet.
-        // More generally, whether or not this check is useful is questionable.
-        // TODO: ^
-        /*if size > memory_type.heap().size() {
-            return Err(OomError::OutOfDeviceMemory);
-        }*/
+        // This check was re-enabled because Mesa aborts if `size` is Very Large.
+        let reported_heap_size = memory_type.heap().size();
+        if reported_heap_size != 0 && size > reported_heap_size {
+            return Err(DeviceMemoryAllocError::OomError(OomError::OutOfDeviceMemory));
+        }
 
         let memory = unsafe {
             let physical_device = device.physical_device();


### PR DESCRIPTION
Not sure how widespread this issue is, I'm on Mesa 20.0 currently. I've re-enabled a heap size check for RADV only because MoltenVK apparently has an issue with the reported heap sizes.