### PR TITLE
Added a .boxed() function to GpuFuture to reduce boilerplate code

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -4,6 +4,7 @@
 - `dynamic-local-size` compute shader example added showing how to utilize `subgroupSize` to compute and set shader's local size in run time.
 - Fixed Vulkano Shaders bug when compute shader local group layout values bound to specialization constants. Now it is possible to define the layout in form of `layout(local_size_x_id = 12, local_size_y_id = 13, local_size_z = 1) in;` and then set the values as `SpecializationConstants {constant_12: 8, constant_13: 4, ...}`.
 - Allow applications to access the instance and device pointers
+- Add a helper function '.boxed()' on the `GpuFuture` that is short for `Box::new(yourFuture) as Box<dyn GpuFuture>`
 
 # Version 0.18.0 (2020-03-11)
 

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -189,7 +189,7 @@ fn main() {
     let mut framebuffers =
         window_size_dependent_setup(&images, render_pass.clone(), &mut dynamic_state);
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
     event_loop.run(move |event, _, control_flow| {
         match event {

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -113,7 +113,7 @@ fn main() {
         TriangleDrawSystem::new(queue.clone(), frame_system.deferred_subpass());
 
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {
@@ -189,15 +189,15 @@ fn main() {
 
             match future {
                 Ok(future) => {
-                    previous_frame_end = Some(Box::new(future) as Box<_>);
+                    previous_frame_end = Some(future.boxed());
                 }
                 Err(FlushError::OutOfDate) => {
                     recreate_swapchain = true;
-                    previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
                 Err(e) => {
                     println!("Failed to flush future: {:?}", e);
-                    previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
             }
         }

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -220,7 +220,7 @@ fn main() {
         window_size_dependent_setup(&images, render_pass.clone(), &mut dynamic_state);
 
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(Box::new(tex_future) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(tex_future.boxed());
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {
@@ -300,15 +300,15 @@ fn main() {
 
             match future {
                 Ok(future) => {
-                    previous_frame_end = Some(Box::new(future) as Box<_>);
+                    previous_frame_end = Some(future.boxed());
                 }
                 Err(FlushError::OutOfDate) => {
                     recreate_swapchain = true;
-                    previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
                 Err(e) => {
                     println!("Failed to flush future: {:?}", e);
-                    previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
             }
         }

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -252,7 +252,7 @@ fn main() {
     let mut framebuffers =
         window_size_dependent_setup(&images, render_pass.clone(), &mut dynamic_state);
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
     event_loop.run(move |event, _, control_flow| {
         match event {
@@ -377,15 +377,15 @@ fn main() {
 
                 match future {
                     Ok(future) => {
-                        previous_frame_end = Some(Box::new(future) as Box<_>);
+                        previous_frame_end = Some(future.boxed());
                     }
                     Err(FlushError::OutOfDate) => {
                         recreate_swapchain = true;
-                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                     Err(e) => {
                         println!("Failed to flush future: {:?}", e);
-                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                 }
             }

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -260,7 +260,7 @@ fn main() {
     let mut framebuffers =
         window_size_dependent_setup(&images, render_pass.clone(), &mut dynamic_state);
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
     event_loop.run(move |event, _, control_flow| {
         match event {
@@ -345,15 +345,15 @@ fn main() {
 
                 match future {
                     Ok(future) => {
-                        previous_frame_end = Some(Box::new(future) as Box<_>);
+                        previous_frame_end = Some(future.boxed());
                     }
                     Err(FlushError::OutOfDate) => {
                         recreate_swapchain = true;
-                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                     Err(e) => {
                         println!("Failed to flush future: {:?}", e);
-                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                 }
             }

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -237,7 +237,7 @@ fn main() {
                 render_pass.clone(),
                 &mut dynamic_state,
             ),
-            previous_frame_end: Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>),
+            previous_frame_end: Some(sync::now(device.clone()).boxed()),
         },
     );
 
@@ -314,9 +314,7 @@ fn main() {
                         render_pass.clone(),
                         &mut dynamic_state,
                     ),
-                    previous_frame_end: Some(
-                        Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>
-                    ),
+                    previous_frame_end: Some(sync::now(device.clone()).boxed()),
                 },
             );
         }
@@ -399,15 +397,15 @@ fn main() {
 
             match future {
                 Ok(future) => {
-                    *previous_frame_end = Some(Box::new(future) as Box<_>);
+                    *previous_frame_end = Some(future.boxed());
                 }
                 Err(FlushError::OutOfDate) => {
                     *recreate_swapchain = true;
-                    *previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    *previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
                 Err(e) => {
                     println!("Failed to flush future: {:?}", e);
-                    *previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    *previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
             }
         }

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -467,7 +467,7 @@ fn main() {
     };
     let mut framebuffers =
         window_size_dependent_setup(&images, render_pass.clone(), &mut dynamic_state);
-    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {
@@ -546,15 +546,15 @@ fn main() {
 
             match future {
                 Ok(future) => {
-                    previous_frame_end = Some(Box::new(future) as Box<_>);
+                    previous_frame_end = Some(future.boxed());
                 }
                 Err(FlushError::OutOfDate) => {
                     recreate_swapchain = true;
-                    previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
                 Err(e) => {
                     println!("Failed to flush future: {:?}", e);
-                    previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
             }
         }

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -152,7 +152,7 @@ fn main() {
         window_size_dependent_setup(device.clone(), &vs, &fs, &images, render_pass.clone());
     let mut recreate_swapchain = false;
 
-    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
     let rotation_start = Instant::now();
 
     event_loop.run(move |event, _, control_flow| {
@@ -284,15 +284,15 @@ fn main() {
 
                 match future {
                     Ok(future) => {
-                        previous_frame_end = Some(Box::new(future) as Box<_>);
+                        previous_frame_end = Some(future.boxed());
                     }
                     Err(FlushError::OutOfDate) => {
                         recreate_swapchain = true;
-                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                     Err(e) => {
                         println!("Failed to flush future: {:?}", e);
-                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                 }
             }

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -286,7 +286,7 @@ fn main() {
     );
 
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
     let mut dynamic_state = DynamicState {
         line_width: None,
         viewports: None,
@@ -379,15 +379,15 @@ fn main() {
 
             match future {
                 Ok(future) => {
-                    previous_frame_end = Some(Box::new(future) as Box<_>);
+                    previous_frame_end = Some(future.boxed());
                 }
                 Err(FlushError::OutOfDate) => {
                     recreate_swapchain = true;
-                    previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
                 Err(e) => {
                     println!("Failed to flush future: {:?}", e);
-                    previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }
             }
         }

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -364,7 +364,7 @@ fn main() {
     //
     // Destroying the `GpuFuture` blocks until the GPU is finished executing it. In order to avoid
     // that, we store the submission of the previous frame here.
-    let mut previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<dyn GpuFuture>);
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
     event_loop.run(move |event, _, control_flow| {
         match event {
@@ -500,15 +500,15 @@ fn main() {
 
                 match future {
                     Ok(future) => {
-                        previous_frame_end = Some(Box::new(future) as Box<_>);
+                        previous_frame_end = Some(future.boxed());
                     }
                     Err(FlushError::OutOfDate) => {
                         recreate_swapchain = true;
-                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                     Err(e) => {
                         println!("Failed to flush future: {:?}", e);
-                        previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
+                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                 }
             }

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -283,6 +283,16 @@ pub unsafe trait GpuFuture: DeviceOwned {
     {
         swapchain::present_incremental(swapchain, self, queue, image_index, present_region)
     }
+
+    /// Turn the current future into a `Box<dyn GpuFuture>`.
+    ///
+    /// This is a helper function that calls `Box::new(yourFuture) as Box<dyn GpuFuture>`.
+    fn boxed(self) -> Box<dyn GpuFuture>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self) as _
+    }
 }
 
 unsafe impl<F: ?Sized> GpuFuture for Box<F>


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.

( I'll update the documentation if this is going to land. )

A simple helper function, akin to [Future::boxed()](https://docs.rs/futures/0.3.5/futures/future/trait.FutureExt.html#method.boxed) that reduces the need for boilerplate code for the developer to write.

```rust
let fut: NowFuture = vulkano::sync::now(device.clone());
// old:
let fut: Box<dyn GpuFuture> = Box::new(fut) as Box<dyn GpuFuture>;
// new:
let fut: Box<dyn GpuFuture> = fut.boxed();
```

One issue I could not figure out or solve is that currently you can chain the function this way:
```rust
let fut: NowFuture = vulkano::sync::now(device.clone());
let fut: Box<NowFuture> = Box::new(fut);
let fut: Box<dyn GpuFuture> = fut.boxed();
````
Where the last future might be a `Box<Box<NowFuture>>`. I'm not sure how Rust handles this internally.

I tried adding an implementation to `impl GpuFuture for Box<F> where F: GpuFuture` that returns `self` but I could not get Rust to operate
