### PR TITLE
Ran rustfmt and added a check to .travis.yml

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
 * [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
 * [ ] Updated documentation to reflect any user-facing changes - in this repository
 * [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
+* [ ] Ran `cargo fmt` on the changes

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,10 @@ before_cache:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install ninja; choco install python3 --params "/InstallAllUsers"; fi
 
-before_script:
-  - if [[ "$TRAVIS_RUST_VERSION" == "stable" ]]; then rustup component add rustfmt; fi
-
 script:
   - git diff-tree --check $(git hash-object -t tree /dev/null) HEAD
   - travis_wait 30 cargo build -j 2 --all
   - travis_wait 30 cargo test -j 2 --all
-  - if [[ "$TRAVIS_RUST_VERSION" == "stable" ]]; then cargo fmt --all -- --check; fi
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,14 @@ before_cache:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install ninja; choco install python3 --params "/InstallAllUsers"; fi
 
+before_script:
+  - if [[ "$TRAVIS_RUST_VERSION" == "stable" ]]; then rustup component add rustfmt; fi
+
 script:
   - git diff-tree --check $(git hash-object -t tree /dev/null) HEAD
   - travis_wait 30 cargo build -j 2 --all
   - travis_wait 30 cargo test -j 2 --all
+  - if [[ "$TRAVIS_RUST_VERSION" == "stable" ]]; then cargo fmt --all -- --check; fi
 
 after_success:
   - |

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -26,6 +26,7 @@
 // drawn after the lighting, and that the whole process consumes more memory.
 
 use vulkano::device::{Device, DeviceExtensions};
+use vulkano::image::ImageUsage;
 use vulkano::instance::{Instance, PhysicalDevice};
 use vulkano::swapchain;
 use vulkano::swapchain::{
@@ -34,7 +35,6 @@ use vulkano::swapchain::{
 };
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
-use vulkano::image::ImageUsage;
 
 use vulkano_win::VkSurfaceBuild;
 use winit::event::{Event, WindowEvent};

--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -1569,9 +1569,9 @@ pub struct ImageCreateInfo {
 
 #[repr(C)]
 pub struct BufferDeviceAddressInfo {
-  pub sType: StructureType,
-  pub pNext: *const c_void,
-  pub buffer: Buffer,
+    pub sType: StructureType,
+    pub pNext: *const c_void,
+    pub buffer: Buffer,
 }
 
 #[repr(C)]
@@ -2560,11 +2560,11 @@ pub struct PhysicalDeviceSparseImageFormatInfo2KHR {
 
 #[repr(C)]
 pub struct PhysicalDeviceBufferAddressFeaturesEXT {
-  pub sType: StructureType,
-  pub pNext: *const c_void,
-  pub bufferDeviceAddress: Bool32,
-  pub bufferDeviceAddressCaptureReplay: Bool32,
-  pub bufferDeviceAddressMultiDevice: Bool32,
+    pub sType: StructureType,
+    pub pNext: *const c_void,
+    pub bufferDeviceAddress: Bool32,
+    pub bufferDeviceAddressCaptureReplay: Bool32,
+    pub bufferDeviceAddressMultiDevice: Bool32,
 }
 
 pub type ViSurfaceCreateFlagsNN = Flags;

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -103,10 +103,14 @@ impl error::Error for CreationError {
 impl fmt::Display for CreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CreationError::SurfaceCreationError(_) => "error while creating the surface",
-            CreationError::WindowCreationError(_) => "error while creating the window",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CreationError::SurfaceCreationError(_) => "error while creating the surface",
+                CreationError::WindowCreationError(_) => "error while creating the window",
+            }
+        )
     }
 }
 

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -572,14 +572,18 @@ impl error::Error for ReadLockError {}
 impl fmt::Display for ReadLockError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            ReadLockError::CpuWriteLocked => {
-                "the buffer is already locked for write mode by the CPU"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                ReadLockError::CpuWriteLocked => {
+                    "the buffer is already locked for write mode by the CPU"
+                }
+                ReadLockError::GpuWriteLocked => {
+                    "the buffer is already locked for write mode by the GPU"
+                }
             }
-            ReadLockError::GpuWriteLocked => {
-                "the buffer is already locked for write mode by the GPU"
-            }
-        })
+        )
     }
 }
 
@@ -636,10 +640,14 @@ impl error::Error for WriteLockError {}
 impl fmt::Display for WriteLockError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            WriteLockError::CpuLocked => "the buffer is already locked by the CPU",
-            WriteLockError::GpuLocked => "the buffer is already locked by the GPU",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                WriteLockError::CpuLocked => "the buffer is already locked by the CPU",
+                WriteLockError::GpuLocked => "the buffer is already locked by the GPU",
+            }
+        )
     }
 }
 

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -431,7 +431,7 @@ impl SparseLevel {
 /// The device address usage flag was not set.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DeviceAddressUsageNotEnabledError;
-impl error::Error for DeviceAddressUsageNotEnabledError { }
+impl error::Error for DeviceAddressUsageNotEnabledError {}
 impl fmt::Display for DeviceAddressUsageNotEnabledError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -467,21 +467,25 @@ impl error::Error for BufferCreationError {
 impl fmt::Display for BufferCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            BufferCreationError::AllocError(_) => "allocating memory failed",
-            BufferCreationError::SparseBindingFeatureNotEnabled => {
-                "sparse binding was requested but the corresponding feature wasn't enabled"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                BufferCreationError::AllocError(_) => "allocating memory failed",
+                BufferCreationError::SparseBindingFeatureNotEnabled => {
+                    "sparse binding was requested but the corresponding feature wasn't enabled"
+                }
+                BufferCreationError::SparseResidencyBufferFeatureNotEnabled => {
+                    "sparse residency was requested but the corresponding feature wasn't enabled"
+                }
+                BufferCreationError::SparseResidencyAliasedFeatureNotEnabled => {
+                    "sparse aliasing was requested but the corresponding feature wasn't enabled"
+                }
+                BufferCreationError::DeviceAddressFeatureNotEnabled => {
+                    "device address was requested but the corresponding feature wasn't enabled"
+                }
             }
-            BufferCreationError::SparseResidencyBufferFeatureNotEnabled => {
-                "sparse residency was requested but the corresponding feature wasn't enabled"
-            }
-            BufferCreationError::SparseResidencyAliasedFeatureNotEnabled => {
-                "sparse aliasing was requested but the corresponding feature wasn't enabled"
-            }
-            BufferCreationError::DeviceAddressFeatureNotEnabled => {
-                "device address was requested but the corresponding feature wasn't enabled"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -13,7 +13,7 @@ use std::num::NonZeroU64;
 use std::ops::Range;
 use std::ptr;
 
-use buffer::sys::{UnsafeBuffer, DeviceAddressUsageNotEnabledError};
+use buffer::sys::{DeviceAddressUsageNotEnabledError, UnsafeBuffer};
 use buffer::BufferSlice;
 use device::DeviceOwned;
 use device::Queue;
@@ -21,7 +21,7 @@ use image::ImageAccess;
 use memory::Content;
 use sync::AccessError;
 
-use ::{SafeDeref, VulkanObject, vk};
+use {vk, SafeDeref, VulkanObject};
 
 /// Trait for objects that represent a way for the GPU to have access to a buffer or a slice of a
 /// buffer.
@@ -166,9 +166,9 @@ pub unsafe trait BufferAccess: DeviceOwned {
                 pNext: ptr::null(),
                 buffer: inner.buffer.internal_object(),
             };
-            let ptr = dev.pointers()
-              .GetBufferDeviceAddressEXT(dev.internal_object(),
-                                         &info);
+            let ptr = dev
+                .pointers()
+                .GetBufferDeviceAddressEXT(dev.internal_object(), &info);
 
             if ptr == 0 {
                 panic!("got null ptr from a valid GetBufferDeviceAddressEXT call");

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -327,22 +327,26 @@ impl error::Error for BufferViewCreationError {
 impl fmt::Display for BufferViewCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            BufferViewCreationError::OomError(_) => "out of memory when creating buffer view",
-            BufferViewCreationError::WrongBufferUsage => {
-                "the buffer is missing correct usage flags"
-            }
-            BufferViewCreationError::WrongBufferAlignment => {
-                "the offset within the buffer is not a multiple of the
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                BufferViewCreationError::OomError(_) => "out of memory when creating buffer view",
+                BufferViewCreationError::WrongBufferUsage => {
+                    "the buffer is missing correct usage flags"
+                }
+                BufferViewCreationError::WrongBufferAlignment => {
+                    "the offset within the buffer is not a multiple of the
                  `min_texel_buffer_offset_alignment` limit"
+                }
+                BufferViewCreationError::UnsupportedFormat => {
+                    "the requested format is not supported for this usage"
+                }
+                BufferViewCreationError::MaxTexelBufferElementsExceeded => {
+                    "the maximum number of texel elements is exceeded"
+                }
             }
-            BufferViewCreationError::UnsupportedFormat => {
-                "the requested format is not supported for this usage"
-            }
-            BufferViewCreationError::MaxTexelBufferElementsExceeded => {
-                "the maximum number of texel elements is exceeded"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -312,11 +312,15 @@ impl error::Error for CommandPoolTrimError {}
 impl fmt::Display for CommandPoolTrimError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CommandPoolTrimError::Maintenance1ExtensionNotEnabled => {
-                "the `KHR_maintenance1` extension was not enabled"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CommandPoolTrimError::Maintenance1ExtensionNotEnabled => {
+                    "the `KHR_maintenance1` extension was not enabled"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/submit/bind_sparse.rs
+++ b/vulkano/src/command_buffer/submit/bind_sparse.rs
@@ -491,10 +491,14 @@ impl error::Error for SubmitBindSparseError {
 impl fmt::Display for SubmitBindSparseError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            SubmitBindSparseError::OomError(_) => "not enough memory",
-            SubmitBindSparseError::DeviceLost => "the connection to the device has been lost",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                SubmitBindSparseError::OomError(_) => "not enough memory",
+                SubmitBindSparseError::DeviceLost => "the connection to the device has been lost",
+            }
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/submit/queue_present.rs
+++ b/vulkano/src/command_buffer/submit/queue_present.rs
@@ -235,15 +235,20 @@ impl error::Error for SubmitPresentError {
 impl fmt::Display for SubmitPresentError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            SubmitPresentError::OomError(_) => "not enough memory",
-            SubmitPresentError::DeviceLost => "the connection to the device has been lost",
-            SubmitPresentError::SurfaceLost => "the surface of this swapchain is no longer valid",
-            SubmitPresentError::OutOfDate => "the swapchain needs to be recreated",
-            SubmitPresentError::FullscreenExclusiveLost => {
-                "the swapchain no longer has fullscreen exclusivity"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                SubmitPresentError::OomError(_) => "not enough memory",
+                SubmitPresentError::DeviceLost => "the connection to the device has been lost",
+                SubmitPresentError::SurfaceLost =>
+                    "the surface of this swapchain is no longer valid",
+                SubmitPresentError::OutOfDate => "the swapchain needs to be recreated",
+                SubmitPresentError::FullscreenExclusiveLost => {
+                    "the swapchain no longer has fullscreen exclusivity"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/submit/queue_submit.rs
+++ b/vulkano/src/command_buffer/submit/queue_submit.rs
@@ -273,10 +273,15 @@ impl error::Error for SubmitCommandBufferError {
 impl fmt::Display for SubmitCommandBufferError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            SubmitCommandBufferError::OomError(_) => "not enough memory",
-            SubmitCommandBufferError::DeviceLost => "the connection to the device has been lost",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                SubmitCommandBufferError::OomError(_) => "not enough memory",
+                SubmitCommandBufferError::DeviceLost =>
+                    "the connection to the device has been lost",
+            }
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/synced/base.rs
+++ b/vulkano/src/command_buffer/synced/base.rs
@@ -160,9 +160,13 @@ impl error::Error for SyncCommandBufferBuilderError {}
 impl fmt::Display for SyncCommandBufferBuilderError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            SyncCommandBufferBuilderError::Conflict { .. } => "unsolvable conflict",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                SyncCommandBufferBuilderError::Conflict { .. } => "unsolvable conflict",
+            }
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -417,17 +417,22 @@ impl error::Error for CommandBufferExecError {
 impl fmt::Display for CommandBufferExecError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CommandBufferExecError::AccessError { .. } => "access to a resource has been denied",
-            CommandBufferExecError::OneTimeSubmitAlreadySubmitted => {
-                "the command buffer or one of the secondary command buffers it executes was \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CommandBufferExecError::AccessError { .. } =>
+                    "access to a resource has been denied",
+                CommandBufferExecError::OneTimeSubmitAlreadySubmitted => {
+                    "the command buffer or one of the secondary command buffers it executes was \
                  created with the \"one time submit\" flag, but has already been submitted it \
                  the past"
-            }
-            CommandBufferExecError::ExclusiveAlreadyInUse => {
-                "the command buffer or one of the secondary command buffers it executes is \
+                }
+                CommandBufferExecError::ExclusiveAlreadyInUse => {
+                    "the command buffer or one of the secondary command buffers it executes is \
                  already in use by the GPU and was not created with the \"concurrent\" flag"
+                }
             }
-        })
+        )
     }
 }

--- a/vulkano/src/command_buffer/validity/blit_image.rs
+++ b/vulkano/src/command_buffer/validity/blit_image.rs
@@ -253,43 +253,47 @@ impl error::Error for CheckBlitImageError {}
 impl fmt::Display for CheckBlitImageError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckBlitImageError::MissingTransferSourceUsage => {
-                "the source is missing the transfer source usage"
-            }
-            CheckBlitImageError::MissingTransferDestinationUsage => {
-                "the destination is missing the transfer destination usage"
-            }
-            CheckBlitImageError::SourceFormatNotSupported => {
-                "the format of the source image doesn't support blit operations"
-            }
-            CheckBlitImageError::DestinationFormatNotSupported => {
-                "the format of the destination image doesn't support blit operations"
-            }
-            CheckBlitImageError::DepthStencilNearestMandatory => {
-                "you must use the nearest filter when blitting depth/stencil images"
-            }
-            CheckBlitImageError::DepthStencilFormatMismatch => {
-                "the format of the source and destination must be equal when blitting \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckBlitImageError::MissingTransferSourceUsage => {
+                    "the source is missing the transfer source usage"
+                }
+                CheckBlitImageError::MissingTransferDestinationUsage => {
+                    "the destination is missing the transfer destination usage"
+                }
+                CheckBlitImageError::SourceFormatNotSupported => {
+                    "the format of the source image doesn't support blit operations"
+                }
+                CheckBlitImageError::DestinationFormatNotSupported => {
+                    "the format of the destination image doesn't support blit operations"
+                }
+                CheckBlitImageError::DepthStencilNearestMandatory => {
+                    "you must use the nearest filter when blitting depth/stencil images"
+                }
+                CheckBlitImageError::DepthStencilFormatMismatch => {
+                    "the format of the source and destination must be equal when blitting \
                  depth/stencil images"
-            }
-            CheckBlitImageError::IncompatibleFormatsTypes { .. } => {
-                "the types of the source format and the destination format aren't compatible"
-            }
-            CheckBlitImageError::UnexpectedMultisampled => {
-                "blitting between multisampled images is forbidden"
-            }
-            CheckBlitImageError::SourceCoordinatesOutOfRange => {
-                "the offsets, array layers and/or mipmap levels are out of range in the source \
+                }
+                CheckBlitImageError::IncompatibleFormatsTypes { .. } => {
+                    "the types of the source format and the destination format aren't compatible"
+                }
+                CheckBlitImageError::UnexpectedMultisampled => {
+                    "blitting between multisampled images is forbidden"
+                }
+                CheckBlitImageError::SourceCoordinatesOutOfRange => {
+                    "the offsets, array layers and/or mipmap levels are out of range in the source \
                  image"
-            }
-            CheckBlitImageError::DestinationCoordinatesOutOfRange => {
-                "the offsets, array layers and/or mipmap levels are out of range in the \
+                }
+                CheckBlitImageError::DestinationCoordinatesOutOfRange => {
+                    "the offsets, array layers and/or mipmap levels are out of range in the \
                  destination image"
+                }
+                CheckBlitImageError::IncompatibleRangeForImageType => {
+                    "the top-left and/or bottom-right coordinates are incompatible with the image type"
+                }
             }
-            CheckBlitImageError::IncompatibleRangeForImageType => {
-                "the top-left and/or bottom-right coordinates are incompatible with the image type"
-            }
-        })
+        )
     }
 }

--- a/vulkano/src/command_buffer/validity/clear_color_image.rs
+++ b/vulkano/src/command_buffer/validity/clear_color_image.rs
@@ -65,13 +65,17 @@ impl error::Error for CheckClearColorImageError {}
 impl fmt::Display for CheckClearColorImageError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckClearColorImageError::MissingTransferUsage => {
-                "the image is missing the transfer destination usage"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckClearColorImageError::MissingTransferUsage => {
+                    "the image is missing the transfer destination usage"
+                }
+                CheckClearColorImageError::OutOfRange => {
+                    "the array layers and mipmap levels are out of range"
+                }
             }
-            CheckClearColorImageError::OutOfRange => {
-                "the array layers and mipmap levels are out of range"
-            }
-        })
+        )
     }
 }

--- a/vulkano/src/command_buffer/validity/copy_buffer.rs
+++ b/vulkano/src/command_buffer/validity/copy_buffer.rs
@@ -85,14 +85,19 @@ impl error::Error for CheckCopyBufferError {}
 impl fmt::Display for CheckCopyBufferError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckCopyBufferError::SourceMissingTransferUsage => {
-                "the source buffer is missing the transfer source usage"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckCopyBufferError::SourceMissingTransferUsage => {
+                    "the source buffer is missing the transfer source usage"
+                }
+                CheckCopyBufferError::DestinationMissingTransferUsage => {
+                    "the destination buffer is missing the transfer destination usage"
+                }
+                CheckCopyBufferError::OverlappingRanges =>
+                    "the source and destination are overlapping",
             }
-            CheckCopyBufferError::DestinationMissingTransferUsage => {
-                "the destination buffer is missing the transfer destination usage"
-            }
-            CheckCopyBufferError::OverlappingRanges => "the source and destination are overlapping",
-        })
+        )
     }
 }

--- a/vulkano/src/command_buffer/validity/copy_image.rs
+++ b/vulkano/src/command_buffer/validity/copy_image.rs
@@ -205,34 +205,38 @@ impl error::Error for CheckCopyImageError {}
 impl fmt::Display for CheckCopyImageError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckCopyImageError::MissingTransferSourceUsage => {
-                "the source is missing the transfer source usage"
-            }
-            CheckCopyImageError::MissingTransferDestinationUsage => {
-                "the destination is missing the transfer destination usage"
-            }
-            CheckCopyImageError::SampleCountMismatch => {
-                "the number of samples in the source and destination do not match"
-            }
-            CheckCopyImageError::DepthStencilFormatMismatch => {
-                "the format of the source and destination must be equal when copying \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckCopyImageError::MissingTransferSourceUsage => {
+                    "the source is missing the transfer source usage"
+                }
+                CheckCopyImageError::MissingTransferDestinationUsage => {
+                    "the destination is missing the transfer destination usage"
+                }
+                CheckCopyImageError::SampleCountMismatch => {
+                    "the number of samples in the source and destination do not match"
+                }
+                CheckCopyImageError::DepthStencilFormatMismatch => {
+                    "the format of the source and destination must be equal when copying \
                  depth/stencil images"
-            }
-            CheckCopyImageError::SizeIncompatibleFormatsTypes { .. } => {
-                "the types of the source format and the destination format aren't size-compatible"
-            }
-            CheckCopyImageError::SourceCoordinatesOutOfRange => {
-                "the offsets, array layers and/or mipmap levels are out of range in the source \
+                }
+                CheckCopyImageError::SizeIncompatibleFormatsTypes { .. } => {
+                    "the types of the source format and the destination format aren't size-compatible"
+                }
+                CheckCopyImageError::SourceCoordinatesOutOfRange => {
+                    "the offsets, array layers and/or mipmap levels are out of range in the source \
                  image"
-            }
-            CheckCopyImageError::DestinationCoordinatesOutOfRange => {
-                "the offsets, array layers and/or mipmap levels are out of range in the \
+                }
+                CheckCopyImageError::DestinationCoordinatesOutOfRange => {
+                    "the offsets, array layers and/or mipmap levels are out of range in the \
                  destination image"
+                }
+                CheckCopyImageError::IncompatibleRangeForImageType => {
+                    "the offsets or extent are incompatible with the image type"
+                }
             }
-            CheckCopyImageError::IncompatibleRangeForImageType => {
-                "the offsets or extent are incompatible with the image type"
-            }
-        })
+        )
     }
 }

--- a/vulkano/src/command_buffer/validity/copy_image_buffer.rs
+++ b/vulkano/src/command_buffer/validity/copy_image_buffer.rs
@@ -222,29 +222,33 @@ impl error::Error for CheckCopyBufferImageError {
 impl fmt::Display for CheckCopyBufferImageError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckCopyBufferImageError::SourceMissingTransferUsage => {
-                "the source buffer is missing the transfer source usage"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckCopyBufferImageError::SourceMissingTransferUsage => {
+                    "the source buffer is missing the transfer source usage"
+                }
+                CheckCopyBufferImageError::DestinationMissingTransferUsage => {
+                    "the destination buffer is missing the transfer destination usage"
+                }
+                CheckCopyBufferImageError::OverlappingRanges => {
+                    "the source and destination are overlapping"
+                }
+                CheckCopyBufferImageError::UnexpectedMultisampled => {
+                    "the image must not be multisampled"
+                }
+                CheckCopyBufferImageError::ImageCoordinatesOutOfRange => {
+                    "the image coordinates are out of range"
+                }
+                CheckCopyBufferImageError::WrongPixelType(_) => {
+                    "the type of pixels in the buffer isn't compatible with the image format"
+                }
+                CheckCopyBufferImageError::BufferTooSmall { .. } => {
+                    "the buffer is too small for the copy operation"
+                }
             }
-            CheckCopyBufferImageError::DestinationMissingTransferUsage => {
-                "the destination buffer is missing the transfer destination usage"
-            }
-            CheckCopyBufferImageError::OverlappingRanges => {
-                "the source and destination are overlapping"
-            }
-            CheckCopyBufferImageError::UnexpectedMultisampled => {
-                "the image must not be multisampled"
-            }
-            CheckCopyBufferImageError::ImageCoordinatesOutOfRange => {
-                "the image coordinates are out of range"
-            }
-            CheckCopyBufferImageError::WrongPixelType(_) => {
-                "the type of pixels in the buffer isn't compatible with the image format"
-            }
-            CheckCopyBufferImageError::BufferTooSmall { .. } => {
-                "the buffer is too small for the copy operation"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/validity/descriptor_sets.rs
+++ b/vulkano/src/command_buffer/validity/descriptor_sets.rs
@@ -94,14 +94,18 @@ impl error::Error for CheckDescriptorSetsValidityError {
 impl fmt::Display for CheckDescriptorSetsValidityError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckDescriptorSetsValidityError::MissingDescriptor { .. } => {
-                "a descriptor is missing in the descriptor sets that were provided"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckDescriptorSetsValidityError::MissingDescriptor { .. } => {
+                    "a descriptor is missing in the descriptor sets that were provided"
+                }
+                CheckDescriptorSetsValidityError::IncompatibleDescriptor { .. } => {
+                    "a descriptor in the provided sets is not compatible with what is expected"
+                }
             }
-            CheckDescriptorSetsValidityError::IncompatibleDescriptor { .. } => {
-                "a descriptor in the provided sets is not compatible with what is expected"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/validity/dispatch.rs
+++ b/vulkano/src/command_buffer/validity/dispatch.rs
@@ -46,11 +46,15 @@ impl error::Error for CheckDispatchError {}
 impl fmt::Display for CheckDispatchError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckDispatchError::UnsupportedDimensions { .. } => {
-                "the dimensions are too large for the device's limits"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckDispatchError::UnsupportedDimensions { .. } => {
+                    "the dimensions are too large for the device's limits"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/validity/dynamic_state.rs
+++ b/vulkano/src/command_buffer/validity/dynamic_state.rs
@@ -155,56 +155,60 @@ impl error::Error for CheckDynamicStateValidityError {}
 impl fmt::Display for CheckDynamicStateValidityError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckDynamicStateValidityError::LineWidthNotDynamic => {
-                "passed a dynamic line width, while the pipeline doesn't have line width set as \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckDynamicStateValidityError::LineWidthNotDynamic => {
+                    "passed a dynamic line width, while the pipeline doesn't have line width set as \
                  dynamic"
-            },
-            CheckDynamicStateValidityError::LineWidthMissing => {
-                "the pipeline has a dynamic line width, but no line width value was passed"
-            },
-            CheckDynamicStateValidityError::LineWidthMissingExtension => {
-                "the `wide_lines` extension must be enabled in order to use line width values \
+                }
+                CheckDynamicStateValidityError::LineWidthMissing => {
+                    "the pipeline has a dynamic line width, but no line width value was passed"
+                }
+                CheckDynamicStateValidityError::LineWidthMissingExtension => {
+                    "the `wide_lines` extension must be enabled in order to use line width values \
                  different from 1.0"
-            },
-            CheckDynamicStateValidityError::ViewportsNotDynamic => {
-                "passed dynamic viewports, while the pipeline doesn't have viewports set as \
+                }
+                CheckDynamicStateValidityError::ViewportsNotDynamic => {
+                    "passed dynamic viewports, while the pipeline doesn't have viewports set as \
                  dynamic"
-            },
-            CheckDynamicStateValidityError::ViewportsMissing => {
-                "the pipeline has dynamic viewports, but no viewports were passed"
-            },
-            CheckDynamicStateValidityError::ViewportsCountMismatch { .. } => {
-                "the number of dynamic viewports doesn't match the expected number of viewports"
-            },
-            CheckDynamicStateValidityError::ScissorsNotDynamic => {
-                "passed dynamic scissors, while the pipeline doesn't have scissors set as dynamic"
-            },
-            CheckDynamicStateValidityError::ScissorsMissing => {
-                "the pipeline has dynamic scissors, but no scissors were passed"
-            },
-            CheckDynamicStateValidityError::ScissorsCountMismatch { .. } => {
-                "the number of dynamic scissors doesn't match the expected number of scissors"
-            },
-            CheckDynamicStateValidityError::CompareMaskNotDynamic => {
-                "passed dynamic compare mask, while the pipeline doesn't have compare mask set as dynamic"
-            },
-            CheckDynamicStateValidityError::CompareMaskMissing => {
-                "the pipeline has dynamic compare mask, but no compare mask was passed"
-            },
-            CheckDynamicStateValidityError::WriteMaskNotDynamic => {
-                "passed dynamic write mask, while the pipeline doesn't have write mask set as dynamic"
-            },
-            CheckDynamicStateValidityError::WriteMaskMissing => {
-                "the pipeline has dynamic write mask, but no write mask was passed"
-            },
-            CheckDynamicStateValidityError::ReferenceNotDynamic => {
-                "passed dynamic Reference, while the pipeline doesn't have reference set as dynamic"
-            },
-            CheckDynamicStateValidityError::ReferenceMissing => {
-                "the pipeline has dynamic reference, but no reference was passed"
-            },
-        })
+                }
+                CheckDynamicStateValidityError::ViewportsMissing => {
+                    "the pipeline has dynamic viewports, but no viewports were passed"
+                }
+                CheckDynamicStateValidityError::ViewportsCountMismatch { .. } => {
+                    "the number of dynamic viewports doesn't match the expected number of viewports"
+                }
+                CheckDynamicStateValidityError::ScissorsNotDynamic => {
+                    "passed dynamic scissors, while the pipeline doesn't have scissors set as dynamic"
+                }
+                CheckDynamicStateValidityError::ScissorsMissing => {
+                    "the pipeline has dynamic scissors, but no scissors were passed"
+                }
+                CheckDynamicStateValidityError::ScissorsCountMismatch { .. } => {
+                    "the number of dynamic scissors doesn't match the expected number of scissors"
+                }
+                CheckDynamicStateValidityError::CompareMaskNotDynamic => {
+                    "passed dynamic compare mask, while the pipeline doesn't have compare mask set as dynamic"
+                }
+                CheckDynamicStateValidityError::CompareMaskMissing => {
+                    "the pipeline has dynamic compare mask, but no compare mask was passed"
+                }
+                CheckDynamicStateValidityError::WriteMaskNotDynamic => {
+                    "passed dynamic write mask, while the pipeline doesn't have write mask set as dynamic"
+                }
+                CheckDynamicStateValidityError::WriteMaskMissing => {
+                    "the pipeline has dynamic write mask, but no write mask was passed"
+                }
+                CheckDynamicStateValidityError::ReferenceNotDynamic => {
+                    "passed dynamic Reference, while the pipeline doesn't have reference set as dynamic"
+                }
+                CheckDynamicStateValidityError::ReferenceMissing => {
+                    "the pipeline has dynamic reference, but no reference was passed"
+                }
+            }
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/validity/fill_buffer.rs
+++ b/vulkano/src/command_buffer/validity/fill_buffer.rs
@@ -55,12 +55,17 @@ impl error::Error for CheckFillBufferError {}
 impl fmt::Display for CheckFillBufferError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckFillBufferError::BufferMissingUsage => {
-                "the transfer destination usage must be enabled on the buffer"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckFillBufferError::BufferMissingUsage => {
+                    "the transfer destination usage must be enabled on the buffer"
+                }
+                CheckFillBufferError::WrongAlignment =>
+                    "the offset or size are not aligned to 4 bytes",
             }
-            CheckFillBufferError::WrongAlignment => "the offset or size are not aligned to 4 bytes",
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/validity/index_buffer.rs
+++ b/vulkano/src/command_buffer/validity/index_buffer.rs
@@ -72,18 +72,22 @@ impl error::Error for CheckIndexBufferError {}
 impl fmt::Display for CheckIndexBufferError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckIndexBufferError::BufferMissingUsage => {
-                "the index buffer usage must be enabled on the index buffer"
-            }
-            CheckIndexBufferError::WrongAlignment => {
-                "the sum of offset and the address of the range of VkDeviceMemory object that is \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckIndexBufferError::BufferMissingUsage => {
+                    "the index buffer usage must be enabled on the index buffer"
+                }
+                CheckIndexBufferError::WrongAlignment => {
+                    "the sum of offset and the address of the range of VkDeviceMemory object that is \
                  backing buffer, must be a multiple of the type indicated by indexType"
+                }
+                CheckIndexBufferError::UnsupportIndexType => {
+                    "the type of the indices is not supported by the device"
+                }
             }
-            CheckIndexBufferError::UnsupportIndexType => {
-                "the type of the indices is not supported by the device"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/validity/push_constants.rs
+++ b/vulkano/src/command_buffer/validity/push_constants.rs
@@ -41,10 +41,14 @@ impl error::Error for CheckPushConstantsValidityError {}
 impl fmt::Display for CheckPushConstantsValidityError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckPushConstantsValidityError::IncompatiblePushConstants => {
-                "the push constants are incompatible with the pipeline layout"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckPushConstantsValidityError::IncompatiblePushConstants => {
+                    "the push constants are incompatible with the pipeline layout"
+                }
             }
-        })
+        )
     }
 }

--- a/vulkano/src/command_buffer/validity/update_buffer.rs
+++ b/vulkano/src/command_buffer/validity/update_buffer.rs
@@ -74,15 +74,19 @@ impl error::Error for CheckUpdateBufferError {}
 impl fmt::Display for CheckUpdateBufferError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckUpdateBufferError::BufferMissingUsage => {
-                "the transfer destination usage must be enabled on the buffer"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckUpdateBufferError::BufferMissingUsage => {
+                    "the transfer destination usage must be enabled on the buffer"
+                }
+                CheckUpdateBufferError::WrongAlignment => {
+                    "the offset or size are not aligned to 4 bytes"
+                }
+                CheckUpdateBufferError::DataTooLarge => "data is too large",
             }
-            CheckUpdateBufferError::WrongAlignment => {
-                "the offset or size are not aligned to 4 bytes"
-            }
-            CheckUpdateBufferError::DataTooLarge => "data is too large",
-        })
+        )
     }
 }
 

--- a/vulkano/src/command_buffer/validity/vertex_buffers.rs
+++ b/vulkano/src/command_buffer/validity/vertex_buffers.rs
@@ -73,10 +73,14 @@ impl error::Error for CheckVertexBufferError {}
 impl fmt::Display for CheckVertexBufferError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CheckVertexBufferError::BufferMissingUsage { .. } => {
-                "the vertex buffer usage is missing on a vertex buffer"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckVertexBufferError::BufferMissingUsage { .. } => {
+                    "the vertex buffer usage is missing on a vertex buffer"
+                }
             }
-        })
+        )
     }
 }

--- a/vulkano/src/descriptor/descriptor.rs
+++ b/vulkano/src/descriptor/descriptor.rs
@@ -599,32 +599,36 @@ impl error::Error for DescriptorDescSupersetError {}
 impl fmt::Display for DescriptorDescSupersetError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            DescriptorDescSupersetError::ArrayTooSmall { .. } => {
-                "the number of array elements of the descriptor is smaller than expected"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                DescriptorDescSupersetError::ArrayTooSmall { .. } => {
+                    "the number of array elements of the descriptor is smaller than expected"
+                }
+                DescriptorDescSupersetError::TypeMismatch => {
+                    "the descriptor type doesn't match the type of the other descriptor"
+                }
+                DescriptorDescSupersetError::MutabilityRequired => {
+                    "the descriptor is marked as read-only, but the other is not"
+                }
+                DescriptorDescSupersetError::ShaderStagesNotSuperset => {
+                    "the shader stages are not a superset of one another"
+                }
+                DescriptorDescSupersetError::DimensionsMismatch { .. } => {
+                    "mismatch between the dimensions of the two descriptors"
+                }
+                DescriptorDescSupersetError::FormatMismatch { .. } => {
+                    "mismatch between the format of the two descriptors"
+                }
+                DescriptorDescSupersetError::MultisampledMismatch { .. } => {
+                    "mismatch between whether the descriptors are multisampled"
+                }
+                DescriptorDescSupersetError::IncompatibleArrayLayers { .. } => {
+                    "the array layers of the descriptors aren't compatible"
+                }
             }
-            DescriptorDescSupersetError::TypeMismatch => {
-                "the descriptor type doesn't match the type of the other descriptor"
-            }
-            DescriptorDescSupersetError::MutabilityRequired => {
-                "the descriptor is marked as read-only, but the other is not"
-            }
-            DescriptorDescSupersetError::ShaderStagesNotSuperset => {
-                "the shader stages are not a superset of one another"
-            }
-            DescriptorDescSupersetError::DimensionsMismatch { .. } => {
-                "mismatch between the dimensions of the two descriptors"
-            }
-            DescriptorDescSupersetError::FormatMismatch { .. } => {
-                "mismatch between the format of the two descriptors"
-            }
-            DescriptorDescSupersetError::MultisampledMismatch { .. } => {
-                "mismatch between whether the descriptors are multisampled"
-            }
-            DescriptorDescSupersetError::IncompatibleArrayLayers { .. } => {
-                "the array layers of the descriptors aren't compatible"
-            }
-        })
+        )
     }
 }
 
@@ -810,8 +814,12 @@ impl error::Error for ShaderStagesSupersetError {}
 impl fmt::Display for ShaderStagesSupersetError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            ShaderStagesSupersetError::NotSuperset => "shader stages not a superset",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                ShaderStagesSupersetError::NotSuperset => "shader stages not a superset",
+            }
+        )
     }
 }

--- a/vulkano/src/descriptor/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor/descriptor_set/persistent.rs
@@ -1196,44 +1196,48 @@ impl error::Error for PersistentDescriptorSetError {}
 impl fmt::Display for PersistentDescriptorSetError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            PersistentDescriptorSetError::WrongDescriptorTy { .. } => {
-                "expected one type of resource but got another"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                PersistentDescriptorSetError::WrongDescriptorTy { .. } => {
+                    "expected one type of resource but got another"
+                }
+                PersistentDescriptorSetError::EmptyExpected => {
+                    "expected an empty descriptor but got something"
+                }
+                PersistentDescriptorSetError::ArrayOutOfBounds => {
+                    "tried to add too many elements to an array"
+                }
+                PersistentDescriptorSetError::MissingArrayElements { .. } => {
+                    "didn't fill all the elements of an array before leaving"
+                }
+                PersistentDescriptorSetError::IncompatibleImageViewSampler => {
+                    "the image view isn't compatible with the sampler"
+                }
+                PersistentDescriptorSetError::MissingBufferUsage { .. } => {
+                    "the buffer is missing the correct usage"
+                }
+                PersistentDescriptorSetError::MissingImageUsage { .. } => {
+                    "the image is missing the correct usage"
+                }
+                PersistentDescriptorSetError::ExpectedMultisampled => {
+                    "expected a multisampled image, but got a single-sampled image"
+                }
+                PersistentDescriptorSetError::UnexpectedMultisampled => {
+                    "expected a single-sampled image, but got a multisampled image"
+                }
+                PersistentDescriptorSetError::ArrayLayersMismatch { .. } => {
+                    "the number of array layers of an image doesn't match what was expected"
+                }
+                PersistentDescriptorSetError::ImageViewFormatMismatch { .. } => {
+                    "the format of an image view doesn't match what was expected"
+                }
+                PersistentDescriptorSetError::ImageViewTypeMismatch { .. } => {
+                    "the type of an image view doesn't match what was expected"
+                }
             }
-            PersistentDescriptorSetError::EmptyExpected => {
-                "expected an empty descriptor but got something"
-            }
-            PersistentDescriptorSetError::ArrayOutOfBounds => {
-                "tried to add too many elements to an array"
-            }
-            PersistentDescriptorSetError::MissingArrayElements { .. } => {
-                "didn't fill all the elements of an array before leaving"
-            }
-            PersistentDescriptorSetError::IncompatibleImageViewSampler => {
-                "the image view isn't compatible with the sampler"
-            }
-            PersistentDescriptorSetError::MissingBufferUsage { .. } => {
-                "the buffer is missing the correct usage"
-            }
-            PersistentDescriptorSetError::MissingImageUsage { .. } => {
-                "the image is missing the correct usage"
-            }
-            PersistentDescriptorSetError::ExpectedMultisampled => {
-                "expected a multisampled image, but got a single-sampled image"
-            }
-            PersistentDescriptorSetError::UnexpectedMultisampled => {
-                "expected a single-sampled image, but got a multisampled image"
-            }
-            PersistentDescriptorSetError::ArrayLayersMismatch { .. } => {
-                "the number of array layers of an image doesn't match what was expected"
-            }
-            PersistentDescriptorSetError::ImageViewFormatMismatch { .. } => {
-                "the format of an image view doesn't match what was expected"
-            }
-            PersistentDescriptorSetError::ImageViewTypeMismatch { .. } => {
-                "the type of an image view doesn't match what was expected"
-            }
-        })
+        )
     }
 }
 
@@ -1264,11 +1268,15 @@ impl From<OomError> for PersistentDescriptorSetBuildError {
 impl fmt::Display for PersistentDescriptorSetBuildError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            PersistentDescriptorSetBuildError::MissingDescriptors { .. } => {
-                "didn't fill all the descriptors before building"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                PersistentDescriptorSetBuildError::MissingDescriptors { .. } => {
+                    "didn't fill all the descriptors before building"
+                }
+                PersistentDescriptorSetBuildError::OomError(_) => "not enough memory available",
             }
-            PersistentDescriptorSetBuildError::OomError(_) => "not enough memory available",
-        })
+        )
     }
 }

--- a/vulkano/src/descriptor/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor/descriptor_set/sys.rs
@@ -524,18 +524,22 @@ impl error::Error for DescriptorPoolAllocError {}
 impl fmt::Display for DescriptorPoolAllocError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            DescriptorPoolAllocError::OutOfHostMemory => "no memory available on the host",
-            DescriptorPoolAllocError::OutOfDeviceMemory => {
-                "no memory available on the graphical device"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                DescriptorPoolAllocError::OutOfHostMemory => "no memory available on the host",
+                DescriptorPoolAllocError::OutOfDeviceMemory => {
+                    "no memory available on the graphical device"
+                }
+                DescriptorPoolAllocError::FragmentedPool => {
+                    "allocation has failed because the pool is too fragmented"
+                }
+                DescriptorPoolAllocError::OutOfPoolMemory => {
+                    "there is no more space available in the descriptor pool"
+                }
             }
-            DescriptorPoolAllocError::FragmentedPool => {
-                "allocation has failed because the pool is too fragmented"
-            }
-            DescriptorPoolAllocError::OutOfPoolMemory => {
-                "there is no more space available in the descriptor pool"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/descriptor/pipeline_layout/limits_check.rs
+++ b/vulkano/src/descriptor/pipeline_layout/limits_check.rs
@@ -380,59 +380,75 @@ impl error::Error for PipelineLayoutLimitsError {}
 impl fmt::Display for PipelineLayoutLimitsError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            PipelineLayoutLimitsError::MaxDescriptorSetsLimitExceeded { .. } => {
-                "the maximum number of descriptor sets has been exceeded"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                PipelineLayoutLimitsError::MaxDescriptorSetsLimitExceeded { .. } => {
+                    "the maximum number of descriptor sets has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxPushConstantsSizeExceeded { .. } => {
+                    "the maximum size of push constants has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxPerStageResourcesLimitExceeded { .. } => {
+                    "the `max_per_stage_resources()` limit has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxPerStageDescriptorSamplersLimitExceeded {
+                    ..
+                } => {
+                    "the `max_per_stage_descriptor_samplers()` limit has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxPerStageDescriptorUniformBuffersLimitExceeded {
+                    ..
+                } => "the `max_per_stage_descriptor_uniform_buffers()` limit has been exceeded",
+                PipelineLayoutLimitsError::MaxPerStageDescriptorStorageBuffersLimitExceeded {
+                    ..
+                } => "the `max_per_stage_descriptor_storage_buffers()` limit has been exceeded",
+                PipelineLayoutLimitsError::MaxPerStageDescriptorSampledImagesLimitExceeded {
+                    ..
+                } => "the `max_per_stage_descriptor_sampled_images()` limit has been exceeded",
+                PipelineLayoutLimitsError::MaxPerStageDescriptorStorageImagesLimitExceeded {
+                    ..
+                } => "the `max_per_stage_descriptor_storage_images()` limit has been exceeded",
+                PipelineLayoutLimitsError::MaxPerStageDescriptorInputAttachmentsLimitExceeded {
+                    ..
+                } => "the `max_per_stage_descriptor_input_attachments()` limit has been exceeded",
+                PipelineLayoutLimitsError::MaxDescriptorSetSamplersLimitExceeded { .. } => {
+                    "the `max_descriptor_set_samplers()` limit has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxDescriptorSetUniformBuffersLimitExceeded {
+                    ..
+                } => {
+                    "the `max_descriptor_set_uniform_buffers()` limit has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxDescriptorSetUniformBuffersDynamicLimitExceeded {
+                    ..
+                } => "the `max_descriptor_set_uniform_buffers_dynamic()` limit has been exceeded",
+                PipelineLayoutLimitsError::MaxDescriptorSetStorageBuffersLimitExceeded {
+                    ..
+                } => {
+                    "the `max_descriptor_set_storage_buffers()` limit has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxDescriptorSetStorageBuffersDynamicLimitExceeded {
+                    ..
+                } => "the `max_descriptor_set_storage_buffers_dynamic()` limit has been exceeded",
+                PipelineLayoutLimitsError::MaxDescriptorSetSampledImagesLimitExceeded {
+                    ..
+                } => {
+                    "the `max_descriptor_set_sampled_images()` limit has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxDescriptorSetStorageImagesLimitExceeded {
+                    ..
+                } => {
+                    "the `max_descriptor_set_storage_images()` limit has been exceeded"
+                }
+                PipelineLayoutLimitsError::MaxDescriptorSetInputAttachmentsLimitExceeded {
+                    ..
+                } => {
+                    "the `max_descriptor_set_input_attachments()` limit has been exceeded"
+                }
             }
-            PipelineLayoutLimitsError::MaxPushConstantsSizeExceeded { .. } => {
-                "the maximum size of push constants has been exceeded"
-            }
-            PipelineLayoutLimitsError::MaxPerStageResourcesLimitExceeded { .. } => {
-                "the `max_per_stage_resources()` limit has been exceeded"
-            }
-            PipelineLayoutLimitsError::MaxPerStageDescriptorSamplersLimitExceeded { .. } => {
-                "the `max_per_stage_descriptor_samplers()` limit has been exceeded"
-            }
-            PipelineLayoutLimitsError::MaxPerStageDescriptorUniformBuffersLimitExceeded {
-                ..
-            } => "the `max_per_stage_descriptor_uniform_buffers()` limit has been exceeded",
-            PipelineLayoutLimitsError::MaxPerStageDescriptorStorageBuffersLimitExceeded {
-                ..
-            } => "the `max_per_stage_descriptor_storage_buffers()` limit has been exceeded",
-            PipelineLayoutLimitsError::MaxPerStageDescriptorSampledImagesLimitExceeded {
-                ..
-            } => "the `max_per_stage_descriptor_sampled_images()` limit has been exceeded",
-            PipelineLayoutLimitsError::MaxPerStageDescriptorStorageImagesLimitExceeded {
-                ..
-            } => "the `max_per_stage_descriptor_storage_images()` limit has been exceeded",
-            PipelineLayoutLimitsError::MaxPerStageDescriptorInputAttachmentsLimitExceeded {
-                ..
-            } => "the `max_per_stage_descriptor_input_attachments()` limit has been exceeded",
-            PipelineLayoutLimitsError::MaxDescriptorSetSamplersLimitExceeded { .. } => {
-                "the `max_descriptor_set_samplers()` limit has been exceeded"
-            }
-            PipelineLayoutLimitsError::MaxDescriptorSetUniformBuffersLimitExceeded { .. } => {
-                "the `max_descriptor_set_uniform_buffers()` limit has been exceeded"
-            }
-            PipelineLayoutLimitsError::MaxDescriptorSetUniformBuffersDynamicLimitExceeded {
-                ..
-            } => "the `max_descriptor_set_uniform_buffers_dynamic()` limit has been exceeded",
-            PipelineLayoutLimitsError::MaxDescriptorSetStorageBuffersLimitExceeded { .. } => {
-                "the `max_descriptor_set_storage_buffers()` limit has been exceeded"
-            }
-            PipelineLayoutLimitsError::MaxDescriptorSetStorageBuffersDynamicLimitExceeded {
-                ..
-            } => "the `max_descriptor_set_storage_buffers_dynamic()` limit has been exceeded",
-            PipelineLayoutLimitsError::MaxDescriptorSetSampledImagesLimitExceeded { .. } => {
-                "the `max_descriptor_set_sampled_images()` limit has been exceeded"
-            }
-            PipelineLayoutLimitsError::MaxDescriptorSetStorageImagesLimitExceeded { .. } => {
-                "the `max_descriptor_set_storage_images()` limit has been exceeded"
-            }
-            PipelineLayoutLimitsError::MaxDescriptorSetInputAttachmentsLimitExceeded { .. } => {
-                "the `max_descriptor_set_input_attachments()` limit has been exceeded"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/descriptor/pipeline_layout/runtime_desc.rs
+++ b/vulkano/src/descriptor/pipeline_layout/runtime_desc.rs
@@ -110,11 +110,15 @@ impl error::Error for RuntimePipelineDescError {}
 impl fmt::Display for RuntimePipelineDescError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            RuntimePipelineDescError::PushConstantsConflict { .. } => {
-                "conflict between different push constants ranges"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                RuntimePipelineDescError::PushConstantsConflict { .. } => {
+                    "conflict between different push constants ranges"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/descriptor/pipeline_layout/sys.rs
+++ b/vulkano/src/descriptor/pipeline_layout/sys.rs
@@ -293,15 +293,19 @@ impl error::Error for PipelineLayoutCreationError {
 impl fmt::Display for PipelineLayoutCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            PipelineLayoutCreationError::OomError(_) => "not enough memory available",
-            PipelineLayoutCreationError::LimitsError(_) => {
-                "the pipeline layout description doesn't fulfill the limit requirements"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                PipelineLayoutCreationError::OomError(_) => "not enough memory available",
+                PipelineLayoutCreationError::LimitsError(_) => {
+                    "the pipeline layout description doesn't fulfill the limit requirements"
+                }
+                PipelineLayoutCreationError::InvalidPushConstant => {
+                    "one of the push constants range didn't obey the rules"
+                }
             }
-            PipelineLayoutCreationError::InvalidPushConstant => {
-                "one of the push constants range didn't obey the rules"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/descriptor/pipeline_layout/traits.rs
+++ b/vulkano/src/descriptor/pipeline_layout/traits.rs
@@ -265,17 +265,21 @@ impl error::Error for PipelineLayoutNotSupersetError {
 impl fmt::Display for PipelineLayoutNotSupersetError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            PipelineLayoutNotSupersetError::DescriptorsCountMismatch { .. } => {
-                "there are more descriptors in the child than in the parent layout"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                PipelineLayoutNotSupersetError::DescriptorsCountMismatch { .. } => {
+                    "there are more descriptors in the child than in the parent layout"
+                }
+                PipelineLayoutNotSupersetError::ExpectedEmptyDescriptor { .. } => {
+                    "expected an empty descriptor, but got something instead"
+                }
+                PipelineLayoutNotSupersetError::IncompatibleDescriptors { .. } => {
+                    "two descriptors are incompatible"
+                }
             }
-            PipelineLayoutNotSupersetError::ExpectedEmptyDescriptor { .. } => {
-                "expected an empty descriptor, but got something instead"
-            }
-            PipelineLayoutNotSupersetError::IncompatibleDescriptors { .. } => {
-                "two descriptors are incompatible"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -723,30 +723,35 @@ impl error::Error for DeviceCreationError {}
 impl fmt::Display for DeviceCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            DeviceCreationError::InitializationFailed => {
-                "failed to create the device for an implementation-specific reason"
-            }
-            DeviceCreationError::OutOfHostMemory => "no memory available on the host",
-            DeviceCreationError::OutOfDeviceMemory => "no memory available on the graphical device",
-            DeviceCreationError::DeviceLost => "failed to connect to the device",
-            DeviceCreationError::TooManyQueuesForFamily => {
-                "tried to create too many queues for a given family"
-            }
-            DeviceCreationError::FeatureNotPresent => {
-                "some of the requested features are unsupported by the physical device"
-            }
-            DeviceCreationError::PriorityOutOfRange => {
-                "the priority of one of the queues is out of the [0.0; 1.0] range"
-            }
-            DeviceCreationError::ExtensionNotPresent => {
-                "some of the requested device extensions are not supported by the physical device"
-            }
-            DeviceCreationError::TooManyObjects => {
-                "you have reached the limit to the number of devices that can be created from the
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                DeviceCreationError::InitializationFailed => {
+                    "failed to create the device for an implementation-specific reason"
+                }
+                DeviceCreationError::OutOfHostMemory => "no memory available on the host",
+                DeviceCreationError::OutOfDeviceMemory =>
+                    "no memory available on the graphical device",
+                DeviceCreationError::DeviceLost => "failed to connect to the device",
+                DeviceCreationError::TooManyQueuesForFamily => {
+                    "tried to create too many queues for a given family"
+                }
+                DeviceCreationError::FeatureNotPresent => {
+                    "some of the requested features are unsupported by the physical device"
+                }
+                DeviceCreationError::PriorityOutOfRange => {
+                    "the priority of one of the queues is out of the [0.0; 1.0] range"
+                }
+                DeviceCreationError::ExtensionNotPresent => {
+                    "some of the requested device extensions are not supported by the physical device"
+                }
+                DeviceCreationError::TooManyObjects => {
+                    "you have reached the limit to the number of devices that can be created from the
                  same physical device"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/extensions.rs
+++ b/vulkano/src/extensions.rs
@@ -195,10 +195,15 @@ impl error::Error for SupportedExtensionsError {
 impl fmt::Display for SupportedExtensionsError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            SupportedExtensionsError::LoadingError(_) => "failed to load the Vulkan shared library",
-            SupportedExtensionsError::OomError(_) => "not enough memory available",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                SupportedExtensionsError::LoadingError(_) =>
+                    "failed to load the Vulkan shared library",
+                SupportedExtensionsError::OomError(_) => "not enough memory available",
+            }
+        )
     }
 }
 

--- a/vulkano/src/features.rs
+++ b/vulkano/src/features.rs
@@ -7,9 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use std::{mem, ptr};
 use std::marker::PhantomPinned;
 use std::pin::Pin;
+use std::{mem, ptr};
 
 use vk;
 
@@ -75,10 +75,10 @@ macro_rules! features_difference {
 }
 
 macro_rules! from_feature_v1 {
-  (core { $name:ident => $vk:ident }, $out:expr, $features:expr) => {
-    $out.$name = $features.$vk != vk::FALSE;
-  };
-  (extension {
+    (core { $name:ident => $vk:ident }, $out:expr, $features:expr) => {
+        $out.$name = $features.$vk != vk::FALSE;
+    };
+    (extension {
     ty: $ty:ty,
     ffi_name: $ffi_name:ident,
     sType: $stype:expr,
@@ -86,14 +86,14 @@ macro_rules! from_feature_v1 {
       $($name:ident => $vk:ident,)+
     ],
   }, $out:expr, $features:expr) => {
-    // nothing.
-  };
+        // nothing.
+    };
 }
 macro_rules! into_feature_v1 {
-  (core { $name:ident => $vk:ident }, $out:expr, $self:expr) => {
-    $out.$vk = if $self.$name { vk::TRUE } else { vk::FALSE };
-  };
-  (extension {
+    (core { $name:ident => $vk:ident }, $out:expr, $self:expr) => {
+        $out.$vk = if $self.$name { vk::TRUE } else { vk::FALSE };
+    };
+    (extension {
     ty: $ty:ty,
     ffi_name: $ffi_name:ident,
     sType: $stype:expr,
@@ -101,8 +101,8 @@ macro_rules! into_feature_v1 {
       $($name:ident => $vk:ident,)+
     ],
   }, $out:expr, $self:expr) => {
-    // nothing.
-  };
+        // nothing.
+    };
 }
 
 macro_rules! from_ext_features_match {
@@ -144,10 +144,10 @@ macro_rules! into_ext_features_match {
   };
 }
 macro_rules! features_ffi_init_pinned {
-  (core { $name:ident => $vk:ident }, $this:expr, $prev:expr) => {
-    // nothing.
-  };
-  (extension {
+    (core { $name:ident => $vk:ident }, $this:expr, $prev:expr) => {
+        // nothing.
+    };
+    (extension {
     ty: $ty:ty,
     ffi_name: $ffi_name:ident,
     sType: $stype:expr,
@@ -155,18 +155,18 @@ macro_rules! features_ffi_init_pinned {
       $($name:ident => $vk:ident,)*
     ],
   }, $this:expr, $prev:expr) => {{
-    $this.$ffi_name.sType = $stype;
-    let next = &mut $this.$ffi_name as *mut _ as *mut Base;
-    (&mut *$prev).pNext = next;
-    $prev = next;
-  }};
+        $this.$ffi_name.sType = $stype;
+        let next = &mut $this.$ffi_name as *mut _ as *mut Base;
+        (&mut *$prev).pNext = next;
+        $prev = next;
+    }};
 }
 
 #[allow(non_snake_case)]
 #[repr(C)]
 pub(crate) struct Base {
-  sType: vk::StructureType,
-  pNext: *mut Base,
+    sType: vk::StructureType,
+    pNext: *mut Base,
 }
 
 // Can't define this structure with macros :(
@@ -203,71 +203,71 @@ pub(crate) struct Base {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 #[allow(missing_docs)]
 pub struct Features {
-  pub robust_buffer_access: bool,
-  pub full_draw_index_uint32: bool,
-  pub image_cube_array: bool,
-  pub independent_blend: bool,
-  pub geometry_shader: bool,
-  pub tessellation_shader: bool,
-  pub sample_rate_shading: bool,
-  pub dual_src_blend: bool,
-  pub logic_op: bool,
-  pub multi_draw_indirect: bool,
-  pub draw_indirect_first_instance: bool,
-  pub depth_clamp: bool,
-  pub depth_bias_clamp: bool,
-  pub fill_mode_non_solid: bool,
-  pub depth_bounds: bool,
-  pub wide_lines: bool,
-  pub large_points: bool,
-  pub alpha_to_one: bool,
-  pub multi_viewport: bool,
-  pub sampler_anisotropy: bool,
-  pub texture_compression_etc2: bool,
-  pub texture_compression_astc_ldr: bool,
-  pub texture_compression_bc: bool,
-  pub occlusion_query_precise: bool,
-  pub pipeline_statistics_query: bool,
-  pub vertex_pipeline_stores_and_atomics: bool,
-  pub fragment_stores_and_atomics: bool,
-  pub shader_tessellation_and_geometry_point_size: bool,
-  pub shader_image_gather_extended: bool,
-  pub shader_storage_image_extended_formats: bool,
-  pub shader_storage_image_multisample: bool,
-  pub shader_storage_image_read_without_format: bool,
-  pub shader_storage_image_write_without_format: bool,
-  pub shader_uniform_buffer_array_dynamic_indexing: bool,
-  pub shader_sampled_image_array_dynamic_indexing: bool,
-  pub shader_storage_buffer_array_dynamic_indexing: bool,
-  pub shader_storage_image_array_dynamic_indexing: bool,
-  pub shader_clip_distance: bool,
-  pub shader_cull_distance: bool,
-  pub shader_f3264: bool,
-  pub shader_int64: bool,
-  pub shader_int16: bool,
-  pub shader_resource_residency: bool,
-  pub shader_resource_min_lod: bool,
-  pub sparse_binding: bool,
-  pub sparse_residency_buffer: bool,
-  pub sparse_residency_image2d: bool,
-  pub sparse_residency_image3d: bool,
-  pub sparse_residency2_samples: bool,
-  pub sparse_residency4_samples: bool,
-  pub sparse_residency8_samples: bool,
-  pub sparse_residency16_samples: bool,
-  pub sparse_residency_aliased: bool,
-  pub variable_multisample_rate: bool,
-  pub inherited_queries: bool,
+    pub robust_buffer_access: bool,
+    pub full_draw_index_uint32: bool,
+    pub image_cube_array: bool,
+    pub independent_blend: bool,
+    pub geometry_shader: bool,
+    pub tessellation_shader: bool,
+    pub sample_rate_shading: bool,
+    pub dual_src_blend: bool,
+    pub logic_op: bool,
+    pub multi_draw_indirect: bool,
+    pub draw_indirect_first_instance: bool,
+    pub depth_clamp: bool,
+    pub depth_bias_clamp: bool,
+    pub fill_mode_non_solid: bool,
+    pub depth_bounds: bool,
+    pub wide_lines: bool,
+    pub large_points: bool,
+    pub alpha_to_one: bool,
+    pub multi_viewport: bool,
+    pub sampler_anisotropy: bool,
+    pub texture_compression_etc2: bool,
+    pub texture_compression_astc_ldr: bool,
+    pub texture_compression_bc: bool,
+    pub occlusion_query_precise: bool,
+    pub pipeline_statistics_query: bool,
+    pub vertex_pipeline_stores_and_atomics: bool,
+    pub fragment_stores_and_atomics: bool,
+    pub shader_tessellation_and_geometry_point_size: bool,
+    pub shader_image_gather_extended: bool,
+    pub shader_storage_image_extended_formats: bool,
+    pub shader_storage_image_multisample: bool,
+    pub shader_storage_image_read_without_format: bool,
+    pub shader_storage_image_write_without_format: bool,
+    pub shader_uniform_buffer_array_dynamic_indexing: bool,
+    pub shader_sampled_image_array_dynamic_indexing: bool,
+    pub shader_storage_buffer_array_dynamic_indexing: bool,
+    pub shader_storage_image_array_dynamic_indexing: bool,
+    pub shader_clip_distance: bool,
+    pub shader_cull_distance: bool,
+    pub shader_f3264: bool,
+    pub shader_int64: bool,
+    pub shader_int16: bool,
+    pub shader_resource_residency: bool,
+    pub shader_resource_min_lod: bool,
+    pub sparse_binding: bool,
+    pub sparse_residency_buffer: bool,
+    pub sparse_residency_image2d: bool,
+    pub sparse_residency_image3d: bool,
+    pub sparse_residency2_samples: bool,
+    pub sparse_residency4_samples: bool,
+    pub sparse_residency8_samples: bool,
+    pub sparse_residency16_samples: bool,
+    pub sparse_residency_aliased: bool,
+    pub variable_multisample_rate: bool,
+    pub inherited_queries: bool,
 
-  pub buffer_device_address: bool,
-  pub buffer_device_address_capture_replay: bool,
-  pub buffer_device_address_multi_device: bool,
+    pub buffer_device_address: bool,
+    pub buffer_device_address_capture_replay: bool,
+    pub buffer_device_address_multi_device: bool,
 }
 
 pub(crate) struct FeaturesFfi {
-  _pinned: PhantomPinned,
-  pub(crate) main: vk::PhysicalDeviceFeatures2KHR,
-  phys_dev_buf_addr: vk::PhysicalDeviceBufferAddressFeaturesEXT,
+    _pinned: PhantomPinned,
+    pub(crate) main: vk::PhysicalDeviceFeatures2KHR,
+    phys_dev_buf_addr: vk::PhysicalDeviceBufferAddressFeaturesEXT,
 }
 
 macro_rules! features {

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -144,7 +144,11 @@ impl error::Error for IncompatiblePixelsType {}
 impl fmt::Display for IncompatiblePixelsType {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", "supplied pixels' type is incompatible with this format")
+        write!(
+            fmt,
+            "{}",
+            "supplied pixels' type is incompatible with this format"
+        )
     }
 }
 

--- a/vulkano/src/framebuffer/compat_atch.rs
+++ b/vulkano/src/framebuffer/compat_atch.rs
@@ -146,29 +146,33 @@ impl error::Error for IncompatibleRenderPassAttachmentError {}
 impl fmt::Display for IncompatibleRenderPassAttachmentError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            IncompatibleRenderPassAttachmentError::FormatMismatch { .. } => {
-                "mismatch between the format expected by the render pass and the actual format"
-            }
-            IncompatibleRenderPassAttachmentError::SamplesMismatch { .. } => {
-                "mismatch between the number of samples expected by the render pass and the actual \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                IncompatibleRenderPassAttachmentError::FormatMismatch { .. } => {
+                    "mismatch between the format expected by the render pass and the actual format"
+                }
+                IncompatibleRenderPassAttachmentError::SamplesMismatch { .. } => {
+                    "mismatch between the number of samples expected by the render pass and the actual \
                  number of samples"
-            }
-            IncompatibleRenderPassAttachmentError::NotIdentitySwizzled => {
-                "the image view does not use identity swizzling"
-            }
-            IncompatibleRenderPassAttachmentError::MissingColorAttachmentUsage => {
-                "the image is used as a color attachment but is missing the color attachment usage"
-            }
-            IncompatibleRenderPassAttachmentError::MissingDepthStencilAttachmentUsage => {
-                "the image is used as a depth/stencil attachment but is missing the depth-stencil \
+                }
+                IncompatibleRenderPassAttachmentError::NotIdentitySwizzled => {
+                    "the image view does not use identity swizzling"
+                }
+                IncompatibleRenderPassAttachmentError::MissingColorAttachmentUsage => {
+                    "the image is used as a color attachment but is missing the color attachment usage"
+                }
+                IncompatibleRenderPassAttachmentError::MissingDepthStencilAttachmentUsage => {
+                    "the image is used as a depth/stencil attachment but is missing the depth-stencil \
                  attachment usage"
-            }
-            IncompatibleRenderPassAttachmentError::MissingInputAttachmentUsage => {
-                "the image is used as an input attachment but is missing the input \
+                }
+                IncompatibleRenderPassAttachmentError::MissingInputAttachmentUsage => {
+                    "the image is used as an input attachment but is missing the input \
                  attachment usage"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -527,24 +527,28 @@ impl error::Error for FramebufferCreationError {
 impl fmt::Display for FramebufferCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            FramebufferCreationError::OomError(_) => "no memory available",
-            FramebufferCreationError::DimensionsTooLarge => {
-                "the dimensions of the framebuffer are too large"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                FramebufferCreationError::OomError(_) => "no memory available",
+                FramebufferCreationError::DimensionsTooLarge => {
+                    "the dimensions of the framebuffer are too large"
+                }
+                FramebufferCreationError::AttachmentDimensionsIncompatible { .. } => {
+                    "the attachment has a size that isn't compatible with the framebuffer dimensions"
+                }
+                FramebufferCreationError::AttachmentsCountMismatch { .. } => {
+                    "the number of attachments doesn't match the number expected by the render pass"
+                }
+                FramebufferCreationError::IncompatibleAttachment(_) => {
+                    "one of the images cannot be used as the requested attachment"
+                }
+                FramebufferCreationError::CantDetermineDimensions => {
+                    "the framebuffer has no attachment and no dimension was specified"
+                }
             }
-            FramebufferCreationError::AttachmentDimensionsIncompatible { .. } => {
-                "the attachment has a size that isn't compatible with the framebuffer dimensions"
-            }
-            FramebufferCreationError::AttachmentsCountMismatch { .. } => {
-                "the number of attachments doesn't match the number expected by the render pass"
-            }
-            FramebufferCreationError::IncompatibleAttachment(_) => {
-                "one of the images cannot be used as the requested attachment"
-            }
-            FramebufferCreationError::CantDetermineDimensions => {
-                "the framebuffer has no attachment and no dimension was specified"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/framebuffer/sys.rs
+++ b/vulkano/src/framebuffer/sys.rs
@@ -557,12 +557,16 @@ impl error::Error for RenderPassCreationError {
 impl fmt::Display for RenderPassCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            RenderPassCreationError::OomError(_) => "not enough memory available",
-            RenderPassCreationError::ColorAttachmentsLimitExceeded => {
-                "the maximum number of color attachments has been exceeded"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                RenderPassCreationError::OomError(_) => "not enough memory available",
+                RenderPassCreationError::ColorAttachmentsLimitExceeded => {
+                    "the maximum number of color attachments has been exceeded"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -933,29 +933,33 @@ impl error::Error for ImageCreationError {
 impl fmt::Display for ImageCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            ImageCreationError::AllocError(_) => "allocating memory failed",
-            ImageCreationError::InvalidMipmapsCount { .. } => {
-                "a wrong number of mipmaps was provided"
-            }
-            ImageCreationError::UnsupportedSamplesCount { .. } => {
-                "the requested number of samples is not supported, or is 0"
-            }
-            ImageCreationError::UnsupportedDimensions { .. } => {
-                "the dimensions are too large, or one of the dimensions is 0"
-            }
-            ImageCreationError::FormatNotSupported => {
-                "the requested format is not supported by the Vulkan implementation"
-            }
-            ImageCreationError::UnsupportedUsage => {
-                "the format is supported, but at least one of the requested usages is not \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                ImageCreationError::AllocError(_) => "allocating memory failed",
+                ImageCreationError::InvalidMipmapsCount { .. } => {
+                    "a wrong number of mipmaps was provided"
+                }
+                ImageCreationError::UnsupportedSamplesCount { .. } => {
+                    "the requested number of samples is not supported, or is 0"
+                }
+                ImageCreationError::UnsupportedDimensions { .. } => {
+                    "the dimensions are too large, or one of the dimensions is 0"
+                }
+                ImageCreationError::FormatNotSupported => {
+                    "the requested format is not supported by the Vulkan implementation"
+                }
+                ImageCreationError::UnsupportedUsage => {
+                    "the format is supported, but at least one of the requested usages is not \
                  supported"
-            }
-            ImageCreationError::ShaderStorageImageMultisampleFeatureNotEnabled => {
-                "the `shader_storage_image_multisample` feature must be enabled to create such \
+                }
+                ImageCreationError::ShaderStorageImageMultisampleFeatureNotEnabled => {
+                    "the `shader_storage_image_multisample` feature must be enabled to create such \
                  an image"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -338,11 +338,15 @@ impl error::Error for DebugCallbackCreationError {}
 impl fmt::Display for DebugCallbackCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            DebugCallbackCreationError::MissingExtension => {
-                "the `EXT_debug_report` extension was not enabled"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                DebugCallbackCreationError::MissingExtension => {
+                    "the `EXT_debug_report` extension was not enabled"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -680,14 +680,19 @@ impl error::Error for InstanceCreationError {
 impl fmt::Display for InstanceCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            InstanceCreationError::LoadingError(_) => "failed to load the Vulkan shared library",
-            InstanceCreationError::OomError(_) => "not enough memory available",
-            InstanceCreationError::InitializationFailed => "initialization failed",
-            InstanceCreationError::LayerNotPresent => "layer not present",
-            InstanceCreationError::ExtensionNotPresent => "extension not present",
-            InstanceCreationError::IncompatibleDriver => "incompatible driver",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                InstanceCreationError::LoadingError(_) =>
+                    "failed to load the Vulkan shared library",
+                InstanceCreationError::OomError(_) => "not enough memory available",
+                InstanceCreationError::InitializationFailed => "initialization failed",
+                InstanceCreationError::LayerNotPresent => "layer not present",
+                InstanceCreationError::ExtensionNotPresent => "extension not present",
+                InstanceCreationError::IncompatibleDriver => "incompatible driver",
+            }
+        )
     }
 }
 

--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -184,10 +184,14 @@ impl error::Error for LayersListError {
 impl fmt::Display for LayersListError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            LayersListError::LoadingError(_) => "failed to load the Vulkan shared library",
-            LayersListError::OomError(_) => "not enough memory available",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                LayersListError::LoadingError(_) => "failed to load the Vulkan shared library",
+                LayersListError::OomError(_) => "not enough memory available",
+            }
+        )
     }
 }
 

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -257,13 +257,17 @@ impl error::Error for LoadingError {
 impl fmt::Display for LoadingError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            LoadingError::LibraryLoadFailure(_) => "failed to load the Vulkan shared library",
-            LoadingError::MissingEntryPoint(_) => {
-                "one of the entry points required to be supported by the Vulkan implementation \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                LoadingError::LibraryLoadFailure(_) => "failed to load the Vulkan shared library",
+                LoadingError::MissingEntryPoint(_) => {
+                    "one of the entry points required to be supported by the Vulkan implementation \
                  is missing"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -160,10 +160,14 @@ impl error::Error for OomError {}
 impl fmt::Display for OomError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            OomError::OutOfHostMemory => "no memory available on the host",
-            OomError::OutOfDeviceMemory => "no memory available on the graphical device",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                OomError::OutOfHostMemory => "no memory available on the host",
+                OomError::OutOfDeviceMemory => "no memory available on the graphical device",
+            }
+        )
     }
 }
 

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -94,7 +94,9 @@ impl DeviceMemory {
         // This check was re-enabled because Mesa aborts if `size` is Very Large.
         let reported_heap_size = memory_type.heap().size();
         if reported_heap_size != 0 && size > reported_heap_size {
-            return Err(DeviceMemoryAllocError::OomError(OomError::OutOfDeviceMemory));
+            return Err(DeviceMemoryAllocError::OomError(
+                OomError::OutOfDeviceMemory,
+            ));
         }
 
         let memory = unsafe {
@@ -496,13 +498,17 @@ impl error::Error for DeviceMemoryAllocError {
 impl fmt::Display for DeviceMemoryAllocError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            DeviceMemoryAllocError::OomError(_) => "not enough memory available",
-            DeviceMemoryAllocError::TooManyObjects => {
-                "the maximum number of allocations has been exceeded"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                DeviceMemoryAllocError::OomError(_) => "not enough memory available",
+                DeviceMemoryAllocError::TooManyObjects => {
+                    "the maximum number of allocations has been exceeded"
+                }
+                DeviceMemoryAllocError::MemoryMapFailed => "memory map failed",
             }
-            DeviceMemoryAllocError::MemoryMapFailed => "memory map failed",
-        })
+        )
     }
 }
 

--- a/vulkano/src/pipeline/graphics_pipeline/creation_error.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/creation_error.rs
@@ -207,138 +207,144 @@ impl fmt::Display for GraphicsPipelineCreationError {
     // TODO: finish
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            GraphicsPipelineCreationError::OomError(_) => "not enough memory available",
-            GraphicsPipelineCreationError::VertexGeometryStagesMismatch(_) => {
-                "the interface between the vertex shader and the geometry shader mismatches"
-            }
-            GraphicsPipelineCreationError::VertexTessControlStagesMismatch(_) => {
-                "the interface between the vertex shader and the tessellation control shader \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                GraphicsPipelineCreationError::OomError(_) => "not enough memory available",
+                GraphicsPipelineCreationError::VertexGeometryStagesMismatch(_) => {
+                    "the interface between the vertex shader and the geometry shader mismatches"
+                }
+                GraphicsPipelineCreationError::VertexTessControlStagesMismatch(_) => {
+                    "the interface between the vertex shader and the tessellation control shader \
                  mismatches"
-            }
-            GraphicsPipelineCreationError::VertexFragmentStagesMismatch(_) => {
-                "the interface between the vertex shader and the fragment shader mismatches"
-            }
-            GraphicsPipelineCreationError::TessControlTessEvalStagesMismatch(_) => {
-                "the interface between the tessellation control shader and the tessellation \
+                }
+                GraphicsPipelineCreationError::VertexFragmentStagesMismatch(_) => {
+                    "the interface between the vertex shader and the fragment shader mismatches"
+                }
+                GraphicsPipelineCreationError::TessControlTessEvalStagesMismatch(_) => {
+                    "the interface between the tessellation control shader and the tessellation \
                  evaluation shader mismatches"
-            }
-            GraphicsPipelineCreationError::TessEvalGeometryStagesMismatch(_) => {
-                "the interface between the tessellation evaluation shader and the geometry \
+                }
+                GraphicsPipelineCreationError::TessEvalGeometryStagesMismatch(_) => {
+                    "the interface between the tessellation evaluation shader and the geometry \
                  shader mismatches"
-            }
-            GraphicsPipelineCreationError::TessEvalFragmentStagesMismatch(_) => {
-                "the interface between the tessellation evaluation shader and the fragment \
+                }
+                GraphicsPipelineCreationError::TessEvalFragmentStagesMismatch(_) => {
+                    "the interface between the tessellation evaluation shader and the fragment \
                  shader mismatches"
-            }
-            GraphicsPipelineCreationError::GeometryFragmentStagesMismatch(_) => {
-                "the interface between the geometry shader and the fragment shader mismatches"
-            }
-            GraphicsPipelineCreationError::IncompatiblePipelineLayout(_) => {
-                "the pipeline layout is not compatible with what the shaders expect"
-            }
-            GraphicsPipelineCreationError::FragmentShaderRenderPassIncompatible => {
-                "the output of the fragment shader is not compatible with what the render pass \
+                }
+                GraphicsPipelineCreationError::GeometryFragmentStagesMismatch(_) => {
+                    "the interface between the geometry shader and the fragment shader mismatches"
+                }
+                GraphicsPipelineCreationError::IncompatiblePipelineLayout(_) => {
+                    "the pipeline layout is not compatible with what the shaders expect"
+                }
+                GraphicsPipelineCreationError::FragmentShaderRenderPassIncompatible => {
+                    "the output of the fragment shader is not compatible with what the render pass \
                  subpass expects"
-            }
-            GraphicsPipelineCreationError::IncompatibleVertexDefinition(_) => {
-                "the vertex definition is not compatible with the input of the vertex shader"
-            }
-            GraphicsPipelineCreationError::MaxVertexInputBindingStrideExceeded { .. } => {
-                "the maximum stride value for vertex input (ie. the distance between two vertex \
+                }
+                GraphicsPipelineCreationError::IncompatibleVertexDefinition(_) => {
+                    "the vertex definition is not compatible with the input of the vertex shader"
+                }
+                GraphicsPipelineCreationError::MaxVertexInputBindingStrideExceeded { .. } => {
+                    "the maximum stride value for vertex input (ie. the distance between two vertex \
                  elements) has been exceeded"
-            }
-            GraphicsPipelineCreationError::MaxVertexInputBindingsExceeded { .. } => {
-                "the maximum number of vertex sources has been exceeded"
-            }
-            GraphicsPipelineCreationError::MaxVertexInputAttributeOffsetExceeded { .. } => {
-                "the maximum offset for a vertex attribute has been exceeded"
-            }
-            GraphicsPipelineCreationError::MaxVertexInputAttributesExceeded { .. } => {
-                "the maximum number of vertex attributes has been exceeded"
-            }
-            GraphicsPipelineCreationError::PrimitiveDoesntSupportPrimitiveRestart { .. } => {
-                "the user requested to use primitive restart, but the primitive topology \
+                }
+                GraphicsPipelineCreationError::MaxVertexInputBindingsExceeded { .. } => {
+                    "the maximum number of vertex sources has been exceeded"
+                }
+                GraphicsPipelineCreationError::MaxVertexInputAttributeOffsetExceeded { .. } => {
+                    "the maximum offset for a vertex attribute has been exceeded"
+                }
+                GraphicsPipelineCreationError::MaxVertexInputAttributesExceeded { .. } => {
+                    "the maximum number of vertex attributes has been exceeded"
+                }
+                GraphicsPipelineCreationError::PrimitiveDoesntSupportPrimitiveRestart {
+                    ..
+                } => {
+                    "the user requested to use primitive restart, but the primitive topology \
                  doesn't support it"
-            }
-            GraphicsPipelineCreationError::MultiViewportFeatureNotEnabled => {
-                "the `multi_viewport` feature must be enabled in order to use multiple viewports \
+                }
+                GraphicsPipelineCreationError::MultiViewportFeatureNotEnabled => {
+                    "the `multi_viewport` feature must be enabled in order to use multiple viewports \
                  at once"
-            }
-            GraphicsPipelineCreationError::MaxViewportsExceeded { .. } => {
-                "the maximum number of viewports has been exceeded"
-            }
-            GraphicsPipelineCreationError::MaxViewportDimensionsExceeded => {
-                "the maximum dimensions of viewports has been exceeded"
-            }
-            GraphicsPipelineCreationError::ViewportBoundsExceeded => {
-                "the minimum or maximum bounds of viewports have been exceeded"
-            }
-            GraphicsPipelineCreationError::WideLinesFeatureNotEnabled => {
-                "the `wide_lines` feature must be enabled in order to use a line width \
+                }
+                GraphicsPipelineCreationError::MaxViewportsExceeded { .. } => {
+                    "the maximum number of viewports has been exceeded"
+                }
+                GraphicsPipelineCreationError::MaxViewportDimensionsExceeded => {
+                    "the maximum dimensions of viewports has been exceeded"
+                }
+                GraphicsPipelineCreationError::ViewportBoundsExceeded => {
+                    "the minimum or maximum bounds of viewports have been exceeded"
+                }
+                GraphicsPipelineCreationError::WideLinesFeatureNotEnabled => {
+                    "the `wide_lines` feature must be enabled in order to use a line width \
                  greater than 1.0"
-            }
-            GraphicsPipelineCreationError::DepthClampFeatureNotEnabled => {
-                "the `depth_clamp` feature must be enabled in order to use depth clamping"
-            }
-            GraphicsPipelineCreationError::DepthBiasClampFeatureNotEnabled => {
-                "the `depth_bias_clamp` feature must be enabled in order to use a depth bias \
+                }
+                GraphicsPipelineCreationError::DepthClampFeatureNotEnabled => {
+                    "the `depth_clamp` feature must be enabled in order to use depth clamping"
+                }
+                GraphicsPipelineCreationError::DepthBiasClampFeatureNotEnabled => {
+                    "the `depth_bias_clamp` feature must be enabled in order to use a depth bias \
                  clamp different from 0.0."
-            }
-            GraphicsPipelineCreationError::FillModeNonSolidFeatureNotEnabled => {
-                "the `fill_mode_non_solid` feature must be enabled in order to use a polygon mode \
+                }
+                GraphicsPipelineCreationError::FillModeNonSolidFeatureNotEnabled => {
+                    "the `fill_mode_non_solid` feature must be enabled in order to use a polygon mode \
                  different from `Fill`"
-            }
-            GraphicsPipelineCreationError::DepthBoundsFeatureNotEnabled => {
-                "the `depth_bounds` feature must be enabled in order to use depth bounds testing"
-            }
-            GraphicsPipelineCreationError::WrongStencilState => {
-                "the requested stencil test is invalid"
-            }
-            GraphicsPipelineCreationError::TopologyNotMatchingGeometryShader => {
-                "the primitives topology does not match what the geometry shader expects"
-            }
-            GraphicsPipelineCreationError::GeometryShaderFeatureNotEnabled => {
-                "the `geometry_shader` feature must be enabled in order to use geometry shaders"
-            }
-            GraphicsPipelineCreationError::TessellationShaderFeatureNotEnabled => {
-                "the `tessellation_shader` feature must be enabled in order to use tessellation \
+                }
+                GraphicsPipelineCreationError::DepthBoundsFeatureNotEnabled => {
+                    "the `depth_bounds` feature must be enabled in order to use depth bounds testing"
+                }
+                GraphicsPipelineCreationError::WrongStencilState => {
+                    "the requested stencil test is invalid"
+                }
+                GraphicsPipelineCreationError::TopologyNotMatchingGeometryShader => {
+                    "the primitives topology does not match what the geometry shader expects"
+                }
+                GraphicsPipelineCreationError::GeometryShaderFeatureNotEnabled => {
+                    "the `geometry_shader` feature must be enabled in order to use geometry shaders"
+                }
+                GraphicsPipelineCreationError::TessellationShaderFeatureNotEnabled => {
+                    "the `tessellation_shader` feature must be enabled in order to use tessellation \
                  shaders"
-            }
-            GraphicsPipelineCreationError::MismatchBlendingAttachmentsCount => {
-                "the number of attachments specified in the blending does not match the number of \
+                }
+                GraphicsPipelineCreationError::MismatchBlendingAttachmentsCount => {
+                    "the number of attachments specified in the blending does not match the number of \
                  attachments in the subpass"
-            }
-            GraphicsPipelineCreationError::IndependentBlendFeatureNotEnabled => {
-                "the `independent_blend` feature must be enabled in order to use different \
+                }
+                GraphicsPipelineCreationError::IndependentBlendFeatureNotEnabled => {
+                    "the `independent_blend` feature must be enabled in order to use different \
                  blending operations per attachment"
-            }
-            GraphicsPipelineCreationError::LogicOpFeatureNotEnabled => {
-                "the `logic_op` feature must be enabled in order to use logic operations"
-            }
-            GraphicsPipelineCreationError::NoDepthAttachment => {
-                "the depth attachment of the render pass does not match the depth test"
-            }
-            GraphicsPipelineCreationError::NoStencilAttachment => {
-                "the stencil attachment of the render pass does not match the stencil test"
-            }
-            GraphicsPipelineCreationError::InvalidPrimitiveTopology => {
-                "trying to use a patch list without a tessellation shader, or a non-patch-list \
+                }
+                GraphicsPipelineCreationError::LogicOpFeatureNotEnabled => {
+                    "the `logic_op` feature must be enabled in order to use logic operations"
+                }
+                GraphicsPipelineCreationError::NoDepthAttachment => {
+                    "the depth attachment of the render pass does not match the depth test"
+                }
+                GraphicsPipelineCreationError::NoStencilAttachment => {
+                    "the stencil attachment of the render pass does not match the stencil test"
+                }
+                GraphicsPipelineCreationError::InvalidPrimitiveTopology => {
+                    "trying to use a patch list without a tessellation shader, or a non-patch-list \
                  with a tessellation shader"
+                }
+                GraphicsPipelineCreationError::MaxTessellationPatchSizeExceeded => {
+                    "the maximum tessellation patch size was exceeded"
+                }
+                GraphicsPipelineCreationError::WrongShaderType => {
+                    "the wrong type of shader has been passed"
+                }
+                GraphicsPipelineCreationError::SampleRateShadingFeatureNotEnabled => {
+                    "the `sample_rate_shading` feature must be enabled in order to use sample shading"
+                }
+                GraphicsPipelineCreationError::AlphaToOneFeatureNotEnabled => {
+                    "the `alpha_to_one` feature must be enabled in order to use alpha-to-one"
+                }
             }
-            GraphicsPipelineCreationError::MaxTessellationPatchSizeExceeded => {
-                "the maximum tessellation patch size was exceeded"
-            }
-            GraphicsPipelineCreationError::WrongShaderType => {
-                "the wrong type of shader has been passed"
-            }
-            GraphicsPipelineCreationError::SampleRateShadingFeatureNotEnabled => {
-                "the `sample_rate_shading` feature must be enabled in order to use sample shading"
-            }
-            GraphicsPipelineCreationError::AlphaToOneFeatureNotEnabled => {
-                "the `alpha_to_one` feature must be enabled in order to use alpha-to-one"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/pipeline/shader.rs
+++ b/vulkano/src/pipeline/shader.rs
@@ -561,15 +561,19 @@ impl error::Error for ShaderInterfaceMismatchError {}
 impl fmt::Display for ShaderInterfaceMismatchError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            ShaderInterfaceMismatchError::ElementsCountMismatch { .. } => {
-                "the number of elements mismatches"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                ShaderInterfaceMismatchError::ElementsCountMismatch { .. } => {
+                    "the number of elements mismatches"
+                }
+                ShaderInterfaceMismatchError::MissingElement { .. } => "an element is missing",
+                ShaderInterfaceMismatchError::FormatMismatch { .. } => {
+                    "the format of an element does not match"
+                }
             }
-            ShaderInterfaceMismatchError::MissingElement { .. } => "an element is missing",
-            ShaderInterfaceMismatchError::FormatMismatch { .. } => {
-                "the format of an element does not match"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/pipeline/vertex/definition.rs
+++ b/vulkano/src/pipeline/vertex/definition.rs
@@ -96,12 +96,17 @@ impl error::Error for IncompatibleVertexDefinitionError {}
 impl fmt::Display for IncompatibleVertexDefinitionError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            IncompatibleVertexDefinitionError::MissingAttribute { .. } => "an attribute is missing",
-            IncompatibleVertexDefinitionError::FormatMismatch { .. } => {
-                "the format of an attribute does not match"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                IncompatibleVertexDefinitionError::MissingAttribute { .. } =>
+                    "an attribute is missing",
+                IncompatibleVertexDefinitionError::FormatMismatch { .. } => {
+                    "the format of an attribute does not match"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/query/mod.rs
+++ b/vulkano/src/query/mod.rs
@@ -287,13 +287,17 @@ impl error::Error for QueryPoolCreationError {
 impl fmt::Display for QueryPoolCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            QueryPoolCreationError::OomError(_) => "not enough memory available",
-            QueryPoolCreationError::PipelineStatisticsQueryFeatureNotEnabled => {
-                "a pipeline statistics pool was requested but the corresponding feature \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                QueryPoolCreationError::OomError(_) => "not enough memory available",
+                QueryPoolCreationError::PipelineStatisticsQueryFeatureNotEnabled => {
+                    "a pipeline statistics pool was requested but the corresponding feature \
                  wasn't enabled"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/sampler.rs
+++ b/vulkano/src/sampler.rs
@@ -735,18 +735,23 @@ impl error::Error for SamplerCreationError {
 impl fmt::Display for SamplerCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}",         match *self {
-            SamplerCreationError::OomError(_) => "not enough memory available",
-            SamplerCreationError::TooManyObjects => "too many simultaneous sampler objects",
-            SamplerCreationError::SamplerAnisotropyFeatureNotEnabled => {
-                "the `sampler_anisotropy` feature is not enabled"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                SamplerCreationError::OomError(_) => "not enough memory available",
+                SamplerCreationError::TooManyObjects => "too many simultaneous sampler objects",
+                SamplerCreationError::SamplerAnisotropyFeatureNotEnabled => {
+                    "the `sampler_anisotropy` feature is not enabled"
+                }
+                SamplerCreationError::AnisotropyLimitExceeded { .. } => "anisotropy limit exceeded",
+                SamplerCreationError::MipLodBiasLimitExceeded { .. } =>
+                    "mip lod bias limit exceeded",
+                SamplerCreationError::SamplerMirrorClampToEdgeExtensionNotEnabled => {
+                    "the device extension `VK_KHR_sampler_mirror_clamp_to_edge` is not enabled"
+                }
             }
-            SamplerCreationError::AnisotropyLimitExceeded { .. } => "anisotropy limit exceeded",
-            SamplerCreationError::MipLodBiasLimitExceeded { .. } => "mip lod bias limit exceeded",
-            SamplerCreationError::SamplerMirrorClampToEdgeExtensionNotEnabled => {
-                "the device extension `VK_KHR_sampler_mirror_clamp_to_edge` is not enabled"
-            }
-        })
+        )
     }
 }
 

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -719,12 +719,16 @@ impl error::Error for SurfaceCreationError {
 impl fmt::Display for SurfaceCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            SurfaceCreationError::OomError(_) => "not enough memory available",
-            SurfaceCreationError::MissingExtension { .. } => {
-                "the extension required for this function was not enabled"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                SurfaceCreationError::OomError(_) => "not enough memory available",
+                SurfaceCreationError::MissingExtension { .. } => {
+                    "the extension required for this function was not enabled"
+                }
             }
-        })
+        )
     }
 }
 
@@ -770,10 +774,14 @@ impl error::Error for CapabilitiesError {
 impl fmt::Display for CapabilitiesError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            CapabilitiesError::OomError(_) => "not enough memory",
-            CapabilitiesError::SurfaceLost => "the surface is no longer valid",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CapabilitiesError::OomError(_) => "not enough memory",
+                CapabilitiesError::SurfaceLost => "the surface is no longer valid",
+            }
+        )
     }
 }
 

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -966,59 +966,63 @@ impl error::Error for SwapchainCreationError {
 impl fmt::Display for SwapchainCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            SwapchainCreationError::OomError(_) => "not enough memory available",
-            SwapchainCreationError::DeviceLost => "the device was lost",
-            SwapchainCreationError::SurfaceLost => "the surface was lost",
-            SwapchainCreationError::SurfaceInUse => {
-                "the surface is already used by another swapchain"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                SwapchainCreationError::OomError(_) => "not enough memory available",
+                SwapchainCreationError::DeviceLost => "the device was lost",
+                SwapchainCreationError::SurfaceLost => "the surface was lost",
+                SwapchainCreationError::SurfaceInUse => {
+                    "the surface is already used by another swapchain"
+                }
+                SwapchainCreationError::NativeWindowInUse => {
+                    "the window is already in use by another API"
+                }
+                SwapchainCreationError::MissingExtensionKHRSwapchain => {
+                    "the `VK_KHR_swapchain` extension was not enabled"
+                }
+                SwapchainCreationError::MissingExtensionExtFullScreenExclusive => {
+                    "the `VK_EXT_full_screen_exclusive` extension was not enabled"
+                }
+                SwapchainCreationError::OldSwapchainSurfaceMismatch => {
+                    "surface mismatch between old and new swapchain"
+                }
+                SwapchainCreationError::OldSwapchainAlreadyUsed => {
+                    "old swapchain has already been used to recreate a new one"
+                }
+                SwapchainCreationError::UnsupportedMinImagesCount => {
+                    "the requested number of swapchain images is not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedMaxImagesCount => {
+                    "the requested number of swapchain images is not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedFormat => {
+                    "the requested image format is not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedDimensions => {
+                    "the requested dimensions are not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedArrayLayers => {
+                    "the requested array layers count is not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedUsageFlags => {
+                    "the requested image usage is not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedSurfaceTransform => {
+                    "the requested surface transform is not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedCompositeAlpha => {
+                    "the requested composite alpha is not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedPresentMode => {
+                    "the requested present mode is not supported by the surface"
+                }
+                SwapchainCreationError::UnsupportedImageConfiguration => {
+                    "the requested image configuration is not supported by the physical device"
+                }
             }
-            SwapchainCreationError::NativeWindowInUse => {
-                "the window is already in use by another API"
-            }
-            SwapchainCreationError::MissingExtensionKHRSwapchain => {
-                "the `VK_KHR_swapchain` extension was not enabled"
-            }
-            SwapchainCreationError::MissingExtensionExtFullScreenExclusive => {
-                "the `VK_EXT_full_screen_exclusive` extension was not enabled"
-            }
-            SwapchainCreationError::OldSwapchainSurfaceMismatch => {
-                "surface mismatch between old and new swapchain"
-            }
-            SwapchainCreationError::OldSwapchainAlreadyUsed => {
-                "old swapchain has already been used to recreate a new one"
-            }
-            SwapchainCreationError::UnsupportedMinImagesCount => {
-                "the requested number of swapchain images is not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedMaxImagesCount => {
-                "the requested number of swapchain images is not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedFormat => {
-                "the requested image format is not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedDimensions => {
-                "the requested dimensions are not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedArrayLayers => {
-                "the requested array layers count is not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedUsageFlags => {
-                "the requested image usage is not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedSurfaceTransform => {
-                "the requested surface transform is not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedCompositeAlpha => {
-                "the requested composite alpha is not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedPresentMode => {
-                "the requested present mode is not supported by the surface"
-            }
-            SwapchainCreationError::UnsupportedImageConfiguration => {
-                "the requested image configuration is not supported by the physical device"
-            }
-        })
+        )
     }
 }
 
@@ -1239,23 +1243,27 @@ impl error::Error for FullscreenExclusiveError {
 impl fmt::Display for FullscreenExclusiveError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            FullscreenExclusiveError::OomError(_) => "not enough memory",
-            FullscreenExclusiveError::SurfaceLost => {
-                "the surface of this swapchain is no longer valid"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                FullscreenExclusiveError::OomError(_) => "not enough memory",
+                FullscreenExclusiveError::SurfaceLost => {
+                    "the surface of this swapchain is no longer valid"
+                }
+                FullscreenExclusiveError::InitializationFailed => {
+                    "operation could not be completed for driver specific reasons"
+                }
+                FullscreenExclusiveError::DoubleAcquire =>
+                    "fullscreen exclusivity is already acquired",
+                FullscreenExclusiveError::DoubleRelease => "fullscreen exclusivity is not acquired",
+                FullscreenExclusiveError::NotAppControlled => {
+                    "swapchain is not in fullscreen exclusive app controlled mode"
+                }
             }
-            FullscreenExclusiveError::InitializationFailed => {
-                "operation could not be completed for driver specific reasons"
-            }
-            FullscreenExclusiveError::DoubleAcquire => "fullscreen exclusivity is already acquired",
-            FullscreenExclusiveError::DoubleRelease => "fullscreen exclusivity is not acquired",
-            FullscreenExclusiveError::NotAppControlled => {
-                "swapchain is not in fullscreen exclusive app controlled mode"
-            }
-        })
+        )
     }
 }
-
 
 /// Error that can happen when calling `acquire_next_image`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -1295,16 +1303,20 @@ impl error::Error for AcquireError {
 impl fmt::Display for AcquireError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            AcquireError::OomError(_) => "not enough memory",
-            AcquireError::DeviceLost => "the connection to the device has been lost",
-            AcquireError::Timeout => "no image is available for acquiring yet",
-            AcquireError::SurfaceLost => "the surface of this swapchain is no longer valid",
-            AcquireError::OutOfDate => "the swapchain needs to be recreated",
-            AcquireError::FullscreenExclusiveLost => {
-                "the swapchain no longer has fullscreen exclusivity"
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                AcquireError::OomError(_) => "not enough memory",
+                AcquireError::DeviceLost => "the connection to the device has been lost",
+                AcquireError::Timeout => "no image is available for acquiring yet",
+                AcquireError::SurfaceLost => "the surface of this swapchain is no longer valid",
+                AcquireError::OutOfDate => "the swapchain needs to be recreated",
+                AcquireError::FullscreenExclusiveLost => {
+                    "the swapchain no longer has fullscreen exclusivity"
+                }
             }
-        })
+        )
     }
 }
 

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -376,11 +376,15 @@ impl error::Error for FenceWaitError {
 impl fmt::Display for FenceWaitError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            FenceWaitError::OomError(_) => "no memory available",
-            FenceWaitError::Timeout => "the timeout has been reached",
-            FenceWaitError::DeviceLostError => "the device was lost",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                FenceWaitError::OomError(_) => "no memory available",
+                FenceWaitError::Timeout => "the timeout has been reached",
+                FenceWaitError::DeviceLostError => "the device was lost",
+            }
+        )
     }
 }
 

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -384,26 +384,30 @@ impl error::Error for AccessError {}
 impl fmt::Display for AccessError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            AccessError::ExclusiveDenied => "only shared access is allowed for this resource",
-            AccessError::AlreadyInUse => {
-                "the resource is already in use, and there is no tracking of concurrent usages"
-            }
-            AccessError::UnexpectedImageLayout { .. } => {
-                unimplemented!() // TODO: find a description
-            }
-            AccessError::ImageNotInitialized { .. } => {
-                "trying to use an image without transitioning it from the undefined or \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                AccessError::ExclusiveDenied => "only shared access is allowed for this resource",
+                AccessError::AlreadyInUse => {
+                    "the resource is already in use, and there is no tracking of concurrent usages"
+                }
+                AccessError::UnexpectedImageLayout { .. } => {
+                    unimplemented!() // TODO: find a description
+                }
+                AccessError::ImageNotInitialized { .. } => {
+                    "trying to use an image without transitioning it from the undefined or \
                  preinitialized layouts first"
-            }
-            AccessError::BufferNotInitialized => {
-                "trying to use a buffer that still contains garbage data"
-            }
-            AccessError::SwapchainImageAcquireOnly => {
-                "trying to use a swapchain image without depending on a corresponding acquire \
+                }
+                AccessError::BufferNotInitialized => {
+                    "trying to use a buffer that still contains garbage data"
+                }
+                AccessError::SwapchainImageAcquireOnly => {
+                    "trying to use a swapchain image without depending on a corresponding acquire \
                  image future"
+                }
             }
-        })
+        )
     }
 }
 
@@ -421,10 +425,14 @@ impl error::Error for AccessCheckError {}
 impl fmt::Display for AccessCheckError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            AccessCheckError::Denied(_) => "access to the resource has been denied",
-            AccessCheckError::Unknown => "the resource is unknown",
-        })
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                AccessCheckError::Denied(_) => "access to the resource has been denied",
+                AccessCheckError::Unknown => "the resource is unknown",
+            }
+        )
     }
 }
 
@@ -476,20 +484,24 @@ impl error::Error for FlushError {
 impl fmt::Display for FlushError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(fmt, "{}", match *self {
-            FlushError::AccessError(_) => "access to a resource has been denied",
-            FlushError::OomError(_) => "not enough memory",
-            FlushError::DeviceLost => "the connection to the device has been lost",
-            FlushError::SurfaceLost => "the surface of this swapchain is no longer valid",
-            FlushError::OutOfDate => "the swapchain needs to be recreated",
-            FlushError::FullscreenExclusiveLost => {
-                "the swapchain no longer has fullscreen exclusivity"
-            }
-            FlushError::Timeout => {
-                "the flush operation needed to block, but the timeout has \
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                FlushError::AccessError(_) => "access to a resource has been denied",
+                FlushError::OomError(_) => "not enough memory",
+                FlushError::DeviceLost => "the connection to the device has been lost",
+                FlushError::SurfaceLost => "the surface of this swapchain is no longer valid",
+                FlushError::OutOfDate => "the swapchain needs to be recreated",
+                FlushError::FullscreenExclusiveLost => {
+                    "the swapchain no longer has fullscreen exclusivity"
+                }
+                FlushError::Timeout => {
+                    "the flush operation needed to block, but the timeout has \
                                     elapsed"
+                }
             }
-        })
+        )
     }
 }
 


### PR DESCRIPTION
I was going to apply clippy suggestions throughout the project when I noticed that my editor automatically ran `cargo fmt` on all files I tried saving.

Assuming that most people use `cargo fmt`, I think it'll be good to keep the entire project properly formatted.

This pull request runs `cargo fmt` over the entire repository, as well as adding a check to `.travis.yml` to see if rustfmt has any suggestions.

There are several options to configure rustfmt, the easiest would be to add a `.rustfmt.yml` file in the root of the project. All options can be found [on rustfmt's github page](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md)

This pull request will probably break other open pull requests, but will not introduce any API or documentation changes. I figured it was not worth adding this to any of the changelogs.