### PR TITLE
Return Send + Sync trait object from FramebufferAbstract

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Added a `properties` method to `Format`.
+- `FramebufferAbstract::attached_image_view` and `AttachmentLists::as_image_view_access` now return a trait object that is `Send + Sync`. Attachments for framebuffers must now also implement these traits.
 
 # Version 0.19.0 (2020-06-01)
 

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -387,7 +387,7 @@ where
     }
 
     #[inline]
-    fn attached_image_view(&self, index: usize) -> Option<&dyn ImageViewAccess> {
+    fn attached_image_view(&self, index: usize) -> Option<&(dyn ImageViewAccess + Send + Sync)> {
         self.resources.as_image_view_access(index)
     }
 }

--- a/vulkano/src/framebuffer/traits.rs
+++ b/vulkano/src/framebuffer/traits.rs
@@ -31,7 +31,7 @@ pub unsafe trait FramebufferAbstract: RenderPassAbstract {
     /// Returns the attachment of the framebuffer with the given index.
     ///
     /// If the `index` is not between `0` and `num_attachments`, then `None` should be returned.
-    fn attached_image_view(&self, index: usize) -> Option<&dyn ImageViewAccess>;
+    fn attached_image_view(&self, index: usize) -> Option<&(dyn ImageViewAccess + Send + Sync)>;
 
     /// Returns the width of the framebuffer in pixels.
     #[inline]
@@ -68,7 +68,7 @@ where
     }
 
     #[inline]
-    fn attached_image_view(&self, index: usize) -> Option<&dyn ImageViewAccess> {
+    fn attached_image_view(&self, index: usize) -> Option<&(dyn ImageViewAccess + Send + Sync)> {
         (**self).attached_image_view(index)
     }
 }


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Ran `cargo fmt` on the changes

This adds a `Send + Sync` bound to the trait object that gets returned from `FramebufferAbstract::attached_image_view` and `AttachmentsList::as_image_view_access`. This presumably means that framebuffers can now only be created from images that are `Send + Sync` themselves, but this requirement is met by all the Vulkano image types. So unless someone has made a custom image type that fails this requirement, it shouldn't break anyone's code.