### PR TITLE
Add a build script to tell rustc to add the path to libvulkan in the rpath of binaries

### DIFF
--- a/vk-sys/build.rs
+++ b/vk-sys/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(not(target_os = "ios")) {
+        println!("cargo:rustc-link-lib=vulkan");
+    }
+}


### PR DESCRIPTION
Thanks for this crate! It's awesome!

This PR just adds a little tweak to make it easier to link binaries to libvulkan. This `build.rs` is useful on platforms where `LD_LIBRARY_PATH` (or equivalent) is not set system-wide, so that the rpath of executables made using vulkano contains libvulkan. The `cfg!` matches the conditions in `vulkano/vulkano/src/instance/loader.rs`.

* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes
