### PR TITLE
CI: minimize cached directories to avoid timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,10 @@ jobs:
 cache:
   directories:
     - $TRAVIS_HOME/.cargo/
-    - $TRAVIS_BUILD_DIR/target/debug/build
-    - $TRAVIS_BUILD_DIR/target/debug/deps
-    - $TRAVIS_BUILD_DIR/target/debug/incremental
 
 before_cache:
   - rm -rf $TRAVIS_HOME/.cargo/registry/src
+  - du -sh $TRAVIS_HOME/.cargo/
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install ninja; choco install python3 --params "/InstallAllUsers"; fi


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/caching/#how-does-caching-work:

> Note that this makes our cache not network-local, it is still bound to
> network bandwidth and DNS resolutions. That impacts what you can and
> should store in the cache. If you store archives larger than a few
> hundred megabytes in the cache, it is unlikely that you’ll see a big
> speed improvement.