### PR TITLE
Call the correct surface creation function on Windows.

### DIFF
--- a/vulkano-win/src/raw_window_handle.rs
+++ b/vulkano-win/src/raw_window_handle.rs
@@ -24,7 +24,7 @@ where
     W: HasRawWindowHandle,
 {
     unsafe {
-        match window.raw_window_handle(){
+        match window.raw_window_handle() {
             #[cfg(target_os = "ios")]
             RawWindowHandle::IOS(h) => handle_to_surface(h.ui_view, instance, window),
             #[cfg(target_os = "macos")]
@@ -152,5 +152,5 @@ unsafe fn handle_to_surface<W: Sized>(
     instance: Arc<Instance>,
     win: W,
 ) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
-    Surface::from_wayland(instance, hinstance as *const _, hwnd as *const _, win)
+    Surface::from_hwnd(instance, hinstance as *const _, hwnd as *const _, win)
 }

--- a/vulkano-win/src/winit.rs
+++ b/vulkano-win/src/winit.rs
@@ -177,12 +177,7 @@ unsafe fn winit_to_surface<W: SafeBorrow<Window>>(
 ) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
     use winit::platform::windows::WindowExtWindows;
 
-    Surface::from_hwnd(
-        instance,
-        win.borrow().hinstance(),
-        win.borrow().hwnd(),
-        win,
-    )
+    Surface::from_hwnd(instance, win.borrow().hinstance(), win.borrow().hwnd(), win)
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
On Windows 'Surface::from_hwnd' should be called rather than 'Surface::from_wayland'.

* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [X] Ran `cargo fmt` on the changes
