### PR TITLE
Bump winit to 0.23

### DIFF
--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -17,7 +17,7 @@ winit_ = ["winit", "metal", "cocoa", "objc"]
 raw-window-handle_ = ["raw-window-handle"]
 
 [dependencies]
-winit = { version = "0.22", optional = true }
+winit = { version = "0.23", optional = true }
 vulkano = { version = "0.19.0", path = "../vulkano" }
 raw-window-handle = { version = "0.3.3", optional = true }
 


### PR DESCRIPTION
Winit 0.23 was released in early october, this brings Vulkano up to date.