### PR TITLE
1418: unsafe array; pass-by-ref

### DIFF
--- a/vk-sys/src/lib.rs
+++ b/vk-sys/src/lib.rs
@@ -3000,7 +3000,7 @@ ptrs!(DevicePointers, {
     CmdSetScissor => (commandBuffer: CommandBuffer, firstScissor: u32, scissorCount: u32, pScissors: *const Rect2D) -> (),
     CmdSetLineWidth => (commandBuffer: CommandBuffer, lineWidth: f32) -> (),
     CmdSetDepthBias => (commandBuffer: CommandBuffer, depthBiasConstantFactor: f32, depthBiasClamp: f32, depthBiasSlopeFactor: f32) -> (),
-    CmdSetBlendConstants => (commandBuffer: CommandBuffer, blendConstants: [f32; 4]) -> (),
+    CmdSetBlendConstants => (commandBuffer: CommandBuffer, blendConstants: &[f32; 4]) -> (),
     CmdSetDepthBounds => (commandBuffer: CommandBuffer, minDepthBounds: f32, maxDepthBounds: f32) -> (),
     CmdSetStencilCompareMask => (commandBuffer: CommandBuffer, faceMask: StencilFaceFlags, compareMask: u32) -> (),
     CmdSetStencilWriteMask => (commandBuffer: CommandBuffer, faceMask: StencilFaceFlags, writeMask: u32) -> (),

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1452,7 +1452,7 @@ impl<P> UnsafeCommandBufferBuilder<P> {
     pub unsafe fn set_blend_constants(&mut self, constants: [f32; 4]) {
         let vk = self.device().pointers();
         let cmd = self.internal_object();
-        vk.CmdSetBlendConstants(cmd, constants); // TODO: correct to pass array?
+        vk.CmdSetBlendConstants(cmd, &constants);
     }
 
     /// Calls `vkCmdSetDepthBias` on the builder.


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x ] Ran `cargo fmt` on the changes

Small fix for passing rust fixed array into FFI;
- I have run tests on stable(1.47.0), beta(1.48.0-beta.8), and nightly(1.49.0-nightly) 
- no more compiler warning