### PR TITLE
Add debug marker commands to AutoCommandBufferBuilder

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -10,6 +10,7 @@
 - Added a `properties` method to `Format`.
 - Added additional device feature flags for enabling SPIR-V related capabilities.
 - Added method `copy_buffer_dimensions` that allows copying parts of buffers containing arrays.
+- Added `debug_marker_begin`, `debug_marker_end` and `debug_marker_insert` to `AutoCommandBufferBuilder`.
 - Fixed surface creation function on Windows(PR #1410).
 - Travis CI Linux Nightly job temporary disabled until #1423 resolved.
 

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -83,6 +83,7 @@ pub use self::auto::ClearColorImageError;
 pub use self::auto::CopyBufferError;
 pub use self::auto::CopyBufferImageError;
 pub use self::auto::CopyImageError;
+pub use self::auto::DebugMarkerError;
 pub use self::auto::DispatchError;
 pub use self::auto::DrawError;
 pub use self::auto::DrawIndexedError;

--- a/vulkano/src/command_buffer/validity/debug_marker.rs
+++ b/vulkano/src/command_buffer/validity/debug_marker.rs
@@ -1,0 +1,32 @@
+use std::{error, fmt};
+
+/// Checks whether the specified color is valid as debug marker color.
+///
+/// The color parameter must contain RGBA values in order, in the range 0.0 to 1.0.
+pub fn check_debug_marker_color(color: [f32; 4]) -> Result<(), CheckColorError> {
+    // The values contain RGBA values in order, in the range 0.0 to 1.0.
+    if color.iter().any(|x| !(0f32..=1f32).contains(x)) {
+        return Err(CheckColorError);
+    }
+
+    Ok(())
+}
+
+/// Error that can happen from `check_debug_marker_color`.
+#[derive(Debug, Copy, Clone)]
+pub struct CheckColorError;
+
+impl error::Error for CheckColorError {}
+
+impl fmt::Display for CheckColorError {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckColorError => "color parameter does contains values out of 0.0 to 1.0 range",
+            }
+        )
+    }
+}

--- a/vulkano/src/command_buffer/validity/mod.rs
+++ b/vulkano/src/command_buffer/validity/mod.rs
@@ -16,6 +16,7 @@ pub use self::copy_image::{check_copy_image, CheckCopyImageError};
 pub use self::copy_image_buffer::{
     check_copy_buffer_image, CheckCopyBufferImageError, CheckCopyBufferImageTy,
 };
+pub use self::debug_marker::{check_debug_marker_color, CheckColorError};
 pub use self::descriptor_sets::{check_descriptor_sets_validity, CheckDescriptorSetsValidityError};
 pub use self::dispatch::{check_dispatch, CheckDispatchError};
 pub use self::dynamic_state::{check_dynamic_state_validity, CheckDynamicStateValidityError};
@@ -30,6 +31,7 @@ mod clear_color_image;
 mod copy_buffer;
 mod copy_image;
 mod copy_image_buffer;
+mod debug_marker;
 mod descriptor_sets;
 mod dispatch;
 mod dynamic_state;


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

---------------

I saw that there are no methods for recording the debug markers in `AutoCommandBufferBuilder` but the methods are implemented for `UnsafeCommandBufferBuilder`. This PR adds support for these methods:
- [x] `AutoCommandBufferBuilder::debug_marker_begin`
- [x] `AutoCommandBufferBuilder::debug_marker_end`
- [x] `AutoCommandBufferBuilder::debug_marker_insert`

Todo:
- [x] validate / document required extension
- [x] document safety for all `unsafe` fns
 
I am unsure about these things:
- is the `'static` lifetime bound on `&CStr` necessary? I looked up the function in [Vulkan Specification][1], but it says nothing about when the pointer should be valid.
- ~is `debug_assert!` the right choice or should we rather make the method return `Result`?~

@Eliah-Lakhin ?

[1]:https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap44.html#VkDebugUtilsLabelEXT