### PR TITLE
Check usage bits on image when creating image view

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -16,6 +16,7 @@
 - Travis CI Linux Nightly job temporary disabled until #1423 resolved.
 - Renamed feature from `shader_f3264` to `shader_float64`.
 - Added method `build_with_cache` to the `GraphicsPipelineBuilder` that enables pipeline caching.
+- Check usage bits on image when creating image view.
 
 # Version 0.19.0 (2020-06-01)
 


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

Fixes #1392. It's only a quick fix using an assert statement, but since `UnsafeImageView` already has a bunch of checks with asserts, it felt appropriate.

I believe that, in the future, it may be good to split off image views as a type separate from images. In https://github.com/vulkano-rs/vulkano/issues/1392#issuecomment-653622619 I mentioned that, in my particular use case, I have no need for an image view on `Swapchain`, and therefore there shouldn't be a need to add one of the usages that views require. This could be solved by having `SwapchainImage` contain only a `vkImage`, with the user then free to create a `vkImageView` for it if they need to.