### PR TITLE
Unlock images correctly on Err

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -16,6 +16,7 @@
 - Travis CI Linux Nightly job temporary disabled until #1423 resolved.
 - Renamed feature from `shader_f3264` to `shader_float64`.
 - Added method `build_with_cache` to the `GraphicsPipelineBuilder` that enables pipeline caching.
+- Fixing an assertion panic in the SyncCommandBuffer. If the buffer encountered an error while locking the necessary resources, it would unlock all previously locked resources. Images were unlocked incorrectly and an assert in the image unlock function would panic.
 
 # Version 0.19.0 (2020-06-01)
 

--- a/vulkano/src/command_buffer/synced/base.rs
+++ b/vulkano/src/command_buffer/synced/base.rs
@@ -1195,7 +1195,7 @@ impl<P> SyncCommandBuffer<P> {
 
         // If we are going to return an error, we have to unlock all the resources we locked above.
         if let Err(_) = ret_value {
-            for key in self.resources.keys().take(locked_resources) {
+            for (key, val) in self.resources.iter().take(locked_resources) {
                 let (command_ids, resource_ty, resource_index) = match *key {
                     CbKey::Command {
                         ref command_ids,
@@ -1218,8 +1218,13 @@ impl<P> SyncCommandBuffer<P> {
                     KeyTy::Image => {
                         let cmd = &commands_lock[command_ids[0]];
                         let img = cmd.image(resource_index);
+                        let trans = if val.final_layout != val.initial_layout {
+                            Some(val.final_layout)
+                        } else {
+                            None
+                        };
                         unsafe {
-                            img.unlock(None);
+                            img.unlock(trans);
                         }
                     }
                 }


### PR DESCRIPTION
If the CommandBuffer encountered an error in the lock_submit function,
it would unlock all the previously locked resources and return the
error. It would unlock all the images with a None value which would
panic in an assertion in the unlock method of the images. Now it checks
for the final_layout and unlocks the image this way.
This change should help with the panics mentioned in #1441 and #1447.
With this fix, it should return the error that is occurring instead of
panicking.

* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
~~* [ ] Updated documentation to reflect any user-facing changes - in this repository~~
~~* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.~~
* [x] Ran `cargo fmt` on the changes
