### PR TITLE
CpuAccessibleBuffer: switch to parking_lot RwLock

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **Breaking** `CpuAccessibleBuffer` now uses `RwLock` from `parking_lot`.
 - **Breaking** The `Kind` and `SubpassContents` types have been moved to the root of the `command_buffer` module.
 - **Breaking** On `AutoCommandBufferBuilder`, the methods `begin_render_pass` and `next_subpass` now take `SubpassContents` instead of a boolean value.
 - **Breaking** The `CommandBuffer` trait now has an additional required method, `kind`.

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -20,3 +20,4 @@ smallvec = "1.4"
 lazy_static = "1.4"
 vk-sys = { version = "0.5.2", path = "../vk-sys" }
 half = "1.6"
+parking_lot = { version = "0.11.1", features = ["send_guard"] }

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -67,6 +67,7 @@ extern crate fnv;
 #[macro_use]
 extern crate lazy_static;
 pub extern crate half;
+extern crate parking_lot;
 extern crate shared_library;
 extern crate smallvec;
 extern crate vk_sys as vk;

--- a/vulkano/src/tests.rs
+++ b/vulkano/src/tests.rs
@@ -68,7 +68,7 @@ macro_rules! gfx_dev_and_queue {
 
 macro_rules! assert_should_panic {
     ($msg:expr, $code:block) => {{
-        let res = ::std::panic::catch_unwind(|| $code);
+        let res = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| $code));
 
         match res {
             Ok(_) => panic!("Test expected to panic but didn't"),
@@ -85,7 +85,7 @@ macro_rules! assert_should_panic {
     }};
 
     ($code:block) => {{
-        let res = ::std::panic::catch_unwind(|| $code);
+        let res = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| $code));
 
         match res {
             Ok(_) => panic!("Test expected to panic but didn't"),


### PR DESCRIPTION
This allows ReadLock and WriteLock to be Send and Sync.

