### PR TITLE
Add support for including precompiled shaders in vulkano-shaders

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -20,6 +20,7 @@
 - Added method `build_with_cache` to the `GraphicsPipelineBuilder` that enables pipeline caching.
 - Check usage bits on image when creating image view.
 - Fixing an assertion panic in the SyncCommandBuffer. If the buffer encountered an error while locking the necessary resources, it would unlock all previously locked resources. Images were unlocked incorrectly and an assert in the image unlock function would panic.
+- Added support for including precompiled shaders in vulkano-shaders using the `bytes` option.
 
 # Version 0.19.0 (2020-06-01)
 


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This PR adds an option `bytes` to the vulkano shader macro for directly loading spri-v bytecode rather than compiling from source. This is useful in circumstances where developers may want to use a different build system for shader compilation (In my case I'm using https://github.com/EmbarkStudios/rust-gpu to compile the shader).

Feel free to bikeshed/improve line 360 in vulkano-shaders/src/lib.rs - while it works on my system, I'm not sure how endianess might affect converting the u8 slice to a u32 slice, or if there's a better way to perform that conversion than pointer magic 👀 