### PR TITLE
Fix vulkano-shaders bytes documentation

### DIFF
--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -129,7 +129,7 @@
 //! ## `bytes: "..."`
 //!
 //! Provides the path to precompiled SPIR-V bytecode, relative to `Cargo.toml`.
-//! Cannot be used in conjunction with the `src` or `bytes` field.
+//! Cannot be used in conjunction with the `src` or `path` field.
 //! This allows using shaders compiled through a separate build system.
 //!
 //! ## `include: ["...", "...", ..., "..."]`


### PR DESCRIPTION
> I think there is a mistake in the documentation for `bytes`: "Cannot be used in conjunction with the `src` or `bytes` field." That should probably say `src` or `path`?

_Originally posted by @Rua in https://github.com/vulkano-rs/vulkano/issues/1455#issuecomment-748470182_

Whoops! Thanks for catching that. This PR should fix the documentation for `bytes` now.