### PR TITLE
Fix Cubemap and CubemapArray framebuffer attachments

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -22,6 +22,7 @@
 - Check usage bits on image when creating image view.
 - Fixing an assertion panic in the SyncCommandBuffer. If the buffer encountered an error while locking the necessary resources, it would unlock all previously locked resources. Images were unlocked incorrectly and an assert in the image unlock function would panic.
 - Added support for including precompiled shaders in vulkano-shaders using the `bytes` option.
+- Fixed clear `Cubemap` and `CubemapArray` framebuffer attachment dimensions; previously only 1/6th of the layers in each of these image layouts were actually considered by the framebuffer (for clearing and rendering). This seems to have been a result of the difference between `Dimensions` and `ImageDimensions`.
 
 # Version 0.19.0 (2020-06-01)
 

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -178,7 +178,7 @@ where
             Err(err) => return Err(FramebufferCreationError::IncompatibleAttachment(err)),
         };
 
-        let img_dims = attachment.dimensions();
+        let img_dims = attachment.dimensions().to_image_dimensions();
         debug_assert_eq!(img_dims.depth(), 1);
 
         let dimensions = match self.dimensions {


### PR DESCRIPTION
A fix for issue #1454 

Graphics pipeline did not clear or render to all the layers in a `Cubemap` or `CubemapArray` because framebuffers incorrectly read the number of array layers when adding an attachment. The proposed fix is to convert the `Dimensions` that is currently used to determine the attachment size to `ImageDimensions` which correctly calculates the number of array layers.