### PR TITLE
Attempting to get travis to build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,4 +42,3 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
-      


### PR DESCRIPTION
Normally to publish on Travis CI it has to be manually restarted several times until it decides to complete. This trailing white space in the commit resolves the error with white space as it will fail to succeed with white space.