### PR TITLE
Fix invalid reference to dropped PipelineCache object in ComputePipeline

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -2,6 +2,7 @@
 
 - Added support for `ImageAspect` and YV12/NV12 formats,  for use with the UnsafeImage API.
 - Added basic VK_KHR_external_memory, VK_KHR_external_memory_fd, and VK_EXT_external_memory_dma_buf support.
+- Fixed potential segmentation fault in `ComputePipeline` when referencing `PipelineCache` objects.
 
 # Version 0.20.0 (2020-12-26)
 

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -163,7 +163,7 @@ impl<Pl> ComputePipeline<Pl> {
             };
 
             let cache_handle = match cache {
-                Some(cache) => cache.internal_object(),
+                Some(ref cache) => cache.internal_object(),
                 None => vk::NULL_HANDLE,
             };
 


### PR DESCRIPTION
* [X] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [X] Updated documentation to reflect any user-facing changes - in this repository
* [X] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [X] Ran `cargo fmt` on the changes

This fixes issue #1466.