### PR TITLE
Fix potential stack overflow error in loading large shaders by storing the bytecode as static

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -4,6 +4,7 @@
 - Added basic VK_KHR_external_memory, VK_KHR_external_memory_fd, and VK_EXT_external_memory_dma_buf support.
 - Fixed potential segmentation fault in `ComputePipeline` when referencing `PipelineCache` objects.
 - Fixed race condition in `StandardCommandPool` when allocating buffers.
+- Fixed potential stack overflow error in loading large shaders by storing the bytecode as static.
 
 # Version 0.20.0 (2020-12-26)
 

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -308,11 +308,11 @@ pub(super) fn reflect(
                         -> Result<#struct_name, ::vulkano::OomError>
             {
                 #( #cap_checks )*
-                let words = [ #( #spirv ),* ];
+                static WORDS: &[u32] = &[ #( #spirv ),* ];
 
                 unsafe {
                     Ok(#struct_name {
-                        shader: ::vulkano::pipeline::shader::ShaderModule::from_words(device, &words)?
+                        shader: ::vulkano::pipeline::shader::ShaderModule::from_words(device, WORDS)?
                     })
                 }
             }


### PR DESCRIPTION
This PR adds a small fix to `vulkano_shaders` - bytecode is now stored as a static slice rather than as an array that is loaded on the stack. This in turn allows writing large uber shaders, or just creating a shader with 500 OpNops...

* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Ran `cargo fmt` on the changes