### PR TITLE
vulkano: memory: fix opaque fd support

### DIFF
--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -175,7 +175,7 @@ impl<'a> DeviceMemoryBuilder<'a> {
         assert!(self.device.loaded_extensions().khr_external_memory_fd);
 
         let handle_bits = handle_types.to_bits();
-        if handle_bits & vk::EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT == 0 {
+        if handle_bits & vk::EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT != 0 {
             assert!(self.device.loaded_extensions().ext_external_memory_dmabuf);
         }
 


### PR DESCRIPTION
Don't panic if user doesn't request dma-buf and dma-buf
isn't present on the system.

Fixes: 2d60c08c10bb4 ("Initial YUV and external memory support")

* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes
