### PR TITLE
[Breaking] Add support for dynamic buffers

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,10 +1,14 @@
 # Unreleased
 
+- **Breaking** On `AutoCommandBufferBuilder`, methods that bind a descriptor set now take a `dynamic_offsets` parameter
+- **Breaking** On `AutoCommandBufferBuilder` and `SyncCommandBufferBuilder`, the `update_buffer` method now takes `data` by reference
+- **Breaking** Made `PipelineLayoutDescTweaks` public, for use with compute pipelines
 - Added support for `ImageAspect` and YV12/NV12 formats,  for use with the UnsafeImage API.
 - Added basic VK_KHR_external_memory, VK_KHR_external_memory_fd, and VK_EXT_external_memory_dma_buf support.
 - Fixed potential segmentation fault in `ComputePipeline` when referencing `PipelineCache` objects.
 - Fixed race condition in `StandardCommandPool` when allocating buffers.
 - Fixed potential stack overflow error in loading large shaders by storing the bytecode as static.
+- Added basic support and safety checks for dynamic uniform/storage buffers
 
 # Version 0.20.0 (2020-12-26)
 

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -139,7 +139,7 @@ fn main() {
         // `Arc`, this only clones the `Arc` and not the whole pipeline or set (which aren't
         // cloneable anyway). In this example we would avoid cloning them since this is the last
         // time we use them, but in a real code you would probably need to clone them.
-        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), ())
+        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), (), vec![])
         .unwrap();
     // Finish building the command buffer by calling `build`.
     let command_buffer = builder.build().unwrap();

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -286,7 +286,7 @@ fn main() {
                     )
                     .unwrap()
                     // Draw our buffer
-                    .draw(pipeline.clone(), &dynamic_state, buffer, (), ())
+                    .draw(pipeline.clone(), &dynamic_state, buffer, (), (), vec![])
                     .unwrap()
                     .end_render_pass()
                     .unwrap();

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -156,6 +156,7 @@ impl AmbientLightingSystem {
                 vec![self.vertex_buffer.clone()],
                 descriptor_set,
                 push_constants,
+                vec![],
             )
             .unwrap();
         builder.build().unwrap()

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -170,6 +170,7 @@ impl DirectionalLightingSystem {
                 vec![self.vertex_buffer.clone()],
                 descriptor_set,
                 push_constants,
+                vec![],
             )
             .unwrap();
         builder.build().unwrap()

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -185,6 +185,7 @@ impl PointLightingSystem {
                 vec![self.vertex_buffer.clone()],
                 descriptor_set,
                 push_constants,
+                vec![],
             )
             .unwrap();
         builder.build().unwrap()

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -104,6 +104,7 @@ impl TriangleDrawSystem {
                 vec![self.vertex_buffer.clone()],
                 (),
                 (),
+                vec![],
             )
             .unwrap();
         builder.build().unwrap()

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -1,0 +1,210 @@
+// Copyright (c) 2021 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+// This example demonstrates how to use dynamic uniform buffers.
+//
+// Dynamic uniform and storage buffers store buffer data for different
+// calls in one large buffer. Each draw or dispatch call can specify an
+// offset into the buffer to read object data from, without having to
+// rebind descriptor sets.
+
+use std::mem;
+use std::sync::Arc;
+use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
+use vulkano::command_buffer::AutoCommandBufferBuilder;
+use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
+use vulkano::descriptor::pipeline_layout::{PipelineLayoutDesc, PipelineLayoutDescTweaks};
+use vulkano::descriptor::PipelineLayoutAbstract;
+use vulkano::device::{Device, DeviceExtensions};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::pipeline::shader::EntryPointAbstract;
+use vulkano::pipeline::ComputePipeline;
+use vulkano::sync;
+use vulkano::sync::GpuFuture;
+
+fn main() {
+    let instance = Instance::new(None, &InstanceExtensions::none(), None).unwrap();
+
+    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
+    let queue_family = physical
+        .queue_families()
+        .find(|&q| q.supports_compute())
+        .unwrap();
+    let (device, mut queues) = Device::new(
+        physical,
+        physical.supported_features(),
+        &DeviceExtensions {
+            khr_storage_buffer_storage_class: true,
+            ..DeviceExtensions::none()
+        },
+        [(queue_family, 0.5)].iter().cloned(),
+    )
+    .unwrap();
+    let queue = queues.next().unwrap();
+
+    mod shader {
+        vulkano_shaders::shader! {
+            ty: "compute",
+            src: "
+                #version 450
+
+                layout(local_size_x = 12) in;
+
+                // Uniform Buffer Object
+                layout(set = 0, binding = 0) uniform readonly InData {
+                    uint data;
+                } ubo;
+
+                // Output Buffer
+                layout(set = 0, binding = 1) buffer OutData {
+                    uint data[];
+                } data;
+
+                // Toy shader that only runs for the index specified in `ubo`.
+                void main() {
+                    uint index = gl_GlobalInvocationID.x;
+                    if(index == ubo.data) {
+                        data.data[index] = index;
+                    }
+                }
+                "
+        }
+    }
+
+    let shader = shader::Shader::load(device.clone()).unwrap();
+
+    // For Graphics pipelines, use the `with_auto_layout` method
+    // instead of the `build` method to specify dynamic buffers.
+    // `with_auto_layout` will automatically handle tweaking the
+    // pipeline.
+    let pipeline = Arc::new(
+        ComputePipeline::with_pipeline_layout(
+            device.clone(),
+            &shader.main_entry_point(),
+            &(),
+            Box::new(
+                PipelineLayoutDescTweaks::new(
+                    shader
+                        .main_entry_point()
+                        .layout()
+                        .clone()
+                        .build(device.clone())
+                        .unwrap(),
+                    vec![(0, 0)], // The dynamic uniform buffer is at set 0, descriptor 0
+                )
+                .build(device.clone())
+                .unwrap(),
+            ),
+            None,
+        )
+        .unwrap(),
+    );
+
+    // Declare input buffer.
+    // Data in a dynamic buffer **MUST** be aligned to min_uniform_buffer_offset_align
+    // or min_storage_buffer_offset_align, depending on the type of buffer.
+    let data: Vec<u8> = vec![3, 11, 7];
+    let min_dynamic_align = device
+        .physical_device()
+        .limits()
+        .min_uniform_buffer_offset_alignment() as usize;
+    println!(
+        "Minimum uniform buffer offset alignment: {}",
+        min_dynamic_align
+    );
+    println!("Input: {:?}", data);
+    // Round size up to the next multiple of align.
+    let align = (mem::size_of::<u32>() + min_dynamic_align - 1) & !(min_dynamic_align - 1);
+    let aligned_data = {
+        let mut aligned_data = Vec::with_capacity(align * data.len());
+        for i in 0..data.len() {
+            let bytes = data[i].to_ne_bytes();
+            // Fill up the buffer with data
+            for bi in 0..bytes.len() {
+                aligned_data.push(bytes[bi]);
+            }
+            // Zero out any padding needed for alignment
+            for _ in 0..align - bytes.len() {
+                aligned_data.push(0);
+            }
+        }
+        aligned_data
+    };
+
+    let input_buffer = CpuAccessibleBuffer::from_iter(
+        device.clone(),
+        BufferUsage::all(),
+        false,
+        aligned_data.into_iter(),
+    )
+    .unwrap();
+
+    let output_buffer = CpuAccessibleBuffer::from_iter(
+        device.clone(),
+        BufferUsage::all(),
+        false,
+        (0..12).map(|_| 0u32),
+    )
+    .unwrap();
+
+    let layout = pipeline.layout().descriptor_set_layout(0).unwrap();
+    let set = Arc::new(
+        PersistentDescriptorSet::start(layout.clone())
+            .add_buffer(input_buffer.clone())
+            .unwrap()
+            .add_buffer(output_buffer.clone())
+            .unwrap()
+            .build()
+            .unwrap(),
+    );
+
+    // Build the command buffer, using different offsets for each call.
+    let mut builder =
+        AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap();
+    builder
+        .dispatch(
+            [12, 1, 1],
+            pipeline.clone(),
+            set.clone(),
+            (),
+            vec![0 * align as u32],
+        )
+        .unwrap()
+        .dispatch(
+            [12, 1, 1],
+            pipeline.clone(),
+            set.clone(),
+            (),
+            vec![1 * align as u32],
+        )
+        .unwrap()
+        .dispatch(
+            [12, 1, 1],
+            pipeline.clone(),
+            set.clone(),
+            (),
+            vec![2 * align as u32],
+        )
+        .unwrap();
+    let command_buffer = builder.build().unwrap();
+
+    let future = sync::now(device.clone())
+        .then_execute(queue.clone(), command_buffer)
+        .unwrap()
+        .then_signal_fence_and_flush()
+        .unwrap();
+
+    future.wait(None).unwrap();
+
+    let output_content = output_buffer.read().unwrap();
+    println!(
+        "Output: {:?}",
+        output_content.iter().cloned().collect::<Vec<u32>>()
+    );
+}

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -204,6 +204,7 @@ fn main() {
             pipeline.clone(),
             set.clone(),
             (),
+            vec![],
         )
         .unwrap()
         .copy_image_to_buffer(image.clone(), buf.clone())

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -286,6 +286,7 @@ fn main() {
                     vertex_buffer.clone(),
                     set.clone(),
                     (),
+                    vec![],
                 )
                 .unwrap()
                 .end_render_pass()

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -349,6 +349,7 @@ fn main() {
                         compute_pipeline.clone(),
                         cs_desciptor_set.clone(),
                         (),
+                        vec![],
                     )
                     .unwrap()
                     .begin_render_pass(
@@ -366,6 +367,7 @@ fn main() {
                         indirect_args.clone(),
                         (),
                         (),
+                        vec![],
                     )
                     .unwrap()
                     .end_render_pass()

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -331,6 +331,7 @@ fn main() {
                         (triangle_vertex_buffer.clone(), instance_data_buffer.clone()),
                         (),
                         (),
+                        vec![],
                     )
                     .unwrap()
                     .end_render_pass()

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -279,6 +279,7 @@ fn main() {
             vertex_buffer.clone(),
             (),
             (),
+            vec![],
         )
         .unwrap()
         .end_render_pass()

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -383,6 +383,7 @@ fn main() {
                     vertex_buffer.clone(),
                     (),
                     (),
+                    vec![],
                 )
                 .unwrap()
                 .end_render_pass()

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -104,7 +104,7 @@ fn main() {
     let mut builder =
         AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap();
     builder
-        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), push_constants)
+        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), push_constants, vec![])
         .unwrap();
     let command_buffer = builder.build().unwrap();
 

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -531,6 +531,7 @@ fn main() {
                     vertex_buffer.clone(),
                     (),
                     (),
+                    vec![],
                 )
                 .unwrap()
                 .end_render_pass()

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -94,7 +94,7 @@ fn main() {
     let mut builder =
         AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap();
     builder
-        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), ())
+        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), (), vec![])
         .unwrap();
     let command_buffer = builder.build().unwrap();
     let future = sync::now(device.clone())

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -102,7 +102,7 @@ fn main() {
     let mut builder =
         AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap();
     builder
-        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), ())
+        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), (), vec![])
         .unwrap();
     let command_buffer = builder.build().unwrap();
 

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -266,6 +266,7 @@ fn main() {
                         index_buffer.clone(),
                         set.clone(),
                         (),
+                        vec![],
                     )
                     .unwrap()
                     .end_render_pass()

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -361,6 +361,7 @@ fn main() {
                     vertex_buffer.clone(),
                     (),
                     (),
+                    vec![],
                 )
                 .unwrap()
                 .end_render_pass()

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -477,6 +477,7 @@ fn main() {
                         vertex_buffer.clone(),
                         (),
                         (),
+                        vec![],
                     )
                     .unwrap()
                     // We leave the render pass by calling `draw_end`. Note that if we had multiple

--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -221,7 +221,7 @@ fn descriptor_infos(
 
                     let desc = quote! {
                         DescriptorDescTy::Buffer(DescriptorBufferDesc {
-                            dynamic: Some(false),
+                            dynamic: None,
                             storage: #is_ssbo,
                         })
                     };

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -91,7 +91,7 @@ use OomError;
 ///         .unwrap()
 ///         // For the sake of the example we just call `update_buffer` on the buffer, even though
 ///         // it is pointless to do that.
-///         .update_buffer(sub_buffer.clone(), [0.2, 0.3, 0.4, 0.5])
+///         .update_buffer(sub_buffer.clone(), &[0.2, 0.3, 0.4, 0.5])
 ///         .unwrap()
 ///         .build().unwrap()
 ///         .execute(queue.clone())

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -70,14 +70,14 @@ use pipeline::ComputePipelineAbstract;
 use pipeline::GraphicsPipelineAbstract;
 use query::QueryPipelineStatisticFlags;
 use sampler::Filter;
+use smallvec::SmallVec;
 use std::ffi::CStr;
 use sync::AccessCheckError;
 use sync::AccessFlagBits;
 use sync::GpuFuture;
 use sync::PipelineStages;
-use {OomError, SafeDeref};
 use VulkanObject;
-use smallvec::SmallVec;
+use {OomError, SafeDeref};
 
 /// Note that command buffers allocated from the default command pool (`Arc<StandardCommandPool>`)
 /// don't implement the `Send` and `Sync` traits. If you use this pool, then the
@@ -1873,7 +1873,7 @@ unsafe fn descriptor_sets<P, Pl, S, Do, Doi>(
     gfx: bool,
     pipeline: Pl,
     sets: S,
-    dynamic_offsets: Do
+    dynamic_offsets: Do,
 ) -> Result<(), SyncCommandBufferBuilderError>
 where
     Pl: PipelineLayoutAbstract + Send + Sync + Clone + 'static,
@@ -1901,7 +1901,12 @@ where
     for set in sets.into_iter().skip(first_binding as usize) {
         sets_binder.add(set);
     }
-    sets_binder.submit(gfx, pipeline.clone(), first_binding, dynamic_offsets.into_iter())?;
+    sets_binder.submit(
+        gfx,
+        pipeline.clone(),
+        first_binding,
+        dynamic_offsets.into_iter(),
+    )?;
     Ok(())
 }
 

--- a/vulkano/src/descriptor/descriptor.rs
+++ b/vulkano/src/descriptor/descriptor.rs
@@ -254,8 +254,6 @@ pub enum DescriptorDescTy {
 
 impl DescriptorDescTy {
     /// Returns the type of descriptor.
-    ///
-    /// Returns `None` if there's not enough info to determine the type.
     // TODO: add example
     pub fn ty(&self) -> DescriptorType {
         match *self {

--- a/vulkano/src/descriptor/descriptor.rs
+++ b/vulkano/src/descriptor/descriptor.rs
@@ -257,8 +257,8 @@ impl DescriptorDescTy {
     ///
     /// Returns `None` if there's not enough info to determine the type.
     // TODO: add example
-    pub fn ty(&self) -> Option<DescriptorType> {
-        Some(match *self {
+    pub fn ty(&self) -> DescriptorType {
+        match *self {
             DescriptorDescTy::Sampler => DescriptorType::Sampler,
             DescriptorDescTy::CombinedImageSampler(_) => DescriptorType::CombinedImageSampler,
             DescriptorDescTy::Image(ref desc) => {
@@ -270,10 +270,7 @@ impl DescriptorDescTy {
             }
             DescriptorDescTy::InputAttachment { .. } => DescriptorType::InputAttachment,
             DescriptorDescTy::Buffer(ref desc) => {
-                let dynamic = match desc.dynamic {
-                    Some(d) => d,
-                    None => return None,
-                };
+                let dynamic = desc.dynamic.unwrap_or(false);
                 match (desc.storage, dynamic) {
                     (false, false) => DescriptorType::UniformBuffer,
                     (true, false) => DescriptorType::StorageBuffer,
@@ -288,7 +285,7 @@ impl DescriptorDescTy {
                     DescriptorType::UniformTexelBuffer
                 }
             }
-        })
+        }
     }
 
     /// Checks whether we are a superset of another descriptor type.
@@ -529,10 +526,12 @@ impl DescriptorImageDescDimensions {
     }
 }
 
-// TODO: documentation
+/// Additional description for descriptors that contain buffers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DescriptorBufferDesc {
+    /// If `true`, this buffer is a dynamic buffer. Assumes false if `None`.
     pub dynamic: Option<bool>,
+    /// If `true`, this buffer is a storage buffer.
     pub storage: bool,
 }
 

--- a/vulkano/src/descriptor/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor/descriptor_set/persistent.rs
@@ -266,7 +266,7 @@ impl<R> PersistentDescriptorSetBuilder<R> {
             None => (),
             Some(desc) => {
                 return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: desc.ty.ty().unwrap(),
+                    expected: desc.ty.ty(),
                 })
             }
         }
@@ -484,18 +484,28 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
                         ));
                     }
 
-                    unsafe {
-                        DescriptorWrite::uniform_buffer(
-                            self.builder.binding_id as u32,
-                            self.array_element as u32,
-                            &buffer,
-                        )
+                    if buffer_desc.dynamic.unwrap_or(false) {
+                        unsafe {
+                            DescriptorWrite::dynamic_uniform_buffer(
+                                self.builder.binding_id as u32,
+                                self.array_element as u32,
+                                &buffer,
+                            )
+                        }
+                    } else {
+                        unsafe {
+                            DescriptorWrite::uniform_buffer(
+                                self.builder.binding_id as u32,
+                                self.array_element as u32,
+                                &buffer,
+                            )
+                        }
                     }
                 }
             }
             ref d => {
                 return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: d.ty().unwrap(),
+                    expected: d.ty(),
                 });
             }
         });
@@ -577,7 +587,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
             }
             ref d => {
                 return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: d.ty().unwrap(),
+                    expected: d.ty(),
                 });
             }
         });
@@ -699,7 +709,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
             }
             ty => {
                 return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: ty.ty().unwrap(),
+                    expected: ty.ty(),
                 });
             }
         });
@@ -778,7 +788,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
             }
             ty => {
                 return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: ty.ty().unwrap(),
+                    expected: ty.ty(),
                 });
             }
         });
@@ -841,7 +851,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
             ),
             ty => {
                 return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: ty.ty().unwrap(),
+                    expected: ty.ty(),
                 });
             }
         });

--- a/vulkano/src/descriptor/descriptor_set/unsafe_layout.rs
+++ b/vulkano/src/descriptor/descriptor_set/unsafe_layout.rs
@@ -68,7 +68,7 @@ impl UnsafeDescriptorSetLayout {
                 // FIXME: it is not legal to pass eg. the TESSELLATION_SHADER bit when the device
                 //        doesn't have tess shaders enabled
 
-                let ty = desc.ty.ty().unwrap(); // TODO: shouldn't panic
+                let ty = desc.ty.ty();
                 descriptors_count.add_one(ty);
 
                 Some(vk::DescriptorSetLayoutBinding {

--- a/vulkano/src/descriptor/pipeline_layout/limits_check.rs
+++ b/vulkano/src/descriptor/pipeline_layout/limits_check.rs
@@ -50,7 +50,7 @@ where
 
             num_resources.increment(descriptor.array_count, &descriptor.stages);
 
-            match descriptor.ty.ty().expect("Not implemented yet") {
+            match descriptor.ty.ty() {
                 // TODO:
                 DescriptorType::Sampler => {
                     num_samplers.increment(descriptor.array_count, &descriptor.stages);

--- a/vulkano/src/descriptor/pipeline_layout/mod.rs
+++ b/vulkano/src/descriptor/pipeline_layout/mod.rs
@@ -63,9 +63,8 @@ pub use self::traits::PipelineLayoutNotSupersetError;
 pub use self::traits::PipelineLayoutPushConstantsCompatible;
 pub use self::traits::PipelineLayoutSetsCompatible;
 pub use self::traits::PipelineLayoutSuperset;
+pub use self::tweaks::PipelineLayoutDescTweaks;
 pub use self::union::PipelineLayoutDescUnion;
-
-pub(crate) use self::tweaks::PipelineLayoutDescTweaks;
 
 mod empty;
 mod limits_check;

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -558,7 +558,8 @@ mod tests {
         let mut cbb =
             AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family())
                 .unwrap();
-        cbb.dispatch([1, 1, 1], pipeline.clone(), set, ()).unwrap();
+        cbb.dispatch([1, 1, 1], pipeline.clone(), set, (), vec![])
+            .unwrap();
         let cb = cbb.build().unwrap();
 
         let future = now(device.clone())


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This PR (finishes) adding support for:
- [dynamic uniform buffers and dynamic storage buffers][1],
- specifying [dynamic offsets][2] in draw and dispatch calls, so that the dynamic buffers are actually useful,
- updating buffers with unsized data to make aligned allocations easier,
- and public usage of `PipelineLayoutDescTweaks` for tweaking compute pipeline layouts

In total, that's 4 breaking changes! Since this PR adds an extra argument to the draw and dispatch methods in `AutoCommandBufferBuilder`, the website will need to be updated along with this PR. All of the existing examples and tests in this repository have been updated, and I've also added a [new example][3] to demostrate using dynamic uniform buffers with vulkano.

Currently, this PR only adds basic support for dynamic buffers - it checks that dynamic offsets are properly aligned, but it doesn't validate the buffer data itself or handle aligned allocation. In the future (maybe after the Rust Allocator API is stablized), we might want to add an API that handles unsafe aligned allocation for dynamic buffers.

[1]: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#descriptorsets-uniformbufferdynamic
[2]: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindDescriptorSets.html#VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971
[3]: https://github.com/Arc-blroth/vulkano/blob/staging/dynamic_buffers/examples/src/bin/dynamic-buffers.rs