### PR TITLE
Fix descriptor pool allocation for layouts that contain arrays

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -5,6 +5,7 @@
 - Fixed potential segmentation fault in `ComputePipeline` when referencing `PipelineCache` objects.
 - Fixed race condition in `StandardCommandPool` when allocating buffers.
 - Fixed potential stack overflow error in loading large shaders by storing the bytecode as static.
+- Fixed descriptor set layouts with arrays containing more than one element triggering unreachable code.
 
 # Version 0.20.0 (2020-12-26)
 

--- a/vulkano/src/descriptor/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor/descriptor_set/sys.rs
@@ -88,22 +88,27 @@ macro_rules! descriptors_count {
                     )+
                 }
             }
-
             /// Adds one descriptor of the given type to the count.
             #[inline]
             pub fn add_one(&mut self, ty: DescriptorType) {
+                self.add_num(ty, 1);
+            }
+
+            /// Adds `num` descriptors of the given type to the count.
+            #[inline]
+            pub fn add_num(&mut self, ty: DescriptorType, num: u32) {
                 match ty {
-                    DescriptorType::Sampler => self.sampler += 1,
-                    DescriptorType::CombinedImageSampler => self.combined_image_sampler += 1,
-                    DescriptorType::SampledImage => self.sampled_image += 1,
-                    DescriptorType::StorageImage => self.storage_image += 1,
-                    DescriptorType::UniformTexelBuffer => self.uniform_texel_buffer += 1,
-                    DescriptorType::StorageTexelBuffer => self.storage_texel_buffer += 1,
-                    DescriptorType::UniformBuffer => self.uniform_buffer += 1,
-                    DescriptorType::StorageBuffer => self.storage_buffer += 1,
-                    DescriptorType::UniformBufferDynamic => self.uniform_buffer_dynamic += 1,
-                    DescriptorType::StorageBufferDynamic => self.storage_buffer_dynamic += 1,
-                    DescriptorType::InputAttachment => self.input_attachment += 1,
+                    DescriptorType::Sampler => self.sampler += num,
+                    DescriptorType::CombinedImageSampler => self.combined_image_sampler += num,
+                    DescriptorType::SampledImage => self.sampled_image += num,
+                    DescriptorType::StorageImage => self.storage_image += num,
+                    DescriptorType::UniformTexelBuffer => self.uniform_texel_buffer += num,
+                    DescriptorType::StorageTexelBuffer => self.storage_texel_buffer += num,
+                    DescriptorType::UniformBuffer => self.uniform_buffer += num,
+                    DescriptorType::StorageBuffer => self.storage_buffer += num,
+                    DescriptorType::UniformBufferDynamic => self.uniform_buffer_dynamic += num,
+                    DescriptorType::StorageBufferDynamic => self.storage_buffer_dynamic += num,
+                    DescriptorType::InputAttachment => self.input_attachment += num,
                 };
             }
         }

--- a/vulkano/src/descriptor/descriptor_set/unsafe_layout.rs
+++ b/vulkano/src/descriptor/descriptor_set/unsafe_layout.rs
@@ -69,7 +69,7 @@ impl UnsafeDescriptorSetLayout {
                 //        doesn't have tess shaders enabled
 
                 let ty = desc.ty.ty().unwrap(); // TODO: shouldn't panic
-                descriptors_count.add_one(ty);
+                descriptors_count.add_num(ty, desc.array_count);
 
                 Some(vk::DescriptorSetLayoutBinding {
                     binding: binding as u32,


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Ran `cargo fmt` on the changes

This PR fixes an error where when allocating memory for an `UnsafeDescriptorSetPool`, vulkano did not consider that arrays could have more than one element. This led to a `OutOfPoolMemory` error being reported from Vulkan, which then led to, in the wise words of Rust:
> ```thread 'main' panicked at 'internal error: entered unreachable code'```
