### PR TITLE
Replace filter map 

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -9,6 +9,7 @@
 - Fixed race condition in `StandardCommandPool` when allocating buffers.
 - Fixed potential stack overflow error in loading large shaders by storing the bytecode as static.
 - Fixed descriptor set layouts with arrays containing more than one element triggering unreachable code.
+- Fixed panic on some machines when calling `Surface::capabilities`
 - Added basic support and safety checks for dynamic uniform/storage buffers
 - Updated dependencies:
   - `crossbeam` 0.7 -> 0.8

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -104,7 +104,13 @@ fn main() {
     let mut builder =
         AutoCommandBufferBuilder::primary_one_time_submit(device.clone(), queue.family()).unwrap();
     builder
-        .dispatch([1024, 1, 1], pipeline.clone(), set.clone(), push_constants, vec![])
+        .dispatch(
+            [1024, 1, 1],
+            pipeline.clone(),
+            set.clone(),
+            push_constants,
+            vec![],
+        )
         .unwrap();
     let command_buffer = builder.build().unwrap();
 

--- a/vulkano/src/descriptor/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor/descriptor_set/persistent.rs
@@ -504,9 +504,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
                 }
             }
             ref d => {
-                return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: d.ty(),
-                });
+                return Err(PersistentDescriptorSetError::WrongDescriptorTy { expected: d.ty() });
             }
         });
 
@@ -586,9 +584,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
                 }
             }
             ref d => {
-                return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: d.ty(),
-                });
+                return Err(PersistentDescriptorSetError::WrongDescriptorTy { expected: d.ty() });
             }
         });
 
@@ -708,9 +704,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
                 )
             }
             ty => {
-                return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: ty.ty(),
-                });
+                return Err(PersistentDescriptorSetError::WrongDescriptorTy { expected: ty.ty() });
             }
         });
 
@@ -787,9 +781,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
                 )
             }
             ty => {
-                return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: ty.ty(),
-                });
+                return Err(PersistentDescriptorSetError::WrongDescriptorTy { expected: ty.ty() });
             }
         });
 
@@ -850,9 +842,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
                 &sampler,
             ),
             ty => {
-                return Err(PersistentDescriptorSetError::WrongDescriptorTy {
-                    expected: ty.ty(),
-                });
+                return Err(PersistentDescriptorSetError::WrongDescriptorTy { expected: ty.ty() });
             }
         });
 

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -528,6 +528,10 @@ impl<W> Surface<W> {
     }
 
     /// Retrieves the capabilities of a surface when used by a certain device.
+    /// 
+    /// # Notes
+    /// 
+    /// - Capabilities that are not supported in `vk-sys` are silently dropped
     ///
     /// # Panic
     ///
@@ -634,7 +638,7 @@ impl<W> Surface<W> {
                 },
                 supported_formats: formats
                     .into_iter()
-                    .filter_map(|f| {
+                    .filter_map(|f| { // TODO: Change the way capabilities not supported in vk-sys are handled
                         Format::from_vulkan_num(f.format).map(|format| {
                             (format, capabilities::color_space_from_num(f.colorSpace))
                         })

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -634,11 +634,13 @@ impl<W> Surface<W> {
                 },
                 supported_formats: formats
                     .into_iter()
-                    .map(|f| {
-                        (
-                            Format::from_vulkan_num(f.format).unwrap(),
-                            capabilities::color_space_from_num(f.colorSpace),
-                        )
+                    .filter_map(|f| {
+                        Format::from_vulkan_num(f.format).map(|format| {
+                            (
+                                format,
+                                capabilities::color_space_from_num(f.colorSpace),
+                            )
+                        })
                     })
                     .collect(),
                 present_modes: modes,

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -636,10 +636,7 @@ impl<W> Surface<W> {
                     .into_iter()
                     .filter_map(|f| {
                         Format::from_vulkan_num(f.format).map(|format| {
-                            (
-                                format,
-                                capabilities::color_space_from_num(f.colorSpace),
-                            )
+                            (format, capabilities::color_space_from_num(f.colorSpace))
                         })
                     })
                     .collect(),


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

Fixes #1485 

I replaced map and unwrap with a filter_map to prevent panics when not all formats reported by Vulkan are supported in `vk-sys`. I don't think this is a good permanent solution. A better solution would be to let `vk-sys` build against the Vulkan sdk on your system, but that's probably best left for another time, and I don't see any downsides to using this as a temporary fix.