### PR TITLE
segfaulting: DebugUtilsMessengerCallbackDataEXT::pMessageIdName may be null in debug callback

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **Breaking** `Message::layer_prefix` turned to Option to prevent segfaults when Vulkan message didn't provide `pMessageIdName` value
 - **Breaking** On `AutoCommandBufferBuilder`, methods that bind a descriptor set now take a `dynamic_offsets` parameter
 - **Breaking** On `AutoCommandBufferBuilder` and `SyncCommandBufferBuilder`, the `update_buffer` method now takes `data` by reference
 - **Breaking** Made `PipelineLayoutDescTweaks` public, for use with compute pipelines

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -99,7 +99,10 @@ fn main() {
 
         println!(
             "{} {} {}: {}",
-            msg.layer_prefix, ty, severity, msg.description
+            msg.layer_prefix.unwrap_or("unknown"),
+            ty,
+            severity,
+            msg.description
         );
     })
     .ok();

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -96,14 +96,11 @@ impl DebugCallback {
                 let user_callback = user_data as *mut Box<dyn Fn()> as *const _;
                 let user_callback: &Box<dyn Fn(&Message)> = &*user_callback;
 
-                let message_id_name = (*callback_data).pMessageIdName;
-                let layer_prefix = if !message_id_name.is_null() {
-                    CStr::from_ptr(message_id_name)
+                let layer_prefix = (*callback_data).pMessageIdName.as_ref().map(|msg_id_name| {
+                    CStr::from_ptr(msg_id_name)
                         .to_str()
                         .expect("debug callback message not utf-8")
-                } else {
-                    "Unknown Layer"
-                };
+                });
 
                 let description = CStr::from_ptr((*callback_data).pMessage)
                     .to_str()
@@ -237,8 +234,8 @@ pub struct Message<'a> {
     pub severity: MessageSeverity,
     /// Type of message,
     pub ty: MessageType,
-    /// Prefix of the layer that reported this message.
-    pub layer_prefix: &'a str,
+    /// Prefix of the layer that reported this message or `None` if unknown.
+    pub layer_prefix: Option<&'a str>,
     /// Description of the message.
     pub description: &'a str,
 }

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -96,9 +96,15 @@ impl DebugCallback {
                 let user_callback = user_data as *mut Box<dyn Fn()> as *const _;
                 let user_callback: &Box<dyn Fn(&Message)> = &*user_callback;
 
-                let layer_prefix = CStr::from_ptr((*callback_data).pMessageIdName)
-                    .to_str()
-                    .expect("debug callback message not utf-8");
+                let message_id_name = (*callback_data).pMessageIdName;
+                let layer_prefix = if !message_id_name.is_null() {
+                    CStr::from_ptr(message_id_name)
+                        .to_str()
+                        .expect("debug callback message not utf-8")
+                } else {
+                    "Unknown Layer"
+                };
+
                 let description = CStr::from_ptr((*callback_data).pMessage)
                     .to_str()
                     .expect("debug callback message not utf-8");


### PR DESCRIPTION
Running on MacOS the `cargo run --bin debug` example is segfaulting (after fixing a layer problem: layer `VK_LAYER_LUNARG_standard_validation` doesn't exist on MoltenVK but it has to be `VK_LAYER_KHRONOS_validation`, but that's another point not in this scope).

- Source: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerCallbackDataEXT.html#VUID-VkDebugUtilsMessengerCallbackDataEXT-pMessageIdName-parameter
- `(*callback_data).pMessageIdName` is a null pointer for some debug callbacks (at least for two on my machine while testing)

* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes
