### PR TITLE
examples: fix debug example layers on macos using "VK_LAYER_KHRONOS_validation"

### DIFF
--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -48,8 +48,11 @@ fn main() {
     }
 
     // NOTE: To simplify the example code we won't verify these layer(s) are actually in the layers list:
-    let layer = "VK_LAYER_LUNARG_standard_validation";
-    let layers = vec![layer];
+    #[cfg(not(target_os = "macos"))]
+    let layers = vec!["VK_LAYER_LUNARG_standard_validation"];
+
+    #[cfg(target_os = "macos")]
+    let layers = vec!["VK_LAYER_KHRONOS_validation"];
 
     // Important: pass the extension(s) and layer(s) when creating the vulkano instance
     let instance =


### PR DESCRIPTION
On macos `cargo run --bin debug` will panic with `LayerNotPresent` as somehow with MoltenVK they have different names.

* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes
