### PR TITLE
fix vkDeviceCreate enabled extensions have to contain "VK_KHR_portability_subset" if supported by device

### DIFF
--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -118,7 +118,7 @@ fn main() {
     let (_, mut queues) = Device::new(
         physical,
         physical.supported_features(),
-        &DeviceExtensions::none(),
+        &DeviceExtensions::required_extensions(physical),
         vec![(queue_family, 0.5)],
     )
     .expect("failed to create device");


### PR DESCRIPTION
- Ref: #1482
- https://vulkan.lunarg.com/doc/view/1.2.162.1/mac/1.2-extensions/vkspec.html#VUID-VkDeviceCreateInfo-pProperties-04451

* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes
