### PR TITLE
Add VK_KHR_portability_subset device extension

### DIFF
--- a/vulkano/src/device/extensions.rs
+++ b/vulkano/src/device/extensions.rs
@@ -122,6 +122,7 @@ device_extensions! {
     khr_external_memory => b"VK_KHR_external_memory",
     khr_external_memory_fd => b"VK_KHR_external_memory_fd",
     ext_external_memory_dmabuf => b"VK_EXT_external_memory_dma_buf",
+    khr_portability_subset => b"VK_KHR_portability_subset",
 }
 
 /// This helper type can only be instantiated inside this module.


### PR DESCRIPTION
Adds support for the VK_KHR_portability_subset device extension.

From the [spec](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_portability_subset.html)
>This extension allows a non-conformant Vulkan implementation to be built on top of another non-Vulkan graphics API, and identifies differences between that implementation and a fully-conformant native Vulkan implementation.

This extension is required when using validation layers on e.g. MoltenVK platforms, such as macOS.
