### PR TITLE
Fix reuse command buffers test

### DIFF
--- a/vulkano/src/command_buffer/pool/standard.rs
+++ b/vulkano/src/command_buffer/pool/standard.rs
@@ -285,6 +285,8 @@ mod tests {
         let queue_family = device.physical_device().queue_families().next().unwrap();
 
         let pool = Device::standard_command_pool(&device, queue_family);
+        // Avoid the weak reference to StandardCommandPoolPerThread expiring.
+        let cb_hold_weakref = pool.alloc(false, 1).unwrap().next().unwrap();
 
         let cb = pool.alloc(false, 1).unwrap().next().unwrap();
         let raw = cb.inner().internal_object();

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -528,9 +528,9 @@ impl<W> Surface<W> {
     }
 
     /// Retrieves the capabilities of a surface when used by a certain device.
-    /// 
+    ///
     /// # Notes
-    /// 
+    ///
     /// - Capabilities that are not supported in `vk-sys` are silently dropped
     ///
     /// # Panic
@@ -638,7 +638,8 @@ impl<W> Surface<W> {
                 },
                 supported_formats: formats
                     .into_iter()
-                    .filter_map(|f| { // TODO: Change the way capabilities not supported in vk-sys are handled
+                    .filter_map(|f| {
+                        // TODO: Change the way capabilities not supported in vk-sys are handled
                         Format::from_vulkan_num(f.format).map(|format| {
                             (format, capabilities::color_space_from_num(f.colorSpace))
                         })


### PR DESCRIPTION
The per-thread weak reference to StandardCommandPoolPerThread in StandardCommandPool can expire forcing the recreation of the pool and its internal objects. This is a problem for the reuse_command_buffers test which asserts that a destroyed command pool must be reused if possible.

This change fixes the test by introducing an extra command buffer that is held through the rest of the test, introducing an extra strong reference to the command pool that keeps the weak reference alive for the duration of the test.

This test fails consistently on my machine with a NVidia 1070 Max-Q otherwise.

* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes
