### PR TITLE
Replace deprecated compare_and_swap

### DIFF
--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -469,7 +469,11 @@ unsafe impl<T: ?Sized, A> BufferAccess for ImmutableBufferInitialization<T, A> {
             return Err(AccessError::AlreadyInUse);
         }
 
-        if !self.used.compare_and_swap(false, true, Ordering::Relaxed) {
+        if !self
+            .used
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .unwrap_or_else(|e| e)
+        {
             Ok(())
         } else {
             Err(AccessError::AlreadyInUse)

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -550,7 +550,12 @@ where
             }
         }
 
-        if self.gpu_lock.compare_and_swap(0, 1, Ordering::SeqCst) == 0 {
+        if self
+            .gpu_lock
+            .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
+            .unwrap_or_else(|e| e)
+            == 0
+        {
             Ok(())
         } else {
             Err(AccessError::AlreadyInUse)

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -719,7 +719,11 @@ where
         }
 
         // FIXME: Mipmapped textures require multiple writes to initialize
-        if !self.used.compare_and_swap(false, true, Ordering::Relaxed) {
+        if !self
+            .used
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .unwrap_or_else(|e| e)
+        {
             Ok(())
         } else {
             Err(AccessError::AlreadyInUse)

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -245,7 +245,10 @@ where
             });
         }
 
-        let val = self.gpu_lock.compare_and_swap(0, 1, Ordering::SeqCst);
+        let val = self
+            .gpu_lock
+            .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
+            .unwrap_or_else(|e| e);
         if val == 0 {
             Ok(())
         } else {


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This replaces atomic `compare_and_swap`, which is deprecated since Rust 1.50, with an equivalent. The replacement code is based on [the current `compare_and_swap` implementation](https://doc.rust-lang.org/src/core/sync/atomic.rs.html#504-509) in std.