### PR TITLE
Allow `const` usage of features and `BufferUsage`

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Allow `const` usage of features and `BufferUsage`
+
 # Version 0.21.0 (2021-03-05)
 
 - **Breaking** `Message::layer_prefix` turned to Option to prevent segfaults when Vulkan message didn't provide `pMessageIdName` value

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -25,6 +25,16 @@ use vulkano::sync::GpuFuture;
 
 use std::sync::Arc;
 
+const DEVICE_EXTENSIONS: DeviceExtensions = DeviceExtensions {
+    khr_storage_buffer_storage_class: true,
+    ..DeviceExtensions::none()
+};
+
+const BUFFER_USAGE: BufferUsage = BufferUsage {
+    storage_buffer: true,
+    ..BufferUsage::none()
+};
+
 fn main() {
     // As with other examples, the first step is to create an instance.
     let instance = Instance::new(None, &InstanceExtensions::none(), None).unwrap();
@@ -45,10 +55,7 @@ fn main() {
     let (device, mut queues) = Device::new(
         physical,
         physical.supported_features(),
-        &DeviceExtensions {
-            khr_storage_buffer_storage_class: true,
-            ..DeviceExtensions::none()
-        },
+        &DEVICE_EXTENSIONS,
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
@@ -107,8 +114,7 @@ fn main() {
         // Iterator that produces the data.
         let data_iter = (0..65536u32).map(|n| n);
         // Builds the buffer and fills it with this iterator.
-        CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), false, data_iter)
-            .unwrap()
+        CpuAccessibleBuffer::from_iter(device.clone(), BUFFER_USAGE, false, data_iter).unwrap()
     };
 
     // In order to let the shader access the buffer, we need to build a *descriptor set* that

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -71,7 +71,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with all values set to false.
     #[inline]
-    pub fn none() -> BufferUsage {
+    pub const fn none() -> BufferUsage {
         BufferUsage {
             transfer_source: false,
             transfer_destination: false,
@@ -88,7 +88,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with all values set to true. Can be used for quick prototyping.
     #[inline]
-    pub fn all() -> BufferUsage {
+    pub const fn all() -> BufferUsage {
         BufferUsage {
             transfer_source: true,
             transfer_destination: true,
@@ -105,7 +105,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with `transfer_source` set to true and the rest to false.
     #[inline]
-    pub fn transfer_source() -> BufferUsage {
+    pub const fn transfer_source() -> BufferUsage {
         BufferUsage {
             transfer_source: true,
             ..BufferUsage::none()
@@ -114,7 +114,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with `transfer_destination` set to true and the rest to false.
     #[inline]
-    pub fn transfer_destination() -> BufferUsage {
+    pub const fn transfer_destination() -> BufferUsage {
         BufferUsage {
             transfer_destination: true,
             ..BufferUsage::none()
@@ -123,7 +123,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with `vertex_buffer` set to true and the rest to false.
     #[inline]
-    pub fn vertex_buffer() -> BufferUsage {
+    pub const fn vertex_buffer() -> BufferUsage {
         BufferUsage {
             vertex_buffer: true,
             ..BufferUsage::none()
@@ -133,7 +133,7 @@ impl BufferUsage {
     /// Builds a `BufferUsage` with `vertex_buffer` and `transfer_destination` set to true and the rest
     /// to false.
     #[inline]
-    pub fn vertex_buffer_transfer_destination() -> BufferUsage {
+    pub const fn vertex_buffer_transfer_destination() -> BufferUsage {
         BufferUsage {
             vertex_buffer: true,
             transfer_destination: true,
@@ -143,7 +143,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with `index_buffer` set to true and the rest to false.
     #[inline]
-    pub fn index_buffer() -> BufferUsage {
+    pub const fn index_buffer() -> BufferUsage {
         BufferUsage {
             index_buffer: true,
             ..BufferUsage::none()
@@ -152,7 +152,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with `index_buffer` and `transfer_destination` set to true and the rest to false.
     #[inline]
-    pub fn index_buffer_transfer_destination() -> BufferUsage {
+    pub const fn index_buffer_transfer_destination() -> BufferUsage {
         BufferUsage {
             index_buffer: true,
             transfer_destination: true,
@@ -162,7 +162,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with `uniform_buffer` set to true and the rest to false.
     #[inline]
-    pub fn uniform_buffer() -> BufferUsage {
+    pub const fn uniform_buffer() -> BufferUsage {
         BufferUsage {
             uniform_buffer: true,
             ..BufferUsage::none()
@@ -172,7 +172,7 @@ impl BufferUsage {
     /// Builds a `BufferUsage` with `uniform_buffer` and `transfer_destination` set to true and the rest
     /// to false.
     #[inline]
-    pub fn uniform_buffer_transfer_destination() -> BufferUsage {
+    pub const fn uniform_buffer_transfer_destination() -> BufferUsage {
         BufferUsage {
             uniform_buffer: true,
             transfer_destination: true,
@@ -182,7 +182,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with `indirect_buffer` set to true and the rest to false.
     #[inline]
-    pub fn indirect_buffer() -> BufferUsage {
+    pub const fn indirect_buffer() -> BufferUsage {
         BufferUsage {
             indirect_buffer: true,
             ..BufferUsage::none()
@@ -192,7 +192,7 @@ impl BufferUsage {
     /// Builds a `BufferUsage` with `indirect_buffer` and `transfer_destination` set to true and the rest
     /// to false.
     #[inline]
-    pub fn indirect_buffer_transfer_destination() -> BufferUsage {
+    pub const fn indirect_buffer_transfer_destination() -> BufferUsage {
         BufferUsage {
             indirect_buffer: true,
             transfer_destination: true,
@@ -202,7 +202,7 @@ impl BufferUsage {
 
     /// Builds a `BufferUsage` with `device_address` set to true and the rest to false.
     #[inline]
-    pub fn device_address() -> BufferUsage {
+    pub const fn device_address() -> BufferUsage {
         BufferUsage {
             device_address: true,
             ..BufferUsage::none()

--- a/vulkano/src/extensions.rs
+++ b/vulkano/src/extensions.rs
@@ -34,7 +34,7 @@ macro_rules! extensions {
         impl $sname {
             /// Returns an `Extensions` object with all members set to `false`.
             #[inline]
-            pub fn none() -> $sname {
+            pub const fn none() -> $sname {
                 $sname {
                     $($ext: false,)*
                     _unbuildable: Unbuildable(())
@@ -43,7 +43,7 @@ macro_rules! extensions {
 
             /// Returns the union of this list and another list.
             #[inline]
-            pub fn union(&self, other: &$sname) -> $sname {
+            pub const fn union(&self, other: &$sname) -> $sname {
                 $sname {
                     $(
                         $ext: self.$ext || other.$ext,
@@ -54,7 +54,7 @@ macro_rules! extensions {
 
             /// Returns the intersection of this list and another list.
             #[inline]
-            pub fn intersection(&self, other: &$sname) -> $sname {
+            pub const fn intersection(&self, other: &$sname) -> $sname {
                 $sname {
                     $(
                         $ext: self.$ext && other.$ext,
@@ -65,7 +65,7 @@ macro_rules! extensions {
 
             /// Returns the difference of another list from this list.
             #[inline]
-            pub fn difference(&self, other: &$sname) -> $sname {
+            pub const fn difference(&self, other: &$sname) -> $sname {
                 $sname {
                     $(
                         $ext: self.$ext && !other.$ext,


### PR DESCRIPTION
* [x] (`CHANGELOG_VULKANO.md` only) Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] (examples) Updated documentation to reflect any user-facing changes - in this repository
* [x] (N/A) Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This PR allows the following code to compile:

```rust
const DEVICE_EXTENSIONS: DeviceExtensions = DeviceExtensions {
    khr_storage_buffer_storage_class: true,
    ..DeviceExtensions::none()
};

const BUFFER_USAGE: BufferUsage = BufferUsage {
    storage_buffer: true,
    ..BufferUsage::none()
};
```