### PR TITLE
Fix descriptor set TypeStruct readonly detection

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -26,6 +26,9 @@
 - Implemented synchronization for `SyncCommandBufferBuilder::execute_commands`.
 - `AutoCommandBufferBuilder::execute_commands` is now fully safe to use.
 - `SyncCommandBufferBuilder` now becomes poisoned when it returns an error, to prevent using the builder in an inconsistent state.
+- Fixed missing barriers in dispatch calls
+  - **Breaking** `shader!` no longer marks descriptor sets as readonly as a fallback when it doesn't know
+    - **Breaking** The keyword `readonly` might need to be added in front of the `buffer` keyword in GLSL files to get them working again
 
 # Version 0.21.0 (2021-03-05)
 

--- a/examples/src/bin/immutable-buffer-initialization.rs
+++ b/examples/src/bin/immutable-buffer-initialization.rs
@@ -57,11 +57,11 @@ fn main() {
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
-layout(set = 0, binding = 0) buffer Data {
+layout(set = 0, binding = 0) restrict buffer Data {
     uint data[];
 } data;
 
-layout(set = 0, binding = 1) buffer ImmutableData {
+layout(set = 0, binding = 1) readonly restrict buffer ImmutableData {
     uint data;
 } immutable_data;
 


### PR DESCRIPTION
* [x] (`CHANGELOG_VULKANO.md` only) Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] (examples) Updated documentation to reflect any user-facing changes - in this repository
* [x] (N/A) Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This fixes #1297.

Before this PR, my Intel GPU was working but my AMD GPU outputted random data. After this PR, both my GPUs work in my application. I have confirmed that before this, `readonly: true` was used everywhere as shown by `cargo expand`, and after this, `readonly: false` is properly emitted when the shader doesn't use `readonly` in front of `buffer`