### PR TITLE
Fix panic string literal warnings

### DIFF
--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -511,7 +511,7 @@ impl Parse for MacroInput {
                     let dump_lit: LitBool = input.parse()?;
                     dump = Some(dump_lit.value);
                 }
-                name => panic!(format!("Unknown field name: {}", name)),
+                name => panic!("Unknown field name: {}", name),
             }
 
             if !input.is_empty() {
@@ -614,7 +614,7 @@ pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             &input.macro_defines,
         ) {
             Ok(ok) => ok,
-            Err(e) => panic!(e.replace("(s): ", "(s):\n")),
+            Err(e) => panic!("{}", e.replace("(s): ", "(s):\n")),
         };
 
         codegen::reflect("Shader", content.as_binary(), input.types_meta, input.dump)


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This fixes two warnings that are appearing since Rust 1.51. There's nothing user-facing nor is it a bug, so I haven't added a changelog entry.