### PR TITLE
Support fixed-length arrays in graphics pipeline in addition to from_iter

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -29,6 +29,7 @@
 - Fixed missing barriers in dispatch calls
   - **Breaking** `shader!` no longer marks descriptor sets as readonly as a fallback when it doesn't know
     - **Breaking** The keyword `readonly` might need to be added in front of the `buffer` keyword in GLSL files to get them working again
+- Add support in `AutoCommandbufferBuilder::draw` for taking `[T; N]` in addition to `[T]`
 
 # Version 0.21.0 (2021-03-05)
 

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -214,6 +214,48 @@ impl<T, B> BufferSlice<[T], B> {
     }
 }
 
+impl<T, B, const N: usize> BufferSlice<[T; N], B> {
+    /// Returns the number of elements in this slice.
+    #[inline]
+    pub fn len(&self) -> usize {
+        N
+    }
+
+    /// Reduces the slice to just one element of the array.
+    ///
+    /// Returns `None` if out of range.
+    #[inline]
+    pub fn index(self, index: usize) -> Option<BufferSlice<T, B>> {
+        if index >= N {
+            return None;
+        }
+
+        Some(BufferSlice {
+            marker: PhantomData,
+            resource: self.resource,
+            offset: self.offset + index * mem::size_of::<T>(),
+            size: mem::size_of::<T>(),
+        })
+    }
+
+    /// Reduces the slice to just a range of the array.
+    ///
+    /// Returns `None` if out of range.
+    #[inline]
+    pub fn slice(self, range: Range<usize>) -> Option<BufferSlice<[T], B>> {
+        if range.end > N {
+            return None;
+        }
+
+        Some(BufferSlice {
+            marker: PhantomData,
+            resource: self.resource,
+            offset: self.offset + range.start * mem::size_of::<T>(),
+            size: (range.end - range.start) * mem::size_of::<T>(),
+        })
+    }
+}
+
 unsafe impl<T: ?Sized, B> BufferAccess for BufferSlice<T, B>
 where
     B: BufferAccess,

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -56,7 +56,7 @@ pub unsafe trait BufferAccess: DeviceOwned {
     where
         Self: Sized + TypedBufferAccess<Content = [T]>,
     {
-        BufferSlice::slice(self.as_buffer_slice(), range)
+        <BufferSlice<[T], &Self>>::slice(self.as_buffer_slice(), range)
     }
 
     /// Builds a `BufferSlice` object holding the buffer by value.

--- a/vulkano/src/pipeline/vertex/instance_buffer.rs
+++ b/vulkano/src/pipeline/vertex/instance_buffer.rs
@@ -121,3 +121,14 @@ where
         (vec![Box::new(source) as Box<_>], 1, len)
     }
 }
+
+unsafe impl<'a, B, V, const N: usize> VertexSource<[B; 1]> for SingleInstanceBufferDefinition<V>
+where
+    B: TypedBufferAccess<Content = [V; N]> + Send + Sync + 'static,
+    V: Vertex,
+{
+    #[inline]
+    fn decode(&self, [source]: [B; 1]) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        (vec![Box::new(source) as Box<_>], 1, N)
+    }
+}

--- a/vulkano/src/pipeline/vertex/one_one.rs
+++ b/vulkano/src/pipeline/vertex/one_one.rs
@@ -133,13 +133,62 @@ where
     Bu: TypedBufferAccess<Content = [U]> + Send + Sync + 'static,
 {
     #[inline]
-    fn decode(&self, source: (Bt, Bu)) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
-        let s1l = source.0.len();
-        let s2l = source.1.len();
-        (
-            vec![Box::new(source.0) as Box<_>, Box::new(source.1) as Box<_>],
-            s1l,
-            s2l,
-        )
+    fn decode(&self, (t, u): (Bt, Bu)) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        let t_l = t.len();
+        let u_l = u.len();
+        (vec![Box::new(t) as Box<_>, Box::new(u) as Box<_>], t_l, u_l)
+    }
+}
+
+unsafe impl<'a, T, U, Bt, Bu, const T_N: usize> VertexSource<([Bt; 1], Bu)>
+    for OneVertexOneInstanceDefinition<T, U>
+where
+    T: Vertex,
+    Bt: TypedBufferAccess<Content = [T; T_N]> + Send + Sync + 'static,
+    U: Vertex,
+    Bu: TypedBufferAccess<Content = [U]> + Send + Sync + 'static,
+{
+    #[inline]
+    fn decode(
+        &self,
+        ([t], u): ([Bt; 1], Bu),
+    ) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        let u_l = u.len();
+        (vec![Box::new(t) as Box<_>, Box::new(u) as Box<_>], T_N, u_l)
+    }
+}
+
+unsafe impl<'a, T, U, Bt, Bu, const U_N: usize> VertexSource<(Bt, [Bu; 1])>
+    for OneVertexOneInstanceDefinition<T, U>
+where
+    T: Vertex,
+    Bt: TypedBufferAccess<Content = [T]> + Send + Sync + 'static,
+    U: Vertex,
+    Bu: TypedBufferAccess<Content = [U; U_N]> + Send + Sync + 'static,
+{
+    #[inline]
+    fn decode(
+        &self,
+        (t, [u]): (Bt, [Bu; 1]),
+    ) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        let t_l = t.len();
+        (vec![Box::new(t) as Box<_>, Box::new(u) as Box<_>], t_l, U_N)
+    }
+}
+
+unsafe impl<'a, T, U, Bt, Bu, const T_N: usize, const U_N: usize> VertexSource<([Bt; 1], [Bu; 1])>
+    for OneVertexOneInstanceDefinition<T, U>
+where
+    T: Vertex,
+    Bt: TypedBufferAccess<Content = [T; T_N]> + Send + Sync + 'static,
+    U: Vertex,
+    Bu: TypedBufferAccess<Content = [U; U_N]> + Send + Sync + 'static,
+{
+    #[inline]
+    fn decode(
+        &self,
+        ([t], [u]): ([Bt; 1], [Bu; 1]),
+    ) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        (vec![Box::new(t) as Box<_>, Box::new(u) as Box<_>], T_N, U_N)
     }
 }

--- a/vulkano/src/pipeline/vertex/single.rs
+++ b/vulkano/src/pipeline/vertex/single.rs
@@ -120,3 +120,14 @@ where
         (vec![Box::new(source) as Box<_>], len, 1)
     }
 }
+
+unsafe impl<'a, B, V, const N: usize> VertexSource<[B; 1]> for SingleBufferDefinition<V>
+where
+    B: TypedBufferAccess<Content = [V; N]> + Send + Sync + 'static,
+    V: Vertex,
+{
+    #[inline]
+    fn decode(&self, [source]: [B; 1]) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        (vec![Box::new(source) as Box<_>], N, 1)
+    }
+}

--- a/vulkano/src/pipeline/vertex/two.rs
+++ b/vulkano/src/pipeline/vertex/two.rs
@@ -137,15 +137,76 @@ where
     Bu: TypedBufferAccess<Content = [U]> + Send + Sync + 'static,
 {
     #[inline]
-    fn decode(&self, source: (Bt, Bu)) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
-        let vertices = [source.0.len(), source.1.len()]
-            .iter()
-            .cloned()
-            .min()
-            .unwrap();
+    fn decode(&self, (t, u): (Bt, Bu)) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        let vertices = t.len().min(u.len());
         (
-            vec![Box::new(source.0) as Box<_>, Box::new(source.1) as Box<_>],
+            vec![Box::new(t) as Box<_>, Box::new(u) as Box<_>],
             vertices,
+            1,
+        )
+    }
+}
+
+unsafe impl<'a, T, U, Bt, Bu, const T_N: usize> VertexSource<([Bt; 1], Bu)>
+    for TwoBuffersDefinition<T, U>
+where
+    T: Vertex,
+    Bt: TypedBufferAccess<Content = [T; T_N]> + Send + Sync + 'static,
+    U: Vertex,
+    Bu: TypedBufferAccess<Content = [U]> + Send + Sync + 'static,
+{
+    #[inline]
+    fn decode(
+        &self,
+        ([t], u): ([Bt; 1], Bu),
+    ) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        let u_l = u.len();
+        (
+            vec![Box::new(t) as Box<_>, Box::new(u) as Box<_>],
+            T_N.min(u_l),
+            1,
+        )
+    }
+}
+
+unsafe impl<'a, T, U, Bt, Bu, const U_N: usize> VertexSource<(Bt, [Bu; 1])>
+    for TwoBuffersDefinition<T, U>
+where
+    T: Vertex,
+    Bt: TypedBufferAccess<Content = [T]> + Send + Sync + 'static,
+    U: Vertex,
+    Bu: TypedBufferAccess<Content = [U; U_N]> + Send + Sync + 'static,
+{
+    #[inline]
+    fn decode(
+        &self,
+        (t, [u]): (Bt, [Bu; 1]),
+    ) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        let t_l = t.len();
+        (
+            vec![Box::new(t) as Box<_>, Box::new(u) as Box<_>],
+            t_l.min(U_N),
+            1,
+        )
+    }
+}
+
+unsafe impl<'a, T, U, Bt, Bu, const T_N: usize, const U_N: usize> VertexSource<([Bt; 1], [Bu; 1])>
+    for TwoBuffersDefinition<T, U>
+where
+    T: Vertex,
+    Bt: TypedBufferAccess<Content = [T; T_N]> + Send + Sync + 'static,
+    U: Vertex,
+    Bu: TypedBufferAccess<Content = [U; U_N]> + Send + Sync + 'static,
+{
+    #[inline]
+    fn decode(
+        &self,
+        ([t], [u]): ([Bt; 1], [Bu; 1]),
+    ) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
+        (
+            vec![Box::new(t) as Box<_>, Box::new(u) as Box<_>],
+            T_N.min(U_N),
             1,
         )
     }


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] (not simple enough for users) Updated documentation to reflect any user-facing changes - in this repository
* [x] (not simple enough for users) Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This adds support for passing buffers statically typed as containing fixed-length arrays to draw calls.

It allows the following snippet of my code to work:

```rust
struct State {
    vertex_positions: Arc<ImmutableBuffer<[Vertex; 4]>>,
    instance_positions: Arc<DeviceLocalBuffer<[Instance; 10]>>,
    // [...]
}
// [...]
.draw(
    self.cursor_pipeline.clone(),
    &self.dynamic_state,
    (
        // After a lot of fighting with Rust, I found that the only solution that worked on stable Rust
        // was to just wrap all arguments of Content=[T; N] in another [T; 1]
        // It might be possible to improve this after const generics and specialization are stabilized
        [self.vertex_positions.clone()],
        self.instance_positions.clone()
            .into_buffer_slice().slice(0..self.positions_length).unwrap(),
        // It is now possible for either or both, in addition to no, arguments to be Content=[T; N]
    ),
    (),
    (),
    std::iter::empty(),
).unwrap()
```

This allows me to avoid preventing GPU optimizations when using `CpuAccessibleBuffer`, avoid having to copy stuff into the buffer each frame, be able to efficiently write to the buffer in a compute shader, and be able to do all of that with the safety of Rust type checking.