### PR TITLE
Split `AutoCommandBuffer` into primary and secondary

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -3,6 +3,9 @@
     Please add new changes at the bottom, preceded by a hyphen -.
     Breaking changes should be listed first, before other changes, and should be preceded by - **Breaking**.
 -->
+- **Breaking** `AutoCommandBuffer` and the `CommandBuffer` trait have been split in two, one for primary and the other for secondary command buffers. `AutoCommandBufferBuilder` remains one type, but has a type parameter for the level of command buffer it will be create, and some of its methods are only implemented for builders that create `PrimaryAutoCommandBuffer`.
+- **Breaking** `Kind` has been renamed to `CommandBufferLevel`, and for secondary command buffers it now contains a single `CommandBufferInheritance` value.
+- **Breaking** `CommandBufferInheritance::occlusion_query` and `UnsafeCommandBufferBuilder::begin_query` now take `QueryControlFlags` instead of a boolean.
 
 # Version 0.22.0 (2021-03-31)
 

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -9,9 +9,9 @@
 
 use vulkano::buffer::BufferUsage;
 use vulkano::buffer::CpuAccessibleBuffer;
-use vulkano::command_buffer::AutoCommandBuffer;
 use vulkano::command_buffer::AutoCommandBufferBuilder;
 use vulkano::command_buffer::DynamicState;
+use vulkano::command_buffer::SecondaryAutoCommandBuffer;
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::Queue;
 use vulkano::framebuffer::RenderPassAbstract;
@@ -119,7 +119,7 @@ impl AmbientLightingSystem {
         viewport_dimensions: [u32; 2],
         color_input: C,
         ambient_color: [f32; 3],
-    ) -> AutoCommandBuffer
+    ) -> SecondaryAutoCommandBuffer
     where
         C: ImageViewAbstract + Send + Sync + 'static,
     {

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -10,9 +10,9 @@
 use cgmath::Vector3;
 use vulkano::buffer::BufferUsage;
 use vulkano::buffer::CpuAccessibleBuffer;
-use vulkano::command_buffer::AutoCommandBuffer;
 use vulkano::command_buffer::AutoCommandBufferBuilder;
 use vulkano::command_buffer::DynamicState;
+use vulkano::command_buffer::SecondaryAutoCommandBuffer;
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::Queue;
 use vulkano::framebuffer::RenderPassAbstract;
@@ -129,7 +129,7 @@ impl DirectionalLightingSystem {
         normals_input: N,
         direction: Vector3<f32>,
         color: [f32; 3],
-    ) -> AutoCommandBuffer
+    ) -> SecondaryAutoCommandBuffer
     where
         C: ImageViewAbstract + Send + Sync + 'static,
         N: ImageViewAbstract + Send + Sync + 'static,

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -11,9 +11,9 @@ use cgmath::Matrix4;
 use cgmath::Vector3;
 use vulkano::buffer::BufferUsage;
 use vulkano::buffer::CpuAccessibleBuffer;
-use vulkano::command_buffer::AutoCommandBuffer;
 use vulkano::command_buffer::AutoCommandBufferBuilder;
 use vulkano::command_buffer::DynamicState;
+use vulkano::command_buffer::SecondaryAutoCommandBuffer;
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::Queue;
 use vulkano::framebuffer::RenderPassAbstract;
@@ -140,7 +140,7 @@ impl PointLightingSystem {
         screen_to_world: Matrix4<f32>,
         position: Vector3<f32>,
         color: [f32; 3],
-    ) -> AutoCommandBuffer
+    ) -> SecondaryAutoCommandBuffer
     where
         C: ImageViewAbstract + Send + Sync + 'static,
         N: ImageViewAbstract + Send + Sync + 'static,

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -7,11 +7,15 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use crate::frame::ambient_lighting_system::AmbientLightingSystem;
+use crate::frame::directional_lighting_system::DirectionalLightingSystem;
+use crate::frame::point_lighting_system::PointLightingSystem;
 use cgmath::Matrix4;
 use cgmath::SquareMatrix;
 use cgmath::Vector3;
 use std::sync::Arc;
 use vulkano::command_buffer::AutoCommandBufferBuilder;
+use vulkano::command_buffer::PrimaryAutoCommandBuffer;
 use vulkano::command_buffer::SecondaryCommandBuffer;
 use vulkano::command_buffer::SubpassContents;
 use vulkano::device::Queue;
@@ -25,10 +29,6 @@ use vulkano::image::AttachmentImage;
 use vulkano::image::ImageUsage;
 use vulkano::image::ImageViewAbstract;
 use vulkano::sync::GpuFuture;
-
-use crate::frame::ambient_lighting_system::AmbientLightingSystem;
-use crate::frame::directional_lighting_system::DirectionalLightingSystem;
-use crate::frame::point_lighting_system::PointLightingSystem;
 
 /// System that contains the necessary facilities for rendering a single frame.
 pub struct FrameSystem {
@@ -349,7 +349,7 @@ pub struct Frame<'a> {
     // Framebuffer that was used when starting the render pass.
     framebuffer: Arc<dyn FramebufferAbstract + Send + Sync>,
     // The command buffer builder that will be built during the lifetime of this object.
-    command_buffer_builder: Option<AutoCommandBufferBuilder>,
+    command_buffer_builder: Option<AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>>,
     // Matrix that was passed to `frame()`.
     world_to_framebuffer: Matrix4<f32>,
 }

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -12,7 +12,7 @@ use cgmath::SquareMatrix;
 use cgmath::Vector3;
 use std::sync::Arc;
 use vulkano::command_buffer::AutoCommandBufferBuilder;
-use vulkano::command_buffer::CommandBuffer;
+use vulkano::command_buffer::SecondaryCommandBuffer;
 use vulkano::command_buffer::SubpassContents;
 use vulkano::device::Queue;
 use vulkano::format::Format;
@@ -439,7 +439,7 @@ impl<'f, 's: 'f> DrawPass<'f, 's> {
     #[inline]
     pub fn execute<C>(&mut self, command_buffer: C)
     where
-        C: CommandBuffer + Send + Sync + 'static,
+        C: SecondaryCommandBuffer + Send + Sync + 'static,
     {
         self.frame
             .command_buffer_builder

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -9,9 +9,9 @@
 
 use vulkano::buffer::BufferUsage;
 use vulkano::buffer::CpuAccessibleBuffer;
-use vulkano::command_buffer::AutoCommandBuffer;
 use vulkano::command_buffer::AutoCommandBufferBuilder;
 use vulkano::command_buffer::DynamicState;
+use vulkano::command_buffer::SecondaryAutoCommandBuffer;
 use vulkano::device::Queue;
 use vulkano::framebuffer::RenderPassAbstract;
 use vulkano::framebuffer::Subpass;
@@ -83,7 +83,7 @@ impl TriangleDrawSystem {
     }
 
     /// Builds a secondary command buffer that draws the triangle on the current subpass.
-    pub fn draw(&self, viewport_dimensions: [u32; 2]) -> AutoCommandBuffer {
+    pub fn draw(&self, viewport_dimensions: [u32; 2]) -> SecondaryAutoCommandBuffer {
         let mut builder = AutoCommandBufferBuilder::secondary_graphics(
             self.gfx_queue.device().clone(),
             self.gfx_queue.family(),

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -71,7 +71,7 @@ use std::path::Path;
 use std::sync::Arc;
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{
-    AutoCommandBufferBuilder, CommandBuffer, DynamicState, SubpassContents,
+    AutoCommandBufferBuilder, DynamicState, PrimaryCommandBuffer, SubpassContents,
 };
 use vulkano::device::{Device, DeviceExtensions};
 use vulkano::format::ClearValue;

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -73,7 +73,7 @@ use crate::OomError;
 /// ```
 /// use vulkano::buffer::CpuBufferPool;
 /// use vulkano::command_buffer::AutoCommandBufferBuilder;
-/// use vulkano::command_buffer::CommandBuffer;
+/// use vulkano::command_buffer::PrimaryCommandBuffer;
 /// use vulkano::sync::GpuFuture;
 /// # let device: std::sync::Arc<vulkano::device::Device> = return;
 /// # let queue: std::sync::Arc<vulkano::device::Queue> = return;

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -26,9 +26,9 @@ use crate::buffer::traits::BufferInner;
 use crate::buffer::traits::TypedBufferAccess;
 use crate::buffer::BufferUsage;
 use crate::buffer::CpuAccessibleBuffer;
-use crate::command_buffer::AutoCommandBuffer;
 use crate::command_buffer::AutoCommandBufferBuilder;
 use crate::command_buffer::CommandBufferExecFuture;
+use crate::command_buffer::PrimaryAutoCommandBuffer;
 use crate::command_buffer::PrimaryCommandBuffer;
 use crate::device::Device;
 use crate::device::DeviceOwned;
@@ -77,7 +77,7 @@ pub struct ImmutableBuffer<T: ?Sized, A = PotentialDedicatedAllocation<StdMemory
 }
 
 // TODO: make this prettier
-type ImmutableBufferFromBufferFuture = CommandBufferExecFuture<NowFuture, AutoCommandBuffer>;
+type ImmutableBufferFromBufferFuture = CommandBufferExecFuture<NowFuture, PrimaryAutoCommandBuffer>;
 
 impl<T: ?Sized> ImmutableBuffer<T> {
     /// Builds an `ImmutableBuffer` from some data.

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -18,15 +18,6 @@
 //! The buffer will be stored in device-local memory if possible
 //!
 
-use smallvec::SmallVec;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::marker::PhantomData;
-use std::mem;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-
 use crate::buffer::sys::BufferCreationError;
 use crate::buffer::sys::SparseLevel;
 use crate::buffer::sys::UnsafeBuffer;
@@ -37,8 +28,8 @@ use crate::buffer::BufferUsage;
 use crate::buffer::CpuAccessibleBuffer;
 use crate::command_buffer::AutoCommandBuffer;
 use crate::command_buffer::AutoCommandBufferBuilder;
-use crate::command_buffer::CommandBuffer;
 use crate::command_buffer::CommandBufferExecFuture;
+use crate::command_buffer::PrimaryCommandBuffer;
 use crate::device::Device;
 use crate::device::DeviceOwned;
 use crate::device::Queue;
@@ -56,6 +47,14 @@ use crate::memory::DeviceMemoryAllocError;
 use crate::sync::AccessError;
 use crate::sync::NowFuture;
 use crate::sync::Sharing;
+use smallvec::SmallVec;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::marker::PhantomData;
+use std::mem;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 /// Buffer that is written once then read for as long as it is alive.
 // TODO: implement Debug
@@ -535,7 +534,7 @@ mod tests {
     use crate::buffer::immutable::ImmutableBuffer;
     use crate::buffer::BufferUsage;
     use crate::command_buffer::AutoCommandBufferBuilder;
-    use crate::command_buffer::CommandBuffer;
+    use crate::command_buffer::PrimaryCommandBuffer;
     use crate::sync::GpuFuture;
 
     #[test]

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -73,7 +73,6 @@
 //! alternative command pool implementations and use them. See the `pool` module for more
 //! information.
 
-pub use self::auto::AutoCommandBuffer;
 pub use self::auto::AutoCommandBufferBuilder;
 pub use self::auto::AutoCommandBufferBuilderContextError;
 pub use self::auto::BeginRenderPassError;
@@ -91,6 +90,8 @@ pub use self::auto::DrawIndexedIndirectError;
 pub use self::auto::DrawIndirectError;
 pub use self::auto::ExecuteCommandsError;
 pub use self::auto::FillBufferError;
+pub use self::auto::PrimaryAutoCommandBuffer;
+pub use self::auto::SecondaryAutoCommandBuffer;
 pub use self::auto::UpdateBufferError;
 pub use self::state_cacher::StateCacher;
 pub use self::state_cacher::StateCacherOutcome;

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -49,7 +49,7 @@
 //!
 //! ```
 //! use vulkano::command_buffer::AutoCommandBufferBuilder;
-//! use vulkano::command_buffer::CommandBuffer;
+//! use vulkano::command_buffer::PrimaryCommandBuffer;
 //!
 //! # let device: std::sync::Arc<vulkano::device::Device> = return;
 //! # let queue: std::sync::Arc<vulkano::device::Queue> = return;
@@ -94,9 +94,10 @@ pub use self::auto::FillBufferError;
 pub use self::auto::UpdateBufferError;
 pub use self::state_cacher::StateCacher;
 pub use self::state_cacher::StateCacherOutcome;
-pub use self::traits::CommandBuffer;
 pub use self::traits::CommandBufferExecError;
 pub use self::traits::CommandBufferExecFuture;
+pub use self::traits::PrimaryCommandBuffer;
+pub use self::traits::SecondaryCommandBuffer;
 
 use crate::framebuffer::{EmptySinglePassRenderPassDesc, Framebuffer, RenderPass, Subpass};
 use crate::pipeline::depth_stencil::DynamicStencilValue;

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -20,8 +20,8 @@ use crate::command_buffer::sys::UnsafeCommandBufferBuilderColorImageClear;
 use crate::command_buffer::sys::UnsafeCommandBufferBuilderExecuteCommands;
 use crate::command_buffer::sys::UnsafeCommandBufferBuilderImageBlit;
 use crate::command_buffer::sys::UnsafeCommandBufferBuilderImageCopy;
-use crate::command_buffer::CommandBuffer;
 use crate::command_buffer::CommandBufferExecError;
+use crate::command_buffer::SecondaryCommandBuffer;
 use crate::command_buffer::SubpassContents;
 use crate::descriptor::descriptor::DescriptorDescTy;
 use crate::descriptor::descriptor::ShaderStages;
@@ -2653,7 +2653,7 @@ impl<'a> SyncCommandBufferBuilderBindVertexBuffer<'a> {
 /// Prototype for a `vkCmdExecuteCommands`.
 pub struct SyncCommandBufferBuilderExecuteCommands<'a> {
     builder: &'a mut SyncCommandBufferBuilder,
-    inner: Vec<Box<dyn CommandBuffer + Send + Sync>>,
+    inner: Vec<Box<dyn SecondaryCommandBuffer + Send + Sync>>,
 }
 
 impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
@@ -2661,16 +2661,16 @@ impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
     #[inline]
     pub fn add<C>(&mut self, command_buffer: C)
     where
-        C: CommandBuffer + Send + Sync + 'static,
+        C: SecondaryCommandBuffer + Send + Sync + 'static,
     {
         self.inner.push(Box::new(command_buffer));
     }
 
     #[inline]
     pub unsafe fn submit(self) -> Result<(), SyncCommandBufferBuilderError> {
-        struct DropUnlock(Box<dyn CommandBuffer + Send + Sync>);
+        struct DropUnlock(Box<dyn SecondaryCommandBuffer + Send + Sync>);
         impl std::ops::Deref for DropUnlock {
-            type Target = Box<dyn CommandBuffer + Send + Sync>;
+            type Target = Box<dyn SecondaryCommandBuffer + Send + Sync>;
 
             fn deref(&self) -> &Self::Target {
                 &self.0

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -11,9 +11,9 @@ use crate::buffer::BufferAccess;
 use crate::buffer::BufferInner;
 use crate::check_errors;
 use crate::command_buffer::pool::UnsafeCommandPoolAlloc;
-use crate::command_buffer::CommandBuffer;
 use crate::command_buffer::Kind;
 use crate::command_buffer::KindOcclusionQuery;
+use crate::command_buffer::SecondaryCommandBuffer;
 use crate::command_buffer::SubpassContents;
 use crate::descriptor::descriptor::ShaderStages;
 use crate::descriptor::descriptor_set::UnsafeDescriptorSet;
@@ -1606,7 +1606,7 @@ impl UnsafeCommandBufferBuilderExecuteCommands {
     #[inline]
     pub fn add<C>(&mut self, cb: &C)
     where
-        C: ?Sized + CommandBuffer,
+        C: ?Sized + SecondaryCommandBuffer,
     {
         // TODO: debug assert that it is a secondary command buffer?
         self.raw_cbs.push(cb.inner().internal_object());

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -11,7 +11,7 @@ use crate::buffer::BufferAccess;
 use crate::command_buffer::submit::SubmitAnyBuilder;
 use crate::command_buffer::submit::SubmitCommandBufferBuilder;
 use crate::command_buffer::sys::UnsafeCommandBuffer;
-use crate::command_buffer::Kind;
+use crate::command_buffer::CommandBufferInheritance;
 use crate::device::Device;
 use crate::device::DeviceOwned;
 use crate::device::Queue;
@@ -219,8 +219,11 @@ pub unsafe trait SecondaryCommandBuffer: DeviceOwned {
     /// Must not be called if you haven't called `lock_record` before.
     unsafe fn unlock(&self);
 
-    /// Returns a `Kind` value describing the command buffer.
-    fn kind(&self) -> Kind<&dyn RenderPassAbstract, &dyn FramebufferAbstract>;
+    /// Returns a `CommandBufferInheritance` value describing the properties that the command
+    /// buffer inherits from its parent primary command buffer.
+    fn inheritance(
+        &self,
+    ) -> CommandBufferInheritance<&dyn RenderPassAbstract, &dyn FramebufferAbstract>;
 
     /// Returns the number of buffers accessed by this command buffer.
     fn num_buffers(&self) -> usize;
@@ -268,8 +271,10 @@ where
     }
 
     #[inline]
-    fn kind(&self) -> Kind<&dyn RenderPassAbstract, &dyn FramebufferAbstract> {
-        (**self).kind()
+    fn inheritance(
+        &self,
+    ) -> CommandBufferInheritance<&dyn RenderPassAbstract, &dyn FramebufferAbstract> {
+        (**self).inheritance()
     }
 
     #[inline]

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -11,9 +11,9 @@ use crate::buffer::BufferAccess;
 use crate::buffer::BufferUsage;
 use crate::buffer::CpuAccessibleBuffer;
 use crate::buffer::TypedBufferAccess;
-use crate::command_buffer::AutoCommandBuffer;
 use crate::command_buffer::AutoCommandBufferBuilder;
 use crate::command_buffer::CommandBufferExecFuture;
+use crate::command_buffer::PrimaryAutoCommandBuffer;
 use crate::command_buffer::PrimaryCommandBuffer;
 use crate::device::Device;
 use crate::device::Queue;
@@ -327,7 +327,7 @@ impl<F> ImmutableImage<F> {
     ) -> Result<
         (
             Arc<Self>,
-            CommandBufferExecFuture<NowFuture, AutoCommandBuffer>,
+            CommandBufferExecFuture<NowFuture, PrimaryAutoCommandBuffer>,
         ),
         ImageCreationError,
     >
@@ -356,7 +356,7 @@ impl<F> ImmutableImage<F> {
     ) -> Result<
         (
             Arc<Self>,
-            CommandBufferExecFuture<NowFuture, AutoCommandBuffer>,
+            CommandBufferExecFuture<NowFuture, PrimaryAutoCommandBuffer>,
         ),
         ImageCreationError,
     >

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -7,21 +7,14 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use smallvec::SmallVec;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-
 use crate::buffer::BufferAccess;
 use crate::buffer::BufferUsage;
 use crate::buffer::CpuAccessibleBuffer;
 use crate::buffer::TypedBufferAccess;
 use crate::command_buffer::AutoCommandBuffer;
 use crate::command_buffer::AutoCommandBufferBuilder;
-use crate::command_buffer::CommandBuffer;
 use crate::command_buffer::CommandBufferExecFuture;
+use crate::command_buffer::PrimaryCommandBuffer;
 use crate::device::Device;
 use crate::device::Queue;
 use crate::format::AcceptsPixels;
@@ -51,6 +44,12 @@ use crate::sampler::Filter;
 use crate::sync::AccessError;
 use crate::sync::NowFuture;
 use crate::sync::Sharing;
+use smallvec::SmallVec;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 /// Image whose purpose is to be used for read-only purposes. You can write to the image once,
 /// but then you must only ever read from it.
@@ -121,8 +120,8 @@ fn has_mipmaps(mipmaps: MipmapsCount) -> bool {
     }
 }
 
-fn generate_mipmaps<Img>(
-    cbb: &mut AutoCommandBufferBuilder,
+fn generate_mipmaps<L, Img>(
+    cbb: &mut AutoCommandBufferBuilder<L>,
     image: Arc<Img>,
     dimensions: ImageDimensions,
     layout: ImageLayout,

--- a/vulkano/src/query/mod.rs
+++ b/vulkano/src/query/mod.rs
@@ -181,7 +181,12 @@ pub enum QueryType {
     Timestamp,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct QueryControlFlags {
+    pub precise: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
 pub struct QueryPipelineStatisticFlags {
     pub input_assembly_vertices: bool,
     pub input_assembly_primitives: bool,

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -241,7 +241,7 @@
 //! # let mut swapchain: ::std::sync::Arc<swapchain::Swapchain<()>> = return;
 //! // let mut (swapchain, images) = Swapchain::new(...);
 //! loop {
-//!     # let mut command_buffer: ::vulkano::command_buffer::AutoCommandBuffer<()> = return;
+//!     # let mut command_buffer: ::vulkano::command_buffer::PrimaryAutoCommandBuffer<()> = return;
 //!     let (image_num, suboptimal, acquire_future)
 //!         = swapchain::acquire_next_image(swapchain.clone(), None).unwrap();
 //!

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -7,18 +7,18 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use std::error;
-use std::fmt;
-use std::sync::Arc;
-
+pub use self::fence_signal::{FenceSignalFuture, FenceSignalFutureBehavior};
+pub use self::join::JoinFuture;
+pub use self::now::{now, NowFuture};
+pub use self::semaphore_signal::SemaphoreSignalFuture;
 use crate::buffer::BufferAccess;
 use crate::command_buffer::submit::SubmitAnyBuilder;
 use crate::command_buffer::submit::SubmitBindSparseError;
 use crate::command_buffer::submit::SubmitCommandBufferError;
 use crate::command_buffer::submit::SubmitPresentError;
-use crate::command_buffer::CommandBuffer;
 use crate::command_buffer::CommandBufferExecError;
 use crate::command_buffer::CommandBufferExecFuture;
+use crate::command_buffer::PrimaryCommandBuffer;
 use crate::device::DeviceOwned;
 use crate::device::Queue;
 use crate::image::ImageAccess;
@@ -31,11 +31,9 @@ use crate::sync::AccessFlagBits;
 use crate::sync::FenceWaitError;
 use crate::sync::PipelineStages;
 use crate::OomError;
-
-pub use self::fence_signal::{FenceSignalFuture, FenceSignalFutureBehavior};
-pub use self::join::JoinFuture;
-pub use self::now::{now, NowFuture};
-pub use self::semaphore_signal::SemaphoreSignalFuture;
+use std::error;
+use std::fmt;
+use std::sync::Arc;
 
 mod fence_signal;
 mod join;
@@ -166,7 +164,7 @@ pub unsafe trait GpuFuture: DeviceOwned {
     ) -> Result<CommandBufferExecFuture<Self, Cb>, CommandBufferExecError>
     where
         Self: Sized,
-        Cb: CommandBuffer + 'static,
+        Cb: PrimaryCommandBuffer + 'static,
     {
         command_buffer.execute_after(self, queue)
     }
@@ -182,7 +180,7 @@ pub unsafe trait GpuFuture: DeviceOwned {
     ) -> Result<CommandBufferExecFuture<Self, Cb>, CommandBufferExecError>
     where
         Self: Sized,
-        Cb: CommandBuffer + 'static,
+        Cb: PrimaryCommandBuffer + 'static,
     {
         let queue = self.queue().unwrap().clone();
         command_buffer.execute_after(self, queue)


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

The `AutoCommandBuffer` is split into `PrimaryAutoCommandBuffer` and `SecondaryAutoCommandBuffer`, and the trait `CommandBuffer` is also split into `PrimaryCommandBuffer` and `SecondaryCommandBuffer`. `AutoCommandBufferBuilder` is still one type, but it has a type parameter for which type it will build.

I've also renamed `Kind` and changed how it works a little, so that it now holds a `CommandBufferInheritance` for secondary command buffers. The `SecondaryCommandBuffer::inheritance` trait method returns this value.

Pros:
- It turns out that there are actually no functions in Vulkano that can accept either type of command buffer. Functions can now specifically ask for one type or the other, giving the wrong type is a compile-time error. This removes a runtime check.
- Likewise, the trait methods of `CommandBuffer` only make sense for primary _or_ secondary command buffers, the only one that works for both is `inner`.
- Some methods on `AutoCommandBufferBuilder` are now only implemented for `AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>`, so this removes a runtime check.

Cons:
- It's now a bit harder to write a function that works for both primary and secondary command buffer builders. You'd have to make it a generic function. Time will tell if this proves to be an obstacle?