### PR TITLE
fix typo in scissor doc comment

### DIFF
--- a/vulkano/src/pipeline/viewport.rs
+++ b/vulkano/src/pipeline/viewport.rs
@@ -169,8 +169,10 @@ pub struct Scissor {
 }
 
 impl Scissor {
-    /// Defines a scissor box that covers the entire viewport.
-    /// https://vulkan-tutorial.com/Drawing_a_triangle/Graphics_pipeline_basics/Fixed_functions#page_Viewports-and-scissors
+    /// Returns a scissor that, when used, will instruct the pipeline to draw to the entire framebuffer, seen
+    /// [here][scissor].
+    ///
+    /// [scissor]: https://vulkan-tutorial.com/Drawing_a_triangle/Graphics_pipeline_basics/Fixed_functions#page_Viewports-and-scissors
     #[inline]
     pub fn irrelevant() -> Scissor {
         Scissor {

--- a/vulkano/src/pipeline/viewport.rs
+++ b/vulkano/src/pipeline/viewport.rs
@@ -48,8 +48,8 @@
 //! In all cases the number of viewports and scissor boxes must be the same.
 //!
 
-use std::ops::Range;
 use crate::vk;
+use std::ops::Range;
 
 /// List of viewports and scissors that are used when creating a graphics pipeline object.
 ///
@@ -169,7 +169,8 @@ pub struct Scissor {
 }
 
 impl Scissor {
-    /// Defines a scissor box that it outside of the image.
+    /// Defines a scissor box that covers the entire viewport.
+    /// https://vulkan-tutorial.com/Drawing_a_triangle/Graphics_pipeline_basics/Fixed_functions#page_Viewports-and-scissors
     #[inline]
     pub fn irrelevant() -> Scissor {
         Scissor {

--- a/vulkano/src/pipeline/viewport.rs
+++ b/vulkano/src/pipeline/viewport.rs
@@ -169,10 +169,7 @@ pub struct Scissor {
 }
 
 impl Scissor {
-    /// Returns a scissor that, when used, will instruct the pipeline to draw to the entire framebuffer, seen
-    /// [here][scissor].
-    ///
-    /// [scissor]: https://vulkan-tutorial.com/Drawing_a_triangle/Graphics_pipeline_basics/Fixed_functions#page_Viewports-and-scissors
+    /// Returns a scissor that, when used, will instruct the pipeline to draw to the entire framebuffer.
     #[inline]
     pub fn irrelevant() -> Scissor {
         Scissor {


### PR DESCRIPTION
👋 thank you all for your work here! I'm just getting started working with vulkano + vulkan (and am really enjoying it). I've made it past the render-a-triangle demo and am now in the process of decomposing the code down chunk by chunk to understand things more. I'm at the part where the graphics pipeline needs to be setup up and am playing around with all the different options.

Based on the  [vulkan-tutorial part covering these steps](https://vulkan-tutorial.com/Drawing_a_triangle/Graphics_pipeline_basics/Fixed_functions#page_Viewports-and-scissors), it looks like what this comment is meaning to say is that the returned `Scissor` from `irrelevant()` covers the entire viewport.

(edit: I'm still learning, so this could be a misunderstanding on my part)

* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes