### PR TITLE
Replace deprecated `Error::cause` with `source`

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -3,6 +3,7 @@
     Please add new changes at the bottom, preceded by a hyphen -.
     Breaking changes should be listed first, before other changes, and should be preceded by - **Breaking**.
 -->
+- The deprecated `cause` trait function on Vulkano error types is replaced with `source`.
 
 # Version 0.22.0 (2021-03-31)
 

--- a/vulkano-win/src/winit.rs
+++ b/vulkano-win/src/winit.rs
@@ -90,7 +90,7 @@ pub enum CreationError {
 
 impl error::Error for CreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             CreationError::SurfaceCreationError(ref err) => Some(err),
             CreationError::WindowCreationError(ref err) => Some(err),

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -456,7 +456,7 @@ pub enum BufferCreationError {
 
 impl error::Error for BufferCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             BufferCreationError::AllocError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -316,7 +316,7 @@ pub enum BufferViewCreationError {
 
 impl error::Error for BufferViewCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             BufferViewCreationError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -2290,7 +2290,7 @@ macro_rules! err_gen {
 
         impl error::Error for $name {
             #[inline]
-            fn cause(&self) -> Option<&dyn error::Error> {
+            fn source(&self) -> Option<&(dyn error::Error + 'static)> {
                 match *self {
                     $(
                         $name::$err(ref err) => Some(err),

--- a/vulkano/src/command_buffer/submit/bind_sparse.rs
+++ b/vulkano/src/command_buffer/submit/bind_sparse.rs
@@ -480,7 +480,7 @@ pub enum SubmitBindSparseError {
 
 impl error::Error for SubmitBindSparseError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SubmitBindSparseError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/command_buffer/submit/queue_present.rs
+++ b/vulkano/src/command_buffer/submit/queue_present.rs
@@ -224,7 +224,7 @@ pub enum SubmitPresentError {
 
 impl error::Error for SubmitPresentError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SubmitPresentError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/command_buffer/submit/queue_submit.rs
+++ b/vulkano/src/command_buffer/submit/queue_submit.rs
@@ -262,7 +262,7 @@ pub enum SubmitCommandBufferError {
 
 impl error::Error for SubmitCommandBufferError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SubmitCommandBufferError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -472,7 +472,7 @@ pub enum CommandBufferExecError {
 
 impl error::Error for CommandBufferExecError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             CommandBufferExecError::AccessError { ref error, .. } => Some(error),
             _ => None,

--- a/vulkano/src/command_buffer/validity/copy_image_buffer.rs
+++ b/vulkano/src/command_buffer/validity/copy_image_buffer.rs
@@ -211,7 +211,7 @@ pub enum CheckCopyBufferImageError {
 }
 
 impl error::Error for CheckCopyBufferImageError {
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             CheckCopyBufferImageError::WrongPixelType(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/command_buffer/validity/descriptor_sets.rs
+++ b/vulkano/src/command_buffer/validity/descriptor_sets.rs
@@ -81,7 +81,7 @@ pub enum CheckDescriptorSetsValidityError {
 
 impl error::Error for CheckDescriptorSetsValidityError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             CheckDescriptorSetsValidityError::IncompatibleDescriptor { ref error, .. } => {
                 Some(error)

--- a/vulkano/src/descriptor/pipeline_layout/sys.rs
+++ b/vulkano/src/descriptor/pipeline_layout/sys.rs
@@ -281,7 +281,7 @@ pub enum PipelineLayoutCreationError {
 
 impl error::Error for PipelineLayoutCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             PipelineLayoutCreationError::OomError(ref err) => Some(err),
             PipelineLayoutCreationError::LimitsError(ref err) => Some(err),

--- a/vulkano/src/descriptor/pipeline_layout/traits.rs
+++ b/vulkano/src/descriptor/pipeline_layout/traits.rs
@@ -252,7 +252,7 @@ pub enum PipelineLayoutNotSupersetError {
 
 impl error::Error for PipelineLayoutNotSupersetError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             PipelineLayoutNotSupersetError::IncompatibleDescriptors { ref error, .. } => {
                 Some(error)

--- a/vulkano/src/extensions.rs
+++ b/vulkano/src/extensions.rs
@@ -184,7 +184,7 @@ pub enum SupportedExtensionsError {
 
 impl error::Error for SupportedExtensionsError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SupportedExtensionsError::LoadingError(ref err) => Some(err),
             SupportedExtensionsError::OomError(ref err) => Some(err),

--- a/vulkano/src/framebuffer/framebuffer.rs
+++ b/vulkano/src/framebuffer/framebuffer.rs
@@ -513,7 +513,7 @@ impl From<OomError> for FramebufferCreationError {
 
 impl error::Error for FramebufferCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             FramebufferCreationError::OomError(ref err) => Some(err),
             FramebufferCreationError::IncompatibleAttachment(ref err) => Some(err),

--- a/vulkano/src/framebuffer/sys.rs
+++ b/vulkano/src/framebuffer/sys.rs
@@ -546,7 +546,7 @@ pub enum RenderPassCreationError {
 
 impl error::Error for RenderPassCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             RenderPassCreationError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -928,7 +928,7 @@ pub enum ImageCreationError {
 
 impl error::Error for ImageCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             ImageCreationError::AllocError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -191,7 +191,7 @@ pub enum ImageViewCreationError {
 
 impl error::Error for ImageViewCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             ImageViewCreationError::AllocError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -668,7 +668,7 @@ pub enum InstanceCreationError {
 
 impl error::Error for InstanceCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             InstanceCreationError::LoadingError(ref err) => Some(err),
             InstanceCreationError::OomError(ref err) => Some(err),

--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -173,7 +173,7 @@ pub enum LayersListError {
 
 impl error::Error for LayersListError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             LayersListError::LoadingError(ref err) => Some(err),
             LayersListError::OomError(ref err) => Some(err),

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -246,7 +246,7 @@ pub enum LoadingError {
 
 impl error::Error for LoadingError {
     /*#[inline]
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             LoadingError::LibraryLoadFailure(ref err) => Some(err),
             _ => None

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -992,7 +992,7 @@ pub enum DeviceMemoryAllocError {
 
 impl error::Error for DeviceMemoryAllocError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             DeviceMemoryAllocError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -340,7 +340,7 @@ pub enum ComputePipelineCreationError {
 
 impl error::Error for ComputePipelineCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             ComputePipelineCreationError::OomError(ref err) => Some(err),
             ComputePipelineCreationError::PipelineLayoutCreationError(ref err) => Some(err),

--- a/vulkano/src/pipeline/graphics_pipeline/creation_error.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/creation_error.rs
@@ -186,7 +186,7 @@ pub enum GraphicsPipelineCreationError {
 
 impl error::Error for GraphicsPipelineCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             GraphicsPipelineCreationError::OomError(ref err) => Some(err),
             GraphicsPipelineCreationError::IncompatiblePipelineLayout(ref err) => Some(err),

--- a/vulkano/src/query/mod.rs
+++ b/vulkano/src/query/mod.rs
@@ -276,7 +276,7 @@ pub enum QueryPoolCreationError {
 
 impl error::Error for QueryPoolCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             QueryPoolCreationError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/sampler.rs
+++ b/vulkano/src/sampler.rs
@@ -724,7 +724,7 @@ pub enum SamplerCreationError {
 
 impl error::Error for SamplerCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SamplerCreationError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -712,7 +712,7 @@ pub enum SurfaceCreationError {
 
 impl error::Error for SurfaceCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SurfaceCreationError::OomError(ref err) => Some(err),
             _ => None,
@@ -767,7 +767,7 @@ pub enum CapabilitiesError {
 
 impl error::Error for CapabilitiesError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             CapabilitiesError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -949,7 +949,7 @@ pub enum SwapchainCreationError {
 
 impl error::Error for SwapchainCreationError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             SwapchainCreationError::OomError(ref err) => Some(err),
             _ => None,
@@ -1226,7 +1226,7 @@ impl From<OomError> for FullscreenExclusiveError {
 
 impl error::Error for FullscreenExclusiveError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             FullscreenExclusiveError::OomError(ref err) => Some(err),
             _ => None,
@@ -1286,7 +1286,7 @@ pub enum AcquireError {
 
 impl error::Error for AcquireError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             AcquireError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -365,7 +365,7 @@ pub enum FenceWaitError {
 
 impl error::Error for FenceWaitError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             FenceWaitError::OomError(ref err) => Some(err),
             _ => None,

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -472,7 +472,7 @@ pub enum FlushError {
 
 impl error::Error for FlushError {
     #[inline]
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             FlushError::AccessError(ref err) => Some(err),
             FlushError::OomError(ref err) => Some(err),


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

The `cause` method on the standard `Error` trait is deprecated, and it's preventing some error handling crates like `anyhow` from reporting Vulkano errors properly. This PR renames all `cause` methods to `source`, which fixes the problem.