### PR TITLE
Fix and refine the generation of `readonly` descriptor attribute

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -3,6 +3,7 @@
     Please add new changes at the bottom, preceded by a hyphen -.
     Breaking changes should be listed first, before other changes, and should be preceded by - **Breaking**.
 -->
+- Vulkano-shaders: Fixed and refined the generation of the `readonly` descriptor attribute. It should now correctly mark uniforms and sampled images as read-only, but storage buffers and images only if explicitly marked as `readonly` in the shader.
 
 # Version 0.22.0 (2021-03-31)
 


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This fixes #1533 and also improves upon #1513, by properly marking storage image descriptors as readonly only if they are marked such in the shader.

I would recommend releasing a version with this fix (and any other non-breaking ones that are waiting) as 0.22.1, perhaps even yanking 0.22.0. If my experiences are an indication, #1533 breaks any code that uses uniform buffers, which is probably almost all of them.

EDIT: After some more digging, it turns out the bug isn't quite as severe as I thought. It's happening because my code defines its own descriptor instead of using the one from the pipeline. My descriptor of course sets `readonly`, so that causes the mismatch. So it probably doesn't break everyone's code, but if you define your own descriptor for a uniform buffer it likely will.