### PR TITLE
Add component mapping to ImageView, create ImageViewBuilder

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -6,6 +6,12 @@
 - **Breaking** `AutoCommandBuffer` and the `CommandBuffer` trait have been split in two, one for primary and the other for secondary command buffers. `AutoCommandBufferBuilder` remains one type, but has a type parameter for the level of command buffer it will be create, and some of its methods are only implemented for builders that create `PrimaryAutoCommandBuffer`.
 - **Breaking** `Kind` has been renamed to `CommandBufferLevel`, and for secondary command buffers it now contains a single `CommandBufferInheritance` value.
 - **Breaking** `CommandBufferInheritance::occlusion_query` and `UnsafeCommandBufferBuilder::begin_query` now take `QueryControlFlags` instead of a boolean.
+- **Breaking** The non-default constructors of `ImageView` have been replaced with a builder, created with `ImageView::start(image)`.
+- **Breaking** Added support for component mapping/swizzling on image views.
+  - `image::Swizzle` is moved and renamed to `image::view::ComponentMapping`. It now has an `is_identity` method.
+  - A non-default component mapping can now be specified for image views, via the new builder. A `ComponentMapping` parameter has been added to `UnsafeImageView` as well.
+  - The `identity_swizzle` method on the `ImageViewAbstract` trait has been replaced with `component_mapping`, which returns a `ComponentMapping` directly.
+  - Storage image and input attachment descriptors now check for identity swizzling when being built.
 - The deprecated `cause` trait function on Vulkano error types is replaced with `source`.
 - Vulkano-shaders: Fixed and refined the generation of the `readonly` descriptor attribute. It should now correctly mark uniforms and sampled images as read-only, but storage buffers and images only if explicitly marked as `readonly` in the shader.
 

--- a/vulkano/src/framebuffer/compat_atch.rs
+++ b/vulkano/src/framebuffer/compat_atch.rs
@@ -51,7 +51,7 @@ where
         });
     }
 
-    if !image_view.identity_swizzle() {
+    if !image_view.component_mapping().is_identity() {
         return Err(IncompatibleRenderPassAttachmentError::NotIdentitySwizzled);
     }
 
@@ -159,7 +159,7 @@ impl fmt::Display for IncompatibleRenderPassAttachmentError {
                  number of samples"
                 }
                 IncompatibleRenderPassAttachmentError::NotIdentitySwizzled => {
-                    "the image view does not use identity swizzling"
+                    "the image view's component mapping is not identity swizzled"
                 }
                 IncompatibleRenderPassAttachmentError::MissingColorAttachmentUsage => {
                     "the image is used as a color attachment but is missing the color attachment usage"

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -168,53 +168,6 @@ impl From<vk::ImageFormatProperties> for ImageFormatProperties {
     }
 }
 
-/// Specifies how the components of an image must be swizzled.
-///
-/// When creating an image view, it is possible to ask the implementation to modify the value
-/// returned when accessing a given component from within a shader.
-///
-/// If all the members are `Identity`, then the view is said to have identity swizzling. This is
-/// what the `Default` trait implementation of this struct returns.
-/// Views that don't have identity swizzling may not be supported for some operations. For example
-/// attaching a view to a framebuffer is only possible if the view is identity-swizzled.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct Swizzle {
-    /// First component.
-    pub r: ComponentSwizzle,
-    /// Second component.
-    pub g: ComponentSwizzle,
-    /// Third component.
-    pub b: ComponentSwizzle,
-    /// Fourth component.
-    pub a: ComponentSwizzle,
-}
-
-/// Describes the value that an individual component must return when being accessed.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ComponentSwizzle {
-    /// Returns the value that this component should normally have.
-    Identity,
-    /// Always return zero.
-    Zero,
-    /// Always return one.
-    One,
-    /// Returns the value of the first component.
-    Red,
-    /// Returns the value of the second component.
-    Green,
-    /// Returns the value of the third component.
-    Blue,
-    /// Returns the value of the fourth component.
-    Alpha,
-}
-
-impl Default for ComponentSwizzle {
-    #[inline]
-    fn default() -> ComponentSwizzle {
-        ComponentSwizzle::Identity
-    }
-}
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub struct ImageCreateFlags {
     pub sparse_binding: bool,


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This adds support for non-identity component mapping/swizzling to image views. Because the situation with the constructors of `ImageView` was getting a bit messy, I decided to create a builder for it, so the user can choose to override only the values they want. For the common case, the default constructor `ImageView::new` is kept, which internally calls the builder and then immediately builds it.

I also added some checks to `PersistentDescriptorSetBuilder`, to ensure that image views are identity swizzled in cases where the standard requires it.