### PR TITLE
Fix check for array layer count with cube descriptors

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -8,6 +8,7 @@
 - **Breaking** `CommandBufferInheritance::occlusion_query` and `UnsafeCommandBufferBuilder::begin_query` now take `QueryControlFlags` instead of a boolean.
 - The deprecated `cause` trait function on Vulkano error types is replaced with `source`.
 - Vulkano-shaders: Fixed and refined the generation of the `readonly` descriptor attribute. It should now correctly mark uniforms and sampled images as read-only, but storage buffers and images only if explicitly marked as `readonly` in the shader.
+- Fixed bug in descriptor array layers check when the image is a cubemap.
 
 # Version 0.22.0 (2021-03-31)
 

--- a/vulkano/src/descriptor/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor/descriptor_set/persistent.rs
@@ -911,7 +911,13 @@ where
         DescriptorImageDescArray::NonArrayed => {
             // TODO: when a non-array is expected, can we pass an image view that is in fact an
             // array with one layer? need to check
-            if num_layers != 1 {
+            let required_layers = if desc.dimensions == DescriptorImageDescDimensions::Cube {
+                6
+            } else {
+                1
+            };
+
+            if num_layers != required_layers {
                 return Err(PersistentDescriptorSetError::ArrayLayersMismatch {
                     expected: 1,
                     obtained: num_layers,
@@ -921,8 +927,14 @@ where
         DescriptorImageDescArray::Arrayed {
             max_layers: Some(max_layers),
         } => {
-            if num_layers > max_layers {
-                // TODO: is this correct? "max" layers? or is it in fact min layers?
+            let required_layers = if desc.dimensions == DescriptorImageDescDimensions::Cube {
+                max_layers * 6
+            } else {
+                max_layers
+            };
+
+            // TODO: is this correct? "max" layers? or is it in fact min layers?
+            if num_layers > required_layers {
                 return Err(PersistentDescriptorSetError::ArrayLayersMismatch {
                     expected: max_layers,
                     obtained: num_layers,


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

Fixes #1539. @hellux can you test your full code with this PR, to make sure it doesn't have more bugs further down the line? I tested your short example, but there may be more that aren't apparent from the code you provided.