### PR TITLE
Add 8-bit push constant support to vulkano-shaders

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -33,8 +33,9 @@
   - Better documentation of everything in the `query` module.
   - An example demonstrating occlusion queries.
 - The deprecated `cause` trait function on Vulkano error types is replaced with `source`.
-- Vulkano-shaders: Fixed and refined the generation of the `readonly` descriptor attribute. It should now correctly mark uniforms and sampled images as read-only, but storage buffers and images only if explicitly marked as `readonly` in the shader.
 - Fixed bug in descriptor array layers check when the image is a cubemap.
+- Vulkano-shaders: Fixed and refined the generation of the `readonly` descriptor attribute. It should now correctly mark uniforms and sampled images as read-only, but storage buffers and images only if explicitly marked as `readonly` in the shader.
+- Vulkano-shaders: Added support for StoragePushConstant8 SPIR-V capability.
 
 # Version 0.22.0 (2021-03-31)
 

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -503,6 +503,9 @@ fn capability_requirement(cap: &Capability) -> DeviceRequirement {
         Capability::CapabilityStorageInputOutput8 => {
             DeviceRequirement::Extensions(&["khr_8bit_storage"])
         }
+        Capability::CapabilityStoragePushConstant8 => {
+            DeviceRequirement::Extensions(&["khr_8bit_storage"])
+        }
     }
 }
 

--- a/vulkano-shaders/src/enums.rs
+++ b/vulkano-shaders/src/enums.rs
@@ -552,5 +552,6 @@ enumeration! {
         CapabilityStoragePushConstant16 = 4435,
         CapabilityStorageInputOutput16 = 4436,
         CapabilityStorageInputOutput8 = 4448,
+        CapabilityStoragePushConstant8 = 4450,
     } Capability;
 }


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

For whatever reason, `StoragePushConstant16` and `StorageInputOutput8`, and other similar capabilities were already supported by `vulkano-shaders`, but not `StoragePushConstant8`, so this PR simply adds it.
