### PR TITLE
Add `exact_entrypoint_interface` flag to shader! (Fixes #1556)

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -37,6 +37,8 @@
   - Traits that no longer make sense in this context have been removed: `FormatDesc`, the `Possible*FormatDesc` traits, `StrongStorage`.
   - In types that had a type parameter for the format type, it has been removed.
   - `AcceptsPixels` has been converted to `Pixel`, which is implemented on the pixel type rather than on the format type.
+- **Breaking** `shader!` will generate descriptor information for all variables declared in the shader module, even if they are not used. *This reverts the default behavior from the last release.*
+  - **Breaking** Added the `exact_entrypoint_interface` option to `shader!` to force vulkano to only generate descriptor information for variables that are used. (the default behavior from the last release)
 - Added two methods to `Format`: `planes` to query the number of planes in the format, and `aspects` to query what aspects an image of this type has.
 - The deprecated `cause` trait function on Vulkano error types is replaced with `source`.
 - Fixed bug in descriptor array layers check when the image is a cubemap.

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -264,8 +264,12 @@ where
     let mut entry_points_outside_impl: Vec<TokenStream> = vec![];
     for instruction in doc.instructions.iter() {
         if let &Instruction::EntryPoint { .. } = instruction {
-            let (outside, entry_point, descriptor_sets) =
-                entry_point::write_entry_point(&doc, instruction, &types_meta, exact_entrypoint_interface);
+            let (outside, entry_point, descriptor_sets) = entry_point::write_entry_point(
+                &doc,
+                instruction,
+                &types_meta,
+                exact_entrypoint_interface,
+            );
             entry_points_inside_impl.push(entry_point);
             entry_points_outside_impl.push(outside);
             entry_points_outside_impl.push(descriptor_sets);

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -204,6 +204,7 @@ pub(super) fn reflect<'a, I>(
     spirv: &[u32],
     types_meta: TypesMeta,
     input_paths: I,
+    exact_entrypoint_interface: bool,
     dump: bool,
 ) -> Result<TokenStream, Error>
 where
@@ -264,7 +265,7 @@ where
     for instruction in doc.instructions.iter() {
         if let &Instruction::EntryPoint { .. } = instruction {
             let (outside, entry_point, descriptor_sets) =
-                entry_point::write_entry_point(&doc, instruction, &types_meta);
+                entry_point::write_entry_point(&doc, instruction, &types_meta, exact_entrypoint_interface);
             entry_points_inside_impl.push(entry_point);
             entry_points_outside_impl.push(outside);
             entry_points_outside_impl.push(descriptor_sets);

--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -169,7 +169,7 @@ fn find_descriptors(
     for set_decoration in doc.get_decorations(Decoration::DecorationDescriptorSet) {
         let variable_id = set_decoration.target_id;
 
-        if exact && !variables.unwrap().contains(&variable_id) {
+        if exact && !variables.as_ref().unwrap().contains(&variable_id) {
             continue;
         }
 

--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -139,7 +139,12 @@ pub(super) fn write_descriptor_sets(
     }
 }
 
-fn find_descriptors(doc: &Spirv, entrypoint_id: u32, interface: &[u32], exact: bool) -> Vec<Descriptor> {
+fn find_descriptors(
+    doc: &Spirv,
+    entrypoint_id: u32,
+    interface: &[u32],
+    exact: bool,
+) -> Vec<Descriptor> {
     let mut descriptors = Vec::new();
 
     // For SPIR-V 1.4+, the entrypoint interface can specify variables of all storage classes,

--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -31,11 +31,12 @@ pub(super) fn write_descriptor_sets(
     entrypoint_id: u32,
     interface: &[u32],
     types_meta: &TypesMeta,
+    exact_entrypoint_interface: bool,
 ) -> TokenStream {
     // TODO: somewhat implemented correctly
 
     // Finding all the descriptors.
-    let descriptors = find_descriptors(doc, entrypoint_id, interface);
+    let descriptors = find_descriptors(doc, entrypoint_id, interface, exact_entrypoint_interface);
 
     // Looping to find all the push constant structs.
     let mut push_constants_size = 0;
@@ -138,14 +139,14 @@ pub(super) fn write_descriptor_sets(
     }
 }
 
-fn find_descriptors(doc: &Spirv, entrypoint_id: u32, interface: &[u32]) -> Vec<Descriptor> {
+fn find_descriptors(doc: &Spirv, entrypoint_id: u32, interface: &[u32], exact: bool) -> Vec<Descriptor> {
     let mut descriptors = Vec::new();
 
     // For SPIR-V 1.4+, the entrypoint interface can specify variables of all storage classes,
     // and most tools will put all used variables in the entrypoint interface. However,
     // SPIR-V 1.0-1.3 do not specify variables other than Input/Output ones in the interface,
     // and instead the function itself must be inspected.
-    let variables = {
+    let variables = if exact {
         let mut found_variables: HashSet<u32> = interface.iter().cloned().collect();
         let mut inspected_functions: HashSet<u32> = HashSet::new();
         find_variables_in_function(
@@ -154,14 +155,16 @@ fn find_descriptors(doc: &Spirv, entrypoint_id: u32, interface: &[u32]) -> Vec<D
             &mut inspected_functions,
             &mut found_variables,
         );
-        found_variables
+        Some(found_variables)
+    } else {
+        None
     };
 
     // Looping to find all the interface elements that have the `DescriptorSet` decoration.
     for set_decoration in doc.get_decorations(Decoration::DecorationDescriptorSet) {
         let variable_id = set_decoration.target_id;
 
-        if !variables.contains(&variable_id) {
+        if exact && !variables.unwrap().contains(&variable_id) {
             continue;
         }
 
@@ -650,7 +653,7 @@ mod tests {
                 id, ref interface, ..
             } = instruction
             {
-                descriptors.push(find_descriptors(&doc, id, interface));
+                descriptors.push(find_descriptors(&doc, id, interface, true));
             }
         }
 
@@ -724,7 +727,7 @@ mod tests {
                 id, ref interface, ..
             } = instruction
             {
-                let descriptors = find_descriptors(&doc, id, interface);
+                let descriptors = find_descriptors(&doc, id, interface, true);
                 let mut bindings = Vec::new();
                 for d in descriptors {
                     bindings.push((d.set, d.binding));

--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -19,6 +19,7 @@ pub(super) fn write_entry_point(
     doc: &Spirv,
     instruction: &Instruction,
     types_meta: &TypesMeta,
+    exact_entrypoint_interface: bool,
 ) -> (TokenStream, TokenStream, TokenStream) {
     let (execution, id, ep_name, interface) = match instruction {
         &Instruction::EntryPoint {
@@ -67,6 +68,7 @@ pub(super) fn write_entry_point(
         id,
         interface,
         &types_meta,
+        exact_entrypoint_interface,
     );
 
     let spec_consts_struct = if crate::spec_consts::has_specialization_constants(doc) {

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -201,7 +201,7 @@
 //! [PipelineLayoutDesc]: https://docs.rs/vulkano/*/vulkano/descriptor/pipeline_layout/trait.PipelineLayoutDesc.html
 //! [SpecializationConstants]: https://docs.rs/vulkano/*/vulkano/pipeline/shader/trait.SpecializationConstants.html
 //! [pipeline]: https://docs.rs/vulkano/*/vulkano/pipeline/index.html
-//! [descriptor_sets]: https://github.com/vulkano-rs/vulkano/blob/master/vulkano-shaders/src/descriptor_sets.rs
+//! [descriptor_sets]: https://github.com/vulkano-rs/vulkano/blob/master/vulkano-shaders/src/descriptor_sets.rs#L142
 
 #![doc(html_logo_url = "https://raw.githubusercontent.com/vulkano-rs/vulkano/master/logo.png")]
 #![recursion_limit = "1024"]


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

See #1556 for the motivation for this PR.

This PR reverts the default behavior for finding descriptors introduced in #1497, and adds a new option `exact_entrypoint_interface` to re-enable strict descriptor search.