### PR TITLE
Fix bug where AttachmentImages can't be used in multiple descriptor sets at the same time

### DIFF
--- a/vulkano/src/command_buffer/synced/base.rs
+++ b/vulkano/src/command_buffer/synced/base.rs
@@ -733,7 +733,9 @@ impl SyncCommandBufferBuilder {
                                 //
                                 unsafe {
                                     let from_layout = if is_layout_initialized {
-                                        actually_exclusive = true;
+                                        // TODO why was this introduced? Everything seems to work
+                                        // better without this
+                                        //actually_exclusive = true;
                                         initial_layout_requirement
                                     } else {
                                         if img.preinitialized_layout() {


### PR DESCRIPTION
This fixes #1557 It seems to work just fine with all the tests I did.
<!--
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
-->
* [x] Ran `cargo fmt` on the changes
