### PR TITLE
Minor refactor of `UnsafeBuffer`

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -43,6 +43,7 @@
 - **Breaking** `shader!` will generate descriptor information for all variables declared in the shader module, even if they are not used. *This reverts the default behavior from the last release.*
   - **Breaking** Added the `exact_entrypoint_interface` option to `shader!` to force vulkano to only generate descriptor information for variables that are used. (the default behavior from the last release)
 - **Breaking** `AccessFlagBits` is renamed to `AccessFlags`.
+- **Breaking** Replaced the various usage functions of `UnsafeBuffer` with a single `usage` function, mirroring the change made earlier to `UnsafeImage`.
 - Added two methods to `Format`: `planes` to query the number of planes in the format, and `aspects` to query what aspects an image of this type has.
 - The deprecated `cause` trait function on Vulkano error types is replaced with `source`.
 - Fixed bug in descriptor array layers check when the image is a cubemap.

--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -43,7 +43,9 @@
 - **Breaking** `shader!` will generate descriptor information for all variables declared in the shader module, even if they are not used. *This reverts the default behavior from the last release.*
   - **Breaking** Added the `exact_entrypoint_interface` option to `shader!` to force vulkano to only generate descriptor information for variables that are used. (the default behavior from the last release)
 - **Breaking** `AccessFlagBits` is renamed to `AccessFlags`.
-- **Breaking** Replaced the various usage functions of `UnsafeBuffer` with a single `usage` function, mirroring the change made earlier to `UnsafeImage`.
+- **Breaking** Minor refactor of `UnsafeBuffer`:
+  - Replaced the various usage functions with a single `usage` function, mirroring the change made earlier to `UnsafeImage`.
+  - The `SparseLevel::sparse` member is removed, and `UnsafeBuffer::new` takes `Option<SparseLevel>` instead.
 - Added two methods to `Format`: `planes` to query the number of planes in the format, and `aspects` to query what aspects an image of this type has.
 - The deprecated `cause` trait function on Vulkano error types is replaced with `source`.
 - Fixed bug in descriptor array layers check when the image is a cubemap.

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -16,21 +16,6 @@
 //! You can read the buffer multiple times simultaneously. Trying to read and write simultaneously,
 //! or write and write simultaneously will block.
 
-use smallvec::SmallVec;
-use std::error;
-use std::fmt;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::iter;
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Deref;
-use std::ops::DerefMut;
-use std::ptr;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-
 use crate::buffer::sys::BufferCreationError;
 use crate::buffer::sys::SparseLevel;
 use crate::buffer::sys::UnsafeBuffer;
@@ -59,6 +44,20 @@ use crate::sync::Sharing;
 use parking_lot::RwLock;
 use parking_lot::RwLockReadGuard;
 use parking_lot::RwLockWriteGuard;
+use smallvec::SmallVec;
+use std::error;
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::iter;
+use std::marker::PhantomData;
+use std::mem;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::ptr;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 /// Buffer whose content is accessible by the CPU.
 ///

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -17,7 +17,6 @@
 //! or write and write simultaneously will block.
 
 use crate::buffer::sys::BufferCreationError;
-use crate::buffer::sys::SparseLevel;
 use crate::buffer::sys::UnsafeBuffer;
 use crate::buffer::traits::BufferAccess;
 use crate::buffer::traits::BufferInner;
@@ -228,7 +227,7 @@ impl<T: ?Sized> CpuAccessibleBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(device.clone(), size, usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(device.clone(), size, usage, sharing, None) {
                 Ok(b) => b,
                 Err(BufferCreationError::AllocError(err)) => return Err(err),
                 Err(_) => unreachable!(), // We don't use sparse binding, therefore the other

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -8,7 +8,6 @@
 // according to those terms.
 
 use crate::buffer::sys::BufferCreationError;
-use crate::buffer::sys::SparseLevel;
 use crate::buffer::sys::UnsafeBuffer;
 use crate::buffer::traits::BufferAccess;
 use crate::buffer::traits::BufferInner;
@@ -29,6 +28,7 @@ use crate::memory::DedicatedAlloc;
 use crate::memory::DeviceMemoryAllocError;
 use crate::sync::AccessError;
 use crate::sync::Sharing;
+use crate::OomError;
 use std::cmp;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -41,8 +41,6 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
-
-use crate::OomError;
 
 // TODO: Add `CpuBufferPoolSubbuffer::read` to read the content of a subbuffer.
 //       But that's hard to do because we must prevent `increase_gpu_lock` from working while a
@@ -376,7 +374,7 @@ where
                     size_bytes,
                     self.usage,
                     Sharing::Exclusive::<iter::Empty<_>>,
-                    SparseLevel::none(),
+                    None,
                 ) {
                     Ok(b) => b,
                     Err(BufferCreationError::AllocError(err)) => return Err(err),

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -13,16 +13,7 @@
 //! You can read the buffer multiple times simultaneously from multiple queues. Trying to read and
 //! write simultaneously, or write and write simultaneously will block with a semaphore.
 
-use smallvec::SmallVec;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::marker::PhantomData;
-use std::mem;
-use std::sync::Arc;
-use std::sync::Mutex;
-
 use crate::buffer::sys::BufferCreationError;
-use crate::buffer::sys::SparseLevel;
 use crate::buffer::sys::UnsafeBuffer;
 use crate::buffer::traits::BufferAccess;
 use crate::buffer::traits::BufferInner;
@@ -44,7 +35,14 @@ use crate::memory::{DedicatedAlloc, MemoryRequirements};
 use crate::memory::{DeviceMemoryAllocError, ExternalMemoryHandleType};
 use crate::sync::AccessError;
 use crate::sync::Sharing;
+use smallvec::SmallVec;
 use std::fs::File;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::marker::PhantomData;
+use std::mem;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 /// Buffer whose content is in device-local memory.
 ///
@@ -221,7 +219,7 @@ impl<T: ?Sized> DeviceLocalBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(device.clone(), size, usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(device.clone(), size, usage, sharing, None) {
                 Ok(b) => b,
                 Err(BufferCreationError::AllocError(err)) => return Err(err),
                 Err(_) => unreachable!(), // We don't use sparse binding, therefore the other

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -19,7 +19,6 @@
 //!
 
 use crate::buffer::sys::BufferCreationError;
-use crate::buffer::sys::SparseLevel;
 use crate::buffer::sys::UnsafeBuffer;
 use crate::buffer::traits::BufferAccess;
 use crate::buffer::traits::BufferInner;
@@ -289,7 +288,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
                 Sharing::Exclusive
             };
 
-            match UnsafeBuffer::new(device.clone(), size, usage, sharing, SparseLevel::none()) {
+            match UnsafeBuffer::new(device.clone(), size, usage, sharing, None) {
                 Ok(b) => b,
                 Err(BufferCreationError::AllocError(err)) => return Err(err),
                 Err(_) => unreachable!(), // We don't use sparse binding, therefore the other

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -155,7 +155,7 @@ pub unsafe trait BufferAccess: DeviceOwned {
     fn raw_device_address(&self) -> Result<NonZeroU64, DeviceAddressUsageNotEnabledError> {
         let inner = self.inner();
 
-        if !inner.buffer.usage_device_address() {
+        if !inner.buffer.usage().device_address {
             return Err(DeviceAddressUsageNotEnabledError);
         }
 

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -104,7 +104,7 @@ where
                 return Err(BufferViewCreationError::WrongBufferAlignment);
             }
 
-            if !buffer.usage_uniform_texel_buffer() && !buffer.usage_storage_texel_buffer() {
+            if !buffer.usage().uniform_texel_buffer && !buffer.usage().storage_texel_buffer {
                 return Err(BufferViewCreationError::WrongBufferUsage);
             }
 
@@ -133,13 +133,13 @@ where
                 output.assume_init().bufferFeatures
             };
 
-            if buffer.usage_uniform_texel_buffer() {
+            if buffer.usage().uniform_texel_buffer {
                 if (format_props & vk::FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT) == 0 {
                     return Err(BufferViewCreationError::UnsupportedFormat);
                 }
             }
 
-            if buffer.usage_storage_texel_buffer() {
+            if buffer.usage().storage_texel_buffer {
                 if (format_props & vk::FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT) == 0 {
                     return Err(BufferViewCreationError::UnsupportedFormat);
                 }
@@ -183,13 +183,13 @@ where
     /// Returns true if the buffer view can be used as a uniform texel buffer.
     #[inline]
     pub fn uniform_texel_buffer(&self) -> bool {
-        self.buffer.inner().buffer.usage_uniform_texel_buffer()
+        self.buffer.inner().buffer.usage().uniform_texel_buffer
     }
 
     /// Returns true if the buffer view can be used as a storage texel buffer.
     #[inline]
     pub fn storage_texel_buffer(&self) -> bool {
-        self.buffer.inner().buffer.usage_storage_texel_buffer()
+        self.buffer.inner().buffer.usage().storage_texel_buffer
     }
 
     /// Returns true if the buffer view can be used as a storage texel buffer with atomic accesses.

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -358,7 +358,7 @@ impl UnsafeCommandBufferBuilder {
 
         let inner = buffer.inner();
         debug_assert!(inner.offset < inner.buffer.size());
-        debug_assert!(inner.buffer.usage_index_buffer());
+        debug_assert!(inner.buffer.usage().index_buffer);
 
         vk.CmdBindIndexBuffer(
             cmd,
@@ -794,11 +794,11 @@ impl UnsafeCommandBufferBuilder {
 
         let source = source.inner();
         debug_assert!(source.offset < source.buffer.size());
-        debug_assert!(source.buffer.usage_transfer_source());
+        debug_assert!(source.buffer.usage().transfer_source);
 
         let destination = destination.inner();
         debug_assert!(destination.offset < destination.buffer.size());
-        debug_assert!(destination.buffer.usage_transfer_destination());
+        debug_assert!(destination.buffer.usage().transfer_destination);
 
         let regions: SmallVec<[_; 8]> = regions
             .map(|(sr, de, sz)| vk::BufferCopy {
@@ -841,7 +841,7 @@ impl UnsafeCommandBufferBuilder {
     {
         let source = source.inner();
         debug_assert!(source.offset < source.buffer.size());
-        debug_assert!(source.buffer.usage_transfer_source());
+        debug_assert!(source.buffer.usage().transfer_source);
 
         debug_assert_eq!(destination.samples(), 1);
         let destination = destination.inner();
@@ -923,7 +923,7 @@ impl UnsafeCommandBufferBuilder {
 
         let destination = destination.inner();
         debug_assert!(destination.offset < destination.buffer.size());
-        debug_assert!(destination.buffer.usage_transfer_destination());
+        debug_assert!(destination.buffer.usage().transfer_destination);
 
         let regions: SmallVec<[_; 8]> = regions
             .map(|copy| {
@@ -985,7 +985,7 @@ impl UnsafeCommandBufferBuilder {
         let destination = destination.inner();
         let range = queries.range();
         debug_assert!(destination.offset < destination.buffer.size());
-        debug_assert!(destination.buffer.usage_transfer_destination());
+        debug_assert!(destination.buffer.usage().transfer_destination);
         debug_assert!(destination.offset % std::mem::size_of::<T>() == 0);
         debug_assert!(stride % std::mem::size_of::<T>() == 0);
 
@@ -1033,7 +1033,7 @@ impl UnsafeCommandBufferBuilder {
 
         let inner = buffer.inner();
         debug_assert!(inner.offset < inner.buffer.size());
-        debug_assert!(inner.buffer.usage_indirect_buffer());
+        debug_assert!(inner.buffer.usage().indirect_buffer);
         debug_assert_eq!(inner.offset % 4, 0);
 
         vk.CmdDispatchIndirect(
@@ -1102,7 +1102,7 @@ impl UnsafeCommandBufferBuilder {
 
         let inner = buffer.inner();
         debug_assert!(inner.offset < inner.buffer.size());
-        debug_assert!(inner.buffer.usage_indirect_buffer());
+        debug_assert!(inner.buffer.usage().indirect_buffer);
 
         vk.CmdDrawIndirect(
             cmd,
@@ -1124,7 +1124,7 @@ impl UnsafeCommandBufferBuilder {
 
         let inner = buffer.inner();
         debug_assert!(inner.offset < inner.buffer.size());
-        debug_assert!(inner.buffer.usage_indirect_buffer());
+        debug_assert!(inner.buffer.usage().indirect_buffer);
 
         vk.CmdDrawIndexedIndirect(
             cmd,
@@ -1182,7 +1182,7 @@ impl UnsafeCommandBufferBuilder {
                 buffer: buffer_inner,
                 offset,
             } = buffer.inner();
-            debug_assert!(buffer_inner.usage_transfer_destination());
+            debug_assert!(buffer_inner.usage().transfer_destination);
             debug_assert_eq!(offset % 4, 0);
             (buffer_inner.internal_object(), offset)
         };
@@ -1459,7 +1459,7 @@ impl UnsafeCommandBufferBuilder {
                 buffer: buffer_inner,
                 offset,
             } = buffer.inner();
-            debug_assert!(buffer_inner.usage_transfer_destination());
+            debug_assert!(buffer_inner.usage().transfer_destination);
             debug_assert_eq!(offset % 4, 0);
             (buffer_inner.internal_object(), offset)
         };
@@ -1578,7 +1578,7 @@ impl UnsafeCommandBufferBuilderBindVertexBuffer {
         B: ?Sized + BufferAccess,
     {
         let inner = buffer.inner();
-        debug_assert!(inner.buffer.usage_vertex_buffer());
+        debug_assert!(inner.buffer.usage().vertex_buffer);
         self.raw_buffers.push(inner.buffer.internal_object());
         self.offsets.push(inner.offset as vk::DeviceSize);
     }

--- a/vulkano/src/command_buffer/validity/copy_buffer.rs
+++ b/vulkano/src/command_buffer/validity/copy_buffer.rs
@@ -41,11 +41,11 @@ where
         device.internal_object()
     );
 
-    if !source.inner().buffer.usage_transfer_source() {
+    if !source.inner().buffer.usage().transfer_source {
         return Err(CheckCopyBufferError::SourceMissingTransferUsage);
     }
 
-    if !destination.inner().buffer.usage_transfer_destination() {
+    if !destination.inner().buffer.usage().transfer_destination {
         return Err(CheckCopyBufferError::DestinationMissingTransferUsage);
     }
 

--- a/vulkano/src/command_buffer/validity/copy_image_buffer.rs
+++ b/vulkano/src/command_buffer/validity/copy_image_buffer.rs
@@ -63,7 +63,7 @@ where
 
     match ty {
         CheckCopyBufferImageTy::BufferToImage => {
-            if !buffer_inner.buffer.usage_transfer_source() {
+            if !buffer_inner.buffer.usage().transfer_source {
                 return Err(CheckCopyBufferImageError::SourceMissingTransferUsage);
             }
             if !image_inner.image.usage().transfer_destination {
@@ -74,7 +74,7 @@ where
             if !image_inner.image.usage().transfer_source {
                 return Err(CheckCopyBufferImageError::SourceMissingTransferUsage);
             }
-            if !buffer_inner.buffer.usage_transfer_destination() {
+            if !buffer_inner.buffer.usage().transfer_destination {
                 return Err(CheckCopyBufferImageError::DestinationMissingTransferUsage);
             }
         }

--- a/vulkano/src/command_buffer/validity/fill_buffer.rs
+++ b/vulkano/src/command_buffer/validity/fill_buffer.rs
@@ -30,7 +30,7 @@ where
         device.internal_object()
     );
 
-    if !buffer.inner().buffer.usage_transfer_destination() {
+    if !buffer.inner().buffer.usage().transfer_destination {
         return Err(CheckFillBufferError::BufferMissingUsage);
     }
 

--- a/vulkano/src/command_buffer/validity/index_buffer.rs
+++ b/vulkano/src/command_buffer/validity/index_buffer.rs
@@ -36,7 +36,7 @@ where
         device.internal_object()
     );
 
-    if !buffer.inner().buffer.usage_index_buffer() {
+    if !buffer.inner().buffer.usage().index_buffer {
         return Err(CheckIndexBufferError::BufferMissingUsage);
     }
 

--- a/vulkano/src/command_buffer/validity/indirect_buffer.rs
+++ b/vulkano/src/command_buffer/validity/indirect_buffer.rs
@@ -27,7 +27,7 @@ where
         device.internal_object()
     );
 
-    if !buffer.inner().buffer.usage_indirect_buffer() {
+    if !buffer.inner().buffer.usage().indirect_buffer {
         return Err(CheckIndirectBufferError::BufferMissingUsage);
     }
 

--- a/vulkano/src/command_buffer/validity/query.rs
+++ b/vulkano/src/command_buffer/validity/query.rs
@@ -269,7 +269,7 @@ where
         query_pool.device().internal_object(),
     );
 
-    if !buffer_inner.buffer.usage_transfer_destination() {
+    if !buffer_inner.buffer.usage().transfer_destination {
         return Err(CheckCopyQueryPoolResultsError::DestinationMissingTransferUsage);
     }
 

--- a/vulkano/src/command_buffer/validity/update_buffer.rs
+++ b/vulkano/src/command_buffer/validity/update_buffer.rs
@@ -37,7 +37,7 @@ where
         device.internal_object()
     );
 
-    if !buffer.inner().buffer.usage_transfer_destination() {
+    if !buffer.inner().buffer.usage().transfer_destination {
         return Err(CheckUpdateBufferError::BufferMissingUsage);
     }
 

--- a/vulkano/src/command_buffer/validity/vertex_buffers.rs
+++ b/vulkano/src/command_buffer/validity/vertex_buffers.rs
@@ -36,7 +36,7 @@ where
             pipeline.device().internal_object()
         );
 
-        if !buf.inner().buffer.usage_vertex_buffer() {
+        if !buf.inner().buffer.usage().vertex_buffer {
             return Err(CheckVertexBufferError::BufferMissingUsage { num_buffer: num });
         }
     }

--- a/vulkano/src/descriptor/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor/descriptor_set/persistent.rs
@@ -464,7 +464,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
                 );
 
                 if buffer_desc.storage {
-                    if !buffer.inner().buffer.usage_storage_buffer() {
+                    if !buffer.inner().buffer.usage().storage_buffer {
                         return Err(PersistentDescriptorSetError::MissingBufferUsage(
                             MissingBufferUsage::StorageBuffer,
                         ));
@@ -478,7 +478,7 @@ impl<R> PersistentDescriptorSetBuilderArray<R> {
                         )
                     }
                 } else {
-                    if !buffer.inner().buffer.usage_uniform_buffer() {
+                    if !buffer.inner().buffer.usage().uniform_buffer {
                         return Err(PersistentDescriptorSetError::MissingBufferUsage(
                             MissingBufferUsage::UniformBuffer,
                         ));


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

Two minor changes have been made:
- `UnsafeBuffer` has a `usage` function now, mirroring the simplification that was done before to `UnsafeImage`.
- Its constructor takes `Option<SparseLevel>` instead, and `SparseLevel::sparse` was removed. This makes the types fit correct usage better.