### PR TITLE
Add `SwapchainBuilder` for easier (re)creation

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -43,6 +43,7 @@
 - **Breaking** `shader!` will generate descriptor information for all variables declared in the shader module, even if they are not used. *This reverts the default behavior from the last release.*
   - **Breaking** Added the `exact_entrypoint_interface` option to `shader!` to force vulkano to only generate descriptor information for variables that are used. (the default behavior from the last release)
 - **Breaking** `AccessFlagBits` is renamed to `AccessFlags`.
+- **Breaking** `Swapchain` is now constructed using a builder. `Swapchain::start` will start building a new blank swapchain. Calling `recreate` on an existing swapchain will create a builder filled with all the properties of the old swapchain.
 - Added two methods to `Format`: `planes` to query the number of planes in the format, and `aspects` to query what aspects an image of this type has.
 - The deprecated `cause` trait function on Vulkano error types is replaced with `source`.
 - Fixed bug in descriptor array layers check when the image is a cubemap.

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -91,7 +91,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -199,7 +199,7 @@ fn main() {
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                        match swapchain.recreate().dimensions(dimensions).build() {
                             Ok(r) => r,
                             Err(SwapchainCreationError::UnsupportedDimensions) => return,
                             Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -33,10 +33,7 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 use vulkano_win::VkSurfaceBuild;
@@ -87,27 +84,19 @@ fn main() {
 
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();
 
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     // Vertex Buffer Pool
@@ -210,7 +199,7 @@ fn main() {
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate_with_dimensions(dimensions) {
+                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
                             Ok(r) => r,
                             Err(SwapchainCreationError::UnsupportedDimensions) => return,
                             Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -88,7 +88,7 @@ fn main() {
         let (swapchain, images) = Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -128,7 +128,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                    match swapchain.recreate().dimensions(dimensions).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -80,7 +80,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -233,7 +233,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                    match swapchain.recreate().dimensions(dimensions).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -23,10 +23,7 @@ use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 
@@ -76,27 +73,19 @@ fn main() {
 
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();
 
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     #[derive(Default, Debug, Clone)]
@@ -244,7 +233,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate_with_dimensions(dimensions) {
+                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -47,10 +47,7 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::{ComputePipeline, GraphicsPipeline};
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 use vulkano_win::VkSurfaceBuild;
@@ -103,27 +100,19 @@ fn main() {
 
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();
 
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     mod vs {
@@ -275,7 +264,7 @@ fn main() {
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate_with_dimensions(dimensions) {
+                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
                             Ok(r) => r,
                             Err(SwapchainCreationError::UnsupportedDimensions) => return,
                             Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -107,7 +107,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -264,7 +264,7 @@ fn main() {
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                        match swapchain.recreate().dimensions(dimensions).build() {
                             Ok(r) => r,
                             Err(SwapchainCreationError::UnsupportedDimensions) => return,
                             Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -31,10 +31,7 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 use vulkano_win::VkSurfaceBuild;
@@ -101,27 +98,19 @@ fn main() {
 
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();
 
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     // We now create a buffer that will store the shape of our triangle.
@@ -283,7 +272,7 @@ fn main() {
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate_with_dimensions(dimensions) {
+                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
                             Ok(r) => r,
                             Err(SwapchainCreationError::UnsupportedDimensions) => return,
                             Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -105,7 +105,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -272,7 +272,7 @@ fn main() {
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                        match swapchain.recreate().dimensions(dimensions).build() {
                             Ok(r) => r,
                             Err(SwapchainCreationError::UnsupportedDimensions) => return,
                             Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -106,7 +106,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(surface_caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -275,7 +275,7 @@ fn main() {
                 Swapchain::start(device.clone(), surface.clone())
                     .num_images(surface_caps.min_image_count)
                     .format(format)
-                    .dimensions(Some(dimensions))
+                    .dimensions(dimensions)
                     .usage(ImageUsage::color_attachment())
                     .sharing_mode(&queue)
                     .composite_alpha(composite_alpha)
@@ -317,7 +317,7 @@ fn main() {
             if *recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                    match swapchain.recreate().dimensions(dimensions).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -31,10 +31,7 @@ use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
 use vulkano::swapchain::Surface;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 use vulkano_win::VkSurfaceBuild;
@@ -98,7 +95,7 @@ fn main() {
     // The swapchain and framebuffer images for this perticular window
 
     let (swapchain, images) = {
-        let alpha = surface_caps
+        let composite_alpha = surface_caps
             .supported_composite_alpha
             .iter()
             .next()
@@ -106,23 +103,15 @@ fn main() {
         let format = surface_caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();
 
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            surface_caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(surface_caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     let vertex_buffer = {
@@ -275,7 +264,7 @@ fn main() {
                 .unwrap();
             let window_id = surface.window().id();
             let (swapchain, images) = {
-                let alpha = surface_caps
+                let composite_alpha = surface_caps
                     .supported_composite_alpha
                     .iter()
                     .next()
@@ -283,23 +272,15 @@ fn main() {
                 let format = surface_caps.supported_formats[0].0;
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
 
-                Swapchain::new(
-                    device.clone(),
-                    surface.clone(),
-                    surface_caps.min_image_count,
-                    format,
-                    dimensions,
-                    1,
-                    ImageUsage::color_attachment(),
-                    &queue,
-                    SurfaceTransform::Identity,
-                    alpha,
-                    PresentMode::Fifo,
-                    FullscreenExclusive::Default,
-                    true,
-                    ColorSpace::SrgbNonLinear,
-                )
-                .unwrap()
+                Swapchain::start(device.clone(), surface.clone())
+                    .num_images(surface_caps.min_image_count)
+                    .format(format)
+                    .dimensions(Some(dimensions))
+                    .usage(ImageUsage::color_attachment())
+                    .sharing_mode(&queue)
+                    .composite_alpha(composite_alpha)
+                    .build()
+                    .unwrap()
             };
 
             window_surfaces.insert(
@@ -336,7 +317,7 @@ fn main() {
             if *recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate_with_dimensions(dimensions) {
+                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -75,7 +75,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -277,7 +277,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                    match swapchain.recreate().dimensions(dimensions).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -25,10 +25,7 @@ use vulkano::pipeline::GraphicsPipeline;
 use vulkano::query::{QueryControlFlags, QueryPool, QueryResultFlags, QueryType};
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 use vulkano_win::VkSurfaceBuild;
@@ -72,26 +69,18 @@ fn main() {
 
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     let vertex_buffer = {
@@ -288,7 +277,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate_with_dimensions(dimensions) {
+                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -104,7 +104,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -476,7 +476,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                    match swapchain.recreate().dimensions(dimensions).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -48,10 +48,7 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 use vulkano_win::VkSurfaceBuild;
@@ -100,27 +97,19 @@ fn main() {
 
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();
 
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     let render_pass = Arc::new(
@@ -487,7 +476,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate_with_dimensions(dimensions) {
+                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -30,10 +30,7 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 use vulkano_win::VkSurfaceBuild;
@@ -83,25 +80,17 @@ fn main() {
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
         let format = caps.supported_formats[0].0;
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
 
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     let vertices = VERTICES.iter().cloned();
@@ -173,7 +162,7 @@ fn main() {
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate_with_dimensions(dimensions) {
+                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
                             Ok(r) => r,
                             Err(SwapchainCreationError::UnsupportedDimensions) => return,
                             Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -85,7 +85,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -162,7 +162,7 @@ fn main() {
                 if recreate_swapchain {
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                        match swapchain.recreate().dimensions(dimensions).build() {
                             Ok(r) => r,
                             Err(SwapchainCreationError::UnsupportedDimensions) => return,
                             Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -31,10 +31,7 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 use vulkano_win::VkSurfaceBuild;
@@ -173,27 +170,19 @@ fn main() {
 
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();
 
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     let vertex_buffer = {
@@ -317,7 +306,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate_with_dimensions(dimensions) {
+                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -177,7 +177,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -306,7 +306,7 @@ fn main() {
             if recreate_swapchain {
                 let dimensions: [u32; 2] = surface.window().inner_size().into();
                 let (new_swapchain, new_images) =
-                    match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                    match swapchain.recreate().dimensions(dimensions).build() {
                         Ok(r) => r,
                         Err(SwapchainCreationError::UnsupportedDimensions) => return,
                         Err(e) => panic!("Failed to recreate swapchain: {:?}", e),

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -175,7 +175,7 @@ fn main() {
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)
             .format(format)
-            .dimensions(Some(dimensions))
+            .dimensions(dimensions)
             .usage(ImageUsage::color_attachment())
             .sharing_mode(&queue)
             .composite_alpha(composite_alpha)
@@ -384,7 +384,7 @@ fn main() {
                     // Get the new dimensions of the window.
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
+                        match swapchain.recreate().dimensions(dimensions).build() {
                             Ok(r) => r,
                             // This error tends to happen when the user is manually resizing the window.
                             // Simply restarting the loop is the easiest way to fix this issue.

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -28,10 +28,7 @@ use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
-use vulkano::swapchain::{
-    AcquireError, ColorSpace, FullscreenExclusive, PresentMode, SurfaceTransform, Swapchain,
-    SwapchainCreationError,
-};
+use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
 use vulkano::sync::{FlushError, GpuFuture};
 
@@ -157,7 +154,7 @@ fn main() {
 
         // The alpha mode indicates how the alpha value of the final image will behave. For example
         // you can choose whether the window will be opaque or transparent.
-        let alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
 
         // Choosing the internal format that the images will have.
         let format = caps.supported_formats[0].0;
@@ -175,23 +172,15 @@ fn main() {
         let dimensions: [u32; 2] = surface.window().inner_size().into();
 
         // Please take a look at the docs for the meaning of the parameters we didn't mention.
-        Swapchain::new(
-            device.clone(),
-            surface.clone(),
-            caps.min_image_count,
-            format,
-            dimensions,
-            1,
-            ImageUsage::color_attachment(),
-            &queue,
-            SurfaceTransform::Identity,
-            alpha,
-            PresentMode::Fifo,
-            FullscreenExclusive::Default,
-            true,
-            ColorSpace::SrgbNonLinear,
-        )
-        .unwrap()
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(Some(dimensions))
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
     };
 
     // We now create a buffer that will store the shape of our triangle.
@@ -395,7 +384,7 @@ fn main() {
                     // Get the new dimensions of the window.
                     let dimensions: [u32; 2] = surface.window().inner_size().into();
                     let (new_swapchain, new_images) =
-                        match swapchain.recreate_with_dimensions(dimensions) {
+                        match swapchain.recreate().dimensions(Some(dimensions)).build() {
                             Ok(r) => r,
                             // This error tends to happen when the user is manually resizing the window.
                             // Simply restarting the loop is the easiest way to fix this issue.

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -178,39 +178,30 @@
 //!     .. ImageUsage::none()
 //! };
 //!
-//! let sharing_mode = SharingMode::Exclusive;
-//!
 //! // Create the swapchain and its buffers.
-//! let (swapchain, buffers) = Swapchain::new(
-//!     // Create the swapchain in this `device`'s memory.
-//!     device,
-//!     // The surface where the images will be presented.
-//!     surface,
+//! let (swapchain, buffers) = Swapchain::start(
+//!         // Create the swapchain in this `device`'s memory.
+//!         device,
+//!         // The surface where the images will be presented.
+//!         surface,
+//!     )
 //!     // How many buffers to use in the swapchain.
-//!     buffers_count,
+//!     .num_images(buffers_count)
 //!     // The format of the images.
-//!     format,
+//!     .format(format)
 //!     // The size of each image.
-//!     dimensions,
-//!     // How many layers each image has.
-//!     1,
+//!     .dimensions(Some(dimensions))
 //!     // What the images are going to be used for.
-//!     usage,
-//!     // Describes which queues will interact with the swapchain.
-//!     sharing_mode,
+//!     .usage(usage)
 //!     // What transformation to use with the surface.
-//!     surface_transform,
+//!     .transform(surface_transform)
 //!     // How to handle the alpha channel.
-//!     composite_alpha,
+//!     .composite_alpha(composite_alpha)
 //!     // How to present images.
-//!     present_mode,
+//!     .present_mode(present_mode)
 //!     // How to handle fullscreen exclusivity
-//!     fullscreen_exclusive,
-//!     // Clip the parts of the buffer which aren't visible.
-//!     true,
-//!     // No previous swapchain.
-//!     ColorSpace::SrgbNonLinear
-//! )?;
+//!     .fullscreen_exclusive(fullscreen_exclusive)
+//!     .build()?;
 //!
 //! # Ok(())
 //! # }
@@ -278,7 +269,7 @@
 //!
 //! loop {
 //!     if recreate_swapchain {
-//!         swapchain = swapchain.0.recreate_with_dimensions([1024, 768]).unwrap();
+//!         swapchain = swapchain.0.recreate().dimensions(Some([1024, 768])).build().unwrap();
 //!         recreate_swapchain = false;
 //!     }
 //!

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -190,7 +190,7 @@
 //!     // The format of the images.
 //!     .format(format)
 //!     // The size of each image.
-//!     .dimensions(Some(dimensions))
+//!     .dimensions(dimensions)
 //!     // What the images are going to be used for.
 //!     .usage(usage)
 //!     // What transformation to use with the surface.
@@ -269,7 +269,7 @@
 //!
 //! loop {
 //!     if recreate_swapchain {
-//!         swapchain = swapchain.0.recreate().dimensions(Some([1024, 768])).build().unwrap();
+//!         swapchain = swapchain.0.recreate().dimensions([1024, 768]).build().unwrap();
 //!         recreate_swapchain = false;
 //!     }
 //!

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -284,9 +284,11 @@ impl<W> Swapchain<W> {
         }
     }
 
-    /// Starts building a new swapchain from an existing swapchain. The builder is pre-filled with
-    /// the parameters of the old one. Use this when a swapchain has become invalidated, such as
-    /// due to window resizes.
+    /// Starts building a new swapchain from an existing swapchain.
+    ///
+    /// Use this when a swapchain has become invalidated, such as due to window resizes.
+    /// The builder is pre-filled with the parameters of the old one, except for `dimensions`,
+    /// which is set to `None`.
     #[inline]
     pub fn recreate(self: &Arc<Self>) -> SwapchainBuilder<W> {
         SwapchainBuilder {
@@ -296,7 +298,7 @@ impl<W> Swapchain<W> {
             num_images: self.images.len() as u32,
             format: Some(self.format),
             color_space: self.color_space,
-            dimensions: Some(self.dimensions),
+            dimensions: None,
             layers: self.layers,
             usage: self.usage,
             sharing_mode: self.sharing_mode.clone(),


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This adds a `SwapchainBuilder`, which provides sensible defaults for several of the values. It also means you don't have to remember the order of all of the parameters of `Swapchain::new`. The builder is used for recreating as well; in that case the values are copied from the existing swapchain. You can then use the builder to override anything you want to, e.g. dimensions.