### PR TITLE
An improved fix for info pointer chain segfault

### DIFF
--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -224,8 +224,10 @@ impl<'a> DeviceMemoryBuilder<'a> {
             let mut prev_head = self.allocate.pNext as *mut BaseOutStructure;
             // Retrieve end of next chain
             let last_next = ptr_chain_iter(next).last().unwrap();
-            // Set end of next chain's next to be previous head
-            (*last_next).p_next = prev_head;
+            // Set end of next chain's next to be previous head only if previous head's next'
+            if !prev_head.is_null() {
+                (*last_next).p_next = (*prev_head).p_next;
+            }
             // Set next ptr to be first one
             prev_head = next_ptr;
         }

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -205,13 +205,29 @@ impl<'a> DeviceMemoryBuilder<'a> {
         self
     }
 
-    // Private function -- no doc comment needed!  Copied shamelessly and poorly from Ash.
+    // Private function copied shamelessly from Ash.
+    // https://github.com/MaikKlein/ash/blob/4ba8637d018fec6d6e3a90d7fa47d11c085f6b4a/generator/src/lib.rs
+    #[allow(unused_assignments)]
     fn push_next<T: ExtendsMemoryAllocateInfo>(self, next: &mut T) -> DeviceMemoryBuilder<'a> {
         unsafe {
+            // `next` here can contain a pointer chain. This means that we must correctly
+            // attach he head to the root and the tail to the rest of the chain
+            // For example:
+            //
+            // next = A -> B
+            // Before: `Root -> C -> D -> E`
+            // After: `Root -> A -> B -> C -> D -> E`
+
+            // Convert next to our ptr structure
             let next_ptr = next as *mut T as *mut BaseOutStructure;
-            let mut prev = self.allocate.pNext as *mut BaseOutStructure;
-            let last_next = ptr_chain_iter(&mut prev).last().unwrap();
-            (*last_next).p_next = next_ptr as _;
+            // Previous head (can be null)
+            let mut prev_head = self.allocate.pNext as *mut BaseOutStructure;
+            // Retrieve end of next chain
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            // Set end of next chain's next to be previous head
+            (*last_next).p_next = prev_head;
+            // Set next ptr to be first one
+            prev_head = next_ptr;
         }
 
         self


### PR DESCRIPTION
* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

This should be a better fix for https://github.com/vulkano-rs/vulkano/issues/1545. At least the test in the issue report works for me in `cargo run` and `--release` without segfault.

The problem seemed to be that `&mut prev` was not null when `prev` was. Also, to achieve the same functionality `ash` had from where the function was copied I think the incoming `next` should be passed instead to `ptr_chain_iter`. And finally the `next_ptr` should become the new head.

1. Find end of `next`
2. Set end's next (which is null) to be `prev_head`'s next only if previous head was not null
3. Set prev_head (`self.allocate.pNext`) be new head `next_ptr`.