### PR TITLE
vulkano/image: SampleCounts for each pixel in an Image.

### DIFF
--- a/CHANGELOG_VULKANO.md
+++ b/CHANGELOG_VULKANO.md
@@ -10,6 +10,9 @@
 - Added `FunctionPointers::api_version` to query the highest supported instance version.
 - Added `Instance::api_version` and `Device::api_version` to return the actual supported Vulkan version. These may differ between instance and device, and be lower than what `FunctionPointers::api_version` and `PhysicalDevice::api_version` return (currently never higher than 1.1, but this may change in the future).
 - Fixed the issue when creating a buffer with exportable fd on Linux(see to #1545).
+- **Breaking**, change to `ImageFormatProperties::sample_counts` field.
+  - `sample_counts` field is originaly represented as u32 type, which is now represented by `SampleCounts` struct-type which is a boolean collection of supported `sample_counts`.
+  - Added conversion function between SampleCountFlagBits (u32-type) and `SampleCounts` type.
 
 # Version 0.23.0 (2021-04-10)
 

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -92,8 +92,8 @@ pub struct SampleCounts {
     pub sample64: bool,
 }
 
-impl From<u32> for SampleCounts {
-    fn from(sample_counts: u32) -> SampleCounts {
+impl From<vk::SampleCountFlags> for SampleCounts {
+    fn from(sample_counts: vk::SampleCountFlags) -> SampleCounts {
         SampleCounts {
             sample1: (sample_counts & vk::SAMPLE_COUNT_1_BIT) != 0,
             sample2: (sample_counts & vk::SAMPLE_COUNT_2_BIT) != 0,
@@ -106,8 +106,8 @@ impl From<u32> for SampleCounts {
     }
 }
 
-impl From<SampleCounts> for u32 {
-    fn from(val: SampleCounts) -> u32 {
+impl From<SampleCounts> for vk::SampleCountFlags {
+    fn from(val: SampleCounts) -> vk::SampleCountFlags {
         let mut sample_counts = vk::SampleCountFlags::default();
 
         if val.sample1 {

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -73,6 +73,69 @@ pub mod traits;
 mod usage;
 pub mod view;
 
+/// Specifies how many sample counts supported for an image used for storage operations.
+#[derive(Debug, Copy, Clone)]
+pub struct SampleCounts {
+    // specify an image with one sample per pixel
+    pub sample1: bool,
+    // specify an image with 2 samples per pixel
+    pub sample2: bool,
+    // specify an image with 4 samples per pixel
+    pub sample4: bool,
+    // specify an image with 8 samples per pixel
+    pub sample8: bool,
+    // specify an image with 16 samples per pixel
+    pub sample16: bool,
+    // specify an image with 32 samples per pixel
+    pub sample32: bool,
+    // specify an image with 64 samples per pixel
+    pub sample64: bool,
+}
+
+impl From<u32> for SampleCounts {
+    fn from(sample_counts: u32) -> SampleCounts {
+        SampleCounts {
+            sample1: (sample_counts & vk::SAMPLE_COUNT_1_BIT) != 0,
+            sample2: (sample_counts & vk::SAMPLE_COUNT_2_BIT) != 0,
+            sample4: (sample_counts & vk::SAMPLE_COUNT_4_BIT) != 0,
+            sample8: (sample_counts & vk::SAMPLE_COUNT_8_BIT) != 0,
+            sample16: (sample_counts & vk::SAMPLE_COUNT_16_BIT) != 0,
+            sample32: (sample_counts & vk::SAMPLE_COUNT_32_BIT) != 0,
+            sample64: (sample_counts & vk::SAMPLE_COUNT_64_BIT) != 0,
+        }
+    }
+}
+
+impl From<SampleCounts> for u32 {
+    fn from(val: SampleCounts) -> u32 {
+        let mut sample_counts = vk::SampleCountFlags::default();
+
+        if val.sample1 {
+            sample_counts |= vk::SAMPLE_COUNT_1_BIT;
+        }
+        if val.sample2 {
+            sample_counts |= vk::SAMPLE_COUNT_2_BIT;
+        }
+        if val.sample4 {
+            sample_counts |= vk::SAMPLE_COUNT_4_BIT;
+        }
+        if val.sample8 {
+            sample_counts |= vk::SAMPLE_COUNT_8_BIT;
+        }
+        if val.sample16 {
+            sample_counts |= vk::SAMPLE_COUNT_16_BIT;
+        }
+        if val.sample32 {
+            sample_counts |= vk::SAMPLE_COUNT_32_BIT;
+        }
+        if val.sample64 {
+            sample_counts |= vk::SAMPLE_COUNT_64_BIT;
+        }
+
+        sample_counts
+    }
+}
+
 /// Specifies how many mipmaps must be allocated.
 ///
 /// Note that at least one mipmap must be allocated, to store the main level of the image.
@@ -101,6 +164,7 @@ impl From<u32> for MipmapsCount {
 }
 
 /// Helper type for creating extents
+#[derive(Debug, Copy, Clone)]
 pub enum Extent {
     E1D([u32; 1]),
     E2D([u32; 2]),
@@ -152,7 +216,7 @@ pub struct ImageFormatProperties {
     pub max_extent: Extent,
     pub max_mip_levels: MipmapsCount,
     pub max_array_layers: u32,
-    pub sample_counts: u32,
+    pub sample_counts: SampleCounts,
     pub max_resource_size: usize,
 }
 
@@ -162,7 +226,7 @@ impl From<vk::ImageFormatProperties> for ImageFormatProperties {
             max_extent: props.maxExtent.into(),
             max_mip_levels: props.maxMipLevels.into(),
             max_array_layers: props.maxArrayLayers,
-            sample_counts: props.sampleCounts,
+            sample_counts: props.sampleCounts.into(),
             max_resource_size: props.maxResourceSize as usize,
         }
     }


### PR DESCRIPTION
Map u32-bit SampleCountsFlagBits type to boolean collection of SampleCounts struct type.

* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes
