### PR TITLE
Add support for the SPIR-V draw parameters capability

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -522,6 +522,9 @@ fn capability_requirement(cap: &Capability) -> DeviceRequirement {
             DeviceRequirement::Features(&["shader_storage_image_write_without_format"])
         }
         Capability::CapabilityMultiViewport => DeviceRequirement::Features(&["multi_viewport"]),
+        Capability::CapabilityDrawParameters => {
+            DeviceRequirement::Features(&["shader_draw_parameters"])
+        }
         Capability::CapabilityStorageUniformBufferBlock16 => {
             DeviceRequirement::Extensions(&["khr_16bit_storage"])
         }

--- a/vulkano-shaders/src/enums.rs
+++ b/vulkano-shaders/src/enums.rs
@@ -547,6 +547,7 @@ enumeration! {
         CapabilityStorageImageReadWithoutFormat = 55,
         CapabilityStorageImageWriteWithoutFormat = 56,
         CapabilityMultiViewport = 57,
+        CapabilityDrawParameters = 4427,
         CapabilityStorageUniformBufferBlock16 = 4433,
         CapabilityStorageUniform16 = 4434,
         CapabilityStoragePushConstant16 = 4435,


### PR DESCRIPTION
* [x] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [x] Updated documentation to reflect any user-facing changes - in this repository
* [x] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [x] Ran `cargo fmt` on the changes

I wanted to use `gl_DrawID` in a shader, but I got an error, so I added support for it.

This feature was originally part of the `VK_KHR_shader_draw_parameters` extension and the feature flag was in the `VkPhysicalDeviceShaderDrawParametersFeatures` struct, but it was made core in Vulkan 1.1 and the feature flag was moved to a new `VkPhysicalDeviceVulkan11Features` struct. This PR will pull the feature flag from either location.