### PR TITLE
Fixing the teapot example on ArchLinux (GTX 1650).

### DIFF
--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -57,7 +57,6 @@ fn main() {
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
-    let dimensions: [u32; 2] = surface.window().inner_size().into();
 
     let queue_family = physical
         .queue_families()
@@ -78,11 +77,13 @@ fn main() {
     .unwrap();
 
     let queue = queues.next().unwrap();
+    let dimensions: [u32; 2] = surface.window().inner_size().into();
 
     let (mut swapchain, images) = {
         let caps = surface.capabilities(physical).unwrap();
         let format = caps.supported_formats[0].0;
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let dimensions: [u32; 2] = surface.window().inner_size().into();
 
         Swapchain::start(device.clone(), surface.clone())
             .num_images(caps.min_image_count)


### PR DESCRIPTION
Teapot example was broken on my machine (Arch, GTX1650) + (ubuntu 20.04, GTX970).
Both are run within awesome, which I guess could resize the window very soon when the window starts.

The error was:

```
Using device: NVIDIA GeForce GTX 1650 (type: DiscreteGpu)
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: UnsupportedDimensions', examples/src/bin/teapot/main.rs:95:14
```
Looking at the functioning triangle example I figured that dimensions was defined elsewhere, modified it and it worked.

I have no idea of what the consequences are, or if other examples are affected. I just hope this could be helpful.


* [ ] Added an entry to `CHANGELOG_VULKANO.md` or `CHANGELOG_VK_SYS.md` if knowledge of this change could be valuable to users
* [ ] Updated documentation to reflect any user-facing changes - in this repository
* [ ] Updated documentation to reflect any user-facing changes - PR to the [guide](https://github.com/vulkano-rs/vulkano-www) that fixes existing documentation invalidated by this PR.
* [ ] Ran `cargo fmt` on the changes