### PR TITLE
Allow use of uninitialized images when being written to

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -87,7 +87,7 @@ use std::slice;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use crate::command_buffer::ImageResourceContext;
+use crate::command_buffer::ImageUninitializedSafe;
 
 /// Note that command buffers allocated from the default command pool (`Arc<StandardCommandPool>`)
 /// don't implement the `Send` and `Sync` traits. If you use this pool, then the
@@ -2484,7 +2484,7 @@ unsafe impl<P> SecondaryCommandBuffer for SecondaryAutoCommandBuffer<P> {
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
-        ImageResourceContext,
+        ImageUninitializedSafe,
     )> {
         self.inner.image(index)
     }

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -87,6 +87,7 @@ use std::slice;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use crate::command_buffer::ImageResourceContext;
 
 /// Note that command buffers allocated from the default command pool (`Arc<StandardCommandPool>`)
 /// don't implement the `Send` and `Sync` traits. If you use this pool, then the
@@ -2483,6 +2484,7 @@ unsafe impl<P> SecondaryCommandBuffer for SecondaryAutoCommandBuffer<P> {
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
+        ImageResourceContext,
     )> {
         self.inner.image(index)
     }

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -31,6 +31,7 @@ use crate::command_buffer::DispatchIndirectCommand;
 use crate::command_buffer::DrawIndexedIndirectCommand;
 use crate::command_buffer::DrawIndirectCommand;
 use crate::command_buffer::DynamicState;
+use crate::command_buffer::ImageUninitializedSafe;
 use crate::command_buffer::PrimaryCommandBuffer;
 use crate::command_buffer::SecondaryCommandBuffer;
 use crate::command_buffer::StateCacher;
@@ -87,7 +88,6 @@ use std::slice;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use crate::command_buffer::ImageUninitializedSafe;
 
 /// Note that command buffers allocated from the default command pool (`Arc<StandardCommandPool>`)
 /// don't implement the `Send` and `Sync` traits. If you use this pool, then the

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -125,6 +125,20 @@ pub mod sys;
 mod traits;
 pub mod validity;
 
+#[derive(Debug, Clone, Copy)]
+pub struct ImageResourceContext {
+    pub uninitialized_safe: bool,
+}
+
+impl ImageResourceContext {
+    pub fn none() -> Self {
+        Self {
+            uninitialized_safe: false,
+        }
+    }
+}
+
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DrawIndirectCommand {

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -126,18 +126,19 @@ mod traits;
 pub mod validity;
 
 #[derive(Debug, Clone, Copy)]
-pub struct ImageResourceContext {
-    pub uninitialized_safe: bool,
+pub enum ImageUninitializedSafe {
+    Safe,
+    Unsafe,
 }
 
-impl ImageResourceContext {
-    pub fn none() -> Self {
-        Self {
-            uninitialized_safe: false,
+impl ImageUninitializedSafe {
+    pub fn is_safe(&self) -> bool {
+        match self {
+            Self::Safe => true,
+            Self::Unsafe => false
         }
     }
 }
-
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -135,7 +135,7 @@ impl ImageUninitializedSafe {
     pub fn is_safe(&self) -> bool {
         match self {
             Self::Safe => true,
-            Self::Unsafe => false
+            Self::Unsafe => false,
         }
     }
 }

--- a/vulkano/src/command_buffer/synced/base.rs
+++ b/vulkano/src/command_buffer/synced/base.rs
@@ -37,6 +37,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::Mutex;
+use crate::command_buffer::ImageResourceContext;
 
 /// Wrapper around `UnsafeCommandBufferBuilder` that handles synchronization for you.
 ///
@@ -64,6 +65,7 @@ pub struct SyncCommandBufferBuilder {
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
+        ImageResourceContext,
     )>,
 
     // Stores the current state of all resources (buffers and images) that are in use by the
@@ -399,6 +401,9 @@ struct ResourceState {
 
     // Current layout at this stage of the building.
     current_layout: ImageLayout,
+
+    // Extra context of how the image will be used
+    image_resource_context: ImageResourceContext
 }
 
 impl ResourceState {
@@ -412,6 +417,7 @@ impl ResourceState {
             exclusive: self.exclusive_any,
             initial_layout: self.initial_layout,
             final_layout: self.current_layout,
+            image_resource_context: self.image_resource_context,
         }
     }
 }
@@ -497,7 +503,7 @@ impl SyncCommandBufferBuilder {
         command: C,
         resources: &[(
             KeyTy,
-            Option<(PipelineMemoryAccess, ImageLayout, ImageLayout)>,
+            Option<(PipelineMemoryAccess, ImageLayout, ImageLayout, ImageResourceContext)>,
         )],
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
@@ -523,7 +529,7 @@ impl SyncCommandBufferBuilder {
         let mut last_cmd_image = 0;
 
         for &(resource_ty, resource) in resources {
-            if let Some((memory, start_layout, end_layout)) = resource {
+            if let Some((memory, start_layout, end_layout, image_resource_context)) = resource {
                 // Anti-dumbness checks.
                 debug_assert!(memory.exclusive || start_layout == end_layout);
                 debug_assert!(memory.access.is_compatible_with(&memory.stages));
@@ -776,6 +782,7 @@ impl SyncCommandBufferBuilder {
                             exclusive_any: actually_exclusive,
                             initial_layout: actual_start_layout,
                             current_layout: end_layout, // TODO: what if we reach the end with Undefined? that's not correct?
+                            image_resource_context,
                         });
                     }
                 }
@@ -796,7 +803,7 @@ impl SyncCommandBufferBuilder {
                     }
                     KeyTy::Image => {
                         self.images
-                            .push((location, memory, start_layout, end_layout));
+                            .push((location, memory, start_layout, end_layout, image_resource_context));
                         last_cmd_image += 1;
                     }
                 }
@@ -962,6 +969,7 @@ pub struct SyncCommandBuffer {
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
+        ImageResourceContext,
     )>,
 
     // State of all the resources used by this command buffer.
@@ -1058,7 +1066,7 @@ impl SyncCommandBuffer {
                     };
 
                     match (
-                        img.try_gpu_lock(entry.exclusive, entry.initial_layout),
+                        img.try_gpu_lock(entry.exclusive, entry.image_resource_context.uninitialized_safe, entry.initial_layout),
                         prev_err,
                     ) {
                         (Ok(_), _) => (),
@@ -1247,16 +1255,18 @@ impl SyncCommandBuffer {
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
+        ImageResourceContext,
     )> {
         self.images
             .get(index)
-            .map(|(location, memory, start_layout, end_layout)| {
+            .map(|(location, memory, start_layout, end_layout, image_resource_context)| {
                 let cmd = &self.commands[location.command_id];
                 (
                     cmd.image(location.resource_index),
                     *memory,
                     *start_layout,
                     *end_layout,
+                    *image_resource_context,
                 )
             })
     }
@@ -1293,6 +1303,8 @@ struct ResourceFinalState {
 
     // Layout the image will be in at the end of the command buffer.
     final_layout: ImageLayout, // TODO: maybe wrap in an Option to mean that the layout doesn't change? because of buffers?
+
+    image_resource_context: ImageResourceContext,
 }
 
 /// Equivalent to `Command`, but with less methods. Typically contains less things than the

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -58,7 +58,7 @@ use std::mem;
 use std::ops::Range;
 use std::ptr;
 use std::sync::Arc;
-use crate::command_buffer::ImageResourceContext;
+use crate::command_buffer::ImageUninitializedSafe;
 use crate::render_pass::LoadOp;
 
 impl SyncCommandBufferBuilder {
@@ -199,9 +199,10 @@ impl SyncCommandBufferBuilder {
                         },
                         desc.initial_layout,
                         desc.final_layout,
-                        ImageResourceContext {
-                            uninitialized_safe: desc.initial_layout != ImageLayout::Undefined || desc.load == LoadOp::Clear,
-                        },
+                        match desc.initial_layout != ImageLayout::Undefined || desc.load == LoadOp::Clear {
+                            true => ImageUninitializedSafe::Safe,
+                            false => ImageUninitializedSafe::Unsafe,
+                        }
                     )),
                 )
             })
@@ -297,7 +298,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
-                    ImageResourceContext::none(),
+                    ImageUninitializedSafe::Unsafe,
                 )),
             )],
         )?;
@@ -534,7 +535,7 @@ impl SyncCommandBufferBuilder {
                         },
                         source_layout,
                         source_layout,
-                        ImageResourceContext::none(),
+                        ImageUninitializedSafe::Unsafe,
                     )),
                 ),
                 (
@@ -553,9 +554,7 @@ impl SyncCommandBufferBuilder {
                         },
                         destination_layout,
                         destination_layout,
-                        ImageResourceContext {
-                            uninitialized_safe: true,
-                        },
+                        ImageUninitializedSafe::Safe,
                     )),
                 ),
             ],
@@ -698,7 +697,7 @@ impl SyncCommandBufferBuilder {
                         },
                         source_layout,
                         source_layout,
-                        ImageResourceContext::none(),
+                        ImageUninitializedSafe::Unsafe,
                     )),
                 ),
                 (
@@ -717,9 +716,7 @@ impl SyncCommandBufferBuilder {
                         },
                         destination_layout,
                         destination_layout,
-                        ImageResourceContext {
-                            uninitialized_safe: true,
-                        },
+                        ImageUninitializedSafe::Safe,
                     )),
                 ),
             ],
@@ -825,9 +822,7 @@ impl SyncCommandBufferBuilder {
                     },
                     layout,
                     layout,
-                    ImageResourceContext {
-                        uninitialized_safe: true,
-                    },
+                    ImageUninitializedSafe::Safe,
                 )),
             )],
         )?;
@@ -948,7 +943,7 @@ impl SyncCommandBufferBuilder {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
-                        ImageResourceContext::none(),
+                        ImageUninitializedSafe::Unsafe,
                     )),
                 ),
                 (
@@ -967,7 +962,7 @@ impl SyncCommandBufferBuilder {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
-                        ImageResourceContext::none(),
+                        ImageUninitializedSafe::Unsafe,
                     )),
                 ),
             ],
@@ -1100,7 +1095,7 @@ impl SyncCommandBufferBuilder {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
-                        ImageResourceContext::none(),
+                        ImageUninitializedSafe::Unsafe,
                     )),
                 ),
                 (
@@ -1119,9 +1114,7 @@ impl SyncCommandBufferBuilder {
                         },
                         destination_layout,
                         destination_layout,
-                        ImageResourceContext {
-                            uninitialized_safe: true,
-                        },
+                        ImageUninitializedSafe::Safe,
                     )),
                 ),
             ],
@@ -1254,7 +1247,7 @@ impl SyncCommandBufferBuilder {
                         },
                         source_layout,
                         source_layout,
-                        ImageResourceContext::none(),
+                        ImageUninitializedSafe::Unsafe,
                     )),
                 ),
                 (
@@ -1273,7 +1266,7 @@ impl SyncCommandBufferBuilder {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
-                        ImageResourceContext::none(),
+                        ImageUninitializedSafe::Unsafe,
                     )),
                 ),
             ],
@@ -1383,7 +1376,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
-                    ImageResourceContext::none(),
+                    ImageUninitializedSafe::Unsafe,
                 )),
             )],
         )?;
@@ -1576,7 +1569,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
-                    ImageResourceContext::none(),
+                    ImageUninitializedSafe::Unsafe,
                 )),
             )],
         )?;
@@ -1765,7 +1758,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
-                    ImageResourceContext::none(),
+                    ImageUninitializedSafe::Unsafe,
                 )),
             )],
         )?;
@@ -1856,7 +1849,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
-                    ImageResourceContext::none(),
+                    ImageUninitializedSafe::Unsafe,
                 )),
             )],
         )?;
@@ -1999,7 +1992,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
-                    ImageResourceContext::none(),
+                    ImageUninitializedSafe::Unsafe,
                 )),
             )],
         )
@@ -2561,7 +2554,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
-                    ImageResourceContext::none(),
+                    ImageUninitializedSafe::Unsafe,
                 )),
             )],
         )
@@ -2786,7 +2779,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
                             },
                             ImageLayout::Undefined,
                             ImageLayout::Undefined,
-                            ImageResourceContext::none(),
+                            ImageUninitializedSafe::Unsafe,
                         )),
                     ));
                 }
@@ -2833,7 +2826,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
                                 },
                                 layout,
                                 layout,
-                                ImageResourceContext::none(),
+                                ImageUninitializedSafe::Unsafe,
                             ))
                         },
                     ));
@@ -2937,7 +2930,7 @@ impl<'a> SyncCommandBufferBuilderBindVertexBuffer<'a> {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
-                        ImageResourceContext::none(),
+                        ImageUninitializedSafe::Unsafe,
                     )),
                 )
             })
@@ -3118,13 +3111,13 @@ impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
                             cbuf.buffer(buf_num).unwrap().1,
                             ImageLayout::Undefined,
                             ImageLayout::Undefined,
-                            ImageResourceContext::none(),
+                            ImageUninitializedSafe::Unsafe,
                         )),
                     ));
                 }
                 for img_num in 0..cbuf.num_images() {
-                    let (_, memory, start_layout, end_layout, image_resource_context) = cbuf.image(img_num).unwrap();
-                    resources.push((KeyTy::Image, Some((memory, start_layout, end_layout, image_resource_context))));
+                    let (_, memory, start_layout, end_layout, image_uninitialized_safe) = cbuf.image(img_num).unwrap();
+                    resources.push((KeyTy::Image, Some((memory, start_layout, end_layout, image_uninitialized_safe))));
                 }
             }
             resources

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -58,6 +58,8 @@ use std::mem;
 use std::ops::Range;
 use std::ptr;
 use std::sync::Arc;
+use crate::command_buffer::ImageResourceContext;
+use crate::render_pass::LoadOp;
 
 impl SyncCommandBufferBuilder {
     /// Calls `vkCmdBeginQuery` on the builder.
@@ -197,6 +199,9 @@ impl SyncCommandBufferBuilder {
                         },
                         desc.initial_layout,
                         desc.final_layout,
+                        ImageResourceContext {
+                            uninitialized_safe: desc.initial_layout != ImageLayout::Undefined || desc.load == LoadOp::Clear,
+                        },
                     )),
                 )
             })
@@ -292,6 +297,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
+                    ImageResourceContext::none(),
                 )),
             )],
         )?;
@@ -528,6 +534,7 @@ impl SyncCommandBufferBuilder {
                         },
                         source_layout,
                         source_layout,
+                        ImageResourceContext::none(),
                     )),
                 ),
                 (
@@ -546,6 +553,9 @@ impl SyncCommandBufferBuilder {
                         },
                         destination_layout,
                         destination_layout,
+                        ImageResourceContext {
+                            uninitialized_safe: true,
+                        },
                     )),
                 ),
             ],
@@ -688,6 +698,7 @@ impl SyncCommandBufferBuilder {
                         },
                         source_layout,
                         source_layout,
+                        ImageResourceContext::none(),
                     )),
                 ),
                 (
@@ -706,6 +717,9 @@ impl SyncCommandBufferBuilder {
                         },
                         destination_layout,
                         destination_layout,
+                        ImageResourceContext {
+                            uninitialized_safe: true,
+                        },
                     )),
                 ),
             ],
@@ -811,6 +825,9 @@ impl SyncCommandBufferBuilder {
                     },
                     layout,
                     layout,
+                    ImageResourceContext {
+                        uninitialized_safe: true,
+                    },
                 )),
             )],
         )?;
@@ -931,6 +948,7 @@ impl SyncCommandBufferBuilder {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
+                        ImageResourceContext::none(),
                     )),
                 ),
                 (
@@ -949,6 +967,7 @@ impl SyncCommandBufferBuilder {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
+                        ImageResourceContext::none(),
                     )),
                 ),
             ],
@@ -1081,6 +1100,7 @@ impl SyncCommandBufferBuilder {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
+                        ImageResourceContext::none(),
                     )),
                 ),
                 (
@@ -1099,6 +1119,9 @@ impl SyncCommandBufferBuilder {
                         },
                         destination_layout,
                         destination_layout,
+                        ImageResourceContext {
+                            uninitialized_safe: true,
+                        },
                     )),
                 ),
             ],
@@ -1231,6 +1254,7 @@ impl SyncCommandBufferBuilder {
                         },
                         source_layout,
                         source_layout,
+                        ImageResourceContext::none(),
                     )),
                 ),
                 (
@@ -1249,6 +1273,7 @@ impl SyncCommandBufferBuilder {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
+                        ImageResourceContext::none(),
                     )),
                 ),
             ],
@@ -1358,6 +1383,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
+                    ImageResourceContext::none(),
                 )),
             )],
         )?;
@@ -1550,6 +1576,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
+                    ImageResourceContext::none(),
                 )),
             )],
         )?;
@@ -1738,6 +1765,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
+                    ImageResourceContext::none(),
                 )),
             )],
         )?;
@@ -1828,6 +1856,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
+                    ImageResourceContext::none(),
                 )),
             )],
         )?;
@@ -1970,6 +1999,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
+                    ImageResourceContext::none(),
                 )),
             )],
         )
@@ -2531,6 +2561,7 @@ impl SyncCommandBufferBuilder {
                     },
                     ImageLayout::Undefined,
                     ImageLayout::Undefined,
+                    ImageResourceContext::none(),
                 )),
             )],
         )
@@ -2755,6 +2786,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
                             },
                             ImageLayout::Undefined,
                             ImageLayout::Undefined,
+                            ImageResourceContext::none(),
                         )),
                     ));
                 }
@@ -2801,6 +2833,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
                                 },
                                 layout,
                                 layout,
+                                ImageResourceContext::none(),
                             ))
                         },
                     ));
@@ -2904,6 +2937,7 @@ impl<'a> SyncCommandBufferBuilderBindVertexBuffer<'a> {
                         },
                         ImageLayout::Undefined,
                         ImageLayout::Undefined,
+                        ImageResourceContext::none(),
                     )),
                 )
             })
@@ -3084,12 +3118,13 @@ impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
                             cbuf.buffer(buf_num).unwrap().1,
                             ImageLayout::Undefined,
                             ImageLayout::Undefined,
+                            ImageResourceContext::none(),
                         )),
                     ));
                 }
                 for img_num in 0..cbuf.num_images() {
-                    let (_, memory, start_layout, end_layout) = cbuf.image(img_num).unwrap();
-                    resources.push((KeyTy::Image, Some((memory, start_layout, end_layout))));
+                    let (_, memory, start_layout, end_layout, image_resource_context) = cbuf.image(img_num).unwrap();
+                    resources.push((KeyTy::Image, Some((memory, start_layout, end_layout, image_resource_context))));
                 }
             }
             resources

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -36,6 +36,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
+use crate::command_buffer::ImageResourceContext;
 
 pub unsafe trait PrimaryCommandBuffer: DeviceOwned {
     /// Returns the underlying `UnsafeCommandBuffer` of this command buffer.
@@ -245,6 +246,7 @@ pub unsafe trait SecondaryCommandBuffer: DeviceOwned {
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
+        ImageResourceContext,
     )>;
 }
 
@@ -297,6 +299,7 @@ where
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
+        ImageResourceContext,
     )> {
         (**self).image(index)
     }

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -36,7 +36,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
-use crate::command_buffer::ImageResourceContext;
+use crate::command_buffer::ImageUninitializedSafe;
 
 pub unsafe trait PrimaryCommandBuffer: DeviceOwned {
     /// Returns the underlying `UnsafeCommandBuffer` of this command buffer.
@@ -246,7 +246,7 @@ pub unsafe trait SecondaryCommandBuffer: DeviceOwned {
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
-        ImageResourceContext,
+        ImageUninitializedSafe,
     )>;
 }
 
@@ -299,7 +299,7 @@ where
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
-        ImageResourceContext,
+        ImageUninitializedSafe,
     )> {
         (**self).image(index)
     }

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -12,6 +12,7 @@ use crate::command_buffer::submit::SubmitAnyBuilder;
 use crate::command_buffer::submit::SubmitCommandBufferBuilder;
 use crate::command_buffer::sys::UnsafeCommandBuffer;
 use crate::command_buffer::CommandBufferInheritance;
+use crate::command_buffer::ImageUninitializedSafe;
 use crate::device::Device;
 use crate::device::DeviceOwned;
 use crate::device::Queue;
@@ -36,7 +37,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
-use crate::command_buffer::ImageUninitializedSafe;
 
 pub unsafe trait PrimaryCommandBuffer: DeviceOwned {
     /// Returns the underlying `UnsafeCommandBuffer` of this command buffer.

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -537,7 +537,7 @@ unsafe impl<A> ImageAccess for AttachmentImage<A> {
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, _: bool, uninitialized_safe: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
         if expected_layout != self.attachment_layout && expected_layout != ImageLayout::Undefined {
             if self.initialized.load(Ordering::SeqCst) {
                 return Err(AccessError::UnexpectedImageLayout {
@@ -552,7 +552,7 @@ unsafe impl<A> ImageAccess for AttachmentImage<A> {
             }
         }
 
-        if expected_layout != ImageLayout::Undefined {
+        if !uninitialized_safe && expected_layout != ImageLayout::Undefined {
             if !self.initialized.load(Ordering::SeqCst) {
                 return Err(AccessError::ImageNotInitialized {
                     requested: expected_layout,

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -537,7 +537,12 @@ unsafe impl<A> ImageAccess for AttachmentImage<A> {
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, uninitialized_safe: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
+    fn try_gpu_lock(
+        &self,
+        _: bool,
+        uninitialized_safe: bool,
+        expected_layout: ImageLayout,
+    ) -> Result<(), AccessError> {
         if expected_layout != self.attachment_layout && expected_layout != ImageLayout::Undefined {
             if self.initialized.load(Ordering::SeqCst) {
                 return Err(AccessError::UnexpectedImageLayout {

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -493,6 +493,7 @@ unsafe impl<A> ImageAccess for ImmutableImage<A> {
     fn try_gpu_lock(
         &self,
         exclusive_access: bool,
+        uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {
         if expected_layout != self.layout && expected_layout != ImageLayout::Undefined {
@@ -589,6 +590,7 @@ unsafe impl ImageAccess for SubImage {
     fn try_gpu_lock(
         &self,
         exclusive_access: bool,
+        uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {
         if expected_layout != self.layout && expected_layout != ImageLayout::Undefined {
@@ -665,7 +667,7 @@ unsafe impl<A> ImageAccess for ImmutableImageInitialization<A> {
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, _: bool, uninitialized_safe: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
         if expected_layout != ImageLayout::Undefined {
             return Err(AccessError::UnexpectedImageLayout {
                 requested: expected_layout,

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -667,7 +667,12 @@ unsafe impl<A> ImageAccess for ImmutableImageInitialization<A> {
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, uninitialized_safe: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
+    fn try_gpu_lock(
+        &self,
+        _: bool,
+        uninitialized_safe: bool,
+        expected_layout: ImageLayout,
+    ) -> Result<(), AccessError> {
         if expected_layout != ImageLayout::Undefined {
             return Err(AccessError::UnexpectedImageLayout {
                 requested: expected_layout,

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -233,7 +233,12 @@ where
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, uninitialized_safe: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
+    fn try_gpu_lock(
+        &self,
+        _: bool,
+        uninitialized_safe: bool,
+        expected_layout: ImageLayout,
+    ) -> Result<(), AccessError> {
         // TODO: handle initial layout transition
         if expected_layout != ImageLayout::General && expected_layout != ImageLayout::Undefined {
             return Err(AccessError::UnexpectedImageLayout {

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -233,7 +233,7 @@ where
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, _: bool, uninitialized_safe: bool, expected_layout: ImageLayout) -> Result<(), AccessError> {
         // TODO: handle initial layout transition
         if expected_layout != ImageLayout::General && expected_layout != ImageLayout::Undefined {
             return Err(AccessError::UnexpectedImageLayout {

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -131,7 +131,7 @@ unsafe impl<W> ImageAccess for SwapchainImage<W> {
     }
 
     #[inline]
-    fn try_gpu_lock(&self, _: bool, _: ImageLayout) -> Result<(), AccessError> {
+    fn try_gpu_lock(&self, _: bool, _: bool, _: ImageLayout) -> Result<(), AccessError> {
         if self.swapchain.is_fullscreen_exclusive() {
             Ok(())
         } else {

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -213,6 +213,7 @@ pub unsafe trait ImageAccess {
     fn try_gpu_lock(
         &self,
         exclusive_access: bool,
+        uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError>;
 
@@ -311,9 +312,10 @@ where
     fn try_gpu_lock(
         &self,
         exclusive_access: bool,
+        uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {
-        (**self).try_gpu_lock(exclusive_access, expected_layout)
+        (**self).try_gpu_lock(exclusive_access, uninitialized_safe, expected_layout)
     }
 
     #[inline]
@@ -416,9 +418,10 @@ where
     fn try_gpu_lock(
         &self,
         exclusive_access: bool,
+        uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {
-        self.image.try_gpu_lock(exclusive_access, expected_layout)
+        self.image.try_gpu_lock(exclusive_access, uninitialized_safe, expected_layout)
     }
 
     #[inline]

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -421,7 +421,8 @@ where
         uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {
-        self.image.try_gpu_lock(exclusive_access, uninitialized_safe, expected_layout)
+        self.image
+            .try_gpu_lock(exclusive_access, uninitialized_safe, expected_layout)
     }
 
     #[inline]

--- a/vulkano/src/pipeline/blend.rs
+++ b/vulkano/src/pipeline/blend.rs
@@ -22,7 +22,6 @@
 //! will take precedence if it is activated, otherwise the blending operation is applied.
 //!
 
-
 /// Describes how the color output of the fragment shader is written to the attachment. See the
 /// documentation of the `blend` module for more info.
 #[derive(Debug, Clone, PartialEq)]
@@ -154,7 +153,11 @@ impl From<AttachmentBlend> for ash::vk::PipelineColorBlendAttachmentState {
     #[inline]
     fn from(val: AttachmentBlend) -> Self {
         ash::vk::PipelineColorBlendAttachmentState {
-            blend_enable: if val.enabled { ash::vk::TRUE } else { ash::vk::FALSE },
+            blend_enable: if val.enabled {
+                ash::vk::TRUE
+            } else {
+                ash::vk::FALSE
+            },
             src_color_blend_factor: val.color_source.into(),
             dst_color_blend_factor: val.color_destination.into(),
             color_blend_op: val.color_op.into(),

--- a/vulkano/src/pipeline/input_assembly.rs
+++ b/vulkano/src/pipeline/input_assembly.rs
@@ -12,7 +12,6 @@
 //! The input assembly is the stage where lists of vertices are turned into primitives.
 //!
 
-
 /// How the input assembly stage should behave.
 #[derive(Copy, Clone, Debug)]
 #[deprecated]

--- a/vulkano/src/pipeline/raster.rs
+++ b/vulkano/src/pipeline/raster.rs
@@ -13,7 +13,6 @@
 //! of pixels or samples.
 //!
 
-
 /// State of the rasterizer.
 #[derive(Clone, Debug)]
 pub struct Rasterization {


### PR DESCRIPTION
This pull request allows for uninitialized images to be used where they are be written to. This will resolve access errors of the image not being initialized. This introduces an extra context for images resources coming from `SyncCommandBufferBuilder`. If the image is used where it is being written to it will mark them image safe to be used uninitialized. `ImageAccess` `try_gpu_lock` method has changed slightly to allow this extra flag to get passed.

    * Entries for Vulkano changelog:
        - **Breaking** `ImageAccess` trait method `try_gpu_lock()` now has an additional argument to allow locking the image in an uninitialized state.`
        - Improve `ImageLayout` checks to prevent `AccessError::ImageNotInitialized` from occurring where the image is safe to use uninitialized.

- This does not provide protection where the image is partial written to. It is assumed that if you are writing to part of the image that it is initialized. Implementing safety around this would add a lot of complexity for little additional safety.
- I op'd for creating the struct `ImageUninitializedSafe` instead of a simple boolean as it makes code related to command_buffers easier to read. This shouldn't effect performance I wouldn't think.
- `msaa-renderpass` example still does not launch with this change. Thought that issue may be related since at that time, I was having issues in Basalt around multisampling returning `AccessError::ImageNotInitialized`.

This fixes issues I was having in Basalt with having to manual transition images myself. I don't know if this issue is related to https://github.com/vulkano-rs/vulkano/pull/1588 and would be curious how these two work together if they provide a more robust solution.
