### PR TITLE
Better feature and device selection in examples

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
 use vulkano::pipeline::ComputePipeline;
 use vulkano::pipeline::ComputePipelineAbstract;
@@ -37,13 +37,7 @@ const BUFFER_USAGE: BufferUsage = BufferUsage {
 
 fn main() {
     // As with other examples, the first step is to create an instance.
-    let instance = Instance::new(
-        None,
-        Version::V1_1,
-        &InstanceExtensions::none(),
-        None,
-    )
-    .unwrap();
+    let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
 
     // Choose which physical device to use.
     let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
@@ -60,7 +54,7 @@ fn main() {
     // Now initializing the device.
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DEVICE_EXTENSIONS,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -18,44 +18,54 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, DeviceExtensions, Features};
-use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::ComputePipeline;
 use vulkano::pipeline::ComputePipelineAbstract;
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;
 
-const DEVICE_EXTENSIONS: DeviceExtensions = DeviceExtensions {
-    khr_storage_buffer_storage_class: true,
-    ..DeviceExtensions::none()
-};
-
-const BUFFER_USAGE: BufferUsage = BufferUsage {
-    storage_buffer: true,
-    ..BufferUsage::none()
-};
-
 fn main() {
     // As with other examples, the first step is to create an instance.
     let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
 
     // Choose which physical device to use.
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-
-    // Choose the queue of the physical device which is going to run our compute operation.
-    //
-    // The Vulkan specs guarantee that a compliant implementation must provide at least one queue
-    // that supports compute operations.
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_compute())
+    let device_extensions = DeviceExtensions {
+        khr_storage_buffer_storage_class: true,
+        ..DeviceExtensions::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            // The Vulkan specs guarantee that a compliant implementation must provide at least one queue
+            // that supports compute operations.
+            p.queue_families()
+                .find(|&q| q.supports_compute())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
         .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
 
     // Now initializing the device.
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &DEVICE_EXTENSIONS,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
@@ -64,8 +74,6 @@ fn main() {
     // example we use only one queue, so we just retrieve the first and only element of the
     // iterator and throw it away.
     let queue = queues.next().unwrap();
-
-    println!("Device initialized");
 
     // Now let's get to the actual example.
     //
@@ -114,7 +122,16 @@ fn main() {
         // Iterator that produces the data.
         let data_iter = (0..65536u32).map(|n| n);
         // Builds the buffer and fills it with this iterator.
-        CpuAccessibleBuffer::from_iter(device.clone(), BUFFER_USAGE, false, data_iter).unwrap()
+        CpuAccessibleBuffer::from_iter(
+            device.clone(),
+            BufferUsage {
+                uniform_buffer: true,
+                ..BufferUsage::none()
+            },
+            false,
+            data_iter,
+        )
+        .unwrap()
     };
 
     // In order to let the shader access the buffer, we need to build a *descriptor set* that

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -28,7 +28,7 @@ use vulkano::command_buffer::{
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
-use vulkano::instance::{Instance, PhysicalDevice};
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
@@ -51,32 +51,45 @@ vulkano::impl_vertex!(Vertex, position);
 fn main() {
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-
-    println!(
-        "Using device: {} (type: {:?})",
-        physical.properties().device_name.as_ref().unwrap(),
-        physical.properties().device_type.unwrap()
-    );
 
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .unwrap();
-
-    let device_ext = DeviceExtensions {
+    let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &device_ext,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
@@ -84,7 +97,7 @@ fn main() {
     let queue = queues.next().unwrap();
 
     let (mut swapchain, images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -25,7 +25,7 @@ use vulkano::buffer::CpuBufferPool;
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
 use vulkano::instance::{Instance, PhysicalDevice};
@@ -75,7 +75,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::Format;
 use vulkano::image::ImageDimensions;
 use vulkano::image::ImmutableImage;
@@ -121,7 +121,7 @@ fn main() {
         .expect("couldn't find a queue family");
     let (_, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DeviceExtensions::required_extensions(physical),
         vec![(queue_family, 0.5)],
     )

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -33,7 +33,7 @@ use cgmath::Vector3;
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::ImageUsage;
-use vulkano::instance::{Instance, PhysicalDevice};
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::swapchain;
 use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync;
@@ -52,33 +52,52 @@ fn main() {
 
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
 
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .expect("couldn't find a graphical queue family");
-
-    let device_ext = DeviceExtensions {
+    let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &device_ext,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
     let queue = queues.next().unwrap();
 
     let (mut swapchain, mut images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -30,7 +30,7 @@ use crate::triangle_draw_system::*;
 use cgmath::Matrix4;
 use cgmath::SquareMatrix;
 use cgmath::Vector3;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::ImageUsage;
 use vulkano::instance::{Instance, PhysicalDevice};
@@ -51,8 +51,7 @@ fn main() {
     // Basic initialization. See the triangle example if you want more details about this.
 
     let required_extensions = vulkano_win::required_extensions();
-    let instance =
-        Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
+    let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
     let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
 
     let event_loop = EventLoop::new();
@@ -71,7 +70,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -20,7 +20,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, DeviceExtensions, Features};
-use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::layout::PipelineLayout;
 use vulkano::pipeline::shader::EntryPointAbstract;
 use vulkano::pipeline::ComputePipeline;
@@ -32,18 +32,39 @@ use vulkano::Version;
 fn main() {
     let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
 
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_compute())
+    let device_extensions = DeviceExtensions {
+        khr_storage_buffer_storage_class: true,
+        ..DeviceExtensions::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_compute())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
         .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &DeviceExtensions {
-            khr_storage_buffer_storage_class: true,
-            ..DeviceExtensions::none()
-        },
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
 use vulkano::pipeline::layout::PipelineLayout;
 use vulkano::pipeline::shader::EntryPointAbstract;
@@ -39,7 +39,7 @@ fn main() {
         .unwrap();
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DeviceExtensions {
             khr_storage_buffer_storage_class: true,
             ..DeviceExtensions::none()

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -24,7 +24,7 @@ use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::Format;
 use vulkano::image::{view::ImageView, ImageDimensions, StorageImage};
-use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::ComputePipeline;
 use vulkano::pipeline::ComputePipelineAbstract;
 use vulkano::sync;
@@ -46,15 +46,38 @@ fn main() {
     )
     .unwrap();
 
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_compute())
+    let device_extensions = DeviceExtensions {
+        ..DeviceExtensions::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_compute())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
         .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &DeviceExtensions::none(),
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
@@ -125,13 +148,9 @@ fn main() {
     // In this case we can find appropriate value in this table: https://vulkan.gpuinfo.org/
     // or just use fallback constant for simplicity, but failure to set proper
     // local size can lead to significant performance penalty.
-    let (local_size_x, local_size_y) = match physical.properties().subgroup_size {
+    let (local_size_x, local_size_y) = match physical_device.properties().subgroup_size {
         Some(subgroup_size) => {
-            println!(
-                "Subgroup size for '{}' device is {}",
-                physical.properties().device_name.as_ref().unwrap(),
-                subgroup_size
-            );
+            println!("Subgroup size is {}", subgroup_size);
 
             // Most of the subgroup values are divisors of 8
             (8, subgroup_size / 8)

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::Format;
 use vulkano::image::{view::ImageView, ImageDimensions, StorageImage};
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
@@ -53,7 +53,7 @@ fn main() {
         .unwrap();
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DeviceExtensions::none(),
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -15,7 +15,7 @@ use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::Format;
 use vulkano::image::{
     view::ImageView, ImageDimensions, ImageUsage, ImmutableImage, MipmapsCount, SwapchainImage,
@@ -65,7 +65,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -20,7 +20,7 @@ use vulkano::format::Format;
 use vulkano::image::{
     view::ImageView, ImageDimensions, ImageUsage, ImmutableImage, MipmapsCount, SwapchainImage,
 };
-use vulkano::instance::{Instance, PhysicalDevice};
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::pipeline::GraphicsPipelineAbstract;
@@ -42,38 +42,52 @@ fn main() {
 
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    println!(
-        "Using device: {} (type: {:?})",
-        physical.properties().device_name.as_ref().unwrap(),
-        physical.properties().device_type.unwrap(),
-    );
 
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .unwrap();
-
-    let device_ext = DeviceExtensions {
+    let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap(),
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &device_ext,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
     let queue = queues.next().unwrap();
 
     let (mut swapchain, images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/immutable-buffer-initialization.rs
+++ b/examples/src/bin/immutable-buffer-initialization.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer, ImmutableBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
 use vulkano::pipeline::ComputePipeline;
 use vulkano::pipeline::ComputePipelineAbstract;
@@ -25,13 +25,7 @@ fn main() {
     // The most part of this example is exactly the same as `basic-compute-shader`. You should read the
     // `basic-compute-shader` example if you haven't done so yet.
 
-    let instance = Instance::new(
-        None,
-        Version::V1_1,
-        &InstanceExtensions::none(),
-        None,
-    )
-    .unwrap();
+    let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
     let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
 
     let queue_family = physical
@@ -41,7 +35,7 @@ fn main() {
 
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DeviceExtensions {
             khr_storage_buffer_storage_class: true,
             ..DeviceExtensions::none()

--- a/examples/src/bin/immutable-buffer-initialization.rs
+++ b/examples/src/bin/immutable-buffer-initialization.rs
@@ -14,7 +14,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer, ImmutableBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, DeviceExtensions, Features};
-use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::ComputePipeline;
 use vulkano::pipeline::ComputePipelineAbstract;
 use vulkano::sync;
@@ -26,27 +26,45 @@ fn main() {
     // `basic-compute-shader` example if you haven't done so yet.
 
     let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_compute())
+    let device_extensions = DeviceExtensions {
+        khr_storage_buffer_storage_class: true,
+        ..DeviceExtensions::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_compute())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
         .unwrap();
 
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &DeviceExtensions {
-            khr_storage_buffer_storage_class: true,
-            ..DeviceExtensions::none()
-        },
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
 
     let queue = queues.next().unwrap();
-
-    println!("Device initialized");
 
     let pipeline = Arc::new({
         mod cs {

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -41,7 +41,7 @@ use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
-use vulkano::instance::{Instance, PhysicalDevice};
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract, GraphicsPipeline};
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
@@ -66,32 +66,46 @@ impl_vertex!(Vertex, position);
 fn main() {
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    println!(
-        "Using device: {} (type: {:?})",
-        physical.properties().device_name.as_ref().unwrap(),
-        physical.properties().device_type.unwrap(),
-    );
 
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .unwrap();
-
-    let device_ext = DeviceExtensions {
+    let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         khr_storage_buffer_storage_class: true,
         ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap(),
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &device_ext,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
@@ -99,7 +113,7 @@ fn main() {
     let queue = queues.next().unwrap();
 
     let (mut swapchain, images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -38,7 +38,7 @@ use vulkano::command_buffer::{
     SubpassContents,
 };
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
 use vulkano::instance::{Instance, PhysicalDevice};
@@ -90,7 +90,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -26,7 +26,7 @@ use vulkano::command_buffer::{
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
-use vulkano::instance::{Instance, PhysicalDevice};
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::vertex::OneVertexOneInstanceDefinition;
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
@@ -65,31 +65,44 @@ fn main() {
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
 
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    println!(
-        "Using device: {} (type: {:?})",
-        physical.properties().device_name.as_ref().unwrap(),
-        physical.properties().device_type.unwrap(),
-    );
-
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .unwrap();
-
-    let device_ext = DeviceExtensions {
+    let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap(),
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &device_ext,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
@@ -97,7 +110,7 @@ fn main() {
     let queue = queues.next().unwrap();
 
     let (mut swapchain, images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -23,7 +23,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
 use vulkano::instance::{Instance, PhysicalDevice};
@@ -88,7 +88,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -74,7 +74,7 @@ use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, PrimaryCommandBuffer,
     SubpassContents,
 };
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::ClearValue;
 use vulkano::format::Format;
 use vulkano::image::{
@@ -90,8 +90,7 @@ use vulkano::Version;
 fn main() {
     // The usual Vulkan initialization.
     let required_extensions = vulkano_win::required_extensions();
-    let instance =
-        Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
+    let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
     let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
     let queue_family = physical
         .queue_families()
@@ -99,7 +98,7 @@ fn main() {
         .unwrap();
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DeviceExtensions::none(),
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -22,7 +22,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
 use vulkano::instance::{Instance, PhysicalDevice};
@@ -53,8 +53,7 @@ struct WindowSurface {
 
 fn main() {
     let required_extensions = vulkano_win::required_extensions();
-    let instance =
-        Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
+    let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
     let event_loop = EventLoop::new();
 
     // A hashmap that contains all of our created windows and their resources
@@ -82,7 +81,7 @@ fn main() {
         };
         let (device, mut queues) = Device::new(
             physical,
-            physical.supported_features(),
+            &Features::none(),
             &device_ext,
             [(queue_family, 0.5)].iter().cloned(),
         )

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -31,7 +31,7 @@ use vulkano::image::{
     StorageImage,
 };
 use vulkano::instance::PhysicalDevice;
-use vulkano::instance::{Instance, InstanceExtensions};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDeviceType};
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{
@@ -54,36 +54,58 @@ fn main() {
     )
     .unwrap();
 
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-
-    // This example renders to two layers of the framebuffer using the multiview extension so we
-    // check that at least two views are supported by the device.
-    // Not checking this on a device that doesn't support two views
-    // will lead to a runtime error when creating the `RenderPass`.
-    // The `max_multiview_view_count` function will return `None`
-    // when the `VK_KHR_get_physical_device_properties2` instance extension has not been enabled.
-    if physical.properties().max_multiview_view_count.unwrap_or(0) < 2 {
-        println!("The device doesn't support two multiview views or the VK_KHR_get_physical_device_properties2 instance extension has not been loaded");
-
+    let device_extensions = DeviceExtensions {
+        ..DeviceExtensions::none()
+    };
+    let features = Features {
+        // enabling the `multiview` feature will use the `VK_KHR_multiview` extension on
+        // Vulkan 1.0 and the device feature on Vulkan 1.1+
+        multiview: true,
+        ..Features::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter(|&p| {
+            p.supported_features().superset_of(&features)
+        })
+        .filter(|&p| {
+            // This example renders to two layers of the framebuffer using the multiview
+            // extension so we check that at least two views are supported by the device.
+            // Not checking this on a device that doesn't support two views
+            // will lead to a runtime error when creating the `RenderPass`.
+            // The `max_multiview_view_count` function will return `None` when the
+            // `VK_KHR_get_physical_device_properties2` instance extension has not been enabled.
+            p.properties().max_multiview_view_count.unwrap_or(0) >= 2
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
         // A real application should probably fall back to rendering the framebuffer layers
         // in multiple passes when multiview isn't supported.
-        return;
-    }
+        .expect("No device supports two multiview views or the VK_KHR_get_physical_device_properties2 instance extension has not been loaded");
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics())
-        .unwrap();
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
 
     let (device, mut queues) = Device::new(
-        physical,
-        &Features {
-            // enabling the `multiview` feature will use the `VK_KHR_multiview` extension on
-            // Vulkan 1.0 and the device feature on Vulkan 1.1+
-            multiview: true,
-            ..Features::none()
-        },
-        &DeviceExtensions::none(),
+        physical_device,
+        &features,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -16,7 +16,7 @@ use vulkano::buffer::{BufferAccess, BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
-use vulkano::device::{Device, DeviceExtensions, DeviceOwned};
+use vulkano::device::{Device, DeviceExtensions, DeviceOwned, Features};
 use vulkano::format::Format;
 use vulkano::image::{view::ImageView, AttachmentImage, ImageUsage, SwapchainImage};
 use vulkano::instance::{Instance, PhysicalDevice};
@@ -61,7 +61,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -19,7 +19,7 @@ use vulkano::command_buffer::{
 use vulkano::device::{Device, DeviceExtensions, DeviceOwned, Features};
 use vulkano::format::Format;
 use vulkano::image::{view::ImageView, AttachmentImage, ImageUsage, SwapchainImage};
-use vulkano::instance::{Instance, PhysicalDevice};
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::query::{QueryControlFlags, QueryPool, QueryResultFlags, QueryType};
@@ -37,39 +37,52 @@ use winit::window::{Window, WindowBuilder};
 fn main() {
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-
-    println!(
-        "Using device: {} (type: {:?})",
-        physical.properties().device_name.as_ref().unwrap(),
-        physical.properties().device_type.unwrap(),
-    );
 
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .unwrap();
-
-    let device_ext = DeviceExtensions {
+    let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap(),
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &device_ext,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
     let queue = queues.next().unwrap();
 
     let (mut swapchain, images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/pipeline-caching.rs
+++ b/examples/src/bin/pipeline-caching.rs
@@ -33,7 +33,7 @@ use std::io::Read;
 use std::io::Write;
 use std::sync::Arc;
 use vulkano::device::{Device, DeviceExtensions, Features};
-use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::cache::PipelineCache;
 use vulkano::pipeline::ComputePipeline;
 use vulkano::Version;
@@ -43,30 +43,43 @@ fn main() {
     let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
 
     // Choose which physical device to use.
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-
-    // Choose the queue of the physical device which is going to run our compute operation.
-    //
-    // The Vulkan specs guarantee that a compliant implementation must provide at least one queue
-    // that supports compute operations.
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_compute())
+    let device_extensions = DeviceExtensions {
+        khr_storage_buffer_storage_class: true,
+        ..DeviceExtensions::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_compute())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
         .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
 
     // Now initializing the device.
     let (device, _) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &DeviceExtensions {
-            khr_storage_buffer_storage_class: true,
-            ..DeviceExtensions::none()
-        },
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
-
-    println!("Device initialized");
 
     // We are creating an empty PipelineCache to start somewhere.
     let pipeline_cache = PipelineCache::empty(device.clone()).unwrap();

--- a/examples/src/bin/pipeline-caching.rs
+++ b/examples/src/bin/pipeline-caching.rs
@@ -32,7 +32,7 @@ use std::fs::File;
 use std::io::Read;
 use std::io::Write;
 use std::sync::Arc;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
 use vulkano::pipeline::cache::PipelineCache;
 use vulkano::pipeline::ComputePipeline;
@@ -57,7 +57,7 @@ fn main() {
     // Now initializing the device.
     let (device, _) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DeviceExtensions {
             khr_storage_buffer_storage_class: true,
             ..DeviceExtensions::none()

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -14,7 +14,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, DeviceExtensions, Features};
-use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
@@ -22,18 +22,40 @@ use vulkano::Version;
 
 fn main() {
     let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_compute())
+
+    let device_extensions = DeviceExtensions {
+        khr_storage_buffer_storage_class: true,
+        ..DeviceExtensions::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_compute())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
         .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &DeviceExtensions {
-            khr_storage_buffer_storage_class: true,
-            ..DeviceExtensions::none()
-        },
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
 use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
 use vulkano::sync;
@@ -29,7 +29,7 @@ fn main() {
         .unwrap();
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DeviceExtensions {
             khr_storage_buffer_storage_class: true,
             ..DeviceExtensions::none()

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -24,7 +24,6 @@ use std::ffi::CStr;
 use std::fs::File;
 use std::io::Read;
 use std::sync::Arc;
-use vulkano as vk;
 use vulkano::buffer::cpu_access::CpuAccessibleBuffer;
 use vulkano::buffer::BufferUsage;
 use vulkano::command_buffer::{
@@ -34,7 +33,7 @@ use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::Format;
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
-use vulkano::instance::Instance;
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::layout::PipelineLayoutDesc;
 use vulkano::pipeline::shader::{
     GraphicsShaderType, ShaderInterface, ShaderInterfaceEntry, ShaderModule,
@@ -65,36 +64,52 @@ vulkano::impl_vertex!(Vertex, position, color);
 fn main() {
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
-    let physical = vk::instance::PhysicalDevice::enumerate(&instance)
-        .next()
-        .unwrap();
 
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .unwrap();
-    let (device, mut queues) = {
-        let device_ext = DeviceExtensions {
-            khr_swapchain: true,
-            ..DeviceExtensions::none()
-        };
-        Device::new(
-            physical,
-            &Features::none(),
-            &device_ext,
-            [(queue_family, 0.5)].iter().cloned(),
-        )
-        .unwrap()
+    let device_extensions = DeviceExtensions {
+        khr_swapchain: true,
+        ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
+    let (device, mut queues) = Device::new(
+        physical_device,
+        &Features::none(),
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
+        [(queue_family, 0.5)].iter().cloned(),
+    )
+    .unwrap();
     let queue = queues.next().unwrap();
 
     let (mut swapchain, images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -30,8 +30,7 @@ use vulkano::buffer::BufferUsage;
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
-use vulkano::device::Device;
-use vulkano::device::DeviceExtensions;
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::Format;
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
@@ -86,7 +85,7 @@ fn main() {
         };
         Device::new(
             physical,
-            physical.supported_features(),
+            &Features::none(),
             &device_ext,
             [(queue_family, 0.5)].iter().cloned(),
         )

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -16,7 +16,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, DeviceExtensions, Features};
-use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
@@ -24,25 +24,44 @@ use vulkano::Version;
 
 fn main() {
     let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_compute())
-        .unwrap();
+
     let device_extensions = DeviceExtensions {
         khr_storage_buffer_storage_class: true,
         ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_compute())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &device_extensions,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
     let queue = queues.next().unwrap();
-
-    println!("Device initialized");
 
     let pipeline = Arc::new({
         mod cs {

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
 use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
 use vulkano::sync;
@@ -23,13 +23,7 @@ use vulkano::sync::GpuFuture;
 use vulkano::Version;
 
 fn main() {
-    let instance = Instance::new(
-        None,
-        Version::V1_1,
-        &InstanceExtensions::none(),
-        None,
-    )
-    .unwrap();
+    let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
     let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
     let queue_family = physical
         .queue_families()
@@ -41,7 +35,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_extensions,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -14,7 +14,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::{Device, DeviceExtensions, Features};
-use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
+use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
@@ -22,18 +22,40 @@ use vulkano::Version;
 
 fn main() {
     let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_compute())
+
+    let device_extensions = DeviceExtensions {
+        khr_storage_buffer_storage_class: true,
+        ..DeviceExtensions::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_compute())
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
         .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &DeviceExtensions {
-            khr_storage_buffer_storage_class: true,
-            ..DeviceExtensions::none()
-        },
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions, PhysicalDevice};
 use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
 use vulkano::sync;
@@ -29,7 +29,7 @@ fn main() {
         .unwrap();
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &DeviceExtensions {
             khr_storage_buffer_storage_class: true,
             ..DeviceExtensions::none()

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -18,7 +18,7 @@ use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::Format;
 use vulkano::image::attachment::AttachmentImage;
 use vulkano::image::view::ImageView;
@@ -69,7 +69,7 @@ fn main() {
 
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -23,8 +23,7 @@ use vulkano::format::Format;
 use vulkano::image::attachment::AttachmentImage;
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
-use vulkano::instance::Instance;
-use vulkano::instance::PhysicalDevice;
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::vertex::TwoBuffersDefinition;
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
@@ -45,32 +44,45 @@ fn main() {
 
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    println!(
-        "Using device: {} (type: {:?})",
-        physical.properties().device_name.as_ref().unwrap(),
-        physical.properties().device_type.unwrap(),
-    );
 
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .unwrap();
-
-    let device_ext = DeviceExtensions {
+    let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::none()
     };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap(),
+    );
 
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
-        &device_ext,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
@@ -79,7 +91,7 @@ fn main() {
     let dimensions: [u32; 2] = surface.window().inner_size().into();
 
     let (mut swapchain, images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let format = caps.supported_formats[0].0;
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -23,7 +23,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
 use vulkano::instance::{Instance, PhysicalDevice};
@@ -162,7 +162,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -26,7 +26,7 @@ use vulkano::command_buffer::{
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
-use vulkano::instance::{Instance, PhysicalDevice};
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
@@ -139,38 +139,57 @@ fn main() {
     let required_extensions = vulkano_win::required_extensions();
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
 
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-    println!(
-        "Using device: {} (type: {:?})",
-        physical.properties().device_name.as_ref().unwrap(),
-        physical.properties().device_type.unwrap()
-    );
-
     let event_loop = EventLoop::new();
     let surface = WindowBuilder::new()
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
-        .unwrap();
-
-    let device_ext = DeviceExtensions {
+    let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::none()
     };
+    let features = Features {
+        tessellation_shader: true,
+        fill_mode_non_solid: true,
+        ..Features::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| {
+            DeviceExtensions::supported_by_device(p).intersection(&device_extensions)
+                == device_extensions
+        })
+        .filter(|&p| p.supported_features().superset_of(&features))
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap()
+    );
+
     let (device, mut queues) = Device::new(
-        physical,
-        &Features::none(),
-        &device_ext,
+        physical_device,
+        &features,
+        &DeviceExtensions::required_extensions(physical_device).union(&device_extensions),
         [(queue_family, 0.5)].iter().cloned(),
     )
     .unwrap();
     let queue = queues.next().unwrap();
 
     let (mut swapchain, images) = {
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
         let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
         let format = caps.supported_formats[0].0;
         let dimensions: [u32; 2] = surface.window().inner_size().into();

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -21,7 +21,7 @@ use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer};
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SubpassContents,
 };
-use vulkano::device::{Device, DeviceExtensions};
+use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
 use vulkano::instance::{Instance, PhysicalDevice};
@@ -132,7 +132,7 @@ fn main() {
     };
     let (device, mut queues) = Device::new(
         physical,
-        physical.supported_features(),
+        &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
     )

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -24,7 +24,7 @@ use vulkano::command_buffer::{
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
-use vulkano::instance::{Instance, PhysicalDevice};
+use vulkano::instance::{Instance, PhysicalDevice, PhysicalDeviceType};
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
@@ -51,29 +51,6 @@ fn main() {
     // Now creating the instance.
     let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
 
-    // We then choose which physical device to use.
-    //
-    // In a real application, there are three things to take into consideration:
-    //
-    // - Some devices may not support some of the optional features that may be required by your
-    //   application. You should filter out the devices that don't support your app.
-    //
-    // - Not all devices can draw to a certain surface. Once you create your window, you have to
-    //   choose a device that is capable of drawing to it.
-    //
-    // - You probably want to leave the choice between the remaining devices to the user.
-    //
-    // For the sake of the example we are just going to use the first device, which should work
-    // most of the time.
-    let physical = PhysicalDevice::enumerate(&instance).next().unwrap();
-
-    // Some little debug infos.
-    println!(
-        "Using device: {} (type: {:?})",
-        physical.properties().device_name.as_ref().unwrap(),
-        physical.properties().device_type.unwrap(),
-    );
-
     // The objective of this example is to draw a triangle on a window. To do so, we first need to
     // create the window.
     //
@@ -89,23 +66,69 @@ fn main() {
         .build_vk_surface(&event_loop, instance.clone())
         .unwrap();
 
-    // The next step is to choose which GPU queue will execute our draw commands.
-    //
-    // Devices can provide multiple queues to run commands in parallel (for example a draw queue
-    // and a compute queue), similar to CPU threads. This is something you have to have to manage
-    // manually in Vulkan.
-    //
-    // In a real-life application, we would probably use at least a graphics queue and a transfers
-    // queue to handle data transfers in parallel. In this example we only use one queue.
-    //
-    // We have to choose which queues to use early on, because we will need this info very soon.
-    let queue_family = physical
-        .queue_families()
-        .find(|&q| {
-            // We take the first queue that supports drawing to our window.
-            q.supports_graphics() && surface.is_supported(q).unwrap_or(false)
+    // We then choose which physical device to use. First, we enumerate all the available physical
+    // devices, then apply filters to narrow them down to those that can support our needs.
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|_p| {
+            // Some devices may not support the extensions or features that your application, or
+            // report properties and limits that are not sufficient for your application. These
+            // should be filtered out here.
+            //
+            // This example does not use any extensions or features, and has no particular
+            // requirements for properties, so any device is fine.
+            true
+        })
+        .filter_map(|p| {
+            // For each physical device, we try to find a suitable queue family that will execute
+            // our draw commands.
+            //
+            // Devices can provide multiple queues to run commands in parallel (for example a draw
+            // queue and a compute queue), similar to CPU threads. This is something you have to
+            // have to manage manually in Vulkan. Queues of the same type belong to the same
+            // queue family.
+            //
+            // Here, we look for a single queue family that is suitable for our purposes. In a
+            // real-life application, you may want to use a separate dedicated transfer queue to
+            // handle data transfers in parallel with graphics operations. You may also need a
+            // separate queue for compute operations, if your application uses those.
+            p.queue_families()
+                .find(|&q| {
+                    // We select a queue family that supports graphics operations. When drawing to
+                    // a window surface, as we do in this example, we also need to check that queues
+                    // in this queue family are capable of presenting images to the surface.
+                    q.supports_graphics() && surface.is_supported(q).unwrap_or(false)
+                })
+                // The code here searches for the first queue family that is suitable. If none is
+                // found, `None` is returned to `filter_map`, which disqualifies this physical
+                // device.
+                .map(|q| (p, q))
+        })
+        // All the physical devices that pass the filters above are suitable for the application.
+        // However, not every device is equal, some are preferred over others. Now, we assign
+        // each physical device a score, and pick the device with the
+        // lowest ("best") score.
+        //
+        // In this example, we simply select the best-scoring device to use in the application.
+        // In a real-life setting, you may want to use the best-scoring device only as a
+        // "default" or "recommended" device, and let the user choose the device themselves.
+        .min_by_key(|(p, _)| {
+            // We assign a better score to device types that are likely to be faster/better.
+            match p.properties().device_type.unwrap() {
+                PhysicalDeviceType::DiscreteGpu => 0,
+                PhysicalDeviceType::IntegratedGpu => 1,
+                PhysicalDeviceType::VirtualGpu => 2,
+                PhysicalDeviceType::Cpu => 3,
+                PhysicalDeviceType::Other => 4,
+            }
         })
         .unwrap();
+
+    // Some little debug infos.
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name.as_ref().unwrap(),
+        physical_device.properties().device_type.unwrap(),
+    );
 
     // Now initializing the device. This is probably the most important object of Vulkan.
     //
@@ -118,8 +141,6 @@ fn main() {
     //   creation. In this example the only thing we are going to need is the `khr_swapchain`
     //   extension that allows us to draw to a window.
     //
-    // - A list of layers to enable. This is very niche, and you will usually pass `None`.
-    //
     // - The list of queues that we are going to use. The exact parameter is an iterator whose
     //   items are `(Queue, f32)` where the floating-point represents the priority of the queue
     //   between 0.0 and 1.0. The priority of the queue is a hint to the implementation about how
@@ -131,7 +152,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (device, mut queues) = Device::new(
-        physical,
+        physical_device,
         &Features::none(),
         &device_ext,
         [(queue_family, 0.5)].iter().cloned(),
@@ -140,7 +161,7 @@ fn main() {
 
     // Since we can request multiple queues, the `queues` variable is in fact an iterator. We
     // only use one queue in this example, so we just retrieve the first and only element of the
-    // iterator and throw it away.
+    // iterator.
     let queue = queues.next().unwrap();
 
     // Before we can draw on the surface, we have to create what is called a swapchain. Creating
@@ -149,7 +170,7 @@ fn main() {
     let (mut swapchain, images) = {
         // Querying the capabilities of the surface. When we create the swapchain we can only
         // pass values that are allowed by the capabilities.
-        let caps = surface.capabilities(physical).unwrap();
+        let caps = surface.capabilities(physical_device).unwrap();
 
         // The alpha mode indicates how the alpha value of the final image will behave. For example,
         // you can choose whether the window will be opaque or transparent.


### PR DESCRIPTION
Instead of blindly enabling all features, it now enables none, unless the particular example requires it. Examples also have much more elaborate device selection, based on the extensions/features needed, and gives priority to certain device types over others.

This fixes #1611, both the original issue and the crash in the second post, and fixes #1621.

Changelog:
```markdown
- Examples now enable only the features they need instead of all of them.
- Examples have much smarter device selection logic. In the triangle example this is supplied with comments.
```

I noticed that all the examples copy the instance and device startup code pretty much verbatim. For maintainability, I think it would be good if this common code was moved into a `common.rs` module, which the examples can then import. This could be something for a future PR.