### PR TITLE
Handle Result from Vulkan calls in device_memory.rs

### DIFF
--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -747,12 +747,13 @@ impl MappedDeviceMemory {
                 ..Default::default()
             };
 
-            // TODO: check result?
-            fns.v1_0.invalidate_mapped_memory_ranges(
+            // TODO: return result instead?
+            check_errors(fns.v1_0.invalidate_mapped_memory_ranges(
                 self.memory.device().internal_object(),
                 1,
                 &range,
-            );
+            ))
+            .unwrap();
         }
 
         CpuAccess {
@@ -984,13 +985,13 @@ impl<'a, T: ?Sized + 'a> Drop for CpuAccess<'a, T> {
                 ..Default::default()
             };
 
-            // TODO: check result?
             unsafe {
-                fns.v1_0.flush_mapped_memory_ranges(
+                check_errors(fns.v1_0.flush_mapped_memory_ranges(
                     self.mem.as_ref().device().internal_object(),
                     1,
                     &range,
-                );
+                ))
+                .unwrap();
             }
         }
     }


### PR DESCRIPTION
This fixes two compiler warnings about an unused `Result` in `device_memory.rs`. In both cases, I decided to simply `unwrap` the error. One of the cases was in a `drop` implementation, so there was really no way to handle an error there except by unwrapping. The other case is in a normal function which doesn't currently return `Result`, so I unwrapped there too so that no breaking changes would be introduced. This case could be changed in the future if someone wants, there is a TODO message.
