### PR TITLE
  (#1618): Add DisplayNativeAmd enum variant to ColorSpaceEnum

### DIFF
--- a/vulkano/src/swapchain/capabilities.rs
+++ b/vulkano/src/swapchain/capabilities.rs
@@ -625,7 +625,7 @@ pub enum ColorSpace {
     AdobeRgbLinear = ash::vk::ColorSpaceKHR::ADOBERGB_LINEAR_EXT.as_raw(),
     AdobeRgbNonLinear = ash::vk::ColorSpaceKHR::ADOBERGB_NONLINEAR_EXT.as_raw(),
     PassThrough = ash::vk::ColorSpaceKHR::PASS_THROUGH_EXT.as_raw(),
-    DisplayNativeAmd = ash::vk::ColorSpaceKHR::DISPLAY_NATIVE_AMD.as_raw()
+    DisplayNative = ash::vk::ColorSpaceKHR::DISPLAY_NATIVE_AMD.as_raw(),
 }
 
 impl From<ColorSpace> for ash::vk::ColorSpaceKHR {
@@ -653,7 +653,7 @@ impl From<ash::vk::ColorSpaceKHR> for ColorSpace {
             ash::vk::ColorSpaceKHR::ADOBERGB_LINEAR_EXT => ColorSpace::AdobeRgbLinear,
             ash::vk::ColorSpaceKHR::ADOBERGB_NONLINEAR_EXT => ColorSpace::AdobeRgbNonLinear,
             ash::vk::ColorSpaceKHR::PASS_THROUGH_EXT => ColorSpace::PassThrough,
-            ash::vk::ColorSpaceKHR::DISPLAY_NATIVE_AMD => ColorSpace::DisplayNativeAmd,
+            ash::vk::ColorSpaceKHR::DISPLAY_NATIVE_AMD => ColorSpace::DisplayNative,
             _ => panic!("Wrong value for color space enum"),
         }
     }

--- a/vulkano/src/swapchain/capabilities.rs
+++ b/vulkano/src/swapchain/capabilities.rs
@@ -625,6 +625,7 @@ pub enum ColorSpace {
     AdobeRgbLinear = ash::vk::ColorSpaceKHR::ADOBERGB_LINEAR_EXT.as_raw(),
     AdobeRgbNonLinear = ash::vk::ColorSpaceKHR::ADOBERGB_NONLINEAR_EXT.as_raw(),
     PassThrough = ash::vk::ColorSpaceKHR::PASS_THROUGH_EXT.as_raw(),
+    DisplayNativeAmd = ash::vk::ColorSpaceKHR::DISPLAY_NATIVE_AMD.as_raw()
 }
 
 impl From<ColorSpace> for ash::vk::ColorSpaceKHR {
@@ -652,6 +653,7 @@ impl From<ash::vk::ColorSpaceKHR> for ColorSpace {
             ash::vk::ColorSpaceKHR::ADOBERGB_LINEAR_EXT => ColorSpace::AdobeRgbLinear,
             ash::vk::ColorSpaceKHR::ADOBERGB_NONLINEAR_EXT => ColorSpace::AdobeRgbNonLinear,
             ash::vk::ColorSpaceKHR::PASS_THROUGH_EXT => ColorSpace::PassThrough,
+            ash::vk::ColorSpaceKHR::DISPLAY_NATIVE_AMD => ColorSpace::DisplayNativeAmd,
             _ => panic!("Wrong value for color space enum"),
         }
     }


### PR DESCRIPTION
Fixes #1618 where GPUs that support VK_COLOR_SPACE_DISPLAY_NATIVE_AMD ( one specific example being the AMD Radeon Rx 580 Series ) in its surface format color spaces would cause Vulkano to Panic when checking the surface capabilities of the device

Fixed by adding a new enum variant to the ColorSpace enum that covers that color space. Ash already provides a value in their ColorSpaceKHR struct for this color space.

