### PR TITLE
Rename `Features::superset_of` to `is_superset_of`, add `is_superset_of` to extensions

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -36,7 +36,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             // The Vulkan specs guarantee that a compliant implementation must provide at least one queue
             // that supports compute operations.

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -63,7 +63,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -117,7 +117,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             Some(
                 p.queue_families()

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -64,7 +64,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -38,7 +38,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_compute())

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -51,7 +51,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_compute())

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -54,7 +54,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/immutable-buffer-initialization.rs
+++ b/examples/src/bin/immutable-buffer-initialization.rs
@@ -33,7 +33,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_compute())

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -79,7 +79,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -76,7 +76,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -98,7 +98,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics())

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -75,9 +75,7 @@ fn main() {
             ..DeviceExtensions::none()
         };
         let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-            .filter(|&p| {
-                p.supported_extensions().intersection(&device_extensions) == device_extensions
-            })
+            .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
             .filter_map(|p| {
                 p.queue_families()
                     .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -65,10 +65,10 @@ fn main() {
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
         .filter(|&p| {
-            p.supported_extensions().intersection(&device_extensions) == device_extensions
+            p.supported_extensions().is_superset_of(&device_extensions)
         })
         .filter(|&p| {
-            p.supported_features().superset_of(&features)
+            p.supported_features().is_superset_of(&features)
         })
         .filter(|&p| {
             // This example renders to two layers of the framebuffer using the multiview

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -49,7 +49,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/pipeline-caching.rs
+++ b/examples/src/bin/pipeline-caching.rs
@@ -49,7 +49,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_compute())

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -29,7 +29,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_compute())

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -76,7 +76,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -30,7 +30,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_compute())

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -29,7 +29,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_compute())

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -56,7 +56,7 @@ fn main() {
         ..DeviceExtensions::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -155,8 +155,8 @@ fn main() {
         ..Features::none()
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
-        .filter(|&p| p.supported_extensions().intersection(&device_extensions) == device_extensions)
-        .filter(|&p| p.supported_features().superset_of(&features))
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
+        .filter(|&p| p.supported_features().is_superset_of(&features))
         .filter_map(|p| {
             p.queue_families()
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -82,7 +82,7 @@ fn main() {
             // Some devices may not support the extensions or features that your application, or
             // report properties and limits that are not sufficient for your application. These
             // should be filtered out here.
-            p.supported_extensions().intersection(&device_extensions) == device_extensions
+            p.supported_extensions().is_superset_of(&device_extensions)
         })
         .filter_map(|p| {
             // For each physical device, we try to find a suitable queue family that will execute

--- a/vulkano/src/device/features.rs
+++ b/vulkano/src/device/features.rs
@@ -43,11 +43,11 @@ macro_rules! features {
         ///     .. Features::none()
         /// };
         ///
-        /// if !physical_device.supported_features().superset_of(&minimal_features) {
+        /// if !physical_device.supported_features().is_superset_of(&minimal_features) {
         ///     panic!("The physical device is not good enough for this application.");
         /// }
         ///
-        /// assert!(optimal_features.superset_of(&minimal_features));
+        /// assert!(optimal_features.is_superset_of(&minimal_features));
         /// let features_to_request = optimal_features.intersection(physical_device.supported_features());
         /// ```
         ///
@@ -130,7 +130,7 @@ macro_rules! features {
             ///
             /// That is, for each feature of the parameter that is true, the corresponding value
             /// in self is true as well.
-            pub fn superset_of(&self, other: &Features) -> bool {
+            pub fn is_superset_of(&self, other: &Features) -> bool {
                 $((self.$member == true || other.$member == false))&&+
             }
 

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -985,7 +985,7 @@ mod tests {
 
         let features = Features::all();
         // In the unlikely situation where the device supports everything, we ignore the test.
-        if physical.supported_features().superset_of(&features) {
+        if physical.supported_features().is_superset_of(&features) {
             return;
         }
 

--- a/vulkano/src/extensions.rs
+++ b/vulkano/src/extensions.rs
@@ -50,6 +50,14 @@ macro_rules! extensions {
                 }
             }
 
+            /// Returns true if `self` is a superset of the parameter.
+            ///
+            /// That is, for each extension of the parameter that is true, the corresponding value
+            /// in self is true as well.
+            pub fn is_superset_of(&self, other: &$sname) -> bool {
+                $((self.$member == true || other.$member == false))&&+
+            }
+
             /// Returns the union of this list and another list.
             #[inline]
             pub const fn union(&self, other: &$sname) -> $sname {

--- a/vulkano/src/tests.rs
+++ b/vulkano/src/tests.rs
@@ -57,7 +57,7 @@ macro_rules! gfx_dev_and_queue {
         };
 
         // If the physical device doesn't support the requested features, just return.
-        if !physical.supported_features().superset_of(&features) {
+        if !physical.supported_features().is_superset_of(&features) {
             return;
         }
 


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** `Features::superset_of` is renamed to `is_superset_of`.
```
```markdown
- Added `is_superset_of` method to `DeviceExtensions` and `InstanceExtensions`.
```

This fixes a small inconsistency in the naming, and adds a new method to extensions.