### PR TITLE
Use dedicated allocation when allocation size is large enough

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -162,7 +162,9 @@ impl UnsafeBuffer {
                     ..Default::default()
                 };
 
-                let mut output2 = if device.enabled_extensions().khr_dedicated_allocation {
+                let mut output2 = if device.api_version() >= Version::V1_1
+                    || device.enabled_extensions().khr_dedicated_allocation
+                {
                     Some(ash::vk::MemoryDedicatedRequirementsKHR::default())
                 } else {
                     None


### PR DESCRIPTION
1. [X] Describe in common words what is the purpose of this change, related Github Issues, and highlight important implementation aspects.  
When allocating a buffer that is extremely large (e.g. 4.5GB), Vulkano's pool allocator would round up that to the next power of two (which is 8GB) and it failed to allocate on my GPU (which has ~7.9GB of memory available for allocation).  
This PR disables memory pool allocations for memory allocation above 256MB, as they would likely lead to allocating unnecessary space as well as delaying returning freed memory to the OS. Dedicated allocations are requested when supported, which might improve efficiency but should have no drawbacks otherwise.  
While on that, also fix a few condition checks since KHR_dedicated_allocation has been promoted to Vulkan 1.1.

2. [X] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   files(`CHANGELOG_VULKANO.md` and `CHANGELOG_VK_SYS.md`)
   by maintainers right after the Pull Request merge.

    * Entries for Vulkano changelog:
        - `Large allocations now use dedicated allocations which improves memory efficiency.`

3. [X] Run `cargo fmt` on the changes.

4. `N/A` Make sure that the changes are covered by unit-tests.  
Note: The changes were tested with an application I am developing.

5. `N/A` Update documentation to reflect any user-facing changes - in this repository.
