### PR TITLE
Derive Clone for LayerProperties

### DIFF
--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -77,6 +77,7 @@ where
 }
 
 /// Properties of a layer.
+#[derive(Clone)]
 pub struct LayerProperties {
     props: ash::vk::LayerProperties,
 }


### PR DESCRIPTION
Make LayerProperties as clonable, so that application structures holding on to `Vec<LayerProperties>` field can return them as owned vector to the caller instead of slice `&[LayerProperties]`

