### PR TITLE
Add `PipelineBindPoint`

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -55,6 +55,7 @@ use crate::pipeline::layout::PipelineLayout;
 use crate::pipeline::vertex::VertexSource;
 use crate::pipeline::ComputePipelineAbstract;
 use crate::pipeline::GraphicsPipelineAbstract;
+use crate::pipeline::PipelineBindPoint;
 use crate::query::QueryControlFlags;
 use crate::query::QueryPipelineStatisticFlags;
 use crate::query::QueryPool;
@@ -1084,7 +1085,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             descriptor_sets(
                 &mut self.inner,
                 &mut self.state_cacher,
-                false,
+                PipelineBindPoint::Compute,
                 pipeline.layout(),
                 sets,
                 dynamic_offsets,
@@ -1137,7 +1138,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             descriptor_sets(
                 &mut self.inner,
                 &mut self.state_cacher,
-                false,
+                PipelineBindPoint::Compute,
                 pipeline.layout(),
                 sets,
                 dynamic_offsets,
@@ -1192,7 +1193,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             descriptor_sets(
                 &mut self.inner,
                 &mut self.state_cacher,
-                true,
+                PipelineBindPoint::Graphics,
                 pipeline.layout(),
                 sets,
                 dynamic_offsets,
@@ -1292,7 +1293,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             descriptor_sets(
                 &mut self.inner,
                 &mut self.state_cacher,
-                true,
+                PipelineBindPoint::Graphics,
                 pipeline.layout(),
                 sets,
                 dynamic_offsets,
@@ -1370,7 +1371,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             descriptor_sets(
                 &mut self.inner,
                 &mut self.state_cacher,
-                true,
+                PipelineBindPoint::Graphics,
                 pipeline.layout(),
                 sets,
                 dynamic_offsets,
@@ -1483,7 +1484,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             descriptor_sets(
                 &mut self.inner,
                 &mut self.state_cacher,
-                true,
+                PipelineBindPoint::Graphics,
                 pipeline.layout(),
                 sets,
                 dynamic_offsets,
@@ -2184,7 +2185,7 @@ unsafe fn vertex_buffers(
 unsafe fn descriptor_sets<S, Do, Doi>(
     destination: &mut SyncCommandBufferBuilder,
     state_cacher: &mut StateCacher,
-    gfx: bool,
+    pipeline_bind_point: PipelineBindPoint,
     pipeline_layout: &Arc<PipelineLayout>,
     sets: S,
     dynamic_offsets: Do,
@@ -2248,7 +2249,7 @@ where
     );
 
     let first_binding = {
-        let mut compare = state_cacher.bind_descriptor_sets(gfx);
+        let mut compare = state_cacher.bind_descriptor_sets(pipeline_bind_point);
         for set in sets.iter() {
             compare.add(set, &dynamic_offsets);
         }
@@ -2265,7 +2266,7 @@ where
         sets_binder.add(set);
     }
     sets_binder.submit(
-        gfx,
+        pipeline_bind_point,
         pipeline_layout.clone(),
         first_binding,
         dynamic_offsets.into_iter(),

--- a/vulkano/src/command_buffer/state_cacher.rs
+++ b/vulkano/src/command_buffer/state_cacher.rs
@@ -13,6 +13,7 @@ use crate::descriptor_set::DescriptorSet;
 use crate::pipeline::input_assembly::IndexType;
 use crate::pipeline::ComputePipelineAbstract;
 use crate::pipeline::GraphicsPipelineAbstract;
+use crate::pipeline::PipelineBindPoint;
 use crate::VulkanObject;
 use smallvec::SmallVec;
 use std::ops::Range;
@@ -124,7 +125,10 @@ impl StateCacher {
     /// This process also updates the state cacher. The state cacher assumes that the state
     /// changes are going to be performed after the `compare` function returns.
     #[inline]
-    pub fn bind_descriptor_sets(&mut self, graphics: bool) -> StateCacherDescriptorSets {
+    pub fn bind_descriptor_sets(
+        &mut self,
+        pipeline_bind_point: PipelineBindPoint,
+    ) -> StateCacherDescriptorSets {
         if self.poisoned_descriptor_sets {
             self.compute_descriptor_sets = SmallVec::new();
             self.graphics_descriptor_sets = SmallVec::new();
@@ -134,10 +138,9 @@ impl StateCacher {
 
         StateCacherDescriptorSets {
             poisoned: &mut self.poisoned_descriptor_sets,
-            state: if graphics {
-                &mut self.graphics_descriptor_sets
-            } else {
-                &mut self.compute_descriptor_sets
+            state: match pipeline_bind_point {
+                PipelineBindPoint::Compute => &mut self.compute_descriptor_sets,
+                PipelineBindPoint::Graphics => &mut self.graphics_descriptor_sets,
             },
             offset: 0,
             found_diff: None,

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -39,6 +39,7 @@ use crate::pipeline::viewport::Scissor;
 use crate::pipeline::viewport::Viewport;
 use crate::pipeline::ComputePipelineAbstract;
 use crate::pipeline::GraphicsPipelineAbstract;
+use crate::pipeline::PipelineBindPoint;
 use crate::query::QueryControlFlags;
 use crate::query::QueryPool;
 use crate::query::QueryResultElement;
@@ -2627,7 +2628,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
     #[inline]
     pub unsafe fn submit<I>(
         self,
-        graphics: bool,
+        pipeline_bind_point: PipelineBindPoint,
         pipeline_layout: Arc<PipelineLayout>,
         first_binding: u32,
         dynamic_offsets: I,
@@ -2641,7 +2642,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
 
         struct Cmd<I> {
             inner: SmallVec<[Box<dyn DescriptorSet + Send + Sync>; 12]>,
-            graphics: bool,
+            pipeline_bind_point: PipelineBindPoint,
             pipeline_layout: Arc<PipelineLayout>,
             first_binding: u32,
             dynamic_offsets: Option<I>,
@@ -2657,7 +2658,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
 
             unsafe fn send(&mut self, out: &mut UnsafeCommandBufferBuilder) {
                 out.bind_descriptor_sets(
-                    self.graphics,
+                    self.pipeline_bind_point,
                     &self.pipeline_layout,
                     self.first_binding,
                     self.inner.iter().map(|s| s.inner()),
@@ -2841,7 +2842,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
         self.builder.append_command(
             Cmd {
                 inner: self.inner,
-                graphics,
+                pipeline_bind_point,
                 pipeline_layout,
                 first_binding,
                 dynamic_offsets: Some(dynamic_offsets),

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -35,6 +35,7 @@ use crate::pipeline::viewport::Scissor;
 use crate::pipeline::viewport::Viewport;
 use crate::pipeline::ComputePipelineAbstract;
 use crate::pipeline::GraphicsPipelineAbstract;
+use crate::pipeline::PipelineBindPoint;
 use crate::query::QueriesRange;
 use crate::query::Query;
 use crate::query::QueryControlFlags;
@@ -313,7 +314,7 @@ impl UnsafeCommandBufferBuilder {
     #[inline]
     pub unsafe fn bind_descriptor_sets<'s, S, I>(
         &mut self,
-        graphics: bool,
+        pipeline_bind_point: PipelineBindPoint,
         pipeline_layout: &PipelineLayout,
         first_binding: u32,
         sets: S,
@@ -336,15 +337,9 @@ impl UnsafeCommandBufferBuilder {
             first_binding + num_bindings <= pipeline_layout.descriptor_set_layouts().len() as u32
         );
 
-        let bind_point = if graphics {
-            ash::vk::PipelineBindPoint::GRAPHICS
-        } else {
-            ash::vk::PipelineBindPoint::COMPUTE
-        };
-
         fns.v1_0.cmd_bind_descriptor_sets(
             cmd,
-            bind_point,
+            pipeline_bind_point.into(),
             pipeline_layout.internal_object(),
             first_binding,
             num_bindings,

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -97,3 +97,17 @@ pub mod raster;
 pub mod shader;
 pub mod vertex;
 pub mod viewport;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum PipelineBindPoint {
+    Compute = ash::vk::PipelineBindPoint::COMPUTE.as_raw(),
+    Graphics = ash::vk::PipelineBindPoint::GRAPHICS.as_raw(),
+}
+
+impl From<PipelineBindPoint> for ash::vk::PipelineBindPoint {
+    #[inline]
+    fn from(val: PipelineBindPoint) -> Self {
+        Self::from_raw(val as i32)
+    }
+}


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** The boolean `graphics` parameter on the `bind_descriptor_sets` method of `SyncCommandBufferBuilder`, `UnsafeCommandBufferBuilder` and `StateCacher` has been replaced with a new enum `PipelineBindPoint`.
```

This change aligns better with the Vulkan spec, where there are more than just two possible bind points. Vulkano still supports only compute and graphics pipelines, but this change makes it easier to extend this in the future. It also makes the code clearer; `true` for graphics and `false` for compute wasn't very obvious for anyone looking at the code.