### PR TITLE
Fix storage buffer detection to work for all SPIR-V versions

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -125,7 +125,7 @@ fn main() {
         CpuAccessibleBuffer::from_iter(
             device.clone(),
             BufferUsage {
-                uniform_buffer: true,
+                storage_buffer: true,
                 ..BufferUsage::none()
             },
             false,

--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -387,7 +387,7 @@ fn descriptor_infos(
 
                     // false -> VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
                     // true -> VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
-                    let storage = pointer_storage == StorageClass::StorageBuffer;
+                    let storage = decoration_buffer_block || decoration_block && pointer_storage == StorageClass::StorageBuffer;
 
                     // Determine whether all members have a NonWritable decoration.
                     let nonwritable = (0..member_types.len() as u32).all(|i| {


### PR DESCRIPTION
Changelog:
```markdown
- Fixed detection of storage buffers in SPIR-V so that it works for all SPIR-V versions.
```

Vulkano-shaders was misdetecting storage buffers in SPIR-V 1.0 shaders, which was causing validation errors. This PR fixes that so that it works for all versions.