### PR TITLE
Add 8bit uniform and storage support

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -543,7 +543,9 @@ fn capability_requirement(cap: &Capability) -> DeviceRequirement {
         Capability::AtomicStorageOps => todo!(),
         Capability::SampleMaskPostDepthCoverage => todo!(),
         Capability::StorageBuffer8BitAccess => todo!(),
-        Capability::UniformAndStorageBuffer8BitAccess => todo!(),
+        Capability::UniformAndStorageBuffer8BitAccess => {
+            DeviceRequirement::Extensions(&["khr_8bit_storage"])
+        }
         Capability::DenormPreserve => todo!(),
         Capability::DenormFlushToZero => todo!(),
         Capability::SignedZeroInfNanPreserve => todo!(),


### PR DESCRIPTION
This enables the use of the `UniformAndStorageBuffer8BitAccess` capability.

* Entries for Vulkano changelog:
  - `Add support for 8bit uniform storage.`