### PR TITLE
Add `VertexInput` type

### DIFF
--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -60,7 +60,7 @@ use std::u32;
 /// Prototype for a `GraphicsPipeline`.
 // TODO: we can optimize this by filling directly the raw vk structs
 pub struct GraphicsPipelineBuilder<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss> {
-    vertex_input: Vdef,
+    vertex_definition: Vdef,
     vertex_shader: Option<(GraphicsEntryPoint<'vs>, Vss)>,
     input_assembly: ash::vk::PipelineInputAssemblyStateCreateInfo,
     // Note: the `input_assembly_topology` member is temporary in order to not lose information
@@ -103,7 +103,7 @@ impl
     /// Builds a new empty builder.
     pub(super) fn new() -> Self {
         GraphicsPipelineBuilder {
-            vertex_input: BufferlessDefinition,
+            vertex_definition: BufferlessDefinition,
             vertex_shader: None,
             input_assembly: ash::vk::PipelineInputAssemblyStateCreateInfo {
                 topology: PrimitiveTopology::TriangleList.into(),
@@ -472,15 +472,14 @@ where
             stages
         };
 
-        // Vertex bindings.
-        let (binding_descriptions, binding_divisor_descriptions, attribute_descriptions) = {
-            let vertex_input = self
-                .vertex_input
-                .definition(self.vertex_shader.as_ref().unwrap().0.input())?;
+        // Vertex input.
+        let vertex_input = self
+            .vertex_definition
+            .definition(self.vertex_shader.as_ref().unwrap().0.input())?;
 
+        let (binding_descriptions, binding_divisor_descriptions) = {
             let mut binding_descriptions = SmallVec::<[_; 8]>::new();
             let mut binding_divisor_descriptions = SmallVec::<[_; 8]>::new();
-            let mut attribute_descriptions = SmallVec::<[_; 8]>::new();
 
             for (binding, binding_desc) in vertex_input.bindings() {
                 if binding_desc.stride
@@ -572,6 +571,12 @@ where
                 );
             }
 
+            (binding_descriptions, binding_divisor_descriptions)
+        };
+
+        let attribute_descriptions = {
+            let mut attribute_descriptions = SmallVec::<[_; 8]>::new();
+
             for (location, attribute_desc) in vertex_input.attributes() {
                 // TODO: check attribute format support
 
@@ -621,11 +626,7 @@ where
                 );
             }
 
-            (
-                binding_descriptions,
-                binding_divisor_descriptions,
-                attribute_descriptions,
-            )
+            attribute_descriptions
         };
 
         let vertex_input_divisor_state = if !binding_divisor_descriptions.is_empty() {
@@ -1190,10 +1191,9 @@ where
                 pipeline,
             },
             layout: pipeline_layout,
-
-            vertex_definition: self.vertex_input,
-
             subpass: self.subpass.take().unwrap(),
+            vertex_definition: self.vertex_definition,
+            vertex_input,
 
             dynamic_line_width: self.raster.line_width.is_none(),
             dynamic_viewport: self.viewport.as_ref().unwrap().dynamic_viewports(),
@@ -1221,10 +1221,10 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
     #[inline]
     pub fn vertex_input<T>(
         self,
-        vertex_input: T,
+        vertex_definition: T,
     ) -> GraphicsPipelineBuilder<'vs, 'tcs, 'tes, 'gs, 'fs, T, Vss, Tcss, Tess, Gss, Fss> {
         GraphicsPipelineBuilder {
-            vertex_input,
+            vertex_definition,
             vertex_shader: self.vertex_shader,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
@@ -1276,7 +1276,7 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         Vss2: SpecializationConstants,
     {
         GraphicsPipelineBuilder {
-            vertex_input: self.vertex_input,
+            vertex_definition: self.vertex_definition,
             vertex_shader: Some((shader, specialization_constants)),
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
@@ -1428,7 +1428,7 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         Tess2: SpecializationConstants,
     {
         GraphicsPipelineBuilder {
-            vertex_input: self.vertex_input,
+            vertex_definition: self.vertex_definition,
             vertex_shader: self.vertex_shader,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
@@ -1473,7 +1473,7 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         Gss2: SpecializationConstants,
     {
         GraphicsPipelineBuilder {
-            vertex_input: self.vertex_input,
+            vertex_definition: self.vertex_definition,
             vertex_shader: self.vertex_shader,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
@@ -1755,7 +1755,7 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         Fss2: SpecializationConstants,
     {
         GraphicsPipelineBuilder {
-            vertex_input: self.vertex_input,
+            vertex_definition: self.vertex_definition,
             vertex_shader: self.vertex_shader,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
@@ -1870,7 +1870,7 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
     #[inline]
     pub fn render_pass(self, subpass: Subpass) -> Self {
         GraphicsPipelineBuilder {
-            vertex_input: self.vertex_input,
+            vertex_definition: self.vertex_definition,
             vertex_shader: self.vertex_shader,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
@@ -1911,7 +1911,7 @@ where
 {
     fn clone(&self) -> Self {
         GraphicsPipelineBuilder {
-            vertex_input: self.vertex_input.clone(),
+            vertex_definition: self.vertex_definition.clone(),
             vertex_shader: self.vertex_shader.clone(),
             input_assembly: unsafe { ptr::read(&self.input_assembly) },
             input_assembly_topology: self.input_assembly_topology,

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -17,7 +17,7 @@ use crate::pipeline::shader::ShaderInterface;
 use crate::pipeline::vertex::BufferlessDefinition;
 use crate::pipeline::vertex::IncompatibleVertexDefinitionError;
 use crate::pipeline::vertex::VertexDefinition;
-use crate::pipeline::vertex::VertexInputBinding;
+use crate::pipeline::vertex::VertexInput;
 use crate::pipeline::vertex::VertexSource;
 use crate::render_pass::RenderPass;
 use crate::render_pass::Subpass;
@@ -420,7 +420,7 @@ where
     fn definition(
         &self,
         interface: &ShaderInterface,
-    ) -> Result<Vec<VertexInputBinding>, IncompatibleVertexDefinitionError> {
+    ) -> Result<VertexInput, IncompatibleVertexDefinitionError> {
         self.vertex_definition.definition(interface)
     }
 }

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -43,10 +43,9 @@ mod creation_error;
 pub struct GraphicsPipeline<VertexDefinition> {
     inner: Inner,
     layout: Arc<PipelineLayout>,
-
     subpass: Subpass,
-
     vertex_definition: VertexDefinition,
+    vertex_input: VertexInput,
 
     dynamic_line_width: bool,
     dynamic_viewport: bool,
@@ -211,6 +210,9 @@ pub unsafe trait GraphicsPipelineAbstract:
     /// Returns the subpass this graphics pipeline is rendering to.
     fn subpass(&self) -> &Subpass;
 
+    /// Returns the vertex input description of the graphics pipeline.
+    fn vertex_input(&self) -> &VertexInput;
+
     /// Returns true if the line width used by this pipeline is dynamic.
     fn has_dynamic_line_width(&self) -> bool;
 
@@ -254,6 +256,11 @@ where
     #[inline]
     fn subpass(&self) -> &Subpass {
         &self.subpass
+    }
+
+    #[inline]
+    fn vertex_input(&self) -> &VertexInput {
+        &self.vertex_input
     }
 
     #[inline]
@@ -315,6 +322,11 @@ where
     #[inline]
     fn subpass(&self) -> &Subpass {
         (**self).subpass()
+    }
+
+    #[inline]
+    fn vertex_input(&self) -> &VertexInput {
+        (**self).vertex_input()
     }
 
     #[inline]

--- a/vulkano/src/pipeline/vertex/bufferless.rs
+++ b/vulkano/src/pipeline/vertex/bufferless.rs
@@ -11,7 +11,7 @@ use crate::buffer::BufferAccess;
 use crate::pipeline::shader::ShaderInterface;
 use crate::pipeline::vertex::IncompatibleVertexDefinitionError;
 use crate::pipeline::vertex::VertexDefinition;
-use crate::pipeline::vertex::VertexInputBinding;
+use crate::pipeline::vertex::VertexInput;
 use crate::pipeline::vertex::VertexSource;
 
 /// Implementation of `VertexDefinition` for drawing with no buffers at all.
@@ -61,7 +61,7 @@ unsafe impl VertexDefinition for BufferlessDefinition {
     fn definition(
         &self,
         _: &ShaderInterface,
-    ) -> Result<Vec<VertexInputBinding>, IncompatibleVertexDefinitionError> {
-        Ok(vec![])
+    ) -> Result<VertexInput, IncompatibleVertexDefinitionError> {
+        Ok(VertexInput::empty())
     }
 }

--- a/vulkano/src/pipeline/vertex/mod.rs
+++ b/vulkano/src/pipeline/vertex/mod.rs
@@ -73,8 +73,10 @@ pub use self::impl_vertex::VertexMember;
 pub use self::vertex::Vertex;
 pub use self::vertex::VertexMemberInfo;
 pub use self::vertex::VertexMemberTy;
+use crate::buffer::BufferAccess;
 use crate::format::Format;
 use fnv::FnvHashMap;
+use std::convert::TryInto;
 
 mod bufferless;
 mod buffers;
@@ -91,6 +93,12 @@ pub struct VertexInput {
 
 impl VertexInput {
     /// Constructs a new `VertexInput` from the given bindings and attributes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any element of `attributes` refers to a binding number that is not provided in
+    /// `bindings`.
+    #[inline]
     pub fn new(
         bindings: impl IntoIterator<Item = (u32, VertexInputBinding)>,
         attributes: impl IntoIterator<Item = (u32, VertexInputAttribute)>,
@@ -127,6 +135,52 @@ impl VertexInput {
     #[inline]
     pub fn attributes(&self) -> impl ExactSizeIterator<Item = (u32, &VertexInputAttribute)> {
         self.attributes.iter().map(|(&key, val)| (key, val))
+    }
+
+    /// Given an iterator of vertex buffers and their binding numbers, returns the maximum number
+    /// of vertices and instances that can be drawn with them.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding number of a provided vertex buffer does not exist in `self`.
+    pub fn max_vertices_instances<'a>(
+        &self,
+        buffers: impl IntoIterator<Item = (u32, &'a dyn BufferAccess)>,
+    ) -> (u32, u32) {
+        let buffers = buffers.into_iter();
+        let mut max_vertices = u32::MAX;
+        let mut max_instances = u32::MAX;
+
+        for (binding, buffer) in buffers {
+            let binding_desc = &self.bindings[&binding];
+            let mut num_elements = (buffer.size() / binding_desc.stride as usize)
+                .try_into()
+                .unwrap_or(u32::MAX);
+
+            match binding_desc.input_rate {
+                VertexInputRate::Vertex => {
+                    max_vertices = max_vertices.min(num_elements);
+                }
+                VertexInputRate::Instance { divisor } => {
+                    if divisor == 0 {
+                        // A divisor of 0 means the same instance data is used for all instances,
+                        // so we can draw any number of instances from a single element.
+                        // The buffer must contain at least one element though.
+                        if num_elements != 0 {
+                            num_elements = u32::MAX;
+                        }
+                    } else {
+                        // If divisor is 2, we use only half the amount of data from the source buffer,
+                        // so the number of instances that can be drawn is twice as large.
+                        num_elements = num_elements.saturating_mul(divisor);
+                    }
+
+                    max_instances = max_instances.min(num_elements);
+                }
+            };
+        }
+
+        (max_vertices, max_instances)
     }
 }
 

--- a/vulkano/src/pipeline/vertex/mod.rs
+++ b/vulkano/src/pipeline/vertex/mod.rs
@@ -66,20 +66,124 @@
 pub use self::bufferless::BufferlessDefinition;
 pub use self::bufferless::BufferlessVertices;
 pub use self::buffers::BuffersDefinition;
-pub use self::definition::AttributeInfo;
 pub use self::definition::IncompatibleVertexDefinitionError;
 pub use self::definition::VertexDefinition;
-pub use self::definition::VertexInputAttribute;
-pub use self::definition::VertexInputBinding;
-pub use self::definition::VertexInputRate;
 pub use self::definition::VertexSource;
 pub use self::impl_vertex::VertexMember;
 pub use self::vertex::Vertex;
 pub use self::vertex::VertexMemberInfo;
 pub use self::vertex::VertexMemberTy;
+use crate::format::Format;
+use fnv::FnvHashMap;
 
 mod bufferless;
 mod buffers;
 mod definition;
 mod impl_vertex;
 mod vertex;
+
+/// A description of the vertex input of a graphics pipeline.
+#[derive(Clone, Debug, Default)]
+pub struct VertexInput {
+    bindings: FnvHashMap<u32, VertexInputBinding>,
+    attributes: FnvHashMap<u32, VertexInputAttribute>,
+}
+
+impl VertexInput {
+    /// Constructs a new `VertexInput` from the given bindings and attributes.
+    pub fn new(
+        bindings: impl IntoIterator<Item = (u32, VertexInputBinding)>,
+        attributes: impl IntoIterator<Item = (u32, VertexInputAttribute)>,
+    ) -> VertexInput {
+        let bindings: FnvHashMap<_, _> = bindings.into_iter().collect();
+        let attributes: FnvHashMap<_, _> = attributes.into_iter().collect();
+
+        assert!(attributes
+            .iter()
+            .all(|(_, attr)| bindings.contains_key(&attr.binding)));
+
+        VertexInput {
+            bindings,
+            attributes,
+        }
+    }
+
+    /// Constructs a new empty `VertexInput`.
+    #[inline]
+    pub fn empty() -> VertexInput {
+        VertexInput {
+            bindings: Default::default(),
+            attributes: Default::default(),
+        }
+    }
+
+    /// Returns an iterator of the binding numbers and their descriptions.
+    #[inline]
+    pub fn bindings(&self) -> impl ExactSizeIterator<Item = (u32, &VertexInputBinding)> {
+        self.bindings.iter().map(|(&key, val)| (key, val))
+    }
+
+    /// Returns an iterator of the attribute numbers and their descriptions.
+    #[inline]
+    pub fn attributes(&self) -> impl ExactSizeIterator<Item = (u32, &VertexInputAttribute)> {
+        self.attributes.iter().map(|(&key, val)| (key, val))
+    }
+}
+
+/// Describes a single vertex buffer binding in a graphics pipeline.
+#[derive(Clone, Debug)]
+pub struct VertexInputBinding {
+    /// The size of each element in the vertex buffer.
+    pub stride: u32,
+    /// How often the vertex input should advance to the next element.
+    pub input_rate: VertexInputRate,
+}
+
+/// Describes how each vertex shader input attribute should be read from a vertex buffer.
+///
+/// An attribute can contain a maximum of four data elements, described by a particular `Format`.
+/// For shader inputs that are larger than this, such as matrices or arrays, multiple separate
+/// attributes should be used, with increasing offsets.
+///
+/// For example, to pass a `mat4` to the shader using sixteen `f32` as input, you would include four
+/// attributes with `Format::R32G32B32A32Sfloat`, using the offset of the matrix from the start of
+/// the vertex buffer element, plus 0, 16, 32, 48 respectively.
+#[derive(Clone, Copy, Debug)]
+pub struct VertexInputAttribute {
+    /// The vertex buffer binding number that this attribute should take its data from.
+    pub binding: u32,
+    /// The size and type of the vertex data.
+    pub format: Format,
+    /// Number of bytes between the start of a vertex buffer element and the location of attribute.
+    pub offset: u32,
+}
+
+/// How the vertex source should be unrolled.
+#[derive(Clone, Copy, Debug)]
+pub enum VertexInputRate {
+    /// Each element of the source corresponds to a vertex.
+    Vertex,
+
+    /// Each element of the source corresponds to an instance.
+    ///
+    /// `divisor` indicates how many consecutive instances will use the same instance buffer data.
+    /// This value must be 1, unless the
+    /// [`vertex_attribute_instance_rate_divisor`](crate::device::Features::vertex_attribute_instance_rate_divisor)
+    /// feature has been enabled on the device.
+    ///
+    /// `divisor` can be 0 if the
+    /// [`vertex_attribute_instance_rate_zero_divisor`](crate::device::Features::vertex_attribute_instance_rate_zero_divisor)
+    /// feature is also enabled. This means that every vertex will use the same vertex and instance
+    /// data.
+    Instance { divisor: u32 },
+}
+
+impl From<VertexInputRate> for ash::vk::VertexInputRate {
+    #[inline]
+    fn from(val: VertexInputRate) -> Self {
+        match val {
+            VertexInputRate::Vertex => ash::vk::VertexInputRate::VERTEX,
+            VertexInputRate::Instance { .. } => ash::vk::VertexInputRate::INSTANCE,
+        }
+    }
+}


### PR DESCRIPTION
Changelog:
Replace the line about `VertexDefinition` with:
```markdown
- **Breaking** The `VertexDefinition` trait no longer has `AttribsIter` and `BuffersIter` as associated types. It instead returns a `VertexInput`.
```
Add:
```markdown
- Added `VertexInput` type, which contains the binding and attribute descriptions.
- Added a `vertex_input` method to `GraphicsPipelineAbstract`, which returns a reference to the vertex input.
```

The main purpose of this change is to allow other code to access the vertex input description. This is needed for the work I'm doing on #1635, since draw commands need to be able to know which of the bound vertex buffers they are going to access. However, it's also a step closer to being able to eliminate the last remaining type parameter of `GraphicsPipeline`, and therefore the `GraphicsPipelineAbstract` trait.