### PR TITLE
Pipeline barriers are placed according to draw/dispatch calls rather than binding calls

### DIFF
--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -614,8 +614,7 @@ impl SyncCommandBufferBuilder {
             .get(&pipeline_bind_point)
             .and_then(|sets| {
                 sets.get(&set_num)
-                    .copied()
-                    .map(|cmd| self.commands[cmd].bound_descriptor_set(set_num))
+                    .map(|cmd| cmd.bound_descriptor_set(set_num))
             })
     }
 
@@ -623,21 +622,24 @@ impl SyncCommandBufferBuilder {
     pub(crate) fn bound_index_buffer(&self) -> Option<&dyn BufferAccess> {
         self.bindings
             .index_buffer
-            .map(|cmd| self.commands[cmd].bound_index_buffer())
+            .as_ref()
+            .map(|cmd| cmd.bound_index_buffer())
     }
 
     /// Returns the compute pipeline currently bound, or `None` if nothing has been bound yet.
     pub(crate) fn bound_pipeline_compute(&self) -> Option<&dyn ComputePipelineAbstract> {
         self.bindings
             .pipeline_compute
-            .map(|cmd| self.commands[cmd].bound_pipeline_compute())
+            .as_ref()
+            .map(|cmd| cmd.bound_pipeline_compute())
     }
 
     /// Returns the graphics pipeline currently bound, or `None` if nothing has been bound yet.
     pub(crate) fn bound_pipeline_graphics(&self) -> Option<&dyn GraphicsPipelineAbstract> {
         self.bindings
             .pipeline_graphics
-            .map(|cmd| self.commands[cmd].bound_pipeline_graphics())
+            .as_ref()
+            .map(|cmd| cmd.bound_pipeline_graphics())
     }
 
     /// Returns the vertex buffer currently bound to a given binding slot number, or `None` if
@@ -646,8 +648,7 @@ impl SyncCommandBufferBuilder {
         self.bindings
             .vertex_buffers
             .get(&binding_num)
-            .copied()
-            .map(|cmd| self.commands[cmd].bound_vertex_buffer(binding_num))
+            .map(|cmd| cmd.bound_vertex_buffer(binding_num))
     }
 }
 
@@ -739,9 +740,9 @@ struct ResourceState {
 /// nothing has been bound yet.
 #[derive(Debug, Default)]
 struct BindingState {
-    descriptor_sets: FnvHashMap<PipelineBindPoint, FnvHashMap<u32, usize>>,
-    index_buffer: Option<usize>,
-    pipeline_compute: Option<usize>,
-    pipeline_graphics: Option<usize>,
-    vertex_buffers: FnvHashMap<u32, usize>,
+    descriptor_sets: FnvHashMap<PipelineBindPoint, FnvHashMap<u32, Arc<dyn Command + Send + Sync>>>,
+    index_buffer: Option<Arc<dyn Command + Send + Sync>>,
+    pipeline_compute: Option<Arc<dyn Command + Send + Sync>>,
+    pipeline_graphics: Option<Arc<dyn Command + Send + Sync>>,
+    vertex_buffers: FnvHashMap<u32, Arc<dyn Command + Send + Sync>>,
 }

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -66,7 +66,7 @@ pub struct SyncCommandBufferBuilder {
     // submitted to the inner builder yet.
     // Each command owns the resources it uses (buffers, images, pipelines, descriptor sets etc.),
     // references to any of these must be indirect in the form of a command index + resource id.
-    commands: Vec<Box<dyn Command + Send + Sync>>,
+    commands: Vec<Arc<dyn Command + Send + Sync>>,
 
     // Prototype for the pipeline barrier that must be submitted before flushing the commands
     // in `commands`.
@@ -210,7 +210,7 @@ impl SyncCommandBufferBuilder {
 
         // Note that we don't submit the command to the inner command buffer yet.
         let (latest_command_id, end) = {
-            self.commands.push(Box::new(command));
+            self.commands.push(Arc::new(command));
             let latest_command_id = self.commands.len() - 1;
             let end = self.latest_render_pass_enter.unwrap_or(latest_command_id);
             (latest_command_id, end)

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -269,7 +269,7 @@ impl SyncCommandBufferBuilder {
                 )),
             )],
         )?;
-        self.bindings.index_buffer = Some(self.commands.len() - 1);
+        self.bindings.index_buffer = self.commands.last().cloned();
 
         Ok(())
     }
@@ -302,7 +302,7 @@ impl SyncCommandBufferBuilder {
         }
 
         self.append_command(Cmd { pipeline }, &[]).unwrap();
-        self.bindings.pipeline_compute = Some(self.commands.len() - 1);
+        self.bindings.pipeline_compute = self.commands.last().cloned();
     }
 
     /// Calls `vkCmdBindPipeline` on the builder with a graphics pipeline.
@@ -333,7 +333,7 @@ impl SyncCommandBufferBuilder {
         }
 
         self.append_command(Cmd { pipeline }, &[]).unwrap();
-        self.bindings.pipeline_graphics = Some(self.commands.len() - 1);
+        self.bindings.pipeline_graphics = self.commands.last().cloned();
     }
 
     /// Starts the process of binding vertex buffers. Returns an intermediate struct which can be
@@ -2296,7 +2296,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
             &resources,
         )?;
 
-        let cmd_id = self.builder.commands.len() - 1;
+        let cmd = self.builder.commands.last().unwrap();
         let sets = self
             .builder
             .bindings
@@ -2306,7 +2306,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
         sets.retain(|&set_num, _| set_num < first_binding); // Remove all descriptor sets with a higher number
 
         for i in 0..num_descriptor_sets {
-            sets.insert(first_binding + i, cmd_id);
+            sets.insert(first_binding + i, cmd.clone());
         }
 
         Ok(())
@@ -2401,12 +2401,12 @@ impl<'a> SyncCommandBufferBuilderBindVertexBuffer<'a> {
             &resources,
         )?;
 
-        let cmd_id = self.builder.commands.len() - 1;
+        let cmd = self.builder.commands.last().unwrap();
         for i in 0..num_buffers {
             self.builder
                 .bindings
                 .vertex_buffers
-                .insert(first_binding + i, cmd_id);
+                .insert(first_binding + i, cmd.clone());
         }
 
         Ok(())

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -509,6 +509,12 @@ trait Command {
     }
 }
 
+impl std::fmt::Debug for dyn Command + Send + Sync {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::SyncCommandBufferBuilder;

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -102,7 +102,7 @@ pub struct SyncCommandBuffer {
 
     // List of commands used by the command buffer. Used to hold the various resources that are
     // being used.
-    commands: Vec<Box<dyn Command + Send + Sync>>,
+    commands: Vec<Arc<dyn Command + Send + Sync>>,
 
     // Locations within commands that pipeline barriers were inserted. For debugging purposes.
     // TODO: present only in cfg(debug_assertions)?
@@ -464,7 +464,7 @@ trait Command {
 
     // Sends the command to the `UnsafeCommandBufferBuilder`. Calling this method twice on the same
     // object will likely lead to a panic.
-    unsafe fn send(&mut self, out: &mut UnsafeCommandBufferBuilder);
+    unsafe fn send(&self, out: &mut UnsafeCommandBufferBuilder);
 
     // Gives access to the `num`th buffer used by the command.
     fn buffer(&self, _num: usize) -> &dyn BufferAccess {

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -321,7 +321,7 @@ impl UnsafeCommandBufferBuilder {
         dynamic_offsets: I,
     ) where
         S: Iterator<Item = &'s UnsafeDescriptorSet>,
-        I: Iterator<Item = u32>,
+        I: IntoIterator<Item = u32>,
     {
         let fns = self.device().fns();
         let cmd = self.internal_object();
@@ -330,7 +330,7 @@ impl UnsafeCommandBufferBuilder {
         if sets.is_empty() {
             return;
         }
-        let dynamic_offsets: SmallVec<[u32; 32]> = dynamic_offsets.collect();
+        let dynamic_offsets: SmallVec<[u32; 32]> = dynamic_offsets.into_iter().collect();
 
         let num_bindings = sets.len() as u32;
         debug_assert!(

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -238,7 +238,7 @@ impl UnsafeCommandBufferBuilder {
         clear_values: I,
     ) where
         F: ?Sized + FramebufferAbstract,
-        I: Iterator<Item = ClearValue>,
+        I: IntoIterator<Item = ClearValue>,
     {
         let fns = self.device().fns();
         let cmd = self.internal_object();
@@ -248,6 +248,7 @@ impl UnsafeCommandBufferBuilder {
         let raw_framebuffer = framebuffer.inner().internal_object();
 
         let raw_clear_values: SmallVec<[_; 12]> = clear_values
+            .into_iter()
             .map(|clear_value| match clear_value {
                 ClearValue::None => ash::vk::ClearValue {
                     color: ash::vk::ClearColorValue { float32: [0.0; 4] },
@@ -320,13 +321,13 @@ impl UnsafeCommandBufferBuilder {
         sets: S,
         dynamic_offsets: I,
     ) where
-        S: Iterator<Item = &'s UnsafeDescriptorSet>,
+        S: IntoIterator<Item = &'s UnsafeDescriptorSet>,
         I: IntoIterator<Item = u32>,
     {
         let fns = self.device().fns();
         let cmd = self.internal_object();
 
-        let sets: SmallVec<[_; 12]> = sets.map(|s| s.internal_object()).collect();
+        let sets: SmallVec<[_; 12]> = sets.into_iter().map(|s| s.internal_object()).collect();
         if sets.is_empty() {
             return;
         }
@@ -453,7 +454,7 @@ impl UnsafeCommandBufferBuilder {
     ) where
         S: ?Sized + ImageAccess,
         D: ?Sized + ImageAccess,
-        R: Iterator<Item = UnsafeCommandBufferBuilderImageCopy>,
+        R: IntoIterator<Item = UnsafeCommandBufferBuilderImageCopy>,
     {
         // TODO: The correct check here is that the uncompressed element size of the source is
         // equal to the compressed element size of the destination.
@@ -487,6 +488,7 @@ impl UnsafeCommandBufferBuilder {
         );
 
         let regions: SmallVec<[_; 8]> = regions
+            .into_iter()
             .filter_map(|copy| {
                 // TODO: not everything is checked here
                 debug_assert!(
@@ -569,7 +571,7 @@ impl UnsafeCommandBufferBuilder {
     ) where
         S: ?Sized + ImageAccess,
         D: ?Sized + ImageAccess,
-        R: Iterator<Item = UnsafeCommandBufferBuilderImageBlit>,
+        R: IntoIterator<Item = UnsafeCommandBufferBuilderImageBlit>,
     {
         debug_assert!(
             filter == Filter::Nearest
@@ -613,6 +615,7 @@ impl UnsafeCommandBufferBuilder {
         );
 
         let regions: SmallVec<[_; 8]> = regions
+            .into_iter()
             .filter_map(|blit| {
                 // TODO: not everything is checked here
                 debug_assert!(
@@ -696,8 +699,8 @@ impl UnsafeCommandBufferBuilder {
     /// no-op and isn't a valid usage of the command anyway.
     #[inline]
     pub unsafe fn clear_attachments<A, R>(&mut self, attachments: A, rects: R)
-        where A: Iterator<Item = >,
-              R: Iterator<Item = >
+        where A: IntoIterator<Item = >,
+              R: IntoIterator<Item = >
     {
         let attachments: SmallVec<[_; 16]> = attachments.map().collect();
         let rects: SmallVec<[_; 4]> = rects.map().collect();
@@ -725,7 +728,7 @@ impl UnsafeCommandBufferBuilder {
         regions: R,
     ) where
         I: ?Sized + ImageAccess,
-        R: Iterator<Item = UnsafeCommandBufferBuilderColorImageClear>,
+        R: IntoIterator<Item = UnsafeCommandBufferBuilderColorImageClear>,
     {
         debug_assert!(
             image.format().ty() == FormatTy::Float
@@ -745,6 +748,7 @@ impl UnsafeCommandBufferBuilder {
         };
 
         let regions: SmallVec<[_; 8]> = regions
+            .into_iter()
             .filter_map(|region| {
                 debug_assert!(
                     region.layer_count + region.base_array_layer <= image.num_layers as u32
@@ -792,7 +796,7 @@ impl UnsafeCommandBufferBuilder {
     where
         S: ?Sized + BufferAccess,
         D: ?Sized + BufferAccess,
-        R: Iterator<Item = (usize, usize, usize)>,
+        R: IntoIterator<Item = (usize, usize, usize)>,
     {
         // TODO: debug assert that there's no overlap in the destinations?
 
@@ -805,6 +809,7 @@ impl UnsafeCommandBufferBuilder {
         debug_assert!(destination.buffer.usage().transfer_destination);
 
         let regions: SmallVec<[_; 8]> = regions
+            .into_iter()
             .map(|(sr, de, sz)| ash::vk::BufferCopy {
                 src_offset: (sr + source.offset) as ash::vk::DeviceSize,
                 dst_offset: (de + destination.offset) as ash::vk::DeviceSize,
@@ -841,7 +846,7 @@ impl UnsafeCommandBufferBuilder {
     ) where
         S: ?Sized + BufferAccess,
         D: ?Sized + ImageAccess,
-        R: Iterator<Item = UnsafeCommandBufferBuilderBufferImageCopy>,
+        R: IntoIterator<Item = UnsafeCommandBufferBuilderBufferImageCopy>,
     {
         let source = source.inner();
         debug_assert!(source.offset < source.buffer.size());
@@ -856,6 +861,7 @@ impl UnsafeCommandBufferBuilder {
         );
 
         let regions: SmallVec<[_; 8]> = regions
+            .into_iter()
             .map(|copy| {
                 debug_assert!(copy.image_layer_count <= destination.num_layers as u32);
                 debug_assert!(copy.image_mip_level < destination.num_mipmap_levels as u32);
@@ -915,7 +921,7 @@ impl UnsafeCommandBufferBuilder {
     ) where
         S: ?Sized + ImageAccess,
         D: ?Sized + BufferAccess,
-        R: Iterator<Item = UnsafeCommandBufferBuilderBufferImageCopy>,
+        R: IntoIterator<Item = UnsafeCommandBufferBuilderBufferImageCopy>,
     {
         debug_assert_eq!(source.samples(), SampleCount::Sample1);
         let source = source.inner();
@@ -930,6 +936,7 @@ impl UnsafeCommandBufferBuilder {
         debug_assert!(destination.buffer.usage().transfer_destination);
 
         let regions: SmallVec<[_; 8]> = regions
+            .into_iter()
             .map(|copy| {
                 debug_assert!(copy.image_layer_count <= source.num_layers as u32);
                 debug_assert!(copy.image_mip_level < source.num_mipmap_levels as u32);
@@ -1388,9 +1395,10 @@ impl UnsafeCommandBufferBuilder {
     #[inline]
     pub unsafe fn set_scissor<I>(&mut self, first_scissor: u32, scissors: I)
     where
-        I: Iterator<Item = Scissor>,
+        I: IntoIterator<Item = Scissor>,
     {
         let scissors = scissors
+            .into_iter()
             .map(|v| ash::vk::Rect2D::from(v.clone()))
             .collect::<SmallVec<[_; 16]>>();
         if scissors.is_empty() {
@@ -1430,9 +1438,10 @@ impl UnsafeCommandBufferBuilder {
     #[inline]
     pub unsafe fn set_viewport<I>(&mut self, first_viewport: u32, viewports: I)
     where
-        I: Iterator<Item = Viewport>,
+        I: IntoIterator<Item = Viewport>,
     {
         let viewports = viewports
+            .into_iter()
             .map(|v| v.clone().into())
             .collect::<SmallVec<[_; 16]>>();
         if viewports.is_empty() {

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -98,7 +98,7 @@ pub mod shader;
 pub mod vertex;
 pub mod viewport;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(i32)]
 pub enum PipelineBindPoint {
     Compute = ash::vk::PipelineBindPoint::COMPUTE.as_raw(),


### PR DESCRIPTION
Changelog:
```markdown
- Fixed synchronization bug where pipeline barriers were placed based on the binding of resources instead of the draw/dispatch calls that use them.
- `SyncCommandBufferBuilder` and `UnsafeCommandBufferBuilder` accept any `IntoIterator` where they previously only accepted `Iterator`.
```

This fixes #1635. In order to do this, quite a few changes needed to be made elsewhere, some of which were in separate PRs that have already been merged. This PR contains only internal changes, nothing user facing. The following changes were made internally to `SyncCommandBufferBuilder`:
- The builder now tracks which binding state was most recently set by which command.
- `FinalCommand` is gone, so the built command buffer now uses the regular `Command`.
- Each `Command` is now stored in an `Arc` instead of a `Box`, which allows them to be referenced from multiple locations. A future PR could probably change the remaining cases where a command index is used to simply clone the `Arc`.
- Using this, draw and dispatch commands can now hold references to the bind commands that set the state they use.

Now that `SyncCommandBufferBuilder` is tracking binding state, it partially overlaps in function with `StateCacher`. This could allow a future PR to make the latter obsolete entirely.