### PR TITLE
Check binding numbers against limit

### DIFF
--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -482,6 +482,25 @@ where
             let mut binding_divisor_descriptions = SmallVec::<[_; 8]>::new();
 
             for (binding, binding_desc) in vertex_input.bindings() {
+                if binding
+                    >= device
+                        .physical_device()
+                        .properties()
+                        .max_vertex_input_bindings
+                        .unwrap()
+                {
+                    return Err(
+                        GraphicsPipelineCreationError::MaxVertexInputBindingsExceeded {
+                            max: device
+                                .physical_device()
+                                .properties()
+                                .max_vertex_input_bindings
+                                .unwrap(),
+                            obtained: binding,
+                        },
+                    );
+                }
+
                 if binding_desc.stride
                     > device
                         .physical_device()
@@ -566,7 +585,7 @@ where
                             .properties()
                             .max_vertex_input_bindings
                             .unwrap(),
-                        obtained: binding_descriptions.len(),
+                        obtained: binding_descriptions.len() as u32,
                     },
                 );
             }

--- a/vulkano/src/pipeline/graphics_pipeline/creation_error.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/creation_error.rs
@@ -55,7 +55,7 @@ pub enum GraphicsPipelineCreationError {
         /// Maximum allowed value.
         max: u32,
         /// Value that was passed.
-        obtained: usize,
+        obtained: u32,
     },
 
     /// The maximum offset for a vertex attribute has been exceeded. This means that your vertex


### PR DESCRIPTION
Changelog:
```markdown
- Added limits check for vertex buffer binding numbers.
```

This wasn't previously being checked, so this PR adds it.