### PR TITLE
add some logic for known properties

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -44,7 +44,7 @@ fn main() {
                 .find(|&q| q.supports_compute())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -55,8 +55,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     // Now initializing the device.

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -69,7 +69,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -80,8 +80,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -126,7 +126,7 @@ fn main() {
                     .expect("couldn't find a queue family"),
             )
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -70,7 +70,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -81,8 +81,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -46,7 +46,7 @@ fn main() {
                 .find(|&q| q.supports_compute())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -57,8 +57,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(
@@ -159,8 +159,7 @@ fn main() {
     let min_dynamic_align = device
         .physical_device()
         .properties()
-        .min_uniform_buffer_offset_alignment
-        .unwrap() as usize;
+        .min_uniform_buffer_offset_alignment as usize;
     println!(
         "Minimum uniform buffer offset alignment: {}",
         min_dynamic_align

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -57,7 +57,7 @@ fn main() {
                 .find(|&q| q.supports_compute())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -68,8 +68,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -60,7 +60,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -71,8 +71,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap(),
+        physical_device.properties().device_name,
+        physical_device.properties().device_type,
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/immutable-buffer-initialization.rs
+++ b/examples/src/bin/immutable-buffer-initialization.rs
@@ -39,7 +39,7 @@ fn main() {
                 .find(|&q| q.supports_compute())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -50,8 +50,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -85,7 +85,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -96,8 +96,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap(),
+        physical_device.properties().device_name,
+        physical_device.properties().device_type,
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -82,7 +82,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -93,8 +93,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap(),
+        physical_device.properties().device_name,
+        physical_device.properties().device_type,
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -104,7 +104,7 @@ fn main() {
                 .find(|&q| q.supports_graphics())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -115,8 +115,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -81,7 +81,7 @@ fn main() {
                     .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                     .map(|q| (p, q))
             })
-            .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+            .min_by_key(|(p, _)| match p.properties().device_type {
                 PhysicalDeviceType::DiscreteGpu => 0,
                 PhysicalDeviceType::IntegratedGpu => 1,
                 PhysicalDeviceType::VirtualGpu => 2,
@@ -92,8 +92,8 @@ fn main() {
 
         println!(
             "Using device: {} (type: {:?})",
-            physical_device.properties().device_name.as_ref().unwrap(),
-            physical_device.properties().device_type.unwrap()
+            physical_device.properties().device_name,
+            physical_device.properties().device_type
         );
 
         let (device, mut queues) = Device::new(

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -84,7 +84,7 @@ fn main() {
                 .find(|&q| q.supports_graphics())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -97,8 +97,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -55,7 +55,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -66,8 +66,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap(),
+        physical_device.properties().device_name,
+        physical_device.properties().device_type,
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/pipeline-caching.rs
+++ b/examples/src/bin/pipeline-caching.rs
@@ -55,7 +55,7 @@ fn main() {
                 .find(|&q| q.supports_compute())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -66,8 +66,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     // Now initializing the device.

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -35,7 +35,7 @@ fn main() {
                 .find(|&q| q.supports_compute())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -46,8 +46,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -80,7 +80,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -91,8 +91,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -36,7 +36,7 @@ fn main() {
                 .find(|&q| q.supports_compute())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -47,8 +47,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -35,7 +35,7 @@ fn main() {
                 .find(|&q| q.supports_compute())
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -46,8 +46,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -62,7 +62,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -73,8 +73,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap(),
+        physical_device.properties().device_name,
+        physical_device.properties().device_type,
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -162,7 +162,7 @@ fn main() {
                 .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
                 .map(|q| (p, q))
         })
-        .min_by_key(|(p, _)| match p.properties().device_type.unwrap() {
+        .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
             PhysicalDeviceType::IntegratedGpu => 1,
             PhysicalDeviceType::VirtualGpu => 2,
@@ -173,8 +173,8 @@ fn main() {
 
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap()
+        physical_device.properties().device_name,
+        physical_device.properties().device_type
     );
 
     let (device, mut queues) = Device::new(

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -119,7 +119,7 @@ fn main() {
         // "default" or "recommended" device, and let the user choose the device themselves.
         .min_by_key(|(p, _)| {
             // We assign a better score to device types that are likely to be faster/better.
-            match p.properties().device_type.unwrap() {
+            match p.properties().device_type {
                 PhysicalDeviceType::DiscreteGpu => 0,
                 PhysicalDeviceType::IntegratedGpu => 1,
                 PhysicalDeviceType::VirtualGpu => 2,
@@ -132,8 +132,8 @@ fn main() {
     // Some little debug infos.
     println!(
         "Using device: {} (type: {:?})",
-        physical_device.properties().device_name.as_ref().unwrap(),
-        physical_device.properties().device_type.unwrap(),
+        physical_device.properties().device_name,
+        physical_device.properties().device_type,
     );
 
     // Now initializing the device. This is probably the most important object of Vulkan.

--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -34,6 +34,7 @@ pub fn write<W: Write>(
             feat.ffi_members.join(", ")
         )
         .unwrap();
+        write!(writer, "\n\t\trequired: {},", feat.required).unwrap();
         write!(writer, "\n\t}},").unwrap();
     }
 
@@ -66,6 +67,7 @@ struct VulkanoProperty {
     vulkan_doc: String,
     ffi_name: String,
     ffi_members: Vec<String>,
+    required: bool,
 }
 
 fn make_vulkano_properties(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<VulkanoProperty> {
@@ -85,6 +87,10 @@ fn make_vulkano_properties(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<Vul
     })
     .for_each(|(ty, _)| {
         let vulkan_ty_name = ty.name.as_ref().unwrap();
+        let required = vulkan_ty_name == "VkPhysicalDeviceProperties"
+            || vulkan_ty_name == "VkPhysicalDeviceLimits"
+            || vulkan_ty_name == "VkPhysicalDeviceSparseProperties"
+        ;
 
         let ty_name = if vulkan_ty_name == "VkPhysicalDeviceProperties" {
             "properties_vulkan10.properties".to_owned()
@@ -116,6 +122,7 @@ fn make_vulkano_properties(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<Vul
                             vulkan_doc: format!("{}.html#limits-{}", vulkan_ty_name, name),
                             ffi_name: vulkano_member,
                             ffi_members: vec![ty_name.to_owned()],
+                            required: required,
                         });
                     }
                     Entry::Occupied(entry) => {

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -468,8 +468,7 @@ where
                         self.device()
                             .physical_device()
                             .properties()
-                            .min_uniform_buffer_offset_alignment
-                            .unwrap() as usize
+                            .min_uniform_buffer_offset_alignment as usize
                     } else {
                         1
                     },
@@ -477,8 +476,7 @@ where
                         self.device()
                             .physical_device()
                             .properties()
-                            .min_storage_buffer_offset_alignment
-                            .unwrap() as usize
+                            .min_storage_buffer_offset_alignment as usize
                     } else {
                         1
                     },

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -220,21 +220,21 @@ impl UnsafeBuffer {
             if usage.uniform_texel_buffer || usage.storage_texel_buffer {
                 output.alignment = align(
                     output.alignment,
-                    properties.min_texel_buffer_offset_alignment.unwrap() as usize,
+                    properties.min_texel_buffer_offset_alignment as usize,
                 );
             }
 
             if usage.storage_buffer {
                 output.alignment = align(
                     output.alignment,
-                    properties.min_storage_buffer_offset_alignment.unwrap() as usize,
+                    properties.min_storage_buffer_offset_alignment as usize,
                 );
             }
 
             if usage.uniform_buffer {
                 output.alignment = align(
                     output.alignment,
-                    properties.min_uniform_buffer_offset_alignment.unwrap() as usize,
+                    properties.min_uniform_buffer_offset_alignment as usize,
                 );
             }
 
@@ -275,17 +275,17 @@ impl UnsafeBuffer {
             let properties = self.device().physical_device().properties();
             if self.usage().uniform_texel_buffer || self.usage().storage_texel_buffer {
                 debug_assert!(
-                    offset % properties.min_texel_buffer_offset_alignment.unwrap() as usize == 0
+                    offset % properties.min_texel_buffer_offset_alignment as usize == 0
                 );
             }
             if self.usage().storage_buffer {
                 debug_assert!(
-                    offset % properties.min_storage_buffer_offset_alignment.unwrap() as usize == 0
+                    offset % properties.min_storage_buffer_offset_alignment as usize == 0
                 );
             }
             if self.usage().uniform_buffer {
                 debug_assert!(
-                    offset % properties.min_uniform_buffer_offset_alignment.unwrap() as usize == 0
+                    offset % properties.min_uniform_buffer_offset_alignment as usize == 0
                 );
             }
         }

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -97,8 +97,7 @@ where
                 % device
                     .physical_device()
                     .properties()
-                    .min_texel_buffer_offset_alignment
-                    .unwrap() as usize)
+                    .min_texel_buffer_offset_alignment as usize)
                 != 0
             {
                 return Err(BufferViewCreationError::WrongBufferAlignment);
@@ -116,8 +115,7 @@ where
                 let l = device
                     .physical_device()
                     .properties()
-                    .max_texel_buffer_elements
-                    .unwrap();
+                    .max_texel_buffer_elements;
                 if nb > l as usize {
                     return Err(BufferViewCreationError::MaxTexelBufferElementsExceeded);
                 }

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -1259,8 +1259,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
                 .device()
                 .physical_device()
                 .properties()
-                .max_draw_indirect_count
-                .unwrap();
+                .max_draw_indirect_count;
 
             if requested > limit {
                 return Err(
@@ -1440,8 +1439,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
                 .device()
                 .physical_device()
                 .properties()
-                .max_draw_indirect_count
-                .unwrap();
+                .max_draw_indirect_count;
 
             if requested > limit {
                 return Err(

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -424,8 +424,7 @@ impl UnsafeCommandBufferBuilder {
                 .device()
                 .physical_device()
                 .properties()
-                .max_vertex_input_bindings
-                .unwrap();
+                .max_vertex_input_bindings;
             first_binding + num_bindings <= max_bindings
         });
 
@@ -1015,8 +1014,7 @@ impl UnsafeCommandBufferBuilder {
                 .device()
                 .physical_device()
                 .properties()
-                .max_compute_work_group_count
-                .unwrap();
+                .max_compute_work_group_count;
             group_counts[0] <= max_group_counts[0]
                 && group_counts[1] <= max_group_counts[1]
                 && group_counts[2] <= max_group_counts[2]
@@ -1413,8 +1411,7 @@ impl UnsafeCommandBufferBuilder {
                 .device()
                 .physical_device()
                 .properties()
-                .max_viewports
-                .unwrap();
+                .max_viewports;
             first_scissor + scissors.len() as u32 <= max
         });
 
@@ -1448,8 +1445,7 @@ impl UnsafeCommandBufferBuilder {
                 .device()
                 .physical_device()
                 .properties()
-                .max_viewports
-                .unwrap();
+                .max_viewports;
             first_viewport + viewports.len() as u32 <= max
         });
 

--- a/vulkano/src/command_buffer/validity/dispatch.rs
+++ b/vulkano/src/command_buffer/validity/dispatch.rs
@@ -73,7 +73,6 @@ mod tests {
             .physical_device()
             .properties()
             .max_compute_work_group_count
-            .unwrap()
             == attempted
         {
             return;

--- a/vulkano/src/command_buffer/validity/dispatch.rs
+++ b/vulkano/src/command_buffer/validity/dispatch.rs
@@ -17,8 +17,7 @@ pub fn check_dispatch(device: &Device, dimensions: [u32; 3]) -> Result<(), Check
     let max = device
         .physical_device()
         .properties()
-        .max_compute_work_group_count
-        .unwrap();
+        .max_compute_work_group_count;
 
     if dimensions[0] > max[0] || dimensions[1] > max[1] || dimensions[2] > max[2] {
         return Err(CheckDispatchError::UnsupportedDimensions {

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -205,8 +205,8 @@ impl DescriptorSetWithOffsets {
         let dynamic_offsets: SmallVec<_> = dynamic_offsets.into_iter().collect();
         let layout = descriptor_set.layout();
         let properties = layout.device().physical_device().properties();
-        let min_uniform_off_align = properties.min_uniform_buffer_offset_alignment.unwrap() as u32;
-        let min_storage_off_align = properties.min_storage_buffer_offset_alignment.unwrap() as u32;
+        let min_uniform_off_align = properties.min_uniform_buffer_offset_alignment as u32;
+        let min_storage_off_align = properties.min_storage_buffer_offset_alignment as u32;
         let mut dynamic_offset_index = 0;
 
         // Ensure that the number of dynamic_offsets is correct and that each

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -405,8 +405,7 @@ impl DescriptorWrite {
                     .device()
                     .physical_device()
                     .properties()
-                    .min_uniform_buffer_offset_alignment
-                    .unwrap() as usize,
+                    .min_uniform_buffer_offset_alignment as usize,
             0
         );
         debug_assert!(
@@ -414,8 +413,7 @@ impl DescriptorWrite {
                 .device()
                 .physical_device()
                 .properties()
-                .max_uniform_buffer_range
-                .unwrap() as usize
+                .max_uniform_buffer_range as usize
         );
 
         DescriptorWrite {
@@ -441,8 +439,7 @@ impl DescriptorWrite {
                     .device()
                     .physical_device()
                     .properties()
-                    .min_storage_buffer_offset_alignment
-                    .unwrap() as usize,
+                    .min_storage_buffer_offset_alignment as usize,
             0
         );
         debug_assert!(
@@ -450,8 +447,7 @@ impl DescriptorWrite {
                 .device()
                 .physical_device()
                 .properties()
-                .max_storage_buffer_range
-                .unwrap() as usize
+                .max_storage_buffer_range as usize
         );
 
         DescriptorWrite {
@@ -481,8 +477,7 @@ impl DescriptorWrite {
                     .device()
                     .physical_device()
                     .properties()
-                    .min_uniform_buffer_offset_alignment
-                    .unwrap() as usize,
+                    .min_uniform_buffer_offset_alignment as usize,
             0
         );
         debug_assert!(
@@ -490,8 +485,7 @@ impl DescriptorWrite {
                 .device()
                 .physical_device()
                 .properties()
-                .max_uniform_buffer_range
-                .unwrap() as usize
+                .max_uniform_buffer_range as usize
         );
 
         DescriptorWrite {
@@ -523,8 +517,7 @@ impl DescriptorWrite {
                     .device()
                     .physical_device()
                     .properties()
-                    .min_storage_buffer_offset_alignment
-                    .unwrap() as usize,
+                    .min_storage_buffer_offset_alignment as usize,
             0
         );
         debug_assert!(
@@ -532,8 +525,7 @@ impl DescriptorWrite {
                 .device()
                 .physical_device()
                 .properties()
-                .max_storage_buffer_range
-                .unwrap() as usize
+                .max_storage_buffer_range as usize
         );
 
         DescriptorWrite {

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -536,6 +536,13 @@ pub enum PhysicalDeviceType {
     Other = ash::vk::PhysicalDeviceType::OTHER.as_raw(),
 }
 
+/// VkPhysicalDeviceType::Other is represented as 0
+impl Default for PhysicalDeviceType {
+  fn default() -> Self {
+    PhysicalDeviceType::Other
+  }
+}
+
 impl TryFrom<ash::vk::PhysicalDeviceType> for PhysicalDeviceType {
     type Error = ();
 

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -295,7 +295,7 @@ fn init_physical_devices_inner2(instance: &Instance, infos: &mut [PhysicalDevice
 /// }
 ///
 /// fn print_infos(dev: PhysicalDevice) {
-///     println!("Name: {}", dev.properties().device_name.as_ref().unwrap());
+///     println!("Name: {}", dev.properties().device_name);
 /// }
 /// ```
 #[derive(Clone, Copy, Debug)]
@@ -318,7 +318,7 @@ impl<'a> PhysicalDevice<'a> {
     ///
     /// # let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
     /// for physical_device in PhysicalDevice::enumerate(&instance) {
-    ///     println!("Available device: {}", physical_device.properties().device_name.as_ref().unwrap());
+    ///     println!("Available device: {}", physical_device.properties().device_name);
     /// }
     /// ```
     #[inline]

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -129,7 +129,7 @@ impl TryFrom<u32> for SampleCount {
 }
 
 /// Specifies how many sample counts supported for an image used for storage operations.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct SampleCounts {
     // specify an image with one sample per pixel
     pub sample1: bool,

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -251,7 +251,6 @@ impl UnsafeImage {
                         .physical_device()
                         .properties()
                         .sampled_image_color_sample_counts
-                        .unwrap()
                         .into();
                 }
                 FormatTy::Uint | FormatTy::Sint => {
@@ -259,7 +258,6 @@ impl UnsafeImage {
                         .physical_device()
                         .properties()
                         .sampled_image_integer_sample_counts
-                        .unwrap()
                         .into();
                 }
                 FormatTy::Depth => {
@@ -267,7 +265,6 @@ impl UnsafeImage {
                         .physical_device()
                         .properties()
                         .sampled_image_depth_sample_counts
-                        .unwrap()
                         .into();
                 }
                 FormatTy::Stencil => {
@@ -275,7 +272,6 @@ impl UnsafeImage {
                         .physical_device()
                         .properties()
                         .sampled_image_stencil_sample_counts
-                        .unwrap()
                         .into();
                 }
                 FormatTy::DepthStencil => {
@@ -283,13 +279,11 @@ impl UnsafeImage {
                         .physical_device()
                         .properties()
                         .sampled_image_depth_sample_counts
-                        .unwrap()
                         .into();
                     supported_samples &= device
                         .physical_device()
                         .properties()
                         .sampled_image_stencil_sample_counts
-                        .unwrap()
                         .into();
                 }
                 FormatTy::Ycbcr => {
@@ -307,7 +301,6 @@ impl UnsafeImage {
                     .physical_device()
                     .properties()
                     .storage_image_sample_counts
-                    .unwrap()
                     .into();
             }
 
@@ -322,7 +315,6 @@ impl UnsafeImage {
                             .physical_device()
                             .properties()
                             .framebuffer_color_sample_counts
-                            .unwrap()
                             .into();
                     }
                     FormatTy::Depth => {
@@ -330,7 +322,6 @@ impl UnsafeImage {
                             .physical_device()
                             .properties()
                             .framebuffer_depth_sample_counts
-                            .unwrap()
                             .into();
                     }
                     FormatTy::Stencil => {
@@ -338,7 +329,6 @@ impl UnsafeImage {
                             .physical_device()
                             .properties()
                             .framebuffer_stencil_sample_counts
-                            .unwrap()
                             .into();
                     }
                     FormatTy::DepthStencil => {
@@ -346,13 +336,11 @@ impl UnsafeImage {
                             .physical_device()
                             .properties()
                             .framebuffer_depth_sample_counts
-                            .unwrap()
                             .into();
                         supported_samples &= device
                             .physical_device()
                             .properties()
                             .framebuffer_stencil_sample_counts
-                            .unwrap()
                             .into();
                     }
                     FormatTy::Ycbcr => {
@@ -451,7 +439,6 @@ impl UnsafeImage {
                 .physical_device()
                 .properties()
                 .max_image_array_layers
-                .unwrap()
         {
             let err = ImageCreationError::UnsupportedDimensions { dimensions };
             capabilities_error = Some(err);
@@ -463,7 +450,6 @@ impl UnsafeImage {
                         .physical_device()
                         .properties()
                         .max_image_dimension1_d
-                        .unwrap()
                 {
                     let err = ImageCreationError::UnsupportedDimensions { dimensions };
                     capabilities_error = Some(err);
@@ -473,8 +459,7 @@ impl UnsafeImage {
                 let limit = device
                     .physical_device()
                     .properties()
-                    .max_image_dimension2_d
-                    .unwrap();
+                    .max_image_dimension2_d;
                 if extent.width > limit || extent.height > limit {
                     let err = ImageCreationError::UnsupportedDimensions { dimensions };
                     capabilities_error = Some(err);
@@ -484,8 +469,7 @@ impl UnsafeImage {
                     let limit = device
                         .physical_device()
                         .properties()
-                        .max_image_dimension_cube
-                        .unwrap();
+                        .max_image_dimension_cube;
                     if extent.width > limit {
                         let err = ImageCreationError::UnsupportedDimensions { dimensions };
                         capabilities_error = Some(err);
@@ -496,8 +480,7 @@ impl UnsafeImage {
                 let limit = device
                     .physical_device()
                     .properties()
-                    .max_image_dimension3_d
-                    .unwrap();
+                    .max_image_dimension3_d;
                 if extent.width > limit || extent.height > limit || extent.depth > limit {
                     let err = ImageCreationError::UnsupportedDimensions { dimensions };
                     capabilities_error = Some(err);

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -35,7 +35,7 @@
 //!
 //! # let instance = Instance::new(None, Version::V1_1, &InstanceExtensions::none(), None).unwrap();
 //! for physical_device in PhysicalDevice::enumerate(&instance) {
-//!     println!("Available device: {}", physical_device.properties().device_name.as_ref().unwrap());
+//!     println!("Available device: {}", physical_device.properties().device_name);
 //! }
 //! ```
 //!

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -339,7 +339,6 @@ impl<'a> DeviceMemoryBuilder<'a> {
                 >= physical_device
                     .properties()
                     .max_memory_allocation_count
-                    .unwrap()
             {
                 return Err(DeviceMemoryAllocError::TooManyObjects);
             }

--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -482,16 +482,14 @@ where
                 > device
                     .physical_device()
                     .properties()
-                    .max_vertex_input_bindings
-                    .unwrap() as usize
+                    .max_vertex_input_bindings as usize
             {
                 return Err(
                     GraphicsPipelineCreationError::MaxVertexInputBindingsExceeded {
                         max: device
                             .physical_device()
                             .properties()
-                            .max_vertex_input_bindings
-                            .unwrap(),
+                            .max_vertex_input_bindings,
                         obtained: bindings.len(),
                     },
                 );
@@ -509,7 +507,6 @@ where
                         .physical_device()
                         .properties()
                         .max_vertex_input_binding_stride
-                        .unwrap()
                 {
                     return Err(
                         GraphicsPipelineCreationError::MaxVertexInputBindingStrideExceeded {
@@ -517,8 +514,7 @@ where
                             max: device
                                 .physical_device()
                                 .properties()
-                                .max_vertex_input_binding_stride
-                                .unwrap(),
+                                .max_vertex_input_binding_stride,
                             obtained: binding_desc.stride,
                         },
                     );
@@ -581,15 +577,13 @@ where
                             .physical_device()
                             .properties()
                             .max_vertex_input_attribute_offset
-                            .unwrap()
                     {
                         return Err(
                             GraphicsPipelineCreationError::MaxVertexInputAttributeOffsetExceeded {
                                 max: device
                                     .physical_device()
                                     .properties()
-                                    .max_vertex_input_attribute_offset
-                                    .unwrap(),
+                                    .max_vertex_input_attribute_offset,
                                 obtained: attribute_desc.offset,
                             },
                         );
@@ -608,16 +602,14 @@ where
                 > device
                     .physical_device()
                     .properties()
-                    .max_vertex_input_attributes
-                    .unwrap() as usize
+                    .max_vertex_input_attributes as usize
             {
                 return Err(
                     GraphicsPipelineCreationError::MaxVertexInputAttributesExceeded {
                         max: device
                             .physical_device()
                             .properties()
-                            .max_vertex_input_attributes
-                            .unwrap(),
+                            .max_vertex_input_attributes,
                         obtained: attribute_descriptions.len(),
                     },
                 );
@@ -688,7 +680,6 @@ where
                         .physical_device()
                         .properties()
                         .max_tessellation_patch_size
-                        .unwrap()
                 {
                     return Err(GraphicsPipelineCreationError::MaxTessellationPatchSizeExceeded);
                 }
@@ -747,10 +738,10 @@ where
             return Err(GraphicsPipelineCreationError::MultiViewportFeatureNotEnabled);
         }
 
-        if vp_num > device.physical_device().properties().max_viewports.unwrap() {
+        if vp_num > device.physical_device().properties().max_viewports {
             return Err(GraphicsPipelineCreationError::MaxViewportsExceeded {
                 obtained: vp_num,
-                max: device.physical_device().properties().max_viewports.unwrap(),
+                max: device.physical_device().properties().max_viewports,
             });
         }
 
@@ -759,14 +750,12 @@ where
                 > device
                     .physical_device()
                     .properties()
-                    .max_viewport_dimensions
-                    .unwrap()[0] as f32
+                    .max_viewport_dimensions[0] as f32
                 || vp.height
                     > device
                         .physical_device()
                         .properties()
-                        .max_viewport_dimensions
-                        .unwrap()[1] as f32
+                        .max_viewport_dimensions[1] as f32
             {
                 return Err(GraphicsPipelineCreationError::MaxViewportDimensionsExceeded);
             }
@@ -775,26 +764,22 @@ where
                 < device
                     .physical_device()
                     .properties()
-                    .viewport_bounds_range
-                    .unwrap()[0]
+                    .viewport_bounds_range[0]
                 || vp.x + vp.width
                     > device
                         .physical_device()
                         .properties()
-                        .viewport_bounds_range
-                        .unwrap()[1]
+                        .viewport_bounds_range[1]
                 || vp.y
                     < device
                         .physical_device()
                         .properties()
-                        .viewport_bounds_range
-                        .unwrap()[0]
+                        .viewport_bounds_range[0]
                 || vp.y + vp.height
                     > device
                         .physical_device()
                         .properties()
-                        .viewport_bounds_range
-                        .unwrap()[1]
+                        .viewport_bounds_range[1]
             {
                 return Err(GraphicsPipelineCreationError::ViewportBoundsExceeded);
             }

--- a/vulkano/src/pipeline/layout/limits_check.rs
+++ b/vulkano/src/pipeline/layout/limits_check.rs
@@ -74,66 +74,66 @@ pub fn check_desc_against_limits(
         }
     }
 
-    if descriptor_set_layouts.len() > properties.max_bound_descriptor_sets.unwrap() as usize {
+    if descriptor_set_layouts.len() > properties.max_bound_descriptor_sets as usize {
         return Err(PipelineLayoutLimitsError::MaxDescriptorSetsLimitExceeded {
-            limit: properties.max_bound_descriptor_sets.unwrap() as usize,
+            limit: properties.max_bound_descriptor_sets as usize,
             requested: descriptor_set_layouts.len(),
         });
     }
 
-    if num_resources.max_per_stage() > properties.max_per_stage_resources.unwrap() {
+    if num_resources.max_per_stage() > properties.max_per_stage_resources {
         return Err(
             PipelineLayoutLimitsError::MaxPerStageResourcesLimitExceeded {
-                limit: properties.max_per_stage_resources.unwrap(),
+                limit: properties.max_per_stage_resources,
                 requested: num_resources.max_per_stage(),
             },
         );
     }
 
-    if num_samplers.max_per_stage() > properties.max_per_stage_descriptor_samplers.unwrap() {
+    if num_samplers.max_per_stage() > properties.max_per_stage_descriptor_samplers {
         return Err(
             PipelineLayoutLimitsError::MaxPerStageDescriptorSamplersLimitExceeded {
-                limit: properties.max_per_stage_descriptor_samplers.unwrap(),
+                limit: properties.max_per_stage_descriptor_samplers,
                 requested: num_samplers.max_per_stage(),
             },
         );
     }
     if num_uniform_buffers.max_per_stage()
-        > properties.max_per_stage_descriptor_uniform_buffers.unwrap()
+        > properties.max_per_stage_descriptor_uniform_buffers
     {
         return Err(
             PipelineLayoutLimitsError::MaxPerStageDescriptorUniformBuffersLimitExceeded {
-                limit: properties.max_per_stage_descriptor_uniform_buffers.unwrap(),
+                limit: properties.max_per_stage_descriptor_uniform_buffers,
                 requested: num_uniform_buffers.max_per_stage(),
             },
         );
     }
     if num_storage_buffers.max_per_stage()
-        > properties.max_per_stage_descriptor_storage_buffers.unwrap()
+        > properties.max_per_stage_descriptor_storage_buffers
     {
         return Err(
             PipelineLayoutLimitsError::MaxPerStageDescriptorStorageBuffersLimitExceeded {
-                limit: properties.max_per_stage_descriptor_storage_buffers.unwrap(),
+                limit: properties.max_per_stage_descriptor_storage_buffers,
                 requested: num_storage_buffers.max_per_stage(),
             },
         );
     }
     if num_sampled_images.max_per_stage()
-        > properties.max_per_stage_descriptor_sampled_images.unwrap()
+        > properties.max_per_stage_descriptor_sampled_images
     {
         return Err(
             PipelineLayoutLimitsError::MaxPerStageDescriptorSampledImagesLimitExceeded {
-                limit: properties.max_per_stage_descriptor_sampled_images.unwrap(),
+                limit: properties.max_per_stage_descriptor_sampled_images,
                 requested: num_sampled_images.max_per_stage(),
             },
         );
     }
     if num_storage_images.max_per_stage()
-        > properties.max_per_stage_descriptor_storage_images.unwrap()
+        > properties.max_per_stage_descriptor_storage_images
     {
         return Err(
             PipelineLayoutLimitsError::MaxPerStageDescriptorStorageImagesLimitExceeded {
-                limit: properties.max_per_stage_descriptor_storage_images.unwrap(),
+                limit: properties.max_per_stage_descriptor_storage_images,
                 requested: num_storage_images.max_per_stage(),
             },
         );
@@ -141,30 +141,28 @@ pub fn check_desc_against_limits(
     if num_input_attachments.max_per_stage()
         > properties
             .max_per_stage_descriptor_input_attachments
-            .unwrap()
     {
         return Err(
             PipelineLayoutLimitsError::MaxPerStageDescriptorInputAttachmentsLimitExceeded {
                 limit: properties
-                    .max_per_stage_descriptor_input_attachments
-                    .unwrap(),
+                    .max_per_stage_descriptor_input_attachments,
                 requested: num_input_attachments.max_per_stage(),
             },
         );
     }
 
-    if num_samplers.total > properties.max_descriptor_set_samplers.unwrap() {
+    if num_samplers.total > properties.max_descriptor_set_samplers {
         return Err(
             PipelineLayoutLimitsError::MaxDescriptorSetSamplersLimitExceeded {
-                limit: properties.max_descriptor_set_samplers.unwrap(),
+                limit: properties.max_descriptor_set_samplers,
                 requested: num_samplers.total,
             },
         );
     }
-    if num_uniform_buffers.total > properties.max_descriptor_set_uniform_buffers.unwrap() {
+    if num_uniform_buffers.total > properties.max_descriptor_set_uniform_buffers {
         return Err(
             PipelineLayoutLimitsError::MaxDescriptorSetUniformBuffersLimitExceeded {
-                limit: properties.max_descriptor_set_uniform_buffers.unwrap(),
+                limit: properties.max_descriptor_set_uniform_buffers,
                 requested: num_uniform_buffers.total,
             },
         );
@@ -172,21 +170,19 @@ pub fn check_desc_against_limits(
     if num_uniform_buffers_dynamic
         > properties
             .max_descriptor_set_uniform_buffers_dynamic
-            .unwrap()
     {
         return Err(
             PipelineLayoutLimitsError::MaxDescriptorSetUniformBuffersDynamicLimitExceeded {
                 limit: properties
-                    .max_descriptor_set_uniform_buffers_dynamic
-                    .unwrap(),
+                    .max_descriptor_set_uniform_buffers_dynamic,
                 requested: num_uniform_buffers_dynamic,
             },
         );
     }
-    if num_storage_buffers.total > properties.max_descriptor_set_storage_buffers.unwrap() {
+    if num_storage_buffers.total > properties.max_descriptor_set_storage_buffers {
         return Err(
             PipelineLayoutLimitsError::MaxDescriptorSetStorageBuffersLimitExceeded {
-                limit: properties.max_descriptor_set_storage_buffers.unwrap(),
+                limit: properties.max_descriptor_set_storage_buffers,
                 requested: num_storage_buffers.total,
             },
         );
@@ -194,46 +190,44 @@ pub fn check_desc_against_limits(
     if num_storage_buffers_dynamic
         > properties
             .max_descriptor_set_storage_buffers_dynamic
-            .unwrap()
     {
         return Err(
             PipelineLayoutLimitsError::MaxDescriptorSetStorageBuffersDynamicLimitExceeded {
                 limit: properties
-                    .max_descriptor_set_storage_buffers_dynamic
-                    .unwrap(),
+                    .max_descriptor_set_storage_buffers_dynamic,
                 requested: num_storage_buffers_dynamic,
             },
         );
     }
-    if num_sampled_images.total > properties.max_descriptor_set_sampled_images.unwrap() {
+    if num_sampled_images.total > properties.max_descriptor_set_sampled_images {
         return Err(
             PipelineLayoutLimitsError::MaxDescriptorSetSampledImagesLimitExceeded {
-                limit: properties.max_descriptor_set_sampled_images.unwrap(),
+                limit: properties.max_descriptor_set_sampled_images,
                 requested: num_sampled_images.total,
             },
         );
     }
-    if num_storage_images.total > properties.max_descriptor_set_storage_images.unwrap() {
+    if num_storage_images.total > properties.max_descriptor_set_storage_images {
         return Err(
             PipelineLayoutLimitsError::MaxDescriptorSetStorageImagesLimitExceeded {
-                limit: properties.max_descriptor_set_storage_images.unwrap(),
+                limit: properties.max_descriptor_set_storage_images,
                 requested: num_storage_images.total,
             },
         );
     }
-    if num_input_attachments.total > properties.max_descriptor_set_input_attachments.unwrap() {
+    if num_input_attachments.total > properties.max_descriptor_set_input_attachments {
         return Err(
             PipelineLayoutLimitsError::MaxDescriptorSetInputAttachmentsLimitExceeded {
-                limit: properties.max_descriptor_set_input_attachments.unwrap(),
+                limit: properties.max_descriptor_set_input_attachments,
                 requested: num_input_attachments.total,
             },
         );
     }
 
     for &PipelineLayoutPcRange { offset, size, .. } in push_constants_ranges {
-        if offset + size > properties.max_push_constants_size.unwrap() as usize {
+        if offset + size > properties.max_push_constants_size as usize {
             return Err(PipelineLayoutLimitsError::MaxPushConstantsSizeExceeded {
-                limit: properties.max_push_constants_size.unwrap() as usize,
+                limit: properties.max_push_constants_size as usize,
                 requested: offset + size,
             });
         }

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -282,9 +282,9 @@ where
         {
             let properties = device.physical_device().properties();
             let limits = [
-                properties.max_framebuffer_width.unwrap(),
-                properties.max_framebuffer_height.unwrap(),
-                properties.max_framebuffer_layers.unwrap(),
+                properties.max_framebuffer_width,
+                properties.max_framebuffer_height,
+                properties.max_framebuffer_layers,
             ];
             if dimensions[0] > limits[0] || dimensions[1] > limits[1] || dimensions[2] > limits[2] {
                 return Err(FramebufferCreationError::DimensionsTooLarge);

--- a/vulkano/src/render_pass/render_pass.rs
+++ b/vulkano/src/render_pass/render_pass.rs
@@ -290,7 +290,6 @@ impl RenderPass {
                         .physical_device()
                         .properties()
                         .max_color_attachments
-                        .unwrap()
                 {
                     return Err(RenderPassCreationError::ColorAttachmentsLimitExceeded);
                 }

--- a/vulkano/src/render_pass/render_pass.rs
+++ b/vulkano/src/render_pass/render_pass.rs
@@ -857,7 +857,6 @@ mod tests {
             .physical_device()
             .properties()
             .max_color_attachments
-            .unwrap()
             >= 10
         {
             return; // test ignored

--- a/vulkano/src/sampler.rs
+++ b/vulkano/src/sampler.rs
@@ -269,8 +269,7 @@ impl Sampler {
             let limit = device
                 .physical_device()
                 .properties()
-                .max_sampler_anisotropy
-                .unwrap();
+                .max_sampler_anisotropy;
             if max_anisotropy > limit {
                 return Err(SamplerCreationError::AnisotropyLimitExceeded {
                     requested: max_anisotropy,
@@ -284,8 +283,7 @@ impl Sampler {
             let limit = device
                 .physical_device()
                 .properties()
-                .max_sampler_lod_bias
-                .unwrap();
+                .max_sampler_lod_bias;
             if mip_lod_bias > limit {
                 return Err(SamplerCreationError::MipLodBiasLimitExceeded {
                     requested: mip_lod_bias,

--- a/vulkano/src/version.rs
+++ b/vulkano/src/version.rs
@@ -40,9 +40,9 @@ impl Version {
 }
 
 impl Default for Version {
-  fn default() -> Self {
-    Self::V1_0
-  }
+    fn default() -> Self {
+        Self::V1_0
+    }
 }
 
 impl From<u32> for Version {

--- a/vulkano/src/version.rs
+++ b/vulkano/src/version.rs
@@ -39,6 +39,12 @@ impl Version {
     }
 }
 
+impl Default for Version {
+  fn default() -> Self {
+    Self::V1_0
+  }
+}
+
 impl From<u32> for Version {
     #[inline]
     fn from(val: u32) -> Self {


### PR DESCRIPTION
makes #1649 go brrr. i haven't updated the examples yet but would something like this be ok?

```
- **Breaking** Known physical device properties (VkPhysicalDeviceProperties, VkPhysicalDeviceLimits, VkPhysicalDeviceSparseProperties) are now no longer `Option<T>`.
  - These properties are available with every `vkGetPhysicalDeviceProperties2` call
- Add some `Default` instances to make the auto trait happy
```