### PR TITLE
Add support for EXTENDED_SRGB_NONLINEAR_EXT color space

### DIFF
--- a/vulkano/src/swapchain/capabilities.rs
+++ b/vulkano/src/swapchain/capabilities.rs
@@ -614,6 +614,7 @@ pub enum ColorSpace {
     SrgbNonLinear = ash::vk::ColorSpaceKHR::SRGB_NONLINEAR.as_raw(),
     DisplayP3NonLinear = ash::vk::ColorSpaceKHR::DISPLAY_P3_NONLINEAR_EXT.as_raw(),
     ExtendedSrgbLinear = ash::vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT.as_raw(),
+    ExtendedSrgbNonLinear = ash::vk::ColorSpaceKHR::EXTENDED_SRGB_NONLINEAR_EXT.as_raw(),
     DciP3Linear = ash::vk::ColorSpaceKHR::DCI_P3_LINEAR_EXT.as_raw(),
     DciP3NonLinear = ash::vk::ColorSpaceKHR::DCI_P3_NONLINEAR_EXT.as_raw(),
     Bt709Linear = ash::vk::ColorSpaceKHR::BT709_LINEAR_EXT.as_raw(),
@@ -642,6 +643,7 @@ impl From<ash::vk::ColorSpaceKHR> for ColorSpace {
             ash::vk::ColorSpaceKHR::SRGB_NONLINEAR => ColorSpace::SrgbNonLinear,
             ash::vk::ColorSpaceKHR::DISPLAY_P3_NONLINEAR_EXT => ColorSpace::DisplayP3NonLinear,
             ash::vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT => ColorSpace::ExtendedSrgbLinear,
+            ash::vk::ColorSpaceKHR::EXTENDED_SRGB_NONLINEAR_EXT => ColorSpace::ExtendedSrgbNonLinear,
             ash::vk::ColorSpaceKHR::DCI_P3_LINEAR_EXT => ColorSpace::DciP3Linear,
             ash::vk::ColorSpaceKHR::DCI_P3_NONLINEAR_EXT => ColorSpace::DciP3NonLinear,
             ash::vk::ColorSpaceKHR::BT709_LINEAR_EXT => ColorSpace::Bt709Linear,
@@ -654,7 +656,7 @@ impl From<ash::vk::ColorSpaceKHR> for ColorSpace {
             ash::vk::ColorSpaceKHR::ADOBERGB_NONLINEAR_EXT => ColorSpace::AdobeRgbNonLinear,
             ash::vk::ColorSpaceKHR::PASS_THROUGH_EXT => ColorSpace::PassThrough,
             ash::vk::ColorSpaceKHR::DISPLAY_NATIVE_AMD => ColorSpace::DisplayNative,
-            _ => panic!("Wrong value for color space enum"),
+            _ => panic!("Wrong value for color space enum {:?}", val),
         }
     }
 }

--- a/vulkano/src/swapchain/capabilities.rs
+++ b/vulkano/src/swapchain/capabilities.rs
@@ -643,7 +643,9 @@ impl From<ash::vk::ColorSpaceKHR> for ColorSpace {
             ash::vk::ColorSpaceKHR::SRGB_NONLINEAR => ColorSpace::SrgbNonLinear,
             ash::vk::ColorSpaceKHR::DISPLAY_P3_NONLINEAR_EXT => ColorSpace::DisplayP3NonLinear,
             ash::vk::ColorSpaceKHR::EXTENDED_SRGB_LINEAR_EXT => ColorSpace::ExtendedSrgbLinear,
-            ash::vk::ColorSpaceKHR::EXTENDED_SRGB_NONLINEAR_EXT => ColorSpace::ExtendedSrgbNonLinear,
+            ash::vk::ColorSpaceKHR::EXTENDED_SRGB_NONLINEAR_EXT => {
+                ColorSpace::ExtendedSrgbNonLinear
+            }
             ash::vk::ColorSpaceKHR::DCI_P3_LINEAR_EXT => ColorSpace::DciP3Linear,
             ash::vk::ColorSpaceKHR::DCI_P3_NONLINEAR_EXT => ColorSpace::DciP3NonLinear,
             ash::vk::ColorSpaceKHR::BT709_LINEAR_EXT => ColorSpace::Bt709Linear,


### PR DESCRIPTION
I got crashes on my AMD Radeon Pro 560X because of missing color space

Change-log:
- Add support for EXTENDED_SRGB_NONLINEAR_EXT color space
- Better error message for wrong color space value