### PR TITLE
update push constant ranges to match the spec. overlapping ranges are OK but intersecting stage flags are not

### DIFF
--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -140,7 +140,7 @@ fn main() {
                         descriptor_set_layouts,
                         shader
                             .main_entry_point()
-                            .push_constant_ranges()
+                            .push_constant_range()
                             .iter()
                             .cloned(),
                     )

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -221,7 +221,7 @@ fn main() {
         vs.graphics_entry_point(
             CStr::from_bytes_with_nul_unchecked(b"main\0"),
             [], // No descriptor sets.
-            [], // No push constants.
+            None, // No push constants.
             <()>::descriptors(),
             vertex_input,
             vertex_output,
@@ -233,7 +233,7 @@ fn main() {
         fs.graphics_entry_point(
             CStr::from_bytes_with_nul_unchecked(b"main\0"),
             [], // No descriptor sets.
-            [], // No push constants.
+            None, // No push constants.
             <()>::descriptors(),
             fragment_input,
             fragment_output,

--- a/vulkano-shaders/src/descriptor_sets.rs
+++ b/vulkano-shaders/src/descriptor_sets.rs
@@ -28,7 +28,7 @@ pub(super) fn write_descriptor_set_layout_descs(
     entrypoint_id: u32,
     interface: &[u32],
     exact_entrypoint_interface: bool,
-    stages: TokenStream,
+    stages: &TokenStream,
 ) -> TokenStream {
     // TODO: somewhat implemented correctly
 
@@ -84,7 +84,7 @@ pub(super) fn write_descriptor_set_layout_descs(
     }
 }
 
-pub(super) fn write_push_constant_ranges(doc: &Spirv, types_meta: &TypesMeta) -> TokenStream {
+pub(super) fn write_push_constant_ranges(doc: &Spirv, stage: &TokenStream, types_meta: &TypesMeta) -> TokenStream {
     // TODO: somewhat implemented correctly
 
     // Looping to find all the push constant structs.
@@ -106,17 +106,17 @@ pub(super) fn write_push_constant_ranges(doc: &Spirv, types_meta: &TypesMeta) ->
 
     if push_constants_size == 0 {
         quote! {
-            []
+            None
         }
     } else {
         quote! {
-            [
+            Some(
                 PipelineLayoutPcRange {
                     offset: 0,                   // FIXME: not necessarily true
                     size: #push_constants_size,
-                    stages: ShaderStages::all(), // FIXME: wrong
+                    stages: #stage,
                 }
-            ]
+            )
         }
     }
 }

--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -82,8 +82,8 @@ pub(super) fn write_entry_point(
     };
 
     let descriptor_set_layout_descs =
-        write_descriptor_set_layout_descs(&doc, id, interface, exact_entrypoint_interface, stage);
-    let push_constant_ranges = write_push_constant_ranges(&doc, &types_meta);
+        write_descriptor_set_layout_descs(&doc, id, interface, exact_entrypoint_interface, &stage);
+    let push_constant_ranges = write_push_constant_ranges(&doc, &stage, &types_meta);
 
     let spec_consts_struct = if crate::spec_consts::has_specialization_constants(doc) {
         quote! { SpecializationConstants }

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -290,7 +290,7 @@ mod tests {
             module.compute_entry_point(
                 CStr::from_ptr(NAME.as_ptr() as *const _),
                 [],
-                [],
+                None,
                 <()>::descriptors(),
             )
         };
@@ -335,7 +335,7 @@ mod tests {
             first_module.compute_entry_point(
                 CStr::from_ptr(NAME.as_ptr() as *const _),
                 [],
-                [],
+                None,
                 <()>::descriptors(),
             )
         };
@@ -376,7 +376,7 @@ mod tests {
             second_module.compute_entry_point(
                 CStr::from_ptr(NAME.as_ptr() as *const _),
                 [],
-                [],
+                None,
                 <()>::descriptors(),
             )
         };
@@ -430,7 +430,7 @@ mod tests {
             module.compute_entry_point(
                 CStr::from_ptr(NAME.as_ptr() as *const _),
                 [],
-                [],
+                None,
                 <()>::descriptors(),
             )
         };

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -76,7 +76,7 @@ impl ComputePipeline {
             let pipeline_layout = Arc::new(PipelineLayout::new(
                 device.clone(),
                 descriptor_set_layouts,
-                shader.push_constant_ranges().iter().cloned(),
+                shader.push_constant_range().iter().cloned(),
             )?);
             ComputePipeline::with_unchecked_pipeline_layout(
                 device,
@@ -110,7 +110,7 @@ impl ComputePipeline {
         unsafe {
             pipeline_layout.ensure_superset_of(
                 shader.descriptor_set_layout_descs(),
-                shader.push_constant_ranges(),
+                shader.push_constant_range(),
             )?;
             ComputePipeline::with_unchecked_pipeline_layout(
                 device,
@@ -460,7 +460,7 @@ mod tests {
                     },
                     readonly: true,
                 })])],
-                [],
+                None,
                 SpecConsts::descriptors(),
             )
         };


### PR DESCRIPTION
this is my attempt at addressing #1657. we also check that a `PipelineLayout`'s push constant ranges completely encompass any range that was passed in `superset`. If the two stage sets intersect, we ensure that our range starts before and ends after the other range.