### PR TITLE
More sensible representation of stencil faces

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -50,6 +50,7 @@ use crate::image::ImageAccess;
 use crate::image::ImageAspect;
 use crate::image::ImageAspects;
 use crate::image::ImageLayout;
+use crate::pipeline::depth_stencil::StencilFaces;
 use crate::pipeline::input_assembly::Index;
 use crate::pipeline::layout::PipelineLayout;
 use crate::pipeline::vertex::VertexSource;
@@ -2125,15 +2126,18 @@ unsafe fn set_state(destination: &mut SyncCommandBufferBuilder, dynamic: &Dynami
     }
 
     if let Some(compare_mask) = dynamic.compare_mask {
-        destination.set_stencil_compare_mask(compare_mask);
+        destination.set_stencil_compare_mask(StencilFaces::Front, compare_mask.front);
+        destination.set_stencil_compare_mask(StencilFaces::Back, compare_mask.back);
     }
 
     if let Some(write_mask) = dynamic.write_mask {
-        destination.set_stencil_write_mask(write_mask);
+        destination.set_stencil_write_mask(StencilFaces::Front, write_mask.front);
+        destination.set_stencil_write_mask(StencilFaces::Back, write_mask.back);
     }
 
     if let Some(reference) = dynamic.reference {
-        destination.set_stencil_reference(reference);
+        destination.set_stencil_reference(StencilFaces::Front, reference.front);
+        destination.set_stencil_reference(StencilFaces::Back, reference.back);
     }
 }
 

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -30,8 +30,7 @@ use crate::descriptor_set::DescriptorSetWithOffsets;
 use crate::format::ClearValue;
 use crate::image::ImageAccess;
 use crate::image::ImageLayout;
-use crate::pipeline::depth_stencil::DynamicStencilValue;
-use crate::pipeline::depth_stencil::StencilFaceFlags;
+use crate::pipeline::depth_stencil::StencilFaces;
 use crate::pipeline::input_assembly::IndexType;
 use crate::pipeline::layout::PipelineLayout;
 use crate::pipeline::shader::ShaderStages;
@@ -2355,9 +2354,9 @@ impl SyncCommandBufferBuilder {
 
     /// Calls `vkCmdSetStencilCompareMask` on the builder.
     #[inline]
-    pub unsafe fn set_stencil_compare_mask(&mut self, compare_mask: DynamicStencilValue) {
+    pub unsafe fn set_stencil_compare_mask(&mut self, face_mask: StencilFaces, compare_mask: u32) {
         struct Cmd {
-            face_mask: StencilFaceFlags,
+            face_mask: StencilFaces,
             compare_mask: u32,
         }
 
@@ -2373,8 +2372,8 @@ impl SyncCommandBufferBuilder {
 
         self.append_command(
             Cmd {
-                face_mask: compare_mask.face,
-                compare_mask: compare_mask.value,
+                face_mask,
+                compare_mask,
             },
             &[],
         )
@@ -2383,9 +2382,9 @@ impl SyncCommandBufferBuilder {
 
     /// Calls `vkCmdSetStencilReference` on the builder.
     #[inline]
-    pub unsafe fn set_stencil_reference(&mut self, reference: DynamicStencilValue) {
+    pub unsafe fn set_stencil_reference(&mut self, face_mask: StencilFaces, reference: u32) {
         struct Cmd {
-            face_mask: StencilFaceFlags,
+            face_mask: StencilFaces,
             reference: u32,
         }
 
@@ -2401,8 +2400,8 @@ impl SyncCommandBufferBuilder {
 
         self.append_command(
             Cmd {
-                face_mask: reference.face,
-                reference: reference.value,
+                face_mask,
+                reference,
             },
             &[],
         )
@@ -2411,9 +2410,9 @@ impl SyncCommandBufferBuilder {
 
     /// Calls `vkCmdSetStencilWriteMask` on the builder.
     #[inline]
-    pub unsafe fn set_stencil_write_mask(&mut self, write_mask: DynamicStencilValue) {
+    pub unsafe fn set_stencil_write_mask(&mut self, face_mask: StencilFaces, write_mask: u32) {
         struct Cmd {
-            face_mask: StencilFaceFlags,
+            face_mask: StencilFaces,
             write_mask: u32,
         }
 
@@ -2429,8 +2428,8 @@ impl SyncCommandBufferBuilder {
 
         self.append_command(
             Cmd {
-                face_mask: write_mask.face,
-                write_mask: write_mask.value,
+                face_mask,
+                write_mask,
             },
             &[],
         )

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -27,7 +27,7 @@ use crate::image::ImageAspect;
 use crate::image::ImageAspects;
 use crate::image::ImageLayout;
 use crate::image::SampleCount;
-use crate::pipeline::depth_stencil::StencilFaceFlags;
+use crate::pipeline::depth_stencil::StencilFaces;
 use crate::pipeline::input_assembly::IndexType;
 use crate::pipeline::layout::PipelineLayout;
 use crate::pipeline::shader::ShaderStages;
@@ -1360,11 +1360,7 @@ impl UnsafeCommandBufferBuilder {
 
     /// Calls `vkCmdSetStencilCompareMask` on the builder.
     #[inline]
-    pub unsafe fn set_stencil_compare_mask(
-        &mut self,
-        face_mask: StencilFaceFlags,
-        compare_mask: u32,
-    ) {
+    pub unsafe fn set_stencil_compare_mask(&mut self, face_mask: StencilFaces, compare_mask: u32) {
         let fns = self.device().fns();
         let cmd = self.internal_object();
         fns.v1_0
@@ -1373,7 +1369,7 @@ impl UnsafeCommandBufferBuilder {
 
     /// Calls `vkCmdSetStencilReference` on the builder.
     #[inline]
-    pub unsafe fn set_stencil_reference(&mut self, face_mask: StencilFaceFlags, reference: u32) {
+    pub unsafe fn set_stencil_reference(&mut self, face_mask: StencilFaces, reference: u32) {
         let fns = self.device().fns();
         let cmd = self.internal_object();
         fns.v1_0
@@ -1382,7 +1378,7 @@ impl UnsafeCommandBufferBuilder {
 
     /// Calls `vkCmdSetStencilWriteMask` on the builder.
     #[inline]
-    pub unsafe fn set_stencil_write_mask(&mut self, face_mask: StencilFaceFlags, write_mask: u32) {
+    pub unsafe fn set_stencil_write_mask(&mut self, face_mask: StencilFaces, write_mask: u32) {
         let fns = self.device().fns();
         let cmd = self.internal_object();
         fns.v1_0

--- a/vulkano/src/pipeline/depth_stencil.rs
+++ b/vulkano/src/pipeline/depth_stencil.rs
@@ -182,27 +182,27 @@ impl From<StencilOp> for ash::vk::StencilOp {
     }
 }
 
-/// Enum to specify which stencil state to use
+/// Specifies a face for stencil operations.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u32)]
-pub enum StencilFaceFlags {
-    StencilFaceFrontBit = ash::vk::StencilFaceFlags::FRONT.as_raw(),
-    StencilFaceBackBit = ash::vk::StencilFaceFlags::BACK.as_raw(),
-    StencilFrontAndBack = ash::vk::StencilFaceFlags::FRONT_AND_BACK.as_raw(),
+pub enum StencilFaces {
+    Front = ash::vk::StencilFaceFlags::FRONT.as_raw(),
+    Back = ash::vk::StencilFaceFlags::BACK.as_raw(),
+    FrontAndBack = ash::vk::StencilFaceFlags::FRONT_AND_BACK.as_raw(),
 }
 
-impl From<StencilFaceFlags> for ash::vk::StencilFaceFlags {
+impl From<StencilFaces> for ash::vk::StencilFaceFlags {
     #[inline]
-    fn from(val: StencilFaceFlags) -> Self {
+    fn from(val: StencilFaces) -> Self {
         Self::from_raw(val as u32)
     }
 }
 
-/// Container for dynamic StencilFaceFlags and value
+/// Specifies a dynamic state value for the front and back faces.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DynamicStencilValue {
-    pub face: StencilFaceFlags,
-    pub value: u32,
+    pub front: u32,
+    pub back: u32,
 }
 
 /// Allows you to ask the GPU to exclude fragments that are outside of a certain range.


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** `StencilFaceFlags` is renamed to `StencilFaces`, and its variants are also shortened.
- **Breaking** `DynamicStencilValue` now contains a `front` and a `back` value.
- **Breaking** The stencil state commands of `SyncCommandBufferBuilder` now take a `StencilFaces` value and a `u32` instead of `DynamicStencilValue`.
```

The way the dynamic state for stencil values was set up was wrong, perhaps due to a misunderstanding of how things work. For each dynamic state setting (compare mask, write mask and reference), there are always two values associated: the value applied to front faces, and the value applied to back faces. These values should both be set when drawing, but Vulkan lets you set both values independently or in one go.

The way Vulkano seems to have treated this previously is as if the face specifier is simply part of the dynamic state being set, but it's not; both values should always be specified. This is why `DynamicStencilValue` is changed so that it always contains both a front and a back value. For the set commands of `SyncCommandBufferBuilder`, I stayed closer to raw Vulkan, so that you specify a new value and the face(s) for which this new value should apply.