### PR TITLE
SubImage: respect layout parameter

### DIFF
--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -100,7 +100,7 @@ impl SubImage {
             image,
             mip_levels_access,
             layer_levels_access,
-            layout: ImageLayout::ShaderReadOnlyOptimal,
+            layout,
         })
     }
 }


### PR DESCRIPTION
This makes `SubImage` respect the value of the `layout` parameter. I suspect it's a simple typo in #1451, maybe happened during testing. cc @qnope 

There is no impact on code in `ImmutableImage` as far as I can tell, because the code anyway always passes `ImageLayout::ShaderReadOnlyOptimal`, so I'm not sure if this fix deserves a changelog entry, but if yes, I guess it's a breaking one, so here it goes:

    * Entries for Vulkano changelog:
        - `**Breaking** Image layout passed to SubImage is now being respected.`

