### PR TITLE
Replace `VertexSource` with `VertexBuffersCollection`, remove pipeline traits

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -21,7 +21,6 @@ use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
 use vulkano::pipeline::ComputePipeline;
-use vulkano::pipeline::ComputePipelineAbstract;
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -160,7 +160,7 @@ impl AmbientLightingSystem {
                 0,
                 self.pipeline.clone(),
                 &dynamic_state,
-                vec![self.vertex_buffer.clone()],
+                self.vertex_buffer.clone(),
                 descriptor_set,
                 push_constants,
             )

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -7,8 +7,10 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use std::sync::Arc;
 use vulkano::buffer::BufferUsage;
 use vulkano::buffer::CpuAccessibleBuffer;
+use vulkano::buffer::TypedBufferAccess;
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SecondaryAutoCommandBuffer,
 };
@@ -20,17 +22,13 @@ use vulkano::pipeline::blend::BlendFactor;
 use vulkano::pipeline::blend::BlendOp;
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
-use vulkano::pipeline::GraphicsPipelineAbstract;
 use vulkano::render_pass::Subpass;
-
-use std::sync::Arc;
-use vulkano::buffer::TypedBufferAccess;
 
 /// Allows applying an ambient lighting to a scene.
 pub struct AmbientLightingSystem {
     gfx_queue: Arc<Queue>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    pipeline: Arc<dyn GraphicsPipelineAbstract + Send + Sync>,
+    pipeline: Arc<GraphicsPipeline>,
 }
 
 impl AmbientLightingSystem {

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -174,7 +174,7 @@ impl DirectionalLightingSystem {
                 0,
                 self.pipeline.clone(),
                 &dynamic_state,
-                vec![self.vertex_buffer.clone()],
+                self.vertex_buffer.clone(),
                 descriptor_set,
                 push_constants,
             )

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -8,8 +8,10 @@
 // according to those terms.
 
 use cgmath::Vector3;
+use std::sync::Arc;
 use vulkano::buffer::BufferUsage;
 use vulkano::buffer::CpuAccessibleBuffer;
+use vulkano::buffer::TypedBufferAccess;
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SecondaryAutoCommandBuffer,
 };
@@ -21,17 +23,13 @@ use vulkano::pipeline::blend::BlendFactor;
 use vulkano::pipeline::blend::BlendOp;
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
-use vulkano::pipeline::GraphicsPipelineAbstract;
 use vulkano::render_pass::Subpass;
-
-use std::sync::Arc;
-use vulkano::buffer::TypedBufferAccess;
 
 /// Allows applying a directional light source to a scene.
 pub struct DirectionalLightingSystem {
     gfx_queue: Arc<Queue>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    pipeline: Arc<dyn GraphicsPipelineAbstract + Send + Sync>,
+    pipeline: Arc<GraphicsPipeline>,
 }
 
 impl DirectionalLightingSystem {

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -22,7 +22,6 @@ use vulkano::pipeline::blend::BlendFactor;
 use vulkano::pipeline::blend::BlendOp;
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
-use vulkano::pipeline::GraphicsPipelineAbstract;
 use vulkano::render_pass::Subpass;
 
 use std::sync::Arc;
@@ -31,7 +30,7 @@ use vulkano::buffer::TypedBufferAccess;
 pub struct PointLightingSystem {
     gfx_queue: Arc<Queue>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    pipeline: Arc<dyn GraphicsPipelineAbstract + Send + Sync>,
+    pipeline: Arc<GraphicsPipeline>,
 }
 
 impl PointLightingSystem {

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -189,7 +189,7 @@ impl PointLightingSystem {
                 0,
                 self.pipeline.clone(),
                 &dynamic_state,
-                vec![self.vertex_buffer.clone()],
+                self.vertex_buffer.clone(),
                 descriptor_set,
                 push_constants,
             )

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -7,24 +7,22 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use std::sync::Arc;
 use vulkano::buffer::BufferUsage;
 use vulkano::buffer::CpuAccessibleBuffer;
+use vulkano::buffer::TypedBufferAccess;
 use vulkano::command_buffer::{
     AutoCommandBufferBuilder, CommandBufferUsage, DynamicState, SecondaryAutoCommandBuffer,
 };
 use vulkano::device::Queue;
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
-use vulkano::pipeline::GraphicsPipelineAbstract;
 use vulkano::render_pass::Subpass;
-
-use std::sync::Arc;
-use vulkano::buffer::TypedBufferAccess;
 
 pub struct TriangleDrawSystem {
     gfx_queue: Arc<Queue>,
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    pipeline: Arc<dyn GraphicsPipelineAbstract + Send + Sync>,
+    pipeline: Arc<GraphicsPipeline>,
 }
 
 impl TriangleDrawSystem {

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -103,7 +103,7 @@ impl TriangleDrawSystem {
                     }]),
                     ..DynamicState::none()
                 },
-                vec![self.vertex_buffer.clone()],
+                self.vertex_buffer.clone(),
                 (),
                 (),
             )

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -26,7 +26,6 @@ use vulkano::instance::{Instance, InstanceExtensions};
 use vulkano::pipeline::layout::PipelineLayout;
 use vulkano::pipeline::shader::EntryPointAbstract;
 use vulkano::pipeline::ComputePipeline;
-use vulkano::pipeline::ComputePipelineAbstract;
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::OomError;

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -27,7 +27,6 @@ use vulkano::format::Format;
 use vulkano::image::{view::ImageView, ImageDimensions, StorageImage};
 use vulkano::instance::{Instance, InstanceExtensions};
 use vulkano::pipeline::ComputePipeline;
-use vulkano::pipeline::ComputePipelineAbstract;
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -24,7 +24,6 @@ use vulkano::image::{
 use vulkano::instance::Instance;
 use vulkano::pipeline::viewport::Viewport;
 use vulkano::pipeline::GraphicsPipeline;
-use vulkano::pipeline::GraphicsPipelineAbstract;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 use vulkano::swapchain;

--- a/examples/src/bin/immutable-buffer-initialization.rs
+++ b/examples/src/bin/immutable-buffer-initialization.rs
@@ -17,7 +17,6 @@ use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
 use vulkano::pipeline::ComputePipeline;
-use vulkano::pipeline::ComputePipelineAbstract;
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -44,7 +44,7 @@ use vulkano::image::view::ImageView;
 use vulkano::image::{ImageUsage, SwapchainImage};
 use vulkano::instance::Instance;
 use vulkano::pipeline::viewport::Viewport;
-use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract, GraphicsPipeline};
+use vulkano::pipeline::{ComputePipeline, GraphicsPipeline};
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
 use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -16,7 +16,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
+use vulkano::pipeline::ComputePipeline;
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -18,7 +18,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
+use vulkano::pipeline::ComputePipeline;
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -16,7 +16,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, ComputePipelineAbstract};
+use vulkano::pipeline::ComputePipeline;
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -271,7 +271,7 @@ fn main() {
                         0,
                         pipeline.clone(),
                         &DynamicState::none(),
-                        vec![vertex_buffer.clone(), normals_buffer.clone()],
+                        (vertex_buffer.clone(), normals_buffer.clone()),
                         index_buffer.clone(),
                         set.clone(),
                         (),

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -28,7 +28,7 @@ use vulkano::image::{ImageUsage, SwapchainImage};
 use vulkano::instance::Instance;
 use vulkano::pipeline::vertex::BuffersDefinition;
 use vulkano::pipeline::viewport::Viewport;
-use vulkano::pipeline::{GraphicsPipeline, GraphicsPipelineAbstract};
+use vulkano::pipeline::GraphicsPipeline;
 use vulkano::render_pass::{Framebuffer, FramebufferAbstract, RenderPass, Subpass};
 use vulkano::swapchain;
 use vulkano::swapchain::{AcquireError, Swapchain, SwapchainCreationError};
@@ -317,7 +317,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
 ) -> (
-    Arc<dyn GraphicsPipelineAbstract + Send + Sync>,
+    Arc<GraphicsPipeline>,
     Vec<Arc<dyn FramebufferAbstract + Send + Sync>>,
 ) {
     let dimensions = images[0].dimensions();

--- a/vulkano/src/command_buffer/state_cacher.rs
+++ b/vulkano/src/command_buffer/state_cacher.rs
@@ -11,8 +11,8 @@ use crate::buffer::BufferAccess;
 use crate::command_buffer::DynamicState;
 use crate::descriptor_set::DescriptorSetWithOffsets;
 use crate::pipeline::input_assembly::IndexType;
-use crate::pipeline::ComputePipelineAbstract;
-use crate::pipeline::GraphicsPipelineAbstract;
+use crate::pipeline::ComputePipeline;
+use crate::pipeline::GraphicsPipeline;
 use crate::pipeline::PipelineBindPoint;
 use crate::DeviceSize;
 use crate::VulkanObject;
@@ -154,11 +154,8 @@ impl StateCacher {
     ///
     /// This function also updates the state cacher. The state cacher assumes that the state
     /// changes are going to be performed after this function returns.
-    pub fn bind_graphics_pipeline<P>(&mut self, pipeline: &P) -> StateCacherOutcome
-    where
-        P: GraphicsPipelineAbstract,
-    {
-        let inner = GraphicsPipelineAbstract::inner(pipeline).internal_object();
+    pub fn bind_graphics_pipeline(&mut self, pipeline: &GraphicsPipeline) -> StateCacherOutcome {
+        let inner = pipeline.internal_object();
         if inner == self.graphics_pipeline {
             StateCacherOutcome::AlreadyOk
         } else {
@@ -173,11 +170,8 @@ impl StateCacher {
     ///
     /// This function also updates the state cacher. The state cacher assumes that the state
     /// changes are going to be performed after this function returns.
-    pub fn bind_compute_pipeline<P>(&mut self, pipeline: &P) -> StateCacherOutcome
-    where
-        P: ComputePipelineAbstract,
-    {
-        let inner = pipeline.inner().internal_object();
+    pub fn bind_compute_pipeline(&mut self, pipeline: &ComputePipeline) -> StateCacherOutcome {
+        let inner = pipeline.internal_object();
         if inner == self.compute_pipeline {
             StateCacherOutcome::AlreadyOk
         } else {

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -27,7 +27,7 @@ use crate::descriptor_set::DescriptorSet;
 use crate::device::Device;
 use crate::device::DeviceOwned;
 use crate::image::ImageLayout;
-use crate::pipeline::{ComputePipelineAbstract, GraphicsPipelineAbstract, PipelineBindPoint};
+use crate::pipeline::{ComputePipeline, GraphicsPipeline, PipelineBindPoint};
 use crate::render_pass::FramebufferAbstract;
 use crate::sync::AccessFlags;
 use crate::sync::PipelineMemoryAccess;
@@ -627,7 +627,7 @@ impl SyncCommandBufferBuilder {
     }
 
     /// Returns the compute pipeline currently bound, or `None` if nothing has been bound yet.
-    pub(crate) fn bound_pipeline_compute(&self) -> Option<&dyn ComputePipelineAbstract> {
+    pub(crate) fn bound_pipeline_compute(&self) -> Option<&Arc<ComputePipeline>> {
         self.bindings
             .pipeline_compute
             .as_ref()
@@ -635,7 +635,7 @@ impl SyncCommandBufferBuilder {
     }
 
     /// Returns the graphics pipeline currently bound, or `None` if nothing has been bound yet.
-    pub(crate) fn bound_pipeline_graphics(&self) -> Option<&dyn GraphicsPipelineAbstract> {
+    pub(crate) fn bound_pipeline_graphics(&self) -> Option<&Arc<GraphicsPipeline>> {
         self.bindings
             .pipeline_graphics
             .as_ref()

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -37,8 +37,8 @@ use crate::pipeline::shader::ShaderStages;
 use crate::pipeline::vertex::VertexInput;
 use crate::pipeline::viewport::Scissor;
 use crate::pipeline::viewport::Viewport;
-use crate::pipeline::ComputePipelineAbstract;
-use crate::pipeline::GraphicsPipelineAbstract;
+use crate::pipeline::ComputePipeline;
+use crate::pipeline::GraphicsPipeline;
 use crate::pipeline::PipelineBindPoint;
 use crate::query::QueryControlFlags;
 use crate::query::QueryPool;
@@ -246,18 +246,12 @@ impl SyncCommandBufferBuilder {
 
     /// Calls `vkCmdBindPipeline` on the builder with a compute pipeline.
     #[inline]
-    pub unsafe fn bind_pipeline_compute<Cp>(&mut self, pipeline: Cp)
-    where
-        Cp: ComputePipelineAbstract + Send + Sync + 'static,
-    {
-        struct Cmd<Gp> {
-            pipeline: Gp,
+    pub unsafe fn bind_pipeline_compute(&mut self, pipeline: Arc<ComputePipeline>) {
+        struct Cmd {
+            pipeline: Arc<ComputePipeline>,
         }
 
-        impl<Gp> Command for Cmd<Gp>
-        where
-            Gp: ComputePipelineAbstract + Send + Sync + 'static,
-        {
+        impl Command for Cmd {
             fn name(&self) -> &'static str {
                 "vkCmdBindPipeline"
             }
@@ -266,7 +260,7 @@ impl SyncCommandBufferBuilder {
                 out.bind_pipeline_compute(&self.pipeline);
             }
 
-            fn bound_pipeline_compute(&self) -> &dyn ComputePipelineAbstract {
+            fn bound_pipeline_compute(&self) -> &Arc<ComputePipeline> {
                 &self.pipeline
             }
         }
@@ -277,18 +271,12 @@ impl SyncCommandBufferBuilder {
 
     /// Calls `vkCmdBindPipeline` on the builder with a graphics pipeline.
     #[inline]
-    pub unsafe fn bind_pipeline_graphics<Gp>(&mut self, pipeline: Gp)
-    where
-        Gp: GraphicsPipelineAbstract + Send + Sync + 'static,
-    {
-        struct Cmd<Gp> {
-            pipeline: Gp,
+    pub unsafe fn bind_pipeline_graphics(&mut self, pipeline: Arc<GraphicsPipeline>) {
+        struct Cmd {
+            pipeline: Arc<GraphicsPipeline>,
         }
 
-        impl<Gp> Command for Cmd<Gp>
-        where
-            Gp: GraphicsPipelineAbstract + Send + Sync + 'static,
-        {
+        impl Command for Cmd {
             fn name(&self) -> &'static str {
                 "vkCmdBindPipeline"
             }
@@ -297,7 +285,7 @@ impl SyncCommandBufferBuilder {
                 out.bind_pipeline_graphics(&self.pipeline);
             }
 
-            fn bound_pipeline_graphics(&self) -> &dyn GraphicsPipelineAbstract {
+            fn bound_pipeline_graphics(&self) -> &Arc<GraphicsPipeline> {
                 &self.pipeline
             }
         }

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -80,7 +80,7 @@ use crate::device::DeviceOwned;
 use crate::device::Queue;
 use crate::image::ImageAccess;
 use crate::image::ImageLayout;
-use crate::pipeline::{ComputePipelineAbstract, GraphicsPipelineAbstract};
+use crate::pipeline::{ComputePipeline, GraphicsPipeline};
 use crate::sync::AccessCheckError;
 use crate::sync::AccessError;
 use crate::sync::AccessFlags;
@@ -496,11 +496,11 @@ trait Command {
         panic!()
     }
 
-    fn bound_pipeline_compute(&self) -> &dyn ComputePipelineAbstract {
+    fn bound_pipeline_compute(&self) -> &Arc<ComputePipeline> {
         panic!()
     }
 
-    fn bound_pipeline_graphics(&self) -> &dyn GraphicsPipelineAbstract {
+    fn bound_pipeline_graphics(&self) -> &Arc<GraphicsPipeline> {
         panic!()
     }
 

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -33,8 +33,8 @@ use crate::pipeline::layout::PipelineLayout;
 use crate::pipeline::shader::ShaderStages;
 use crate::pipeline::viewport::Scissor;
 use crate::pipeline::viewport::Viewport;
-use crate::pipeline::ComputePipelineAbstract;
-use crate::pipeline::GraphicsPipelineAbstract;
+use crate::pipeline::ComputePipeline;
+use crate::pipeline::GraphicsPipeline;
 use crate::pipeline::PipelineBindPoint;
 use crate::query::QueriesRange;
 use crate::query::Query;
@@ -374,30 +374,26 @@ impl UnsafeCommandBufferBuilder {
 
     /// Calls `vkCmdBindPipeline` on the builder with a compute pipeline.
     #[inline]
-    pub unsafe fn bind_pipeline_compute<Cp>(&mut self, pipeline: &Cp)
-    where
-        Cp: ?Sized + ComputePipelineAbstract,
-    {
+    pub unsafe fn bind_pipeline_compute(&mut self, pipeline: &ComputePipeline) {
         let fns = self.device().fns();
         let cmd = self.internal_object();
         fns.v1_0.cmd_bind_pipeline(
             cmd,
             ash::vk::PipelineBindPoint::COMPUTE,
-            pipeline.inner().internal_object(),
+            pipeline.internal_object(),
         );
     }
 
     /// Calls `vkCmdBindPipeline` on the builder with a graphics pipeline.
     #[inline]
-    pub unsafe fn bind_pipeline_graphics<Gp>(&mut self, pipeline: &Gp)
-    where
-        Gp: ?Sized + GraphicsPipelineAbstract,
-    {
+    pub unsafe fn bind_pipeline_graphics(&mut self, pipeline: &GraphicsPipeline) {
         let fns = self.device().fns();
         let cmd = self.internal_object();
-        let inner = GraphicsPipelineAbstract::inner(pipeline).internal_object();
-        fns.v1_0
-            .cmd_bind_pipeline(cmd, ash::vk::PipelineBindPoint::GRAPHICS, inner);
+        fns.v1_0.cmd_bind_pipeline(
+            cmd,
+            ash::vk::PipelineBindPoint::GRAPHICS,
+            pipeline.internal_object(),
+        );
     }
 
     /// Calls `vkCmdBindVertexBuffers` on the builder.

--- a/vulkano/src/command_buffer/validity/dynamic_state.rs
+++ b/vulkano/src/command_buffer/validity/dynamic_state.rs
@@ -7,20 +7,16 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use crate::command_buffer::DynamicState;
+use crate::pipeline::GraphicsPipeline;
 use std::error;
 use std::fmt;
 
-use crate::command_buffer::DynamicState;
-use crate::pipeline::GraphicsPipelineAbstract;
-
 /// Checks whether states that are about to be set are correct.
-pub fn check_dynamic_state_validity<Pl>(
-    pipeline: &Pl,
+pub fn check_dynamic_state_validity(
+    pipeline: &GraphicsPipeline,
     state: &DynamicState,
-) -> Result<(), CheckDynamicStateValidityError>
-where
-    Pl: GraphicsPipelineAbstract,
-{
+) -> Result<(), CheckDynamicStateValidityError> {
     let device = pipeline.device();
 
     if pipeline.has_dynamic_line_width() {

--- a/vulkano/src/command_buffer/validity/vertex_buffers.rs
+++ b/vulkano/src/command_buffer/validity/vertex_buffers.rs
@@ -9,7 +9,7 @@
 
 use crate::buffer::BufferAccess;
 use crate::device::DeviceOwned;
-use crate::pipeline::GraphicsPipelineAbstract;
+use crate::pipeline::GraphicsPipeline;
 use crate::VulkanObject;
 use std::error;
 use std::fmt;
@@ -20,13 +20,10 @@ use std::fmt;
 ///
 /// - Panics if one of the vertex buffers was not created with the same device as `pipeline`.
 ///
-pub fn check_vertex_buffers<GP>(
-    pipeline: &GP,
+pub fn check_vertex_buffers(
+    pipeline: &GraphicsPipeline,
     vertex_buffers: &[Box<dyn BufferAccess + Send + Sync>],
-) -> Result<(), CheckVertexBufferError>
-where
-    GP: GraphicsPipelineAbstract,
-{
+) -> Result<(), CheckVertexBufferError> {
     for (num, buf) in vertex_buffers.iter().enumerate() {
         assert_eq!(
             buf.inner().buffer.device().internal_object(),

--- a/vulkano/src/descriptor_set/fixed_size_pool.rs
+++ b/vulkano/src/descriptor_set/fixed_size_pool.rs
@@ -18,11 +18,11 @@
 //!
 //! ```rust
 //! use vulkano::descriptor_set::FixedSizeDescriptorSetsPool;
-//! # use vulkano::pipeline::GraphicsPipelineAbstract;
+//! # use vulkano::pipeline::GraphicsPipeline;
 //! # use std::sync::Arc;
-//! # let graphics_pipeline: Arc<GraphicsPipelineAbstract> = return;
-//! // use vulkano::pipeline::GraphicsPipelineAbstract;
-//! // let graphics_pipeline: Arc<GraphicsPipelineAbstract> = ...;
+//! # let graphics_pipeline: Arc<GraphicsPipeline> = return;
+//! // use vulkano::pipeline::GraphicsPipeline;
+//! // let graphics_pipeline: Arc<GraphicsPipeline> = ...;
 //!
 //! let layout = graphics_pipeline.layout().descriptor_set_layouts().get(0).unwrap();
 //! let pool = FixedSizeDescriptorSetsPool::new(layout.clone());
@@ -34,7 +34,7 @@
 //! ```rust
 //! # use std::sync::Arc;
 //! # use vulkano::descriptor_set::FixedSizeDescriptorSetsPool;
-//! # use vulkano::pipeline::GraphicsPipelineAbstract;
+//! # use vulkano::pipeline::GraphicsPipeline;
 //! # let mut pool: FixedSizeDescriptorSetsPool = return;
 //! let descriptor_set = pool.next()
 //!     //.add_buffer(...)

--- a/vulkano/src/pipeline/compute_pipeline.rs
+++ b/vulkano/src/pipeline/compute_pipeline.rs
@@ -19,7 +19,6 @@ use crate::pipeline::shader::EntryPointAbstract;
 use crate::pipeline::shader::SpecializationConstants;
 use crate::Error;
 use crate::OomError;
-use crate::SafeDeref;
 use crate::VulkanObject;
 use std::error;
 use std::fmt;
@@ -193,57 +192,24 @@ impl ComputePipeline {
             pipeline_layout: pipeline_layout,
         })
     }
+
+    /// Returns the `Device` this compute pipeline was created with.
+    #[inline]
+    pub fn device(&self) -> &Arc<Device> {
+        &self.inner.device
+    }
+
+    /// Returns the pipeline layout used in this compute pipeline.
+    #[inline]
+    pub fn layout(&self) -> &Arc<PipelineLayout> {
+        &self.pipeline_layout
+    }
 }
 
 impl fmt::Debug for ComputePipeline {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(fmt, "<Vulkan compute pipeline {:?}>", self.inner.pipeline)
-    }
-}
-
-impl ComputePipeline {
-    /// Returns the `Device` this compute pipeline was created with.
-    #[inline]
-    pub fn device(&self) -> &Arc<Device> {
-        &self.inner.device
-    }
-}
-
-/// Trait implemented on all compute pipelines.
-pub unsafe trait ComputePipelineAbstract: DeviceOwned {
-    /// Returns an opaque object that represents the inside of the compute pipeline.
-    fn inner(&self) -> ComputePipelineSys;
-
-    /// Returns the pipeline layout used in this compute pipeline.
-    fn layout(&self) -> &Arc<PipelineLayout>;
-}
-
-unsafe impl ComputePipelineAbstract for ComputePipeline {
-    #[inline]
-    fn inner(&self) -> ComputePipelineSys {
-        ComputePipelineSys(self.inner.pipeline, PhantomData)
-    }
-
-    #[inline]
-    fn layout(&self) -> &Arc<PipelineLayout> {
-        &self.pipeline_layout
-    }
-}
-
-unsafe impl<T> ComputePipelineAbstract for T
-where
-    T: SafeDeref,
-    T::Target: ComputePipelineAbstract,
-{
-    #[inline]
-    fn inner(&self) -> ComputePipelineSys {
-        (**self).inner()
-    }
-
-    #[inline]
-    fn layout(&self) -> &Arc<PipelineLayout> {
-        (**self).layout()
     }
 }
 
@@ -387,7 +353,6 @@ mod tests {
     use crate::pipeline::shader::SpecializationConstants;
     use crate::pipeline::shader::SpecializationMapEntry;
     use crate::pipeline::ComputePipeline;
-    use crate::pipeline::ComputePipelineAbstract;
     use crate::sync::now;
     use crate::sync::GpuFuture;
     use std::ffi::CStr;

--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -138,7 +138,7 @@ where
     pub fn build(
         self,
         device: Arc<Device>,
-    ) -> Result<GraphicsPipeline<Vdef>, GraphicsPipelineCreationError> {
+    ) -> Result<GraphicsPipeline, GraphicsPipelineCreationError> {
         self.with_auto_layout(device, &[])
     }
 
@@ -150,7 +150,7 @@ where
         self,
         device: Arc<Device>,
         dynamic_buffers: &[(usize, usize)],
-    ) -> Result<GraphicsPipeline<Vdef>, GraphicsPipelineCreationError> {
+    ) -> Result<GraphicsPipeline, GraphicsPipelineCreationError> {
         let (descriptor_set_layout_descs, push_constant_ranges) = {
             let stages: SmallVec<[&GraphicsEntryPoint; 5]> = std::array::IntoIter::new([
                 self.vertex_shader.as_ref().map(|s| &s.0),
@@ -229,7 +229,7 @@ where
         mut self,
         device: Arc<Device>,
         pipeline_layout: Arc<PipelineLayout>,
-    ) -> Result<GraphicsPipeline<Vdef>, GraphicsPipelineCreationError> {
+    ) -> Result<GraphicsPipeline, GraphicsPipelineCreationError> {
         // TODO: return errors instead of panicking if missing param
 
         let fns = device.fns();
@@ -1213,7 +1213,6 @@ where
             },
             layout: pipeline_layout,
             subpass: self.subpass.take().unwrap(),
-            vertex_definition: self.vertex_definition,
             vertex_input,
 
             dynamic_line_width: self.raster.line_width.is_none(),

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -12,14 +12,9 @@ pub use self::creation_error::GraphicsPipelineCreationError;
 use crate::device::Device;
 use crate::device::DeviceOwned;
 use crate::pipeline::layout::PipelineLayout;
-use crate::pipeline::shader::ShaderInterface;
 use crate::pipeline::vertex::BuffersDefinition;
-use crate::pipeline::vertex::IncompatibleVertexDefinitionError;
-use crate::pipeline::vertex::VertexDefinition;
 use crate::pipeline::vertex::VertexInput;
-use crate::render_pass::RenderPass;
 use crate::render_pass::Subpass;
-use crate::SafeDeref;
 use crate::VulkanObject;
 use std::fmt;
 use std::hash::Hash;
@@ -38,11 +33,10 @@ mod creation_error;
 ///
 /// This object contains the shaders and the various fixed states that describe how the
 /// implementation should perform the various operations needed by a draw command.
-pub struct GraphicsPipeline<VertexDefinition> {
+pub struct GraphicsPipeline {
     inner: Inner,
     layout: Arc<PipelineLayout>,
     subpass: Subpass,
-    vertex_definition: VertexDefinition,
     vertex_input: VertexInput,
 
     dynamic_line_width: bool,
@@ -64,7 +58,7 @@ struct Inner {
     device: Arc<Device>,
 }
 
-impl GraphicsPipeline<()> {
+impl GraphicsPipeline {
     /// Starts the building process of a graphics pipeline. Returns a builder object that you can
     /// fill with the various parameters.
     pub fn start<'a>() -> GraphicsPipelineBuilder<
@@ -82,14 +76,6 @@ impl GraphicsPipeline<()> {
     > {
         GraphicsPipelineBuilder::new()
     }
-}
-
-impl<Mv> GraphicsPipeline<Mv> {
-    /// Returns the vertex definition used in the constructor.
-    #[inline]
-    pub fn vertex_definition(&self) -> &Mv {
-        &self.vertex_definition
-    }
 
     /// Returns the device used to create this pipeline.
     #[inline]
@@ -97,16 +83,22 @@ impl<Mv> GraphicsPipeline<Mv> {
         &self.inner.device
     }
 
-    /// Returns the pass used in the constructor.
+    /// Returns the pipeline layout used to create this pipeline.
     #[inline]
-    pub fn subpass(&self) -> Subpass {
-        self.subpass.clone()
+    pub fn layout(&self) -> &Arc<PipelineLayout> {
+        &self.layout
     }
 
-    /// Returns the render pass used in the constructor.
+    /// Returns the subpass this graphics pipeline is rendering to.
     #[inline]
-    pub fn render_pass(&self) -> &Arc<RenderPass> {
-        self.subpass.render_pass()
+    pub fn subpass(&self) -> &Subpass {
+        &self.subpass
+    }
+
+    /// Returns the vertex input description of the graphics pipeline.
+    #[inline]
+    pub fn vertex_input(&self) -> &VertexInput {
+        &self.vertex_input
     }
 
     /// Returns true if the line width used by this pipeline is dynamic.
@@ -158,21 +150,21 @@ impl<Mv> GraphicsPipeline<Mv> {
     }
 }
 
-unsafe impl<Mv> DeviceOwned for GraphicsPipeline<Mv> {
+unsafe impl DeviceOwned for GraphicsPipeline {
     #[inline]
     fn device(&self) -> &Arc<Device> {
         &self.inner.device
     }
 }
 
-impl<Mv> fmt::Debug for GraphicsPipeline<Mv> {
+impl fmt::Debug for GraphicsPipeline {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(fmt, "<Vulkan graphics pipeline {:?}>", self.inner.pipeline)
     }
 }
 
-unsafe impl<Mv> VulkanObject for GraphicsPipeline<Mv> {
+unsafe impl VulkanObject for GraphicsPipeline {
     type Object = ash::vk::Pipeline;
 
     #[inline]
@@ -192,208 +184,19 @@ impl Drop for Inner {
     }
 }
 
-/// Trait implemented on objects that reference a graphics pipeline. Can be made into a trait
-/// object.
-/// When using this trait `AutoCommandBufferBuilder::draw*` calls will need the buffers to be
-/// wrapped in a `vec!()`.
-pub unsafe trait GraphicsPipelineAbstract: DeviceOwned {
-    /// Returns an opaque object that represents the inside of the graphics pipeline.
-    fn inner(&self) -> GraphicsPipelineSys;
-
-    /// Returns the pipeline layout used in the constructor.
-    fn layout(&self) -> &Arc<PipelineLayout>;
-
-    /// Returns the subpass this graphics pipeline is rendering to.
-    fn subpass(&self) -> &Subpass;
-
-    /// Returns the vertex input description of the graphics pipeline.
-    fn vertex_input(&self) -> &VertexInput;
-
-    /// Returns true if the line width used by this pipeline is dynamic.
-    fn has_dynamic_line_width(&self) -> bool;
-
-    /// Returns the number of viewports and scissors of this pipeline.
-    fn num_viewports(&self) -> u32;
-
-    /// Returns true if the viewports used by this pipeline are dynamic.
-    fn has_dynamic_viewports(&self) -> bool;
-
-    /// Returns true if the scissors used by this pipeline are dynamic.
-    fn has_dynamic_scissors(&self) -> bool;
-
-    /// Returns true if the depth bounds used by this pipeline are dynamic.
-    fn has_dynamic_depth_bounds(&self) -> bool;
-
-    /// Returns true if the stencil compare masks used by this pipeline are dynamic.
-    fn has_dynamic_stencil_compare_mask(&self) -> bool;
-
-    /// Returns true if the stencil write masks used by this pipeline are dynamic.
-    fn has_dynamic_stencil_write_mask(&self) -> bool;
-
-    /// Returns true if the stencil references used by this pipeline are dynamic.
-    fn has_dynamic_stencil_reference(&self) -> bool;
-}
-
-unsafe impl<Mv> GraphicsPipelineAbstract for GraphicsPipeline<Mv> {
-    #[inline]
-    fn inner(&self) -> GraphicsPipelineSys {
-        GraphicsPipelineSys(self.inner.pipeline, PhantomData)
-    }
-
-    /// Returns the pipeline layout used in the constructor.
-    #[inline]
-    fn layout(&self) -> &Arc<PipelineLayout> {
-        &self.layout
-    }
-
-    #[inline]
-    fn subpass(&self) -> &Subpass {
-        &self.subpass
-    }
-
-    #[inline]
-    fn vertex_input(&self) -> &VertexInput {
-        &self.vertex_input
-    }
-
-    #[inline]
-    fn has_dynamic_line_width(&self) -> bool {
-        self.dynamic_line_width
-    }
-
-    #[inline]
-    fn num_viewports(&self) -> u32 {
-        self.num_viewports
-    }
-
-    #[inline]
-    fn has_dynamic_viewports(&self) -> bool {
-        self.dynamic_viewport
-    }
-
-    #[inline]
-    fn has_dynamic_scissors(&self) -> bool {
-        self.dynamic_scissor
-    }
-
-    #[inline]
-    fn has_dynamic_depth_bounds(&self) -> bool {
-        self.dynamic_depth_bounds
-    }
-
-    #[inline]
-    fn has_dynamic_stencil_compare_mask(&self) -> bool {
-        self.dynamic_stencil_compare_mask
-    }
-
-    #[inline]
-    fn has_dynamic_stencil_write_mask(&self) -> bool {
-        self.dynamic_stencil_write_mask
-    }
-
-    #[inline]
-    fn has_dynamic_stencil_reference(&self) -> bool {
-        self.dynamic_stencil_reference
-    }
-}
-
-unsafe impl<T> GraphicsPipelineAbstract for T
-where
-    T: SafeDeref,
-    T::Target: GraphicsPipelineAbstract,
-{
-    #[inline]
-    fn inner(&self) -> GraphicsPipelineSys {
-        GraphicsPipelineAbstract::inner(&**self)
-    }
-
-    #[inline]
-    fn layout(&self) -> &Arc<PipelineLayout> {
-        (**self).layout()
-    }
-
-    #[inline]
-    fn subpass(&self) -> &Subpass {
-        (**self).subpass()
-    }
-
-    #[inline]
-    fn vertex_input(&self) -> &VertexInput {
-        (**self).vertex_input()
-    }
-
-    #[inline]
-    fn has_dynamic_line_width(&self) -> bool {
-        (**self).has_dynamic_line_width()
-    }
-
-    #[inline]
-    fn num_viewports(&self) -> u32 {
-        (**self).num_viewports()
-    }
-
-    #[inline]
-    fn has_dynamic_viewports(&self) -> bool {
-        (**self).has_dynamic_viewports()
-    }
-
-    #[inline]
-    fn has_dynamic_scissors(&self) -> bool {
-        (**self).has_dynamic_scissors()
-    }
-
-    #[inline]
-    fn has_dynamic_depth_bounds(&self) -> bool {
-        (**self).has_dynamic_depth_bounds()
-    }
-
-    #[inline]
-    fn has_dynamic_stencil_compare_mask(&self) -> bool {
-        (**self).has_dynamic_stencil_compare_mask()
-    }
-
-    #[inline]
-    fn has_dynamic_stencil_write_mask(&self) -> bool {
-        (**self).has_dynamic_stencil_write_mask()
-    }
-
-    #[inline]
-    fn has_dynamic_stencil_reference(&self) -> bool {
-        (**self).has_dynamic_stencil_reference()
-    }
-}
-
-impl<Mv> PartialEq for GraphicsPipeline<Mv> {
+impl PartialEq for GraphicsPipeline {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.inner == other.inner
     }
 }
 
-impl<Mv> Eq for GraphicsPipeline<Mv> {}
+impl Eq for GraphicsPipeline {}
 
-impl<Mv> Hash for GraphicsPipeline<Mv> {
+impl Hash for GraphicsPipeline {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner.hash(state);
-    }
-}
-
-impl PartialEq for dyn GraphicsPipelineAbstract + Send + Sync {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        GraphicsPipelineAbstract::inner(self).0 == GraphicsPipelineAbstract::inner(other).0
-            && DeviceOwned::device(self) == DeviceOwned::device(other)
-    }
-}
-
-impl Eq for dyn GraphicsPipelineAbstract + Send + Sync {}
-
-impl Hash for dyn GraphicsPipelineAbstract + Send + Sync {
-    #[inline]
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        GraphicsPipelineAbstract::inner(self).0.hash(state);
-        DeviceOwned::device(self).hash(state);
     }
 }
 
@@ -407,18 +210,5 @@ unsafe impl<'a> VulkanObject for GraphicsPipelineSys<'a> {
     #[inline]
     fn internal_object(&self) -> ash::vk::Pipeline {
         self.0
-    }
-}
-
-unsafe impl<Mv> VertexDefinition for GraphicsPipeline<Mv>
-where
-    Mv: VertexDefinition,
-{
-    #[inline]
-    fn definition(
-        &self,
-        interface: &ShaderInterface,
-    ) -> Result<VertexInput, IncompatibleVertexDefinitionError> {
-        self.vertex_definition.definition(interface)
     }
 }

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -76,11 +76,9 @@
 #![allow(deprecated)]
 
 pub use self::compute_pipeline::ComputePipeline;
-pub use self::compute_pipeline::ComputePipelineAbstract;
 pub use self::compute_pipeline::ComputePipelineCreationError;
 pub use self::compute_pipeline::ComputePipelineSys;
 pub use self::graphics_pipeline::GraphicsPipeline;
-pub use self::graphics_pipeline::GraphicsPipelineAbstract;
 pub use self::graphics_pipeline::GraphicsPipelineBuilder;
 pub use self::graphics_pipeline::GraphicsPipelineCreationError;
 pub use self::graphics_pipeline::GraphicsPipelineSys;

--- a/vulkano/src/pipeline/vertex/collection.rs
+++ b/vulkano/src/pipeline/vertex/collection.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use crate::buffer::BufferAccess;
+
+/// A collection of vertex buffers.
+pub unsafe trait VertexBuffersCollection {
+    /// Converts `self` into a list of buffers.
+    // TODO: better than a Vec
+    fn into_vec(self) -> Vec<Box<dyn BufferAccess + Send + Sync>>;
+}
+
+unsafe impl VertexBuffersCollection for () {
+    #[inline]
+    fn into_vec(self) -> Vec<Box<dyn BufferAccess + Send + Sync>> {
+        vec![]
+    }
+}
+
+unsafe impl<T> VertexBuffersCollection for T
+where
+    T: BufferAccess + Send + Sync + 'static,
+{
+    #[inline]
+    fn into_vec(self) -> Vec<Box<dyn BufferAccess + Send + Sync>> {
+        vec![Box::new(self) as Box<_>]
+    }
+}
+
+unsafe impl<T> VertexBuffersCollection for Vec<T>
+where
+    T: BufferAccess + Send + Sync + 'static,
+{
+    #[inline]
+    fn into_vec(self) -> Vec<Box<dyn BufferAccess + Send + Sync>> {
+        self.into_iter()
+            .map(|source| Box::new(source) as Box<_>)
+            .collect()
+    }
+}
+
+macro_rules! impl_collection {
+    ($first:ident $(, $others:ident)+) => (
+        unsafe impl<$first$(, $others)+> VertexBuffersCollection for ($first, $($others),+)
+            where $first: BufferAccess + Send + Sync + 'static
+                  $(, $others: BufferAccess + Send + Sync + 'static)*
+        {
+            #[inline]
+            fn into_vec(self) -> Vec<Box<dyn BufferAccess + Send + Sync>> {
+                #![allow(non_snake_case)]
+
+                let ($first, $($others,)*) = self;
+
+                let mut list = Vec::new();
+                list.push(Box::new($first) as Box<_>);
+                $(
+                    list.push(Box::new($others) as Box<_>);
+                )+
+                list
+            }
+        }
+
+        impl_collection!($($others),+);
+    );
+
+    ($i:ident) => ();
+}
+
+impl_collection!(Z, Y, X, W, V, U, T, S, R, Q, P, O, N, M, L, K, J, I, H, G, F, E, D, C, B, A);

--- a/vulkano/src/pipeline/vertex/definition.rs
+++ b/vulkano/src/pipeline/vertex/definition.rs
@@ -7,7 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::buffer::BufferAccess;
 use crate::format::Format;
 use crate::pipeline::shader::ShaderInterface;
 use crate::pipeline::vertex::VertexInput;
@@ -15,12 +14,9 @@ use crate::pipeline::vertex::VertexMemberTy;
 use crate::SafeDeref;
 use std::error;
 use std::fmt;
-use std::sync::Arc;
 
 /// Trait for types that describe the definition of the vertex input used by a graphics pipeline.
-pub unsafe trait VertexDefinition:
-    VertexSource<Vec<Arc<dyn BufferAccess + Send + Sync>>>
-{
+pub unsafe trait VertexDefinition {
     /// Builds the vertex definition to use to link this definition to a vertex shader's input
     /// interface.
     // TODO: remove error return, move checks to GraphicsPipelineBuilder
@@ -80,26 +76,5 @@ impl fmt::Display for IncompatibleVertexDefinitionError {
                 }
             }
         )
-    }
-}
-
-/// Extension trait of `VertexDefinition`. The `L` parameter is an acceptable vertex source for this
-/// vertex definition.
-pub unsafe trait VertexSource<L> {
-    /// Checks and returns the list of buffers with offsets, number of vertices and number of instances.
-    // TODO: return error if problem
-    // TODO: better than a Vec
-    // TODO: return a struct instead
-    fn decode(&self, list: L) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize);
-}
-
-unsafe impl<L, T> VertexSource<L> for T
-where
-    T: SafeDeref,
-    T::Target: VertexSource<L>,
-{
-    #[inline]
-    fn decode(&self, list: L) -> (Vec<Box<dyn BufferAccess + Send + Sync>>, usize, usize) {
-        (**self).decode(list)
     }
 }

--- a/vulkano/src/pipeline/vertex/mod.rs
+++ b/vulkano/src/pipeline/vertex/mod.rs
@@ -64,9 +64,9 @@
 //! ```
 
 pub use self::buffers::BuffersDefinition;
+pub use self::collection::VertexBuffersCollection;
 pub use self::definition::IncompatibleVertexDefinitionError;
 pub use self::definition::VertexDefinition;
-pub use self::definition::VertexSource;
 pub use self::impl_vertex::VertexMember;
 pub use self::vertex::Vertex;
 pub use self::vertex::VertexMemberInfo;
@@ -78,6 +78,7 @@ use fnv::FnvHashMap;
 use std::convert::TryInto;
 
 mod buffers;
+mod collection;
 mod definition;
 mod impl_vertex;
 mod vertex;


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** The `VertexSource` trait is removed, and has been replaced with the new `VertexBuffersCollection` trait, which works analogously to `DescriptorSetsCollection`. Vertex buffers can now be passed in as a tuple, just like descriptor sets.
- **Breaking** Removed the vertex definition type parameter from `GraphicsPipeline`, which is no longer needed with the change above.
- **Breaking** The `ComputePipelineAbstract` and `GraphicsPipelineAbstract` traits are no longer needed and have been removed, with their methods made available on the base `ComputePipeline` and `GraphicsPipeline` types.
```

This refactoring further simplifies the API by making the way that the vertex buffers are passed to draw calls no longer dependent on the `VertexDefinition` being used. You can now always pass the vertex buffers as a single item, a tuple of various sizes, or a vec of trait objects, regardless of the vertex definition. This in turn allows the type parameter to be removed, which then makes the traits unnecessary as well.