### PR TITLE
Add: missing method `vulkano::buffer::BufferUsage::storage_buffer()`

### DIFF
--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -132,6 +132,15 @@ impl BufferUsage {
         }
     }
 
+    /// Builds a `BufferUsage` with only `storage_buffer` set, while rest are not
+    #[inline]
+    pub const fn storage_buffer() -> BufferUsage {
+        BufferUsage {
+            storage_buffer: true,
+            ..BufferUsage::none()
+        }
+    }
+
     /// Builds a `BufferUsage` with `uniform_buffer` and `transfer_destination` set to true and the rest
     /// to false.
     #[inline]


### PR DESCRIPTION
Added missing method `vulkano::buffer::BufferUsage::storage_buffer()`, which I mentioned of in [issue](#1675). 

It doesn't break anything & minimal user targeted documentation, I've added. This method enables using allocated buffer only as storage buffer.