### PR TITLE
Fixed AttachmentImage reporting incorrect layer level access.

### DIFF
--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -478,11 +478,11 @@ impl AttachmentImage {
 }
 
 impl<A> AttachmentImage<A> {
-    /// Returns the dimensions of the image.
+    /// Returns the width, height and layers of the image.
     #[inline]
-    pub fn dimensions(&self) -> [u32; 2] {
+    pub fn dimensions(&self) -> [u32; 3] {
         let dims = self.image.dimensions();
-        [dims.width(), dims.height()]
+        [dims.width(), dims.height(), dims.array_layers()]
     }
 }
 
@@ -598,7 +598,7 @@ unsafe impl<A> ImageAccess for AttachmentImage<A> {
 
     #[inline]
     fn current_layer_levels_access(&self) -> std::ops::Range<u32> {
-        0..1
+        0..self.dimensions()[2]
     }
 }
 


### PR DESCRIPTION
1. [ ] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Since multiview support has been merged, `AttachmentImage` can have multiple layers. However `current_layer_levels_access` method still returns 0..1 range, resulting in partial pipeline barriers and validation errors. I've made it return correct layer count and also included layer count in the `AttachmentImage::dimensions()`.

2. [ ] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   files(`CHANGELOG_VULKANO.md` and `CHANGELOG_VK_SYS.md`)
   by maintainers right after the Pull Request merge.

    * Entries for Vulkano changelog:
        - Fixed pipeline barriers only affecting the first layers of multi-layer `AttachmentImage`.
        - Included layer count in `AttachmentImage::dimensions()`.

3. [ ] Run `cargo fmt` on the changes.

4. [ ] Make sure that the changes are covered by unit-tests.

5. [ ] Update documentation to reflect any user-facing changes - in this repository.
