### PR TITLE
Fix warnings & errors

### DIFF
--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -160,7 +160,8 @@ fn main() {
         let png_bytes = include_bytes!("image_img.png").to_vec();
         let cursor = Cursor::new(png_bytes);
         let decoder = png::Decoder::new(cursor);
-        let (info, mut reader) = decoder.read_info().unwrap();
+        let mut reader = decoder.read_info().unwrap();
+        let info = reader.info();
         let dimensions = ImageDimensions::Dim2d {
             width: info.width,
             height: info.height,

--- a/vulkano-win/src/winit.rs
+++ b/vulkano-win/src/winit.rs
@@ -1,8 +1,6 @@
 use std::borrow::Borrow;
 use std::error;
 use std::fmt;
-#[cfg(target_os = "windows")]
-use std::ptr;
 use std::rc::Rc;
 use std::sync::Arc;
 

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -31,18 +31,28 @@ use crate::memory::pool::MemoryPoolAlloc;
 use crate::memory::pool::PotentialDedicatedAllocation;
 use crate::memory::pool::StdMemoryPoolAlloc;
 use crate::memory::{DedicatedAlloc, MemoryRequirements};
-use crate::memory::{DeviceMemoryAllocError, ExternalMemoryHandleType};
+use crate::memory::DeviceMemoryAllocError;
 use crate::sync::AccessError;
 use crate::sync::Sharing;
 use crate::DeviceSize;
 use smallvec::SmallVec;
-use std::fs::File;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::marker::PhantomData;
 use std::mem;
 use std::sync::Arc;
 use std::sync::Mutex;
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonflybsd",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+use {
+    crate::memory::ExternalMemoryHandleType,
+    std::fs::File
+};
 
 /// Buffer whose content is in device-local memory.
 ///

--- a/vulkano/src/sync/semaphore/semaphore.rs
+++ b/vulkano/src/sync/semaphore/semaphore.rs
@@ -304,11 +304,8 @@ impl From<OomError> for SemaphoreError {
 
 #[cfg(test)]
 mod tests {
-    use crate::device::physical::PhysicalDevice;
-    use crate::device::{Device, DeviceExtensions};
-    use crate::instance::{Instance, InstanceExtensions};
     use crate::VulkanObject;
-    use crate::{sync::Semaphore, Version};
+    use crate::sync::Semaphore;
 
     #[test]
     fn semaphore_create() {
@@ -342,6 +339,11 @@ mod tests {
         target_os = "openbsd"
     ))]
     fn semaphore_export() {
+        use crate::device::physical::PhysicalDevice;
+        use crate::device::{Device, DeviceExtensions};
+        use crate::instance::{Instance, InstanceExtensions};
+        use crate::Version;
+
         let supported_ext = InstanceExtensions::supported_by_core().unwrap();
         if supported_ext.khr_get_display_properties2
             && supported_ext.khr_external_semaphore_capabilities


### PR DESCRIPTION
Windows warnings related to external memory, which isn't supported, so these imports are not used.

```
warning: unused import: `ExternalMemoryHandleType`
  --> vulkano\src\buffer\device_local.rs:34:45
   |
34 | use crate::memory::{DeviceMemoryAllocError, ExternalMemoryHandleType};
   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::fs::File`
  --> vulkano\src\buffer\device_local.rs:39:5
   |
39 | use std::fs::File;
   |     ^^^^^^^^^^^^^

warning: unused import: `crate::device::physical::PhysicalDevice`
   --> vulkano\src\sync\semaphore\semaphore.rs:307:9
    |
307 |     use crate::device::physical::PhysicalDevice;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused imports: `DeviceExtensions`, `Device`
   --> vulkano\src\sync\semaphore\semaphore.rs:308:25
    |
308 |     use crate::device::{Device, DeviceExtensions};
    |                         ^^^^^^  ^^^^^^^^^^^^^^^^

warning: unused imports: `InstanceExtensions`, `Instance`
   --> vulkano\src\sync\semaphore\semaphore.rs:309:27
    |
309 |     use crate::instance::{Instance, InstanceExtensions};
    |                           ^^^^^^^^  ^^^^^^^^^^^^^^^^^^

warning: unused import: `Version`
   --> vulkano\src\sync\semaphore\semaphore.rs:311:34
    |
311 |     use crate::{sync::Semaphore, Version};
    |                                  ^^^^^^^

```

Left over dead code.

```
warning: unused import: `std::ptr`
 --> vulkano-win\src\winit.rs:5:5
  |
5 | use std::ptr;
  |     ^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```

https://github.com/vulkano-rs/vulkano/pull/1689 didn't update example from https://github.com/vulkano-rs/vulkano/pull/1688

```
error[E0308]: mismatched types
   --> examples\src\bin\immutable-sampler\main.rs:163:13
    |
163 |         let (info, mut reader) = decoder.read_info().unwrap();
    |             ^^^^^^^^^^^^^^^^^^   ---------------------------- this expression has type `Reader<std::io::Cursor<Vec<u8>>>`
    |             |
    |             expected struct `Reader`, found tuple
    |
    = note: expected struct `Reader<std::io::Cursor<Vec<u8>>>`
                found tuple `(_, _)`
```
