### PR TITLE
Additional check_copy_buffer_image checks

### DIFF
--- a/vulkano/src/command_buffer/validity/copy_image_buffer.rs
+++ b/vulkano/src/command_buffer/validity/copy_image_buffer.rs
@@ -118,13 +118,13 @@ where
             if image_offset[2] != 0 || image_size[2] != 1 {
                 return Err(CheckCopyBufferImageError::ImageCoordinatesOutOfRange);
             }
-        },
+        }
         ImageDimensions::Dim2d { .. } => {
             // VUID-vkCmdCopyBufferToImage-srcImage-00201
             if image_offset[2] != 0 || image_size[2] != 1 {
                 return Err(CheckCopyBufferImageError::ImageCoordinatesOutOfRange);
             }
-        },
+        }
         ImageDimensions::Dim3d { .. } => {
             // VUID-vkCmdCopyBufferToImage-baseArrayLayer-00213
             if image_first_layer != 0 || image_num_layers != 1 {

--- a/vulkano/src/command_buffer/validity/copy_image_buffer.rs
+++ b/vulkano/src/command_buffer/validity/copy_image_buffer.rs
@@ -14,6 +14,7 @@ use crate::format::Format;
 use crate::format::IncompatiblePixelsType;
 use crate::format::Pixel;
 use crate::image::ImageAccess;
+use crate::image::ImageDimensions;
 use crate::image::SampleCount;
 use crate::DeviceSize;
 use crate::VulkanObject;
@@ -104,6 +105,32 @@ where
 
     if image_offset[2] + image_size[2] > image_dimensions.depth() {
         return Err(CheckCopyBufferImageError::ImageCoordinatesOutOfRange);
+    }
+
+    match image.dimensions() {
+        ImageDimensions::Dim1d { .. } => {
+            // VUID-vkCmdCopyBufferToImage-srcImage-00199
+            if image_offset[1] != 0 || image_size[1] != 1 {
+                return Err(CheckCopyBufferImageError::ImageCoordinatesOutOfRange);
+            }
+
+            // VUID-vkCmdCopyBufferToImage-srcImage-00201
+            if image_offset[2] != 0 || image_size[2] != 1 {
+                return Err(CheckCopyBufferImageError::ImageCoordinatesOutOfRange);
+            }
+        },
+        ImageDimensions::Dim2d { .. } => {
+            // VUID-vkCmdCopyBufferToImage-srcImage-00201
+            if image_offset[2] != 0 || image_size[2] != 1 {
+                return Err(CheckCopyBufferImageError::ImageCoordinatesOutOfRange);
+            }
+        },
+        ImageDimensions::Dim3d { .. } => {
+            // VUID-vkCmdCopyBufferToImage-baseArrayLayer-00213
+            if image_first_layer != 0 || image_num_layers != 1 {
+                return Err(CheckCopyBufferImageError::ImageCoordinatesOutOfRange);
+            }
+        }
     }
 
     Px::ensure_accepts(image.format())?;


### PR DESCRIPTION
**Implements these checks:**
```
VUID-vkCmdCopyBufferToImage-srcImage-00199
If dstImage is of type VK_IMAGE_TYPE_1D, then for each element of pRegions, imageOffset.y must be 0 and imageExtent.height must be 1

VUID-vkCmdCopyBufferToImage-srcImage-00201
If dstImage is of type VK_IMAGE_TYPE_1D or VK_IMAGE_TYPE_2D, then for each element of pRegions, imageOffset.z must be 0 and imageExtent.depth must be 1

VUID-vkCmdCopyBufferToImage-baseArrayLayer-00213
If dstImage is of type VK_IMAGE_TYPE_3D, for each element of pRegions, imageSubresource.baseArrayLayer must be 0 and imageSubresource.layerCount must be 1
```

    * Entries for Vulkano changelog:
        - Additional copy buffer to image checks.
