### PR TITLE
fix immutable_samplers index in builder

### DIFF
--- a/vulkano/src/descriptor_set/builder.rs
+++ b/vulkano/src/descriptor_set/builder.rs
@@ -384,7 +384,7 @@ impl DescriptorSetBuilder {
                     ));
                 }
 
-                if !image_view.can_be_sampled(&immutable_samplers[self.cur_binding as usize]) {
+                if !image_view.can_be_sampled(&immutable_samplers[descriptor.array_element as usize]) {
                     return Err(DescriptorSetError::IncompatibleImageViewSampler);
                 }
 


### PR DESCRIPTION
@Rua 

https://github.com/vulkano-rs/vulkano/blob/13b7188b711d7bec67bfb0267979f76b82030d5a/vulkano/src/descriptor_set/builder.rs#L387

I think should be:
```rust
if !image_view.can_be_sampled(&immutable_samplers[descriptor.array_element as usize]) {
```

**No changelog entries required as this fixes unreleased code.**
