### PR TITLE
add derive feature to serde build dependency

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -32,6 +32,6 @@ lazy_static = "1.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.5"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 vk-parse = "0.6"


### PR DESCRIPTION
Latest master fails to build on Windows at least.

`serde` needs the `derive` feature enabled.

```
error: cannot find derive macro `Deserialize` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:18:24
   |
18 | #[derive(Clone, Debug, Deserialize)]
   |                        ^^^^^^^^^^^

error: cannot find derive macro `Deserialize` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:36:24
   |
36 | #[derive(Clone, Debug, Deserialize)]
   |                        ^^^^^^^^^^^

error: cannot find attribute `serde` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:41:7
   |
41 |     #[serde(default)]
   |       ^^^^^

error: cannot find attribute `serde` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:43:7
   |
43 |     #[serde(default)]
   |       ^^^^^

error: cannot find attribute `serde` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:45:7
   |
45 |     #[serde(default)]
   |       ^^^^^

error: cannot find derive macro `Deserialize` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:49:24
   |
49 | #[derive(Clone, Debug, Deserialize)]
   |                        ^^^^^^^^^^^

error: cannot find derive macro `Deserialize` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:56:24
   |
56 | #[derive(Clone, Debug, Deserialize)]
   |                        ^^^^^^^^^^^

error: cannot find attribute `serde` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:60:7
   |
60 |     #[serde(default)]
   |       ^^^^^

error: cannot find derive macro `Deserialize` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:64:24
   |
64 | #[derive(Clone, Debug, Deserialize)]
   |                        ^^^^^^^^^^^

error: cannot find attribute `serde` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:68:7
   |
68 |     #[serde(default)]
   |       ^^^^^

error: cannot find attribute `serde` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:70:7
   |
70 |     #[serde(default)]
   |       ^^^^^

error: cannot find derive macro `Deserialize` in this scope
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:74:24
   |
74 | #[derive(Clone, Debug, Deserialize)]
   |                        ^^^^^^^^^^^

warning: unused import: `serde::Deserialize`
  --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:10:5
   |
10 | use serde::Deserialize;
   |     ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

error[E0277]: the trait bound `SpirvGrammar: Deserialize<'_>` is not satisfied
    --> C:\Workspace\vulkano\vulkano\autogen\spirv_grammar.rs:32:9
     |
32   |         serde_json::from_str(&json).unwrap()
     |         ^^^^^^^^^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `SpirvGrammar`
     | 
    ::: C:\Users\Austin\.cargo\registry\src\github.com-1ecc6299db9ec823\serde_json-1.0.67\src\de.rs:2587:8
     |
2587 |     T: de::Deserialize<'a>,
     |        ------------------- required by this bound in `serde_json::from_str`

For more information about this error, try `rustc --explain E0277`.
```