### PR TITLE
Add `inner` method to `AutoCommandBufferBuilder`

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -496,6 +496,12 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             .unwrap()
     }
 
+    /// Returns the inner `SyncCommandBufferBuilder`, which can be queried for the current state.
+    #[inline]
+    pub fn inner(&self) -> &SyncCommandBufferBuilder {
+        &self.inner
+    }
+
     /// Binds descriptor sets for future dispatch or draw calls.
     ///
     /// # Panics


### PR DESCRIPTION
Changelog:
```markdown
- Added an `inner` method to `AutoCommandBufferBuilder`, which returns the inner `SyncCommandBufferBuilder` and can be used to query the current state/bindings.
```

A small PR that allows users to retrieve the state when using `AutoCommandBufferBuilder`.