### PR TITLE
Change inner-documentation html links to use Rust paths

### DIFF
--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -16,24 +16,24 @@
 //!
 //! # Various kinds of buffers
 //!
-//! The low level implementation of a buffer is [`UnsafeBuffer`](sys/struct.UnsafeBuffer.html).
+//! The low level implementation of a buffer is [`UnsafeBuffer`](crate::buffer::sys::UnsafeBuffer).
 //! This type makes it possible to use all the features that Vulkan is capable of, but as its name
 //! tells it is unsafe to use.
 //!
 //! Instead you are encouraged to use one of the high-level wrappers that vulkano provides. Which
 //! wrapper to use depends on the way you are going to use the buffer:
 //!
-//! - A [`DeviceLocalBuffer`](device_local/struct.DeviceLocalBuffer.html) designates a buffer
+//! - A [`DeviceLocalBuffer`](crate::buffer::device_local::DeviceLocalBuffer) designates a buffer
 //!   usually located in video memory and whose content can't be directly accessed by your
 //!   application. Accessing this buffer from the GPU is generally faster compared to accessing a
 //!   CPU-accessible buffer.
-//! - An [`ImmutableBuffer`](immutable/struct.ImmutableBuffer.html) designates a buffer in video
+//! - An [`ImmutableBuffer`](crate::buffer::immutable::ImmutableBuffer) designates a buffer in video
 //!   memory and whose content can only be written at creation. Compared to `DeviceLocalBuffer`,
 //!   this buffer requires less CPU processing because we don't need to keep track of the reads
 //!   and writes.
-//! - A [`CpuBufferPool`](cpu_pool/struct.CpuBufferPool.html) is a ring buffer that can be used to
+//! - A [`CpuBufferPool`](crate::buffer::cpu_pool::CpuBufferPool) is a ring buffer that can be used to
 //!   transfer data between the CPU and the GPU at a high rate.
-//! - A [`CpuAccessibleBuffer`](cpu_access/struct.CpuAccessibleBuffer.html) is a simple buffer that
+//! - A [`CpuAccessibleBuffer`](crate::buffer::cpu_access::CpuAccessibleBuffer) is a simple buffer that
 //!   can be used to prototype. It may be removed from vulkano in the far future.
 //!
 //! Here is a quick way to choose which buffer to use. Do you often need to read or write

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -37,11 +37,11 @@
 //! # The `AutoCommandBufferBuilder`
 //!
 //! The most basic (and recommended) way to create a command buffer is to create a
-//! [`AutoCommandBufferBuilder`](struct.AutoCommandBufferBuilder.html), then record commands to it.
+//! [`AutoCommandBufferBuilder`], then record commands to it.
 //! When you are done adding commands, build it to obtain either a `PrimaryAutoCommandBuffer` or
 //! `SecondAutoCommandBuffer`.
 //!
-//! Once built, use [the `PrimaryCommandBuffer` trait](trait.PrimaryCommandBuffer.html) to submit the
+//! Once built, use [the `PrimaryCommandBuffer` trait](crate::command_buffer::PrimaryCommandBuffer) to submit the
 //! command buffer. Submitting a command buffer returns an object that implements the `GpuFuture` trait
 //! and that represents the moment when the execution will end on the GPU.
 //!

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -30,7 +30,7 @@
 //! }).ok();
 //! ```
 //!
-//! The type of `msg` in the callback is [`Message`](struct.Message.html).
+//! The type of `msg` in the callback is [`Message`].
 //!
 //! Note that you must keep the `_callback` object alive for as long as you want your callback to
 //! be callable. If you don't store the return value of `DebugCallback`'s constructor in a

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -127,7 +127,7 @@ use std::sync::Arc;
 ///
 /// When creating an `Instance`, you have the possibility to pass a list of **layers** that will
 /// be activated on the newly-created instance. The list of available layers can be retrieved by
-/// calling [the `layers_list` function](fn.layers_list.html).
+/// calling [the `layers_list` function](crate::instance::layers_list).
 ///
 /// A layer is a component that will hook and potentially modify the Vulkan function calls.
 /// For example, activating a layer could add a frames-per-second counter on the screen, or it
@@ -194,7 +194,7 @@ impl ::std::panic::RefUnwindSafe for Instance {}
 impl Instance {
     /// Initializes a new instance of Vulkan.
     ///
-    /// See the documentation of `Instance` or of [the `instance` module](index.html) for more
+    /// See the documentation of `Instance` or of [the `instance` module](crate::instance) for more
     /// details.
     ///
     /// # Example

--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -23,9 +23,9 @@ use crate::Version;
 /// Queries the list of layers that are available when creating an instance.
 ///
 /// On success, this function returns an iterator that produces
-/// [`LayerProperties`](struct.LayerProperties.html) objects. In order to enable a layer, you need
+/// [`LayerProperties`](crate::instance::LayerProperties) objects. In order to enable a layer, you need
 /// to pass its name (returned by `LayerProperties::name()`) when creating the
-/// [`Instance`](struct.Instance.html).
+/// [`Instance`](crate::instance::Instance).
 ///
 /// This function returns an error if it failed to load the Vulkan library.
 ///

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -12,48 +12,48 @@
 //!
 //! # Brief summary of Vulkan
 //!
-//! - The [`Instance`](instance/struct.Instance.html) object is the API entry point. It is the
+//! - The [`Instance`](crate::instance::Instance) object is the API entry point. It is the
 //!   first object you must create before starting to use Vulkan.
 //!
-//! - The [`PhysicalDevice`](instance/struct.PhysicalDevice.html) object represents an
+//! - The [`PhysicalDevice`](crate::device::physical::PhysicalDevice) object represents an
 //!   implementation of Vulkan available on the system (eg. a graphics card, a software
 //!   implementation, etc.). Physical devices can be enumerated from an instance with
-//!   [`PhysicalDevice::enumerate()`](instance/struct.PhysicalDevice.html#method.enumerate).
+//!   [`PhysicalDevice::enumerate`](crate::device::physical::PhysicalDevice::enumerate).
 //!
 //! - Once you have chosen a physical device to use, you can create a
-//!   [`Device`](device/index.html) object from it. The `Device` is the most important
+//!   [`Device`](crate::device::Device) object from it. The `Device` is the most important
 //!   object of Vulkan, as it represents an open channel of communication with a physical device.
 //!   You always need to have one before you can do interesting things with Vulkan.
 //!
-//! - [*Buffers*](buffer/index.html) and [*images*](image/index.html) can be used to store data on
+//! - [*Buffers*](crate::buffer) and [*images*](crate::image) can be used to store data on
 //!   memory accessible by the GPU (or more generally by the Vulkan implementation). Buffers are
 //!   usually used to store information about vertices, lights, etc. or arbitrary data, while
 //!   images are used to store textures or multi-dimensional data.
 //!
-//! - In order to show something on the screen, you need a [`Swapchain`](swapchain/index.html).
+//! - In order to show something on the screen, you need a [`Swapchain`](crate::swapchain).
 //!   A `Swapchain` contains special `Image`s that correspond to the content of the window or the
 //!   monitor. When you *present* a swapchain, the content of one of these special images is shown
 //!   on the screen.
 //!
 //! - In order to ask the GPU to do something, you must create a
-//!   [*command buffer*](command_buffer/index.html). A command buffer contains a list of commands
+//!   [*command buffer*](crate::command_buffer). A command buffer contains a list of commands
 //!   that the GPU must perform. This can include copies between buffers and images, compute
 //!   operations, or graphics operations. For the work to start, the command buffer must then be
-//!   submitted to a [`Queue`](device/struct.Queue.html), which is obtained when you create the
+//!   submitted to a [`Queue`](crate::device::Queue), which is obtained when you create the
 //!   `Device`.
 //!
 //! - In order to be able to add a compute operation or a graphics operation to a command buffer,
 //!   you need to have created a [`ComputePipeline` or a `GraphicsPipeline`
-//!   object](pipeline/index.html) that describes the operation you want. These objects are usually
+//!   object](crate::pipeline) that describes the operation you want. These objects are usually
 //!   created during your program's initialization. `Shader`s are programs that the GPU will
-//!   execute as part of a pipeline. [*Descriptors*](descriptor/index.html) can be used to access
+//!   execute as part of a pipeline. [*Descriptor sets*](crate::descriptor_set) can be used to access
 //!   the content of buffers or images from within shaders.
 //!
-//! - For graphical operations, [`RenderPass`es and `Framebuffer`s](framebuffer/index.html)
+//! - For graphical operations, [`RenderPass`es and `Framebuffer`s](crate::render_pass)
 //!   describe on which images the implementation must draw upon.
 //!
 //! - Once you have built a *command buffer* that contains a list of commands, submitting it to the
-//!   GPU will return an object that implements [the `GpuFuture` trait](sync/index.html).
+//!   GPU will return an object that implements [the `GpuFuture` trait](crate::sync::GpuFuture).
 //!   `GpuFuture`s allow you to chain multiple submissions together and are essential to performing
 //!   multiple operations on multiple different GPU queues.
 //!

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -18,8 +18,8 @@
 //! doesn't exist.
 //!
 //! Once that is done, you can extract the data from the cache and store it. See the documentation
-//! of [`get_data`](struct.PipelineCache.html#method.get_data) for example of how to store the data
-//! on the disk, and [`with_data`](struct.PipelineCache.html#method.with_data) for how to reload it.
+//! of [`get_data`](crate::pipeline::cache::PipelineCache::get_data) for example of how to store the data
+//! on the disk, and [`with_data`](crate::pipeline::cache::PipelineCache::with_data) for how to reload it.
 
 use crate::check_errors;
 use crate::device::Device;
@@ -31,7 +31,7 @@ use std::sync::Arc;
 
 /// Opaque cache that contains pipeline objects.
 ///
-/// See [the documentation of the module](index.html) for more info.
+/// See [the documentation of the module](crate::pipeline::cache) for more info.
 pub struct PipelineCache {
     device: Arc<Device>,
     cache: ash::vk::PipelineCache,

--- a/vulkano/src/pipeline/shader.rs
+++ b/vulkano/src/pipeline/shader.rs
@@ -531,7 +531,7 @@ impl fmt::Display for ShaderInterfaceMismatchError {
 ///
 /// Note that it is the shader module that chooses which type that implements
 /// `SpecializationConstants` it is possible to pass when creating the pipeline, through [the
-/// `EntryPointAbstract` trait](trait.EntryPointAbstract.html). Therefore there is generally no
+/// `EntryPointAbstract` trait](crate::pipeline::shader::EntryPointAbstract). Therefore there is generally no
 /// point to implement this trait yourself, unless you are also writing your own implementation of
 /// `EntryPointAbstract`.
 ///

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -113,7 +113,7 @@
 //!  - How to perform the cycling between images in regard to vsync.
 //!
 //! You can query the supported values of all these properties with
-//! [`Surface::capabilities()]`](struct.Surface.html#method.capabilities).
+//! [`Surface::capabilities`](crate::swapchain::Surface::capabilities).
 //!
 //! ## Creating a swapchain
 //!
@@ -129,7 +129,7 @@
 //! ```
 //!
 //! Then, query the capabilities of the surface with
-//! [`Surface::capabilities()`](struct.Surface.html#method.capabilities)
+//! [`Surface::capabilities`](crate::swapchain::Surface::capabilities)
 //! and choose which values you are going to use.
 //!
 //! ```no_run
@@ -158,7 +158,7 @@
 //! # }
 //! ```
 //!
-//! Then, call [`Swapchain::new()`](struct.Swapchain.html#method.new).
+//! Then, call [`Swapchain::start`](crate::swapchain::Swapchain::start).
 //!
 //! ```no_run
 //! # use std::sync::Arc;

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! Whenever you ask the GPU to start an operation by using a function of the vulkano library (for
 //! example executing a command buffer), this function will return a *future*. A future is an
-//! object that implements [the `GpuFuture` trait](trait.GpuFuture.html) and that represents the
+//! object that implements [the `GpuFuture` trait](crate::sync::GpuFuture) and that represents the
 //! point in time when this operation is over.
 //!
 //! No function in vulkano immediately sends an operation to the GPU (with the exception of some


### PR DESCRIPTION
Fixes #1711. I converted remaining html links to use Rust module paths, which should hopefully prevent this from happening in the future (rustdoc gives a warning when a path-item isn't found).