### PR TITLE
Limit compatibility check for bound descriptor sets to the length of the current layout

### DIFF
--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -3135,7 +3135,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
                         .retain(|&num, _| num < invalidate_from);
                     state.pipeline_layout = pipeline_layout;
                 } else if (first_set + num_descriptor_sets) as usize
-                    > state.pipeline_layout.descriptor_set_layouts().len()
+                    >= state.pipeline_layout.descriptor_set_layouts().len()
                 {
                     // New layout is a superset of the old one.
                     state.pipeline_layout = pipeline_layout;

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -3128,11 +3128,16 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
                     })
                 };
 
-                // Remove disturbed sets and set new pipeline layout.
                 if let Some(invalidate_from) = invalidate_from {
+                    // Remove disturbed sets and set new pipeline layout.
                     state
                         .descriptor_sets
                         .retain(|&num, _| num < invalidate_from);
+                    state.pipeline_layout = pipeline_layout;
+                } else if (first_set + num_descriptor_sets) as usize
+                    > state.pipeline_layout.descriptor_set_layouts().len()
+                {
+                    // New layout is a superset of the old one.
                     state.pipeline_layout = pipeline_layout;
                 }
 

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -3121,7 +3121,8 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
                     // be disturbed.
                     let current_layouts = state.pipeline_layout.descriptor_set_layouts();
                     let new_layouts = pipeline_layout.descriptor_set_layouts();
-                    (0..first_set + num_descriptor_sets).find(|&num| {
+                    let max = (current_layouts.len() as u32).min(first_set + num_descriptor_sets);
+                    (0..max).find(|&num| {
                         let num = num as usize;
                         !current_layouts[num].is_compatible_with(&new_layouts[num])
                     })


### PR DESCRIPTION
This fixes a bug introduced in #1684, where an out-of-bound access panic occurs if the newly bound descriptor sets contain set numbers beyond the end of pipeline layout used for the previous bind.