### PR TITLE
fix array_element accounting for add_buffer_view

### DIFF
--- a/vulkano/src/descriptor_set/builder.rs
+++ b/vulkano/src/descriptor_set/builder.rs
@@ -341,6 +341,7 @@ impl DescriptorSetBuilder {
         });
 
         self.resources.add_buffer_view(self.cur_binding, view);
+        descriptor.array_element += 1;
 
         if leave_array {
             self.leave_array()


### PR DESCRIPTION
Seems like nobody uses {Storage,Uniform} Texel Buffers, and this was missed in #1674 