### PR TITLE
Add `AutoCommandBufferBuilder::clear_depth_stencil_image`

### DIFF
--- a/vulkano/src/command_buffer/validity/clear_depth_stencil_image.rs
+++ b/vulkano/src/command_buffer/validity/clear_depth_stencil_image.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::error;
+use std::fmt;
+
+use crate::device::Device;
+use crate::image::ImageAccess;
+use crate::VulkanObject;
+
+/// Checks whether a clear depth / stencil image command is valid.
+///
+/// # Panic
+///
+/// - Panics if the destination was not created with `device`.
+///
+pub fn check_clear_depth_stencil_image<I>(
+    device: &Device,
+    image: &I,
+    first_layer: u32,
+    num_layers: u32,
+) -> Result<(), CheckClearDepthStencilImageError>
+where
+    I: ?Sized + ImageAccess,
+{
+    assert_eq!(
+        image.inner().image.device().internal_object(),
+        device.internal_object()
+    );
+
+    if !image.inner().image.usage().transfer_destination {
+        return Err(CheckClearDepthStencilImageError::MissingTransferUsage);
+    }
+
+    if first_layer + num_layers > image.dimensions().array_layers() {
+        return Err(CheckClearDepthStencilImageError::OutOfRange);
+    }
+
+    Ok(())
+}
+
+/// Error that can happen from `check_clear_depth_stencil_image`.
+#[derive(Debug, Copy, Clone)]
+pub enum CheckClearDepthStencilImageError {
+    /// The image is missing the transfer destination usage.
+    MissingTransferUsage,
+    /// The array layers are out of range.
+    OutOfRange,
+}
+
+impl error::Error for CheckClearDepthStencilImageError {}
+
+impl fmt::Display for CheckClearDepthStencilImageError {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            fmt,
+            "{}",
+            match *self {
+                CheckClearDepthStencilImageError::MissingTransferUsage => {
+                    "the image is missing the transfer destination usage"
+                }
+                CheckClearDepthStencilImageError::OutOfRange => {
+                    "the array layers are out of range"
+                }
+            }
+        )
+    }
+}

--- a/vulkano/src/command_buffer/validity/mod.rs
+++ b/vulkano/src/command_buffer/validity/mod.rs
@@ -11,6 +11,9 @@
 
 pub use self::blit_image::{check_blit_image, CheckBlitImageError};
 pub use self::clear_color_image::{check_clear_color_image, CheckClearColorImageError};
+pub use self::clear_depth_stencil_image::{
+    check_clear_depth_stencil_image, CheckClearDepthStencilImageError,
+};
 pub use self::copy_buffer::{check_copy_buffer, CheckCopyBuffer, CheckCopyBufferError};
 pub use self::copy_image::{check_copy_image, CheckCopyImageError};
 pub use self::copy_image_buffer::{
@@ -39,6 +42,7 @@ pub(super) use {
 
 mod blit_image;
 mod clear_color_image;
+mod clear_depth_stencil_image;
 mod copy_buffer;
 mod copy_image;
 mod copy_image_buffer;


### PR DESCRIPTION
This adds `AutoCommandBufferBuilder::clear_depth_stencil_image` following what is done for `clear_color_image`. 

Entries for Vulkano changelog:
- Add `clear_depth_stencil_image` to `AutoCommandBufferBuilder` to clear depth / stencil images