### PR TITLE
Add `Send + Sync` requirements to various traits

### DIFF
--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -328,7 +328,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -342,7 +342,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -113,7 +113,7 @@ impl AmbientLightingSystem {
     pub fn draw(
         &self,
         viewport_dimensions: [u32; 2],
-        color_input: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        color_input: Arc<dyn ImageViewAbstract + 'static>,
         ambient_color: [f32; 3],
     ) -> SecondaryAutoCommandBuffer {
         let push_constants = fs::ty::PushConstants {

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -121,8 +121,8 @@ impl DirectionalLightingSystem {
     pub fn draw(
         &self,
         viewport_dimensions: [u32; 2],
-        color_input: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
-        normals_input: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        color_input: Arc<dyn ImageViewAbstract + 'static>,
+        normals_input: Arc<dyn ImageViewAbstract + 'static>,
         direction: Vector3<f32>,
         color: [f32; 3],
     ) -> SecondaryAutoCommandBuffer {

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -130,9 +130,9 @@ impl PointLightingSystem {
     pub fn draw(
         &self,
         viewport_dimensions: [u32; 2],
-        color_input: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
-        normals_input: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
-        depth_input: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        color_input: Arc<dyn ImageViewAbstract + 'static>,
+        normals_input: Arc<dyn ImageViewAbstract + 'static>,
+        depth_input: Arc<dyn ImageViewAbstract + 'static>,
         screen_to_world: Matrix4<f32>,
         position: Vector3<f32>,
         color: [f32; 3],

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -439,7 +439,7 @@ impl<'f, 's: 'f> DrawPass<'f, 's> {
     #[inline]
     pub fn execute<C>(&mut self, command_buffer: C)
     where
-        C: SecondaryCommandBuffer + Send + Sync + 'static,
+        C: SecondaryCommandBuffer + 'static,
     {
         self.frame
             .command_buffer_builder

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -228,7 +228,7 @@ impl FrameSystem {
     pub fn frame<F>(
         &mut self,
         before_future: F,
-        final_image: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        final_image: Arc<dyn ImageViewAbstract + 'static>,
         world_to_framebuffer: Matrix4<f32>,
     ) -> Frame
     where

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -347,7 +347,7 @@ pub struct Frame<'a> {
     // Future to wait upon before the main rendering.
     before_main_cb_future: Option<Box<dyn GpuFuture>>,
     // Framebuffer that was used when starting the render pass.
-    framebuffer: Arc<dyn FramebufferAbstract + Send + Sync>,
+    framebuffer: Arc<dyn FramebufferAbstract>,
     // The command buffer builder that will be built during the lifetime of this object.
     command_buffer_builder: Option<AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>>,
     // Matrix that was passed to `frame()`.

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -329,7 +329,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -343,7 +343,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -338,7 +338,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -352,7 +352,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -411,7 +411,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -425,7 +425,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -378,7 +378,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -392,7 +392,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -109,10 +109,7 @@ impl PixelsDrawPipeline {
         }
     }
 
-    fn create_descriptor_set(
-        &self,
-        image: Arc<dyn ImageViewAbstract + Send + Sync>,
-    ) -> PersistentDescriptorSet {
+    fn create_descriptor_set(&self, image: Arc<dyn ImageViewAbstract>) -> PersistentDescriptorSet {
         let layout = self
             .pipeline
             .layout()
@@ -144,7 +141,7 @@ impl PixelsDrawPipeline {
     pub fn draw(
         &mut self,
         viewport_dimensions: [u32; 2],
-        image: Arc<dyn ImageViewAbstract + Send + Sync>,
+        image: Arc<dyn ImageViewAbstract>,
     ) -> SecondaryAutoCommandBuffer {
         let mut builder = AutoCommandBufferBuilder::secondary_graphics(
             self.gfx_queue.device().clone(),

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -45,7 +45,7 @@ use winit::window::{Window, WindowBuilder};
 struct WindowSurface {
     surface: Arc<Surface<Window>>,
     swapchain: Arc<Swapchain<Window>>,
-    framebuffers: Vec<Arc<(dyn FramebufferAbstract + Send + Sync + 'static)>>,
+    framebuffers: Vec<Arc<(dyn FramebufferAbstract + 'static)>>,
     recreate_swapchain: bool,
     previous_frame_end: Option<Box<dyn GpuFuture>>,
 }
@@ -408,7 +408,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -422,7 +422,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -440,7 +440,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -471,7 +471,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -391,7 +391,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -405,7 +405,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -460,7 +460,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -474,7 +474,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -308,10 +308,7 @@ fn window_size_dependent_setup(
     fs: &fs::Shader,
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
-) -> (
-    Arc<GraphicsPipeline>,
-    Vec<Arc<dyn FramebufferAbstract + Send + Sync>>,
-) {
+) -> (Arc<GraphicsPipeline>, Vec<Arc<dyn FramebufferAbstract>>) {
     let dimensions = images[0].dimensions();
 
     let depth_buffer = ImageView::new(
@@ -331,7 +328,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>();
 

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -398,7 +398,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -412,7 +412,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -536,7 +536,7 @@ fn window_size_dependent_setup(
     images: &[Arc<SwapchainImage<Window>>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-) -> Vec<Arc<dyn FramebufferAbstract + Send + Sync>> {
+) -> Vec<Arc<dyn FramebufferAbstract>> {
     let dimensions = images[0].dimensions();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 
@@ -550,7 +550,7 @@ fn window_size_dependent_setup(
                     .unwrap()
                     .build()
                     .unwrap(),
-            ) as Arc<dyn FramebufferAbstract + Send + Sync>
+            ) as Arc<dyn FramebufferAbstract>
         })
         .collect::<Vec<_>>()
 }

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -484,7 +484,7 @@ where
 
 unsafe impl<T: ?Sized, A> TypedBufferAccess for CpuAccessibleBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
     type Content = T;
@@ -499,7 +499,7 @@ unsafe impl<T: ?Sized, A> DeviceOwned for CpuAccessibleBuffer<T, A> {
 
 impl<T: ?Sized, A> PartialEq for CpuAccessibleBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
     #[inline]
@@ -510,14 +510,14 @@ where
 
 impl<T: ?Sized, A> Eq for CpuAccessibleBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
 }
 
 impl<T: ?Sized, A> Hash for CpuAccessibleBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
     #[inline]

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -367,7 +367,7 @@ where
 
 unsafe impl<T: ?Sized, A> BufferAccess for CpuAccessibleBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
     #[inline]

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -622,7 +622,6 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolChunk<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
     #[inline]
     fn inner(&self) -> BufferInner {
@@ -735,7 +734,6 @@ unsafe impl<T, A> TypedBufferAccess for CpuBufferPoolChunk<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
     type Content = [T];
 }
@@ -754,7 +752,6 @@ impl<T, A> PartialEq for CpuBufferPoolChunk<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -766,7 +763,6 @@ impl<T, A> Eq for CpuBufferPoolChunk<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
 }
 
@@ -774,7 +770,6 @@ impl<T, A> Hash for CpuBufferPoolChunk<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -798,7 +793,6 @@ unsafe impl<T, A> BufferAccess for CpuBufferPoolSubbuffer<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
     #[inline]
     fn inner(&self) -> BufferInner {
@@ -835,7 +829,6 @@ unsafe impl<T, A> TypedBufferAccess for CpuBufferPoolSubbuffer<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
     type Content = T;
 }
@@ -854,7 +847,6 @@ impl<T, A> PartialEq for CpuBufferPoolSubbuffer<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -866,7 +858,6 @@ impl<T, A> Eq for CpuBufferPoolSubbuffer<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
 }
 
@@ -874,7 +865,6 @@ impl<T, A> Hash for CpuBufferPoolSubbuffer<T, A>
 where
     T: Send + Sync,
     A: MemoryPool,
-    <A as MemoryPool>::Alloc: Send + Sync,
 {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -398,7 +398,7 @@ where
 
 unsafe impl<T: ?Sized, A> TypedBufferAccess for DeviceLocalBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
     type Content = T;
@@ -406,7 +406,7 @@ where
 
 impl<T: ?Sized, A> PartialEq for DeviceLocalBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
     #[inline]
@@ -417,14 +417,14 @@ where
 
 impl<T: ?Sized, A> Eq for DeviceLocalBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
 }
 
 impl<T: ?Sized, A> Hash for DeviceLocalBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
     #[inline]

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -308,7 +308,7 @@ unsafe impl<T: ?Sized, A> DeviceOwned for DeviceLocalBuffer<T, A> {
 
 unsafe impl<T: ?Sized, A> BufferAccess for DeviceLocalBuffer<T, A>
 where
-    T: 'static + Send + Sync,
+    T: Send + Sync + 'static,
     A: Send + Sync,
 {
     #[inline]

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -119,8 +119,8 @@ impl<T: ?Sized> ImmutableBuffer<T> {
         queue: Arc<Queue>,
     ) -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferFromBufferFuture), DeviceMemoryAllocError>
     where
-        B: BufferAccess + TypedBufferAccess<Content = T> + 'static + Clone + Send + Sync,
-        T: 'static + Send + Sync,
+        B: TypedBufferAccess<Content = T> + Clone + 'static,
+        T: Send + Sync + 'static,
     {
         unsafe {
             // We automatically set `transfer_destination` to true in order to avoid annoying errors.

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -96,7 +96,7 @@ impl<T: ?Sized> ImmutableBuffer<T> {
         queue: Arc<Queue>,
     ) -> Result<(Arc<ImmutableBuffer<T>>, ImmutableBufferFromBufferFuture), DeviceMemoryAllocError>
     where
-        T: 'static + Copy + Send + Sync + Sized,
+        T: Copy + Send + Sync + Sized + 'static,
     {
         let source = CpuAccessibleBuffer::from_data(
             queue.device().clone(),
@@ -194,7 +194,7 @@ impl<T> ImmutableBuffer<[T]> {
     ) -> Result<(Arc<ImmutableBuffer<[T]>>, ImmutableBufferFromBufferFuture), DeviceMemoryAllocError>
     where
         D: ExactSizeIterator<Item = T>,
-        T: 'static + Send + Sync + Sized,
+        T: Send + Sync + Sized + 'static,
     {
         let source = CpuAccessibleBuffer::from_iter(
             queue.device().clone(),

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -255,7 +255,7 @@ where
 
 unsafe impl<T, B> TypedBufferAccess for BufferSlice<T, B>
 where
-    T: ?Sized + Send + Sync,
+    T: Send + Sync + ?Sized,
     B: BufferAccess,
 {
     type Content = T;

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -12,6 +12,7 @@ use crate::buffer::TypedBufferAccess;
 use crate::command_buffer::pool::standard::StandardCommandPoolAlloc;
 use crate::command_buffer::pool::standard::StandardCommandPoolBuilder;
 use crate::command_buffer::pool::CommandPool;
+use crate::command_buffer::pool::CommandPoolAlloc;
 use crate::command_buffer::pool::CommandPoolBuilderAlloc;
 use crate::command_buffer::synced::SyncCommandBuffer;
 use crate::command_buffer::synced::SyncCommandBufferBuilder;
@@ -2338,7 +2339,7 @@ where
         command_buffer: C,
     ) -> Result<&mut Self, ExecuteCommandsError>
     where
-        C: SecondaryCommandBuffer + Send + Sync + 'static,
+        C: SecondaryCommandBuffer + 'static,
     {
         self.check_command_buffer(&command_buffer)?;
         let secondary_usage = command_buffer.inner().usage();
@@ -2369,7 +2370,7 @@ where
         command_buffers: Vec<C>,
     ) -> Result<&mut Self, ExecuteCommandsError>
     where
-        C: SecondaryCommandBuffer + Send + Sync + 'static,
+        C: SecondaryCommandBuffer + 'static,
     {
         for command_buffer in &command_buffers {
             self.check_command_buffer(command_buffer)?;
@@ -2400,7 +2401,7 @@ where
         command_buffer: &C,
     ) -> Result<(), AutoCommandBufferBuilderContextError>
     where
-        C: SecondaryCommandBuffer + Send + Sync + 'static,
+        C: SecondaryCommandBuffer + 'static,
     {
         if let Some(render_pass) = command_buffer.inheritance().render_pass {
             self.ensure_inside_render_pass_secondary(&render_pass)?;
@@ -2545,7 +2546,10 @@ unsafe impl<P> DeviceOwned for PrimaryAutoCommandBuffer<P> {
     }
 }
 
-unsafe impl<P> PrimaryCommandBuffer for PrimaryAutoCommandBuffer<P> {
+unsafe impl<P> PrimaryCommandBuffer for PrimaryAutoCommandBuffer<P>
+where
+    P: CommandPoolAlloc,
+{
     #[inline]
     fn inner(&self) -> &UnsafeCommandBuffer {
         self.inner.as_ref()
@@ -2654,7 +2658,10 @@ unsafe impl<P> DeviceOwned for SecondaryAutoCommandBuffer<P> {
     }
 }
 
-unsafe impl<P> SecondaryCommandBuffer for SecondaryAutoCommandBuffer<P> {
+unsafe impl<P> SecondaryCommandBuffer for SecondaryAutoCommandBuffer<P>
+where
+    P: CommandPoolAlloc,
+{
     #[inline]
     fn inner(&self) -> &UnsafeCommandBuffer {
         self.inner.as_ref()

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -586,7 +586,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     ///   enabled on the device.
     pub fn bind_index_buffer<Ib, I>(&mut self, index_buffer: Ib) -> &mut Self
     where
-        Ib: BufferAccess + TypedBufferAccess<Content = [I]> + Send + Sync + 'static,
+        Ib: TypedBufferAccess<Content = [I]> + 'static,
         I: Index + 'static,
     {
         assert!(
@@ -1367,11 +1367,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         indirect_buffer: Inb,
     ) -> Result<&mut Self, DispatchIndirectError>
     where
-        Inb: BufferAccess
-            + TypedBufferAccess<Content = [DispatchIndirectCommand]>
-            + Send
-            + Sync
-            + 'static,
+        Inb: TypedBufferAccess<Content = [DispatchIndirectCommand]> + 'static,
     {
         if !self.queue_family().supports_compute() {
             return Err(AutoCommandBufferBuilderContextError::NotSupportedByQueueFamily.into());
@@ -1560,11 +1556,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         indirect_buffer: Inb,
     ) -> Result<&mut Self, DrawIndexedIndirectError>
     where
-        Inb: BufferAccess
-            + TypedBufferAccess<Content = [DrawIndexedIndirectCommand]>
-            + Send
-            + Sync
-            + 'static,
+        Inb: TypedBufferAccess<Content = [DrawIndexedIndirectCommand]> + 'static,
     {
         let pipeline = check_pipeline_graphics(&self.inner)?;
         self.ensure_inside_render_pass_inline(pipeline)?;
@@ -2092,7 +2084,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         flags: QueryResultFlags,
     ) -> Result<&mut Self, CopyQueryPoolResultsError>
     where
-        D: BufferAccess + TypedBufferAccess<Content = [T]> + Send + Sync + 'static,
+        D: TypedBufferAccess<Content = [T]> + 'static,
         T: QueryResultElement,
     {
         unsafe {

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -830,8 +830,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         filter: Filter,
     ) -> Result<&mut Self, BlitImageError>
     where
-        S: ImageAccess + Send + Sync + 'static,
-        D: ImageAccess + Send + Sync + 'static,
+        S: ImageAccess + 'static,
+        D: ImageAccess + 'static,
     {
         unsafe {
             if !self.queue_family().supports_graphics() {
@@ -902,7 +902,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         color: ClearValue,
     ) -> Result<&mut Self, ClearColorImageError>
     where
-        I: ImageAccess + Send + Sync + 'static,
+        I: ImageAccess + 'static,
     {
         let layers = image.dimensions().array_layers();
         let levels = image.mipmap_levels();
@@ -926,7 +926,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         color: ClearValue,
     ) -> Result<&mut Self, ClearColorImageError>
     where
-        I: ImageAccess + Send + Sync + 'static,
+        I: ImageAccess + 'static,
     {
         unsafe {
             if !self.queue_family().supports_graphics() && !self.queue_family().supports_compute() {
@@ -977,8 +977,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         destination: D,
     ) -> Result<&mut Self, CopyBufferError>
     where
-        S: TypedBufferAccess<Content = T> + Send + Sync + 'static,
-        D: TypedBufferAccess<Content = T> + Send + Sync + 'static,
+        S: TypedBufferAccess<Content = T> + 'static,
+        D: TypedBufferAccess<Content = T> + 'static,
         T: ?Sized,
     {
         unsafe {
@@ -1002,8 +1002,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         count: DeviceSize,
     ) -> Result<&mut Self, CopyBufferError>
     where
-        S: TypedBufferAccess<Content = [T]> + Send + Sync + 'static,
-        D: TypedBufferAccess<Content = [T]> + Send + Sync + 'static,
+        S: TypedBufferAccess<Content = [T]> + 'static,
+        D: TypedBufferAccess<Content = [T]> + 'static,
     {
         self.ensure_outside_render_pass()?;
 
@@ -1033,8 +1033,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         destination: D,
     ) -> Result<&mut Self, CopyBufferImageError>
     where
-        S: TypedBufferAccess<Content = [Px]> + Send + Sync + 'static,
-        D: ImageAccess + Send + Sync + 'static,
+        S: TypedBufferAccess<Content = [Px]> + 'static,
+        D: ImageAccess + 'static,
         Px: Pixel,
     {
         self.ensure_outside_render_pass()?;
@@ -1055,8 +1055,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         mipmap: u32,
     ) -> Result<&mut Self, CopyBufferImageError>
     where
-        S: TypedBufferAccess<Content = [Px]> + Send + Sync + 'static,
-        D: ImageAccess + Send + Sync + 'static,
+        S: TypedBufferAccess<Content = [Px]> + 'static,
+        D: ImageAccess + 'static,
         Px: Pixel,
     {
         unsafe {
@@ -1136,8 +1136,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         layer_count: u32,
     ) -> Result<&mut Self, CopyImageError>
     where
-        S: ImageAccess + Send + Sync + 'static,
-        D: ImageAccess + Send + Sync + 'static,
+        S: ImageAccess + 'static,
+        D: ImageAccess + 'static,
     {
         unsafe {
             self.ensure_outside_render_pass()?;
@@ -1203,8 +1203,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         destination: D,
     ) -> Result<&mut Self, CopyBufferImageError>
     where
-        S: ImageAccess + Send + Sync + 'static,
-        D: TypedBufferAccess<Content = [Px]> + Send + Sync + 'static,
+        S: ImageAccess + 'static,
+        D: TypedBufferAccess<Content = [Px]> + 'static,
         Px: Pixel,
     {
         self.ensure_outside_render_pass()?;
@@ -1225,8 +1225,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         mipmap: u32,
     ) -> Result<&mut Self, CopyBufferImageError>
     where
-        S: ImageAccess + Send + Sync + 'static,
-        D: TypedBufferAccess<Content = [Px]> + Send + Sync + 'static,
+        S: ImageAccess + 'static,
+        D: TypedBufferAccess<Content = [Px]> + 'static,
         Px: Pixel,
     {
         unsafe {
@@ -1936,7 +1936,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         data: Dd,
     ) -> Result<&mut Self, UpdateBufferError>
     where
-        B: TypedBufferAccess<Content = D> + Send + Sync + 'static,
+        B: TypedBufferAccess<Content = D> + 'static,
         D: ?Sized,
         Dd: SafeDeref<Target = D> + Send + Sync + 'static,
     {

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -105,7 +105,7 @@ pub struct AutoCommandBufferBuilder<L, P = StandardCommandPoolBuilder> {
 
     // The inheritance for secondary command buffers.
     // Must be `None` in a primary command buffer and `Some` in a secondary command buffer.
-    inheritance: Option<CommandBufferInheritance<Box<dyn FramebufferAbstract + Send + Sync>>>,
+    inheritance: Option<CommandBufferInheritance<Box<dyn FramebufferAbstract>>>,
 
     // Usage flags passed when creating the command buffer.
     usage: CommandBufferUsage,
@@ -274,7 +274,7 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
         level: CommandBufferLevel<F>,
     ) -> Result<AutoCommandBufferBuilder<L, StandardCommandPoolBuilder>, OomError>
     where
-        F: FramebufferAbstract + Clone + Send + Sync + 'static,
+        F: FramebufferAbstract + Clone + 'static,
     {
         let (inheritance, render_pass_state) = match &level {
             CommandBufferLevel::Primary => (None, None),
@@ -2158,7 +2158,7 @@ where
         clear_values: I,
     ) -> Result<&mut Self, BeginRenderPassError>
     where
-        F: FramebufferAbstract + Clone + Send + Sync + 'static,
+        F: FramebufferAbstract + Clone + 'static,
         I: IntoIterator<Item = ClearValue>,
     {
         unsafe {
@@ -2284,7 +2284,7 @@ where
                 }
             }
 
-            let framebuffer_object = FramebufferAbstract::inner(&framebuffer).internal_object();
+            let framebuffer_object = framebuffer.inner().internal_object();
             self.inner
                 .begin_render_pass(framebuffer.clone(), contents, clear_values)?;
             self.render_pass_state = Some(RenderPassState {
@@ -2470,9 +2470,7 @@ where
         // Framebuffer, if present on the secondary command buffer, must be the
         // same as the one in the current render pass.
         if let Some(framebuffer) = render_pass.framebuffer {
-            if FramebufferAbstract::inner(framebuffer).internal_object()
-                != render_pass_state.framebuffer
-            {
+            if framebuffer.inner().internal_object() != render_pass_state.framebuffer {
                 return Err(AutoCommandBufferBuilderContextError::IncompatibleFramebuffer);
             }
         }
@@ -2643,7 +2641,7 @@ unsafe impl<P> PrimaryCommandBuffer for PrimaryAutoCommandBuffer<P> {
 pub struct SecondaryAutoCommandBuffer<P = StandardCommandPoolAlloc> {
     inner: SyncCommandBuffer,
     pool_alloc: P, // Safety: must be dropped after `inner`
-    inheritance: CommandBufferInheritance<Box<dyn FramebufferAbstract + Send + Sync>>,
+    inheritance: CommandBufferInheritance<Box<dyn FramebufferAbstract>>,
 
     // Tracks usage of the command buffer on the GPU.
     submit_state: SubmitState,

--- a/vulkano/src/command_buffer/pool/mod.rs
+++ b/vulkano/src/command_buffer/pool/mod.rs
@@ -94,7 +94,7 @@ pub unsafe trait CommandPoolBuilderAlloc: DeviceOwned {
 ///
 /// See `CommandPool` for information about safety.
 ///
-pub unsafe trait CommandPoolAlloc: DeviceOwned {
+pub unsafe trait CommandPoolAlloc: DeviceOwned + Send + Sync {
     /// Returns the internal object that contains the command buffer.
     fn inner(&self) -> &UnsafeCommandPoolAlloc;
 

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -65,7 +65,7 @@ pub struct SyncCommandBufferBuilder {
     // submitted to the inner builder yet.
     // Each command owns the resources it uses (buffers, images, pipelines, descriptor sets etc.),
     // references to any of these must be indirect in the form of a command index + resource id.
-    commands: Vec<Arc<dyn Command + Send + Sync>>,
+    commands: Vec<Arc<dyn Command>>,
 
     // Prototype for the pipeline barrier that must be submitted before flushing the commands
     // in `commands`.
@@ -208,7 +208,7 @@ impl SyncCommandBufferBuilder {
         )],
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
-        C: Command + Send + Sync + 'static,
+        C: Command + 'static,
     {
         // TODO: see comment for the `is_poisoned` member in the struct
         assert!(

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -1089,7 +1089,7 @@ impl SyncCommandBufferBuilder {
         flags: QueryResultFlags,
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
-        D: BufferAccess + TypedBufferAccess<Content = [T]> + Send + Sync + 'static,
+        D: TypedBufferAccess<Content = [T]> + 'static,
         T: QueryResultElement,
     {
         struct Cmd<D> {
@@ -1102,7 +1102,7 @@ impl SyncCommandBufferBuilder {
 
         impl<D, T> Command for Cmd<D>
         where
-            D: BufferAccess + TypedBufferAccess<Content = [T]> + Send + Sync + 'static,
+            D: TypedBufferAccess<Content = [T]> + 'static,
             T: QueryResultElement,
         {
             fn name(&self) -> &'static str {

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -153,7 +153,7 @@ impl SyncCommandBufferBuilder {
         clear_values: I,
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
-        F: FramebufferAbstract + Send + Sync + 'static,
+        F: FramebufferAbstract + 'static,
         I: IntoIterator<Item = ClearValue> + Send + Sync + 'static,
     {
         struct Cmd<F, I> {
@@ -164,7 +164,7 @@ impl SyncCommandBufferBuilder {
 
         impl<F, I> Command for Cmd<F, I>
         where
-            F: FramebufferAbstract + Send + Sync + 'static,
+            F: FramebufferAbstract + 'static,
             I: IntoIterator<Item = ClearValue>,
         {
             fn name(&self) -> &'static str {

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -421,8 +421,8 @@ impl SyncCommandBufferBuilder {
         regions: R,
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
-        S: ImageAccess + Send + Sync + 'static,
-        D: ImageAccess + Send + Sync + 'static,
+        S: ImageAccess + 'static,
+        D: ImageAccess + 'static,
         R: IntoIterator<Item = UnsafeCommandBufferBuilderImageCopy> + Send + Sync + 'static,
     {
         struct Cmd<S, D, R> {
@@ -435,8 +435,8 @@ impl SyncCommandBufferBuilder {
 
         impl<S, D, R> Command for Cmd<S, D, R>
         where
-            S: ImageAccess + Send + Sync + 'static,
-            D: ImageAccess + Send + Sync + 'static,
+            S: ImageAccess + 'static,
+            D: ImageAccess + 'static,
             R: IntoIterator<Item = UnsafeCommandBufferBuilderImageCopy>,
         {
             fn name(&self) -> &'static str {
@@ -542,8 +542,8 @@ impl SyncCommandBufferBuilder {
         filter: Filter,
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
-        S: ImageAccess + Send + Sync + 'static,
-        D: ImageAccess + Send + Sync + 'static,
+        S: ImageAccess + 'static,
+        D: ImageAccess + 'static,
         R: IntoIterator<Item = UnsafeCommandBufferBuilderImageBlit> + Send + Sync + 'static,
     {
         struct Cmd<S, D, R> {
@@ -557,8 +557,8 @@ impl SyncCommandBufferBuilder {
 
         impl<S, D, R> Command for Cmd<S, D, R>
         where
-            S: ImageAccess + Send + Sync + 'static,
-            D: ImageAccess + Send + Sync + 'static,
+            S: ImageAccess + 'static,
+            D: ImageAccess + 'static,
             R: IntoIterator<Item = UnsafeCommandBufferBuilderImageBlit>,
         {
             fn name(&self) -> &'static str {
@@ -663,7 +663,7 @@ impl SyncCommandBufferBuilder {
         regions: R,
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
-        I: ImageAccess + Send + Sync + 'static,
+        I: ImageAccess + 'static,
         R: IntoIterator<Item = UnsafeCommandBufferBuilderColorImageClear> + Send + Sync + 'static,
     {
         struct Cmd<I, R> {
@@ -675,7 +675,7 @@ impl SyncCommandBufferBuilder {
 
         impl<I, R> Command for Cmd<I, R>
         where
-            I: ImageAccess + Send + Sync + 'static,
+            I: ImageAccess + 'static,
             R: IntoIterator<Item = UnsafeCommandBufferBuilderColorImageClear>
                 + Send
                 + Sync
@@ -858,7 +858,7 @@ impl SyncCommandBufferBuilder {
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
         S: BufferAccess + 'static,
-        D: ImageAccess + Send + Sync + 'static,
+        D: ImageAccess + 'static,
         R: IntoIterator<Item = UnsafeCommandBufferBuilderBufferImageCopy> + Send + Sync + 'static,
     {
         struct Cmd<S, D, R> {
@@ -871,7 +871,7 @@ impl SyncCommandBufferBuilder {
         impl<S, D, R> Command for Cmd<S, D, R>
         where
             S: BufferAccess + 'static,
-            D: ImageAccess + Send + Sync + 'static,
+            D: ImageAccess + 'static,
             R: IntoIterator<Item = UnsafeCommandBufferBuilderBufferImageCopy>,
         {
             fn name(&self) -> &'static str {
@@ -973,7 +973,7 @@ impl SyncCommandBufferBuilder {
         regions: R,
     ) -> Result<(), SyncCommandBufferBuilderError>
     where
-        S: ImageAccess + Send + Sync + 'static,
+        S: ImageAccess + 'static,
         D: BufferAccess + 'static,
         R: IntoIterator<Item = UnsafeCommandBufferBuilderBufferImageCopy> + Send + Sync + 'static,
     {
@@ -986,7 +986,7 @@ impl SyncCommandBufferBuilder {
 
         impl<S, D, R> Command for Cmd<S, D, R>
         where
-            S: ImageAccess + Send + Sync + 'static,
+            S: ImageAccess + 'static,
             D: BufferAccess + 'static,
             R: IntoIterator<Item = UnsafeCommandBufferBuilderBufferImageCopy>,
         {

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -3211,7 +3211,7 @@ impl<'a> SyncCommandBufferBuilderBindVertexBuffer<'a> {
 /// Prototype for a `vkCmdExecuteCommands`.
 pub struct SyncCommandBufferBuilderExecuteCommands<'a> {
     builder: &'a mut SyncCommandBufferBuilder,
-    inner: Vec<Box<dyn SecondaryCommandBuffer + Send + Sync>>,
+    inner: Vec<Box<dyn SecondaryCommandBuffer>>,
 }
 
 impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
@@ -3219,16 +3219,16 @@ impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
     #[inline]
     pub fn add<C>(&mut self, command_buffer: C)
     where
-        C: SecondaryCommandBuffer + Send + Sync + 'static,
+        C: SecondaryCommandBuffer + 'static,
     {
         self.inner.push(Box::new(command_buffer));
     }
 
     #[inline]
     pub unsafe fn submit(self) -> Result<(), SyncCommandBufferBuilderError> {
-        struct DropUnlock(Box<dyn SecondaryCommandBuffer + Send + Sync>);
+        struct DropUnlock(Box<dyn SecondaryCommandBuffer>);
         impl std::ops::Deref for DropUnlock {
-            type Target = Box<dyn SecondaryCommandBuffer + Send + Sync>;
+            type Target = Box<dyn SecondaryCommandBuffer>;
 
             fn deref(&self) -> &Self::Target {
                 &self.0

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -104,7 +104,7 @@ pub struct SyncCommandBuffer {
 
     // List of commands used by the command buffer. Used to hold the various resources that are
     // being used.
-    commands: Vec<Arc<dyn Command + Send + Sync>>,
+    commands: Vec<Arc<dyn Command>>,
 
     // Locations within commands that pipeline barriers were inserted. For debugging purposes.
     // TODO: present only in cfg(debug_assertions)?
@@ -460,7 +460,7 @@ struct ResourceLocation {
 }
 
 // Trait for single commands within the list of commands.
-trait Command {
+trait Command: Send + Sync {
     // Returns a user-friendly name for the command, for error reporting purposes.
     fn name(&self) -> &'static str;
 
@@ -511,7 +511,7 @@ trait Command {
     }
 }
 
-impl std::fmt::Debug for dyn Command + Send + Sync {
+impl std::fmt::Debug for dyn Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.name())
     }

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -136,7 +136,7 @@ impl UnsafeCommandBufferBuilder {
                     Some(ref fb) => {
                         // TODO: debug assert that the framebuffer is compatible with
                         //       the render pass?
-                        FramebufferAbstract::inner(fb).internal_object()
+                        fb.inner().internal_object()
                     }
                     None => ash::vk::Framebuffer::null(),
                 };

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -977,7 +977,7 @@ impl UnsafeCommandBufferBuilder {
         stride: DeviceSize,
         flags: QueryResultFlags,
     ) where
-        D: BufferAccess + TypedBufferAccess<Content = [T]>,
+        D: TypedBufferAccess<Content = [T]>,
         T: QueryResultElement,
     {
         let destination = destination.inner();

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -38,7 +38,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-pub unsafe trait PrimaryCommandBuffer: DeviceOwned {
+pub unsafe trait PrimaryCommandBuffer: DeviceOwned + Send + Sync {
     /// Returns the underlying `UnsafeCommandBuffer` of this command buffer.
     fn inner(&self) -> &UnsafeCommandBuffer;
 
@@ -159,7 +159,7 @@ pub unsafe trait PrimaryCommandBuffer: DeviceOwned {
 
 unsafe impl<T> PrimaryCommandBuffer for T
 where
-    T: SafeDeref,
+    T: SafeDeref + Send + Sync,
     T::Target: PrimaryCommandBuffer,
 {
     #[inline]
@@ -203,7 +203,7 @@ where
     }
 }
 
-pub unsafe trait SecondaryCommandBuffer: DeviceOwned {
+pub unsafe trait SecondaryCommandBuffer: DeviceOwned + Send + Sync {
     /// Returns the underlying `UnsafeCommandBuffer` of this command buffer.
     fn inner(&self) -> &UnsafeCommandBuffer;
 
@@ -252,7 +252,7 @@ pub unsafe trait SecondaryCommandBuffer: DeviceOwned {
 
 unsafe impl<T> SecondaryCommandBuffer for T
 where
-    T: SafeDeref,
+    T: SafeDeref + Send + Sync,
     T::Target: SecondaryCommandBuffer,
 {
     #[inline]

--- a/vulkano/src/descriptor_set/builder.rs
+++ b/vulkano/src/descriptor_set/builder.rs
@@ -353,7 +353,7 @@ impl DescriptorSetBuilder {
     /// Binds an image view as the next descriptor or array element.
     pub fn add_image(
         &mut self,
-        image_view: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        image_view: Arc<dyn ImageViewAbstract + 'static>,
     ) -> Result<(), DescriptorSetError> {
         if image_view.image().inner().image.device().internal_object()
             != self.layout.device().internal_object()
@@ -385,7 +385,9 @@ impl DescriptorSetBuilder {
                     ));
                 }
 
-                if !image_view.can_be_sampled(&immutable_samplers[descriptor.array_element as usize]) {
+                if !image_view
+                    .can_be_sampled(&immutable_samplers[descriptor.array_element as usize])
+                {
                     return Err(DescriptorSetError::IncompatibleImageViewSampler);
                 }
 
@@ -481,7 +483,7 @@ impl DescriptorSetBuilder {
     /// `add_image` instead.
     pub fn add_sampled_image(
         &mut self,
-        image_view: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        image_view: Arc<dyn ImageViewAbstract + 'static>,
         sampler: Arc<Sampler>,
     ) -> Result<(), DescriptorSetError> {
         if image_view.image().inner().image.device().internal_object()

--- a/vulkano/src/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor_set/persistent.rs
@@ -240,7 +240,7 @@ impl PersistentDescriptorSetBuilder {
     #[inline]
     pub fn add_image(
         &mut self,
-        image_view: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        image_view: Arc<dyn ImageViewAbstract + 'static>,
     ) -> Result<&mut Self, DescriptorSetError> {
         if self.poisoned {
             Err(DescriptorSetError::BuilderPoisoned)
@@ -264,7 +264,7 @@ impl PersistentDescriptorSetBuilder {
     #[inline]
     pub fn add_sampled_image(
         &mut self,
-        image_view: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        image_view: Arc<dyn ImageViewAbstract + 'static>,
         sampler: Arc<Sampler>,
     ) -> Result<&mut Self, DescriptorSetError> {
         if self.poisoned {

--- a/vulkano/src/descriptor_set/pool/mod.rs
+++ b/vulkano/src/descriptor_set/pool/mod.rs
@@ -39,7 +39,7 @@ pub unsafe trait DescriptorPool: DeviceOwned {
 }
 
 /// An allocated descriptor set.
-pub trait DescriptorPoolAlloc {
+pub trait DescriptorPoolAlloc: Send + Sync {
     /// Returns the inner unsafe descriptor set object.
     fn inner(&self) -> &UnsafeDescriptorSet;
 

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -158,7 +158,7 @@ impl UnsafeDescriptorPool {
         I: IntoIterator<Item = &'l DescriptorSetLayout>,
     {
         let mut variable_descriptor_counts: SmallVec<[_; 8]> = SmallVec::new();
-        
+
         let layouts: SmallVec<[_; 8]> = layouts
             .into_iter()
             .map(|l| {
@@ -195,7 +195,7 @@ impl UnsafeDescriptorPool {
             Some(ash::vk::DescriptorSetVariableDescriptorCountAllocateInfo {
                 descriptor_set_count: layouts.len() as u32,
                 p_descriptor_counts: variable_descriptor_counts.as_ptr(),
-                .. Default::default()
+                ..Default::default()
             })
         } else {
             None

--- a/vulkano/src/descriptor_set/resources.rs
+++ b/vulkano/src/descriptor_set/resources.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 pub struct DescriptorSetResources {
     buffers: Vec<(Arc<dyn BufferAccess + 'static>, u32)>,
-    images: Vec<(Arc<dyn ImageViewAbstract + Send + Sync + 'static>, u32)>,
+    images: Vec<(Arc<dyn ImageViewAbstract + 'static>, u32)>,
     samplers: Vec<(Arc<Sampler>, u32)>,
 }
 
@@ -100,11 +100,7 @@ impl DescriptorSetResources {
             .push((Arc::new(BufferViewResource(view)), desc_index));
     }
 
-    pub fn add_image(
-        &mut self,
-        desc_index: u32,
-        image: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
-    ) {
+    pub fn add_image(&mut self, desc_index: u32, image: Arc<dyn ImageViewAbstract + 'static>) {
         self.images.push((image, desc_index));
     }
 

--- a/vulkano/src/descriptor_set/single_layout_pool.rs
+++ b/vulkano/src/descriptor_set/single_layout_pool.rs
@@ -351,7 +351,7 @@ impl<'a> SingleLayoutDescSetBuilder<'a> {
     #[inline]
     pub fn add_image(
         &mut self,
-        image_view: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        image_view: Arc<dyn ImageViewAbstract + 'static>,
     ) -> Result<&mut Self, DescriptorSetError> {
         if self.poisoned {
             Err(DescriptorSetError::BuilderPoisoned)
@@ -375,7 +375,7 @@ impl<'a> SingleLayoutDescSetBuilder<'a> {
     #[inline]
     pub fn add_sampled_image(
         &mut self,
-        image_view: Arc<dyn ImageViewAbstract + Send + Sync + 'static>,
+        image_view: Arc<dyn ImageViewAbstract + 'static>,
         sampler: Arc<Sampler>,
     ) -> Result<&mut Self, DescriptorSetError> {
         if self.poisoned {

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -627,7 +627,10 @@ impl<A> AttachmentImage<A> {
     }
 }
 
-unsafe impl<A> ImageAccess for AttachmentImage<A> {
+unsafe impl<A> ImageAccess for AttachmentImage<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn inner(&self) -> ImageInner {
         ImageInner {
@@ -743,33 +746,45 @@ unsafe impl<A> ImageAccess for AttachmentImage<A> {
     }
 }
 
-unsafe impl<A> ImageClearValue<ClearValue> for Arc<AttachmentImage<A>> {
+unsafe impl<A> ImageClearValue<ClearValue> for Arc<AttachmentImage<A>>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn decode(&self, value: ClearValue) -> Option<ClearValue> {
         Some(self.format.decode_clear_value(value))
     }
 }
 
-unsafe impl<P, A> ImageContent<P> for Arc<AttachmentImage<A>> {
+unsafe impl<P, A> ImageContent<P> for Arc<AttachmentImage<A>>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn matches_format(&self) -> bool {
         true // FIXME:
     }
 }
 
-impl<A> PartialEq for AttachmentImage<A> {
+impl<A> PartialEq for AttachmentImage<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        ImageAccess::inner(self) == ImageAccess::inner(other)
+        self.inner() == other.inner()
     }
 }
 
-impl<A> Eq for AttachmentImage<A> {}
+impl<A> Eq for AttachmentImage<A> where A: MemoryPoolAlloc {}
 
-impl<A> Hash for AttachmentImage<A> {
+impl<A> Hash for AttachmentImage<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ImageAccess::inner(self).hash(state);
+        self.inner().hash(state);
     }
 }
 

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -7,7 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::buffer::BufferAccess;
 use crate::buffer::BufferUsage;
 use crate::buffer::CpuAccessibleBuffer;
 use crate::buffer::TypedBufferAccess;
@@ -357,7 +356,7 @@ impl ImmutableImage {
         ImageCreationError,
     >
     where
-        B: BufferAccess + TypedBufferAccess<Content = [Px]> + 'static + Clone + Send + Sync,
+        B: TypedBufferAccess<Content = [Px]> + Clone + 'static,
         Px: Pixel + Send + Sync + Clone + 'static,
     {
         let need_to_generate_mipmaps = has_mipmaps(mipmaps);

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -71,7 +71,7 @@ pub struct ImmutableImage<A = PotentialDedicatedAllocation<StdMemoryPoolAlloc>> 
 /// The layer_levels_access must be a range showing which layers will be accessed
 /// The layout must be the layout of the image at the beginning and at the end of the command buffer
 pub struct SubImage {
-    image: Arc<dyn ImageAccess + Sync + Send>,
+    image: Arc<dyn ImageAccess>,
     mip_levels_access: std::ops::Range<u32>,
     layer_levels_access: std::ops::Range<u32>,
     layout: ImageLayout,
@@ -79,7 +79,7 @@ pub struct SubImage {
 
 impl SubImage {
     pub fn new(
-        image: Arc<dyn ImageAccess + Sync + Send>,
+        image: Arc<dyn ImageAccess>,
         mip_level: u32,
         mip_level_count: u32,
         layer_level: u32,
@@ -126,7 +126,7 @@ fn generate_mipmaps<L, Img>(
     dimensions: ImageDimensions,
     layout: ImageLayout,
 ) where
-    Img: ImageAccess + Send + Sync + 'static,
+    Img: ImageAccess + 'static,
 {
     for level in 1..image.mipmap_levels() {
         let [xs, ys, ds] = dimensions
@@ -441,7 +441,10 @@ impl<A> ImmutableImage<A> {
     }
 }
 
-unsafe impl<A> ImageAccess for ImmutableImage<A> {
+unsafe impl<A> ImageAccess for ImmutableImage<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn inner(&self) -> ImageInner {
         ImageInner {
@@ -522,7 +525,10 @@ unsafe impl<A> ImageAccess for ImmutableImage<A> {
     }
 }
 
-unsafe impl<P, A> ImageContent<P> for ImmutableImage<A> {
+unsafe impl<P, A> ImageContent<P> for ImmutableImage<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn matches_format(&self) -> bool {
         true // FIXME:
@@ -591,26 +597,35 @@ unsafe impl ImageAccess for SubImage {
     }
 }
 
-impl<A> PartialEq for ImmutableImage<A> {
+impl<A> PartialEq for ImmutableImage<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        ImageAccess::inner(self) == ImageAccess::inner(other)
+        self.inner() == other.inner()
     }
 }
 
-impl<A> Eq for ImmutableImage<A> {}
+impl<A> Eq for ImmutableImage<A> where A: MemoryPoolAlloc {}
 
-impl<A> Hash for ImmutableImage<A> {
+impl<A> Hash for ImmutableImage<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ImageAccess::inner(self).hash(state);
+        self.inner().hash(state);
     }
 }
 
-unsafe impl<A> ImageAccess for ImmutableImageInitialization<A> {
+unsafe impl<A> ImageAccess for ImmutableImageInitialization<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn inner(&self) -> ImageInner {
-        ImageAccess::inner(&self.image)
+        self.image.inner()
     }
 
     #[inline]
@@ -685,18 +700,24 @@ unsafe impl<A> ImageAccess for ImmutableImageInitialization<A> {
     }
 }
 
-impl<A> PartialEq for ImmutableImageInitialization<A> {
+impl<A> PartialEq for ImmutableImageInitialization<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        ImageAccess::inner(self) == ImageAccess::inner(other)
+        self.inner() == other.inner()
     }
 }
 
-impl<A> Eq for ImmutableImageInitialization<A> {}
+impl<A> Eq for ImmutableImageInitialization<A> where A: MemoryPoolAlloc {}
 
-impl<A> Hash for ImmutableImageInitialization<A> {
+impl<A> Hash for ImmutableImageInitialization<A>
+where
+    A: MemoryPoolAlloc,
+{
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ImageAccess::inner(self).hash(state);
+        self.inner().hash(state);
     }
 }

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -427,7 +427,7 @@ where
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        ImageAccess::inner(self) == ImageAccess::inner(other)
+        self.inner() == other.inner()
     }
 }
 
@@ -439,7 +439,7 @@ where
 {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ImageAccess::inner(self).hash(state);
+        self.inner().hash(state);
     }
 }
 

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -88,7 +88,10 @@ impl<W> SwapchainImage<W> {
     }
 }
 
-unsafe impl<W> ImageAccess for SwapchainImage<W> {
+unsafe impl<W> ImageAccess for SwapchainImage<W>
+where
+    W: Send + Sync,
+{
     #[inline]
     fn inner(&self) -> ImageInner {
         self.my_image()
@@ -158,32 +161,44 @@ unsafe impl<W> ImageAccess for SwapchainImage<W> {
     }
 }
 
-unsafe impl<W> ImageClearValue<ClearValue> for SwapchainImage<W> {
+unsafe impl<W> ImageClearValue<ClearValue> for SwapchainImage<W>
+where
+    W: Send + Sync,
+{
     #[inline]
     fn decode(&self, value: ClearValue) -> Option<ClearValue> {
         Some(self.swapchain.format().decode_clear_value(value))
     }
 }
 
-unsafe impl<P, W> ImageContent<P> for SwapchainImage<W> {
+unsafe impl<P, W> ImageContent<P> for SwapchainImage<W>
+where
+    W: Send + Sync,
+{
     #[inline]
     fn matches_format(&self) -> bool {
         true // FIXME:
     }
 }
 
-impl<W> PartialEq for SwapchainImage<W> {
+impl<W> PartialEq for SwapchainImage<W>
+where
+    W: Send + Sync,
+{
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        ImageAccess::inner(self) == ImageAccess::inner(other)
+        self.inner() == other.inner()
     }
 }
 
-impl<W> Eq for SwapchainImage<W> {}
+impl<W> Eq for SwapchainImage<W> where W: Send + Sync {}
 
-impl<W> Hash for SwapchainImage<W> {
+impl<W> Hash for SwapchainImage<W>
+where
+    W: Send + Sync,
+{
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ImageAccess::inner(self).hash(state);
+        self.inner().hash(state);
     }
 }

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -20,7 +20,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 /// Trait for types that represent the way a GPU can access an image.
-pub unsafe trait ImageAccess {
+pub unsafe trait ImageAccess: Send + Sync {
     /// Returns the inner unsafe image object used by this image.
     fn inner(&self) -> ImageInner;
 
@@ -222,7 +222,7 @@ pub struct ImageInner<'a> {
 
 unsafe impl<T> ImageAccess for T
 where
-    T: SafeDeref,
+    T: SafeDeref + Send + Sync,
     T::Target: ImageAccess,
 {
     #[inline]
@@ -289,16 +289,16 @@ where
     }
 }
 
-impl PartialEq for dyn ImageAccess + Send + Sync {
+impl PartialEq for dyn ImageAccess {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.inner() == other.inner()
     }
 }
 
-impl Eq for dyn ImageAccess + Send + Sync {}
+impl Eq for dyn ImageAccess {}
 
-impl Hash for dyn ImageAccess + Send + Sync {
+impl Hash for dyn ImageAccess {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner().hash(state);

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -613,7 +613,7 @@ pub unsafe trait ImageViewAbstract: Send + Sync {
 
 unsafe impl<I> ImageViewAbstract for ImageView<I>
 where
-    I: ImageAccess + Send + Sync,
+    I: ImageAccess,
 {
     #[inline]
     fn image(&self) -> &dyn ImageAccess {

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -582,7 +582,7 @@ impl Default for ComponentSwizzle {
 }
 
 /// Trait for types that represent the GPU can access an image view.
-pub unsafe trait ImageViewAbstract {
+pub unsafe trait ImageViewAbstract: Send + Sync {
     /// Returns the wrapped image that this image view was created from.
     fn image(&self) -> &dyn ImageAccess;
 
@@ -613,7 +613,7 @@ pub unsafe trait ImageViewAbstract {
 
 unsafe impl<I> ImageViewAbstract for ImageView<I>
 where
-    I: ImageAccess,
+    I: ImageAccess + Send + Sync,
 {
     #[inline]
     fn image(&self) -> &dyn ImageAccess {
@@ -649,7 +649,7 @@ where
 
 unsafe impl<T> ImageViewAbstract for T
 where
-    T: SafeDeref,
+    T: SafeDeref + Send + Sync,
     T::Target: ImageViewAbstract,
 {
     #[inline]
@@ -688,16 +688,16 @@ where
     }
 }
 
-impl PartialEq for dyn ImageViewAbstract + Send + Sync {
+impl PartialEq for dyn ImageViewAbstract {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.inner() == other.inner()
     }
 }
 
-impl Eq for dyn ImageViewAbstract + Send + Sync {}
+impl Eq for dyn ImageViewAbstract {}
 
-impl Hash for dyn ImageViewAbstract + Send + Sync {
+impl Hash for dyn ImageViewAbstract {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner().hash(state);

--- a/vulkano/src/memory/pool/mod.rs
+++ b/vulkano/src/memory/pool/mod.rs
@@ -245,7 +245,7 @@ pub enum AllocFromRequirementsFilter {
 }
 
 /// Object that represents a single allocation. Its destructor should free the chunk.
-pub unsafe trait MemoryPoolAlloc {
+pub unsafe trait MemoryPoolAlloc: Send + Sync {
     /// Returns the memory object from which this is allocated. Returns `None` if the memory is
     /// not mapped.
     fn mapped_memory(&self) -> Option<&MappedDeviceMemory>;

--- a/vulkano/src/pipeline/vertex/vertex.rs
+++ b/vulkano/src/pipeline/vertex/vertex.rs
@@ -14,7 +14,7 @@ use crate::format::Format;
 ///
 /// At this stage, the vertex is in a "raw" format. For example a `[f32; 4]` can match both a
 /// `vec4` or a `float[4]`. The way the things are bound depends on the shader.
-pub unsafe trait Vertex: 'static + Send + Sync {
+pub unsafe trait Vertex: Send + Sync + 'static {
     /// Returns the characteristics of a vertex member by its name.
     fn member(name: &str) -> Option<VertexMemberInfo>;
 }

--- a/vulkano/src/render_pass/attachments_list.rs
+++ b/vulkano/src/render_pass/attachments_list.rs
@@ -49,7 +49,7 @@ unsafe impl AttachmentsList for () {
     }
 }
 
-unsafe impl AttachmentsList for Vec<Arc<dyn ImageViewAbstract + Send + Sync>> {
+unsafe impl AttachmentsList for Vec<Arc<dyn ImageViewAbstract>> {
     #[inline]
     fn num_attachments(&self) -> usize {
         self.len()

--- a/vulkano/src/render_pass/attachments_list.rs
+++ b/vulkano/src/render_pass/attachments_list.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 /// A list of attachments.
 // TODO: rework this trait
-pub unsafe trait AttachmentsList {
+pub unsafe trait AttachmentsList: Send + Sync {
     fn num_attachments(&self) -> usize;
 
     fn as_image_view_access(&self, index: usize) -> Option<&dyn ImageViewAbstract>;
@@ -23,7 +23,7 @@ pub unsafe trait AttachmentsList {
 
 unsafe impl<T> AttachmentsList for T
 where
-    T: SafeDeref,
+    T: SafeDeref + Send + Sync,
     T::Target: AttachmentsList,
 {
     #[inline]

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -48,7 +48,7 @@ use std::sync::Arc;
 /// use vulkano::render_pass::Framebuffer;
 ///
 /// # let render_pass: Arc<RenderPass> = return;
-/// # let view: Arc<vulkano::image::view::ImageView<Arc<vulkano::image::AttachmentImage<vulkano::format::Format>>>> = return;
+/// # let view: Arc<vulkano::image::view::ImageView<Arc<vulkano::image::AttachmentImage>>> = return;
 /// // let render_pass: Arc<_> = ...;
 /// let framebuffer = Framebuffer::start(render_pass.clone())
 ///     .add(view).unwrap()

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -56,7 +56,7 @@ use std::sync::Arc;
 /// ```
 ///
 /// All framebuffer objects implement the `FramebufferAbstract` trait. This means that you can cast
-/// any `Arc<Framebuffer<..>>` into an `Arc<FramebufferAbstract + Send + Sync>` for easier storage.
+/// any `Arc<Framebuffer<..>>` into an `Arc<FramebufferAbstract>` for easier storage.
 ///
 /// ## Framebuffer dimensions
 ///
@@ -387,8 +387,8 @@ impl<A> Framebuffer<A> {
 /// Trait for objects that contain a Vulkan framebuffer object.
 ///
 /// Any `Framebuffer` object implements this trait. You can therefore turn a `Arc<Framebuffer<_>>`
-/// into a `Arc<FramebufferAbstract + Send + Sync>` for easier storage.
-pub unsafe trait FramebufferAbstract {
+/// into a `Arc<FramebufferAbstract>` for easier storage.
+pub unsafe trait FramebufferAbstract: Send + Sync {
     /// Returns an opaque struct that represents the framebuffer's internals.
     fn inner(&self) -> FramebufferSys;
 
@@ -424,12 +424,12 @@ pub unsafe trait FramebufferAbstract {
 
 unsafe impl<T> FramebufferAbstract for T
 where
-    T: SafeDeref,
+    T: SafeDeref + Send + Sync,
     T::Target: FramebufferAbstract,
 {
     #[inline]
     fn inner(&self) -> FramebufferSys {
-        FramebufferAbstract::inner(&**self)
+        (**self).inner()
     }
 
     #[inline]

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -233,7 +233,7 @@
 //! # let mut swapchain: ::std::sync::Arc<swapchain::Swapchain<()>> = return;
 //! // let mut (swapchain, images) = Swapchain::new(...);
 //! loop {
-//!     # let mut command_buffer: ::vulkano::command_buffer::PrimaryAutoCommandBuffer<()> = return;
+//!     # let mut command_buffer: ::vulkano::command_buffer::PrimaryAutoCommandBuffer = return;
 //!     let (image_num, suboptimal, acquire_future)
 //!         = swapchain::acquire_next_image(swapchain.clone(), None).unwrap();
 //!


### PR DESCRIPTION
Changelog:
Remove the "BREAKING BufferAccess now requires Send + Sync" line, and replace with:
```markdown
- **Breaking** Many traits now require `Send + Sync`: `BufferAccess`, `ImageAccess`, `ImageViewAbstract`, `FramebufferAbstract`, `AttachmentsList`, `MemoryPoolAlloc`, `DescriptorSet`, `DescriptorPoolAlloc`, `PrimaryCommandBuffer`, `SecondaryCommandBuffer`, `CommandPoolAlloc`. This further means that any type parameters of types implementing these traits also require `Send + Sync`.
```

Per the discussion at https://github.com/vulkano-rs/vulkano/pull/1674#issuecomment-928977049, this adds an explicit `Send + Sync` requirement to various traits that are generally accompanied by this requirement anyway. This makes it unnecessary to write `Send + Sync` all over the place, as it's now implied by the trait.