### PR TITLE
Group command buffer state retrieval under a new `CommandBufferState`

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -13,6 +13,7 @@ use crate::command_buffer::pool::standard::StandardCommandPoolAlloc;
 use crate::command_buffer::pool::standard::StandardCommandPoolBuilder;
 use crate::command_buffer::pool::CommandPool;
 use crate::command_buffer::pool::CommandPoolBuilderAlloc;
+use crate::command_buffer::synced::CommandBufferState;
 use crate::command_buffer::synced::SyncCommandBuffer;
 use crate::command_buffer::synced::SyncCommandBufferBuilder;
 use crate::command_buffer::synced::SyncCommandBufferBuilderError;
@@ -496,10 +497,10 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             .unwrap()
     }
 
-    /// Returns the inner `SyncCommandBufferBuilder`, which can be queried for the current state.
+    /// Returns the binding/setting state.
     #[inline]
-    pub fn inner(&self) -> &SyncCommandBufferBuilder {
-        &self.inner
+    pub fn state(&self) -> CommandBufferState {
+        self.inner.state()
     }
 
     /// Binds descriptor sets for future dispatch or draw calls.
@@ -1346,10 +1347,14 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             return Err(AutoCommandBufferBuilderContextError::NotSupportedByQueueFamily.into());
         }
 
-        let pipeline = check_pipeline_compute(&self.inner)?;
+        let pipeline = check_pipeline_compute(self.state())?;
         self.ensure_outside_render_pass()?;
-        check_descriptor_sets_validity(&self.inner, pipeline.layout(), PipelineBindPoint::Compute)?;
-        check_push_constants_validity(&self.inner, pipeline.layout())?;
+        check_descriptor_sets_validity(
+            self.state(),
+            pipeline.layout(),
+            PipelineBindPoint::Compute,
+        )?;
+        check_push_constants_validity(self.state(), pipeline.layout())?;
         check_dispatch(self.device(), group_counts)?;
 
         unsafe {
@@ -1377,10 +1382,14 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             return Err(AutoCommandBufferBuilderContextError::NotSupportedByQueueFamily.into());
         }
 
-        let pipeline = check_pipeline_compute(&self.inner)?;
+        let pipeline = check_pipeline_compute(self.state())?;
         self.ensure_outside_render_pass()?;
-        check_descriptor_sets_validity(&self.inner, pipeline.layout(), PipelineBindPoint::Compute)?;
-        check_push_constants_validity(&self.inner, pipeline.layout())?;
+        check_descriptor_sets_validity(
+            self.state(),
+            pipeline.layout(),
+            PipelineBindPoint::Compute,
+        )?;
+        check_push_constants_validity(self.state(), pipeline.layout())?;
         check_indirect_buffer(self.device(), &indirect_buffer)?;
 
         unsafe {
@@ -1404,17 +1413,17 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         first_vertex: u32,
         first_instance: u32,
     ) -> Result<&mut Self, DrawError> {
-        let pipeline = check_pipeline_graphics(&self.inner)?;
+        let pipeline = check_pipeline_graphics(self.state())?;
         self.ensure_inside_render_pass_inline(pipeline)?;
-        check_dynamic_state_validity(&self.inner, pipeline)?;
+        check_dynamic_state_validity(self.state(), pipeline)?;
         check_descriptor_sets_validity(
-            &self.inner,
+            self.state(),
             pipeline.layout(),
             PipelineBindPoint::Graphics,
         )?;
-        check_push_constants_validity(&self.inner, pipeline.layout())?;
+        check_push_constants_validity(self.state(), pipeline.layout())?;
         check_vertex_buffers(
-            &self.inner,
+            self.state(),
             pipeline,
             Some((first_vertex, vertex_count)),
             Some((first_instance, instance_count)),
@@ -1454,16 +1463,16 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             + Sync
             + 'static,
     {
-        let pipeline = check_pipeline_graphics(&self.inner)?;
+        let pipeline = check_pipeline_graphics(self.state())?;
         self.ensure_inside_render_pass_inline(pipeline)?;
-        check_dynamic_state_validity(&self.inner, pipeline)?;
+        check_dynamic_state_validity(self.state(), pipeline)?;
         check_descriptor_sets_validity(
-            &self.inner,
+            self.state(),
             pipeline.layout(),
             PipelineBindPoint::Graphics,
         )?;
-        check_push_constants_validity(&self.inner, pipeline.layout())?;
-        check_vertex_buffers(&self.inner, pipeline, None, None)?;
+        check_push_constants_validity(self.state(), pipeline.layout())?;
+        check_vertex_buffers(self.state(), pipeline, None, None)?;
         check_indirect_buffer(self.device(), &indirect_buffer)?;
 
         let requested = indirect_buffer.len() as u32;
@@ -1509,22 +1518,22 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         first_instance: u32,
     ) -> Result<&mut Self, DrawIndexedError> {
         // TODO: how to handle an index out of range of the vertex buffers?
-        let pipeline = check_pipeline_graphics(&self.inner)?;
+        let pipeline = check_pipeline_graphics(self.state())?;
         self.ensure_inside_render_pass_inline(pipeline)?;
-        check_dynamic_state_validity(&self.inner, pipeline)?;
+        check_dynamic_state_validity(self.state(), pipeline)?;
         check_descriptor_sets_validity(
-            &self.inner,
+            self.state(),
             pipeline.layout(),
             PipelineBindPoint::Graphics,
         )?;
-        check_push_constants_validity(&self.inner, pipeline.layout())?;
+        check_push_constants_validity(self.state(), pipeline.layout())?;
         check_vertex_buffers(
-            &self.inner,
+            self.state(),
             pipeline,
             None,
             Some((first_instance, instance_count)),
         )?;
-        check_index_buffer(&self.inner, Some((first_index, index_count)))?;
+        check_index_buffer(self.state(), Some((first_index, index_count)))?;
 
         unsafe {
             self.inner.draw_indexed(
@@ -1566,17 +1575,17 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             + Sync
             + 'static,
     {
-        let pipeline = check_pipeline_graphics(&self.inner)?;
+        let pipeline = check_pipeline_graphics(self.state())?;
         self.ensure_inside_render_pass_inline(pipeline)?;
-        check_dynamic_state_validity(&self.inner, pipeline)?;
+        check_dynamic_state_validity(self.state(), pipeline)?;
         check_descriptor_sets_validity(
-            &self.inner,
+            self.state(),
             pipeline.layout(),
             PipelineBindPoint::Graphics,
         )?;
-        check_push_constants_validity(&self.inner, pipeline.layout())?;
-        check_vertex_buffers(&self.inner, pipeline, None, None)?;
-        check_index_buffer(&self.inner, None)?;
+        check_push_constants_validity(self.state(), pipeline.layout())?;
+        check_vertex_buffers(self.state(), pipeline, None, None)?;
+        check_index_buffer(self.state(), None)?;
         check_indirect_buffer(self.device(), &indirect_buffer)?;
 
         let requested = indirect_buffer.len() as u32;

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -15,6 +15,7 @@ use super::ResourceFinalState;
 use super::ResourceKey;
 use super::ResourceLocation;
 use super::SyncCommandBuffer;
+use crate::buffer::BufferAccess;
 use crate::command_buffer::pool::UnsafeCommandPoolAlloc;
 use crate::command_buffer::sys::UnsafeCommandBufferBuilder;
 use crate::command_buffer::sys::UnsafeCommandBufferBuilderPipelineBarrier;
@@ -22,16 +23,22 @@ use crate::command_buffer::CommandBufferExecError;
 use crate::command_buffer::CommandBufferLevel;
 use crate::command_buffer::CommandBufferUsage;
 use crate::command_buffer::ImageUninitializedSafe;
+use crate::descriptor_set::DescriptorSet;
 use crate::device::Device;
 use crate::device::DeviceOwned;
 use crate::image::ImageLayout;
+use crate::pipeline::input_assembly::IndexType;
+use crate::pipeline::layout::PipelineLayout;
+use crate::pipeline::viewport::Scissor;
+use crate::pipeline::viewport::Viewport;
+use crate::pipeline::ComputePipeline;
+use crate::pipeline::GraphicsPipeline;
+use crate::pipeline::PipelineBindPoint;
 use crate::render_pass::FramebufferAbstract;
 use crate::sync::AccessFlags;
 use crate::sync::PipelineMemoryAccess;
 use crate::sync::PipelineStages;
 use crate::OomError;
-use commands::CurrentState;
-pub use commands::StencilState;
 use fnv::FnvHashMap;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
@@ -170,6 +177,14 @@ impl SyncCommandBufferBuilder {
             current_state: Default::default(),
             is_poisoned: false,
             is_secondary,
+        }
+    }
+
+    /// Returns the binding/setting state.
+    #[inline]
+    pub fn state(&self) -> CommandBufferState {
+        CommandBufferState {
+            current_state: &self.current_state,
         }
     }
 
@@ -693,4 +708,183 @@ struct ResourceState {
 
     // Extra context of how the image will be used
     image_uninitialized_safe: ImageUninitializedSafe,
+}
+
+/// Holds the current binding and setting state.
+#[derive(Debug, Default)]
+struct CurrentState {
+    descriptor_sets: FnvHashMap<PipelineBindPoint, DescriptorSetState>,
+    index_buffer: Option<Arc<dyn Command + Send + Sync>>,
+    pipeline_compute: Option<Arc<dyn Command + Send + Sync>>,
+    pipeline_graphics: Option<Arc<dyn Command + Send + Sync>>,
+    vertex_buffers: FnvHashMap<u32, Arc<dyn Command + Send + Sync>>,
+
+    push_constants: Option<PushConstantState>,
+
+    blend_constants: Option<[f32; 4]>,
+    depth_bias: Option<(f32, f32, f32)>,
+    depth_bounds: Option<(f32, f32)>,
+    line_width: Option<f32>,
+    stencil_compare_mask: StencilState,
+    stencil_reference: StencilState,
+    stencil_write_mask: StencilState,
+    scissor: FnvHashMap<u32, Scissor>,
+    viewport: FnvHashMap<u32, Viewport>,
+}
+
+#[derive(Debug)]
+struct DescriptorSetState {
+    descriptor_sets: FnvHashMap<u32, Arc<dyn Command + Send + Sync>>,
+    pipeline_layout: Arc<PipelineLayout>,
+}
+
+#[derive(Debug)]
+struct PushConstantState {
+    pipeline_layout: Arc<PipelineLayout>,
+}
+
+/// Allows you to retrieve the current state of a command buffer builder.
+#[derive(Clone, Copy, Debug)]
+pub struct CommandBufferState<'a> {
+    current_state: &'a CurrentState,
+}
+
+impl<'a> CommandBufferState<'a> {
+    /// Returns the descriptor set currently bound to a given set number, or `None` if nothing has
+    /// been bound yet.
+    pub fn descriptor_set(
+        &self,
+        pipeline_bind_point: PipelineBindPoint,
+        set_num: u32,
+    ) -> Option<(&'a dyn DescriptorSet, &'a [u32])> {
+        self.current_state
+            .descriptor_sets
+            .get(&pipeline_bind_point)
+            .and_then(|state| {
+                state
+                    .descriptor_sets
+                    .get(&set_num)
+                    .map(|cmd| cmd.bound_descriptor_set(set_num))
+            })
+    }
+
+    /// Returns the pipeline layout that describes all currently bound descriptor sets.
+    ///
+    /// This can be the layout used to perform the last bind operation, but it can also be the
+    /// layout of an earlier bind if it was compatible with more recent binds.
+    #[inline]
+    pub fn descriptor_sets_pipeline_layout(
+        &self,
+        pipeline_bind_point: PipelineBindPoint,
+    ) -> Option<&'a Arc<PipelineLayout>> {
+        self.current_state
+            .descriptor_sets
+            .get(&pipeline_bind_point)
+            .map(|state| &state.pipeline_layout)
+    }
+
+    /// Returns the index buffer currently bound, or `None` if nothing has been bound yet.
+    pub fn index_buffer(&self) -> Option<(&'a dyn BufferAccess, IndexType)> {
+        self.current_state
+            .index_buffer
+            .as_ref()
+            .map(|cmd| cmd.bound_index_buffer())
+    }
+
+    /// Returns the compute pipeline currently bound, or `None` if nothing has been bound yet.
+    pub fn pipeline_compute(&self) -> Option<&'a Arc<ComputePipeline>> {
+        self.current_state
+            .pipeline_compute
+            .as_ref()
+            .map(|cmd| cmd.bound_pipeline_compute())
+    }
+
+    /// Returns the graphics pipeline currently bound, or `None` if nothing has been bound yet.
+    pub fn pipeline_graphics(&self) -> Option<&'a Arc<GraphicsPipeline>> {
+        self.current_state
+            .pipeline_graphics
+            .as_ref()
+            .map(|cmd| cmd.bound_pipeline_graphics())
+    }
+
+    /// Returns the vertex buffer currently bound to a given binding slot number, or `None` if
+    /// nothing has been bound yet.
+    pub fn vertex_buffer(&self, binding_num: u32) -> Option<&'a dyn BufferAccess> {
+        self.current_state
+            .vertex_buffers
+            .get(&binding_num)
+            .map(|cmd| cmd.bound_vertex_buffer(binding_num))
+    }
+
+    /// Returns the pipeline layout that describes the current push constants.
+    ///
+    /// This is the layout used to perform the last push constant write operation.
+    #[inline]
+    pub fn push_constants_pipeline_layout(&self) -> Option<&'a Arc<PipelineLayout>> {
+        self.current_state
+            .push_constants
+            .as_ref()
+            .map(|state| &state.pipeline_layout)
+    }
+
+    /// Returns the current blend constants, or `None` if nothing has been set yet.
+    #[inline]
+    pub fn blend_constants(&self) -> Option<[f32; 4]> {
+        self.current_state.blend_constants
+    }
+
+    /// Returns the current depth bias settings, or `None` if nothing has been set yet.
+    #[inline]
+    pub fn depth_bias(&self) -> Option<(f32, f32, f32)> {
+        self.current_state.depth_bias
+    }
+
+    /// Returns the current depth bounds settings, or `None` if nothing has been set yet.
+    #[inline]
+    pub fn depth_bounds(&self) -> Option<(f32, f32)> {
+        self.current_state.depth_bounds
+    }
+
+    /// Returns the current line width, or `None` if nothing has been set yet.
+    #[inline]
+    pub fn line_width(&self) -> Option<f32> {
+        self.current_state.line_width
+    }
+
+    /// Returns the current stencil compare masks.
+    #[inline]
+    pub fn stencil_compare_mask(&self) -> StencilState {
+        self.current_state.stencil_compare_mask
+    }
+
+    /// Returns the current stencil references.
+    #[inline]
+    pub fn stencil_reference(&self) -> StencilState {
+        self.current_state.stencil_reference
+    }
+
+    /// Returns the current stencil write masks.
+    #[inline]
+    pub fn stencil_write_mask(&self) -> StencilState {
+        self.current_state.stencil_write_mask
+    }
+
+    /// Returns the current viewport for a given viewport slot, or `None` if nothing has been set yet.
+    #[inline]
+    pub fn viewport(&self, num: u32) -> Option<&'a Viewport> {
+        self.current_state.viewport.get(&num)
+    }
+
+    /// Returns the current scissor for a given viewport slot, or `None` if nothing has been set yet.
+    #[inline]
+    pub fn scissor(&self, num: u32) -> Option<&'a Scissor> {
+        self.current_state.scissor.get(&num)
+    }
+}
+
+/// Holds the current stencil state of a command buffer builder.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct StencilState {
+    pub front: Option<u32>,
+    pub back: Option<u32>,
 }

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::Command;
+use super::*;
 use crate::buffer::BufferAccess;
 use crate::buffer::TypedBufferAccess;
 use crate::command_buffer::synced::builder::KeyTy;
@@ -55,7 +55,6 @@ use crate::sync::PipelineStages;
 use crate::DeviceSize;
 use crate::SafeDeref;
 use crate::VulkanObject;
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
@@ -64,46 +63,6 @@ use std::mem;
 use std::ops::Range;
 use std::ptr;
 use std::sync::{Arc, Mutex};
-
-/// Holds the current binding and setting state.
-#[derive(Debug, Default)]
-pub(super) struct CurrentState {
-    descriptor_sets: FnvHashMap<PipelineBindPoint, DescriptorSetState>,
-    index_buffer: Option<Arc<dyn Command + Send + Sync>>,
-    pipeline_compute: Option<Arc<dyn Command + Send + Sync>>,
-    pipeline_graphics: Option<Arc<dyn Command + Send + Sync>>,
-    vertex_buffers: FnvHashMap<u32, Arc<dyn Command + Send + Sync>>,
-
-    push_constants: Option<PushConstantState>,
-
-    blend_constants: Option<[f32; 4]>,
-    depth_bias: Option<(f32, f32, f32)>,
-    depth_bounds: Option<(f32, f32)>,
-    line_width: Option<f32>,
-    stencil_compare_mask: StencilState,
-    stencil_reference: StencilState,
-    stencil_write_mask: StencilState,
-    scissor: FnvHashMap<u32, Scissor>,
-    viewport: FnvHashMap<u32, Viewport>,
-}
-
-#[derive(Debug)]
-struct DescriptorSetState {
-    descriptor_sets: FnvHashMap<u32, Arc<dyn Command + Send + Sync>>,
-    pipeline_layout: Arc<PipelineLayout>,
-}
-
-#[derive(Debug)]
-struct PushConstantState {
-    pipeline_layout: Arc<PipelineLayout>,
-}
-
-/// Holds the current stencil state of a `SyncCommandBufferBuilder`.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct StencilState {
-    pub front: Option<u32>,
-    pub back: Option<u32>,
-}
 
 impl SyncCommandBufferBuilder {
     /// Calls `vkCmdBeginQuery` on the builder.
@@ -248,39 +207,6 @@ impl SyncCommandBufferBuilder {
         }
     }
 
-    /// Returns the descriptor set currently bound to a given set number, or `None` if nothing has
-    /// been bound yet.
-    pub fn bound_descriptor_set(
-        &self,
-        pipeline_bind_point: PipelineBindPoint,
-        set_num: u32,
-    ) -> Option<(&dyn DescriptorSet, &[u32])> {
-        self.current_state
-            .descriptor_sets
-            .get(&pipeline_bind_point)
-            .and_then(|state| {
-                state
-                    .descriptor_sets
-                    .get(&set_num)
-                    .map(|cmd| cmd.bound_descriptor_set(set_num))
-            })
-    }
-
-    /// Returns the pipeline layout that describes all currently bound descriptor sets.
-    ///
-    /// This can be the layout used to perform the last bind operation, but it can also be the
-    /// layout of an earlier bind if it was compatible with more recent binds.
-    #[inline]
-    pub fn bound_descriptor_sets_pipeline_layout(
-        &self,
-        pipeline_bind_point: PipelineBindPoint,
-    ) -> Option<&Arc<PipelineLayout>> {
-        self.current_state
-            .descriptor_sets
-            .get(&pipeline_bind_point)
-            .map(|state| &state.pipeline_layout)
-    }
-
     /// Calls `vkCmdBindIndexBuffer` on the builder.
     #[inline]
     pub unsafe fn bind_index_buffer<B>(&mut self, buffer: B, index_ty: IndexType)
@@ -313,14 +239,6 @@ impl SyncCommandBufferBuilder {
         self.current_state.index_buffer = self.commands.last().cloned();
     }
 
-    /// Returns the index buffer currently bound, or `None` if nothing has been bound yet.
-    pub fn bound_index_buffer(&self) -> Option<(&dyn BufferAccess, IndexType)> {
-        self.current_state
-            .index_buffer
-            .as_ref()
-            .map(|cmd| cmd.bound_index_buffer())
-    }
-
     /// Calls `vkCmdBindPipeline` on the builder with a compute pipeline.
     #[inline]
     pub unsafe fn bind_pipeline_compute(&mut self, pipeline: Arc<ComputePipeline>) {
@@ -344,14 +262,6 @@ impl SyncCommandBufferBuilder {
 
         self.append_command(Cmd { pipeline }, &[]).unwrap();
         self.current_state.pipeline_compute = self.commands.last().cloned();
-    }
-
-    /// Returns the compute pipeline currently bound, or `None` if nothing has been bound yet.
-    pub fn bound_pipeline_compute(&self) -> Option<&Arc<ComputePipeline>> {
-        self.current_state
-            .pipeline_compute
-            .as_ref()
-            .map(|cmd| cmd.bound_pipeline_compute())
     }
 
     /// Calls `vkCmdBindPipeline` on the builder with a graphics pipeline.
@@ -379,14 +289,6 @@ impl SyncCommandBufferBuilder {
         self.current_state.pipeline_graphics = self.commands.last().cloned();
     }
 
-    /// Returns the graphics pipeline currently bound, or `None` if nothing has been bound yet.
-    pub fn bound_pipeline_graphics(&self) -> Option<&Arc<GraphicsPipeline>> {
-        self.current_state
-            .pipeline_graphics
-            .as_ref()
-            .map(|cmd| cmd.bound_pipeline_graphics())
-    }
-
     /// Starts the process of binding vertex buffers. Returns an intermediate struct which can be
     /// used to add the buffers.
     #[inline]
@@ -396,15 +298,6 @@ impl SyncCommandBufferBuilder {
             inner: UnsafeCommandBufferBuilderBindVertexBuffer::new(),
             buffers: SmallVec::new(),
         }
-    }
-
-    /// Returns the vertex buffer currently bound to a given binding slot number, or `None` if
-    /// nothing has been bound yet.
-    pub fn bound_vertex_buffer(&self, binding_num: u32) -> Option<&dyn BufferAccess> {
-        self.current_state
-            .vertex_buffers
-            .get(&binding_num)
-            .map(|cmd| cmd.bound_vertex_buffer(binding_num))
     }
 
     /// Calls `vkCmdCopyImage` on the builder.
@@ -2289,17 +2182,6 @@ impl SyncCommandBufferBuilder {
         self.current_state.push_constants = Some(PushConstantState { pipeline_layout });
     }
 
-    /// Returns the pipeline layout that describes the current push constants.
-    ///
-    /// This is the layout used to perform the last push constant write operation.
-    #[inline]
-    pub fn current_push_constants_pipeline_layout(&self) -> Option<&Arc<PipelineLayout>> {
-        self.current_state
-            .push_constants
-            .as_ref()
-            .map(|state| &state.pipeline_layout)
-    }
-
     /// Calls `vkCmdResetEvent` on the builder.
     #[inline]
     pub unsafe fn reset_event(&mut self, event: Arc<Event>, stages: PipelineStages) {
@@ -2370,12 +2252,6 @@ impl SyncCommandBufferBuilder {
         self.current_state.blend_constants = Some(constants);
     }
 
-    /// Returns the current blend constants, or `None` if nothing has been set yet.
-    #[inline]
-    pub fn current_blend_constants(&self) -> Option<[f32; 4]> {
-        self.current_state.blend_constants
-    }
-
     /// Calls `vkCmdSetDepthBias` on the builder.
     #[inline]
     pub unsafe fn set_depth_bias(&mut self, constant_factor: f32, clamp: f32, slope_factor: f32) {
@@ -2407,12 +2283,6 @@ impl SyncCommandBufferBuilder {
         self.current_state.depth_bias = Some((constant_factor, clamp, slope_factor));
     }
 
-    /// Returns the current depth bias settings, or `None` if nothing has been set yet.
-    #[inline]
-    pub fn current_depth_bias(&self) -> Option<(f32, f32, f32)> {
-        self.current_state.depth_bias
-    }
-
     /// Calls `vkCmdSetDepthBounds` on the builder.
     #[inline]
     pub unsafe fn set_depth_bounds(&mut self, min: f32, max: f32) {
@@ -2433,12 +2303,6 @@ impl SyncCommandBufferBuilder {
 
         self.append_command(Cmd { min, max }, &[]).unwrap();
         self.current_state.depth_bounds = Some((min, max));
-    }
-
-    /// Returns the current depth bounds settings, or `None` if nothing has been set yet.
-    #[inline]
-    pub fn current_depth_bounds(&self) -> Option<(f32, f32)> {
-        self.current_state.depth_bounds
     }
 
     /// Calls `vkCmdSetEvent` on the builder.
@@ -2483,12 +2347,6 @@ impl SyncCommandBufferBuilder {
         self.current_state.line_width = Some(line_width);
     }
 
-    /// Returns the current line width, or `None` if nothing has been set yet.
-    #[inline]
-    pub fn current_line_width(&self) -> Option<f32> {
-        self.current_state.line_width
-    }
-
     /// Calls `vkCmdSetStencilCompareMask` on the builder.
     #[inline]
     pub unsafe fn set_stencil_compare_mask(&mut self, faces: StencilFaces, compare_mask: u32) {
@@ -2527,12 +2385,6 @@ impl SyncCommandBufferBuilder {
         }
     }
 
-    /// Returns the current stencil compare masks.
-    #[inline]
-    pub fn current_stencil_compare_mask(&self) -> StencilState {
-        self.current_state.stencil_compare_mask
-    }
-
     /// Calls `vkCmdSetStencilReference` on the builder.
     #[inline]
     pub unsafe fn set_stencil_reference(&mut self, faces: StencilFaces, reference: u32) {
@@ -2564,12 +2416,6 @@ impl SyncCommandBufferBuilder {
         }
     }
 
-    /// Returns the current stencil references.
-    #[inline]
-    pub fn current_stencil_reference(&self) -> StencilState {
-        self.current_state.stencil_reference
-    }
-
     /// Calls `vkCmdSetStencilWriteMask` on the builder.
     #[inline]
     pub unsafe fn set_stencil_write_mask(&mut self, faces: StencilFaces, write_mask: u32) {
@@ -2599,12 +2445,6 @@ impl SyncCommandBufferBuilder {
         if faces.intersects(ash::vk::StencilFaceFlags::BACK) {
             self.current_state.stencil_write_mask.back = Some(write_mask);
         }
-    }
-
-    /// Returns the current stencil write masks.
-    #[inline]
-    pub fn current_stencil_write_mask(&self) -> StencilState {
-        self.current_state.stencil_write_mask
     }
 
     /// Calls `vkCmdSetScissor` on the builder.
@@ -2645,12 +2485,6 @@ impl SyncCommandBufferBuilder {
             &[],
         )
         .unwrap();
-    }
-
-    /// Returns the current scissor for a given viewport slot, or `None` if nothing has been set yet.
-    #[inline]
-    pub fn current_scissor(&self, num: u32) -> Option<&Scissor> {
-        self.current_state.scissor.get(&num)
     }
 
     /// Calls `vkCmdSetViewport` on the builder.
@@ -2694,12 +2528,6 @@ impl SyncCommandBufferBuilder {
             &[],
         )
         .unwrap();
-    }
-
-    /// Returns the current viewport for a given viewport slot, or `None` if nothing has been set yet.
-    #[inline]
-    pub fn current_viewport(&self, num: u32) -> Option<&Viewport> {
-        self.current_state.viewport.get(&num)
     }
 
     /// Calls `vkCmdUpdateBuffer` on the builder.

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -64,6 +64,7 @@
 //! queue. If not possible, the queue will be entirely flushed and the command added to a fresh new
 //! queue with a fresh new barrier prototype.
 
+pub use self::builder::CommandBufferState;
 pub use self::builder::StencilState;
 pub use self::builder::SyncCommandBufferBuilder;
 pub use self::builder::SyncCommandBufferBuilderBindDescriptorSets;
@@ -689,9 +690,9 @@ mod tests {
             buf_builder.add(buf);
             buf_builder.submit(1);
 
-            assert!(sync.bound_vertex_buffer(0).is_none());
-            assert!(sync.bound_vertex_buffer(1).is_some());
-            assert!(sync.bound_vertex_buffer(2).is_none());
+            assert!(sync.state().vertex_buffer(0).is_none());
+            assert!(sync.state().vertex_buffer(1).is_some());
+            assert!(sync.state().vertex_buffer(2).is_none());
         }
     }
 
@@ -741,16 +742,20 @@ mod tests {
             set_builder.submit(PipelineBindPoint::Graphics, pipeline_layout.clone(), 1);
 
             assert!(sync
-                .bound_descriptor_set(PipelineBindPoint::Compute, 0)
+                .state()
+                .descriptor_set(PipelineBindPoint::Compute, 0)
                 .is_none());
             assert!(sync
-                .bound_descriptor_set(PipelineBindPoint::Graphics, 0)
+                .state()
+                .descriptor_set(PipelineBindPoint::Graphics, 0)
                 .is_none());
             assert!(sync
-                .bound_descriptor_set(PipelineBindPoint::Graphics, 1)
+                .state()
+                .descriptor_set(PipelineBindPoint::Graphics, 1)
                 .is_some());
             assert!(sync
-                .bound_descriptor_set(PipelineBindPoint::Graphics, 2)
+                .state()
+                .descriptor_set(PipelineBindPoint::Graphics, 2)
                 .is_none());
 
             let mut set_builder = sync.bind_descriptor_sets();
@@ -758,10 +763,12 @@ mod tests {
             set_builder.submit(PipelineBindPoint::Graphics, pipeline_layout, 0);
 
             assert!(sync
-                .bound_descriptor_set(PipelineBindPoint::Graphics, 0)
+                .state()
+                .descriptor_set(PipelineBindPoint::Graphics, 0)
                 .is_some());
             assert!(sync
-                .bound_descriptor_set(PipelineBindPoint::Graphics, 1)
+                .state()
+                .descriptor_set(PipelineBindPoint::Graphics, 1)
                 .is_some());
 
             let pipeline_layout = Arc::new(
@@ -789,10 +796,12 @@ mod tests {
             set_builder.submit(PipelineBindPoint::Graphics, pipeline_layout, 1);
 
             assert!(sync
-                .bound_descriptor_set(PipelineBindPoint::Graphics, 0)
+                .state()
+                .descriptor_set(PipelineBindPoint::Graphics, 0)
                 .is_none());
             assert!(sync
-                .bound_descriptor_set(PipelineBindPoint::Graphics, 1)
+                .state()
+                .descriptor_set(PipelineBindPoint::Graphics, 1)
                 .is_some());
         }
     }

--- a/vulkano/src/command_buffer/validity/descriptor_sets.rs
+++ b/vulkano/src/command_buffer/validity/descriptor_sets.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::command_buffer::synced::SyncCommandBufferBuilder;
+use crate::command_buffer::synced::CommandBufferState;
 use crate::descriptor_set::layout::DescriptorSetCompatibilityError;
 use crate::pipeline::layout::PipelineLayout;
 use crate::pipeline::PipelineBindPoint;
@@ -17,7 +17,7 @@ use std::fmt;
 
 /// Checks whether descriptor sets are compatible with the pipeline.
 pub(in super::super) fn check_descriptor_sets_validity(
-    builder: &SyncCommandBufferBuilder,
+    current_state: CommandBufferState,
     pipeline_layout: &PipelineLayout,
     pipeline_bind_point: PipelineBindPoint,
 ) -> Result<(), CheckDescriptorSetsValidityError> {
@@ -25,8 +25,8 @@ pub(in super::super) fn check_descriptor_sets_validity(
         return Ok(());
     }
 
-    let bindings_pipeline_layout = match builder
-        .bound_descriptor_sets_pipeline_layout(pipeline_bind_point)
+    let bindings_pipeline_layout = match current_state
+        .descriptor_sets_pipeline_layout(pipeline_bind_point)
     {
         Some(x) => x,
         None => return Err(CheckDescriptorSetsValidityError::MissingDescriptorSet { set_num: 0 }),
@@ -41,7 +41,7 @@ pub(in super::super) fn check_descriptor_sets_validity(
     for (set_num, pipeline_set) in pipeline_layout.descriptor_set_layouts().iter().enumerate() {
         let set_num = set_num as u32;
 
-        let descriptor_set = match builder.bound_descriptor_set(pipeline_bind_point, set_num) {
+        let descriptor_set = match current_state.descriptor_set(pipeline_bind_point, set_num) {
             Some(s) => s,
             None => return Err(CheckDescriptorSetsValidityError::MissingDescriptorSet { set_num }),
         };

--- a/vulkano/src/command_buffer/validity/dynamic_state.rs
+++ b/vulkano/src/command_buffer/validity/dynamic_state.rs
@@ -7,46 +7,46 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::command_buffer::synced::SyncCommandBufferBuilder;
+use crate::command_buffer::synced::CommandBufferState;
 use crate::pipeline::GraphicsPipeline;
 use std::error;
 use std::fmt;
 
 /// Checks whether states that are about to be set are correct.
 pub(in super::super) fn check_dynamic_state_validity(
-    builder: &SyncCommandBufferBuilder,
+    current_state: CommandBufferState,
     pipeline: &GraphicsPipeline,
 ) -> Result<(), CheckDynamicStateValidityError> {
     let device = pipeline.device();
 
     if pipeline.has_dynamic_blend_constants() {
-        if builder.current_blend_constants().is_none() {
+        if current_state.blend_constants().is_none() {
             return Err(CheckDynamicStateValidityError::BlendConstantsNotSet);
         }
     }
 
     if pipeline.has_dynamic_depth_bounds() {
-        if builder.current_blend_constants().is_none() {
+        if current_state.blend_constants().is_none() {
             return Err(CheckDynamicStateValidityError::BlendConstantsNotSet);
         }
     }
 
     if pipeline.has_dynamic_line_width() {
-        if builder.current_line_width().is_none() {
+        if current_state.line_width().is_none() {
             return Err(CheckDynamicStateValidityError::LineWidthNotSet);
         }
     }
 
     if pipeline.has_dynamic_scissor() {
         for num in 0..pipeline.num_viewports() {
-            if builder.current_scissor(num).is_none() {
+            if current_state.scissor(num).is_none() {
                 return Err(CheckDynamicStateValidityError::ScissorNotSet { num });
             }
         }
     }
 
     if pipeline.has_dynamic_stencil_compare_mask() {
-        let state = builder.current_stencil_compare_mask();
+        let state = current_state.stencil_compare_mask();
 
         if state.front.is_none() || state.back.is_none() {
             return Err(CheckDynamicStateValidityError::StencilCompareMaskNotSet);
@@ -54,7 +54,7 @@ pub(in super::super) fn check_dynamic_state_validity(
     }
 
     if pipeline.has_dynamic_stencil_reference() {
-        let state = builder.current_stencil_reference();
+        let state = current_state.stencil_reference();
 
         if state.front.is_none() || state.back.is_none() {
             return Err(CheckDynamicStateValidityError::StencilReferenceNotSet);
@@ -62,7 +62,7 @@ pub(in super::super) fn check_dynamic_state_validity(
     }
 
     if pipeline.has_dynamic_stencil_write_mask() {
-        let state = builder.current_stencil_write_mask();
+        let state = current_state.stencil_write_mask();
 
         if state.front.is_none() || state.back.is_none() {
             return Err(CheckDynamicStateValidityError::StencilWriteMaskNotSet);
@@ -71,7 +71,7 @@ pub(in super::super) fn check_dynamic_state_validity(
 
     if pipeline.has_dynamic_viewport() {
         for num in 0..pipeline.num_viewports() {
-            if builder.current_viewport(num).is_none() {
+            if current_state.viewport(num).is_none() {
                 return Err(CheckDynamicStateValidityError::ViewportNotSet { num });
             }
         }

--- a/vulkano/src/command_buffer/validity/index_buffer.rs
+++ b/vulkano/src/command_buffer/validity/index_buffer.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::command_buffer::synced::SyncCommandBufferBuilder;
+use crate::command_buffer::synced::CommandBufferState;
 use std::error;
 use std::fmt;
 
@@ -18,10 +18,10 @@ use std::fmt;
 /// - Panics if the buffer was not created with `device`.
 ///
 pub(in super::super) fn check_index_buffer(
-    builder: &SyncCommandBufferBuilder,
+    current_state: CommandBufferState,
     indices: Option<(u32, u32)>,
 ) -> Result<(), CheckIndexBufferError> {
-    let (index_buffer, index_type) = match builder.bound_index_buffer() {
+    let (index_buffer, index_type) = match current_state.index_buffer() {
         Some(x) => x,
         None => return Err(CheckIndexBufferError::BufferNotBound),
     };

--- a/vulkano/src/command_buffer/validity/pipeline.rs
+++ b/vulkano/src/command_buffer/validity/pipeline.rs
@@ -8,15 +8,15 @@
 // according to those terms.
 
 use crate::{
-    command_buffer::synced::SyncCommandBufferBuilder,
+    command_buffer::synced::CommandBufferState,
     pipeline::{ComputePipeline, GraphicsPipeline},
 };
 use std::{error, fmt};
 
 pub(in super::super) fn check_pipeline_compute(
-    builder: &SyncCommandBufferBuilder,
+    current_state: CommandBufferState,
 ) -> Result<&ComputePipeline, CheckPipelineError> {
-    let pipeline = match builder.bound_pipeline_compute() {
+    let pipeline = match current_state.pipeline_compute() {
         Some(x) => x,
         None => return Err(CheckPipelineError::PipelineNotBound),
     };
@@ -25,9 +25,9 @@ pub(in super::super) fn check_pipeline_compute(
 }
 
 pub(in super::super) fn check_pipeline_graphics(
-    builder: &SyncCommandBufferBuilder,
+    current_state: CommandBufferState,
 ) -> Result<&GraphicsPipeline, CheckPipelineError> {
-    let pipeline = match builder.bound_pipeline_graphics() {
+    let pipeline = match current_state.pipeline_graphics() {
         Some(x) => x,
         None => return Err(CheckPipelineError::PipelineNotBound),
     };

--- a/vulkano/src/command_buffer/validity/push_constants.rs
+++ b/vulkano/src/command_buffer/validity/push_constants.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::command_buffer::synced::SyncCommandBufferBuilder;
+use crate::command_buffer::synced::CommandBufferState;
 use crate::pipeline::layout::PipelineLayout;
 use crate::VulkanObject;
 use std::error;
@@ -15,14 +15,14 @@ use std::fmt;
 
 /// Checks whether push constants are compatible with the pipeline.
 pub(in super::super) fn check_push_constants_validity(
-    builder: &SyncCommandBufferBuilder,
+    current_state: CommandBufferState,
     pipeline_layout: &PipelineLayout,
 ) -> Result<(), CheckPushConstantsValidityError> {
     if pipeline_layout.push_constant_ranges().is_empty() {
         return Ok(());
     }
 
-    let constants_pipeline_layout = match builder.current_push_constants_pipeline_layout() {
+    let constants_pipeline_layout = match current_state.push_constants_pipeline_layout() {
         Some(x) => x,
         None => return Err(CheckPushConstantsValidityError::MissingPushConstants),
     };

--- a/vulkano/src/command_buffer/validity/vertex_buffers.rs
+++ b/vulkano/src/command_buffer/validity/vertex_buffers.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::command_buffer::synced::SyncCommandBufferBuilder;
+use crate::command_buffer::synced::CommandBufferState;
 use crate::pipeline::vertex::VertexInputRate;
 use crate::pipeline::GraphicsPipeline;
 use crate::DeviceSize;
@@ -16,7 +16,7 @@ use std::error;
 use std::fmt;
 
 pub(in super::super) fn check_vertex_buffers(
-    builder: &SyncCommandBufferBuilder,
+    current_state: CommandBufferState,
     pipeline: &GraphicsPipeline,
     vertices: Option<(u32, u32)>,
     instances: Option<(u32, u32)>,
@@ -26,7 +26,7 @@ pub(in super::super) fn check_vertex_buffers(
     let mut max_instance_count: Option<u32> = None;
 
     for (binding_num, binding_desc) in vertex_input.bindings() {
-        let vertex_buffer = match builder.bound_vertex_buffer(binding_num) {
+        let vertex_buffer = match current_state.vertex_buffer(binding_num) {
             Some(x) => x,
             None => return Err(CheckVertexBufferError::BufferNotBound { binding_num }),
         };


### PR DESCRIPTION
Changelog:
1. Remove "SyncCommandBufferBuilder now has methods to return the state set by previous commands" line.
2. Remove "Added an inner method to AutoCommandBufferBuilder" line.

Replace 1. with:
```markdown
- `AutoCommandBufferBuilder` and `SyncCommandBufferBuilder` now have a `state` method, which can be used to query the state set by previous "bind" and "set" commands.
```

This is a better solution to #1712, which doesn't expose the whole inner builder. It also doesn't clog up the documentation of `SyncCommandBufferBuilder` with state retrieval methods.