### PR TITLE
Track state in the pipeline, invalidate dynamic state when binding pipeline with fixed state

### DIFF
--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -32,6 +32,7 @@ use crate::pipeline::layout::PipelineLayout;
 use crate::pipeline::viewport::Scissor;
 use crate::pipeline::viewport::Viewport;
 use crate::pipeline::ComputePipeline;
+use crate::pipeline::DynamicState;
 use crate::pipeline::GraphicsPipeline;
 use crate::pipeline::PipelineBindPoint;
 use crate::render_pass::FramebufferAbstract;
@@ -730,6 +731,26 @@ struct CurrentState {
     stencil_write_mask: StencilState,
     scissor: FnvHashMap<u32, Scissor>,
     viewport: FnvHashMap<u32, Viewport>,
+}
+
+impl CurrentState {
+    fn reset_dynamic_states(&mut self, states: impl IntoIterator<Item = DynamicState>) {
+        for state in states {
+            // TODO: If more dynamic states are added to CurrentState, add match arms here
+            match state {
+                DynamicState::BlendConstants => self.blend_constants = None,
+                DynamicState::DepthBias => self.depth_bias = None,
+                DynamicState::DepthBounds => self.depth_bounds = None,
+                DynamicState::LineWidth => self.line_width = None,
+                DynamicState::StencilCompareMask => self.stencil_compare_mask = Default::default(),
+                DynamicState::StencilReference => self.stencil_reference = Default::default(),
+                DynamicState::StencilWriteMask => self.stencil_write_mask = Default::default(),
+                DynamicState::Scissor => self.scissor.clear(),
+                DynamicState::Viewport => self.viewport.clear(),
+                _ => (),
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -39,6 +39,7 @@ use crate::pipeline::vertex::VertexInput;
 use crate::pipeline::viewport::Scissor;
 use crate::pipeline::viewport::Viewport;
 use crate::pipeline::ComputePipeline;
+use crate::pipeline::DynamicStateMode;
 use crate::pipeline::GraphicsPipeline;
 use crate::pipeline::PipelineBindPoint;
 use crate::query::QueryControlFlags;
@@ -286,6 +287,16 @@ impl SyncCommandBufferBuilder {
             }
         }
 
+        self.current_state
+            .reset_dynamic_states(pipeline.dynamic_states().filter_map(|(state, mode)| {
+                // Reset any states that are fixed in the new pipeline. The pipeline bind command
+                // will overwrite these states.
+                if matches!(mode, DynamicStateMode::Fixed) {
+                    Some(state)
+                } else {
+                    None
+                }
+            }));
         self.append_command(Cmd { pipeline }, &[]).unwrap();
         self.current_state.pipeline_graphics = self.commands.last().cloned();
     }

--- a/vulkano/src/command_buffer/validity/dynamic_state.rs
+++ b/vulkano/src/command_buffer/validity/dynamic_state.rs
@@ -8,6 +8,8 @@
 // according to those terms.
 
 use crate::command_buffer::synced::CommandBufferState;
+use crate::pipeline::DynamicState;
+use crate::pipeline::DynamicStateMode;
 use crate::pipeline::GraphicsPipeline;
 use std::error;
 use std::fmt;
@@ -19,25 +21,37 @@ pub(in super::super) fn check_dynamic_state_validity(
 ) -> Result<(), CheckDynamicStateValidityError> {
     let device = pipeline.device();
 
-    if pipeline.has_dynamic_blend_constants() {
+    if matches!(
+        pipeline.dynamic_state(DynamicState::BlendConstants),
+        Some(DynamicStateMode::Dynamic)
+    ) {
         if current_state.blend_constants().is_none() {
             return Err(CheckDynamicStateValidityError::BlendConstantsNotSet);
         }
     }
 
-    if pipeline.has_dynamic_depth_bounds() {
-        if current_state.blend_constants().is_none() {
-            return Err(CheckDynamicStateValidityError::BlendConstantsNotSet);
+    if matches!(
+        pipeline.dynamic_state(DynamicState::DepthBounds),
+        Some(DynamicStateMode::Dynamic)
+    ) {
+        if current_state.depth_bounds().is_none() {
+            return Err(CheckDynamicStateValidityError::DepthBoundsNotSet);
         }
     }
 
-    if pipeline.has_dynamic_line_width() {
+    if matches!(
+        pipeline.dynamic_state(DynamicState::LineWidth),
+        Some(DynamicStateMode::Dynamic)
+    ) {
         if current_state.line_width().is_none() {
             return Err(CheckDynamicStateValidityError::LineWidthNotSet);
         }
     }
 
-    if pipeline.has_dynamic_scissor() {
+    if matches!(
+        pipeline.dynamic_state(DynamicState::Scissor),
+        Some(DynamicStateMode::Dynamic)
+    ) {
         for num in 0..pipeline.num_viewports() {
             if current_state.scissor(num).is_none() {
                 return Err(CheckDynamicStateValidityError::ScissorNotSet { num });
@@ -45,7 +59,10 @@ pub(in super::super) fn check_dynamic_state_validity(
         }
     }
 
-    if pipeline.has_dynamic_stencil_compare_mask() {
+    if matches!(
+        pipeline.dynamic_state(DynamicState::StencilCompareMask),
+        Some(DynamicStateMode::Dynamic)
+    ) {
         let state = current_state.stencil_compare_mask();
 
         if state.front.is_none() || state.back.is_none() {
@@ -53,7 +70,10 @@ pub(in super::super) fn check_dynamic_state_validity(
         }
     }
 
-    if pipeline.has_dynamic_stencil_reference() {
+    if matches!(
+        pipeline.dynamic_state(DynamicState::StencilReference),
+        Some(DynamicStateMode::Dynamic)
+    ) {
         let state = current_state.stencil_reference();
 
         if state.front.is_none() || state.back.is_none() {
@@ -61,7 +81,10 @@ pub(in super::super) fn check_dynamic_state_validity(
         }
     }
 
-    if pipeline.has_dynamic_stencil_write_mask() {
+    if matches!(
+        pipeline.dynamic_state(DynamicState::StencilWriteMask),
+        Some(DynamicStateMode::Dynamic)
+    ) {
         let state = current_state.stencil_write_mask();
 
         if state.front.is_none() || state.back.is_none() {
@@ -69,7 +92,10 @@ pub(in super::super) fn check_dynamic_state_validity(
         }
     }
 
-    if pipeline.has_dynamic_viewport() {
+    if matches!(
+        pipeline.dynamic_state(DynamicState::Viewport),
+        Some(DynamicStateMode::Dynamic)
+    ) {
         for num in 0..pipeline.num_viewports() {
             if current_state.viewport(num).is_none() {
                 return Err(CheckDynamicStateValidityError::ViewportNotSet { num });

--- a/vulkano/src/command_buffer/validity/dynamic_state.rs
+++ b/vulkano/src/command_buffer/validity/dynamic_state.rs
@@ -21,85 +21,95 @@ pub(in super::super) fn check_dynamic_state_validity(
 ) -> Result<(), CheckDynamicStateValidityError> {
     let device = pipeline.device();
 
-    if matches!(
-        pipeline.dynamic_state(DynamicState::BlendConstants),
-        Some(DynamicStateMode::Dynamic)
-    ) {
-        if current_state.blend_constants().is_none() {
-            return Err(CheckDynamicStateValidityError::BlendConstantsNotSet);
+    for state in pipeline.dynamic_states().filter_map(|(state, mode)| {
+        if matches!(mode, DynamicStateMode::Dynamic) {
+            Some(state)
+        } else {
+            None
         }
-    }
-
-    if matches!(
-        pipeline.dynamic_state(DynamicState::DepthBounds),
-        Some(DynamicStateMode::Dynamic)
-    ) {
-        if current_state.depth_bounds().is_none() {
-            return Err(CheckDynamicStateValidityError::DepthBoundsNotSet);
-        }
-    }
-
-    if matches!(
-        pipeline.dynamic_state(DynamicState::LineWidth),
-        Some(DynamicStateMode::Dynamic)
-    ) {
-        if current_state.line_width().is_none() {
-            return Err(CheckDynamicStateValidityError::LineWidthNotSet);
-        }
-    }
-
-    if matches!(
-        pipeline.dynamic_state(DynamicState::Scissor),
-        Some(DynamicStateMode::Dynamic)
-    ) {
-        for num in 0..pipeline.num_viewports() {
-            if current_state.scissor(num).is_none() {
-                return Err(CheckDynamicStateValidityError::ScissorNotSet { num });
+    }) {
+        match state {
+            DynamicState::BlendConstants => {
+                if current_state.blend_constants().is_none() {
+                    return Err(CheckDynamicStateValidityError::BlendConstantsNotSet);
+                }
             }
-        }
-    }
-
-    if matches!(
-        pipeline.dynamic_state(DynamicState::StencilCompareMask),
-        Some(DynamicStateMode::Dynamic)
-    ) {
-        let state = current_state.stencil_compare_mask();
-
-        if state.front.is_none() || state.back.is_none() {
-            return Err(CheckDynamicStateValidityError::StencilCompareMaskNotSet);
-        }
-    }
-
-    if matches!(
-        pipeline.dynamic_state(DynamicState::StencilReference),
-        Some(DynamicStateMode::Dynamic)
-    ) {
-        let state = current_state.stencil_reference();
-
-        if state.front.is_none() || state.back.is_none() {
-            return Err(CheckDynamicStateValidityError::StencilReferenceNotSet);
-        }
-    }
-
-    if matches!(
-        pipeline.dynamic_state(DynamicState::StencilWriteMask),
-        Some(DynamicStateMode::Dynamic)
-    ) {
-        let state = current_state.stencil_write_mask();
-
-        if state.front.is_none() || state.back.is_none() {
-            return Err(CheckDynamicStateValidityError::StencilWriteMaskNotSet);
-        }
-    }
-
-    if matches!(
-        pipeline.dynamic_state(DynamicState::Viewport),
-        Some(DynamicStateMode::Dynamic)
-    ) {
-        for num in 0..pipeline.num_viewports() {
-            if current_state.viewport(num).is_none() {
-                return Err(CheckDynamicStateValidityError::ViewportNotSet { num });
+            DynamicState::ColorWriteEnable => todo!(),
+            DynamicState::CullMode => todo!(),
+            DynamicState::DepthBias => todo!(),
+            DynamicState::DepthBiasEnable => todo!(),
+            DynamicState::DepthBounds => {
+                if current_state.depth_bounds().is_none() {
+                    return Err(CheckDynamicStateValidityError::DepthBoundsNotSet);
+                }
             }
+            DynamicState::DepthBoundsTestEnable => todo!(),
+            DynamicState::DepthCompareOp => todo!(),
+            DynamicState::DepthTestEnable => todo!(),
+            DynamicState::DepthWriteEnable => todo!(),
+            DynamicState::DiscardRectangle => todo!(),
+            DynamicState::ExclusiveScissor => todo!(),
+            DynamicState::FragmentShadingRate => todo!(),
+            DynamicState::FrontFace => todo!(),
+            DynamicState::LineStipple => todo!(),
+            DynamicState::LineWidth => {
+                if current_state.line_width().is_none() {
+                    return Err(CheckDynamicStateValidityError::LineWidthNotSet);
+                }
+            }
+            DynamicState::LogicOp => todo!(),
+            DynamicState::PatchControlPoints => todo!(),
+            DynamicState::PrimitiveRestartEnable => todo!(),
+            DynamicState::PrimitiveTopology => todo!(),
+            DynamicState::RasterizerDiscardEnable => todo!(),
+            DynamicState::RayTracingPipelineStackSize => unreachable!(
+                "RayTracingPipelineStackSize dynamic state should not occur on a graphics pipeline"
+            ),
+            DynamicState::SampleLocations => todo!(),
+            DynamicState::Scissor => {
+                for num in 0..pipeline.num_viewports() {
+                    if current_state.scissor(num).is_none() {
+                        return Err(CheckDynamicStateValidityError::ScissorNotSet { num });
+                    }
+                }
+            }
+            DynamicState::ScissorWithCount => todo!(),
+            DynamicState::StencilCompareMask => {
+                let state = current_state.stencil_compare_mask();
+
+                if state.front.is_none() || state.back.is_none() {
+                    return Err(CheckDynamicStateValidityError::StencilCompareMaskNotSet);
+                }
+            }
+            DynamicState::StencilOp => todo!(),
+            DynamicState::StencilReference => {
+                let state = current_state.stencil_reference();
+
+                if state.front.is_none() || state.back.is_none() {
+                    return Err(CheckDynamicStateValidityError::StencilReferenceNotSet);
+                }
+            }
+            DynamicState::StencilTestEnable => todo!(),
+            DynamicState::StencilWriteMask => {
+                let state = current_state.stencil_write_mask();
+
+                if state.front.is_none() || state.back.is_none() {
+                    return Err(CheckDynamicStateValidityError::StencilWriteMaskNotSet);
+                }
+            }
+            DynamicState::VertexInput => todo!(),
+            DynamicState::VertexInputBindingStride => todo!(),
+            DynamicState::Viewport => {
+                for num in 0..pipeline.num_viewports() {
+                    if current_state.viewport(num).is_none() {
+                        return Err(CheckDynamicStateValidityError::ViewportNotSet { num });
+                    }
+                }
+            }
+            DynamicState::ViewportCoarseSampleOrder => todo!(),
+            DynamicState::ViewportShadingRatePalette => todo!(),
+            DynamicState::ViewportWithCount => todo!(),
+            DynamicState::ViewportWScaling => todo!(),
         }
     }
 
@@ -164,5 +174,3 @@ impl fmt::Display for CheckDynamicStateValidityError {
         )
     }
 }
-
-// TODO: tests

--- a/vulkano/src/pipeline/depth_stencil.rs
+++ b/vulkano/src/pipeline/depth_stencil.rs
@@ -28,7 +28,7 @@ use std::u32;
 pub struct DepthStencil {
     /// Comparison to use between the depth value of each fragment and the depth value currently
     /// in the depth buffer.
-    pub depth_compare: Compare,
+    pub depth_compare: CompareOp,
 
     /// If `true`, then the value in the depth buffer will be updated when the depth test succeeds.
     pub depth_write: bool,
@@ -51,7 +51,7 @@ impl DepthStencil {
     pub fn disabled() -> DepthStencil {
         DepthStencil {
             depth_write: false,
-            depth_compare: Compare::Always,
+            depth_compare: CompareOp::Always,
             depth_bounds_test: DepthBounds::Disabled,
             stencil_front: Default::default(),
             stencil_back: Default::default(),
@@ -64,7 +64,7 @@ impl DepthStencil {
     pub fn simple_depth_test() -> DepthStencil {
         DepthStencil {
             depth_write: true,
-            depth_compare: Compare::Less,
+            depth_compare: CompareOp::Less,
             depth_bounds_test: DepthBounds::Disabled,
             stencil_front: Default::default(),
             stencil_back: Default::default(),
@@ -84,7 +84,7 @@ impl Default for DepthStencil {
 pub struct Stencil {
     /// The comparison to perform between the existing stencil value in the stencil buffer, and
     /// the reference value (given by `reference`).
-    pub compare: Compare,
+    pub compare: CompareOp,
 
     /// The operation to perform when both the depth test and the stencil test passed.
     pub pass_op: StencilOp,
@@ -133,10 +133,10 @@ impl Stencil {
     #[inline]
     pub fn always_keep(&self) -> bool {
         match self.compare {
-            Compare::Always => {
+            CompareOp::Always => {
                 self.pass_op == StencilOp::Keep && self.depth_fail_op == StencilOp::Keep
             }
-            Compare::Never => self.fail_op == StencilOp::Keep,
+            CompareOp::Never => self.fail_op == StencilOp::Keep,
             _ => {
                 self.pass_op == StencilOp::Keep
                     && self.fail_op == StencilOp::Keep
@@ -150,7 +150,7 @@ impl Default for Stencil {
     #[inline]
     fn default() -> Stencil {
         Stencil {
-            compare: Compare::Never,
+            compare: CompareOp::Never,
             pass_op: StencilOp::Keep,
             fail_op: StencilOp::Keep,
             depth_fail_op: StencilOp::Keep,
@@ -236,7 +236,7 @@ impl DepthBounds {
 /// Used for both depth testing and stencil testing.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
-pub enum Compare {
+pub enum CompareOp {
     /// The test never passes.
     Never = ash::vk::CompareOp::NEVER.as_raw(),
     /// The test passes if `value < reference_value`.
@@ -255,9 +255,9 @@ pub enum Compare {
     Always = ash::vk::CompareOp::ALWAYS.as_raw(),
 }
 
-impl From<Compare> for ash::vk::CompareOp {
+impl From<CompareOp> for ash::vk::CompareOp {
     #[inline]
-    fn from(val: Compare) -> Self {
+    fn from(val: CompareOp) -> Self {
         Self::from_raw(val as i32)
     }
 }

--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -17,7 +17,7 @@ use crate::device::Device;
 use crate::image::SampleCount;
 use crate::pipeline::blend::{AttachmentBlend, AttachmentsBlend, Blend, LogicOp};
 use crate::pipeline::cache::PipelineCache;
-use crate::pipeline::depth_stencil::{Compare, DepthBounds, DepthStencil};
+use crate::pipeline::depth_stencil::{CompareOp, DepthBounds, DepthStencil};
 use crate::pipeline::graphics_pipeline::{
     GraphicsPipeline, GraphicsPipelineCreationError, Inner as GraphicsPipelineInner,
 };
@@ -43,27 +43,29 @@ use std::u32;
 /// Prototype for a `GraphicsPipeline`.
 // TODO: we can optimize this by filling directly the raw vk structs
 pub struct GraphicsPipelineBuilder<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss> {
-    vertex_definition: Vdef,
     vertex_shader: Option<(GraphicsEntryPoint<'vs>, Vss)>,
+    tessellation_shaders: Option<TessellationShaders<'tcs, 'tes, Tcss, Tess>>,
+    geometry_shader: Option<(GraphicsEntryPoint<'gs>, Gss)>,
+    fragment_shader: Option<(GraphicsEntryPoint<'fs>, Fss)>,
+
+    vertex_definition: Vdef,
     input_assembly: ash::vk::PipelineInputAssemblyStateCreateInfo,
     // Note: the `input_assembly_topology` member is temporary in order to not lose information
     // about the number of patches per primitive.
     input_assembly_topology: PrimitiveTopology,
-    tessellation: Option<TessInfo<'tcs, 'tes, Tcss, Tess>>,
-    geometry_shader: Option<(GraphicsEntryPoint<'gs>, Gss)>,
     viewport: Option<ViewportsState>,
     raster: Rasterization,
     multisample: ash::vk::PipelineMultisampleStateCreateInfo,
-    fragment_shader: Option<(GraphicsEntryPoint<'fs>, Fss)>,
     depth_stencil: DepthStencil,
     blend: Blend,
+
     subpass: Option<Subpass>,
     cache: Option<Arc<PipelineCache>>,
 }
 
 // Additional parameters if tessellation is used.
 #[derive(Clone, Debug)]
-struct TessInfo<'tcs, 'tes, Tcss, Tess> {
+struct TessellationShaders<'tcs, 'tes, Tcss, Tess> {
     tessellation_control_shader: (GraphicsEntryPoint<'tcs>, Tcss),
     tessellation_evaluation_shader: (GraphicsEntryPoint<'tes>, Tess),
 }
@@ -86,21 +88,23 @@ impl
     /// Builds a new empty builder.
     pub(super) fn new() -> Self {
         GraphicsPipelineBuilder {
-            vertex_definition: BuffersDefinition::new(),
             vertex_shader: None,
+            tessellation_shaders: None,
+            geometry_shader: None,
+            fragment_shader: None,
+
+            vertex_definition: BuffersDefinition::new(),
             input_assembly: ash::vk::PipelineInputAssemblyStateCreateInfo {
                 topology: PrimitiveTopology::TriangleList.into(),
                 ..Default::default()
             },
             input_assembly_topology: PrimitiveTopology::TriangleList,
-            tessellation: None,
-            geometry_shader: None,
             viewport: None,
             raster: Default::default(),
             multisample: ash::vk::PipelineMultisampleStateCreateInfo::default(),
-            fragment_shader: None,
             depth_stencil: DepthStencil::disabled(),
             blend: Blend::pass_through(),
+
             subpass: None,
             cache: None,
         }
@@ -139,10 +143,10 @@ where
         let (descriptor_set_layout_descs, push_constant_ranges) = {
             let stages: SmallVec<[&GraphicsEntryPoint; 5]> = std::array::IntoIter::new([
                 self.vertex_shader.as_ref().map(|s| &s.0),
-                self.tessellation
+                self.tessellation_shaders
                     .as_ref()
                     .map(|s| &s.tessellation_control_shader.0),
-                self.tessellation
+                self.tessellation_shaders
                     .as_ref()
                     .map(|s| &s.tessellation_evaluation_shader.0),
                 self.geometry_shader.as_ref().map(|s| &s.0),
@@ -237,7 +241,7 @@ where
             )?;
         }
 
-        if let Some(ref tess) = self.tessellation {
+        if let Some(ref tess) = self.tessellation_shaders {
             {
                 let shader = &tess.tessellation_control_shader.0;
                 pipeline_layout.ensure_compatible_with_shader(
@@ -295,7 +299,7 @@ where
             }
         };
 
-        let tess_shader_specialization = if let Some(ref tess) = self.tessellation {
+        let tess_shader_specialization = if let Some(ref tess) = self.tessellation_shaders {
             let tcs_spec = {
                 let shader = &tess.tessellation_control_shader;
                 let spec_descriptors = Tcss::descriptors();
@@ -389,7 +393,7 @@ where
                 ..Default::default()
             });
 
-            if let Some(ref tess) = self.tessellation {
+            if let Some(ref tess) = self.tessellation_shaders {
                 // FIXME: must check that the control shader and evaluation shader are compatible
 
                 if !device.enabled_features().tessellation_shader {
@@ -694,7 +698,7 @@ where
 
         let tessellation_state = match self.input_assembly_topology {
             PrimitiveTopology::PatchList { vertices_per_patch } => {
-                if self.tessellation.is_none() {
+                if self.tessellation_shaders.is_none() {
                     return Err(GraphicsPipelineCreationError::InvalidPrimitiveTopology);
                 }
                 if vertices_per_patch
@@ -713,7 +717,7 @@ where
                 })
             }
             _ => {
-                if self.tessellation.is_some() {
+                if self.tessellation_shaders.is_some() {
                     return Err(GraphicsPipelineCreationError::InvalidPrimitiveTopology);
                 }
 
@@ -957,7 +961,7 @@ where
                 return Err(GraphicsPipelineCreationError::NoDepthAttachment);
             }
 
-            if self.depth_stencil.depth_compare != Compare::Always
+            if self.depth_stencil.depth_compare != CompareOp::Always
                 && !self.subpass.as_ref().unwrap().has_depth()
             {
                 return Err(GraphicsPipelineCreationError::NoDepthAttachment);
@@ -975,7 +979,7 @@ where
             Some(ash::vk::PipelineDepthStencilStateCreateInfo {
                 flags: ash::vk::PipelineDepthStencilStateCreateFlags::empty(),
                 depth_test_enable: if !self.depth_stencil.depth_write
-                    && self.depth_stencil.depth_compare == Compare::Always
+                    && self.depth_stencil.depth_compare == CompareOp::Always
                 {
                     ash::vk::FALSE
                 } else {
@@ -1232,7 +1236,7 @@ where
                     return Err(GraphicsPipelineCreationError::MultiviewGeometryShaderNotSupported);
                 }
 
-                if self.tessellation.is_some()
+                if self.tessellation_shaders.is_some()
                     && !device
                         .physical_device()
                         .supported_features()
@@ -1352,18 +1356,20 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         vertex_definition: T,
     ) -> GraphicsPipelineBuilder<'vs, 'tcs, 'tes, 'gs, 'fs, T, Vss, Tcss, Tess, Gss, Fss> {
         GraphicsPipelineBuilder {
-            vertex_definition,
             vertex_shader: self.vertex_shader,
+            tessellation_shaders: self.tessellation_shaders,
+            geometry_shader: self.geometry_shader,
+            fragment_shader: self.fragment_shader,
+
+            vertex_definition,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
-            tessellation: self.tessellation,
-            geometry_shader: self.geometry_shader,
             viewport: self.viewport,
             raster: self.raster,
             multisample: self.multisample,
-            fragment_shader: self.fragment_shader,
             depth_stencil: self.depth_stencil,
             blend: self.blend,
+
             subpass: self.subpass,
             cache: self.cache,
         }
@@ -1404,18 +1410,20 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         Vss2: SpecializationConstants,
     {
         GraphicsPipelineBuilder {
-            vertex_definition: self.vertex_definition,
             vertex_shader: Some((shader, specialization_constants)),
+            tessellation_shaders: self.tessellation_shaders,
+            geometry_shader: self.geometry_shader,
+            fragment_shader: self.fragment_shader,
+
+            vertex_definition: self.vertex_definition,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
-            tessellation: self.tessellation,
-            geometry_shader: self.geometry_shader,
             viewport: self.viewport,
             raster: self.raster,
             multisample: self.multisample,
-            fragment_shader: self.fragment_shader,
             depth_stencil: self.depth_stencil,
             blend: self.blend,
+
             subpass: self.subpass,
             cache: self.cache,
         }
@@ -1556,11 +1564,8 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         Tess2: SpecializationConstants,
     {
         GraphicsPipelineBuilder {
-            vertex_definition: self.vertex_definition,
             vertex_shader: self.vertex_shader,
-            input_assembly: self.input_assembly,
-            input_assembly_topology: self.input_assembly_topology,
-            tessellation: Some(TessInfo {
+            tessellation_shaders: Some(TessellationShaders {
                 tessellation_control_shader: (
                     tessellation_control_shader,
                     tessellation_control_shader_spec_constants,
@@ -1571,12 +1576,17 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
                 ),
             }),
             geometry_shader: self.geometry_shader,
+            fragment_shader: self.fragment_shader,
+
+            vertex_definition: self.vertex_definition,
+            input_assembly: self.input_assembly,
+            input_assembly_topology: self.input_assembly_topology,
             viewport: self.viewport,
             raster: self.raster,
             multisample: self.multisample,
-            fragment_shader: self.fragment_shader,
             depth_stencil: self.depth_stencil,
             blend: self.blend,
+
             subpass: self.subpass,
             cache: self.cache,
         }
@@ -1585,7 +1595,7 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
     /// Sets the tessellation shaders stage as disabled. This is the default.
     #[inline]
     pub fn tessellation_shaders_disabled(mut self) -> Self {
-        self.tessellation = None;
+        self.tessellation_shaders = None;
         self
     }
 
@@ -1601,18 +1611,20 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         Gss2: SpecializationConstants,
     {
         GraphicsPipelineBuilder {
-            vertex_definition: self.vertex_definition,
             vertex_shader: self.vertex_shader,
+            tessellation_shaders: self.tessellation_shaders,
+            geometry_shader: Some((shader, specialization_constants)),
+            fragment_shader: self.fragment_shader,
+
+            vertex_definition: self.vertex_definition,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
-            tessellation: self.tessellation,
-            geometry_shader: Some((shader, specialization_constants)),
             viewport: self.viewport,
             raster: self.raster,
             multisample: self.multisample,
-            fragment_shader: self.fragment_shader,
             depth_stencil: self.depth_stencil,
             blend: self.blend,
+
             subpass: self.subpass,
             cache: self.cache,
         }
@@ -1883,18 +1895,20 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
         Fss2: SpecializationConstants,
     {
         GraphicsPipelineBuilder {
-            vertex_definition: self.vertex_definition,
             vertex_shader: self.vertex_shader,
+            tessellation_shaders: self.tessellation_shaders,
+            geometry_shader: self.geometry_shader,
+            fragment_shader: Some((shader, specialization_constants)),
+
+            vertex_definition: self.vertex_definition,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
-            tessellation: self.tessellation,
-            geometry_shader: self.geometry_shader,
             viewport: self.viewport,
             raster: self.raster,
             multisample: self.multisample,
-            fragment_shader: Some((shader, specialization_constants)),
             depth_stencil: self.depth_stencil,
             blend: self.blend,
+
             subpass: self.subpass,
             cache: self.cache,
         }
@@ -1998,18 +2012,20 @@ impl<'vs, 'tcs, 'tes, 'gs, 'fs, Vdef, Vss, Tcss, Tess, Gss, Fss>
     #[inline]
     pub fn render_pass(self, subpass: Subpass) -> Self {
         GraphicsPipelineBuilder {
-            vertex_definition: self.vertex_definition,
             vertex_shader: self.vertex_shader,
+            tessellation_shaders: self.tessellation_shaders,
+            geometry_shader: self.geometry_shader,
+            fragment_shader: self.fragment_shader,
+
+            vertex_definition: self.vertex_definition,
             input_assembly: self.input_assembly,
             input_assembly_topology: self.input_assembly_topology,
-            tessellation: self.tessellation,
-            geometry_shader: self.geometry_shader,
             viewport: self.viewport,
             raster: self.raster,
             multisample: self.multisample,
-            fragment_shader: self.fragment_shader,
             depth_stencil: self.depth_stencil,
             blend: self.blend,
+
             subpass: Some(subpass),
             cache: self.cache,
         }
@@ -2039,18 +2055,20 @@ where
 {
     fn clone(&self) -> Self {
         GraphicsPipelineBuilder {
-            vertex_definition: self.vertex_definition.clone(),
             vertex_shader: self.vertex_shader.clone(),
+            tessellation_shaders: self.tessellation_shaders.clone(),
+            geometry_shader: self.geometry_shader.clone(),
+            fragment_shader: self.fragment_shader.clone(),
+
+            vertex_definition: self.vertex_definition.clone(),
             input_assembly: unsafe { ptr::read(&self.input_assembly) },
             input_assembly_topology: self.input_assembly_topology,
-            tessellation: self.tessellation.clone(),
-            geometry_shader: self.geometry_shader.clone(),
             viewport: self.viewport.clone(),
             raster: self.raster.clone(),
             multisample: self.multisample,
-            fragment_shader: self.fragment_shader.clone(),
             depth_stencil: self.depth_stencil.clone(),
             blend: self.blend.clone(),
+
             subpass: self.subpass.clone(),
             cache: self.cache.clone(),
         }

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -16,6 +16,7 @@ use crate::pipeline::vertex::BuffersDefinition;
 use crate::pipeline::vertex::VertexInput;
 use crate::render_pass::Subpass;
 use crate::VulkanObject;
+use fnv::FnvHashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -38,17 +39,7 @@ pub struct GraphicsPipeline {
     layout: Arc<PipelineLayout>,
     subpass: Subpass,
     vertex_input: VertexInput,
-
-    dynamic_line_width: bool,
-    dynamic_viewport: bool,
-    dynamic_scissor: bool,
-    dynamic_depth_bias: bool,
-    dynamic_depth_bounds: bool,
-    dynamic_stencil_compare_mask: bool,
-    dynamic_stencil_write_mask: bool,
-    dynamic_stencil_reference: bool,
-    dynamic_blend_constants: bool,
-
+    dynamic_state: FnvHashMap<DynamicState, DynamicStateMode>,
     num_viewports: u32,
 }
 
@@ -107,52 +98,19 @@ impl GraphicsPipeline {
         self.num_viewports
     }
 
-    /// Returns true if the blend constants used by this pipeline are dynamic.
-    #[inline]
-    pub fn has_dynamic_blend_constants(&self) -> bool {
-        self.dynamic_blend_constants
+    /// Returns the mode of a particular dynamic state.
+    ///
+    /// `None` is returned if the pipeline does not contain this state. Previously set dynamic
+    /// state is not disturbed when binding it.
+    pub fn dynamic_state(&self, state: DynamicState) -> Option<DynamicStateMode> {
+        self.dynamic_state.get(&state).copied()
     }
 
-    /// Returns true if the depth bounds used by this pipeline are dynamic.
-    #[inline]
-    pub fn has_dynamic_depth_bounds(&self) -> bool {
-        self.dynamic_depth_bounds
-    }
-
-    /// Returns true if the line width used by this pipeline is dynamic.
-    #[inline]
-    pub fn has_dynamic_line_width(&self) -> bool {
-        self.dynamic_line_width
-    }
-
-    /// Returns true if the scissors used by this pipeline are dynamic.
-    #[inline]
-    pub fn has_dynamic_scissor(&self) -> bool {
-        self.dynamic_scissor
-    }
-
-    /// Returns true if the stencil compare masks used by this pipeline are dynamic.
-    #[inline]
-    pub fn has_dynamic_stencil_compare_mask(&self) -> bool {
-        self.dynamic_stencil_compare_mask
-    }
-
-    /// Returns true if the stencil references used by this pipeline are dynamic.
-    #[inline]
-    pub fn has_dynamic_stencil_reference(&self) -> bool {
-        self.dynamic_stencil_reference
-    }
-
-    /// Returns true if the stencil write masks used by this pipeline are dynamic.
-    #[inline]
-    pub fn has_dynamic_stencil_write_mask(&self) -> bool {
-        self.dynamic_stencil_write_mask
-    }
-
-    /// Returns true if the viewports used by this pipeline are dynamic.
-    #[inline]
-    pub fn has_dynamic_viewport(&self) -> bool {
-        self.dynamic_viewport
+    /// Returns all dynamic states and their modes.
+    pub fn dynamic_states(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (DynamicState, DynamicStateMode)> + '_ {
+        self.dynamic_state.iter().map(|(k, v)| (*k, *v))
     }
 }
 
@@ -217,4 +175,67 @@ unsafe impl<'a> VulkanObject for GraphicsPipelineSys<'a> {
     fn internal_object(&self) -> ash::vk::Pipeline {
         self.0
     }
+}
+
+/// A particular state value within a graphics pipeline that can be dynamically set by a command
+/// buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum DynamicState {
+    Viewport = ash::vk::DynamicState::VIEWPORT.as_raw(),
+    Scissor = ash::vk::DynamicState::SCISSOR.as_raw(),
+    LineWidth = ash::vk::DynamicState::LINE_WIDTH.as_raw(),
+    DepthBias = ash::vk::DynamicState::DEPTH_BIAS.as_raw(),
+    BlendConstants = ash::vk::DynamicState::BLEND_CONSTANTS.as_raw(),
+    DepthBounds = ash::vk::DynamicState::DEPTH_BOUNDS.as_raw(),
+    StencilCompareMask = ash::vk::DynamicState::STENCIL_COMPARE_MASK.as_raw(),
+    StencilWriteMask = ash::vk::DynamicState::STENCIL_WRITE_MASK.as_raw(),
+    StencilReference = ash::vk::DynamicState::STENCIL_REFERENCE.as_raw(),
+    ViewportWScaling = ash::vk::DynamicState::VIEWPORT_W_SCALING_NV.as_raw(),
+    DiscardRectangle = ash::vk::DynamicState::DISCARD_RECTANGLE_EXT.as_raw(),
+    SampleLocations = ash::vk::DynamicState::SAMPLE_LOCATIONS_EXT.as_raw(),
+    RayTracingPipelineStackSize =
+        ash::vk::DynamicState::RAY_TRACING_PIPELINE_STACK_SIZE_KHR.as_raw(),
+    ViewportShadingRatePalette = ash::vk::DynamicState::VIEWPORT_SHADING_RATE_PALETTE_NV.as_raw(),
+    ViewportCoarseSampleOrder = ash::vk::DynamicState::VIEWPORT_COARSE_SAMPLE_ORDER_NV.as_raw(),
+    ExclusiveScissor = ash::vk::DynamicState::EXCLUSIVE_SCISSOR_NV.as_raw(),
+    FragmentShadingRate = ash::vk::DynamicState::FRAGMENT_SHADING_RATE_KHR.as_raw(),
+    LineStipple = ash::vk::DynamicState::LINE_STIPPLE_EXT.as_raw(),
+    CullMode = ash::vk::DynamicState::CULL_MODE_EXT.as_raw(),
+    FrontFace = ash::vk::DynamicState::FRONT_FACE_EXT.as_raw(),
+    PrimitiveTopology = ash::vk::DynamicState::PRIMITIVE_TOPOLOGY_EXT.as_raw(),
+    ViewportWithCount = ash::vk::DynamicState::VIEWPORT_WITH_COUNT_EXT.as_raw(),
+    ScissorWithCount = ash::vk::DynamicState::SCISSOR_WITH_COUNT_EXT.as_raw(),
+    VertexInputBindingStride = ash::vk::DynamicState::VERTEX_INPUT_BINDING_STRIDE_EXT.as_raw(),
+    DepthTestEnable = ash::vk::DynamicState::DEPTH_TEST_ENABLE_EXT.as_raw(),
+    DepthWriteEnable = ash::vk::DynamicState::DEPTH_WRITE_ENABLE_EXT.as_raw(),
+    DepthCompareOp = ash::vk::DynamicState::DEPTH_COMPARE_OP_EXT.as_raw(),
+    DepthBoundsTestEnable = ash::vk::DynamicState::DEPTH_BOUNDS_TEST_ENABLE_EXT.as_raw(),
+    StencilTestEnable = ash::vk::DynamicState::STENCIL_TEST_ENABLE_EXT.as_raw(),
+    StencilOp = ash::vk::DynamicState::STENCIL_OP_EXT.as_raw(),
+    VertexInput = ash::vk::DynamicState::VERTEX_INPUT_EXT.as_raw(),
+    PatchControlPoints = ash::vk::DynamicState::PATCH_CONTROL_POINTS_EXT.as_raw(),
+    RasterizerDiscardEnable = ash::vk::DynamicState::RASTERIZER_DISCARD_ENABLE_EXT.as_raw(),
+    DepthBiasEnable = ash::vk::DynamicState::DEPTH_BIAS_ENABLE_EXT.as_raw(),
+    LogicOp = ash::vk::DynamicState::LOGIC_OP_EXT.as_raw(),
+    PrimitiveRestartEnable = ash::vk::DynamicState::PRIMITIVE_RESTART_ENABLE_EXT.as_raw(),
+    ColorWriteEnable = ash::vk::DynamicState::COLOR_WRITE_ENABLE_EXT.as_raw(),
+}
+
+impl From<DynamicState> for ash::vk::DynamicState {
+    #[inline]
+    fn from(val: DynamicState) -> Self {
+        Self::from_raw(val as i32)
+    }
+}
+
+/// Specifies how a dynamic state is handled by a graphics pipeline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DynamicStateMode {
+    /// The pipeline has a fixed value for this state. Previously set dynamic state will be lost
+    /// when binding it, and will have to be re-set after binding a pipeline that uses it.
+    Fixed,
+    /// The pipeline expects a dynamic value to be set by a command buffer. Previously set dynamic
+    /// state is not disturbed when binding it.
+    Dynamic,
 }

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -78,6 +78,8 @@
 pub use self::compute_pipeline::ComputePipeline;
 pub use self::compute_pipeline::ComputePipelineCreationError;
 pub use self::compute_pipeline::ComputePipelineSys;
+pub use self::graphics_pipeline::DynamicState;
+pub use self::graphics_pipeline::DynamicStateMode;
 pub use self::graphics_pipeline::GraphicsPipeline;
 pub use self::graphics_pipeline::GraphicsPipelineBuilder;
 pub use self::graphics_pipeline::GraphicsPipelineCreationError;

--- a/vulkano/src/sampler.rs
+++ b/vulkano/src/sampler.rs
@@ -65,7 +65,7 @@
 use crate::check_errors;
 use crate::device::Device;
 use crate::device::DeviceOwned;
-pub use crate::pipeline::depth_stencil::Compare;
+use crate::pipeline::depth_stencil::CompareOp;
 use crate::Error;
 use crate::OomError;
 use crate::VulkanObject;
@@ -225,7 +225,7 @@ impl Sampler {
         max_anisotropy: f32,
         min_lod: f32,
         max_lod: f32,
-        compare: Compare,
+        compare: CompareOp,
     ) -> Result<Arc<Sampler>, SamplerCreationError> {
         Sampler::new_impl(
             device,
@@ -255,7 +255,7 @@ impl Sampler {
         max_anisotropy: f32,
         min_lod: f32,
         max_lod: f32,
-        compare: Option<Compare>,
+        compare: Option<CompareOp>,
     ) -> Result<Arc<Sampler>, SamplerCreationError> {
         assert!(max_anisotropy >= 1.0);
         assert!(min_lod <= max_lod);
@@ -854,7 +854,7 @@ mod tests {
             1.0,
             0.0,
             2.0,
-            sampler::Compare::Less,
+            sampler::CompareOp::Less,
         )
         .unwrap();
 


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** `Compare` is renamed to `CompareOp` to match Vulkan.
```
```markdown
- Replaced the various dynamic state querying methods of `GraphicsPipeline` with two: `dynamic_state` to query a single dynamic state, and `dynamic_states` to iterate over all of them.
```

According to the Vulkan spec, if a pipeline contains _fixed_ state, then it overwrites any _dynamic_ state that was previously set. Vulkano didn't track this before, but it became an issue with #1684. This PR fixes that by tracking, for every graphics pipeline, which state is "baked into" the pipeline, which it expects to be given dynamically, and which state isn't in the pipeline at all. `SyncCommandBufferBuilder` in turn deletes all the overwritten state whenever you bind a new pipeline.

The changelog doesn't mention any of this, since it's internal behaviour. The only user-visible changes are the rename, and the different interface on `GraphicsPipeline` and the two new types I introduced for this purpose, `DynamicState` and `DynamicStateMode`.