### PR TITLE
Replace `BufferViewRef` with `BufferViewAbstract`

### DIFF
--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -88,7 +88,7 @@ pub use self::traits::BufferInner;
 pub use self::traits::TypedBufferAccess;
 pub use self::usage::BufferUsage;
 pub use self::view::BufferView;
-pub use self::view::BufferViewRef;
+pub use self::view::BufferViewAbstract;
 
 pub mod cpu_access;
 pub mod cpu_pool;


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** `BufferViewRef` is replaced with `BufferViewAbstract`, similar to the existing `ImageViewAbstract`.
```

A small consistency change. This isn't so useful on its own, but a future PR I'm working on relies on being able to create `Arc<dyn BufferViewAbstract>`.