### PR TITLE
Check against DescriptorRequirements instead of pipeline layout at draw time

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -19,7 +19,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -18,7 +18,7 @@ use vulkano::image::ImageViewAbstract;
 use vulkano::pipeline::color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState};
 use vulkano::pipeline::input_assembly::InputAssemblyState;
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::Subpass;
 
 /// Allows applying an ambient lighting to a scene.

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -19,7 +19,7 @@ use vulkano::image::ImageViewAbstract;
 use vulkano::pipeline::color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState};
 use vulkano::pipeline::input_assembly::InputAssemblyState;
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::Subpass;
 
 /// Allows applying a directional light source to a scene.

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -19,7 +19,7 @@ use vulkano::image::ImageViewAbstract;
 use vulkano::pipeline::color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState};
 use vulkano::pipeline::input_assembly::InputAssemblyState;
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::Subpass;
 
 pub struct PointLightingSystem {

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -21,7 +21,7 @@ use vulkano::descriptor_set::{DescriptorSet, PersistentDescriptorSet};
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -25,7 +25,7 @@ use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::format::Format;
 use vulkano::image::{view::ImageView, ImageDimensions, StorageImage};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -24,7 +24,7 @@ use vulkano::instance::Instance;
 use vulkano::pipeline::color_blend::ColorBlendState;
 use vulkano::pipeline::input_assembly::{InputAssemblyState, PrimitiveTopology};
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::{Framebuffer, RenderPass, Subpass};
 use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 use vulkano::swapchain::{self, AcquireError, Swapchain, SwapchainCreationError};

--- a/examples/src/bin/immutable-buffer-initialization.rs
+++ b/examples/src/bin/immutable-buffer-initialization.rs
@@ -15,7 +15,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -33,7 +33,7 @@ use vulkano::instance::Instance;
 use vulkano::pipeline::color_blend::ColorBlendState;
 use vulkano::pipeline::input_assembly::{InputAssemblyState, PrimitiveTopology};
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::{Framebuffer, RenderPass, Subpass};
 use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 use vulkano::swapchain::{self, AcquireError, Swapchain, SwapchainCreationError};

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -44,7 +44,7 @@ use vulkano::image::{ImageAccess, ImageUsage, SwapchainImage};
 use vulkano::instance::Instance;
 use vulkano::pipeline::input_assembly::InputAssemblyState;
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{ComputePipeline, GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::{Framebuffer, RenderPass, Subpass};
 use vulkano::swapchain::{self, AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync::{self, FlushError, GpuFuture};

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -17,7 +17,7 @@ use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage};
 use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::Queue;
 use vulkano::image::ImageAccess;
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync::GpuFuture;
 
 pub struct FractalComputePipeline {

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -17,7 +17,7 @@ use vulkano::device::Queue;
 use vulkano::image::ImageViewAbstract;
 use vulkano::pipeline::input_assembly::InputAssemblyState;
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::Subpass;
 use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -15,7 +15,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -24,7 +24,7 @@ use vulkano::instance::Instance;
 use vulkano::pipeline::color_blend::ColorBlendState;
 use vulkano::pipeline::input_assembly::{InputAssemblyState, PrimitiveTopology};
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::{Framebuffer, RenderPass, Subpass};
 use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 use vulkano::swapchain::{self, AcquireError, Swapchain, SwapchainCreationError};

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -27,7 +27,7 @@ use vulkano::instance::Instance;
 use vulkano::pipeline::color_blend::ColorBlendState;
 use vulkano::pipeline::layout::PipelineLayout;
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::{Framebuffer, RenderPass, Subpass};
 use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 use vulkano::swapchain::{self, AcquireError, Swapchain, SwapchainCreationError};

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -17,7 +17,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -34,7 +34,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features, Queue};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -15,7 +15,7 @@ use vulkano::descriptor_set::PersistentDescriptorSet;
 use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
 use vulkano::device::{Device, DeviceExtensions, Features};
 use vulkano::instance::{Instance, InstanceExtensions};
-use vulkano::pipeline::{ComputePipeline, PipelineBindPoint};
+use vulkano::pipeline::{ComputePipeline, Pipeline, PipelineBindPoint};
 use vulkano::sync;
 use vulkano::sync::GpuFuture;
 use vulkano::Version;

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -26,7 +26,7 @@ use vulkano::pipeline::depth_stencil::DepthStencilState;
 use vulkano::pipeline::input_assembly::InputAssemblyState;
 use vulkano::pipeline::vertex::BuffersDefinition;
 use vulkano::pipeline::viewport::{Viewport, ViewportState};
-use vulkano::pipeline::{GraphicsPipeline, PipelineBindPoint};
+use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::{Framebuffer, RenderPass, Subpass};
 use vulkano::swapchain::{self, AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync::{self, FlushError, GpuFuture};

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -67,6 +67,7 @@ use crate::pipeline::viewport::Viewport;
 use crate::pipeline::ComputePipeline;
 use crate::pipeline::DynamicState;
 use crate::pipeline::GraphicsPipeline;
+use crate::pipeline::Pipeline;
 use crate::pipeline::PipelineBindPoint;
 use crate::query::QueryControlFlags;
 use crate::query::QueryPipelineStatisticFlags;
@@ -1393,11 +1394,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
         let pipeline = check_pipeline_compute(self.state())?;
         self.ensure_outside_render_pass()?;
-        check_descriptor_sets_validity(
-            self.state(),
-            pipeline.layout(),
-            PipelineBindPoint::Compute,
-        )?;
+        check_descriptor_sets_validity(self.state(), pipeline, pipeline.descriptor_requirements())?;
         check_push_constants_validity(self.state(), pipeline.layout())?;
         check_dispatch(self.device(), group_counts)?;
 
@@ -1424,11 +1421,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
         let pipeline = check_pipeline_compute(self.state())?;
         self.ensure_outside_render_pass()?;
-        check_descriptor_sets_validity(
-            self.state(),
-            pipeline.layout(),
-            PipelineBindPoint::Compute,
-        )?;
+        check_descriptor_sets_validity(self.state(), pipeline, pipeline.descriptor_requirements())?;
         check_push_constants_validity(self.state(), pipeline.layout())?;
         check_indirect_buffer(self.device(), indirect_buffer.as_ref())?;
 
@@ -1456,11 +1449,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         let pipeline = check_pipeline_graphics(self.state())?;
         self.ensure_inside_render_pass_inline(pipeline)?;
         check_dynamic_state_validity(self.state(), pipeline)?;
-        check_descriptor_sets_validity(
-            self.state(),
-            pipeline.layout(),
-            PipelineBindPoint::Graphics,
-        )?;
+        check_descriptor_sets_validity(self.state(), pipeline, pipeline.descriptor_requirements())?;
         check_push_constants_validity(self.state(), pipeline.layout())?;
         check_vertex_buffers(
             self.state(),
@@ -1502,11 +1491,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         let pipeline = check_pipeline_graphics(self.state())?;
         self.ensure_inside_render_pass_inline(pipeline)?;
         check_dynamic_state_validity(self.state(), pipeline)?;
-        check_descriptor_sets_validity(
-            self.state(),
-            pipeline.layout(),
-            PipelineBindPoint::Graphics,
-        )?;
+        check_descriptor_sets_validity(self.state(), pipeline, pipeline.descriptor_requirements())?;
         check_push_constants_validity(self.state(), pipeline.layout())?;
         check_vertex_buffers(self.state(), pipeline, None, None)?;
         check_indirect_buffer(self.device(), indirect_buffer.as_ref())?;
@@ -1557,11 +1542,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         let pipeline = check_pipeline_graphics(self.state())?;
         self.ensure_inside_render_pass_inline(pipeline)?;
         check_dynamic_state_validity(self.state(), pipeline)?;
-        check_descriptor_sets_validity(
-            self.state(),
-            pipeline.layout(),
-            PipelineBindPoint::Graphics,
-        )?;
+        check_descriptor_sets_validity(self.state(), pipeline, pipeline.descriptor_requirements())?;
         check_push_constants_validity(self.state(), pipeline.layout())?;
         check_vertex_buffers(
             self.state(),
@@ -1610,11 +1591,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         let pipeline = check_pipeline_graphics(self.state())?;
         self.ensure_inside_render_pass_inline(pipeline)?;
         check_dynamic_state_validity(self.state(), pipeline)?;
-        check_descriptor_sets_validity(
-            self.state(),
-            pipeline.layout(),
-            PipelineBindPoint::Graphics,
-        )?;
+        check_descriptor_sets_validity(self.state(), pipeline, pipeline.descriptor_requirements())?;
         check_push_constants_validity(self.state(), pipeline.layout())?;
         check_vertex_buffers(self.state(), pipeline, None, None)?;
         check_index_buffer(self.state(), None)?;

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -104,7 +104,7 @@ pub struct SyncCommandBuffer {
 
     // List of commands used by the command buffer. Used to hold the various resources that are
     // being used.
-    commands: Vec<Arc<dyn Command>>,
+    commands: Vec<Box<dyn Command>>,
 
     // Locations within commands that pipeline barriers were inserted. For debugging purposes.
     // TODO: present only in cfg(debug_assertions)?
@@ -468,10 +468,6 @@ trait Command: Send + Sync {
     // Sends the command to the `UnsafeCommandBufferBuilder`. Calling this method twice on the same
     // object will likely lead to a panic.
     unsafe fn send(&self, out: &mut UnsafeCommandBufferBuilder);
-
-    fn bound_descriptor_set(&self, set_num: u32) -> SetOrPush {
-        panic!()
-    }
 }
 
 impl std::fmt::Debug for dyn Command {
@@ -493,8 +489,8 @@ mod tests {
     use crate::command_buffer::CommandBufferLevel;
     use crate::command_buffer::CommandBufferUsage;
     use crate::descriptor_set::layout::DescriptorDesc;
-    use crate::descriptor_set::layout::DescriptorDescTy;
     use crate::descriptor_set::layout::DescriptorSetLayout;
+    use crate::descriptor_set::layout::DescriptorType;
     use crate::descriptor_set::PersistentDescriptorSet;
     use crate::device::Device;
     use crate::pipeline::layout::PipelineLayout;
@@ -674,13 +670,11 @@ mod tests {
             let set_layout = DescriptorSetLayout::new(
                 device.clone(),
                 [Some(DescriptorDesc {
-                    ty: DescriptorDescTy::Sampler {
-                        immutable_samplers: vec![],
-                    },
+                    ty: DescriptorType::Sampler,
                     descriptor_count: 1,
-                    stages: ShaderStages::all(),
-                    mutable: false,
                     variable_count: false,
+                    stages: ShaderStages::all(),
+                    immutable_samplers: Vec::new(),
                 })],
             )
             .unwrap();

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1375,11 +1375,10 @@ impl UnsafeCommandBufferBuilder {
                 let descriptor = pipeline_layout.descriptor_set_layouts()[set_num as usize]
                     .descriptor(write.binding_num)
                     .unwrap();
-                let descriptor_type = descriptor.ty.ty();
 
                 (
-                    write.to_vulkan_info(descriptor_type),
-                    write.to_vulkan(ash::vk::DescriptorSet::null(), descriptor_type),
+                    write.to_vulkan_info(descriptor.ty),
+                    write.to_vulkan(ash::vk::DescriptorSet::null(), descriptor.ty),
                 )
             })
             .unzip();

--- a/vulkano/src/command_buffer/validity/descriptor_sets.rs
+++ b/vulkano/src/command_buffer/validity/descriptor_sets.rs
@@ -8,56 +8,97 @@
 // according to those terms.
 
 use crate::command_buffer::synced::CommandBufferState;
-use crate::command_buffer::synced::SetOrPush;
-use crate::descriptor_set::layout::DescriptorSetCompatibilityError;
-use crate::pipeline::layout::PipelineLayout;
-use crate::pipeline::PipelineBindPoint;
-use crate::VulkanObject;
+use crate::descriptor_set::DescriptorBindingResources;
+use crate::format::Format;
+use crate::image::view::ImageViewType;
+use crate::image::ImageViewAbstract;
+use crate::image::SampleCount;
+use crate::pipeline::shader::DescriptorRequirements;
+use crate::pipeline::Pipeline;
 use std::error;
 use std::fmt;
+use std::sync::Arc;
 
 /// Checks whether descriptor sets are compatible with the pipeline.
-pub(in super::super) fn check_descriptor_sets_validity(
+pub(in super::super) fn check_descriptor_sets_validity<'a, P: Pipeline>(
     current_state: CommandBufferState,
-    pipeline_layout: &PipelineLayout,
-    pipeline_bind_point: PipelineBindPoint,
+    pipeline: &P,
+    descriptor_requirements: impl IntoIterator<Item = ((u32, u32), &'a DescriptorRequirements)>,
 ) -> Result<(), CheckDescriptorSetsValidityError> {
-    if pipeline_layout.descriptor_set_layouts().is_empty() {
+    if pipeline.num_used_descriptor_sets() == 0 {
         return Ok(());
     }
 
-    let bindings_pipeline_layout = match current_state
-        .descriptor_sets_pipeline_layout(pipeline_bind_point)
-    {
-        Some(x) => x,
-        None => return Err(CheckDescriptorSetsValidityError::MissingDescriptorSet { set_num: 0 }),
-    };
+    let bindings_pipeline_layout =
+        match current_state.descriptor_sets_pipeline_layout(pipeline.bind_point()) {
+            Some(x) => x,
+            None => return Err(CheckDescriptorSetsValidityError::IncompatiblePipelineLayout),
+        };
 
-    if bindings_pipeline_layout.internal_object() != pipeline_layout.internal_object()
-        && bindings_pipeline_layout.push_constant_ranges() != pipeline_layout.push_constant_ranges()
-    {
-        return Err(CheckDescriptorSetsValidityError::IncompatiblePushConstants);
+    if !pipeline.layout().is_compatible_with(
+        bindings_pipeline_layout,
+        pipeline.num_used_descriptor_sets(),
+    ) {
+        return Err(CheckDescriptorSetsValidityError::IncompatiblePipelineLayout);
     }
 
-    for (set_num, pipeline_set) in pipeline_layout.descriptor_set_layouts().iter().enumerate() {
-        let set_num = set_num as u32;
+    for ((set_num, binding_num), reqs) in descriptor_requirements {
+        let check_image_view = |image_view: &Arc<dyn ImageViewAbstract>| {
+            if let Some(image_view_type) = reqs.image_view_type {
+                if image_view.ty() != image_view_type {
+                    return Err(InvalidDescriptorResource::ImageViewTypeMismatch {
+                        required: reqs.image_view_type.unwrap(),
+                        obtained: image_view.ty(),
+                    });
+                }
+            }
 
-        let descriptor_set = match current_state.descriptor_set(pipeline_bind_point, set_num) {
-            Some(s) => s,
+            if let Some(format) = reqs.format {
+                if image_view.format() != format {
+                    return Err(InvalidDescriptorResource::ImageViewFormatMismatch {
+                        required: format,
+                        obtained: image_view.format(),
+                    });
+                }
+            }
+
+            if reqs.multisampled != (image_view.image().samples() != SampleCount::Sample1) {
+                return Err(InvalidDescriptorResource::ImageMultisampledMismatch {
+                    required: reqs.multisampled,
+                    obtained: image_view.image().samples() != SampleCount::Sample1,
+                });
+            }
+
+            Ok(())
+        };
+
+        let set_resources = match current_state.descriptor_set(pipeline.bind_point(), set_num) {
+            Some(x) => x.resources(),
             None => return Err(CheckDescriptorSetsValidityError::MissingDescriptorSet { set_num }),
         };
 
-        let descriptor_set_layout = match descriptor_set {
-            SetOrPush::Set(descriptor_set, _dynamic_offsets) => descriptor_set.layout(),
-            SetOrPush::Push(descriptor_writes) => descriptor_writes.layout(),
-        };
+        let binding_resources = set_resources.binding(binding_num).unwrap();
 
-        match pipeline_set.ensure_compatible_with_bind(descriptor_set_layout) {
-            Ok(_) => (),
-            Err(error) => {
-                return Err(
-                    CheckDescriptorSetsValidityError::IncompatibleDescriptorSet { error, set_num },
-                );
+        match binding_resources {
+            DescriptorBindingResources::None => (),
+            DescriptorBindingResources::Buffer(elements) => {
+                check_resources(set_num, binding_num, reqs, elements, |_| Ok(()))?;
+            }
+            DescriptorBindingResources::BufferView(elements) => {
+                check_resources(set_num, binding_num, reqs, elements, |_| Ok(()))?;
+            }
+            DescriptorBindingResources::ImageView(elements) => {
+                check_resources(set_num, binding_num, reqs, elements, |i| {
+                    check_image_view(i)
+                })?;
+            }
+            DescriptorBindingResources::ImageViewSampler(elements) => {
+                check_resources(set_num, binding_num, reqs, elements, |(i, s)| {
+                    check_image_view(i)
+                })?;
+            }
+            DescriptorBindingResources::Sampler(elements) => {
+                check_resources(set_num, binding_num, reqs, elements, |_| Ok(()))?;
             }
         }
     }
@@ -66,25 +107,25 @@ pub(in super::super) fn check_descriptor_sets_validity(
 }
 
 /// Error that can happen when checking descriptor sets validity.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub enum CheckDescriptorSetsValidityError {
+    IncompatiblePipelineLayout,
+    InvalidDescriptorResource {
+        set_num: u32,
+        binding_num: u32,
+        index: u32,
+        error: InvalidDescriptorResource,
+    },
     MissingDescriptorSet {
         set_num: u32,
     },
-    IncompatibleDescriptorSet {
-        /// The error returned by the descriptor set.
-        error: DescriptorSetCompatibilityError,
-        /// The index of the set of the descriptor.
-        set_num: u32,
-    },
-    IncompatiblePushConstants,
 }
 
 impl error::Error for CheckDescriptorSetsValidityError {
     #[inline]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            Self::IncompatibleDescriptorSet { error, .. } => Some(error),
+            Self::InvalidDescriptorResource { error, .. } => Some(error),
             _ => None,
         }
     }
@@ -94,17 +135,103 @@ impl fmt::Display for CheckDescriptorSetsValidityError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
+            Self::IncompatiblePipelineLayout => {
+                write!(fmt, "the bound pipeline is not compatible with the layout used to bind the descriptor sets")
+            }
+            Self::InvalidDescriptorResource {
+                set_num,
+                binding_num,
+                index,
+                ..
+            } => {
+                write!(
+                    fmt,
+                    "the resource bound to descriptor set {} binding {} index {} was not valid",
+                    set_num, binding_num, index,
+                )
+            }
             Self::MissingDescriptorSet { set_num } => {
                 write!(fmt, "descriptor set {} has not been not bound, but is required by the pipeline layout", set_num)
-            }
-            Self::IncompatibleDescriptorSet { set_num, .. } => {
-                write!(fmt, "compatibility error in descriptor set {}", set_num)
-            }
-            Self::IncompatiblePushConstants => {
-                write!(fmt, "the push constant ranges in the bound pipeline do not match the ranges of layout used to bind the descriptor sets")
             }
         }
     }
 }
 
-// TODO: tests
+fn check_resources<T>(
+    set_num: u32,
+    binding_num: u32,
+    reqs: &DescriptorRequirements,
+    elements: &[Option<T>],
+    mut extra_check: impl FnMut(&T) -> Result<(), InvalidDescriptorResource>,
+) -> Result<(), CheckDescriptorSetsValidityError> {
+    for (index, element) in elements[0..reqs.descriptor_count as usize]
+        .iter()
+        .enumerate()
+    {
+        let element = match element {
+            Some(x) => x,
+            None => {
+                return Err(
+                    CheckDescriptorSetsValidityError::InvalidDescriptorResource {
+                        set_num,
+                        binding_num,
+                        index: index as u32,
+                        error: InvalidDescriptorResource::Missing,
+                    },
+                )
+            }
+        };
+
+        if let Err(error) = extra_check(element) {
+            return Err(
+                CheckDescriptorSetsValidityError::InvalidDescriptorResource {
+                    set_num,
+                    binding_num,
+                    index: index as u32,
+                    error,
+                },
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum InvalidDescriptorResource {
+    ImageViewFormatMismatch {
+        required: Format,
+        obtained: Format,
+    },
+    ImageMultisampledMismatch {
+        required: bool,
+        obtained: bool,
+    },
+    ImageViewTypeMismatch {
+        required: ImageViewType,
+        obtained: ImageViewType,
+    },
+    Missing,
+}
+
+impl error::Error for InvalidDescriptorResource {}
+
+impl fmt::Display for InvalidDescriptorResource {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Self::Missing => {
+                write!(fmt, "no resource was bound")
+            }
+            Self::ImageViewFormatMismatch { required, obtained } => {
+                write!(fmt, "the bound image view did not have the required format; required {:?}, obtained {:?}", required, obtained)
+            }
+            Self::ImageMultisampledMismatch { required, obtained } => {
+                write!(fmt, "the bound image did not have the required multisampling; required {}, obtained {}", required, obtained)
+            }
+            Self::ImageViewTypeMismatch { required, obtained } => {
+                write!(fmt, "the bound image view did not have the required type; required {:?}, obtained {:?}", required, obtained)
+            }
+        }
+    }
+}

--- a/vulkano/src/descriptor_set/layout/desc.rs
+++ b/vulkano/src/descriptor_set/layout/desc.rs
@@ -41,13 +41,9 @@
 //!   in a render pass. Can only give access to the same pixel as the one you're processing.
 //!
 
-use crate::format::Format;
-use crate::image::view::ImageViewType;
 use crate::pipeline::shader::DescriptorRequirements;
 use crate::pipeline::shader::ShaderStages;
 use crate::sampler::Sampler;
-use crate::sync::AccessFlags;
-use crate::sync::PipelineStages;
 use smallvec::SmallVec;
 use std::cmp;
 use std::error;
@@ -146,7 +142,7 @@ impl DescriptorSetDesc {
         assert!(
             self.descriptor(binding_num).map_or(false, |desc| matches!(
                 desc.ty,
-                DescriptorDescTy::StorageBuffer | DescriptorDescTy::UniformBuffer
+                DescriptorType::StorageBuffer | DescriptorType::UniformBuffer
             )),
             "tried to make the non-buffer descriptor at binding {} a dynamic buffer",
             binding_num
@@ -159,11 +155,11 @@ impl DescriptorSetDesc {
 
         if let Some(desc) = binding {
             match &desc.ty {
-                DescriptorDescTy::StorageBuffer => {
-                    desc.ty = DescriptorDescTy::StorageBufferDynamic;
+                DescriptorType::StorageBuffer => {
+                    desc.ty = DescriptorType::StorageBufferDynamic;
                 }
-                DescriptorDescTy::UniformBuffer => {
-                    desc.ty = DescriptorDescTy::UniformBufferDynamic;
+                DescriptorType::UniformBuffer => {
+                    desc.ty = DescriptorType::UniformBufferDynamic;
                 }
                 _ => (),
             };
@@ -185,13 +181,10 @@ impl DescriptorSetDesc {
             .descriptors
             .get_mut(binding_num as usize)
             .and_then(|b| b.as_mut())
-            .and_then(|desc| match &mut desc.ty {
-                DescriptorDescTy::Sampler {
-                    immutable_samplers, ..
+            .and_then(|desc| match desc.ty {
+                DescriptorType::Sampler | DescriptorType::CombinedImageSampler => {
+                    Some(&mut desc.immutable_samplers)
                 }
-                | DescriptorDescTy::CombinedImageSampler {
-                    immutable_samplers, ..
-                } => Some(immutable_samplers),
                 _ => None,
             })
             .expect("binding_num does not refer to a sampler or combined image sampler descriptor");
@@ -214,7 +207,7 @@ impl DescriptorSetDesc {
             assert!(
                 !self.descriptors.iter().flatten().any(|desc| {
                     matches!(
-                        desc.ty.ty(),
+                        desc.ty,
                         DescriptorType::UniformBufferDynamic | DescriptorType::StorageBufferDynamic
                     )
                 }),
@@ -256,62 +249,10 @@ impl DescriptorSetDesc {
         (0..num_bindings).all(|binding_num| {
             match (self.descriptor(binding_num), other.descriptor(binding_num)) {
                 (None, None) => true,
-                (Some(first), Some(second)) => first.is_compatible_with(second),
+                (Some(first), Some(second)) => first == second,
                 _ => false,
             }
         })
-    }
-
-    /// Checks whether the descriptor set of a pipeline layout `self` is compatible with the
-    /// descriptor set being bound `other`.
-    ///
-    /// This performs the same check as `is_compatible_with`, but additionally ensures that the
-    /// shader can accept the binding.
-    pub fn ensure_compatible_with_bind(
-        &self,
-        other: &DescriptorSetDesc,
-    ) -> Result<(), DescriptorSetCompatibilityError> {
-        if self.push_descriptor != other.push_descriptor {
-            return Err(DescriptorSetCompatibilityError::PushDescriptorMismatch {
-                self_enabled: self.push_descriptor,
-                other_enabled: other.push_descriptor,
-            });
-        }
-
-        if self.descriptors.len() != other.descriptors.len() {
-            return Err(DescriptorSetCompatibilityError::DescriptorsCountMismatch {
-                self_num: self.descriptors.len() as u32,
-                other_num: other.descriptors.len() as u32,
-            });
-        }
-
-        for binding_num in 0..other.descriptors.len() as u32 {
-            let self_desc = self.descriptor(binding_num);
-            let other_desc = self.descriptor(binding_num);
-
-            match (self_desc, other_desc) {
-                (Some(mine), Some(other)) => {
-                    if let Err(err) = mine.ensure_compatible_with_bind(&other) {
-                        return Err(DescriptorSetCompatibilityError::IncompatibleDescriptors {
-                            error: err,
-                            binding_num: binding_num as u32,
-                        });
-                    }
-                }
-                (None, None) => (),
-                (a, b) => {
-                    return Err(DescriptorSetCompatibilityError::IncompatibleDescriptors {
-                        error: DescriptorCompatibilityError::Empty {
-                            first: a.is_none(),
-                            second: b.is_none(),
-                        },
-                        binding_num: binding_num as u32,
-                    })
-                }
-            }
-        }
-
-        Ok(())
     }
 }
 
@@ -334,40 +275,32 @@ where
 /// > will be checked when you create a pipeline layout, a descriptor set, or when you try to bind
 /// > a descriptor set.
 // TODO: add example
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DescriptorDesc {
     /// Describes the content and layout of each array element of a descriptor.
-    pub ty: DescriptorDescTy,
+    pub ty: DescriptorType,
 
     /// How many array elements this descriptor is made of. The value 0 is invalid and may trigger
     /// a panic depending on the situation.
     pub descriptor_count: u32,
 
+    /// True if the descriptor has a variable descriptor count. The value of `descriptor_count`
+    /// is taken as the maximum number of descriptors allowed. There may only be one binding with a
+    /// variable count in a descriptor set, and it must be the last binding.
+    pub variable_count: bool,
+
     /// Which shader stages are going to access this descriptor.
     pub stages: ShaderStages,
 
-    /// True if the descriptor has a variable descriptor count.
-    pub variable_count: bool,
-
-    /// True if the attachment can be written by the shader.
-    pub mutable: bool,
+    /// Samplers that are included as a fixed part of the descriptor set layout. Once bound, they
+    /// do not need to be provided when creating a descriptor set.
+    ///
+    /// The list must be either empty, or contain exactly `descriptor_count` samplers. It must be
+    /// empty if `ty` is something other than `Sampler` or `CombinedImageSampler`.
+    pub immutable_samplers: Vec<Arc<Sampler>>,
 }
 
 impl DescriptorDesc {
-    /// Returns whether `self` is compatible with `other`.
-    ///
-    /// "Compatible" in this sense is defined by the Vulkan specification under the section
-    /// "Pipeline layout compatibility": the two must be identically defined to the Vulkan API,
-    /// meaning they have identical `VkDescriptorSetLayoutBinding` values.
-    #[inline]
-    pub fn is_compatible_with(&self, other: &DescriptorDesc) -> bool {
-        self.ty.ty() == other.ty.ty()
-            && self.ty.immutable_samplers() == other.ty.immutable_samplers()
-            && self.stages == other.stages
-            && self.descriptor_count == other.descriptor_count
-            && self.variable_count == other.variable_count
-    }
-
     /// Checks whether the descriptor of a pipeline layout `self` is compatible with the descriptor
     /// of a shader `other`.
     #[inline]
@@ -385,10 +318,10 @@ impl DescriptorDesc {
             stages,
         } = descriptor_requirements;
 
-        if !descriptor_types.contains(&self.ty.ty()) {
+        if !descriptor_types.contains(&self.ty) {
             return Err(DescriptorRequirementsNotMet::DescriptorType {
                 required: descriptor_types.clone(),
-                obtained: self.ty.ty(),
+                obtained: self.ty,
             });
         }
 
@@ -397,35 +330,6 @@ impl DescriptorDesc {
                 required: *descriptor_count,
                 obtained: self.descriptor_count,
             });
-        }
-
-        if let Some(format) = *format {
-            if self.ty.format() != Some(format) {
-                return Err(DescriptorRequirementsNotMet::Format {
-                    required: format,
-                    obtained: self.ty.format(),
-                });
-            }
-        }
-
-        if let Some(image_view_type) = *image_view_type {
-            if self.ty.image_view_type() != Some(image_view_type) {
-                return Err(DescriptorRequirementsNotMet::ImageViewType {
-                    required: image_view_type,
-                    obtained: self.ty.image_view_type(),
-                });
-            }
-        }
-
-        if *multisampled != self.ty.multisampled() {
-            return Err(DescriptorRequirementsNotMet::Multisampling {
-                required: *multisampled,
-                obtained: self.ty.multisampled(),
-            });
-        }
-
-        if *mutable && !self.mutable {
-            return Err(DescriptorRequirementsNotMet::Mutability);
         }
 
         if !self.stages.is_superset_of(stages) {
@@ -437,147 +341,35 @@ impl DescriptorDesc {
 
         Ok(())
     }
-
-    /// Checks whether the descriptor of a pipeline layout `self` is compatible with the descriptor
-    /// of a descriptor set being bound `other`.
-    #[inline]
-    pub fn ensure_compatible_with_bind(
-        &self,
-        other: &DescriptorDesc,
-    ) -> Result<(), DescriptorCompatibilityError> {
-        other.ty.ensure_superset_of(&self.ty)?;
-
-        if self.stages != other.stages {
-            return Err(DescriptorCompatibilityError::ShaderStages {
-                first: self.stages,
-                second: other.stages,
-            });
-        }
-
-        if self.descriptor_count != other.descriptor_count {
-            return Err(DescriptorCompatibilityError::DescriptorCount {
-                first: self.descriptor_count,
-                second: other.descriptor_count,
-            });
-        }
-
-        if self.variable_count != other.variable_count {
-            return Err(DescriptorCompatibilityError::VariableCount {
-                first: self.variable_count,
-                second: other.variable_count,
-            });
-        }
-
-        if self.mutable && !other.mutable {
-            return Err(DescriptorCompatibilityError::Mutability {
-                first: self.mutable,
-                second: other.mutable,
-            });
-        }
-
-        Ok(())
-    }
-
-    /// Returns the pipeline stages and access flags corresponding to the usage of this descriptor.
-    ///
-    /// # Panic
-    ///
-    /// Panics if the type is `Sampler`.
-    ///
-    pub fn pipeline_stages_and_access(&self) -> (PipelineStages, AccessFlags) {
-        let stages: PipelineStages = self.stages.into();
-
-        let access = match self.ty.ty() {
-            DescriptorType::Sampler => panic!(),
-            DescriptorType::CombinedImageSampler
-            | DescriptorType::SampledImage
-            | DescriptorType::StorageImage => AccessFlags {
-                shader_read: true,
-                shader_write: self.mutable,
-                ..AccessFlags::none()
-            },
-            DescriptorType::InputAttachment => AccessFlags {
-                input_attachment_read: true,
-                ..AccessFlags::none()
-            },
-            DescriptorType::UniformTexelBuffer | DescriptorType::StorageTexelBuffer => {
-                AccessFlags {
-                    shader_read: true,
-                    shader_write: self.mutable,
-                    ..AccessFlags::none()
-                }
-            }
-            DescriptorType::UniformBuffer | DescriptorType::UniformBufferDynamic => AccessFlags {
-                uniform_read: true,
-                ..AccessFlags::none()
-            },
-            DescriptorType::StorageBuffer | DescriptorType::StorageBufferDynamic => AccessFlags {
-                shader_read: true,
-                shader_write: self.mutable,
-                ..AccessFlags::none()
-            },
-        };
-
-        (stages, access)
-    }
 }
 
 impl From<&DescriptorRequirements> for DescriptorDesc {
     fn from(reqs: &DescriptorRequirements) -> Self {
         let ty = match reqs.descriptor_types[0] {
-            DescriptorType::Sampler => DescriptorDescTy::Sampler {
-                immutable_samplers: Vec::new(),
-            },
-            DescriptorType::CombinedImageSampler => DescriptorDescTy::CombinedImageSampler {
-                image_desc: DescriptorDescImage {
-                    format: reqs.format,
-                    multisampled: reqs.multisampled,
-                    view_type: reqs.image_view_type.unwrap(),
-                },
-                immutable_samplers: Vec::new(),
-            },
-            DescriptorType::SampledImage => DescriptorDescTy::SampledImage {
-                image_desc: DescriptorDescImage {
-                    format: reqs.format,
-                    multisampled: reqs.multisampled,
-                    view_type: reqs.image_view_type.unwrap(),
-                },
-            },
-            DescriptorType::StorageImage => DescriptorDescTy::StorageImage {
-                image_desc: DescriptorDescImage {
-                    format: reqs.format,
-                    multisampled: reqs.multisampled,
-                    view_type: reqs.image_view_type.unwrap(),
-                },
-            },
-            DescriptorType::UniformTexelBuffer => DescriptorDescTy::UniformTexelBuffer {
-                format: reqs.format,
-            },
-            DescriptorType::StorageTexelBuffer => DescriptorDescTy::StorageTexelBuffer {
-                format: reqs.format,
-            },
-            DescriptorType::UniformBuffer => DescriptorDescTy::UniformBuffer,
-            DescriptorType::StorageBuffer => DescriptorDescTy::StorageBuffer,
-            DescriptorType::UniformBufferDynamic => DescriptorDescTy::UniformBufferDynamic,
-            DescriptorType::StorageBufferDynamic => DescriptorDescTy::StorageBufferDynamic,
-            DescriptorType::InputAttachment => DescriptorDescTy::InputAttachment {
-                multisampled: reqs.multisampled,
-            },
+            DescriptorType::Sampler => DescriptorType::Sampler,
+            DescriptorType::CombinedImageSampler => DescriptorType::CombinedImageSampler,
+            DescriptorType::SampledImage => DescriptorType::SampledImage,
+            DescriptorType::StorageImage => DescriptorType::StorageImage,
+            DescriptorType::UniformTexelBuffer => DescriptorType::UniformTexelBuffer,
+            DescriptorType::StorageTexelBuffer => DescriptorType::StorageTexelBuffer,
+            DescriptorType::UniformBuffer => DescriptorType::UniformBuffer,
+            DescriptorType::StorageBuffer => DescriptorType::StorageBuffer,
+            DescriptorType::UniformBufferDynamic => DescriptorType::UniformBufferDynamic,
+            DescriptorType::StorageBufferDynamic => DescriptorType::StorageBufferDynamic,
+            DescriptorType::InputAttachment => DescriptorType::InputAttachment,
         };
 
         Self {
             ty,
             descriptor_count: reqs.descriptor_count,
-            stages: reqs.stages,
             variable_count: false,
-            mutable: reqs.mutable,
+            stages: reqs.stages,
+            immutable_samplers: Vec::new(),
         }
     }
 }
 
 /// Describes what kind of resource may later be bound to a descriptor.
-///
-/// This is mostly the same as a `DescriptorDescTy` but with less precise information.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum DescriptorType {
@@ -613,24 +405,6 @@ pub enum DescriptorRequirementsNotMet {
     /// The descriptor count is less than what is required.
     DescriptorCount { required: u32, obtained: u32 },
 
-    /// The descriptor's format does not match what is required.
-    Format {
-        required: Format,
-        obtained: Option<Format>,
-    },
-
-    /// The descriptor's image view type does not match what is required.
-    ImageViewType {
-        required: ImageViewType,
-        obtained: Option<ImageViewType>,
-    },
-
-    /// The descriptor's multisampling does not match what is required.
-    Multisampling { required: bool, obtained: bool },
-
-    /// The descriptor is marked as read-only, but mutability is required.
-    Mutability,
-
     /// The descriptor's shader stages do not contain the stages that are required.
     ShaderStages {
         required: ShaderStages,
@@ -654,379 +428,10 @@ impl fmt::Display for DescriptorRequirementsNotMet {
                 "the descriptor count ({}) is less than what is required ({})",
                 obtained, required
             ),
-            Self::Format { required, obtained } => write!(
-                fmt,
-                "the descriptor's format ({:?}) does not match what is required ({:?})",
-                obtained, required
-            ),
-            Self::ImageViewType { required, obtained } => write!(
-                fmt,
-                "the descriptor's image view type ({:?}) does not match what is required ({:?})",
-                obtained, required
-            ),
-            Self::Multisampling { required, obtained } => write!(
-                fmt,
-                "the descriptor's multisampling ({}) does not match what is required ({})",
-                obtained, required
-            ),
-            Self::Mutability => write!(
-                fmt,
-                "the descriptor is marked as read-only, but mutability is required",
-            ),
             Self::ShaderStages { required, obtained } => write!(
                 fmt,
                 "the descriptor's shader stages do not contain the stages that are required",
             ),
         }
-    }
-}
-
-/// Describes the content and layout of each array element of a descriptor.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DescriptorDescTy {
-    Sampler {
-        /// Samplers that are included as a fixed part of the descriptor set layout. Once bound, they
-        /// do not need to be provided when creating a descriptor set.
-        ///
-        /// The list must be either empty, or contain exactly `descriptor_count` samplers.
-        immutable_samplers: Vec<Arc<Sampler>>,
-    },
-    CombinedImageSampler {
-        image_desc: DescriptorDescImage,
-
-        /// Samplers that are included as a fixed part of the descriptor set layout. Once bound, they
-        /// do not need to be provided when creating a descriptor set.
-        ///
-        /// The list must be either empty, or contain exactly `descriptor_count` samplers.
-        immutable_samplers: Vec<Arc<Sampler>>,
-    },
-    SampledImage {
-        image_desc: DescriptorDescImage,
-    },
-    StorageImage {
-        image_desc: DescriptorDescImage,
-    },
-    UniformTexelBuffer {
-        /// The format of the content, or `None` if the format is unknown. Depending on the
-        /// context, it may be invalid to have a `None` value here. If the format is `Some`, only
-        /// buffer views that have this exact format can be attached to this descriptor.
-        format: Option<Format>,
-    },
-    StorageTexelBuffer {
-        /// The format of the content, or `None` if the format is unknown. Depending on the
-        /// context, it may be invalid to have a `None` value here. If the format is `Some`, only
-        /// buffer views that have this exact format can be attached to this descriptor.
-        format: Option<Format>,
-    },
-    UniformBuffer,
-    StorageBuffer,
-    UniformBufferDynamic,
-    StorageBufferDynamic,
-    InputAttachment {
-        /// If `true`, the input attachment is multisampled. Only multisampled images can be
-        /// attached to this descriptor. If `false`, only single-sampled images can be attached.
-        multisampled: bool,
-    },
-}
-
-impl DescriptorDescTy {
-    /// Returns the type of descriptor.
-    // TODO: add example
-    #[inline]
-    pub fn ty(&self) -> DescriptorType {
-        match *self {
-            Self::Sampler { .. } => DescriptorType::Sampler,
-            Self::CombinedImageSampler { .. } => DescriptorType::CombinedImageSampler,
-            Self::SampledImage { .. } => DescriptorType::SampledImage,
-            Self::StorageImage { .. } => DescriptorType::StorageImage,
-            Self::UniformTexelBuffer { .. } => DescriptorType::UniformTexelBuffer,
-            Self::StorageTexelBuffer { .. } => DescriptorType::StorageTexelBuffer,
-            Self::UniformBuffer => DescriptorType::UniformBuffer,
-            Self::StorageBuffer => DescriptorType::StorageBuffer,
-            Self::UniformBufferDynamic => DescriptorType::UniformBufferDynamic,
-            Self::StorageBufferDynamic => DescriptorType::StorageBufferDynamic,
-            Self::InputAttachment { .. } => DescriptorType::InputAttachment,
-        }
-    }
-
-    #[inline]
-    fn format(&self) -> Option<Format> {
-        match self {
-            Self::CombinedImageSampler { image_desc, .. }
-            | Self::SampledImage { image_desc, .. }
-            | Self::StorageImage { image_desc, .. } => image_desc.format,
-            Self::UniformTexelBuffer { format } | Self::StorageTexelBuffer { format } => *format,
-            _ => None,
-        }
-    }
-
-    #[inline]
-    fn image_desc(&self) -> Option<&DescriptorDescImage> {
-        match self {
-            Self::CombinedImageSampler { image_desc, .. }
-            | Self::SampledImage { image_desc, .. }
-            | Self::StorageImage { image_desc, .. } => Some(image_desc),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    fn image_view_type(&self) -> Option<ImageViewType> {
-        match self {
-            Self::CombinedImageSampler { image_desc, .. }
-            | Self::SampledImage { image_desc, .. }
-            | Self::StorageImage { image_desc, .. } => Some(image_desc.view_type),
-            _ => None,
-        }
-    }
-
-    #[inline]
-    pub(crate) fn immutable_samplers(&self) -> &[Arc<Sampler>] {
-        match self {
-            Self::Sampler {
-                immutable_samplers, ..
-            } => immutable_samplers,
-            Self::CombinedImageSampler {
-                immutable_samplers, ..
-            } => immutable_samplers,
-            _ => &[],
-        }
-    }
-
-    #[inline]
-    fn multisampled(&self) -> bool {
-        match self {
-            Self::CombinedImageSampler { image_desc, .. }
-            | Self::SampledImage { image_desc, .. }
-            | Self::StorageImage { image_desc, .. } => image_desc.multisampled,
-            DescriptorDescTy::InputAttachment { multisampled } => *multisampled,
-            _ => false,
-        }
-    }
-
-    /// Checks whether we are a superset of another descriptor type.
-    // TODO: add example
-    #[inline]
-    pub fn ensure_superset_of(&self, other: &Self) -> Result<(), DescriptorCompatibilityError> {
-        if self.ty() != other.ty() {
-            return Err(DescriptorCompatibilityError::Type {
-                first: self.ty(),
-                second: other.ty(),
-            });
-        }
-
-        if self.immutable_samplers() != other.immutable_samplers() {
-            return Err(DescriptorCompatibilityError::ImmutableSamplers);
-        }
-
-        if let (Some(me), Some(other)) = (self.image_desc(), other.image_desc()) {
-            me.ensure_superset_of(other)?;
-        }
-
-        if let (me, other @ Some(_)) = (self.format(), other.format()) {
-            if me != other {
-                return Err(DescriptorCompatibilityError::Format {
-                    first: me,
-                    second: other.unwrap(),
-                });
-            }
-        }
-
-        if self.multisampled() != other.multisampled() {
-            return Err(DescriptorCompatibilityError::Multisampling {
-                first: self.multisampled(),
-                second: other.multisampled(),
-            });
-        }
-
-        Ok(())
-    }
-}
-
-/// Additional description for descriptors that contain images.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct DescriptorDescImage {
-    /// The image format that is required for an attached image, or `None` no particular format is required.
-    pub format: Option<Format>,
-    /// True if the image is multisampled.
-    pub multisampled: bool,
-    /// The type of image view that must be attached to this descriptor.
-    pub view_type: ImageViewType,
-}
-
-impl DescriptorDescImage {
-    /// Checks whether we are a superset of another image.
-    // TODO: add example
-    #[inline]
-    pub fn ensure_superset_of(
-        &self,
-        other: &DescriptorDescImage,
-    ) -> Result<(), DescriptorCompatibilityError> {
-        if other.format.is_some() && self.format != other.format {
-            return Err(DescriptorCompatibilityError::Format {
-                first: self.format,
-                second: other.format.unwrap(),
-            });
-        }
-
-        if self.multisampled != other.multisampled {
-            return Err(DescriptorCompatibilityError::Multisampling {
-                first: self.multisampled,
-                second: other.multisampled,
-            });
-        }
-
-        if self.view_type != other.view_type {
-            return Err(DescriptorCompatibilityError::ImageViewType {
-                first: self.view_type,
-                second: other.view_type,
-            });
-        }
-
-        Ok(())
-    }
-}
-
-/// Error when checking whether a descriptor set is compatible with another one.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DescriptorSetCompatibilityError {
-    /// The number of descriptors in the two sets is not compatible.
-    DescriptorsCountMismatch { self_num: u32, other_num: u32 },
-
-    /// Two descriptors are incompatible.
-    IncompatibleDescriptors {
-        error: DescriptorCompatibilityError,
-        binding_num: u32,
-    },
-
-    /// The push descriptor settings of the two sets are not compatible.
-    PushDescriptorMismatch {
-        self_enabled: bool,
-        other_enabled: bool,
-    },
-}
-
-impl error::Error for DescriptorSetCompatibilityError {
-    #[inline]
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match *self {
-            DescriptorSetCompatibilityError::IncompatibleDescriptors { ref error, .. } => {
-                Some(error)
-            }
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for DescriptorSetCompatibilityError {
-    #[inline]
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            DescriptorSetCompatibilityError::DescriptorsCountMismatch { .. } => {
-                write!(
-                    fmt,
-                    "the number of descriptors in the two sets is not compatible"
-                )
-            }
-            DescriptorSetCompatibilityError::IncompatibleDescriptors { .. } => {
-                write!(fmt, "two descriptors are incompatible")
-            }
-            DescriptorSetCompatibilityError::PushDescriptorMismatch { .. } => {
-                write!(
-                    fmt,
-                    "the push descriptor settings of the two sets are not compatible"
-                )
-            }
-        }
-    }
-}
-
-/// Error when checking whether a descriptor compatible with another one.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DescriptorCompatibilityError {
-    /// The number of descriptors is not compatible.
-    DescriptorCount { first: u32, second: u32 },
-
-    /// The presence or absence of a descriptor in a binding is not compatible.
-    Empty { first: bool, second: bool },
-
-    /// The formats of an image descriptor are not compatible.
-    Format {
-        first: Option<Format>,
-        second: Format,
-    },
-
-    /// The image view types of an image descriptor are not compatible.
-    ImageViewType {
-        first: ImageViewType,
-        second: ImageViewType,
-    },
-
-    /// The immutable samplers of the descriptors are not compatible.
-    ImmutableSamplers,
-
-    /// The multisampling of an image descriptor is not compatible.
-    Multisampling { first: bool, second: bool },
-
-    /// The mutability of the descriptors is not compatible.
-    Mutability { first: bool, second: bool },
-
-    /// The shader stages of the descriptors are not compatible.
-    ShaderStages {
-        first: ShaderStages,
-        second: ShaderStages,
-    },
-
-    /// The types of the two descriptors are not compatible.
-    Type {
-        first: DescriptorType,
-        second: DescriptorType,
-    },
-
-    /// The variable counts of the descriptors is not compatible.
-    VariableCount { first: bool, second: bool },
-}
-
-impl error::Error for DescriptorCompatibilityError {}
-
-impl fmt::Display for DescriptorCompatibilityError {
-    #[inline]
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(
-            fmt,
-            "{}",
-            match *self {
-                DescriptorCompatibilityError::DescriptorCount { .. } => {
-                    "the number of descriptors is not compatible"
-                }
-                DescriptorCompatibilityError::VariableCount { .. } => {
-                    "the variable counts of the descriptors is not compatible"
-                }
-                DescriptorCompatibilityError::Empty { .. } => {
-                    "the presence or absence of a descriptor in a binding is not compatible"
-                }
-                DescriptorCompatibilityError::Format { .. } => {
-                    "the formats of an image descriptor are not compatible"
-                }
-                DescriptorCompatibilityError::ImageViewType { .. } => {
-                    "the image view types of an image descriptor are not compatible"
-                }
-                DescriptorCompatibilityError::ImmutableSamplers { .. } => {
-                    "the immutable samplers of the descriptors are not compatible"
-                }
-                DescriptorCompatibilityError::Multisampling { .. } => {
-                    "the multisampling of an image descriptor is not compatible"
-                }
-                DescriptorCompatibilityError::Mutability { .. } => {
-                    "the mutability of the descriptors is not compatible"
-                }
-                DescriptorCompatibilityError::ShaderStages { .. } => {
-                    "the shader stages of the descriptors are not compatible"
-                }
-                DescriptorCompatibilityError::Type { .. } => {
-                    "the types of the two descriptors are not compatible"
-                }
-            }
-        )
     }
 }

--- a/vulkano/src/descriptor_set/layout/mod.rs
+++ b/vulkano/src/descriptor_set/layout/mod.rs
@@ -13,12 +13,8 @@
 //! can create a descriptor set layout manually, but it is normally created automatically by each
 //! pipeline layout.
 
-pub use self::desc::DescriptorCompatibilityError;
 pub use self::desc::DescriptorDesc;
-pub use self::desc::DescriptorDescImage;
-pub use self::desc::DescriptorDescTy;
 pub use self::desc::DescriptorRequirementsNotMet;
-pub use self::desc::DescriptorSetCompatibilityError;
 pub use self::desc::DescriptorSetDesc;
 pub use self::desc::DescriptorType;
 pub use self::sys::DescriptorSetLayout;

--- a/vulkano/src/descriptor_set/layout/sys.rs
+++ b/vulkano/src/descriptor_set/layout/sys.rs
@@ -9,8 +9,6 @@
 
 use crate::check_errors;
 use crate::descriptor_set::layout::DescriptorDesc;
-use crate::descriptor_set::layout::DescriptorDescTy;
-use crate::descriptor_set::layout::DescriptorSetCompatibilityError;
 use crate::descriptor_set::layout::DescriptorSetDesc;
 use crate::descriptor_set::layout::DescriptorType;
 use crate::descriptor_set::pool::DescriptorsCount;
@@ -85,7 +83,7 @@ impl DescriptorSetLayout {
             // FIXME: it is not legal to pass eg. the TESSELLATION_SHADER bit when the device
             //        doesn't have tess shaders enabled
 
-            let ty = binding_desc.ty.ty();
+            let ty = binding_desc.ty;
 
             if set_desc.is_push_descriptor() {
                 if matches!(
@@ -107,13 +105,19 @@ impl DescriptorSetLayout {
 
             descriptors_count.add_num(ty, binding_desc.descriptor_count);
             let mut binding_flags = ash::vk::DescriptorBindingFlags::empty();
-            let immutable_samplers = binding_desc.ty.immutable_samplers();
 
-            let p_immutable_samplers = if !immutable_samplers.is_empty() {
-                if binding_desc.descriptor_count != immutable_samplers.len() as u32 {
+            let p_immutable_samplers = if !binding_desc.immutable_samplers.is_empty() {
+                if !matches!(
+                    ty,
+                    DescriptorType::Sampler | DescriptorType::CombinedImageSampler
+                ) {
+                    return Err(DescriptorSetLayoutError::ImmutableSamplersWrongDescriptorType);
+                }
+
+                if binding_desc.descriptor_count != binding_desc.immutable_samplers.len() as u32 {
                     return Err(DescriptorSetLayoutError::ImmutableSamplersCountMismatch {
                         descriptor_count: binding_desc.descriptor_count,
-                        sampler_count: immutable_samplers.len() as u32,
+                        sampler_count: binding_desc.immutable_samplers.len() as u32,
                     });
                 }
 
@@ -122,7 +126,8 @@ impl DescriptorSetLayout {
                 // with one of the values VK_BORDER_COLOR_FLOAT_CUSTOM_EXT or
                 // VK_BORDER_COLOR_INT_CUSTOM_EXT
 
-                let sampler_handles = immutable_samplers
+                let sampler_handles = binding_desc
+                    .immutable_samplers
                     .iter()
                     .map(|s| s.internal_object())
                     .collect::<Vec<_>>()
@@ -139,8 +144,8 @@ impl DescriptorSetLayout {
                     return Err(DescriptorSetLayoutError::VariableCountDescMustBeLast);
                 }
 
-                if binding_desc.ty == DescriptorDescTy::UniformBufferDynamic
-                    || binding_desc.ty == DescriptorDescTy::StorageBufferDynamic
+                if binding_desc.ty == DescriptorType::UniformBufferDynamic
+                    || binding_desc.ty == DescriptorType::StorageBufferDynamic
                 {
                     return Err(DescriptorSetLayoutError::VariableCountDescMustNotBeDynamic);
                 }
@@ -293,19 +298,6 @@ impl DescriptorSetLayout {
     pub fn is_compatible_with(&self, other: &DescriptorSetLayout) -> bool {
         self.handle == other.handle || self.desc.is_compatible_with(&other.desc)
     }
-
-    /// Checks whether the descriptor of a pipeline layout `self` is compatible with the descriptor
-    /// of a descriptor set being bound `other`.
-    pub fn ensure_compatible_with_bind(
-        &self,
-        other: &DescriptorSetLayout,
-    ) -> Result<(), DescriptorSetCompatibilityError> {
-        if self.handle == other.handle {
-            return Ok(());
-        }
-
-        self.desc.ensure_compatible_with_bind(&other.desc)
-    }
 }
 
 unsafe impl DeviceOwned for DescriptorSetLayout {
@@ -356,6 +348,10 @@ pub enum DescriptorSetLayoutError {
         sampler_count: u32,
     },
 
+    /// Immutable samplers were included on a descriptor type other than `Sampler` or
+    /// `CombinedImageSampler`.
+    ImmutableSamplersWrongDescriptorType,
+
     /// The maximum number of push descriptors has been exceeded.
     MaxPushDescriptorsExceeded {
         /// Maximum allowed value.
@@ -405,6 +401,12 @@ impl std::fmt::Display for DescriptorSetLayoutError {
                     "the number of immutable samplers does not match the descriptor count"
                 )
             }
+            Self::ImmutableSamplersWrongDescriptorType => {
+                write!(
+                    fmt,
+                    "immutable samplers were included on a descriptor type other than Sampler or CombinedImageSampler"
+                )
+            }
             Self::MaxPushDescriptorsExceeded { .. } => {
                 write!(
                     fmt,
@@ -433,9 +435,9 @@ impl std::fmt::Display for DescriptorSetLayoutError {
 #[cfg(test)]
 mod tests {
     use crate::descriptor_set::layout::DescriptorDesc;
-    use crate::descriptor_set::layout::DescriptorDescTy;
     use crate::descriptor_set::layout::DescriptorSetDesc;
     use crate::descriptor_set::layout::DescriptorSetLayout;
+    use crate::descriptor_set::layout::DescriptorType;
     use crate::descriptor_set::pool::DescriptorsCount;
     use crate::pipeline::shader::ShaderStages;
     use std::iter;
@@ -451,11 +453,11 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let layout = DescriptorDesc {
-            ty: DescriptorDescTy::UniformBuffer,
+            ty: DescriptorType::UniformBuffer,
             descriptor_count: 1,
-            stages: ShaderStages::all_graphics(),
-            mutable: false,
             variable_count: false,
+            stages: ShaderStages::all_graphics(),
+            immutable_samplers: Vec::new(),
         };
 
         let sl = DescriptorSetLayout::new(

--- a/vulkano/src/descriptor_set/pool/standard.rs
+++ b/vulkano/src/descriptor_set/pool/standard.rs
@@ -178,9 +178,9 @@ impl Drop for StdDescriptorPoolAlloc {
 #[cfg(test)]
 mod tests {
     use crate::descriptor_set::layout::DescriptorDesc;
-    use crate::descriptor_set::layout::DescriptorDescTy;
     use crate::descriptor_set::layout::DescriptorSetDesc;
     use crate::descriptor_set::layout::DescriptorSetLayout;
+    use crate::descriptor_set::layout::DescriptorType;
     use crate::descriptor_set::pool::DescriptorPool;
     use crate::descriptor_set::pool::StdDescriptorPool;
     use crate::pipeline::shader::ShaderStages;
@@ -193,13 +193,11 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let desc = DescriptorDesc {
-            ty: DescriptorDescTy::Sampler {
-                immutable_samplers: vec![],
-            },
+            ty: DescriptorType::Sampler,
             descriptor_count: 1,
-            stages: ShaderStages::all(),
-            mutable: true,
             variable_count: false,
+            stages: ShaderStages::all(),
+            immutable_samplers: Vec::new(),
         };
         let layout = DescriptorSetLayout::new(
             device.clone(),

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -360,9 +360,9 @@ impl fmt::Display for DescriptorPoolAllocError {
 #[cfg(test)]
 mod tests {
     use crate::descriptor_set::layout::DescriptorDesc;
-    use crate::descriptor_set::layout::DescriptorDescTy;
     use crate::descriptor_set::layout::DescriptorSetDesc;
     use crate::descriptor_set::layout::DescriptorSetLayout;
+    use crate::descriptor_set::layout::DescriptorType;
     use crate::descriptor_set::pool::DescriptorsCount;
     use crate::descriptor_set::pool::UnsafeDescriptorPool;
     use crate::pipeline::shader::ShaderStages;
@@ -406,11 +406,11 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let layout = DescriptorDesc {
-            ty: DescriptorDescTy::UniformBuffer,
+            ty: DescriptorType::UniformBuffer,
             descriptor_count: 1,
-            stages: ShaderStages::all_graphics(),
-            mutable: false,
             variable_count: false,
+            stages: ShaderStages::all_graphics(),
+            immutable_samplers: Vec::new(),
         };
 
         let set_layout = DescriptorSetLayout::new(
@@ -437,11 +437,11 @@ mod tests {
         let (device2, _) = gfx_dev_and_queue!();
 
         let layout = DescriptorDesc {
-            ty: DescriptorDescTy::UniformBuffer,
+            ty: DescriptorType::UniformBuffer,
             descriptor_count: 1,
-            stages: ShaderStages::all_graphics(),
-            mutable: false,
             variable_count: false,
+            stages: ShaderStages::all_graphics(),
+            immutable_samplers: Vec::new(),
         };
 
         let set_layout =

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -55,7 +55,7 @@ impl UnsafeDescriptorSet {
         let (infos, mut writes): (SmallVec<[_; 8]>, SmallVec<[_; 8]>) = writes
             .into_iter()
             .map(|write| {
-                let descriptor_type = layout.descriptor(write.binding_num).unwrap().ty.ty();
+                let descriptor_type = layout.descriptor(write.binding_num).unwrap().ty;
 
                 (
                     write.to_vulkan_info(descriptor_type),

--- a/vulkano/src/pipeline/graphics_pipeline/builder.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/builder.rs
@@ -357,6 +357,13 @@ where
             }
         }
 
+        let num_used_descriptor_sets = descriptor_requirements
+            .keys()
+            .map(|loc| loc.0)
+            .max()
+            .map(|x| x + 1)
+            .unwrap_or(0);
+
         // Will contain the list of dynamic states. Filled throughout this function.
         let mut dynamic_state_modes: FnvHashMap<DynamicState, bool> = HashMap::default();
 
@@ -1018,6 +1025,7 @@ where
             subpass,
             shaders,
             descriptor_requirements,
+            num_used_descriptor_sets,
 
             vertex_input, // Can be None if there's a mesh shader, but we don't support that yet
             input_assembly_state: self.input_assembly_state, // Can be None if there's a mesh shader, but we don't support that yet

--- a/vulkano/src/pipeline/graphics_pipeline/mod.rs
+++ b/vulkano/src/pipeline/graphics_pipeline/mod.rs
@@ -21,7 +21,7 @@ use crate::pipeline::shader::{DescriptorRequirements, ShaderStage};
 use crate::pipeline::tessellation::TessellationState;
 use crate::pipeline::vertex::{BuffersDefinition, VertexInput};
 use crate::pipeline::viewport::ViewportState;
-use crate::pipeline::DynamicState;
+use crate::pipeline::{DynamicState, Pipeline, PipelineBindPoint};
 use crate::render_pass::Subpass;
 use crate::VulkanObject;
 use fnv::FnvHashMap;
@@ -48,6 +48,7 @@ pub struct GraphicsPipeline {
     // TODO: replace () with an object that describes the shaders in some way.
     shaders: FnvHashMap<ShaderStage, ()>,
     descriptor_requirements: FnvHashMap<(u32, u32), DescriptorRequirements>,
+    num_used_descriptor_sets: u32,
 
     vertex_input: VertexInput,
     input_assembly_state: InputAssemblyState,
@@ -84,12 +85,6 @@ impl GraphicsPipeline {
     #[inline]
     pub fn device(&self) -> &Arc<Device> {
         &self.device
-    }
-
-    /// Returns the pipeline layout used to create this pipeline.
-    #[inline]
-    pub fn layout(&self) -> &Arc<PipelineLayout> {
-        &self.layout
     }
 
     /// Returns the subpass this graphics pipeline is rendering to.
@@ -184,6 +179,23 @@ impl GraphicsPipeline {
     /// Returns all potentially dynamic states in the pipeline, and whether they are dynamic or not.
     pub fn dynamic_states(&self) -> impl ExactSizeIterator<Item = (DynamicState, bool)> + '_ {
         self.dynamic_state.iter().map(|(k, v)| (*k, *v))
+    }
+}
+
+impl Pipeline for GraphicsPipeline {
+    #[inline]
+    fn bind_point(&self) -> PipelineBindPoint {
+        PipelineBindPoint::Graphics
+    }
+
+    #[inline]
+    fn layout(&self) -> &Arc<PipelineLayout> {
+        &self.layout
+    }
+
+    #[inline]
+    fn num_used_descriptor_sets(&self) -> u32 {
+        self.num_used_descriptor_sets
     }
 }
 

--- a/vulkano/src/pipeline/layout/limits_check.rs
+++ b/vulkano/src/pipeline/layout/limits_check.rs
@@ -38,7 +38,7 @@ pub fn check_desc_against_limits(
         for descriptor in (0..set.num_bindings()).filter_map(|i| set.descriptor(i).map(|d| d)) {
             num_resources.increment(descriptor.descriptor_count, &descriptor.stages);
 
-            match descriptor.ty.ty() {
+            match descriptor.ty {
                 // TODO:
                 DescriptorType::Sampler => {
                     num_samplers.increment(descriptor.descriptor_count, &descriptor.stages);

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -80,6 +80,8 @@ pub use self::compute_pipeline::ComputePipelineCreationError;
 pub use self::graphics_pipeline::GraphicsPipeline;
 pub use self::graphics_pipeline::GraphicsPipelineBuilder;
 pub use self::graphics_pipeline::GraphicsPipelineCreationError;
+use self::layout::PipelineLayout;
+use std::sync::Arc;
 
 pub mod cache;
 pub mod color_blend;
@@ -95,6 +97,19 @@ pub mod shader;
 pub mod tessellation;
 pub mod vertex;
 pub mod viewport;
+
+// A trait for operations shared between pipeline types.
+pub trait Pipeline {
+    /// Returns the bind point of this pipeline.
+    fn bind_point(&self) -> PipelineBindPoint;
+
+    /// Returns the pipeline layout used in this pipeline.
+    fn layout(&self) -> &Arc<PipelineLayout>;
+
+    /// Returns the number of descriptor sets actually accessed by this pipeline. This may be less
+    /// than the number of sets in the pipeline layout.
+    fn num_used_descriptor_sets(&self) -> u32;
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(i32)]


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** Replaced `DescriptorDescTy` with `DescriptorType` and made further changes to the members of `DescriptorDesc`.
- **Breaking** Added a `Pipeline` trait to hold methods that are common to all pipeline types.
```
```markdown
- Descriptor resources are now checked against the shader requirements at the time of a draw/dispatch call, rather than at the time the descriptor set is created. Only the resources that are actually needed in the shader are checked, the other resources in a descriptor set are ignored and don't need to be valid.
```

At draw/dispatch time, the code will now check whether the bound descriptor sets are valid by using `DescriptorRequirements`. Previously, the pipeline layout object was used for this, but a pipeline layout isn't really the right place for it, since the same layout could be used with multiple shaders, each with their own specific requirements. Moreover, a shader might not actually use every descriptor that's declared in the pipeline layout, the layout can be a superset of what the shader needs. In this PR, only the resources the shader actually needs are checked. Descriptors that aren't used by the shader can still be bound, but are ignored in the check.

In theory this means that it's now safe to create a descriptor set that doesn't contain resources in all of its descriptors, because all that matters is that the resources needed in the shader are valid. That is required for allowing incremental bindings for push descriptors. But that isn't implemented yet; I'm still thinking of ways to do that. Descriptor set builders currently require you to provide a resource for every binding in the layout, which would need changing. A possibility I'm considering is removing descriptor set builders altogether, and letting the user provide `DescriptorWrite` objects instead.