### PR TITLE
Two fixes for extension requirements

### DIFF
--- a/vulkano/src/device/extensions.rs
+++ b/vulkano/src/device/extensions.rs
@@ -9,7 +9,8 @@
 
 use crate::device::physical::PhysicalDevice;
 pub use crate::extensions::{
-    ExtensionRestriction, ExtensionRestrictionError, SupportedExtensionsError, Unbuildable,
+    ExtensionRestriction, ExtensionRestrictionError, OneOfRequirements, SupportedExtensionsError,
+    Unbuildable,
 };
 use crate::instance::InstanceExtensions;
 use crate::Version;

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -9,7 +9,8 @@
 
 use crate::check_errors;
 pub use crate::extensions::{
-    ExtensionRestriction, ExtensionRestrictionError, SupportedExtensionsError, Unbuildable,
+    ExtensionRestriction, ExtensionRestrictionError, OneOfRequirements, SupportedExtensionsError,
+    Unbuildable,
 };
 use crate::instance::loader;
 use crate::instance::loader::LoadingError;


### PR DESCRIPTION
```markdown
- Fixed two bugs related to the requirements for enabled extensions:
  - For required extensions that have been promoted, the promoted version now also fulfills the requirement.
  - For features that must be enabled in tandem with extensions (e.g. `descriptor_indexing`), the requirement only applies to Vulkan 1.2 and above, since these features do not exist on earlier versions and thus cannot be enabled.
```

Fixes #1730, fixes #1750. It doesn't fix the fact that `khr_get_physical_device_properties2` needs to be enabled on the instance, whenever the device requires `khr_portability_subset`. That's basically impossible. But now it does consider promotions, so that you only actually need `khr_get_physical_device_properties2` if you're running a Vulkan 1.0 instance; Vulkan 1.1 will also satisfy the requirement.