### PR TITLE
Allocate less than the maximum descriptor count when variable

### DIFF
--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -83,7 +83,6 @@ fn main() {
             shader_uniform_buffer_array_non_uniform_indexing: true,
             runtime_descriptor_array: true,
             descriptor_binding_variable_descriptor_count: true,
-            descriptor_binding_partially_bound: true,
             ..Features::none()
         },
         &physical_device

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -1567,7 +1567,7 @@ impl SyncCommandBufferBuilder {
         let set_resources = match state
             .descriptor_sets
             .entry(set_num)
-            .or_insert(SetOrPush::Push(DescriptorSetResources::new(layout)))
+            .or_insert(SetOrPush::Push(DescriptorSetResources::new(layout, 0)))
         {
             SetOrPush::Push(set_resources) => set_resources,
             _ => unreachable!(),

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -237,9 +237,6 @@ where
 /// Error related to descriptor sets.
 #[derive(Debug, Clone)]
 pub enum DescriptorSetError {
-    /// Builder is already within an array.
-    AlreadyInArray,
-
     /// The number of array layers of an image doesn't match what was expected.
     ArrayLayersMismatch {
         /// Number of expected array layers for the image.
@@ -278,6 +275,9 @@ pub enum DescriptorSetError {
         obtained: u32,
     },
 
+    /// The builder is within an array, but the operation requires it not to be.
+    InArray,
+
     /// The image view isn't compatible with the sampler.
     IncompatibleImageViewSampler,
 
@@ -290,7 +290,7 @@ pub enum DescriptorSetError {
     /// The image view has a component swizzle that is different from identity.
     NotIdentitySwizzled,
 
-    /// Builder is not in an array.
+    /// The builder is not in an array, but the operation requires it to be.
     NotInArray,
 
     /// Out of memory
@@ -327,7 +327,6 @@ impl fmt::Display for DescriptorSetError {
             fmt,
             "{}",
             match *self {
-                Self::AlreadyInArray => "builder is already within an array",
                 Self::ArrayLayersMismatch { .. } =>
                     "the number of array layers of an image doesn't match what was expected",
                 Self::ArrayLengthMismatch { .. } =>
@@ -338,13 +337,14 @@ impl fmt::Display for DescriptorSetError {
                     "the builder has previously return an error and is an unknown state",
                 Self::DescriptorIsEmpty => "operation can not be performed on an empty descriptor",
                 Self::DescriptorsMissing { .. } => "not all descriptors have been added",
+                Self::InArray => "the builder is within an array, but the operation requires it not to be",
                 Self::IncompatibleImageViewSampler =>
                     "the image view isn't compatible with the sampler",
                 Self::MissingBufferUsage(_) => "the buffer is missing the correct usage",
                 Self::MissingImageUsage(_) => "the image is missing the correct usage",
                 Self::NotIdentitySwizzled =>
                     "the image view has a component swizzle that is different from identity",
-                Self::NotInArray => "builder is not in an array",
+                Self::NotInArray => "the builder is not in an array, but the operation requires it to be",
                 Self::OomError(_) => "out of memory",
                 Self::ResourceWrongDevice => "resource belongs to another device",
                 Self::SamplerIsImmutable => "provided a dynamically assigned sampler, but the descriptor has an immutable sampler",

--- a/vulkano/src/descriptor_set/pool/mod.rs
+++ b/vulkano/src/descriptor_set/pool/mod.rs
@@ -11,6 +11,7 @@
 
 pub use self::standard::StdDescriptorPool;
 pub use self::sys::DescriptorPoolAllocError;
+pub use self::sys::DescriptorSetAllocateInfo;
 pub use self::sys::UnsafeDescriptorPool;
 use crate::descriptor_set::layout::DescriptorSetLayout;
 use crate::descriptor_set::layout::DescriptorType;
@@ -34,7 +35,11 @@ pub unsafe trait DescriptorPool: DeviceOwned {
     type Alloc: DescriptorPoolAlloc;
 
     /// Allocates a descriptor set.
-    fn alloc(&mut self, layout: &DescriptorSetLayout) -> Result<Self::Alloc, OomError>;
+    fn alloc(
+        &mut self,
+        layout: &DescriptorSetLayout,
+        variable_descriptor_count: u32,
+    ) -> Result<Self::Alloc, OomError>;
 }
 
 /// An allocated descriptor set.

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -177,8 +177,9 @@ impl UnsafeDescriptorPool {
         let output = if layouts.len() == 0 {
             vec![]
         } else {
-            let variable_desc_count_alloc_info = if self.device.api_version() >= Version::V1_2
-                || self.device.enabled_extensions().ext_descriptor_indexing
+            let variable_desc_count_alloc_info = if (self.device.api_version() >= Version::V1_2
+                || self.device.enabled_extensions().ext_descriptor_indexing)
+                && variable_descriptor_counts.iter().any(|c| *c != 0)
             {
                 Some(ash::vk::DescriptorSetVariableDescriptorCountAllocateInfo {
                     descriptor_set_count: layouts.len() as u32,

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -14,6 +14,7 @@ use crate::descriptor_set::UnsafeDescriptorSet;
 use crate::device::Device;
 use crate::device::DeviceOwned;
 use crate::OomError;
+use crate::Version;
 use crate::VulkanObject;
 use smallvec::SmallVec;
 use std::error;
@@ -129,7 +130,7 @@ impl UnsafeDescriptorPool {
         })
     }
 
-    /// Allocates descriptor sets from the pool, one for each layout.
+    /// Allocates descriptor sets from the pool, one for each element in `create_info`.
     /// Returns an iterator to the allocated sets, or an error.
     ///
     /// The `FragmentedPool` errors often can't be prevented. If the function returns this error,
@@ -148,44 +149,45 @@ impl UnsafeDescriptorPool {
     /// - You must ensure that the allocated descriptor sets are no longer in use when the pool
     ///   is destroyed, as destroying the pool is equivalent to freeing all the sets.
     ///
-    pub unsafe fn alloc<'l, I>(
+    pub unsafe fn alloc<'a>(
         &mut self,
-        layouts: I,
-    ) -> Result<impl ExactSizeIterator<Item = UnsafeDescriptorSet>, DescriptorPoolAllocError>
-    where
-        I: IntoIterator<Item = &'l DescriptorSetLayout>,
-    {
-        let mut variable_descriptor_counts: SmallVec<[_; 8]> = SmallVec::new();
+        create_info: impl IntoIterator<Item = DescriptorSetAllocateInfo<'a>>,
+    ) -> Result<impl ExactSizeIterator<Item = UnsafeDescriptorSet>, DescriptorPoolAllocError> {
+        let (layouts, variable_descriptor_counts): (SmallVec<[_; 1]>, SmallVec<[_; 1]>) =
+            create_info
+                .into_iter()
+                .map(|info| {
+                    assert_eq!(
+                        self.device.internal_object(),
+                        info.layout.device().internal_object(),
+                        "Tried to allocate from a pool with a set layout of a different device"
+                    );
+                    debug_assert!(!info.layout.desc().is_push_descriptor());
+                    debug_assert!(
+                        info.variable_descriptor_count <= info.layout.variable_descriptor_count()
+                    );
 
-        let layouts: SmallVec<[_; 8]> = layouts
-            .into_iter()
-            .map(|layout| {
-                assert_eq!(
-                    self.device.internal_object(),
-                    layout.device().internal_object(),
-                    "Tried to allocate from a pool with a set layout of a different device"
-                );
-                debug_assert!(!layout.desc().is_push_descriptor());
+                    (
+                        info.layout.internal_object(),
+                        info.variable_descriptor_count,
+                    )
+                })
+                .unzip();
 
-                variable_descriptor_counts.push(layout.variable_descriptor_count());
-                layout.internal_object()
-            })
-            .collect();
-        let num = layouts.len();
-
-        let output = if num == 0 {
+        let output = if layouts.len() == 0 {
             vec![]
         } else {
-            let variable_desc_count_alloc_info =
-                if variable_descriptor_counts.iter().any(|c| *c != 0) {
-                    Some(ash::vk::DescriptorSetVariableDescriptorCountAllocateInfo {
-                        descriptor_set_count: layouts.len() as u32,
-                        p_descriptor_counts: variable_descriptor_counts.as_ptr(),
-                        ..Default::default()
-                    })
-                } else {
-                    None
-                };
+            let variable_desc_count_alloc_info = if self.device.api_version() >= Version::V1_2
+                || self.device.enabled_extensions().ext_descriptor_indexing
+            {
+                Some(ash::vk::DescriptorSetVariableDescriptorCountAllocateInfo {
+                    descriptor_set_count: layouts.len() as u32,
+                    p_descriptor_counts: variable_descriptor_counts.as_ptr(),
+                    ..Default::default()
+                })
+            } else {
+                None
+            };
 
             let infos = ash::vk::DescriptorSetAllocateInfo {
                 descriptor_pool: self.pool,
@@ -199,7 +201,7 @@ impl UnsafeDescriptorPool {
                 ..Default::default()
             };
 
-            let mut output = Vec::with_capacity(num);
+            let mut output = Vec::with_capacity(layouts.len());
 
             let fns = self.device.fns();
             let ret = fns.v1_0.allocate_descriptor_sets(
@@ -227,7 +229,7 @@ impl UnsafeDescriptorPool {
                 _ => (),
             };
 
-            output.set_len(num);
+            output.set_len(layouts.len());
             output
         };
 
@@ -320,6 +322,17 @@ impl Drop for UnsafeDescriptorPool {
     }
 }
 
+/// Parameters to use when allocating a new descriptor set from a descriptor pool.
+#[derive(Clone, Debug)]
+pub struct DescriptorSetAllocateInfo<'a> {
+    /// The descriptor set layout to create the set for.
+    pub layout: &'a DescriptorSetLayout,
+
+    /// For layouts with a variable-count binding, the number of descriptors to allocate for that
+    /// binding. This should be 0 for layouts that don't have a variable-count binding.
+    pub variable_descriptor_count: u32,
+}
+
 /// Error that can be returned when creating a device.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DescriptorPoolAllocError {
@@ -363,6 +376,7 @@ mod tests {
     use crate::descriptor_set::layout::DescriptorSetDesc;
     use crate::descriptor_set::layout::DescriptorSetLayout;
     use crate::descriptor_set::layout::DescriptorType;
+    use crate::descriptor_set::pool::sys::DescriptorSetAllocateInfo;
     use crate::descriptor_set::pool::DescriptorsCount;
     use crate::descriptor_set::pool::UnsafeDescriptorPool;
     use crate::shader::ShaderStages;
@@ -426,7 +440,12 @@ mod tests {
 
         let mut pool = UnsafeDescriptorPool::new(device, &desc, 10, false).unwrap();
         unsafe {
-            let sets = pool.alloc([set_layout.as_ref()]).unwrap();
+            let sets = pool
+                .alloc([DescriptorSetAllocateInfo {
+                    layout: set_layout.as_ref(),
+                    variable_descriptor_count: 0,
+                }])
+                .unwrap();
             assert_eq!(sets.count(), 1);
         }
     }
@@ -454,13 +473,15 @@ mod tests {
         };
 
         assert_should_panic!(
-            "Tried to allocate from a pool with a set layout \
-                              of a different device",
+            "Tried to allocate from a pool with a set layout of a different device",
             {
                 let mut pool = UnsafeDescriptorPool::new(device2, &desc, 10, false).unwrap();
 
                 unsafe {
-                    let _ = pool.alloc([set_layout.as_ref()]);
+                    let _ = pool.alloc([DescriptorSetAllocateInfo {
+                        layout: set_layout.as_ref(),
+                        variable_descriptor_count: 0,
+                    }]);
                 }
             }
         );

--- a/vulkano/src/descriptor_set/resources.rs
+++ b/vulkano/src/descriptor_set/resources.rs
@@ -26,7 +26,9 @@ pub struct DescriptorSetResources {
 impl DescriptorSetResources {
     /// Creates a new `DescriptorSetResources` matching the provided descriptor set layout, and
     /// all descriptors set to `None`.
-    pub fn new(layout: &DescriptorSetLayout) -> Self {
+    pub fn new(layout: &DescriptorSetLayout, variable_descriptor_count: u32) -> Self {
+        assert!(variable_descriptor_count <= layout.variable_descriptor_count());
+
         let descriptors = layout
             .desc()
             .bindings()
@@ -34,7 +36,12 @@ impl DescriptorSetResources {
             .enumerate()
             .filter_map(|(b, d)| d.as_ref().map(|d| (b as u32, d)))
             .map(|(binding_num, binding_desc)| {
-                let count = binding_desc.descriptor_count as usize;
+                let count = if binding_desc.variable_count {
+                    variable_descriptor_count
+                } else {
+                    binding_desc.descriptor_count
+                } as usize;
+
                 let binding_resources = match binding_desc.ty {
                     DescriptorType::UniformBuffer
                     | DescriptorType::StorageBuffer


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** Changes to allow allocating variable descriptor counts:
  - The `alloc` method of the `DescriptorPool` trait now has a second parameter to specify the number of descriptors to allocate for the variable count binding. If there is no variable count binding in the layout, this should be 0.
  - The `alloc` method of `UnsafeDescriptorPool` now takes an iterator of `DescriptorSetAllocateInfo`.
```
```markdown
- For `PersistentDescriptorSet` when using a layout with a variable count binding, allocate only the number of descriptors needed instead of always the maximum.
```

Fixes #1740.

Unfortunately I wasn't able to retain variable count functionality for `SingleLayoutDescSetPool`. I thought it would be enough to split the internal reserve of available descriptor sets based on the number of variable descriptors. However, I noticed that this reserve is filled with new descriptor sets as soon as the previous one runs out, which causes problems for variable counts.

When the reserve is empty, and you call `next`, it creates a new internal `UnsafeDescriptorPool`, then immediately allocates as many descriptor sets as possible from it. It then returns one of those descriptor sets for you to build, and adds the rest in its reserve. In the case of variable count layouts, this would mean that it allocates not just one descriptor set with the desired variable count, but a whole bunch of them.

My concern is that this would lead to a lot of wasted descriptor sets, because those descriptor sets can only be used if the variable count is exactly the same. Perhaps the allocation strategy should be changed so that it allocates only one descriptor set at a time, and the reserve is only filled when allocated descriptor sets are dropped and returned to the pool. But I think that should be considered for a future PR.