### PR TITLE
Add shaderc-debug feature to Vulkano-shaders

### DIFF
--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -25,3 +25,4 @@ vulkano = { version = "0.26.0", path = "../vulkano" }
 
 [features]
 shaderc-build-from-source = ["shaderc/build-from-source"]
+shaderc-debug = []

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -193,6 +193,9 @@ pub fn compile(
         compile_options.add_macro_definition(macro_name.as_ref(), Some(macro_value.as_ref()));
     }
 
+    #[cfg(feature = "shaderc-debug")]
+    compile_options.set_generate_debug_info();
+
     let content = compiler
         .compile_into_spirv(&code, ty, root_source_path, "main", Some(&compile_options))
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Changelog:
```markdown
- Added a `shaderc-debug` cargo feature to Vulkano-shaders, to emit debug information in the generated SPIR-V code.
```

Fixes #1742. @ProtoByter can you let me know if this implementation is sufficient for your purposes?