### PR TITLE
use repr(C)

### DIFF
--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -40,6 +40,7 @@ use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::{Window, WindowBuilder};
 
+#[repr(C)]
 #[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2],

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -151,6 +151,7 @@ impl AmbientLightingSystem {
     }
 }
 
+#[repr(C)]
 #[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2],

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -166,6 +166,7 @@ impl DirectionalLightingSystem {
     }
 }
 
+#[repr(C)]
 #[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2],

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -179,6 +179,7 @@ impl PointLightingSystem {
     }
 }
 
+#[repr(C)]
 #[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2],

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -99,6 +99,7 @@ impl TriangleDrawSystem {
     }
 }
 
+#[repr(C)]
 #[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2],

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -101,6 +101,7 @@ fn main() {
             .unwrap()
     };
 
+    #[repr(C)]
     #[derive(Default, Debug, Clone)]
     struct Vertex {
         position: [f32; 2],

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -107,6 +107,7 @@ fn main() {
             .unwrap()
     };
 
+    #[repr(C)]
     #[derive(Default, Debug, Clone)]
     struct Vertex {
         position: [f32; 2],

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -56,6 +56,7 @@ use winit::window::{Window, WindowBuilder};
 
 // # Vertex Types
 // `Vertex` is the vertex type that will be output from the compute shader and be input to the vertex shader.
+#[repr(C)]
 #[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2],

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -45,6 +45,7 @@ use winit::window::{Window, WindowBuilder};
 // graphics pipeline, we need to define two vertex types:
 //
 // 1. `Vertex` is the vertex type that we will use to describe the triangle's geometry.
+#[repr(C)]
 #[derive(Default, Debug, Clone)]
 struct Vertex {
     position: [f32; 2],
@@ -52,6 +53,7 @@ struct Vertex {
 impl_vertex!(Vertex, position);
 
 // 2. `InstanceData` is the vertex type that describes the unique data per instance.
+#[repr(C)]
 #[derive(Default, Debug, Clone)]
 struct InstanceData {
     position_offset: [f32; 2],

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -22,6 +22,7 @@ use vulkano::render_pass::Subpass;
 use vulkano::sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode};
 
 /// Vertex for textured quads
+#[repr(C)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct TexturedVertex {
     pub position: [f32; 2],

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -241,6 +241,7 @@ fn main() {
     let vs = vs::load(device.clone()).unwrap();
     let fs = fs::load(device.clone()).unwrap();
 
+    #[repr(C)]
     #[derive(Default, Copy, Clone)]
     struct Vertex {
         position: [f32; 2],

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -130,6 +130,7 @@ fn main() {
             .unwrap()
     };
 
+    #[repr(C)]
     #[derive(Default, Debug, Clone)]
     struct Vertex {
         position: [f32; 2],

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -130,6 +130,7 @@ fn main() {
 
     let image_view = ImageView::new(image.clone()).unwrap();
 
+    #[repr(C)]
     #[derive(Default, Debug, Clone)]
     struct Vertex {
         position: [f32; 2],

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -96,6 +96,7 @@ fn main() {
             .unwrap()
     };
 
+    #[repr(C)]
     #[derive(Default, Debug, Clone)]
     struct Vertex {
         position: [f32; 3],

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -99,6 +99,7 @@ fn main() {
             .unwrap()
     };
 
+    #[repr(C)]
     #[derive(Default, Debug, Clone)]
     struct Vertex {
         position: [f32; 2],

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -44,6 +44,7 @@ use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::{Window, WindowBuilder};
 
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct Vertex {
     pub position: [f32; 2],

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -111,6 +111,7 @@ fn main() {
             .unwrap()
     };
 
+    #[repr(C)]
     #[derive(Default, Debug, Clone)]
     struct Vertex {
         position: [f32; 2],

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -205,6 +205,7 @@ fn main() {
     };
 
     #[derive(Default, Debug, Clone)]
+    #[repr(C)]
     struct Vertex {
         position: [f32; 2],
     }

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -208,6 +208,9 @@ fn main() {
     };
 
     // We now create a buffer that will store the shape of our triangle.
+    // We use #[repr(C)] here to force rustc to not do anything funky with our data, although for this
+    // particular example, it doesn't actually change the in-memory representation.
+    #[repr(C)]
     #[derive(Default, Debug, Clone)]
     struct Vertex {
         position: [f32; 2],

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -14,6 +14,12 @@
 //! between a Vulkan buffer and a regular buffer is that the content of a Vulkan buffer is
 //! accessible from the GPU.
 //!
+//! Vulkano does not perform any specific marshalling of buffer data. The representation of the buffer in
+//! memory is identical between the CPU and GPU. Because the Rust compiler is allowed to reorder struct
+//! fields at will by default when using `#[repr(Rust)]`, it is advised to mark each struct requiring
+//! imput assembly as `#[repr(C)]`. This forces Rust to follow the standard C procedure. Each element is
+//! laid out in memory in the order of declaration and aligned to a multiple of their alignment.
+//!
 //! # Various kinds of buffers
 //!
 //! The low level implementation of a buffer is [`UnsafeBuffer`](crate::buffer::sys::UnsafeBuffer).


### PR DESCRIPTION
fixes #1755. also updates two docstrings to briefly mention why you should use `#[repr(C)]`.

if it is advisable to touch some other examples that share more complicated data with the gpu i can do that as well.