### PR TITLE
Use `General` layout for `storage_image` regardless of image type

### DIFF
--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -649,7 +649,7 @@ where
     #[inline]
     fn descriptor_layouts(&self) -> Option<ImageDescriptorLayouts> {
         Some(ImageDescriptorLayouts {
-            storage_image: ImageLayout::ShaderReadOnlyOptimal,
+            storage_image: ImageLayout::General,
             combined_image_sampler: ImageLayout::ShaderReadOnlyOptimal,
             sampled_image: ImageLayout::ShaderReadOnlyOptimal,
             input_attachment: ImageLayout::ShaderReadOnlyOptimal,

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -447,7 +447,7 @@ where
     #[inline]
     fn descriptor_layouts(&self) -> Option<ImageDescriptorLayouts> {
         Some(ImageDescriptorLayouts {
-            storage_image: self.layout,
+            storage_image: ImageLayout::General,
             combined_image_sampler: self.layout,
             sampled_image: self.layout,
             input_attachment: self.layout,

--- a/vulkano/src/image/layout.rs
+++ b/vulkano/src/image/layout.rs
@@ -9,35 +9,72 @@
 
 use crate::descriptor_set::layout::DescriptorType;
 
-/// Layout of an image.
+/// In-memory layout of the pixel data of an image.
 ///
-/// > **Note**: In vulkano, image layouts are mostly a low-level detail. You can ignore them,
-/// > unless you use an unsafe function that states in its documentation that you must take care of
-/// > an image's layout.
+/// The pixel data of a Vulkan image is arranged in a particular way, which is called its *layout*.
+/// Each image subresource (mipmap level and array layer) in an image can have a different layout,
+/// but usually the whole image has its data in the same layout. Layouts are abstract in the sense
+/// that the user does not know the specific details of each layout; the device driver is free to
+/// implement each layout in the way it sees fit.
 ///
-/// In the Vulkan API, each mipmap level of each array layer is in one of the layouts of this enum.
+/// The layout of a newly created image is either `Undefined` or `Preinitialized`. Every operation
+/// that can be performed on an image is only possible with specific layouts, so before the
+/// operation is performed, the user must perform a *layout transition* on the image. This
+/// rearranges the pixel data from one layout into another. Layout transitions are performed as part
+/// of pipeline barriers in a command buffer.
 ///
-/// Unless you use some sort of high-level shortcut function, an image always starts in either
-/// the `Undefined` or the `Preinitialized` layout.
-/// Before you can use an image for a given purpose, you must ensure that the image in question is
-/// in the layout required for that purpose. For example if you want to write data to an image, you
-/// must first transition the image to the `TransferDstOptimal` layout. The `General` layout can
-/// also be used as a general-purpose fit-all layout, but using it will result in slower operations.
+/// The `General` layout is compatible with any operation, so layout transitions are never needed.
+/// However, the other layouts, while more restricted, are usually better optimised for a particular
+/// type of operation than `General`, so they are usually preferred.
 ///
-/// Transitioning between layouts can only be done through a GPU-side operation that is part of
-/// a command buffer.
+/// Vulkan does not keep track of layouts itself, so it is the responsibility of the user to keep
+/// track of this information. When performing a layout transition, the previous layout must be
+/// specified as well. Some operations allow for different layouts, but require the user to specify
+/// which one. Vulkano helps with this by providing sensible defaults, automatically tracking the
+/// layout of each image when creating a command buffer, and adding layout transitions where needed.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum ImageLayout {
+    /// The layout of the data is unknown, and the image is treated as containing no valid data.
+    /// Transitioning from `Undefined` will discard any existing pixel data.
     Undefined = ash::vk::ImageLayout::UNDEFINED.as_raw(),
+
+    /// A general-purpose layout that can be used for any operation. Some operations may only allow
+    /// `General`, such as storage images, but many have a more specific layout that is better
+    /// optimized for that purpose.
     General = ash::vk::ImageLayout::GENERAL.as_raw(),
+
+    /// For a color image used as a color or resolve attachment in a framebuffer. Images that are
+    /// transitioned into this layout must have the `color_attachment` usage enabled.
     ColorAttachmentOptimal = ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL.as_raw(),
+
+    /// For a depth/stencil image used as a depth/stencil attachment in a framebuffer.
     DepthStencilAttachmentOptimal = ash::vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL.as_raw(),
+
+    /// For a depth/stencil image used as a read-only depth/stencil attachment in a framebuffer, or
+    /// as a (combined) sampled image or input attachment in a shader.
     DepthStencilReadOnlyOptimal = ash::vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL.as_raw(),
+
+    /// For a color image used as a (combined) sampled image or input attachment in a shader.
+    /// Images that are transitioned into this layout must have the `sampled` or `input_attachment`
+    /// usages enabled.
     ShaderReadOnlyOptimal = ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL.as_raw(),
+
+    /// For operations that transfer data from an image (copy, blit).
     TransferSrcOptimal = ash::vk::ImageLayout::TRANSFER_SRC_OPTIMAL.as_raw(),
+
+    /// For operations that transfer data to an image (copy, blit, clear).
     TransferDstOptimal = ash::vk::ImageLayout::TRANSFER_DST_OPTIMAL.as_raw(),
+
+    /// When creating an image, this specifies that the initial data is going to be directly
+    /// written to from the CPU. Unlike `Undefined`, the image is assumed to contain valid data when
+    /// transitioning from this layout. However, this only works right when the image has linear
+    /// tiling, optimal tiling gives undefined results.
     Preinitialized = ash::vk::ImageLayout::PREINITIALIZED.as_raw(),
+
+    /// The layout of images that are held in a swapchain. Images are in this layout when they are
+    /// acquired from the swapchain, and must be transitioned back into this layout before
+    /// presenting them.
     PresentSrc = ash::vk::ImageLayout::PRESENT_SRC_KHR.as_raw(),
 }
 

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -101,7 +101,7 @@ where
     #[inline]
     fn descriptor_layouts(&self) -> Option<ImageDescriptorLayouts> {
         Some(ImageDescriptorLayouts {
-            storage_image: ImageLayout::ShaderReadOnlyOptimal,
+            storage_image: ImageLayout::General,
             combined_image_sampler: ImageLayout::ShaderReadOnlyOptimal,
             sampled_image: ImageLayout::ShaderReadOnlyOptimal,
             input_attachment: ImageLayout::ShaderReadOnlyOptimal,


### PR DESCRIPTION
Changelog:
```markdown
- Fixed bug where the wrong image layout was used for images used as a storage image.
```

Fixes #1762. According to the spec, only `General` can be used for a storage image (and `VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR` but Vulkan doesn't support that yet anyway). I added some better documentation to the `ImageLayout` type as well.