### PR TITLE
Fix typo in clear_depth_stencil

### DIFF
--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -834,7 +834,7 @@ impl UnsafeCommandBufferBuilder {
                 if region.clear_depth {
                     aspect_mask |= ash::vk::ImageAspectFlags::DEPTH;
                 }
-                if region.clear_depth {
+                if region.clear_stencil {
                     aspect_mask |= ash::vk::ImageAspectFlags::STENCIL;
                 }
 


### PR DESCRIPTION
Whoops, sorry :(

- segfaults with mesa on intel :)
- causes graphics glitches or crashes the GPU on MoltenVK on intel :) 