### PR TITLE
Upgrade to Rust 2021, update dependencies

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "examples"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 publish = false
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@ vulkano = { path = "../vulkano" }
 vulkano-shaders = { path = "../vulkano-shaders" }
 # The Vulkan library doesn't provide any functionality to create and handle windows, as
 # this would be out of scope. In order to open a window, we are going to use the `winit` crate.
-winit = "0.25"
+winit = "0.26"
 # The `vulkano_win` crate is the link between `vulkano` and `winit`. Vulkano doesn't know about winit,
 # and winit doesn't know about vulkano, so import a crate that will provide a link between the two.
 vulkano-win = { path = "../vulkano-win" }
@@ -21,7 +21,7 @@ cgmath = "0.18"
 png = "0.17"
 time = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-ron = "0.6"
+ron = "0.7"
 rand = "0.8.4"
 
 glium = { git = "https://github.com/glium/glium.git" }

--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vulkano-shaders"
 version = "0.27.0"
-edition = "2018"
+edition = "2021"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Shaders rust code generation macro"

--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -10,16 +10,24 @@
 use fnv::FnvHashMap;
 use proc_macro2::TokenStream;
 use vulkano::pipeline::layout::PipelineLayoutPcRange;
+use vulkano::shader::spirv::ExecutionModel;
 use vulkano::shader::{
     DescriptorRequirements, GeometryShaderExecution, ShaderExecution, ShaderInterfaceEntry,
     ShaderInterfaceEntryType, SpecializationConstantRequirements,
 };
 use vulkano::shader::{EntryPointInfo, ShaderInterface, ShaderStages};
-use vulkano::shader::spirv::ExecutionModel;
 
-pub(super) fn write_entry_point(name: &str, model: ExecutionModel, info: &EntryPointInfo) -> TokenStream {
+pub(super) fn write_entry_point(
+    name: &str,
+    model: ExecutionModel,
+    info: &EntryPointInfo,
+) -> TokenStream {
     let execution = write_shader_execution(&info.execution);
-    let model = syn::parse_str::<syn::Path>(&format!("vulkano::shader::spirv::ExecutionModel::{:?}", model)).unwrap();
+    let model = syn::parse_str::<syn::Path>(&format!(
+        "vulkano::shader::spirv::ExecutionModel::{:?}",
+        model
+    ))
+    .unwrap();
     let descriptor_requirements = write_descriptor_requirements(&info.descriptor_requirements);
     let push_constant_requirements =
         write_push_constant_requirements(&info.push_constant_requirements);
@@ -34,9 +42,9 @@ pub(super) fn write_entry_point(name: &str, model: ExecutionModel, info: &EntryP
             #model,
             EntryPointInfo {
                 execution: #execution,
-                descriptor_requirements: std::array::IntoIter::new(#descriptor_requirements).collect(),
+                descriptor_requirements: #descriptor_requirements.into_iter().collect(),
                 push_constant_requirements: #push_constant_requirements,
-                specialization_constant_requirements: std::array::IntoIter::new(#specialization_constant_requirements).collect(),
+                specialization_constant_requirements: #specialization_constant_requirements.into_iter().collect(),
                 input_interface: #input_interface,
                 output_interface: #output_interface,
             },

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vulkano-win"
 version = "0.27.0"
-edition = "2018"
+edition = "2021"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Link between vulkano and winit"
@@ -17,9 +17,9 @@ winit_ = ["winit", "metal", "cocoa", "objc"]
 raw-window-handle_ = ["raw-window-handle"]
 
 [dependencies]
-winit = { version = "0.25", optional = true }
+winit = { version = "0.26", optional = true }
 vulkano = { version = "0.27.0", path = "../vulkano" }
-raw-window-handle = { version = "0.3.3", optional = true }
+raw-window-handle = { version = "0.4", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = { version = "0.18.0", optional = true }

--- a/vulkano-win/src/raw_window_handle.rs
+++ b/vulkano-win/src/raw_window_handle.rs
@@ -1,15 +1,5 @@
-use std::ffi::c_void;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonflybsd",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-use std::os::raw::c_ulong;
-use std::sync::Arc;
-
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use std::sync::Arc;
 use vulkano::instance::Instance;
 use vulkano::swapchain::Surface;
 use vulkano::swapchain::SurfaceCreationError;
@@ -25,132 +15,19 @@ where
 {
     unsafe {
         match window.raw_window_handle() {
-            #[cfg(target_os = "ios")]
-            RawWindowHandle::IOS(h) => handle_to_surface(h.ui_view, instance, window),
-            #[cfg(target_os = "macos")]
-            RawWindowHandle::MacOS(h) => handle_to_surface(h.ns_view, instance, window),
-            #[cfg(any(
-                target_os = "linux",
-                target_os = "dragonflybsd",
-                target_os = "freebsd",
-                target_os = "netbsd",
-                target_os = "openbsd"
-            ))]
-            RawWindowHandle::Xlib(h) => {
-                handle_to_surface_xlib(h.window, h.display, instance, window)
-            }
-            #[cfg(any(
-                target_os = "linux",
-                target_os = "dragonflybsd",
-                target_os = "freebsd",
-                target_os = "netbsd",
-                target_os = "openbsd"
-            ))]
-            RawWindowHandle::Xcb(h) => {
-                handle_to_surface_xcb(h.window, h.connection, instance, window)
-            }
-            #[cfg(any(
-                target_os = "linux",
-                target_os = "dragonflybsd",
-                target_os = "freebsd",
-                target_os = "netbsd",
-                target_os = "openbsd"
-            ))]
+            RawWindowHandle::UiKit(h) => Surface::from_ios_moltenvk(instance, h.ui_view, window),
+            RawWindowHandle::AppKit(h) => Surface::from_macos_moltenvk(instance, h.ns_view, window),
+            RawWindowHandle::Xlib(h) => Surface::from_xlib(instance, h.display, h.window, window),
+            RawWindowHandle::Xcb(h) => Surface::from_xcb(instance, h.connection, h.window, window),
             RawWindowHandle::Wayland(h) => {
-                handle_to_surface_wl(h.surface, h.display, instance, window)
+                Surface::from_wayland(instance, h.display, h.surface, window)
             }
-            #[cfg(target_os = "android")]
-            RawWindowHandle::Android(h) => handle_to_surface(h.a_native_window, instance, window),
-            #[cfg(target_os = "windows")]
-            RawWindowHandle::Windows(h) => handle_to_surface(h.hinstance, h.hwnd, instance, window),
-            #[cfg(target_os = "wasm")]
+            RawWindowHandle::AndroidNdk(h) => {
+                Surface::from_anativewindow(instance, h.a_native_window, window)
+            }
+            RawWindowHandle::Win32(h) => Surface::from_hwnd(instance, h.hinstance, h.hwnd, window),
             RawWindowHandle::Web(_) => unimplemented!(),
             _ => unimplemented!(),
         }
     }
-}
-
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonflybsd",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-unsafe fn handle_to_surface_xlib<W: Sized>(
-    window: c_ulong,
-    handle: *const c_void,
-    instance: Arc<Instance>,
-    win: W,
-) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
-    Surface::from_xlib(instance, handle, window, win)
-}
-
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonflybsd",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-unsafe fn handle_to_surface_xcb<W: Sized>(
-    window: u32,
-    handle: *mut c_void,
-    instance: Arc<Instance>,
-    win: W,
-) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
-    Surface::from_xcb(instance, handle as *const _, window, win)
-}
-
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonflybsd",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-unsafe fn handle_to_surface_wl<W: Sized>(
-    surface: *mut c_void,
-    display: *mut c_void,
-    instance: Arc<Instance>,
-    win: W,
-) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
-    Surface::from_wayland(instance, display as *const _, surface as *const _, win)
-}
-
-#[cfg(target_os = "macos")]
-unsafe fn handle_to_surface<W: Sized>(
-    view: *mut c_void,
-    instance: Arc<Instance>,
-    win: W,
-) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
-    Surface::from_macos_moltenvk(instance, view as *const _, win)
-}
-
-#[cfg(target_os = "ios")]
-unsafe fn handle_to_surface<W: Sized>(
-    view: *mut c_void,
-    instance: Arc<Instance>,
-    win: W,
-) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
-    Surface::from_ios_moltenvk(instance, view as *const _, win)
-}
-
-#[cfg(target_os = "android")]
-unsafe fn handle_to_surface<W: Sized>(
-    window: *mut c_void,
-    instance: Arc<Instance>,
-    win: W,
-) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
-    Surface::from_anativewindow(instance, window as *const _, win)
-}
-
-#[cfg(target_os = "windows")]
-unsafe fn handle_to_surface<W: Sized>(
-    hinstance: *mut c_void,
-    hwnd: *mut c_void,
-    instance: Arc<Instance>,
-    win: W,
-) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
-    Surface::from_hwnd(instance, hinstance as *const _, hwnd as *const _, win)
 }

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vulkano"
 version = "0.27.0"
-edition = "2018"
+edition = "2021"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Safe wrapper for the Vulkan graphics API"
@@ -19,11 +19,11 @@ build = "build.rs"
 ash = "0.33.3"
 crossbeam-queue = "0.3"
 fnv = "1.0"
-half = "1.7"
+half = "1.8"
 lazy_static = "1.4"
 parking_lot = { version = "0.11", features = ["send_guard"] }
 shared_library = "0.1"
-smallvec = "1.6"
+smallvec = "1.7"
 
 [build-dependencies]
 heck = "0.3"

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -199,18 +199,18 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
                     quote! { self.#ffi_member.as_mut().map(|s| &mut s #ffi_member_field .#ffi_name) }
                 });
                 quote! {
-                    std::array::IntoIter::new([
+                    [
                         #(#ffi_members),*
-                    ]).flatten().next().map(|f| *f = features.#name as ash::vk::Bool32);
+                    ].into_iter().flatten().next().map(|f| *f = features.#name as ash::vk::Bool32);
                 }
             } else {
                 let ffi_members = ffi_members.iter().map(|(ffi_member, ffi_member_field)| {
                     quote! { &mut self.#ffi_member #ffi_member_field .#ffi_name }
                 });
                 quote! {
-                    std::array::IntoIter::new([
+                    [
                         #(#ffi_members),*
-                    ]).next().map(|f| *f = features.#name as ash::vk::Bool32);
+                    ].into_iter().next().map(|f| *f = features.#name as ash::vk::Bool32);
                 }
             }
         },
@@ -229,18 +229,18 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
                     quote! { features_ffi.#ffi_member.map(|s| s #ffi_member_field .#ffi_name) }
                 });
                 quote! {
-                    #name: std::array::IntoIter::new([
+                    #name: [
                         #(#ffi_members),*
-                    ]).flatten().next().unwrap_or(0) != 0,
+                    ].into_iter().flatten().next().unwrap_or(0) != 0,
                 }
             } else {
                 let ffi_members = ffi_members.iter().map(|(ffi_member, ffi_member_field)| {
                     quote! { features_ffi.#ffi_member #ffi_member_field .#ffi_name }
                 });
                 quote! {
-                    #name: std::array::IntoIter::new([
+                    #name: [
                         #(#ffi_members),*
-                    ]).next().unwrap_or(0) != 0,
+                    ].into_iter().next().unwrap_or(0) != 0,
                 }
             }
         },
@@ -518,8 +518,8 @@ fn features_ffi_output(members: &[FeaturesFfiMember]) -> TokenStream {
              ..
          }| {
             quote! {
-                if std::array::IntoIter::new([#(#provided_by),*]).any(|x| x) &&
-                    std::array::IntoIter::new([#(self.#conflicts.is_none()),*]).all(|x| x) {
+                if [#(#provided_by),*].into_iter().any(|x| x) &&
+                    [#(self.#conflicts.is_none()),*].into_iter().all(|x| x) {
                     self.#name = Some(Default::default());
                     let member = self.#name.as_mut().unwrap();
                     member.p_next = head.p_next;

--- a/vulkano/autogen/fns.rs
+++ b/vulkano/autogen/fns.rs
@@ -43,7 +43,8 @@ struct FnsMember {
 
 fn fns_output(extension_members: &[FnsMember], fns_level: &str) -> TokenStream {
     let struct_name = format_ident!("{}Functions", fns_level);
-    let members = std::array::IntoIter::new(["1_0", "1_1", "1_2"])
+    let members = ["1_0", "1_1", "1_2"]
+        .into_iter()
         .map(|version| FnsMember {
             name: format_ident!("v{}", version),
             fn_struct: format_ident!("{}FnV{}", fns_level, version),

--- a/vulkano/autogen/formats.rs
+++ b/vulkano/autogen/formats.rs
@@ -692,7 +692,8 @@ fn formats_members(formats: &[&str]) -> Vec<FormatMember> {
                                 };
                                 let ty = format_ident!("{}{}", prefix, bits);
 
-                                let elements = std::array::IntoIter::new(components)
+                                let elements = components
+                                    .into_iter()
                                     .filter(|&c| {
                                         if c != 0 {
                                             debug_assert!(c == bits);

--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -81,9 +81,9 @@ fn properties_output(members: &[PropertiesMember]) -> TokenStream {
                 });
 
                 quote! {
-                    #name: std::array::IntoIter::new([
+                    #name: [
                         #(#ffi_members),*
-                    ]).flatten().next().and_then(|x| <#ty>::from_vulkan(x)),
+                    ].into_iter().flatten().next().and_then(|x| <#ty>::from_vulkan(x)),
                 }
             } else {
                 let ffi_members = ffi_members.iter().map(|(ffi_member, ffi_member_field)| {
@@ -91,9 +91,9 @@ fn properties_output(members: &[PropertiesMember]) -> TokenStream {
                 });
 
                 quote! {
-                    #name: std::array::IntoIter::new([
+                    #name: [
                         #(#ffi_members),*
-                    ]).next().and_then(|x| <#ty>::from_vulkan(x)).unwrap(),
+                    ].into_iter().next().and_then(|x| <#ty>::from_vulkan(x)).unwrap(),
                 }
             }
         },
@@ -122,11 +122,13 @@ fn properties_output(members: &[PropertiesMember]) -> TokenStream {
 
 fn properties_members(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<PropertiesMember> {
     let mut properties = HashMap::new();
-    std::array::IntoIter::new([
+
+    [
         &types["VkPhysicalDeviceProperties"],
         &types["VkPhysicalDeviceLimits"],
         &types["VkPhysicalDeviceSparseProperties"],
-    ])
+    ]
+    .into_iter()
     .chain(sorted_structs(types).into_iter())
     .filter(|(ty, _)| {
         let name = ty.name.as_ref().map(|s| s.as_str());
@@ -235,8 +237,8 @@ fn properties_ffi_output(members: &[PropertiesFfiMember]) -> TokenStream {
              ..
          }| {
             quote! {
-                if std::array::IntoIter::new([#(#provided_by),*]).any(|x| x) &&
-                    std::array::IntoIter::new([#(self.#conflicts.is_none()),*]).all(|x| x) {
+                if [#(#provided_by),*].into_iter().any(|x| x) &&
+                    [#(self.#conflicts.is_none()),*].into_iter().all(|x| x) {
                     self.#name = Some(Default::default());
                     let member = self.#name.as_mut().unwrap();
                     member.p_next = head.p_next;

--- a/vulkano/autogen/spirv_parse.rs
+++ b/vulkano/autogen/spirv_parse.rs
@@ -12,10 +12,7 @@ use heck::SnakeCase;
 use lazy_static::lazy_static;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use std::{
-    collections::{HashMap, HashSet},
-    iter::FromIterator,
-};
+use std::collections::{HashMap, HashSet};
 
 lazy_static! {
     static ref SPEC_CONSTANT_OP: HashSet<&'static str> = {

--- a/vulkano/src/command_buffer/validity/vertex_buffers.rs
+++ b/vulkano/src/command_buffer/validity/vertex_buffers.rs
@@ -11,7 +11,6 @@ use crate::command_buffer::synced::CommandBufferState;
 use crate::pipeline::graphics::vertex_input::VertexInputRate;
 use crate::pipeline::GraphicsPipeline;
 use crate::DeviceSize;
-use std::convert::TryInto;
 use std::error;
 use std::fmt;
 

--- a/vulkano/src/descriptor_set/pool/mod.rs
+++ b/vulkano/src/descriptor_set/pool/mod.rs
@@ -88,7 +88,7 @@ macro_rules! descriptors_count {
             /// Returns the total number of descriptors.
             #[inline]
             pub fn total(&self) -> u32 {
-                std::array::IntoIter::new([$(self.$name,)+]).sum()
+                [$(self.$name,)+].into_iter().sum()
             }
 
             /// Adds one descriptor of the given type to the count.

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -14,7 +14,6 @@ use crate::sync::PipelineStage;
 use crate::DeviceSize;
 use crate::Version;
 use crate::VulkanObject;
-use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::fmt;
 use std::hash::Hash;

--- a/vulkano/src/device/properties.rs
+++ b/vulkano/src/device/properties.rs
@@ -9,7 +9,6 @@ use crate::render_pass::ResolveModes;
 use crate::shader::ShaderStages;
 use crate::DeviceSize;
 use crate::Version;
-use std::convert::TryInto;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -99,7 +99,6 @@ use crate::shader::spirv::ImageFormat;
 use crate::DeviceSize;
 use crate::VulkanObject;
 use half::f16;
-use std::convert::TryFrom;
 use std::mem::MaybeUninit;
 use std::vec::IntoIter as VecIntoIter;
 use std::{error, fmt, mem};

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -60,7 +60,6 @@ pub use self::traits::ImageInner;
 pub use self::usage::ImageUsage;
 pub use self::view::ImageViewAbstract;
 use std::cmp;
-use std::convert::TryFrom;
 
 mod aspect;
 pub mod attachment; // TODO: make private

--- a/vulkano/src/instance/instance.rs
+++ b/vulkano/src/instance/instance.rs
@@ -22,7 +22,6 @@ use crate::Version;
 use crate::VulkanObject;
 use smallvec::SmallVec;
 use std::borrow::Cow;
-use std::convert::TryInto;
 use std::error;
 use std::ffi::CString;
 use std::fmt;

--- a/vulkano/src/pipeline/graphics/builder.rs
+++ b/vulkano/src/pipeline/graphics/builder.rs
@@ -147,13 +147,14 @@ where
         F: FnOnce(&mut [DescriptorSetDesc]),
     {
         let (descriptor_set_layout_descs, push_constant_ranges) = {
-            let stages: SmallVec<[&EntryPoint; 5]> = std::array::IntoIter::new([
+            let stages: SmallVec<[&EntryPoint; 5]> = [
                 self.vertex_shader.as_ref().map(|s| &s.0),
                 self.tessellation_shaders.as_ref().map(|s| &s.control.0),
                 self.tessellation_shaders.as_ref().map(|s| &s.evaluation.0),
                 self.geometry_shader.as_ref().map(|s| &s.0),
                 self.fragment_shader.as_ref().map(|s| &s.0),
-            ])
+            ]
+            .into_iter()
             .flatten()
             .collect();
 
@@ -410,7 +411,7 @@ where
             specialization_data: &'a [u8],
         }
 
-        let stages_info: SmallVec<[ShaderStageInfo; 5]> = std::array::IntoIter::new([
+        let stages_info: SmallVec<[ShaderStageInfo; 5]> = [
             self.vertex_shader
                 .as_ref()
                 .map(|(entry_point, spec_consts)| ShaderStageInfo {
@@ -477,7 +478,8 @@ where
                         )
                     },
                 }),
-        ])
+        ]
+        .into_iter()
         .flatten()
         .collect();
 

--- a/vulkano/src/pipeline/graphics/color_blend.rs
+++ b/vulkano/src/pipeline/graphics/color_blend.rs
@@ -185,12 +185,13 @@ impl ColorBlendState {
         for state in self.attachments.iter() {
             let blend = if let Some(blend) = &state.blend {
                 if !device.enabled_features().dual_src_blend
-                    && std::array::IntoIter::new([
+                    && [
                         blend.color_source,
                         blend.color_destination,
                         blend.alpha_source,
                         blend.alpha_destination,
-                    ])
+                    ]
+                    .into_iter()
                     .any(|blend_factor| {
                         matches!(
                             blend_factor,

--- a/vulkano/src/render_pass/macros.rs
+++ b/vulkano/src/render_pass/macros.rs
@@ -72,7 +72,7 @@ macro_rules! ordered_passes_renderpass {
             use $crate::image::ImageLayout;
             use $crate::sync::AccessFlags;
             use $crate::sync::PipelineStages;
-            use std::convert::TryInto;
+            use std::convert::TryFrom;
 
             let mut attachment_num = 0;
             $(
@@ -166,7 +166,7 @@ macro_rules! ordered_passes_renderpass {
 
                     AttachmentDesc {
                         format: $format,
-                        samples: $samples.try_into().unwrap(),
+                        samples: $crate::image::SampleCount::try_from($samples).unwrap(),
                         load: $crate::render_pass::LoadOp::$load,
                         store: $crate::render_pass::StoreOp::$store,
                         stencil_load: $crate::render_pass::LoadOp::$load,

--- a/vulkano/src/swapchain/capabilities.rs
+++ b/vulkano/src/swapchain/capabilities.rs
@@ -9,7 +9,6 @@
 
 use crate::format::Format;
 use crate::image::ImageUsage;
-use std::iter::FromIterator;
 
 /// The capabilities of a surface when used by a physical device.
 ///
@@ -158,12 +157,13 @@ impl SupportedPresentModes {
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = PresentMode> {
         let moved = *self;
-        std::array::IntoIter::new([
+        [
             PresentMode::Immediate,
             PresentMode::Mailbox,
             PresentMode::Fifo,
             PresentMode::Relaxed,
-        ])
+        ]
+        .into_iter()
         .filter(move |&mode| moved.supports(mode))
     }
 }
@@ -288,12 +288,13 @@ impl SupportedCompositeAlpha {
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = CompositeAlpha> {
         let moved = *self;
-        std::array::IntoIter::new([
+        [
             CompositeAlpha::Opaque,
             CompositeAlpha::PreMultiplied,
             CompositeAlpha::PostMultiplied,
             CompositeAlpha::Inherit,
-        ])
+        ]
+        .into_iter()
         .filter(move |&mode| moved.supports(mode))
     }
 }
@@ -418,7 +419,7 @@ impl SupportedSurfaceTransforms {
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = SurfaceTransform> {
         let moved = *self;
-        std::array::IntoIter::new([
+        [
             SurfaceTransform::Identity,
             SurfaceTransform::Rotate90,
             SurfaceTransform::Rotate180,
@@ -428,7 +429,8 @@ impl SupportedSurfaceTransforms {
             SurfaceTransform::HorizontalMirrorRotate180,
             SurfaceTransform::HorizontalMirrorRotate270,
             SurfaceTransform::Inherit,
-        ])
+        ]
+        .into_iter()
         .filter(move |&mode| moved.supports(mode))
     }
 }

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -137,7 +137,7 @@
 //! # use vulkano::device::Device;
 //! # use vulkano::swapchain::Surface;
 //! # use std::cmp::{max, min};
-//! # fn choose_caps(device: Arc<Device>, surface: Arc<Surface<()>>) -> Result<(), Box<std::error::Error>> {
+//! # fn choose_caps(device: Arc<Device>, surface: Arc<Surface<()>>) -> Result<(), Box<dyn std::error::Error>> {
 //! let caps = surface.capabilities(device.physical_device())?;
 //!
 //! // Use the current window size or some fixed resolution.

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -21,7 +21,6 @@ use crate::swapchain::SurfaceSwapchainLock;
 use crate::Error;
 use crate::OomError;
 use crate::VulkanObject;
-use std::convert::TryFrom;
 use std::error;
 use std::fmt;
 use std::mem::MaybeUninit;

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -71,7 +71,7 @@ pub enum FenceSignalFutureBehavior {
 /// use std::sync::Arc;
 /// use vulkano::sync::GpuFuture;
 ///
-/// # let future: Box<GpuFuture> = return;
+/// # let future: Box<dyn GpuFuture> = return;
 /// // Assuming you have a chain of operations, like this:
 /// // let future = ...
 /// //      .then_execute(foo)

--- a/vulkano/src/version.rs
+++ b/vulkano/src/version.rs
@@ -9,7 +9,6 @@
 
 // The `Version` object is reexported from the `instance` module.
 
-use std::convert::TryFrom;
 use std::fmt;
 
 /// Represents an API version of Vulkan.
@@ -89,7 +88,6 @@ impl fmt::Display for Version {
 #[cfg(test)]
 mod tests {
     use super::Version;
-    use std::convert::TryFrom;
 
     #[test]
     fn into_vk_version() {


### PR DESCRIPTION
```markdown
- **Breaking** Updated to half 1.8, smallvec 1.7, winit 0.26, raw-window-handle 0.4.
```

```markdown
- Upgraded to Rust 2021.
```

Rust 2021 is a much smaller change than 2018 was, but it's still nice to have, especially for the ability to call `into_iter` on arrays properly now. This does mean that Vulkano 0.28 will require Rust 1.56 to compile. Because of how editions work, Vulkano can still be included in *other* projects using the 2018 or 2015 editions, compatibility is not broken.