### PR TITLE
Always generate shader requirements for the exact entrypoint interface

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -210,7 +210,6 @@ pub(super) fn reflect<'a, I>(
     words: &[u32],
     types_meta: &TypesMeta,
     input_paths: I,
-    exact_entrypoint_interface: bool,
     shared_constants: bool,
     types_registry: &'a mut HashMap<String, RegisteredType>,
 ) -> Result<(TokenStream, TokenStream), Error>
@@ -244,7 +243,7 @@ where
         quote! { &Capability::#name }
     });
     let spirv_extensions = reflect::spirv_extensions(&spirv);
-    let entry_points = reflect::entry_points(&spirv, exact_entrypoint_interface)
+    let entry_points = reflect::entry_points(&spirv)
         .map(|(name, model, info)| entry_point::write_entry_point(&name, model, &info));
 
     let specialization_constants = structs::write_specialization_constants(
@@ -711,7 +710,7 @@ mod tests {
         let spirv = Spirv::new(&instructions).unwrap();
 
         let mut descriptors = Vec::new();
-        for (_, _, info) in reflect::entry_points(&spirv, true) {
+        for (_, _, info) in reflect::entry_points(&spirv) {
             descriptors.push(info.descriptor_requirements);
         }
 
@@ -782,7 +781,7 @@ mod tests {
         .unwrap();
         let spirv = Spirv::new(comp.as_binary()).unwrap();
 
-        for (_, _, info) in reflect::entry_points(&spirv, true) {
+        for (_, _, info) in reflect::entry_points(&spirv) {
             let mut bindings = Vec::new();
             for (loc, _reqs) in info.descriptor_requirements {
                 bindings.push(loc);

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -356,7 +356,6 @@ impl RegisteredType {
 
 struct MacroInput {
     dump: bool,
-    exact_entrypoint_interface: bool,
     include_directories: Vec<String>,
     macro_defines: Vec<(String, String)>,
     shared_constants: bool,
@@ -762,7 +761,6 @@ impl Parse for MacroInput {
 
         Ok(Self {
             dump: dump.unwrap_or(false),
-            exact_entrypoint_interface: exact_entrypoint_interface.unwrap_or(false),
             include_directories,
             macro_defines,
             shared_constants: shared_constants.unwrap_or(false),
@@ -818,7 +816,6 @@ pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 unsafe { from_raw_parts(bytes.as_slice().as_ptr() as *const u32, bytes.len() / 4) },
                 &input.types_meta,
                 empty(),
-                input.exact_entrypoint_interface,
                 input.shared_constants,
                 &mut types_registry,
             )
@@ -884,7 +881,6 @@ pub fn shader(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 content.as_binary(),
                 &input.types_meta,
                 input_paths,
-                input.exact_entrypoint_interface,
                 input.shared_constants,
                 &mut types_registry,
             )

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -80,7 +80,7 @@ impl ShaderModule {
             spirv.version(),
             reflect::spirv_capabilities(&spirv),
             reflect::spirv_extensions(&spirv),
-            reflect::entry_points(&spirv, false),
+            reflect::entry_points(&spirv),
         )
     }
 
@@ -170,14 +170,18 @@ impl ShaderModule {
             .collect::<HashSet<_>>()
             .iter()
             .map(|name| {
-                ((*name).clone(),
-                    entries.iter().filter_map(|(entry_name, entry_model, info)| {
-                        if &entry_name == name {
-                            Some((*entry_model, info.clone()))
-                        } else {
-                            None
-                        }
-                    }).collect::<HashMap<_, _>>()
+                (
+                    (*name).clone(),
+                    entries
+                        .iter()
+                        .filter_map(|(entry_name, entry_model, info)| {
+                            if &entry_name == name {
+                                Some((*entry_model, info.clone()))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<HashMap<_, _>>(),
                 )
             })
             .collect();
@@ -235,7 +239,11 @@ impl ShaderModule {
 
     /// Returns information about the entry point with the provided name and execution model. Returns
     /// `None` if no entry and execution model exists in the shader module.
-    pub fn entry_point_with_execution<'a>(&'a self, name: &str, execution: ExecutionModel) -> Option<EntryPoint<'a>> {
+    pub fn entry_point_with_execution<'a>(
+        &'a self,
+        name: &str,
+        execution: ExecutionModel,
+    ) -> Option<EntryPoint<'a>> {
         self.entry_points.get(name).and_then(|infos| {
             infos.get(&execution).map(|info| EntryPoint {
                 module: self,


### PR DESCRIPTION
```markdown
- **Breaking** Shader reflection now always generates only the descriptor requirements needed for each given entry point, instead of for all of them. The `exact_entrypoint_interface` argument to the `shader!` macro is removed.
```

@Arc-blroth This effectively undoes #1559. This could be controversial, and I realise I was in favour of the original change back in April, but I have a few reasons for making this change:
1. Since #1729 and #1744, the information that is gathered from shaders is only what is *required* as a minimum by the shader. It no longer generates a full-blown descriptor set layout like it did before. In this light, I think it makes more sense that the requirements reflect the entry point chosen by the user, instead of every possible entry point.
2. As noted at https://github.com/vulkano-rs/vulkano/issues/1556#issuecomment-821658405, different entry points can have conflicting requirements. For example, one entry point could want a buffer on binding 0, another could have a texture on the same binding.
3. I want to improve checking whether a storage descriptor is mutable or not, by analysing whether a given entry point performs any write operations on it. This is what the official validation layer does, and it would remove the need for users to put `readonly` in their shaders. This check makes more sense on a per-entrypoint basis.
4. I would like to do more validation on shader requirements than currently, with additional fields on `DescriptorRequirements`. The official validation layer checks for atomic operations on images, which require `VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT`. It also makes a list of which images are used with which samplers, which is needed for checking if the image and sampler are compatible. This is needed for supporting the `VK_KHR_sampler_ycbcr_conversion` extension, which I'd like to implement at some point. This extra validation only makes sense on a per-entrypoint basis too.

Both `ComputePipeline` and `GraphicsPipelineBuilder` have ways to construct a pipeline with a user-provided pipeline layout, so the user already has the ability to make a layout with more sets and bindings than the minimum needed by the shader entry point. When using raw Vulkan, this is what the user would always have to do; the ability to create a minimal layout automatically based on the requirements of the shader is purely a convenience to the user.

There is, in fact, an advantage to creating an explicit pipeline layout that is compatible with multiple shaders: it allows descriptor sets to remain bound when switching between pipelines, as long as the shaders have compatible interfaces. So this may be something Vulkano should actually encourage the user to do (in documentation), and make it more explicit that creating a new layout based on the minimum requirements is only a convenience that's useful for certain situations, not generally.