### PR TITLE
Added command `clear_attachment`

### DIFF
--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -242,7 +242,7 @@ fn main() {
                         },
                         // Relative offset and extent
                         ClearRect {
-                            rect_offset: [width as i32 / 2, height as i32 / 2],
+                            rect_offset: [width / 2, height / 2],
                             rect_extent: [width / 3, height / 5],
                             base_array_layer: 0,
                             layer_count: 1,

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -1,0 +1,300 @@
+// Copyright (c) 2016 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::sync::Arc;
+use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage, SubpassContents};
+use vulkano::device::physical::{PhysicalDevice, PhysicalDeviceType};
+use vulkano::device::{Device, DeviceExtensions, Features};
+use vulkano::format::ClearValue;
+use vulkano::image::attachment::{ClearAttachment, ClearRect};
+use vulkano::image::{view::ImageView, ImageUsage, SwapchainImage};
+use vulkano::instance::Instance;
+use vulkano::pipeline::graphics::viewport::ViewportState;
+use vulkano::pipeline::GraphicsPipeline;
+use vulkano::render_pass::{Framebuffer, RenderPass, Subpass};
+use vulkano::swapchain::{self, AcquireError, Swapchain, SwapchainCreationError};
+use vulkano::sync::{self, FlushError, GpuFuture};
+use vulkano::Version;
+use vulkano_win::VkSurfaceBuild;
+use winit::event::{Event, WindowEvent};
+use winit::event_loop::{ControlFlow, EventLoop};
+use winit::window::{Window, WindowBuilder};
+
+fn main() {
+    // The start of this example is exactly the same as `triangle`. You should read the
+    // `triangle` example if you haven't done so yet.
+
+    let required_extensions = vulkano_win::required_extensions();
+    let instance = Instance::new(None, Version::V1_1, &required_extensions, None).unwrap();
+
+    let event_loop = EventLoop::new();
+    let surface = WindowBuilder::new()
+        .build_vk_surface(&event_loop, instance.clone())
+        .unwrap();
+
+    let device_extensions = DeviceExtensions {
+        khr_swapchain: true,
+        ..DeviceExtensions::none()
+    };
+    let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
+        .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
+        .filter_map(|p| {
+            p.queue_families()
+                .find(|&q| q.supports_graphics() && surface.is_supported(q).unwrap_or(false))
+                .map(|q| (p, q))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        })
+        .unwrap();
+
+    println!(
+        "Using device: {} (type: {:?})",
+        physical_device.properties().device_name,
+        physical_device.properties().device_type,
+    );
+
+    let (device, mut queues) = Device::new(
+        physical_device,
+        &Features::none(),
+        &physical_device
+            .required_extensions()
+            .union(&device_extensions),
+        [(queue_family, 0.5)].iter().cloned(),
+    )
+    .unwrap();
+    let queue = queues.next().unwrap();
+
+    let (mut swapchain, images) = {
+        let caps = surface.capabilities(physical_device).unwrap();
+        let composite_alpha = caps.supported_composite_alpha.iter().next().unwrap();
+        let format = caps.supported_formats[0].0;
+        let dimensions: [u32; 2] = surface.window().inner_size().into();
+
+        Swapchain::start(device.clone(), surface.clone())
+            .num_images(caps.min_image_count)
+            .format(format)
+            .dimensions(dimensions)
+            .usage(ImageUsage::color_attachment())
+            .sharing_mode(&queue)
+            .composite_alpha(composite_alpha)
+            .build()
+            .unwrap()
+    };
+
+    mod vs {
+        vulkano_shaders::shader! {
+            ty: "vertex",
+            src: "
+    			#version 450
+
+
+    			void main() {
+    			}
+    		"
+        }
+    }
+
+    mod fs {
+        vulkano_shaders::shader! {
+            ty: "fragment",
+            src: "
+    			#version 450
+
+    			layout(location = 0) out vec4 f_color;
+
+    			void main() {
+    				f_color = vec4(1.0, 0.0, 0.0, 1.0);
+    			}
+    		"
+        }
+    }
+
+    let vs = vs::load(device.clone()).unwrap();
+    let fs = fs::load(device.clone()).unwrap();
+
+    let render_pass = vulkano::single_pass_renderpass!(device.clone(),
+        attachments: {
+            color: {
+                load: Clear,
+                store: Store,
+                format: swapchain.format(),
+                samples: 1,
+            }
+        },
+        pass: {
+            color: [color],
+            depth_stencil: {}
+        }
+    )
+    .unwrap();
+
+    let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
+    let pipeline = GraphicsPipeline::start()
+        .vertex_shader(vs.entry_point("main").unwrap(), ())
+        .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
+        .fragment_shader(fs.entry_point("main").unwrap(), ())
+        .render_pass(subpass)
+        .build(device.clone())
+        .unwrap();
+
+    let mut width = swapchain.dimensions()[0];
+    let mut height = swapchain.dimensions()[1];
+    let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone());
+
+    let mut recreate_swapchain = false;
+    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
+
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        } => {
+            *control_flow = ControlFlow::Exit;
+        }
+        Event::WindowEvent {
+            event: WindowEvent::Resized(_),
+            ..
+        } => {
+            recreate_swapchain = true;
+        }
+        Event::RedrawEventsCleared => {
+            previous_frame_end.as_mut().unwrap().cleanup_finished();
+
+            if recreate_swapchain {
+                let dimensions: [u32; 2] = surface.window().inner_size().into();
+                width = dimensions[0];
+                height = dimensions[1];
+                let (new_swapchain, new_images) =
+                    match swapchain.recreate().dimensions(dimensions).build() {
+                        Ok(r) => r,
+                        Err(SwapchainCreationError::UnsupportedDimensions) => return,
+                        Err(e) => panic!("Failed to recreate swapchain: {:?}", e),
+                    };
+
+                swapchain = new_swapchain;
+                framebuffers = window_size_dependent_setup(&new_images, render_pass.clone());
+                recreate_swapchain = false;
+            }
+
+            let (image_num, suboptimal, acquire_future) =
+                match swapchain::acquire_next_image(swapchain.clone(), None) {
+                    Ok(r) => r,
+                    Err(AcquireError::OutOfDate) => {
+                        recreate_swapchain = true;
+                        return;
+                    }
+                    Err(e) => panic!("Failed to acquire next image: {:?}", e),
+                };
+
+            if suboptimal {
+                recreate_swapchain = true;
+            }
+
+            let clear_values = vec![[0.0, 0.0, 1.0, 1.0].into()];
+            let mut builder = AutoCommandBufferBuilder::primary(
+                device.clone(),
+                queue.family(),
+                CommandBufferUsage::OneTimeSubmit,
+            )
+            .unwrap();
+            builder
+                .begin_render_pass(
+                    framebuffers[image_num].clone(),
+                    SubpassContents::Inline,
+                    clear_values,
+                )
+                .unwrap()
+                .bind_pipeline_graphics(pipeline.clone())
+                // Clear attachments with clear values and rects information, all the rects will be cleared by the same value
+                // Note that the ClearRect offsets and extents are not affected by the viewport,
+                // they are directly applied to the rendering image
+                .clear_attachments(
+                    [ClearAttachment::Color(
+                        ClearValue::Float([1.0, 0.0, 0.0, 1.0]),
+                        0,
+                    )],
+                    [
+                        // Fixed offset and extent
+                        ClearRect {
+                            rect_offset: [0, 0],
+                            rect_extent: [100, 100],
+                            base_array_layer: 0,
+                            layer_count: 1,
+                        },
+                        // Fixed offset
+                        // Relative extent
+                        ClearRect {
+                            rect_offset: [100, 150],
+                            rect_extent: [width / 4, height / 4],
+                            base_array_layer: 0,
+                            layer_count: 1,
+                        },
+                        // Relative offset and extent
+                        ClearRect {
+                            rect_offset: [width as i32 / 2, height as i32 / 2],
+                            rect_extent: [width / 3, height / 5],
+                            base_array_layer: 0,
+                            layer_count: 1,
+                        },
+                    ],
+                )
+                .unwrap()
+                .end_render_pass()
+                .unwrap();
+            let command_buffer = builder.build().unwrap();
+
+            let future = previous_frame_end
+                .take()
+                .unwrap()
+                .join(acquire_future)
+                .then_execute(queue.clone(), command_buffer)
+                .unwrap()
+                .then_swapchain_present(queue.clone(), swapchain.clone(), image_num)
+                .then_signal_fence_and_flush();
+
+            match future {
+                Ok(future) => {
+                    previous_frame_end = Some(future.boxed());
+                }
+                Err(FlushError::OutOfDate) => {
+                    recreate_swapchain = true;
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
+                }
+                Err(e) => {
+                    println!("Failed to flush future: {:?}", e);
+                    previous_frame_end = Some(sync::now(device.clone()).boxed());
+                }
+            }
+        }
+        _ => (),
+    });
+}
+
+/// This method is called once during initialization, then again whenever the window is resized
+fn window_size_dependent_setup(
+    images: &[Arc<SwapchainImage<Window>>],
+    render_pass: Arc<RenderPass>,
+) -> Vec<Arc<Framebuffer>> {
+    images
+        .iter()
+        .map(|image| {
+            let view = ImageView::new(image.clone()).unwrap();
+            Framebuffer::start(render_pass.clone())
+                .add(view)
+                .unwrap()
+                .build()
+                .unwrap()
+        })
+        .collect::<Vec<_>>()
+}

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -46,6 +46,8 @@ use crate::device::Queue;
 use crate::format::ClearValue;
 use crate::format::NumericType;
 use crate::format::Pixel;
+use crate::image::attachment::ClearAttachment;
+use crate::image::attachment::ClearRect;
 use crate::image::ImageAccess;
 use crate::image::ImageAspect;
 use crate::image::ImageAspects;
@@ -133,6 +135,8 @@ pub struct AutoCommandBufferBuilder<L, P = StandardCommandPoolBuilder> {
 struct RenderPassState {
     subpass: Subpass,
     contents: SubpassContents,
+    attached_layers_ranges: SmallVec<[Range<u32>; 4]>,
+    dimensions: [u32; 3],
     framebuffer: ash::vk::Framebuffer, // Always null for secondary command buffers
 }
 
@@ -293,6 +297,14 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
                      }| RenderPassState {
                         subpass: subpass.clone(),
                         contents: SubpassContents::Inline,
+                        dimensions: framebuffer
+                            .as_ref()
+                            .map(|f| f.dimensions())
+                            .unwrap_or_default(),
+                        attached_layers_ranges: framebuffer
+                            .as_ref()
+                            .map(|f| f.attached_layers_ranges())
+                            .unwrap_or_default(),
                         framebuffer: ash::vk::Framebuffer::null(), // Only needed for primary command buffers
                     },
                 );
@@ -879,6 +891,92 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             )?;
             Ok(self)
         }
+    }
+
+    /// Adds a command that clears specific regions of specific attachments of the framebuffer.
+    ///
+    /// `attachments` specify the types of attachments and their clear values.
+    /// `rects` specify the regions to clear.
+    ///
+    /// A graphics pipeline must have been bound using
+    /// [`bind_pipeline_graphics`](Self::bind_pipeline_graphics). And the command must be inside render pass.
+    ///
+    /// If the render pass instance this is recorded in uses multiview,
+    /// then `ClearRect.base_array_layer` must be zero and `ClearRect.layer_count` must be one
+    pub fn clear_attachments<A, R>(
+        &mut self,
+        attachments: A,
+        rects: R,
+    ) -> Result<&mut Self, ClearAttachmentsError>
+    where
+        A: IntoIterator<Item = ClearAttachment>,
+        R: IntoIterator<Item = ClearRect>,
+    {
+        let pipeline = check_pipeline_graphics(self.state())?;
+        self.ensure_inside_render_pass_inline(pipeline)?;
+
+        let render_pass_state = self.render_pass_state.as_ref().unwrap();
+        let subpass = &render_pass_state.subpass;
+        let multiview = subpass.render_pass().desc().multiview().is_some();
+        let has_depth_stencil_attachment = subpass.has_depth_stencil_attachment();
+        let num_color_attachments = subpass.num_color_attachments();
+        let dimensions = render_pass_state.dimensions;
+        let attached_layers_ranges = &render_pass_state.attached_layers_ranges;
+
+        let attachments: SmallVec<[ClearAttachment; 3]> = attachments.into_iter().collect();
+        let rects: SmallVec<[ClearRect; 4]> = rects.into_iter().collect();
+
+        for attachment in &attachments {
+            match attachment {
+                ClearAttachment::Color(_, color_attachment) => {
+                    if *color_attachment >= num_color_attachments as u32 {
+                        return Err(ClearAttachmentsError::InvalidColorAttachmentIndex(
+                            *color_attachment,
+                        ));
+                    }
+                }
+                ClearAttachment::Depth(_)
+                | ClearAttachment::Stencil(_)
+                | ClearAttachment::DepthStencil(_) => {
+                    if !has_depth_stencil_attachment {
+                        return Err(ClearAttachmentsError::DepthStencilAttachmentNotPresent);
+                    }
+                }
+            }
+        }
+
+        for rect in &rects {
+            if rect.rect_extent[0] == 0 || rect.rect_extent[1] == 0 {
+                return Err(ClearAttachmentsError::ZeroRectExtent);
+            }
+            if rect.layer_count == 0 {
+                return Err(ClearAttachmentsError::ZeroLayerCount);
+            }
+            if multiview && (rect.base_array_layer != 0 || rect.layer_count != 1) {
+                return Err(ClearAttachmentsError::InvalidMultiviewLayerRange);
+            }
+            // TODO: handle checking `rect.rect_offset` (the start of the rect)
+            if rect.rect_offset[0] + rect.rect_extent[0] as i32 > dimensions[0] as i32
+                || rect.rect_offset[1] + rect.rect_extent[1] as i32 > dimensions[1] as i32
+            {
+                return Err(ClearAttachmentsError::RectOutOfBounds);
+            }
+
+            // make sure rect's layers is inside attached layers ranges
+            for range in attached_layers_ranges {
+                if rect.base_array_layer < range.start
+                    || rect.base_array_layer + rect.layer_count > range.end
+                {
+                    return Err(ClearAttachmentsError::LayersOutOfBounds);
+                }
+            }
+        }
+
+        unsafe {
+            self.inner.clear_attachments(attachments, rects);
+        }
+
+        Ok(self)
     }
 
     /// Adds a command that clears all the layers and mipmap levels of a color image with a
@@ -3194,6 +3292,8 @@ where
                 .begin_render_pass(framebuffer.clone(), contents, clear_values)?;
             self.render_pass_state = Some(RenderPassState {
                 subpass: framebuffer.render_pass().clone().first_subpass(),
+                dimensions: framebuffer.dimensions(),
+                attached_layers_ranges: framebuffer.attached_layers_ranges(),
                 contents,
                 framebuffer: framebuffer_object,
             });
@@ -3870,6 +3970,80 @@ err_gen!(UpdateBufferError {
     AutoCommandBufferBuilderContextError,
     CheckUpdateBufferError,
 });
+
+/// Errors that can happen when calling [`clear_attachments`](AutoCommandBufferBuilder::clear_attachments)
+#[derive(Debug, Copy, Clone)]
+pub enum ClearAttachmentsError {
+    /// AutoCommandBufferBuilderContextError
+    AutoCommandBufferBuilderContextError(AutoCommandBufferBuilderContextError),
+    /// CheckPipelineError
+    CheckPipelineError(CheckPipelineError),
+
+    /// The index of the color attachment is not present
+    InvalidColorAttachmentIndex(u32),
+    /// There is no depth/stencil attachment present
+    DepthStencilAttachmentNotPresent,
+    /// The clear rect cannot have extent of `0`
+    ZeroRectExtent,
+    /// The layer count cannot be `0`
+    ZeroLayerCount,
+    /// The clear rect region must be inside the render area of the render pass
+    RectOutOfBounds,
+    /// The clear rect's layers must be inside the layers ranges for all the attachments
+    LayersOutOfBounds,
+    /// If the render pass instance this is recorded in uses multiview,
+    /// then `ClearRect.base_array_layer` must be zero and `ClearRect.layer_count` must be one
+    InvalidMultiviewLayerRange,
+}
+
+impl error::Error for ClearAttachmentsError {}
+
+impl fmt::Display for ClearAttachmentsError {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ClearAttachmentsError::AutoCommandBufferBuilderContextError(e) => write!(fmt, "{}", e)?,
+            ClearAttachmentsError::CheckPipelineError(e) => write!(fmt, "{}", e)?,
+            ClearAttachmentsError::InvalidColorAttachmentIndex(index) => {
+                write!(fmt, "Color attachment {} is not present", index)?
+            }
+            ClearAttachmentsError::DepthStencilAttachmentNotPresent => {
+                write!(fmt, "There is no depth/stencil attachment present")?
+            }
+            ClearAttachmentsError::ZeroRectExtent => {
+                write!(fmt, "The clear rect cannot have extent of 0")?
+            }
+            ClearAttachmentsError::ZeroLayerCount => write!(fmt, "The layer count cannot be 0")?,
+            ClearAttachmentsError::RectOutOfBounds => write!(
+                fmt,
+                "The clear rect region must be inside the render area of the render pass"
+            )?,
+            ClearAttachmentsError::LayersOutOfBounds => write!(
+                fmt,
+                "The clear rect's layers must be inside the layers ranges for all the attachments"
+            )?,
+            ClearAttachmentsError::InvalidMultiviewLayerRange => write!(
+                fmt,
+                "If the render pass instance this is recorded in uses multiview, then `ClearRect.base_array_layer` must be zero and `ClearRect.layer_count` must be one" 
+            )?,
+        }
+        Ok(())
+    }
+}
+
+impl From<AutoCommandBufferBuilderContextError> for ClearAttachmentsError {
+    #[inline]
+    fn from(err: AutoCommandBufferBuilderContextError) -> ClearAttachmentsError {
+        ClearAttachmentsError::AutoCommandBufferBuilderContextError(err)
+    }
+}
+
+impl From<CheckPipelineError> for ClearAttachmentsError {
+    #[inline]
+    fn from(err: CheckPipelineError) -> ClearAttachmentsError {
+        ClearAttachmentsError::CheckPipelineError(err)
+    }
+}
 
 #[derive(Debug, Copy, Clone)]
 pub enum AutoCommandBufferBuilderContextError {

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -709,8 +709,8 @@ impl UnsafeCommandBufferBuilder {
                 Some(ash::vk::ClearRect {
                     rect: ash::vk::Rect2D {
                         offset: ash::vk::Offset2D {
-                            x: rect.rect_offset[0],
-                            y: rect.rect_offset[1],
+                            x: rect.rect_offset[0] as i32,
+                            y: rect.rect_offset[1] as i32,
                         },
                         extent: ash::vk::Extent2D {
                             width: rect.rect_extent[0],

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -24,6 +24,8 @@ use crate::device::Device;
 use crate::device::DeviceOwned;
 use crate::format::ClearValue;
 use crate::format::NumericType;
+use crate::image::attachment::ClearAttachment;
+use crate::image::attachment::ClearRect;
 use crate::image::ImageAccess;
 use crate::image::ImageAspect;
 use crate::image::ImageAspects;
@@ -686,18 +688,40 @@ impl UnsafeCommandBufferBuilder {
         );
     }
 
-    // TODO: missing structs
-    /*/// Calls `vkCmdClearAttachments` on the builder.
+    /// Calls `vkCmdClearAttachments` on the builder.
     ///
     /// Does nothing if the list of attachments or the list of rects is empty, as it would be a
     /// no-op and isn't a valid usage of the command anyway.
     #[inline]
     pub unsafe fn clear_attachments<A, R>(&mut self, attachments: A, rects: R)
-        where A: IntoIterator<Item = >,
-              R: IntoIterator<Item = >
+    where
+        A: IntoIterator<Item = ClearAttachment>,
+        R: IntoIterator<Item = ClearRect>,
     {
-        let attachments: SmallVec<[_; 16]> = attachments.map().collect();
-        let rects: SmallVec<[_; 4]> = rects.map().collect();
+        let attachments: SmallVec<[_; 3]> = attachments.into_iter().map(|v| v.into()).collect();
+        let rects: SmallVec<[_; 4]> = rects
+            .into_iter()
+            .filter_map(|rect| {
+                if rect.layer_count == 0 {
+                    return None;
+                }
+
+                Some(ash::vk::ClearRect {
+                    rect: ash::vk::Rect2D {
+                        offset: ash::vk::Offset2D {
+                            x: rect.rect_offset[0],
+                            y: rect.rect_offset[1],
+                        },
+                        extent: ash::vk::Extent2D {
+                            width: rect.rect_extent[0],
+                            height: rect.rect_extent[1],
+                        },
+                    },
+                    base_array_layer: rect.base_array_layer,
+                    layer_count: rect.layer_count,
+                })
+            })
+            .collect();
 
         if attachments.is_empty() || rects.is_empty() {
             return;
@@ -705,9 +729,14 @@ impl UnsafeCommandBufferBuilder {
 
         let fns = self.device().fns();
         let cmd = self.internal_object();
-        fns.v1_0.CmdClearAttachments(cmd, attachments.len() as u32, attachments.as_ptr(),
-                               rects.len() as u32, rects.as_ptr());
-    }*/
+        fns.v1_0.cmd_clear_attachments(
+            cmd,
+            attachments.len() as u32,
+            attachments.as_ptr(),
+            rects.len() as u32,
+            rects.as_ptr(),
+        );
+    }
 
     /// Calls `vkCmdClearColorImage` on the builder.
     ///

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -841,7 +841,7 @@ impl From<ClearAttachment> for ash::vk::ClearAttachment {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClearRect {
     /// The rectangle offset.
-    pub rect_offset: [i32; 2],
+    pub rect_offset: [u32; 2],
     /// The width and height of the rectangle.
     pub rect_extent: [u32; 2],
     /// The first layer to be cleared.

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -782,6 +782,74 @@ where
     }
 }
 
+/// Clear attachment type, used in [`clear_attachments`](crate::command_buffer::AutoCommandBufferBuilder::clear_attachments) command.
+pub enum ClearAttachment {
+    /// Clear the color attachment at the specified index, with the specified clear value.
+    Color(ClearValue, u32),
+    /// Clear the depth attachment with the speficied depth value.
+    Depth(f32),
+    /// Clear the stencil attachment with the speficied stencil value.
+    Stencil(u32),
+    /// Clear the depth and stencil attachments with the speficied depth and stencil values.
+    DepthStencil((f32, u32)),
+}
+
+impl From<ClearAttachment> for ash::vk::ClearAttachment {
+    fn from(v: ClearAttachment) -> Self {
+        match v {
+            ClearAttachment::Color(clear_value, color_attachment) => ash::vk::ClearAttachment {
+                aspect_mask: ash::vk::ImageAspectFlags::COLOR,
+                color_attachment,
+                clear_value: ash::vk::ClearValue {
+                    color: match clear_value {
+                        ClearValue::Float(val) => ash::vk::ClearColorValue { float32: val },
+                        ClearValue::Int(val) => ash::vk::ClearColorValue { int32: val },
+                        ClearValue::Uint(val) => ash::vk::ClearColorValue { uint32: val },
+                        _ => ash::vk::ClearColorValue { float32: [0.0; 4] },
+                    },
+                },
+            },
+            ClearAttachment::Depth(depth) => ash::vk::ClearAttachment {
+                aspect_mask: ash::vk::ImageAspectFlags::DEPTH,
+                color_attachment: 0,
+                clear_value: ash::vk::ClearValue {
+                    depth_stencil: ash::vk::ClearDepthStencilValue { depth, stencil: 0 },
+                },
+            },
+            ClearAttachment::Stencil(stencil) => ash::vk::ClearAttachment {
+                aspect_mask: ash::vk::ImageAspectFlags::STENCIL,
+                color_attachment: 0,
+                clear_value: ash::vk::ClearValue {
+                    depth_stencil: ash::vk::ClearDepthStencilValue {
+                        depth: 0.0,
+                        stencil,
+                    },
+                },
+            },
+            ClearAttachment::DepthStencil((depth, stencil)) => ash::vk::ClearAttachment {
+                aspect_mask: ash::vk::ImageAspectFlags::DEPTH | ash::vk::ImageAspectFlags::STENCIL,
+                color_attachment: 0,
+                clear_value: ash::vk::ClearValue {
+                    depth_stencil: ash::vk::ClearDepthStencilValue { depth, stencil },
+                },
+            },
+        }
+    }
+}
+
+/// Specifies the clear region for the [`clear_attachments`](crate::command_buffer::AutoCommandBufferBuilder::clear_attachments) command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClearRect {
+    /// The rectangle offset.
+    pub rect_offset: [i32; 2],
+    /// The width and height of the rectangle.
+    pub rect_extent: [u32; 2],
+    /// The first layer to be cleared.
+    pub base_array_layer: u32,
+    /// The number of layers to be cleared.
+    pub layer_count: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::AttachmentImage;

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -22,6 +22,7 @@ use std::cmp;
 use std::error;
 use std::fmt;
 use std::mem::MaybeUninit;
+use std::ops::Range;
 use std::ptr;
 use std::sync::Arc;
 
@@ -154,6 +155,15 @@ impl Framebuffer {
     #[inline]
     pub fn attached_image_view(&self, index: usize) -> Option<&Arc<dyn ImageViewAbstract>> {
         self.resources.get(index)
+    }
+
+    /// Returns the layer ranges for all attachments.
+    #[inline]
+    pub fn attached_layers_ranges(&self) -> SmallVec<[Range<u32>; 4]> {
+        self.resources
+            .iter()
+            .map(|img| img.array_layers())
+            .collect()
     }
 }
 

--- a/vulkano/src/render_pass/render_pass.rs
+++ b/vulkano/src/render_pass/render_pass.rs
@@ -773,6 +773,16 @@ impl Subpass {
         self.attachment_desc(atch_num).format.aspects().stencil
     }
 
+    /// Returns true if the subpass has any depth/stencil attachment.
+    #[inline]
+    pub fn has_depth_stencil_attachment(&self) -> bool {
+        let subpass_desc = self.subpass_desc();
+        match subpass_desc.depth_stencil {
+            Some((d, _)) => true,
+            None => false,
+        }
+    }
+
     /// Returns true if the subpass has any color or depth/stencil attachment.
     #[inline]
     pub fn has_color_or_depth_stencil_attachment(&self) -> bool {


### PR DESCRIPTION
fixes #1749

This command implements `vkClearAttachments`, most checks are done
except for:
- Handling attachments with `VK_ATTACHMENT_UNUSED`, `vulkano` doesn't
  support unused attachments for now.
- command buffer protection and protectedNoFault, which `vulkano` is not
  supporting now.

1. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

2. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   files(`CHANGELOG_VULKANO.md` and `CHANGELOG_VK_SYS.md`)
   by maintainers right after the Pull Request merge.

    * Entries for Vulkano changelog:
       -  Added `ClearRect` struct, which contains the region information to be cleared
       - Added `ClearAttachment` enum, which will contain the `ClearValue` and type of attachment
       - Implemented `AutoCommandBufferBuilder::clear_attachments`, which implements all possible checks from the vulkan standards to make it safe.
       - Implemented `SyncCommandBufferBuilder::clear_attachments` and `UnsafeCommandBufferBuilder::clear_attachments`.

    * Entries for VkSys changelog:
       - Implemented `clear_attachments` command

3. [x] Run `cargo fmt` on the changes.

4. [x] Make sure that the changes are covered by unit-tests.
    Not sure how to test this, `draw` is not tested as well, suggestions are welcome on the procedure of testing these kind of functions.

5. [x] Update documentation to reflect any user-facing changes - in this repository.
