### PR TITLE
Fix undefined behaviour on external semaphore & image creation; Fix wrong device chosen on hybrid graphics

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,4 +24,4 @@ serde = { version = "1.0", features = ["derive"] }
 ron = "0.7"
 rand = "0.8.4"
 
-glium = { git = "https://github.com/glium/glium.git" }
+glium = { git = "https://github.com/glium/glium.git", rev = "60889a2" }


### PR DESCRIPTION
Currently, whenever an exportable image or semaphore are created, the p_next structure used to specify the exportable handle types falls out of scope prematurely, which means segmentation faults can occur in certain situations, most likely when the stack memory is overwritten or is invalidated. 

In order to fix this, I've not only made sure to define these p_next structures in the appropriate scope, but I've also changed the implementations to use ash builders. This way, this issue would have been impossible to begin with, and two unsafe calls are removed.

@pwaller Please confirm this fixes the issues you encountered.

Using new functionality recently added in https://github.com/glium/glium/pull/1977, there is now UUID checking in the gl-interop example during physical device creation. This is useful since previously, if a computer had more than one graphics card or drivers, it was possible for Vulkan to choose a different device and/or driver than the GL context it is sharing resources with. This would result in undefined behaviour.

    * Entries for Vulkano changelog:
        - Fix undefined behaviour on external semaphore creation
        - Fix undefined behaviour on external image creation
        - Add uuid checking to gl-interop example
