### PR TITLE
Fixed failing `basic_conflict` test and added replacement for it

### DIFF
--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -520,29 +520,6 @@ mod tests {
     }
 
     #[test]
-    fn basic_conflict() {
-        unsafe {
-            let (device, queue) = gfx_dev_and_queue!();
-
-            let pool = Device::standard_command_pool(&device, queue.family());
-            let pool_builder_alloc = pool.alloc(false, 1).unwrap().next().unwrap();
-            let mut sync = SyncCommandBufferBuilder::new(
-                &pool_builder_alloc.inner(),
-                CommandBufferLevel::primary(),
-                CommandBufferUsage::MultipleSubmit,
-            )
-            .unwrap();
-            let buf =
-                CpuAccessibleBuffer::from_data(device, BufferUsage::all(), false, 0u32).unwrap();
-
-            assert!(matches!(
-                sync.copy_buffer(buf.clone(), buf.clone(), std::iter::once((0, 0, 4))),
-                Err(SyncCommandBufferBuilderError::Conflict { .. })
-            ));
-        }
-    }
-
-    #[test]
     fn secondary_conflicting_writes() {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();


### PR DESCRIPTION
Fixes #1789

When we implemented self_copy for images and buffers (#1782),
`basic_conflict` test failed. So we removed it and added tests for
`overlapping` and `non_overlapping` ranges checks when using buffer self
copy.

* Entries for Vulkano changelog (not sure if tests are added in changelogs):
    - Added `buffer_self_copy_overlapping` and `buffer_self_copy_not_overlapping` as unit tests for self_copy feature (#1782).
    - Removed test `basic_conflict` (failed after #1782).