### PR TITLE
Implement VertexMember for nalgebra Vectors and Points

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -21,6 +21,7 @@ crossbeam-queue = "0.3"
 fnv = "1.0"
 half = "1.8"
 lazy_static = "1.4"
+nalgebra = { version = "0.30.0", optional = true }
 parking_lot = { version = "0.11", features = ["send_guard"] }
 shared_library = "0.1"
 smallvec = "1.7"

--- a/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
@@ -164,6 +164,100 @@ where
     }
 }
 
+#[cfg(feature = "nalgebra")]
+unsafe impl<T> VertexMember for nalgebra::Vector1<T>
+where
+    T: VertexMember,
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        <T as VertexMember>::format()
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+unsafe impl<T> VertexMember for nalgebra::Vector2<T>
+where
+    T: VertexMember,
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 2)
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+unsafe impl<T> VertexMember for nalgebra::Vector3<T>
+where
+    T: VertexMember,
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 3)
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+unsafe impl<T> VertexMember for nalgebra::Vector4<T>
+where
+    T: VertexMember,
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 4)
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+unsafe impl<T> VertexMember for nalgebra::Point1<T>
+where
+    T: VertexMember + nalgebra::Scalar,
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        <T as VertexMember>::format()
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+unsafe impl<T> VertexMember for nalgebra::Point2<T>
+where
+    T: VertexMember + nalgebra::Scalar,
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 2)
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+unsafe impl<T> VertexMember for nalgebra::Point3<T>
+where
+    T: VertexMember + nalgebra::Scalar,
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 3)
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+unsafe impl<T> VertexMember for nalgebra::Point4<T>
+where
+    T: VertexMember + nalgebra::Scalar,
+{
+    #[inline]
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 4)
+    }
+}
+
 macro_rules! impl_vm_array {
     ($sz:expr) => {
         unsafe impl<T> VertexMember for [T; $sz]


### PR DESCRIPTION
1. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Implemented `VertexMember` for `nalgebra::Vector*<T>` and `nalgebra::Point*<T>` where * ∈ [1, 4]. 

Tested to be also working with `nalgebra_glm::Vec*`, since they are aliasing to the same types as `nalgebra::Vector*<f32>`.

64-bit floats won't work, but vulkano [doesn't](https://github.com/vulkano-rs/vulkano/blob/0ebf05f35d44c9742654cb6905abc69dbce619cb/vulkano/src/shader/mod.rs#L860) [seem to](https://github.com/vulkano-rs/vulkano/blob/0ebf05f35d44c9742654cb6905abc69dbce619cb/vulkano/src/shader/mod.rs#L887) support those anyway. (?)

Related: #1572, #1133, #1326

2. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   files(`CHANGELOG_VULKANO.md` and `CHANGELOG_VK_SYS.md`)
   by maintainers right after the Pull Request merge.

    * Entries for Vulkano changelog:
        - `**Breaking** Breaking entry description.`
        - `Non-breaking entry description.`...

    * Entries for VkSys changelog:
        - `Entry 1.`
        - `Entry 2.`...

- Added support for nalgebra `Vector`s and `Point`s in vertex definitions.

3. [x] Run `cargo fmt` on the changes.

4. [ ] Make sure that the changes are covered by unit-tests.

Sorry, but I couldn't find the right place for tests.

If anyone could point that out, I'll add them.

5. [ ] Update documentation to reflect any user-facing changes - in this repository.

I have to apologize again, but I don't know where are the docs located either.
