### PR TITLE
Add Sandbox project to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ contributing(opening a PR) into [README.md](https://github.com/vulkano-rs/vulkan
 | ------------ | ----------- |
 | [Basalt](https://github.com/AustinJ235/basalt) | GUI framework for Desktop applications |
 | [Ferret](https://github.com/Rua/ferret) | Doom-compatible game engine |
+| [Sandbox](https://github.com/hakolao/sandbox) | 2D Pixel Physics Simulator |
 
 We would love to help you keep your project in sync with the most recent changes in Vulkano
 if you give us feedback by adding your project into this list.


### PR DESCRIPTION
I've been working on a [2D Pixel Physics Simulator](https://github.com/hakolao/sandbox) using Vulkano for the rendering and compute shaders for CA simulation. The project is more like a tech demo / simulator, but I'll continue on it separately to make a game. But I wanted to release the simulator as is and thought it would be nice to addition to Vulkano showcase. I also use my [egui_winit_vulkano](https://github.com/hakolao/egui_winit_vulkano) integration so I can use [Egui](https://github.com/emilk/egui) for the user interface.

![image](https://raw.githubusercontent.com/hakolao/sandbox/master/img/sandbox.gif)

Perhaps the weirdest part of this Simulator is just having been able to make the Cellular Automata work with compute shaders.

I sometimes wonder why Vulkano isn't more popular, or if it is, why isn't it visible like `wgpu` is or others. I've found the API much nicer to work with than any other rendering APIs that I've use (limited use). Perhaps I follow wrong places (Reddit and some gamedev stuff mostly).

[Here's a little badly compressed video of it](https://www.youtube.com/watch?v=7B-BkzuzOuk)

Some things that could be cool if resources existed for it:
- How to use Renderdoc with Vulkano (perhaps just how to use renderdoc works, but I haven't yet actually attempted)
- How to do multi-threaded rendering with Vulkano (Will dive into it at some point...)
- Gui with Vulkano (Examples section)

I might take a moment at some point and extract parts from this project to add to the Vulkano examples, for example: "Software Renderer (how to access just pixels...)" or "Drawing on a Canvas", "more complex compute shaders" type of examples... Just because I'd like to help make Vulkano more accessible.

Also I certainly would not mind to get some feedback from you guys!