### PR TITLE
Add boxed_send(), boxed_sync(), boxed_send_sync() for GpuFuture

### DIFF
--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -291,6 +291,36 @@ pub unsafe trait GpuFuture: DeviceOwned {
     {
         Box::new(self) as _
     }
+        
+    /// Turn the current future into a `Box<dyn GpuFuture + Send>`.
+    ///
+    /// This is a helper function that calls `Box::new(yourFuture) as Box<dyn GpuFuture + Send>`.
+    fn boxed_send(self) -> Box<dyn GpuFuture + Send>
+        where
+            Self: Sized + Send + 'static,
+    {
+        Box::new(self) as _
+    }
+    
+    /// Turn the current future into a `Box<dyn GpuFuture + Sync>`.
+    ///
+    /// This is a helper function that calls `Box::new(yourFuture) as Box<dyn GpuFuture + Sync>`.
+    fn boxed_sync(self) -> Box<dyn GpuFuture + Sync>
+        where
+            Self: Sized + Sync + 'static,
+    {
+        Box::new(self) as _
+    }
+    
+    /// Turn the current future into a `Box<dyn GpuFuture + Send + Sync>`.
+    ///
+    /// This is a helper function that calls `Box::new(yourFuture) as Box<dyn GpuFuture + Send + Sync>`.
+    fn boxed_send_sync(self) -> Box<dyn GpuFuture + Send + Sync>
+        where
+            Self: Sized + Send + Sync + 'static,
+    {
+        Box::new(self) as _
+    }
 }
 
 unsafe impl<F: ?Sized> GpuFuture for Box<F>


### PR DESCRIPTION
1. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

The current recommended (?) approach for building complex `GpuFuture`s is to mutate an `Option<Box<dyn GpuFuture>>` and chaining them with `future = Some(future.take()?.join(another).boxed());` which builds into a non-`Send` object even if the underlying `GpuFuture`s are all perfectly `Send` and/or `Sync`. These helper methods help reduce repetitive `Box` casting.

Rant: is making `Surface` non-`Send`-`Sync` even necessary? From my experience with vulkano + [sdl2](https://github.com/Rust-SDL2/rust-sdl2), just passing `()` to the surface constructor and forgetting about resource dropping does not produce any error at all...

2. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   files(`CHANGELOG_VULKANO.md` and `CHANGELOG_VK_SYS.md`)
   by maintainers right after the Pull Request merge.

    * Entries for Vulkano changelog:
        - `**Breaking** Breaking entry description.`
        - `Non-breaking entry description.`...

    * Entries for VkSys changelog:
        - `Entry 1.`
        - `Entry 2.`...

Add boxed_send(), boxed_sync(), boxed_send_sync() for GpuFuture

3. [x] Run `cargo fmt` on the changes.

4. [ ] Make sure that the changes are covered by unit-tests.

Sorry, but nobody told me where the unit tests are the last time...

Works on my machine™

5. [ ] Update documentation to reflect any user-facing changes - in this repository.

My bad, but what is this sentence referring to? Doc comments?