### PR TITLE
fix not being able to create multi-layer framebuffers

### DIFF
--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -334,7 +334,7 @@ impl FramebufferBuilder {
             }
         }
 
-        let mut layers = 1;
+        let mut layers = dimensions[2];
 
         if let Some(multiview) = self.render_pass.desc().multiview() {
             // There needs to be at least as many layers in the framebuffer


### PR DESCRIPTION
I accidentally introduced a [bug](https://github.com/vulkano-rs/vulkano/pull/1598/files#diff-18589b8e2f8ac1459a2328526e37714b13a1c4badaab289b0741dc188a5d3a30R294) that prevents the creation of framebuffers with multiple layers when the multiview feature is *disabled*. This PR fixes that bug.

Entries for changelog:
- fix not being able to create multi-layer framebuffers
