### PR TITLE
Fix sync bug in same image blit/copy commands

### DIFF
--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -332,7 +332,9 @@ impl SyncCommandBufferBuilder {
         let mut resources: SmallVec<[_; 2]> = SmallVec::new();
 
         // if its the same image in source and destination, we need to lock it once
-        if source.conflict_key() == destination.conflict_key() {
+        let source_key = ResourceKey::from(source.as_ref());
+        let destination_key = ResourceKey::from(destination.as_ref());
+        if source_key == destination_key {
             resources.push((
                 KeyTy::Image(source.clone()),
                 "source_and_destination".into(),
@@ -463,7 +465,9 @@ impl SyncCommandBufferBuilder {
         let mut resources: SmallVec<[_; 2]> = SmallVec::new();
 
         // if its the same image in source and destination, we need to lock it once
-        if source.conflict_key() == destination.conflict_key() {
+        let source_key = ResourceKey::from(source.as_ref());
+        let destination_key = ResourceKey::from(destination.as_ref());
+        if source_key == destination_key {
             resources.push((
                 KeyTy::Image(source.clone()),
                 "source_and_destination".into(),


### PR DESCRIPTION
Fixes #1816 

The bug was introduced by #1782.
When we implemented "same image blit/copy" feature,
we added only `one` image to the reserved resources for the command if
the same image was used as `source` and `destination`.

The bug happens if we passed the same image, but with different
mip level and/or array layer. In that case, we will only add the
`source` resource and not the `destination`, and that would result in
failing to know when to flush the pipeline barrier.

CHANGELOG:
```
- Fix sync bug in `copy_image` and `blit_image` where the `src` and `dest` images are the same but with different mip level and/or array layer.
```
