### PR TITLE
Move `Unbuildable` to crate root and rename to `NonExhaustive`

### DIFF
--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -197,7 +197,7 @@ fn device_extensions_output(members: &[ExtensionsMember]) -> TokenStream {
             pub(crate) fn required_if_supported_extensions() -> Self {
                 Self {
                     #(#required_if_supported_extensions_items)*
-                    _unbuildable: Unbuildable(())
+                    _ne: crate::NonExhaustive(()),
                 }
             }
         }
@@ -358,11 +358,7 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
         pub struct #struct_name {
             #(#struct_items)*
 
-            /// This field ensures that an instance of this `Extensions` struct
-            /// can only be created through Vulkano functions and the update
-            /// syntax. This way, extensions can be added to Vulkano without
-            /// breaking existing code.
-            pub _unbuildable: Unbuildable,
+            pub _ne: crate::NonExhaustive,
         }
 
         impl #struct_name {
@@ -371,7 +367,7 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
             pub const fn none() -> Self {
                 Self {
                     #(#none_items)*
-                    _unbuildable: Unbuildable(())
+                    _ne: crate::NonExhaustive(()),
                 }
             }
 
@@ -388,7 +384,7 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
             pub const fn union(&self, other: &Self) -> Self {
                 Self {
                     #(#union_items)*
-                    _unbuildable: Unbuildable(())
+                    _ne: crate::NonExhaustive(()),
                 }
             }
 
@@ -397,7 +393,7 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
             pub const fn intersection(&self, other: &Self) -> Self {
                 Self {
                     #(#intersection_items)*
-                    _unbuildable: Unbuildable(())
+                    _ne: crate::NonExhaustive(()),
                 }
             }
 
@@ -406,7 +402,7 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
             pub const fn difference(&self, other: &Self) -> Self {
                 Self {
                     #(#difference_items)*
-                    _unbuildable: Unbuildable(())
+                    _ne: crate::NonExhaustive(()),
                 }
             }
         }

--- a/vulkano/src/device/extensions.rs
+++ b/vulkano/src/device/extensions.rs
@@ -10,7 +10,6 @@
 use crate::device::physical::PhysicalDevice;
 pub use crate::extensions::{
     ExtensionRestriction, ExtensionRestrictionError, OneOfRequirements, SupportedExtensionsError,
-    Unbuildable,
 };
 use crate::instance::InstanceExtensions;
 use crate::Version;

--- a/vulkano/src/extensions.rs
+++ b/vulkano/src/extensions.rs
@@ -186,8 +186,3 @@ impl Display for OneOfRequirements {
         Ok(())
     }
 }
-
-/// This helper type can only be instantiated inside this module.
-#[doc(hidden)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Unbuildable(pub(crate) ());

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -10,7 +10,6 @@
 use crate::check_errors;
 pub use crate::extensions::{
     ExtensionRestriction, ExtensionRestrictionError, OneOfRequirements, SupportedExtensionsError,
-    Unbuildable,
 };
 use crate::instance::loader;
 use crate::instance::loader::LoadingError;

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -238,3 +238,12 @@ fn check_errors(result: ash::vk::Result) -> Result<Success, Error> {
         c => unreachable!("Unexpected error code returned by Vulkan: {}", c),
     }
 }
+
+/// A helper type for non-exhaustive structs.
+///
+/// This type cannot be constructed outside Vulkano. Structures with a field of this type can only
+/// be constructed by calling a function such as `Default::default()`. The effect is similar to the
+/// standard Rust `#[non_exhaustive]` attribute, except that it does not prevent update syntax from
+/// being used.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)] // add traits as needed
+pub struct NonExhaustive(pub(crate) ());


### PR DESCRIPTION
This moves a type that already existed in Vulkano to a place where it can be used more universally, and adds some documentation for anyone who stumbles upon it. It's a way to work around the limitation I hit in https://github.com/vulkano-rs/vulkano/issues/1808#issuecomment-1030870783.