### PR TITLE
fix typo in begin_render_pass

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -3248,7 +3248,7 @@ where
                                     atch_i,
                                     clear_value,
                                 );
-                            } else if aspects.depth {
+                            } else if aspects.stencil {
                                 assert!(
                                     matches!(clear_value, ClearValue::Stencil(_)),
                                     "Bad ClearValue! index: {}, attachment index: {}, expected: Stencil, got: {:?}",


### PR DESCRIPTION
There was a copy/paste typo in `vulkano::command_buffer::auto::AutoCommandBufferBuilder` that cargo clippy pointed out.
