### PR TITLE
fix shader! macro for geometry stages failing to compile

### DIFF
--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -64,9 +64,11 @@ fn write_shader_execution(execution: &ShaderExecution) -> TokenStream {
         ShaderExecution::Geometry(::vulkano::shader::GeometryShaderExecution { input }) => {
             let input = format_ident!("{}", format!("{:?}", input));
             quote! {
-                ::vulkano::shader::ShaderExecution::Geometry {
-                    input: GeometryShaderInput::#input,
-                }
+                ::vulkano::shader::ShaderExecution::Geometry(
+                    ::vulkano::shader::GeometryShaderExecution {
+                        input: ::vulkano::shader::GeometryShaderInput::#input
+                    }
+                )
             }
         }
         ShaderExecution::Fragment => quote! { ::vulkano::shader::ShaderExecution::Fragment },


### PR DESCRIPTION
Using the `vulkano_shaders::shader!` macro with geometry type would fail to compile. It seemed to use an earlier version of `ShaderExecution` enum. Also `GeometryShaderInput` would have to be manually imported for it to compile.

    * Entries for Vulkano changelog:
        - `fixed shader! macro failing to compile with geometry shaders`
