### PR TITLE
Refactor VertexBuffersCollection to allow Arc<dyn BufferAccess>

### DIFF
--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -32,7 +32,7 @@ use vulkano::pipeline::graphics::vertex_input::BuffersDefinition;
 use vulkano::pipeline::graphics::viewport::{Viewport, ViewportState};
 use vulkano::pipeline::{GraphicsPipeline, Pipeline, PipelineBindPoint};
 use vulkano::render_pass::{Framebuffer, RenderPass, Subpass};
-use vulkano::sampler::{Sampler};
+use vulkano::sampler::Sampler;
 use vulkano::swapchain::{self, AcquireError, Swapchain, SwapchainCreationError};
 use vulkano::sync::{self, FlushError, GpuFuture};
 use vulkano::Version;

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -19,6 +19,7 @@
 use crate::buffer::sys::BufferCreationError;
 use crate::buffer::sys::UnsafeBuffer;
 use crate::buffer::traits::BufferAccess;
+use crate::buffer::traits::BufferAccessObject;
 use crate::buffer::traits::BufferInner;
 use crate::buffer::traits::TypedBufferAccess;
 use crate::buffer::BufferUsage;
@@ -482,6 +483,17 @@ where
                 num: AtomicUsize::new(0),
             };
         }
+    }
+}
+
+impl<T: ?Sized, A> BufferAccessObject for Arc<CpuAccessibleBuffer<T, A>>
+where
+    T: Send + Sync + 'static,
+    A: Send + Sync + 'static,
+{
+    #[inline]
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess> {
+        self.clone()
     }
 }
 

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -10,6 +10,7 @@
 use crate::buffer::sys::BufferCreationError;
 use crate::buffer::sys::UnsafeBuffer;
 use crate::buffer::traits::BufferAccess;
+use crate::buffer::traits::BufferAccessObject;
 use crate::buffer::traits::BufferInner;
 use crate::buffer::traits::TypedBufferAccess;
 use crate::buffer::BufferUsage;
@@ -716,6 +717,17 @@ where
     }
 }
 
+impl<T, A> BufferAccessObject for Arc<CpuBufferPoolChunk<T, A>>
+where
+    T: Send + Sync + 'static,
+    A: MemoryPool + 'static,
+{
+    #[inline]
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess> {
+        self.clone()
+    }
+}
+
 impl<T, A> Drop for CpuBufferPoolChunk<T, A>
 where
     A: MemoryPool,
@@ -833,6 +845,17 @@ where
     #[inline]
     unsafe fn unlock(&self) {
         self.chunk.unlock()
+    }
+}
+
+impl<T, A> BufferAccessObject for Arc<CpuBufferPoolSubbuffer<T, A>>
+where
+    T: Send + Sync + 'static,
+    A: MemoryPool + 'static,
+{
+    #[inline]
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess> {
+        self.clone()
     }
 }
 

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -16,6 +16,7 @@
 use crate::buffer::sys::BufferCreationError;
 use crate::buffer::sys::UnsafeBuffer;
 use crate::buffer::traits::BufferAccess;
+use crate::buffer::traits::BufferAccessObject;
 use crate::buffer::traits::BufferInner;
 use crate::buffer::traits::TypedBufferAccess;
 use crate::buffer::BufferUsage;
@@ -393,6 +394,17 @@ where
         };
 
         *lock = GpuAccess::None;
+    }
+}
+
+impl<T: ?Sized, A> BufferAccessObject for Arc<DeviceLocalBuffer<T, A>>
+where
+    T: Send + Sync + 'static,
+    A: Send + Sync + 'static,
+{
+    #[inline]
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess> {
+        self.clone()
     }
 }
 

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -21,6 +21,7 @@
 use crate::buffer::sys::BufferCreationError;
 use crate::buffer::sys::UnsafeBuffer;
 use crate::buffer::traits::BufferAccess;
+use crate::buffer::traits::BufferAccessObject;
 use crate::buffer::traits::BufferInner;
 use crate::buffer::traits::TypedBufferAccess;
 use crate::buffer::BufferUsage;
@@ -413,6 +414,17 @@ where
     unsafe fn unlock(&self) {}
 }
 
+impl<T, A> BufferAccessObject for Arc<ImmutableBuffer<T, A>>
+where
+    T: Send + Sync + ?Sized + 'static,
+    A: Send + Sync + 'static,
+{
+    #[inline]
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess> {
+        self.clone()
+    }
+}
+
 unsafe impl<T, A> TypedBufferAccess for ImmutableBuffer<T, A>
 where
     T: Send + Sync + ?Sized,
@@ -513,6 +525,17 @@ where
     #[inline]
     unsafe fn unlock(&self) {
         self.buffer.initialized.store(true, Ordering::Relaxed);
+    }
+}
+
+impl<T, A> BufferAccessObject for Arc<ImmutableBufferInitialization<T, A>>
+where
+    T: Send + Sync + ?Sized + 'static,
+    A: Send + Sync + 'static,
+{
+    #[inline]
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess> {
+        self.clone()
     }
 }
 

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -90,6 +90,7 @@ pub use self::immutable::ImmutableBuffer;
 pub use self::slice::BufferSlice;
 pub use self::sys::BufferCreationError;
 pub use self::traits::BufferAccess;
+pub use self::traits::BufferAccessObject;
 pub use self::traits::BufferInner;
 pub use self::traits::TypedBufferAccess;
 pub use self::usage::BufferUsage;

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -8,6 +8,7 @@
 // according to those terms.
 
 use crate::buffer::traits::BufferAccess;
+use crate::buffer::traits::BufferAccessObject;
 use crate::buffer::traits::BufferInner;
 use crate::buffer::traits::TypedBufferAccess;
 use crate::device::Device;
@@ -247,6 +248,17 @@ where
     #[inline]
     unsafe fn unlock(&self) {
         self.resource.unlock()
+    }
+}
+
+impl<T, B> BufferAccessObject for Arc<BufferSlice<T, B>>
+where
+    B: BufferAccess + 'static,
+    T: Send + Sync + ?Sized + 'static,
+{
+    #[inline]
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess> {
+        self.clone()
     }
 }
 

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -140,6 +140,16 @@ pub unsafe trait BufferAccess: DeviceOwned + Send + Sync {
     }
 }
 
+pub trait BufferAccessObject {
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess>;
+}
+
+impl BufferAccessObject for Arc<dyn BufferAccess> {
+    fn as_buffer_access_object(&self) -> Arc<dyn BufferAccess> {
+        self.clone()
+    }
+}
+
 /// Inner information about a buffer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BufferInner<'a> {


### PR DESCRIPTION
This pull request makes it possible to `Arc<dyn BufferAccess>` in collections where `VertexBuffersCollection` is accepted.

**Changelog Entries**
```
- Refactor `VertexBuffersCollection` to allow `Arc<dyn BufferAccess>`
```

I am not sure if this is a breaking change or not. It ***shouldn't*** break existing code.