### PR TITLE
Fix game of life example on macos

### DIFF
--- a/examples/src/bin/multi_window_game_of_life/vulkano_window.rs
+++ b/examples/src/bin/multi_window_game_of_life/vulkano_window.rs
@@ -23,7 +23,7 @@ use vulkano::{
     sync,
     sync::{FlushError, GpuFuture},
 };
-use vulkano_win::create_surface_from_handle;
+use vulkano_win::create_surface_from_winit;
 use winit::window::Window;
 
 pub struct VulkanoWindow {
@@ -52,7 +52,7 @@ impl VulkanoWindow {
         vsync: bool,
     ) -> VulkanoWindow {
         // Create rendering surface from window
-        let surface = create_surface_from_handle(window, vulkano_context.instance()).unwrap();
+        let surface = create_surface_from_winit(window, vulkano_context.instance()).unwrap();
         // Create swap chain & frame(s) to which we'll render
         let (swapchain, final_views) = vulkano_context.create_swapchain(
             surface.clone(),

--- a/vulkano-win/src/raw_window_handle.rs
+++ b/vulkano-win/src/raw_window_handle.rs
@@ -5,7 +5,10 @@ use vulkano::swapchain::Surface;
 use vulkano::swapchain::SurfaceCreationError;
 
 /// Creates a vulkan surface from a generic window
-/// which implements HasRawWindowHandle and thus can reveal the os-dependent handle
+/// which implements HasRawWindowHandle and thus can reveal the os-dependent handle.
+/// - Note that if you wish to use this function with MacOS, you will need to ensure that the
+/// `CAMetalLayer` is set to the ns_view. You can do that by calling `vulkano_win::set_ca_metal_layer_to_winit`
+/// before using this function.
 pub fn create_surface_from_handle<W>(
     window: W,
     instance: Arc<Instance>,

--- a/vulkano-win/src/raw_window_handle.rs
+++ b/vulkano-win/src/raw_window_handle.rs
@@ -7,8 +7,8 @@ use vulkano::swapchain::SurfaceCreationError;
 /// Creates a vulkan surface from a generic window
 /// which implements HasRawWindowHandle and thus can reveal the os-dependent handle.
 /// - Note that if you wish to use this function with MacOS, you will need to ensure that the
-/// `CAMetalLayer` is set to the ns_view. You can do that by calling `vulkano_win::set_ca_metal_layer_to_winit`
-/// before using this function.
+/// `CAMetalLayer` is set to the ns_view. An example of how one might do that can be found in
+/// `vulkano_win::set_ca_metal_layer_to_winit`
 pub fn create_surface_from_handle<W>(
     window: W,
     instance: Arc<Instance>,

--- a/vulkano-win/src/winit.rs
+++ b/vulkano-win/src/winit.rs
@@ -175,7 +175,7 @@ use std::mem;
 /// Ensure `CAMetalLayer` (native rendering surface on MacOs) is used by the ns_view.
 /// This is necessary to be able to render on Mac.
 #[cfg(target_os = "macos")]
-pub unsafe fn set_ca_metal_layer_to_winit<W: SafeBorrow<Window>>(win: W) {
+unsafe fn set_ca_metal_layer_to_winit<W: SafeBorrow<Window>>(win: W) {
     use winit::platform::macos::WindowExtMacOS;
 
     let wnd: cocoa_id = mem::transmute(win.borrow().ns_window());

--- a/vulkano-win/src/winit.rs
+++ b/vulkano-win/src/winit.rs
@@ -172,11 +172,10 @@ use objc::runtime::YES;
 #[cfg(target_os = "macos")]
 use std::mem;
 
+/// Ensure `CAMetalLayer` (native rendering surface on MacOs) is used by the ns_view.
+/// This is necessary to be able to render on Mac.
 #[cfg(target_os = "macos")]
-unsafe fn winit_to_surface<W: SafeBorrow<Window>>(
-    instance: Arc<Instance>,
-    win: W,
-) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
+pub unsafe fn set_ca_metal_layer_to_winit<W: SafeBorrow<Window>>(win: W) {
     use winit::platform::macos::WindowExtMacOS;
 
     let wnd: cocoa_id = mem::transmute(win.borrow().ns_window());
@@ -191,7 +190,14 @@ unsafe fn winit_to_surface<W: SafeBorrow<Window>>(
     layer.set_contents_scale(view.backingScaleFactor());
     view.setLayer(mem::transmute(layer.as_ref())); // Bombs here with out of memory
     view.setWantsLayer(YES);
+}
 
+#[cfg(target_os = "macos")]
+unsafe fn winit_to_surface<W: SafeBorrow<Window>>(
+    instance: Arc<Instance>,
+    win: W,
+) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
+    set_ca_metal_layer_to_winit(win.borrow());
     Surface::from_mac_os(instance, win.borrow().ns_view() as *const (), win)
 }
 

--- a/vulkano-win/src/winit.rs
+++ b/vulkano-win/src/winit.rs
@@ -197,6 +197,8 @@ unsafe fn winit_to_surface<W: SafeBorrow<Window>>(
     instance: Arc<Instance>,
     win: W,
 ) -> Result<Arc<Surface<W>>, SurfaceCreationError> {
+    use winit::platform::macos::WindowExtMacOS;
+
     set_ca_metal_layer_to_winit(win.borrow());
     Surface::from_mac_os(instance, win.borrow().ns_view() as *const (), win)
 }


### PR DESCRIPTION
1. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

3. [x] Run `cargo fmt` on the changes.

I noticed that on my macos the `create_vk_surface_from_handle` encounters an error:

```
[mvk-error] VK_ERROR_INITIALIZATION_FAILED: vkCreateMacOSSurfaceMVK(): On-screen rendering requires a layer of type CAMetalLayer.
```
What is done in `winit_to_surface` prevents this. I wasn't even sure why the handle version was used anyway...
