### PR TITLE
Include raw function pointer structs in documentation

### DIFF
--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -108,7 +108,7 @@ use crate::device::physical::QueueFamily;
 pub use crate::extensions::{
     ExtensionRestriction, ExtensionRestrictionError, SupportedExtensionsError,
 };
-use crate::fns::DeviceFunctions;
+pub use crate::fns::DeviceFunctions;
 use crate::instance::Instance;
 use crate::memory::pool::StdMemoryPool;
 use crate::Error;

--- a/vulkano/src/instance/loader.rs
+++ b/vulkano/src/instance/loader.rs
@@ -22,7 +22,7 @@
 //! a Vulkan implementation from the system.
 
 use crate::check_errors;
-use crate::fns::EntryFunctions;
+pub use crate::fns::EntryFunctions;
 use crate::OomError;
 use crate::SafeDeref;
 use crate::Version;

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -61,7 +61,7 @@ use crate::device::physical::{init_physical_devices, PhysicalDeviceInfo};
 pub use crate::extensions::{
     ExtensionRestriction, ExtensionRestrictionError, SupportedExtensionsError,
 };
-use crate::fns::InstanceFunctions;
+pub use crate::fns::InstanceFunctions;
 use crate::instance::loader::FunctionPointers;
 use crate::instance::loader::Loader;
 pub use crate::version::Version;


### PR DESCRIPTION
I noticed that these were missing from the documentation. The `fns` methods of `FunctionPointers`, `Instance` and `Device` do reference these structs, and they are useful for people who want to use functionality that Vulkano doesn't support yet.