### PR TITLE
Implement is_layout_initialized for ImmutableImage

### DIFF
--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -415,6 +415,11 @@ where
     }
 
     #[inline]
+    fn is_layout_initialized(&self) -> bool {
+        true
+    }
+
+    #[inline]
     fn initial_layout_requirement(&self) -> ImageLayout {
         self.layout
     }


### PR DESCRIPTION
The default implementation always returns `false`. However, in
`ImmutableImage`'s case, by the time we are doing operations with
`ImmutableImage`, the layout should have already been initialized by
`ImmutableImageInitialization`.

Without this function, vulkano thinks the image referenced by the
`ImmutableImage` isn't initialized, and will insert a pipeline
transition from Undefined to `self.layout`, which isn't incorrect; the
command buffer created to initialize the image had a
`final_layout_requirement` of the final layout, and thus had already
transitioned the layout to the correct layout.

See, for example, the discussion in #1578.