### PR TITLE
convert fnv types into std

### DIFF
--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["rendering::graphics-api"]
 proc-macro = true
 
 [dependencies]
-fnv = "1.0"
 heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -7,8 +7,8 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use fnv::FnvHashMap;
 use proc_macro2::TokenStream;
+use std::collections::HashMap;
 use vulkano::pipeline::layout::PushConstantRange;
 use vulkano::shader::spirv::ExecutionModel;
 use vulkano::shader::{
@@ -77,7 +77,7 @@ fn write_shader_execution(execution: &ShaderExecution) -> TokenStream {
 }
 
 fn write_descriptor_requirements(
-    descriptor_requirements: &FnvHashMap<(u32, u32), DescriptorRequirements>,
+    descriptor_requirements: &HashMap<(u32, u32), DescriptorRequirements>,
 ) -> TokenStream {
     let descriptor_requirements = descriptor_requirements.into_iter().map(|(loc, reqs)| {
         let (set_num, binding_num) = loc;
@@ -276,7 +276,7 @@ fn write_push_constant_requirements(
 }
 
 fn write_specialization_constant_requirements(
-    specialization_constant_requirements: &FnvHashMap<u32, SpecializationConstantRequirements>,
+    specialization_constant_requirements: &HashMap<u32, SpecializationConstantRequirements>,
 ) -> TokenStream {
     let specialization_constant_requirements = specialization_constant_requirements
         .into_iter()

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -18,7 +18,6 @@ build = "build.rs"
 # All versions of vk.xml can be found at https://github.com/KhronosGroup/Vulkan-Headers/commits/main/registry/vk.xml.
 ash = "0.36"
 crossbeam-queue = "0.3"
-fnv = "1.0"
 half = "1.8"
 lazy_static = "1.4"
 nalgebra = { version = "0.30.0", optional = true }

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -77,10 +77,11 @@ use crate::{
     },
     DeviceSize, OomError, SafeDeref, Version, VulkanObject,
 };
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
 use std::{
-    cmp, error,
+    cmp,
+    collections::HashMap,
+    error,
     ffi::CStr,
     fmt, iter,
     marker::PhantomData,
@@ -115,7 +116,7 @@ pub struct AutoCommandBufferBuilder<L, P = StandardCommandPoolBuilder> {
     render_pass_state: Option<RenderPassState>,
 
     // If any queries are active, this hashmap contains their state.
-    query_state: FnvHashMap<ash::vk::QueryType, QueryState>,
+    query_state: HashMap<ash::vk::QueryType, QueryState>,
 
     _data: PhantomData<L>,
 }
@@ -349,7 +350,7 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
             pool_builder_alloc,
             queue_family_id: queue_family.id(),
             render_pass_state,
-            query_state: FnvHashMap::default(),
+            query_state: HashMap::default(),
             inheritance_info,
             usage,
             _data: PhantomData,

--- a/vulkano/src/command_buffer/pool/standard.rs
+++ b/vulkano/src/command_buffer/pool/standard.rs
@@ -9,8 +9,8 @@ use crate::{
     OomError, VulkanObject,
 };
 use crossbeam_queue::SegQueue;
-use fnv::FnvHashMap;
 use std::{
+    collections::HashMap,
     marker::PhantomData,
     mem::ManuallyDrop,
     ptr,
@@ -45,7 +45,7 @@ pub struct StandardCommandPool {
     queue_family: u32,
 
     // For each thread, we store thread-specific info.
-    per_thread: Mutex<FnvHashMap<thread::ThreadId, Weak<StandardCommandPoolPerThread>>>,
+    per_thread: Mutex<HashMap<thread::ThreadId, Weak<StandardCommandPoolPerThread>>>,
 }
 
 unsafe impl Send for StandardCommandPool {}

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -40,9 +40,13 @@ use crate::{
     sync::{AccessFlags, PipelineMemoryAccess, PipelineStages},
     OomError, VulkanObject,
 };
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
-use std::{borrow::Cow, collections::hash_map::Entry, error, fmt, sync::Arc};
+use std::{
+    borrow::Cow,
+    collections::{hash_map::Entry, HashMap},
+    error, fmt,
+    sync::Arc,
+};
 
 #[path = "commands.rs"]
 mod commands;
@@ -87,7 +91,7 @@ pub struct SyncCommandBufferBuilder {
     latest_render_pass_enter: Option<usize>,
 
     // Stores the current state of buffers and images that are in use by the command buffer.
-    resources: FnvHashMap<ResourceKey, ResourceState>,
+    resources: HashMap<ResourceKey, ResourceState>,
 
     // Resources and their accesses. Used for executing secondary command buffers in a primary.
     buffers: Vec<(Arc<dyn BufferAccess>, PipelineMemoryAccess)>,
@@ -165,7 +169,7 @@ impl SyncCommandBufferBuilder {
             barriers: Vec::new(),
             first_unflushed: 0,
             latest_render_pass_enter,
-            resources: FnvHashMap::default(),
+            resources: HashMap::default(),
             buffers: Vec::new(),
             images: Vec::new(),
             current_state: Default::default(),
@@ -564,7 +568,7 @@ impl SyncCommandBufferBuilder {
         }
 
         // Build the final resources states.
-        let final_resources_states: FnvHashMap<_, _> = {
+        let final_resources_states: HashMap<_, _> = {
             self.resources
                 .into_iter()
                 .map(|(resource, state)| {
@@ -670,11 +674,11 @@ struct ResourceState {
 /// Holds the current binding and setting state.
 #[derive(Default)]
 struct CurrentState {
-    descriptor_sets: FnvHashMap<PipelineBindPoint, DescriptorSetState>,
+    descriptor_sets: HashMap<PipelineBindPoint, DescriptorSetState>,
     index_buffer: Option<(Arc<dyn BufferAccess>, IndexType)>,
     pipeline_compute: Option<Arc<ComputePipeline>>,
     pipeline_graphics: Option<Arc<GraphicsPipeline>>,
-    vertex_buffers: FnvHashMap<u32, Arc<dyn BufferAccess>>,
+    vertex_buffers: HashMap<u32, Arc<dyn BufferAccess>>,
 
     push_constants: RangeSet<u32>,
     push_constants_pipeline_layout: Option<Arc<PipelineLayout>>,
@@ -689,7 +693,7 @@ struct CurrentState {
     depth_compare_op: Option<CompareOp>,
     depth_test_enable: Option<bool>,
     depth_write_enable: Option<bool>,
-    discard_rectangle: FnvHashMap<u32, Scissor>,
+    discard_rectangle: HashMap<u32, Scissor>,
     front_face: Option<FrontFace>,
     line_stipple: Option<LineStipple>,
     line_width: Option<f32>,
@@ -698,14 +702,14 @@ struct CurrentState {
     primitive_restart_enable: Option<bool>,
     primitive_topology: Option<PrimitiveTopology>,
     rasterizer_discard_enable: Option<bool>,
-    scissor: FnvHashMap<u32, Scissor>,
+    scissor: HashMap<u32, Scissor>,
     scissor_with_count: Option<SmallVec<[Scissor; 2]>>,
     stencil_compare_mask: StencilStateDynamic,
     stencil_op: StencilOpStateDynamic,
     stencil_reference: StencilStateDynamic,
     stencil_test_enable: Option<bool>,
     stencil_write_mask: StencilStateDynamic,
-    viewport: FnvHashMap<u32, Viewport>,
+    viewport: HashMap<u32, Viewport>,
     viewport_with_count: Option<SmallVec<[Viewport; 2]>>,
 }
 
@@ -814,7 +818,7 @@ impl CurrentState {
 }
 
 struct DescriptorSetState {
-    descriptor_sets: FnvHashMap<u32, SetOrPush>,
+    descriptor_sets: HashMap<u32, SetOrPush>,
     pipeline_layout: Arc<PipelineLayout>,
 }
 

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -82,8 +82,7 @@ use crate::{
         AccessCheckError, AccessError, AccessFlags, GpuFuture, PipelineMemoryAccess, PipelineStages,
     },
 };
-use fnv::FnvHashMap;
-use std::{borrow::Cow, ops::Range, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, ops::Range, sync::Arc};
 
 mod builder;
 
@@ -102,7 +101,7 @@ pub struct SyncCommandBuffer {
     barriers: Vec<usize>,
 
     // State of all the resources used by this command buffer.
-    resources: FnvHashMap<ResourceKey, ResourceFinalState>,
+    resources: HashMap<ResourceKey, ResourceFinalState>,
 
     // Resources and their accesses. Used for executing secondary command buffers in a primary.
     buffers: Vec<(Arc<dyn BufferAccess>, PipelineMemoryAccess)>,

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -18,9 +18,8 @@ use crate::{
     shader::{DescriptorRequirements, ShaderStages},
     OomError, Version, VulkanObject,
 };
-use fnv::FnvHashMap;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     error, fmt,
     hash::{Hash, Hasher},
     mem::MaybeUninit,
@@ -37,7 +36,7 @@ pub struct DescriptorSetLayout {
     bindings: BTreeMap<u32, DescriptorSetLayoutBinding>,
     push_descriptor: bool,
 
-    descriptor_counts: FnvHashMap<DescriptorType, u32>,
+    descriptor_counts: HashMap<DescriptorType, u32>,
 }
 
 impl DescriptorSetLayout {
@@ -69,14 +68,14 @@ impl DescriptorSetLayout {
     fn validate(
         device: &Device,
         create_info: &mut DescriptorSetLayoutCreateInfo,
-    ) -> Result<FnvHashMap<DescriptorType, u32>, DescriptorSetLayoutCreationError> {
+    ) -> Result<HashMap<DescriptorType, u32>, DescriptorSetLayoutCreationError> {
         let &mut DescriptorSetLayoutCreateInfo {
             ref bindings,
             push_descriptor,
             _ne: _,
         } = create_info;
 
-        let mut descriptor_counts = FnvHashMap::default();
+        let mut descriptor_counts = HashMap::default();
 
         if push_descriptor {
             if !device.enabled_extensions().khr_push_descriptor {
@@ -334,7 +333,7 @@ impl DescriptorSetLayout {
     ///
     /// The map is guaranteed to not contain any elements with a count of `0`.
     #[inline]
-    pub fn descriptor_counts(&self) -> &FnvHashMap<DescriptorType, u32> {
+    pub fn descriptor_counts(&self) -> &HashMap<DescriptorType, u32> {
         &self.descriptor_counts
     }
 
@@ -819,7 +818,7 @@ mod tests {
     use crate::descriptor_set::layout::DescriptorSetLayoutCreateInfo;
     use crate::descriptor_set::layout::DescriptorType;
     use crate::shader::ShaderStages;
-    use fnv::FnvHashMap;
+    use fnv::HashMap;
 
     #[test]
     fn empty() {
@@ -851,7 +850,7 @@ mod tests {
             sl.descriptor_counts(),
             &[(DescriptorType::UniformBuffer, 1)]
                 .into_iter()
-                .collect::<FnvHashMap<_, _>>(),
+                .collect::<HashMap<_, _>>(),
         );
     }
 }

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -818,7 +818,7 @@ mod tests {
     use crate::descriptor_set::layout::DescriptorSetLayoutCreateInfo;
     use crate::descriptor_set::layout::DescriptorType;
     use crate::shader::ShaderStages;
-    use fnv::HashMap;
+    use std::collections::HashMap;
 
     #[test]
     fn empty() {

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -88,8 +88,8 @@ use crate::image::view::ImageViewAbstract;
 use crate::sampler::Sampler;
 use crate::OomError;
 use crate::VulkanObject;
-use fnv::FnvHashMap;
 use smallvec::{smallvec, SmallVec};
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::ptr;
@@ -246,7 +246,7 @@ impl DescriptorSetInner {
 /// The resources that are bound to a descriptor set.
 #[derive(Clone)]
 pub struct DescriptorSetResources {
-    binding_resources: FnvHashMap<u32, DescriptorBindingResources>,
+    binding_resources: HashMap<u32, DescriptorBindingResources>,
 }
 
 impl DescriptorSetResources {

--- a/vulkano/src/descriptor_set/pool/standard.rs
+++ b/vulkano/src/descriptor_set/pool/standard.rs
@@ -19,7 +19,7 @@ use crate::{
     device::{Device, DeviceOwned},
     OomError,
 };
-use fnv::FnvHashMap;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// Standard implementation of a descriptor pool.
@@ -39,7 +39,7 @@ pub struct StdDescriptorPool {
 #[derive(Debug)]
 struct Pool {
     pool: UnsafeDescriptorPool,
-    remaining_capacity: FnvHashMap<DescriptorType, u32>,
+    remaining_capacity: HashMap<DescriptorType, u32>,
     remaining_sets_count: u32,
 }
 
@@ -59,7 +59,7 @@ pub struct StdDescriptorPoolAlloc {
     // The set. Inside an option so that we can extract it in the destructor.
     set: Option<UnsafeDescriptorSet>,
     // We need to keep track of this count in order to add it back to the capacity when freeing.
-    descriptor_counts: FnvHashMap<DescriptorType, u32>,
+    descriptor_counts: HashMap<DescriptorType, u32>,
     // We keep the parent of the pool alive, otherwise it would be destroyed.
     pool_parent: Arc<StdDescriptorPool>,
 }

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -16,9 +16,9 @@ use crate::{
     device::{Device, DeviceOwned},
     OomError, Version, VulkanObject,
 };
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
 use std::{
+    collections::HashMap,
     error, fmt,
     hash::{Hash, Hasher},
     mem::MaybeUninit,
@@ -36,7 +36,7 @@ pub struct UnsafeDescriptorPool {
     device: Arc<Device>,
 
     max_sets: u32,
-    pool_sizes: FnvHashMap<DescriptorType, u32>,
+    pool_sizes: HashMap<DescriptorType, u32>,
     can_free_descriptor_sets: bool,
 }
 
@@ -124,7 +124,7 @@ impl UnsafeDescriptorPool {
 
     /// Returns the number of descriptors of each type that the pool was created with.
     #[inline]
-    pub fn pool_sizes(&self) -> &FnvHashMap<DescriptorType, u32> {
+    pub fn pool_sizes(&self) -> &HashMap<DescriptorType, u32> {
         &self.pool_sizes
     }
 
@@ -347,7 +347,7 @@ pub struct UnsafeDescriptorPoolCreateInfo {
     /// The number of descriptors of each type to allocate for the pool.
     ///
     /// The default value is empty, which must be overridden.
-    pub pool_sizes: FnvHashMap<DescriptorType, u32>,
+    pub pool_sizes: HashMap<DescriptorType, u32>,
 
     /// Whether individual descriptor sets can be freed from the pool. Otherwise you must reset or
     /// destroy the whole pool at once.
@@ -363,7 +363,7 @@ impl Default for UnsafeDescriptorPoolCreateInfo {
     fn default() -> Self {
         Self {
             max_sets: 0,
-            pool_sizes: FnvHashMap::default(),
+            pool_sizes: HashMap::default(),
             can_free_descriptor_sets: false,
             _ne: crate::NonExhaustive(()),
         }

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -115,7 +115,6 @@ pub use crate::{
     fns::DeviceFunctions,
 };
 use ash::vk::Handle;
-use fnv::FnvHasher;
 use smallvec::SmallVec;
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -123,7 +122,7 @@ use std::{
     ffi::{CStr, CString},
     fmt,
     fs::File,
-    hash::{BuildHasherDefault, Hash, Hasher},
+    hash::{Hash, Hasher},
     mem::{self, MaybeUninit},
     ops::Deref,
     ptr,
@@ -149,8 +148,7 @@ pub struct Device {
     fns: DeviceFunctions,
     standard_pool: Mutex<Weak<StdMemoryPool>>,
     standard_descriptor_pool: Mutex<Weak<StdDescriptorPool>>,
-    standard_command_pools:
-        Mutex<HashMap<u32, Weak<StandardCommandPool>, BuildHasherDefault<FnvHasher>>>,
+    standard_command_pools: Mutex<HashMap<u32, Weak<StandardCommandPool>>>,
     enabled_extensions: DeviceExtensions,
     enabled_features: Features,
     active_queue_families: SmallVec<[u32; 2]>,

--- a/vulkano/src/memory/pool/pool.rs
+++ b/vulkano/src/memory/pool/pool.rs
@@ -22,10 +22,8 @@ use crate::memory::DeviceMemory;
 use crate::memory::DeviceMemoryAllocationError;
 use crate::memory::MappedDeviceMemory;
 use crate::DeviceSize;
-use fnv::FnvHasher;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -34,8 +32,7 @@ pub struct StdMemoryPool {
     device: Arc<Device>,
 
     // For each memory type index, stores the associated pool.
-    pools:
-        Mutex<HashMap<(u32, AllocLayout, MappingRequirement), Pool, BuildHasherDefault<FnvHasher>>>,
+    pools: Mutex<HashMap<(u32, AllocLayout, MappingRequirement), Pool>>,
 }
 
 impl StdMemoryPool {
@@ -43,11 +40,10 @@ impl StdMemoryPool {
     #[inline]
     pub fn new(device: Arc<Device>) -> Arc<StdMemoryPool> {
         let cap = device.physical_device().memory_types().len();
-        let hasher = BuildHasherDefault::<FnvHasher>::default();
 
         Arc::new(StdMemoryPool {
             device: device.clone(),
-            pools: Mutex::new(HashMap::with_capacity_and_hasher(cap, hasher)),
+            pools: Mutex::new(HashMap::with_capacity(cap)),
         })
     }
 }

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -38,7 +38,7 @@ use crate::DeviceSize;
 use crate::Error;
 use crate::OomError;
 use crate::VulkanObject;
-use fnv::FnvHashMap;
+use std::collections::HashMap;
 use std::error;
 use std::fmt;
 use std::mem;
@@ -58,7 +58,7 @@ pub struct ComputePipeline {
     handle: ash::vk::Pipeline,
     device: Arc<Device>,
     layout: Arc<PipelineLayout>,
-    descriptor_requirements: FnvHashMap<(u32, u32), DescriptorRequirements>,
+    descriptor_requirements: HashMap<(u32, u32), DescriptorRequirements>,
     num_used_descriptor_sets: u32,
 }
 
@@ -216,7 +216,7 @@ impl ComputePipeline {
             output.assume_init()
         };
 
-        let descriptor_requirements: FnvHashMap<_, _> = shader
+        let descriptor_requirements: HashMap<_, _> = shader
             .descriptor_requirements()
             .map(|(loc, reqs)| (loc, reqs.clone()))
             .collect();

--- a/vulkano/src/pipeline/graphics/builder.rs
+++ b/vulkano/src/pipeline/graphics/builder.rs
@@ -41,9 +41,8 @@ use crate::shader::{
 };
 use crate::DeviceSize;
 use crate::VulkanObject;
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
-use std::collections::hash_map::{Entry, HashMap};
+use std::collections::{hash_map::Entry, HashMap};
 use std::mem::MaybeUninit;
 use std::ptr;
 use std::sync::Arc;
@@ -160,7 +159,7 @@ where
 
             // Produce `DescriptorRequirements` for each binding, by iterating over all shaders
             // and adding the requirements of each.
-            let mut descriptor_requirements: FnvHashMap<(u32, u32), DescriptorRequirements> =
+            let mut descriptor_requirements: HashMap<(u32, u32), DescriptorRequirements> =
                 HashMap::default();
 
             for (loc, reqs) in stages
@@ -485,7 +484,7 @@ where
         .flatten()
         .collect();
 
-        let mut descriptor_requirements: FnvHashMap<(u32, u32), DescriptorRequirements> =
+        let mut descriptor_requirements: HashMap<(u32, u32), DescriptorRequirements> =
             HashMap::default();
 
         // Check that the pipeline layout is compatible with the shader requirements, and collect
@@ -586,7 +585,7 @@ where
         debug_assert_eq!(stages.len(), stages_info.len());
 
         // Will contain the list of dynamic states. Filled while checking the states.
-        let mut dynamic_state_modes: FnvHashMap<DynamicState, bool> = HashMap::default();
+        let mut dynamic_state_modes: HashMap<DynamicState, bool> = HashMap::default();
 
         // Vertex input state
         let binding_descriptions = self_vertex_input_state.to_vulkan_bindings(&device)?;

--- a/vulkano/src/pipeline/graphics/color_blend.rs
+++ b/vulkano/src/pipeline/graphics/color_blend.rs
@@ -23,8 +23,8 @@
 
 use super::{DynamicState, GraphicsPipelineCreationError};
 use crate::{device::Device, pipeline::StateMode, render_pass::Subpass};
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
+use std::collections::HashMap;
 
 /// Describes how the color output of the fragment shader is written to the attachment. See the
 /// documentation of the `blend` module for more info.
@@ -137,7 +137,7 @@ impl ColorBlendState {
     pub(crate) fn to_vulkan_attachments(
         &mut self, // TODO: make non-mut
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         subpass: &Subpass,
     ) -> Result<
         (
@@ -254,7 +254,7 @@ impl ColorBlendState {
     pub(crate) fn to_vulkan_color_write(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         color_write_enables: &[ash::vk::Bool32],
     ) -> Result<Option<ash::vk::PipelineColorWriteCreateInfoEXT>, GraphicsPipelineCreationError>
     {
@@ -272,7 +272,7 @@ impl ColorBlendState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         color_blend_attachments: &[ash::vk::PipelineColorBlendAttachmentState],
         color_write: Option<&mut ash::vk::PipelineColorWriteCreateInfoEXT>,
     ) -> Result<ash::vk::PipelineColorBlendStateCreateInfo, GraphicsPipelineCreationError> {

--- a/vulkano/src/pipeline/graphics/depth_stencil.rs
+++ b/vulkano/src/pipeline/graphics/depth_stencil.rs
@@ -25,7 +25,7 @@ use crate::pipeline::graphics::GraphicsPipelineCreationError;
 use crate::pipeline::{DynamicState, StateMode};
 use crate::render_pass::Subpass;
 use crate::Version;
-use fnv::FnvHashMap;
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::u32;
 
@@ -80,7 +80,7 @@ impl DepthStencilState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         subpass: &Subpass,
     ) -> Result<ash::vk::PipelineDepthStencilStateCreateInfo, GraphicsPipelineCreationError> {
         let (depth_test_enable, depth_write_enable, depth_compare_op) =

--- a/vulkano/src/pipeline/graphics/discard_rectangle.rs
+++ b/vulkano/src/pipeline/graphics/discard_rectangle.rs
@@ -15,8 +15,8 @@ use crate::device::Device;
 use crate::pipeline::graphics::viewport::Scissor;
 use crate::pipeline::graphics::GraphicsPipelineCreationError;
 use crate::pipeline::{DynamicState, PartialStateMode};
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
+use std::collections::HashMap;
 
 /// The state in a graphics pipeline describing how the discard rectangle test should behave.
 #[derive(Clone, Debug)]
@@ -46,7 +46,7 @@ impl DiscardRectangleState {
     pub(crate) fn to_vulkan_rectangles(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
     ) -> Result<SmallVec<[ash::vk::Rect2D; 2]>, GraphicsPipelineCreationError> {
         Ok(match &self.rectangles {
             PartialStateMode::Fixed(rectangles) => {
@@ -63,7 +63,7 @@ impl DiscardRectangleState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         discard_rectangles: &[ash::vk::Rect2D],
     ) -> Result<
         Option<ash::vk::PipelineDiscardRectangleStateCreateInfoEXT>,

--- a/vulkano/src/pipeline/graphics/input_assembly.rs
+++ b/vulkano/src/pipeline/graphics/input_assembly.rs
@@ -13,7 +13,7 @@ use crate::device::Device;
 use crate::pipeline::graphics::GraphicsPipelineCreationError;
 use crate::pipeline::{DynamicState, PartialStateMode, StateMode};
 use crate::{DeviceSize, Version};
-use fnv::FnvHashMap;
+use std::collections::HashMap;
 
 /// The state in a graphics pipeline describing how the input assembly stage should behave.
 #[derive(Clone, Copy, Debug)]
@@ -83,7 +83,7 @@ impl InputAssemblyState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
     ) -> Result<ash::vk::PipelineInputAssemblyStateCreateInfo, GraphicsPipelineCreationError> {
         let topology = match self.topology {
             PartialStateMode::Fixed(topology) => {

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -73,7 +73,7 @@ use crate::pipeline::{DynamicState, Pipeline, PipelineBindPoint};
 use crate::render_pass::Subpass;
 use crate::shader::{DescriptorRequirements, ShaderStage};
 use crate::VulkanObject;
-use fnv::FnvHashMap;
+use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -104,8 +104,8 @@ pub struct GraphicsPipeline {
     layout: Arc<PipelineLayout>,
     subpass: Subpass,
     // TODO: replace () with an object that describes the shaders in some way.
-    shaders: FnvHashMap<ShaderStage, ()>,
-    descriptor_requirements: FnvHashMap<(u32, u32), DescriptorRequirements>,
+    shaders: HashMap<ShaderStage, ()>,
+    descriptor_requirements: HashMap<(u32, u32), DescriptorRequirements>,
     num_used_descriptor_sets: u32,
 
     vertex_input_state: VertexInputState,
@@ -117,7 +117,7 @@ pub struct GraphicsPipeline {
     multisample_state: Option<MultisampleState>,
     depth_stencil_state: Option<DepthStencilState>,
     color_blend_state: Option<ColorBlendState>,
-    dynamic_state: FnvHashMap<DynamicState, bool>,
+    dynamic_state: HashMap<DynamicState, bool>,
 }
 
 impl GraphicsPipeline {

--- a/vulkano/src/pipeline/graphics/multisample.rs
+++ b/vulkano/src/pipeline/graphics/multisample.rs
@@ -15,7 +15,7 @@ use crate::image::SampleCount;
 use crate::pipeline::graphics::GraphicsPipelineCreationError;
 use crate::pipeline::DynamicState;
 use crate::render_pass::Subpass;
-use fnv::FnvHashMap;
+use std::collections::HashMap;
 use std::ptr;
 
 // TODO: handle some weird behaviors with non-floating-point targets
@@ -77,7 +77,7 @@ impl MultisampleState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         subpass: &Subpass,
     ) -> Result<ash::vk::PipelineMultisampleStateCreateInfo, GraphicsPipelineCreationError> {
         let rasterization_samples = subpass.num_samples().unwrap_or(SampleCount::Sample1).into();

--- a/vulkano/src/pipeline/graphics/rasterization.rs
+++ b/vulkano/src/pipeline/graphics/rasterization.rs
@@ -13,7 +13,7 @@ use crate::device::Device;
 use crate::pipeline::graphics::GraphicsPipelineCreationError;
 use crate::pipeline::{DynamicState, StateMode};
 use crate::Version;
-use fnv::FnvHashMap;
+use std::collections::HashMap;
 
 /// The state in a graphics pipeline describing how the rasterization stage should behave.
 #[derive(Clone, Debug)]
@@ -141,7 +141,7 @@ impl RasterizationState {
     pub(crate) fn to_vulkan_line_state(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
     ) -> Result<
         Option<ash::vk::PipelineRasterizationLineStateCreateInfoEXT>,
         GraphicsPipelineCreationError,
@@ -274,7 +274,7 @@ impl RasterizationState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         rasterization_line_state: Option<&mut ash::vk::PipelineRasterizationLineStateCreateInfoEXT>,
     ) -> Result<ash::vk::PipelineRasterizationStateCreateInfo, GraphicsPipelineCreationError> {
         if self.depth_clamp_enable && !device.enabled_features().depth_clamp {

--- a/vulkano/src/pipeline/graphics/tessellation.rs
+++ b/vulkano/src/pipeline/graphics/tessellation.rs
@@ -15,7 +15,7 @@ use crate::pipeline::graphics::input_assembly::{
 };
 use crate::pipeline::graphics::GraphicsPipelineCreationError;
 use crate::pipeline::{DynamicState, PartialStateMode, StateMode};
-use fnv::FnvHashMap;
+use std::collections::HashMap;
 
 /// The state in a graphics pipeline describing the tessellation shader execution of a graphics
 /// pipeline.
@@ -54,7 +54,7 @@ impl TessellationState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         input_assembly_state: &InputAssemblyState,
     ) -> Result<ash::vk::PipelineTessellationStateCreateInfo, GraphicsPipelineCreationError> {
         if !matches!(

--- a/vulkano/src/pipeline/graphics/vertex_input/mod.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/mod.rs
@@ -110,8 +110,8 @@ use crate::device::Device;
 use crate::format::Format;
 use crate::pipeline::graphics::GraphicsPipelineCreationError;
 use crate::pipeline::DynamicState;
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
+use std::collections::HashMap;
 use std::ptr;
 
 mod buffers;
@@ -124,11 +124,11 @@ mod vertex;
 #[derive(Clone, Debug, Default)]
 pub struct VertexInputState {
     /// A description of the vertex buffers that the vertex input stage will read from.
-    pub bindings: FnvHashMap<u32, VertexInputBindingDescription>,
+    pub bindings: HashMap<u32, VertexInputBindingDescription>,
 
     /// Describes, for each shader input location, the mapping between elements in a vertex buffer
     /// and the components of that location in the shader.
-    pub attributes: FnvHashMap<u32, VertexInputAttributeDescription>,
+    pub attributes: HashMap<u32, VertexInputAttributeDescription>,
 }
 
 impl VertexInputState {
@@ -182,7 +182,7 @@ impl VertexInputState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         binding_descriptions: &[ash::vk::VertexInputBindingDescription],
         attribute_descriptions: &[ash::vk::VertexInputAttributeDescription],
         binding_divisor_state: Option<&ash::vk::PipelineVertexInputDivisorStateCreateInfoEXT>,

--- a/vulkano/src/pipeline/graphics/viewport.rs
+++ b/vulkano/src/pipeline/graphics/viewport.rs
@@ -51,8 +51,8 @@
 use crate::pipeline::graphics::GraphicsPipelineCreationError;
 use crate::pipeline::DynamicState;
 use crate::{device::Device, Version};
-use fnv::FnvHashMap;
 use smallvec::SmallVec;
+use std::collections::HashMap;
 use std::{ops::Range, ptr};
 
 /// List of viewports and scissors that are used when creating a graphics pipeline object.
@@ -196,7 +196,7 @@ impl ViewportState {
     pub(crate) fn to_vulkan_viewports_scissors(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
     ) -> Result<
         (
             u32,
@@ -351,7 +351,7 @@ impl ViewportState {
     pub(crate) fn to_vulkan(
         &self,
         device: &Device,
-        dynamic_state_modes: &mut FnvHashMap<DynamicState, bool>,
+        dynamic_state_modes: &mut HashMap<DynamicState, bool>,
         viewport_count: u32,
         viewports: &[ash::vk::Viewport],
         scissor_count: u32,

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -30,7 +30,6 @@ use crate::DeviceSize;
 use crate::OomError;
 use crate::Version;
 use crate::VulkanObject;
-use fnv::{FnvHashMap, FnvHashSet};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::error;
@@ -368,9 +367,9 @@ impl Display for ShaderSupportError {
 #[derive(Clone, Debug)]
 pub struct EntryPointInfo {
     pub execution: ShaderExecution,
-    pub descriptor_requirements: FnvHashMap<(u32, u32), DescriptorRequirements>,
+    pub descriptor_requirements: HashMap<(u32, u32), DescriptorRequirements>,
     pub push_constant_requirements: Option<PushConstantRange>,
-    pub specialization_constant_requirements: FnvHashMap<u32, SpecializationConstantRequirements>,
+    pub specialization_constant_requirements: HashMap<u32, SpecializationConstantRequirements>,
     pub input_interface: ShaderInterface,
     pub output_interface: ShaderInterface,
 }
@@ -554,35 +553,35 @@ pub struct DescriptorRequirements {
     pub image_view_type: Option<ImageViewType>,
 
     /// For sampler bindings, the descriptor indices that require a depth comparison sampler.
-    pub sampler_compare: FnvHashSet<u32>,
+    pub sampler_compare: HashSet<u32>,
 
     /// For sampler bindings, the descriptor indices that perform sampling operations that are not
     /// permitted with unnormalized coordinates. This includes sampling with `ImplicitLod`,
     /// `Dref` or `Proj` SPIR-V instructions or with an LOD bias or offset.
-    pub sampler_no_unnormalized_coordinates: FnvHashSet<u32>,
+    pub sampler_no_unnormalized_coordinates: HashSet<u32>,
 
     /// For sampler bindings, the descriptor indices that perform sampling operations that are not
     /// permitted with a sampler YCbCr conversion. This includes sampling with `Gather` SPIR-V
     /// instructions or with an offset.
-    pub sampler_no_ycbcr_conversion: FnvHashSet<u32>,
+    pub sampler_no_ycbcr_conversion: HashSet<u32>,
 
     /// For sampler bindings, the sampled image descriptors that are used in combination with each
     /// sampler descriptor index.
-    pub sampler_with_images: FnvHashMap<u32, FnvHashSet<DescriptorIdentifier>>,
+    pub sampler_with_images: HashMap<u32, HashSet<DescriptorIdentifier>>,
 
     /// The shader stages that the descriptor must be declared for.
     pub stages: ShaderStages,
 
     /// For storage image bindings, the descriptor indices that atomic operations are used with.
-    pub storage_image_atomic: FnvHashSet<u32>,
+    pub storage_image_atomic: HashSet<u32>,
 
     /// For storage images and storage texel buffers, the descriptor indices that perform read
     /// operations on the bound resource.
-    pub storage_read: FnvHashSet<u32>,
+    pub storage_read: HashSet<u32>,
 
     /// For storage buffers, storage images and storage texel buffers, the descriptor indices that
     /// perform write operations on the bound resource.
-    pub storage_write: FnvHashSet<u32>,
+    pub storage_write: HashSet<u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/vulkano/src/shader/reflect.rs
+++ b/vulkano/src/shader/reflect.rs
@@ -25,8 +25,8 @@ use crate::{
         ShaderInterfaceEntryType, ShaderStage, SpecializationConstantRequirements,
     },
 };
-use fnv::{FnvHashMap, FnvHashSet};
 use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 
 /// Returns an iterator of the capabilities used by `spirv`.
 pub fn spirv_capabilities<'a>(spirv: &'a Spirv) -> impl Iterator<Item = &'a Capability> {
@@ -170,7 +170,7 @@ fn shader_execution(
 
 #[derive(Clone, Debug, Default)]
 struct InterfaceVariables {
-    descriptor: FnvHashMap<Id, DescriptorVariable>,
+    descriptor: HashMap<Id, DescriptorVariable>,
 }
 
 // See also section 14.5.2 of the Vulkan specs: Descriptor Set Interface.
@@ -209,14 +209,14 @@ fn interface_variables(spirv: &Spirv) -> InterfaceVariables {
 }
 
 fn inspect_entry_point(
-    global: &FnvHashMap<Id, DescriptorVariable>,
+    global: &HashMap<Id, DescriptorVariable>,
     spirv: &Spirv,
     entry_point: Id,
-) -> FnvHashMap<(u32, u32), DescriptorRequirements> {
+) -> HashMap<(u32, u32), DescriptorRequirements> {
     #[inline]
     fn instruction_chain<'a, const N: usize>(
-        result: &'a mut FnvHashMap<Id, DescriptorVariable>,
-        global: &FnvHashMap<Id, DescriptorVariable>,
+        result: &'a mut HashMap<Id, DescriptorVariable>,
+        global: &HashMap<Id, DescriptorVariable>,
         spirv: &Spirv,
         chain: [fn(&Spirv, Id) -> Option<Id>; N],
         id: Id,
@@ -276,9 +276,9 @@ fn inspect_entry_point(
     }
 
     fn inspect_entry_point_r(
-        result: &mut FnvHashMap<Id, DescriptorVariable>,
-        inspected_functions: &mut FnvHashSet<Id>,
-        global: &FnvHashMap<Id, DescriptorVariable>,
+        result: &mut HashMap<Id, DescriptorVariable>,
+        inspected_functions: &mut HashSet<Id>,
+        global: &HashMap<Id, DescriptorVariable>,
         spirv: &Spirv,
         function: Id,
     ) {
@@ -672,8 +672,8 @@ fn inspect_entry_point(
         }
     }
 
-    let mut result = FnvHashMap::default();
-    let mut inspected_functions = FnvHashSet::default();
+    let mut result = HashMap::default();
+    let mut inspected_functions = HashSet::default();
     inspect_entry_point_r(
         &mut result,
         &mut inspected_functions,
@@ -940,7 +940,7 @@ fn push_constant_requirements(spirv: &Spirv, stage: ShaderStage) -> Option<PushC
 /// Extracts the `SpecializationConstantRequirements` from `spirv`.
 fn specialization_constant_requirements(
     spirv: &Spirv,
-) -> FnvHashMap<u32, SpecializationConstantRequirements> {
+) -> HashMap<u32, SpecializationConstantRequirements> {
     spirv
         .iter_global()
         .filter_map(|instruction| {


### PR DESCRIPTION
The `fnv` crate hasn't seen some updates in some time. The `std` implementation has improved greatly since `fnv` was introduced, making it on pair or even better than `fnv`. Overall this removes a dependency and might bring some performance gain. I wasn't able to measure any sort of significant performance gain from this change. One of my applications went from a 246 microsecond cpu time down to 230 microseconds.

```
- Replaced `fnv` crate's `FnvHashMap`, `FnvHashSet` & `FnvHasher` with their `std` counterparts.
```

There shouldn't be any breaking changes compared to what is released. I believe `descriptors_count()` was the only public point where this was exposed and that change has not been released.