### PR TITLE
Fix validation of SPIR-V contains OpUndef

### DIFF
--- a/vulkano/src/shader/spirv.rs
+++ b/vulkano/src/shader/spirv.rs
@@ -229,7 +229,8 @@ impl Spirv {
                 | Instruction::SpecConstantFalse { .. }
                 | Instruction::SpecConstant { .. }
                 | Instruction::SpecConstantComposite { .. }
-                | Instruction::SpecConstantOp { .. } => set_range(&mut range_global, index)?,
+                | Instruction::SpecConstantOp { .. }
+                | Instruction::Undef { .. } => set_range(&mut range_global, index)?,
                 Instruction::Variable { storage_class, .. }
                     if *storage_class != StorageClass::Function =>
                 {

--- a/vulkano/src/shader/spirv.rs
+++ b/vulkano/src/shader/spirv.rs
@@ -229,8 +229,8 @@ impl Spirv {
                 | Instruction::SpecConstantFalse { .. }
                 | Instruction::SpecConstant { .. }
                 | Instruction::SpecConstantComposite { .. }
-                | Instruction::SpecConstantOp { .. }
-                | Instruction::Undef { .. } => set_range(&mut range_global, index)?,
+                | Instruction::SpecConstantOp { .. } => set_range(&mut range_global, index)?,
+                Instruction::Undef { .. } if !in_function => set_range(&mut range_global, index)?,
                 Instruction::Variable { storage_class, .. }
                     if *storage_class != StorageClass::Function =>
                 {


### PR DESCRIPTION
This PR makes OpUndef the same group as OpTypeXXX and OpConstantXXX while validation of SPIR-V.

The basis for the change is the following text from the [SPIR-V specification](https://www.khronos.org/registry/SPIR-V/specs/1.2/SPIRV.html#LogicalLayout).

> 9. All type declarations (OpTypeXXX instructions), all constant instructions, and all global variable declarations (all OpVariable instructions whose Storage Class is not Function). This is the preferred location for OpUndef instructions, though they can also appear in function bodies.

This PR will allow the following SPIR-V to pass validation.

```
%67 = OpConstant %34 0.333333343
%68 = OpConstantTrue %46
%69 = OpUndef %27
%70 = OpUndef %34
%71 = OpConstantComposite %35 %55 %55
%72 = OpConstantComposite %35 %54 %55
```
(disassembled by spirv-dis)

changelog: 
```
- validate SPIR-V code containing OpUndef correctly.
```
