### PR TITLE
Fixed potential overflow in multiview vertex buffer validation

### DIFF
--- a/vulkano/src/command_buffer/validity/vertex_buffers.rs
+++ b/vulkano/src/command_buffer/validity/vertex_buffers.rs
@@ -95,7 +95,10 @@ pub(in super::super) fn check_vertex_buffers(
                 .max_multiview_instance_index
                 .unwrap_or(0);
 
-            if first_instance + instance_count > max_instance_index + 1 {
+            // The condition is somewhat convoluted to avoid integer overflows.
+            let out_of_range = first_instance > max_instance_index
+                || (instance_count > 0 && instance_count - 1 > max_instance_index - first_instance);
+            if out_of_range {
                 return Err(CheckVertexBufferError::TooManyInstances {
                     instance_count,
                     max_instance_count: max_instance_index + 1, // TODO: this can overflow


### PR DESCRIPTION
Fixed a potential integer overflow in the "valid" path of multiview vertex buffer validation when `max_instance_index` equals `u32::MAX`. In this case, the addition `max_instance_index + 1` on the right-hand side of the comparison overflows even for valid cases. The potential overflow in the error path (already marked "TODO") is not fixed by this.

I got hit by this issue when trying to run the multiview example on a Radeon 6700 XT with the amdgpu driver. The MESA driver apparently returns i32::MAX for `max_instance_index` and so it doesn't cause this overflow.