### PR TITLE
Release 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     Pull Request merge. 
 -->
 
+# Version 0.29.0 (2022-03-11)
+
 - **Breaking** `Instance` creation parameters are given using `InstanceCreateInfo`.
 - **Breaking** `ApplicationInfo` and the `app_info_from_cargo_toml!` macro are removed, their functionality is now integrated into `InstanceCreateInfo`.
 - **Breaking** `Device` creation parameters are given using `DeviceCreateInfo`.

--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano-shaders"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
@@ -20,7 +20,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 shaderc = "0.7.4"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-vulkano = { version = "0.28.0", path = "../vulkano" }
+vulkano = { version = "0.29.0", path = "../vulkano" }
 
 [features]
 shaderc-build-from-source = ["shaderc/build-from-source"]

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano-win"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
@@ -18,7 +18,7 @@ raw-window-handle_ = ["raw-window-handle"]
 
 [dependencies]
 winit = { version = "0.26", optional = true }
-vulkano = { version = "0.28.0", path = "../vulkano" }
+vulkano = { version = "0.29.0", path = "../vulkano" }
 raw-window-handle = { version = "0.4", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vulkano"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"


### PR DESCRIPTION
A lot of breaking changes have accumulated already. I am also working on an overhaul of buffer and image synchronization, which will be a big process spanning several PRs. There's a lot of potential for errors and it needs thorough testing, so I would prefer to submit those changes after the 0.29 release if possible.