### PR TITLE
Implement new locking for `UnsafeBuffer` and `UnsafeImage`

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -23,7 +23,7 @@ half = "1.8"
 lazy_static = "1.4"
 nalgebra = { version = "0.30.0", optional = true }
 parking_lot = { version = "0.12", features = ["send_guard"] }
-rangemap = { git = "https://github.com/Rua/rangemap", branch = "range-split" }
+rangemap = { git = "https://github.com/vulkano-rs/rangemap", branch = "range-split" }
 shared_library = "0.1"
 smallvec = "1.8"
 

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -23,6 +23,7 @@ half = "1.8"
 lazy_static = "1.4"
 nalgebra = { version = "0.30.0", optional = true }
 parking_lot = { version = "0.12", features = ["send_guard"] }
+rangemap = { git = "https://github.com/Rua/rangemap", branch = "range-split" }
 shared_library = "0.1"
 smallvec = "1.8"
 

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -21,7 +21,7 @@ use super::{
 };
 use crate::{
     buffer::{sys::UnsafeBufferCreateInfo, BufferCreationError, TypedBufferAccess},
-    device::{physical::QueueFamily, Device, DeviceOwned, Queue},
+    device::{physical::QueueFamily, Device, DeviceOwned},
     memory::{
         pool::{
             AllocFromRequirementsFilter, AllocLayout, MappingRequirement, MemoryPoolAlloc,
@@ -29,7 +29,7 @@ use crate::{
         },
         DedicatedAllocation, DeviceMemoryAllocationError, MemoryPool,
     },
-    sync::{AccessError, Sharing},
+    sync::Sharing,
     DeviceSize,
 };
 use smallvec::SmallVec;
@@ -405,27 +405,6 @@ where
     #[inline]
     fn conflict_key(&self) -> (u64, u64) {
         (self.inner.key(), 0)
-    }
-
-    #[inline]
-    fn try_gpu_lock(&self, write: bool, _: &Queue) -> Result<(), AccessError> {
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.try_gpu_lock(range, write)
-    }
-
-    #[inline]
-    unsafe fn increase_gpu_lock(&self, write: bool) {
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.increase_gpu_lock(range, write)
-    }
-
-    #[inline]
-    unsafe fn unlock(&self, write: bool) {
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.gpu_unlock(range, write)
     }
 }
 

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -19,7 +19,7 @@ use super::{
     BufferUsage, TypedBufferAccess,
 };
 use crate::{
-    device::{physical::QueueFamily, Device, DeviceOwned, Queue},
+    device::{physical::QueueFamily, Device, DeviceOwned},
     memory::{
         pool::{
             alloc_dedicated_with_exportable_fd, AllocFromRequirementsFilter, AllocLayout,
@@ -28,7 +28,7 @@ use crate::{
         DedicatedAllocation, DeviceMemoryAllocationError, DeviceMemoryExportError,
         ExternalMemoryHandleType, MemoryPool, MemoryRequirements,
     },
-    sync::{AccessError, Sharing},
+    sync::Sharing,
     DeviceSize,
 };
 use smallvec::SmallVec;
@@ -323,27 +323,6 @@ where
     #[inline]
     fn conflict_key(&self) -> (u64, u64) {
         (self.inner.key(), 0)
-    }
-
-    #[inline]
-    fn try_gpu_lock(&self, write: bool, _: &Queue) -> Result<(), AccessError> {
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.try_gpu_lock(range, write)
-    }
-
-    #[inline]
-    unsafe fn increase_gpu_lock(&self, write: bool) {
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.increase_gpu_lock(range, write)
-    }
-
-    #[inline]
-    unsafe fn unlock(&self, write: bool) {
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.gpu_unlock(range, write)
     }
 }
 

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -36,7 +36,7 @@ use crate::{
         },
         DedicatedAllocation, DeviceMemoryAllocationError, MemoryPool,
     },
-    sync::{AccessError, NowFuture, Sharing},
+    sync::{NowFuture, Sharing},
     DeviceSize,
 };
 use smallvec::SmallVec;
@@ -44,10 +44,7 @@ use std::{
     hash::{Hash, Hasher},
     marker::PhantomData,
     mem::size_of,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+    sync::Arc,
 };
 
 /// Buffer that is written once then read for as long as it is alive.
@@ -61,10 +58,6 @@ where
 
     // Memory allocated for the buffer.
     memory: A,
-
-    // True if the `ImmutableBufferInitialization` object was used by the GPU then dropped.
-    // This means that the `ImmutableBuffer` can be used as much as we want without any restriction.
-    initialized: AtomicBool,
 
     // Queue families allowed to access this buffer.
     queue_families: SmallVec<[u32; 4]>,
@@ -370,13 +363,11 @@ where
             inner: buffer,
             memory: mem,
             queue_families: queue_families,
-            initialized: AtomicBool::new(false),
             marker: PhantomData,
         });
 
         let initialization = Arc::new(ImmutableBufferInitialization {
             buffer: final_buf.clone(),
-            used: Arc::new(AtomicBool::new(false)),
         });
 
         Ok((final_buf, initialization))
@@ -430,35 +421,6 @@ where
     #[inline]
     fn conflict_key(&self) -> (u64, u64) {
         (self.inner.key(), 0)
-    }
-
-    #[inline]
-    fn try_gpu_lock(&self, write: bool, _: &Queue) -> Result<(), AccessError> {
-        if write {
-            return Err(AccessError::ExclusiveDenied);
-        }
-
-        if !self.initialized.load(Ordering::Relaxed) {
-            return Err(AccessError::BufferNotInitialized);
-        }
-
-        let mut state = self.inner.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.try_gpu_lock(range, write)
-    }
-
-    #[inline]
-    unsafe fn increase_gpu_lock(&self, write: bool) {
-        let mut state = self.inner.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.increase_gpu_lock(range, write)
-    }
-
-    #[inline]
-    unsafe fn unlock(&self, write: bool) {
-        let mut state = self.inner.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.gpu_unlock(range, write)
     }
 }
 
@@ -528,7 +490,6 @@ where
     T: BufferContents + ?Sized,
 {
     buffer: Arc<ImmutableBuffer<T, A>>,
-    used: Arc<AtomicBool>,
 }
 
 unsafe impl<T, A> BufferAccess for ImmutableBufferInitialization<T, A>
@@ -549,43 +510,6 @@ where
     #[inline]
     fn conflict_key(&self) -> (u64, u64) {
         (self.buffer.inner.key(), 0)
-    }
-
-    #[inline]
-    fn try_gpu_lock(&self, write: bool, _: &Queue) -> Result<(), AccessError> {
-        if self.buffer.initialized.load(Ordering::Relaxed) {
-            return Err(AccessError::AlreadyInUse);
-        }
-
-        if self
-            .used
-            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-            .unwrap_or_else(|e| e)
-        {
-            return Err(AccessError::AlreadyInUse);
-        }
-
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.try_gpu_lock(range, write)
-    }
-
-    #[inline]
-    unsafe fn increase_gpu_lock(&self, write: bool) {
-        debug_assert!(self.used.load(Ordering::Relaxed));
-
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.increase_gpu_lock(range, write)
-    }
-
-    #[inline]
-    unsafe fn unlock(&self, write: bool) {
-        self.buffer.initialized.store(true, Ordering::Relaxed);
-
-        let mut state = self.inner().buffer.state();
-        let range = self.inner().offset..self.inner().offset + self.size();
-        state.gpu_unlock(range, write)
     }
 }
 
@@ -626,7 +550,6 @@ where
     fn clone(&self) -> ImmutableBufferInitialization<T, A> {
         ImmutableBufferInitialization {
             buffer: self.buffer.clone(),
-            used: self.used.clone(),
         }
     }
 }
@@ -738,62 +661,6 @@ mod tests {
         for (n, &v) in destination_content.iter().enumerate() {
             assert_eq!(n * 2, v as usize);
         }
-    }
-
-    #[test]
-    fn writing_forbidden() {
-        let (device, queue) = gfx_dev_and_queue!();
-
-        let (buffer, _) =
-            ImmutableBuffer::from_data(12u32, BufferUsage::all(), queue.clone()).unwrap();
-
-        assert_should_panic!({
-            // TODO: check Result error instead of panicking
-            let mut cbb = AutoCommandBufferBuilder::primary(
-                device.clone(),
-                queue.family(),
-                CommandBufferUsage::MultipleSubmit,
-            )
-            .unwrap();
-            cbb.fill_buffer(buffer, 50).unwrap();
-            let _ = cbb
-                .build()
-                .unwrap()
-                .execute(queue.clone())
-                .unwrap()
-                .then_signal_fence_and_flush()
-                .unwrap();
-        });
-    }
-
-    #[test]
-    fn read_uninitialized_forbidden() {
-        let (device, queue) = gfx_dev_and_queue!();
-
-        let (buffer, _) = unsafe {
-            ImmutableBuffer::<u32>::uninitialized(device.clone(), BufferUsage::all()).unwrap()
-        };
-
-        let source =
-            CpuAccessibleBuffer::from_data(device.clone(), BufferUsage::all(), false, 0).unwrap();
-
-        assert_should_panic!({
-            // TODO: check Result error instead of panicking
-            let mut cbb = AutoCommandBufferBuilder::primary(
-                device.clone(),
-                queue.family(),
-                CommandBufferUsage::MultipleSubmit,
-            )
-            .unwrap();
-            cbb.copy_buffer(source, buffer).unwrap();
-            let _ = cbb
-                .build()
-                .unwrap()
-                .execute(queue.clone())
-                .unwrap()
-                .then_signal_fence_and_flush()
-                .unwrap();
-        });
     }
 
     #[test]

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -237,18 +237,18 @@ where
     }
 
     #[inline]
-    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue) -> Result<(), AccessError> {
-        self.resource.try_gpu_lock(exclusive_access, queue)
+    fn try_gpu_lock(&self, write: bool, queue: &Queue) -> Result<(), AccessError> {
+        self.resource.try_gpu_lock(write, queue)
     }
 
     #[inline]
-    unsafe fn increase_gpu_lock(&self) {
-        self.resource.increase_gpu_lock()
+    unsafe fn increase_gpu_lock(&self, write: bool) {
+        self.resource.increase_gpu_lock(write)
     }
 
     #[inline]
-    unsafe fn unlock(&self) {
-        self.resource.unlock()
+    unsafe fn unlock(&self, write: bool) {
+        self.resource.unlock(write)
     }
 }
 

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -24,35 +24,40 @@
 //!   sparse binding.
 //! - Type safety.
 
-use crate::check_errors;
-use crate::device::Device;
-use crate::device::DeviceOwned;
-use crate::memory::DeviceMemory;
-use crate::memory::DeviceMemoryAllocationError;
-use crate::memory::MemoryRequirements;
-use crate::sync::Sharing;
-use crate::DeviceSize;
-use crate::Error;
-use crate::OomError;
-use crate::VulkanObject;
-use crate::{buffer::BufferUsage, Version};
+use super::{
+    cpu_access::{ReadLockError, WriteLockError},
+    BufferUsage,
+};
+use crate::{
+    check_errors,
+    device::{Device, DeviceOwned},
+    memory::{DeviceMemory, DeviceMemoryAllocationError, MemoryRequirements},
+    sync::{AccessError, CurrentAccess, Sharing},
+    DeviceSize, Error, OomError, Version, VulkanObject,
+};
 use ash::vk::Handle;
+use parking_lot::{Mutex, MutexGuard};
+use rangemap::RangeMap;
 use smallvec::SmallVec;
-use std::error;
-use std::fmt;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::mem::MaybeUninit;
-use std::ptr;
-use std::sync::Arc;
+use std::{
+    error, fmt,
+    hash::{Hash, Hasher},
+    mem::MaybeUninit,
+    ops::Range,
+    ptr,
+    sync::Arc,
+};
 
 /// Data storage in a GPU-accessible location.
 #[derive(Debug)]
 pub struct UnsafeBuffer {
     handle: ash::vk::Buffer,
     device: Arc<Device>,
+
     size: DeviceSize,
     usage: BufferUsage,
+
+    state: Mutex<BufferState>,
 }
 
 impl UnsafeBuffer {
@@ -167,8 +172,11 @@ impl UnsafeBuffer {
         let buffer = UnsafeBuffer {
             handle,
             device,
+
             size,
             usage,
+
+            state: Mutex::new(BufferState::new(size)),
         };
 
         Ok(buffer)
@@ -311,6 +319,10 @@ impl UnsafeBuffer {
             offset,
         ))?;
         Ok(())
+    }
+
+    pub(crate) fn state(&self) -> MutexGuard<BufferState> {
+        self.state.lock()
     }
 
     /// Returns the size of the buffer in bytes.
@@ -525,6 +537,254 @@ impl From<SparseLevel> for ash::vk::BufferCreateFlags {
         }
         result
     }
+}
+
+/// The current state of a buffer.
+#[derive(Debug)]
+pub(crate) struct BufferState {
+    ranges: RangeMap<DeviceSize, BufferRangeState>,
+}
+
+impl BufferState {
+    fn new(size: DeviceSize) -> Self {
+        BufferState {
+            ranges: [(
+                0..size,
+                BufferRangeState {
+                    current_access: CurrentAccess::Shared {
+                        cpu_reads: 0,
+                        gpu_reads: 0,
+                    },
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }
+    }
+
+    pub(crate) fn try_cpu_read(&mut self, range: Range<DeviceSize>) -> Result<(), ReadLockError> {
+        for (_range, state) in self.ranges.range(&range) {
+            match &state.current_access {
+                CurrentAccess::CpuExclusive { .. } => return Err(ReadLockError::CpuWriteLocked),
+                CurrentAccess::GpuExclusive { .. } => return Err(ReadLockError::GpuWriteLocked),
+                CurrentAccess::Shared { .. } => (),
+            }
+        }
+
+        self.ranges.split_at(&range.start);
+        self.ranges.split_at(&range.end);
+
+        for (_range, state) in self.ranges.range_mut(&range) {
+            match &mut state.current_access {
+                CurrentAccess::Shared { cpu_reads, .. } => {
+                    *cpu_reads += 1;
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn try_cpu_write(&mut self, range: Range<DeviceSize>) -> Result<(), WriteLockError> {
+        for (_range, state) in self.ranges.range(&range) {
+            match &state.current_access {
+                CurrentAccess::CpuExclusive => return Err(WriteLockError::CpuLocked),
+                CurrentAccess::GpuExclusive { .. } => return Err(WriteLockError::GpuLocked),
+                CurrentAccess::Shared {
+                    cpu_reads: 0,
+                    gpu_reads: 0,
+                } => (),
+                CurrentAccess::Shared { cpu_reads, .. } if *cpu_reads > 0 => {
+                    return Err(WriteLockError::CpuLocked)
+                }
+                CurrentAccess::Shared { .. } => return Err(WriteLockError::GpuLocked),
+            }
+        }
+
+        self.ranges.split_at(&range.start);
+        self.ranges.split_at(&range.end);
+
+        for (_range, state) in self.ranges.range_mut(&range) {
+            state.current_access = CurrentAccess::CpuExclusive;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) unsafe fn cpu_unlock(&mut self, range: Range<DeviceSize>, write: bool) {
+        if write {
+            self.ranges.split_at(&range.start);
+            self.ranges.split_at(&range.end);
+
+            for (_range, state) in self.ranges.range_mut(&range) {
+                match &mut state.current_access {
+                    CurrentAccess::CpuExclusive => {
+                        state.current_access = CurrentAccess::Shared {
+                            cpu_reads: 0,
+                            gpu_reads: 0,
+                        }
+                    }
+                    CurrentAccess::GpuExclusive { .. } => {
+                        unreachable!("Buffer is being written by the GPU")
+                    }
+                    CurrentAccess::Shared { .. } => {
+                        unreachable!("Buffer is not being written by the CPU")
+                    }
+                }
+            }
+        } else {
+            self.ranges.split_at(&range.start);
+            self.ranges.split_at(&range.end);
+
+            for (_range, state) in self.ranges.range_mut(&range) {
+                match &mut state.current_access {
+                    CurrentAccess::CpuExclusive => {
+                        unreachable!("Buffer is being written by the CPU")
+                    }
+                    CurrentAccess::GpuExclusive { .. } => {
+                        unreachable!("Buffer is being written by the GPU")
+                    }
+                    CurrentAccess::Shared { cpu_reads, .. } => *cpu_reads -= 1,
+                }
+            }
+        }
+    }
+
+    pub(crate) fn try_gpu_lock(
+        &mut self,
+        range: Range<DeviceSize>,
+        write: bool,
+    ) -> Result<(), AccessError> {
+        if write {
+            for (_range, state) in self.ranges.range(&range) {
+                match &state.current_access {
+                    CurrentAccess::Shared {
+                        cpu_reads: 0,
+                        gpu_reads: 0,
+                    } => (),
+                    _ => return Err(AccessError::AlreadyInUse),
+                }
+            }
+
+            self.ranges.split_at(&range.start);
+            self.ranges.split_at(&range.end);
+
+            for (_range, state) in self.ranges.range_mut(&range) {
+                state.current_access = CurrentAccess::GpuExclusive {
+                    gpu_reads: 0,
+                    gpu_writes: 1,
+                };
+            }
+        } else {
+            for (_range, state) in self.ranges.range(&range) {
+                match &state.current_access {
+                    CurrentAccess::Shared { .. } => (),
+                    _ => return Err(AccessError::AlreadyInUse),
+                }
+            }
+
+            self.ranges.split_at(&range.start);
+            self.ranges.split_at(&range.end);
+
+            for (_range, state) in self.ranges.range_mut(&range) {
+                match &mut state.current_access {
+                    CurrentAccess::Shared { gpu_reads, .. } => *gpu_reads += 1,
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) unsafe fn increase_gpu_lock(&mut self, range: Range<DeviceSize>, write: bool) {
+        if write {
+            self.ranges.split_at(&range.start);
+            self.ranges.split_at(&range.end);
+
+            for (_range, state) in self.ranges.range_mut(&range) {
+                match &mut state.current_access {
+                    CurrentAccess::CpuExclusive => {
+                        unreachable!("Buffer is being written by the CPU")
+                    }
+                    CurrentAccess::GpuExclusive { gpu_writes, .. } => *gpu_writes += 1,
+                    &mut CurrentAccess::Shared {
+                        cpu_reads: 0,
+                        gpu_reads,
+                    } => {
+                        state.current_access = CurrentAccess::GpuExclusive {
+                            gpu_reads,
+                            gpu_writes: 1,
+                        }
+                    }
+                    CurrentAccess::Shared { .. } => {
+                        unreachable!("Buffer is being read by the CPU")
+                    }
+                }
+            }
+        } else {
+            self.ranges.split_at(&range.start);
+            self.ranges.split_at(&range.end);
+
+            for (_range, state) in self.ranges.range_mut(&range) {
+                match &mut state.current_access {
+                    CurrentAccess::CpuExclusive => {
+                        unreachable!("Buffer is being written by the CPU")
+                    }
+                    CurrentAccess::GpuExclusive { gpu_reads, .. }
+                    | CurrentAccess::Shared { gpu_reads, .. } => *gpu_reads += 1,
+                }
+            }
+        }
+    }
+
+    pub(crate) unsafe fn gpu_unlock(&mut self, range: Range<DeviceSize>, write: bool) {
+        if write {
+            self.ranges.split_at(&range.start);
+            self.ranges.split_at(&range.end);
+
+            for (_range, state) in self.ranges.range_mut(&range) {
+                match &mut state.current_access {
+                    CurrentAccess::CpuExclusive => {
+                        unreachable!("Buffer is being written by the CPU")
+                    }
+                    &mut CurrentAccess::GpuExclusive {
+                        gpu_reads,
+                        gpu_writes: 1,
+                    } => {
+                        state.current_access = CurrentAccess::Shared {
+                            cpu_reads: 0,
+                            gpu_reads,
+                        }
+                    }
+                    CurrentAccess::GpuExclusive { gpu_writes, .. } => *gpu_writes -= 1,
+                    CurrentAccess::Shared { .. } => {
+                        unreachable!("Buffer is not being written by the GPU")
+                    }
+                }
+            }
+        } else {
+            self.ranges.split_at(&range.start);
+            self.ranges.split_at(&range.end);
+
+            for (_range, state) in self.ranges.range_mut(&range) {
+                match &mut state.current_access {
+                    CurrentAccess::CpuExclusive => {
+                        unreachable!("Buffer is being written by the CPU")
+                    }
+                    CurrentAccess::GpuExclusive { gpu_reads, .. } => *gpu_reads -= 1,
+                    CurrentAccess::Shared { gpu_reads, .. } => *gpu_reads -= 1,
+                }
+            }
+        }
+    }
+}
+
+/// The current state of a specific range of bytes in a buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct BufferRangeState {
+    current_access: CurrentAccess,
 }
 
 #[cfg(test)]

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -89,7 +89,7 @@ pub unsafe trait BufferAccess: DeviceOwned + Send + Sync {
     /// If you call this function, you should call `unlock()` once the resource is no longer in use
     /// by the GPU. The implementation is not expected to automatically perform any unlocking and
     /// can rely on the fact that `unlock()` is going to be called.
-    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue) -> Result<(), AccessError>;
+    fn try_gpu_lock(&self, write: bool, queue: &Queue) -> Result<(), AccessError>;
 
     /// Locks the resource for usage on the GPU. Supposes that the resource is already locked, and
     /// simply increases the lock by one.
@@ -99,14 +99,14 @@ pub unsafe trait BufferAccess: DeviceOwned + Send + Sync {
     /// If you call this function, you should call `unlock()` once the resource is no longer in use
     /// by the GPU. The implementation is not expected to automatically perform any unlocking and
     /// can rely on the fact that `unlock()` is going to be called.
-    unsafe fn increase_gpu_lock(&self);
+    unsafe fn increase_gpu_lock(&self, write: bool);
 
     /// Unlocks the resource previously acquired with `try_gpu_lock` or `increase_gpu_lock`.
     ///
     /// # Safety
     ///
     /// Must only be called once per previous lock.
-    unsafe fn unlock(&self);
+    unsafe fn unlock(&self, write: bool);
 
     /// Gets the device address for this buffer.
     ///
@@ -189,18 +189,18 @@ where
     }
 
     #[inline]
-    fn try_gpu_lock(&self, exclusive_access: bool, queue: &Queue) -> Result<(), AccessError> {
-        (**self).try_gpu_lock(exclusive_access, queue)
+    fn try_gpu_lock(&self, write: bool, queue: &Queue) -> Result<(), AccessError> {
+        (**self).try_gpu_lock(write, queue)
     }
 
     #[inline]
-    unsafe fn increase_gpu_lock(&self) {
-        (**self).increase_gpu_lock()
+    unsafe fn increase_gpu_lock(&self, write: bool) {
+        (**self).increase_gpu_lock(write)
     }
 
     #[inline]
-    unsafe fn unlock(&self) {
-        (**self).unlock()
+    unsafe fn unlock(&self, write: bool) {
+        (**self).unlock(write)
     }
 }
 

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -135,21 +135,36 @@ impl SyncCommandBuffer {
 
             match &resource_use.resource {
                 KeyTy::Buffer(buffer) => {
+                    // Can happen with `CpuBufferPool`
+                    if buffer.size() == 0 {
+                        continue;
+                    }
+
+                    let inner = buffer.inner();
+                    let mut buffer_state = inner.buffer.state();
+
                     // Because try_gpu_lock needs to be called first,
                     // this should never return Ok without first returning Err
                     let prev_err =
                         match future.check_buffer_access(buffer.as_ref(), state.exclusive, queue) {
-                            Ok(_) => {
-                                unsafe {
-                                    buffer.increase_gpu_lock(state.exclusive);
-                                }
+                            Ok(_) => unsafe {
+                                buffer_state.increase_gpu_lock(
+                                    inner.offset..inner.offset + buffer.size(),
+                                    state.exclusive,
+                                );
                                 locked_resources += 1;
                                 continue;
-                            }
+                            },
                             Err(err) => err,
                         };
 
-                    match (buffer.try_gpu_lock(state.exclusive, queue), prev_err) {
+                    match (
+                        buffer_state.try_gpu_lock(
+                            inner.offset..inner.offset + buffer.size(),
+                            state.exclusive,
+                        ),
+                        prev_err,
+                    ) {
                         (Ok(_), _) => (),
                         (Err(err), AccessCheckError::Unknown)
                         | (_, AccessCheckError::Denied(err)) => {
@@ -167,27 +182,37 @@ impl SyncCommandBuffer {
                 }
 
                 KeyTy::Image(image) => {
+                    let inner = image.inner();
+                    let mut image_state = inner.image.state();
+
                     let prev_err = match future.check_image_access(
                         image.as_ref(),
                         state.initial_layout,
                         state.exclusive,
                         queue,
                     ) {
-                        Ok(_) => {
-                            unsafe {
-                                image.increase_gpu_lock(state.exclusive);
-                            }
+                        Ok(_) => unsafe {
+                            image_state.increase_gpu_lock(
+                                inner.image.format().unwrap().aspects(),
+                                image.current_mip_levels_access(),
+                                image.current_array_layers_access(),
+                                state.exclusive,
+                                state.final_layout,
+                            );
                             locked_resources += 1;
                             continue;
-                        }
+                        },
                         Err(err) => err,
                     };
 
                     match (
-                        image.try_gpu_lock(
+                        image_state.try_gpu_lock(
+                            inner.image.format().unwrap().aspects(),
+                            image.current_mip_levels_access(),
+                            image.current_array_layers_access(),
                             state.exclusive,
-                            state.image_uninitialized_safe.is_safe(),
                             state.initial_layout,
+                            state.final_layout,
                         ),
                         prev_err,
                     ) {
@@ -218,18 +243,23 @@ impl SyncCommandBuffer {
 
                 match &resource_use.resource {
                     KeyTy::Buffer(buffer) => unsafe {
-                        buffer.unlock(state.exclusive);
+                        let inner = buffer.inner();
+                        let mut buffer_state = inner.buffer.state();
+                        buffer_state.gpu_unlock(
+                            inner.offset..inner.offset + buffer.size(),
+                            state.exclusive,
+                        );
                     },
-                    KeyTy::Image(image) => {
-                        let trans = if state.final_layout != state.initial_layout {
-                            Some(state.final_layout)
-                        } else {
-                            None
-                        };
-                        unsafe {
-                            image.unlock(state.exclusive, trans);
-                        }
-                    }
+                    KeyTy::Image(image) => unsafe {
+                        let inner = image.inner();
+                        let mut image_state = inner.image.state();
+                        image_state.gpu_unlock(
+                            inner.image.format().unwrap().aspects(),
+                            image.current_mip_levels_access(),
+                            image.current_array_layers_access(),
+                            state.exclusive,
+                        )
+                    },
                 }
             }
         }
@@ -253,15 +283,20 @@ impl SyncCommandBuffer {
 
             match &resource_use.resource {
                 KeyTy::Buffer(buffer) => {
-                    buffer.unlock(state.exclusive);
+                    let inner = buffer.inner();
+                    let mut buffer_state = inner.buffer.state();
+                    buffer_state
+                        .gpu_unlock(inner.offset..inner.offset + buffer.size(), state.exclusive);
                 }
                 KeyTy::Image(image) => {
-                    let trans = if state.final_layout != state.initial_layout {
-                        Some(state.final_layout)
-                    } else {
-                        None
-                    };
-                    image.unlock(state.exclusive, trans);
+                    let inner = image.inner();
+                    let mut image_state = inner.image.state();
+                    image_state.gpu_unlock(
+                        inner.image.format().unwrap().aspects(),
+                        image.current_mip_levels_access(),
+                        image.current_array_layers_access(),
+                        state.exclusive,
+                    )
                 }
             }
         }

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -141,7 +141,7 @@ impl SyncCommandBuffer {
                         match future.check_buffer_access(buffer.as_ref(), state.exclusive, queue) {
                             Ok(_) => {
                                 unsafe {
-                                    buffer.increase_gpu_lock();
+                                    buffer.increase_gpu_lock(state.exclusive);
                                 }
                                 locked_resources += 1;
                                 continue;
@@ -175,7 +175,7 @@ impl SyncCommandBuffer {
                     ) {
                         Ok(_) => {
                             unsafe {
-                                image.increase_gpu_lock();
+                                image.increase_gpu_lock(state.exclusive);
                             }
                             locked_resources += 1;
                             continue;
@@ -218,7 +218,7 @@ impl SyncCommandBuffer {
 
                 match &resource_use.resource {
                     KeyTy::Buffer(buffer) => unsafe {
-                        buffer.unlock();
+                        buffer.unlock(state.exclusive);
                     },
                     KeyTy::Image(image) => {
                         let trans = if state.final_layout != state.initial_layout {
@@ -227,7 +227,7 @@ impl SyncCommandBuffer {
                             None
                         };
                         unsafe {
-                            image.unlock(trans);
+                            image.unlock(state.exclusive, trans);
                         }
                     }
                 }
@@ -253,7 +253,7 @@ impl SyncCommandBuffer {
 
             match &resource_use.resource {
                 KeyTy::Buffer(buffer) => {
-                    buffer.unlock();
+                    buffer.unlock(state.exclusive);
                 }
                 KeyTy::Image(image) => {
                     let trans = if state.final_layout != state.initial_layout {
@@ -261,7 +261,7 @@ impl SyncCommandBuffer {
                     } else {
                         None
                     };
-                    image.unlock(trans);
+                    image.unlock(state.exclusive, trans);
                 }
             }
         }

--- a/vulkano/src/image/aspect.rs
+++ b/vulkano/src/image/aspect.rs
@@ -12,7 +12,7 @@ use std::ops::BitOr;
 /// An individual data type within an image.
 ///
 /// Most images have only the `Color` aspect, but some may have several.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ImageAspect {
     Color = ash::vk::ImageAspectFlags::COLOR.as_raw(),
@@ -91,6 +91,36 @@ impl ImageAspects {
             && (memory_plane0 || !other.memory_plane0)
             && (memory_plane1 || !other.memory_plane1)
             && (memory_plane2 || !other.memory_plane2)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = ImageAspect> {
+        let Self {
+            color,
+            depth,
+            stencil,
+            metadata,
+            plane0,
+            plane1,
+            plane2,
+            memory_plane0,
+            memory_plane1,
+            memory_plane2,
+        } = *self;
+
+        [
+            color.then(|| ImageAspect::Color),
+            depth.then(|| ImageAspect::Depth),
+            stencil.then(|| ImageAspect::Stencil),
+            metadata.then(|| ImageAspect::Metadata),
+            plane0.then(|| ImageAspect::Plane0),
+            plane1.then(|| ImageAspect::Plane1),
+            plane2.then(|| ImageAspect::Plane2),
+            memory_plane0.then(|| ImageAspect::MemoryPlane0),
+            memory_plane1.then(|| ImageAspect::MemoryPlane1),
+            memory_plane2.then(|| ImageAspect::MemoryPlane2),
+        ]
+        .into_iter()
+        .flatten()
     }
 }
 

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -25,7 +25,7 @@ use crate::{
         DedicatedAllocation, DeviceMemoryExportError, ExternalMemoryHandleType,
         ExternalMemoryHandleTypes, MemoryPool,
     },
-    sync::{AccessError, Sharing},
+    sync::Sharing,
     DeviceSize,
 };
 use smallvec::SmallVec;
@@ -277,53 +277,6 @@ where
     #[inline]
     fn conflict_key(&self) -> u64 {
         self.image.key()
-    }
-
-    #[inline]
-    fn try_gpu_lock(
-        &self,
-        write: bool,
-        uninitialized_safe: bool,
-        expected_layout: ImageLayout,
-    ) -> Result<(), AccessError> {
-        let mut state = self.inner().image.state();
-        state.try_gpu_lock(
-            self.inner().image.format().unwrap().aspects(),
-            self.inner().first_mipmap_level as u32
-                ..self.inner().first_mipmap_level as u32 + self.inner().num_mipmap_levels as u32,
-            self.inner().first_layer as u32
-                ..self.inner().first_layer as u32 + self.inner().num_layers as u32,
-            write,
-            expected_layout,
-            self.final_layout_requirement(),
-        )
-    }
-
-    #[inline]
-    unsafe fn increase_gpu_lock(&self, write: bool) {
-        let mut state = self.inner().image.state();
-        state.increase_gpu_lock(
-            self.inner().image.format().unwrap().aspects(),
-            self.inner().first_mipmap_level as u32
-                ..self.inner().first_mipmap_level as u32 + self.inner().num_mipmap_levels as u32,
-            self.inner().first_layer as u32
-                ..self.inner().first_layer as u32 + self.inner().num_layers as u32,
-            write,
-            self.final_layout_requirement(),
-        )
-    }
-
-    #[inline]
-    unsafe fn unlock(&self, write: bool, new_layout: Option<ImageLayout>) {
-        let mut state = self.inner().image.state();
-        state.gpu_unlock(
-            self.inner().image.format().unwrap().aspects(),
-            self.inner().first_mipmap_level as u32
-                ..self.inner().first_mipmap_level as u32 + self.inner().num_mipmap_levels as u32,
-            self.inner().first_layer as u32
-                ..self.inner().first_layer as u32 + self.inner().num_layers as u32,
-            write,
-        )
     }
 
     #[inline]

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -11,7 +11,7 @@ use super::{
     traits::{ImageClearValue, ImageContent},
     ImageAccess, ImageDescriptorLayouts, ImageInner, ImageLayout,
 };
-use crate::{format::ClearValue, swapchain::Swapchain, sync::AccessError, OomError};
+use crate::{format::ClearValue, swapchain::Swapchain, OomError};
 use std::{
     hash::{Hash, Hasher},
     sync::Arc,
@@ -107,58 +107,6 @@ where
     #[inline]
     fn conflict_key(&self) -> u64 {
         self.my_image().image.key()
-    }
-
-    #[inline]
-    fn try_gpu_lock(
-        &self,
-        write: bool,
-        uninitialized_safe: bool,
-        expected_layout: ImageLayout,
-    ) -> Result<(), AccessError> {
-        if !self.swapchain.is_full_screen_exclusive() {
-            // Swapchain image are only accessible after being acquired.
-            return Err(AccessError::SwapchainImageAcquireOnly);
-        }
-
-        let mut state = self.inner().image.state();
-        state.try_gpu_lock(
-            self.inner().image.format().unwrap().aspects(),
-            self.inner().first_mipmap_level as u32
-                ..self.inner().first_mipmap_level as u32 + self.inner().num_mipmap_levels as u32,
-            self.inner().first_layer as u32
-                ..self.inner().first_layer as u32 + self.inner().num_layers as u32,
-            write,
-            expected_layout,
-            self.final_layout_requirement(),
-        )
-    }
-
-    #[inline]
-    unsafe fn increase_gpu_lock(&self, write: bool) {
-        let mut state = self.inner().image.state();
-        state.increase_gpu_lock(
-            self.inner().image.format().unwrap().aspects(),
-            self.inner().first_mipmap_level as u32
-                ..self.inner().first_mipmap_level as u32 + self.inner().num_mipmap_levels as u32,
-            self.inner().first_layer as u32
-                ..self.inner().first_layer as u32 + self.inner().num_layers as u32,
-            write,
-            self.final_layout_requirement(),
-        )
-    }
-
-    #[inline]
-    unsafe fn unlock(&self, write: bool, new_layout: Option<ImageLayout>) {
-        let mut state = self.inner().image.state();
-        state.gpu_unlock(
-            self.inner().image.format().unwrap().aspects(),
-            self.inner().first_mipmap_level as u32
-                ..self.inner().first_mipmap_level as u32 + self.inner().num_mipmap_levels as u32,
-            self.inner().first_layer as u32
-                ..self.inner().first_layer as u32 + self.inner().num_layers as u32,
-            write,
-        )
     }
 
     #[inline]

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -160,7 +160,7 @@ pub unsafe trait ImageAccess: Send + Sync {
     /// can rely on the fact that `unlock()` is going to be called.
     fn try_gpu_lock(
         &self,
-        exclusive_access: bool,
+        write: bool,
         uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError>;
@@ -173,7 +173,7 @@ pub unsafe trait ImageAccess: Send + Sync {
     /// If you call this function, you should call `unlock()` once the resource is no longer in use
     /// by the GPU. The implementation is not expected to automatically perform any unlocking and
     /// can rely on the fact that `unlock()` is going to be called.
-    unsafe fn increase_gpu_lock(&self);
+    unsafe fn increase_gpu_lock(&self, write: bool);
 
     /// Unlocks the resource previously acquired with `try_gpu_lock` or `increase_gpu_lock`.
     ///
@@ -194,7 +194,7 @@ pub unsafe trait ImageAccess: Send + Sync {
     ///   `ColorAttachmentOptimal` if the image wasn't created with the `color_attachment` usage).
     /// - The transitioned layout must not be `Undefined`.
     ///
-    unsafe fn unlock(&self, transitioned_layout: Option<ImageLayout>);
+    unsafe fn unlock(&self, write: bool, transitioned_layout: Option<ImageLayout>);
 }
 
 /// Inner information about an image.
@@ -276,22 +276,22 @@ where
     #[inline]
     fn try_gpu_lock(
         &self,
-        exclusive_access: bool,
+        write: bool,
         uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {
         self.image
-            .try_gpu_lock(exclusive_access, uninitialized_safe, expected_layout)
+            .try_gpu_lock(write, uninitialized_safe, expected_layout)
     }
 
     #[inline]
-    unsafe fn increase_gpu_lock(&self) {
-        self.image.increase_gpu_lock()
+    unsafe fn increase_gpu_lock(&self, write: bool) {
+        self.image.increase_gpu_lock(write)
     }
 
     #[inline]
-    unsafe fn unlock(&self, new_layout: Option<ImageLayout>) {
-        self.image.unlock(new_layout)
+    unsafe fn unlock(&self, write: bool, new_layout: Option<ImageLayout>) {
+        self.image.unlock(write, new_layout)
     }
 
     fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
@@ -370,21 +370,21 @@ where
     #[inline]
     fn try_gpu_lock(
         &self,
-        exclusive_access: bool,
+        write: bool,
         uninitialized_safe: bool,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {
-        (**self).try_gpu_lock(exclusive_access, uninitialized_safe, expected_layout)
+        (**self).try_gpu_lock(write, uninitialized_safe, expected_layout)
     }
 
     #[inline]
-    unsafe fn increase_gpu_lock(&self) {
-        (**self).increase_gpu_lock()
+    unsafe fn increase_gpu_lock(&self, write: bool) {
+        (**self).increase_gpu_lock(write)
     }
 
     #[inline]
-    unsafe fn unlock(&self, transitioned_layout: Option<ImageLayout>) {
-        (**self).unlock(transitioned_layout)
+    unsafe fn unlock(&self, write: bool, transitioned_layout: Option<ImageLayout>) {
+        (**self).unlock(write, transitioned_layout)
     }
 
     #[inline]

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -7,19 +7,15 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::format::ClearValue;
-use crate::format::Format;
-use crate::format::FormatFeatures;
-use crate::image::sys::UnsafeImage;
-use crate::image::ImageDescriptorLayouts;
-use crate::image::ImageDimensions;
-use crate::image::ImageLayout;
-use crate::image::SampleCount;
-use crate::sync::AccessError;
-use crate::SafeDeref;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::sync::Arc;
+use super::{sys::UnsafeImage, ImageDescriptorLayouts, ImageDimensions, ImageLayout, SampleCount};
+use crate::{
+    format::{ClearValue, Format, FormatFeatures},
+    SafeDeref,
+};
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 /// Trait for types that represent the way a GPU can access an image.
 pub unsafe trait ImageAccess: Send + Sync {
@@ -140,61 +136,6 @@ pub unsafe trait ImageAccess: Send + Sync {
 
     /// Returns the current array layer that is accessed by the gpu
     fn current_array_layers_access(&self) -> std::ops::Range<u32>;
-
-    /// Locks the resource for usage on the GPU. Returns an error if the lock can't be acquired.
-    ///
-    /// After this function returns `Ok`, you are authorized to use the image on the GPU. If the
-    /// GPU operation requires an exclusive access to the image (which includes image layout
-    /// transitions) then `exclusive_access` should be true.
-    ///
-    /// The `expected_layout` is the layout we expect the image to be in when we lock it. If the
-    /// actual layout doesn't match this expected layout, then an error should be returned. If
-    /// `Undefined` is passed, that means that the caller doesn't care about the actual layout,
-    /// and that a layout mismatch shouldn't return an error.
-    ///
-    /// This function exists to prevent the user from causing a data race by reading and writing
-    /// to the same resource at the same time.
-    ///
-    /// If you call this function, you should call `unlock()` once the resource is no longer in use
-    /// by the GPU. The implementation is not expected to automatically perform any unlocking and
-    /// can rely on the fact that `unlock()` is going to be called.
-    fn try_gpu_lock(
-        &self,
-        write: bool,
-        uninitialized_safe: bool,
-        expected_layout: ImageLayout,
-    ) -> Result<(), AccessError>;
-
-    /// Locks the resource for usage on the GPU. Supposes that the resource is already locked, and
-    /// simply increases the lock by one.
-    ///
-    /// Must only be called after `try_gpu_lock()` succeeded.
-    ///
-    /// If you call this function, you should call `unlock()` once the resource is no longer in use
-    /// by the GPU. The implementation is not expected to automatically perform any unlocking and
-    /// can rely on the fact that `unlock()` is going to be called.
-    unsafe fn increase_gpu_lock(&self, write: bool);
-
-    /// Unlocks the resource previously acquired with `try_gpu_lock` or `increase_gpu_lock`.
-    ///
-    /// If the GPU operation that we unlock from transitioned the image to another layout, then
-    /// it should be passed as parameter.
-    ///
-    /// A layout transition requires exclusive access to the image, which means two things:
-    ///
-    /// - The implementation can panic if it finds out that the layout is not the same as it
-    ///   currently is and that it is not locked in exclusive mode.
-    /// - There shouldn't be any possible race between `unlock` and `try_gpu_lock`, since
-    ///   `try_gpu_lock` should fail if the image is already locked in exclusive mode.
-    ///
-    /// # Safety
-    ///
-    /// - Must only be called once per previous lock.
-    /// - The transitioned layout must be supported by the image (eg. the layout shouldn't be
-    ///   `ColorAttachmentOptimal` if the image wasn't created with the `color_attachment` usage).
-    /// - The transitioned layout must not be `Undefined`.
-    ///
-    unsafe fn unlock(&self, write: bool, transitioned_layout: Option<ImageLayout>);
 }
 
 /// Inner information about an image.
@@ -273,27 +214,6 @@ where
         self.image.conflict_key()
     }
 
-    #[inline]
-    fn try_gpu_lock(
-        &self,
-        write: bool,
-        uninitialized_safe: bool,
-        expected_layout: ImageLayout,
-    ) -> Result<(), AccessError> {
-        self.image
-            .try_gpu_lock(write, uninitialized_safe, expected_layout)
-    }
-
-    #[inline]
-    unsafe fn increase_gpu_lock(&self, write: bool) {
-        self.image.increase_gpu_lock(write)
-    }
-
-    #[inline]
-    unsafe fn unlock(&self, write: bool, new_layout: Option<ImageLayout>) {
-        self.image.unlock(write, new_layout)
-    }
-
     fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
         self.image.current_mip_levels_access()
     }
@@ -365,26 +285,6 @@ where
     #[inline]
     fn conflict_key(&self) -> u64 {
         (**self).conflict_key()
-    }
-
-    #[inline]
-    fn try_gpu_lock(
-        &self,
-        write: bool,
-        uninitialized_safe: bool,
-        expected_layout: ImageLayout,
-    ) -> Result<(), AccessError> {
-        (**self).try_gpu_lock(write, uninitialized_safe, expected_layout)
-    }
-
-    #[inline]
-    unsafe fn increase_gpu_lock(&self, write: bool) {
-        (**self).increase_gpu_lock(write)
-    }
-
-    #[inline]
-    unsafe fn unlock(&self, write: bool, transitioned_layout: Option<ImageLayout>) {
-        (**self).unlock(write, transitioned_layout)
     }
 
     #[inline]

--- a/vulkano/src/pipeline/graphics/vertex_input/collection.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/collection.rs
@@ -109,15 +109,15 @@ mod tests {
             unimplemented!()
         }
 
-        fn try_gpu_lock(&self, _: bool, _: &Queue) -> Result<(), AccessError> {
+        fn try_gpu_lock(&self, write: bool, queue: &Queue) -> Result<(), AccessError> {
             unimplemented!()
         }
 
-        unsafe fn increase_gpu_lock(&self) {
+        unsafe fn increase_gpu_lock(&self, write: bool) {
             unimplemented!()
         }
 
-        unsafe fn unlock(&self) {
+        unsafe fn unlock(&self, write: bool) {
             unimplemented!()
         }
     }
@@ -147,15 +147,15 @@ mod tests {
             unimplemented!()
         }
 
-        fn try_gpu_lock(&self, _: bool, _: &Queue) -> Result<(), AccessError> {
+        fn try_gpu_lock(&self, write: bool, queue: &Queue) -> Result<(), AccessError> {
             unimplemented!()
         }
 
-        unsafe fn increase_gpu_lock(&self) {
+        unsafe fn increase_gpu_lock(&self, write: bool) {
             unimplemented!()
         }
 
-        unsafe fn unlock(&self) {
+        unsafe fn unlock(&self, write: bool) {
             unimplemented!()
         }
     }

--- a/vulkano/src/pipeline/graphics/vertex_input/collection.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/collection.rs
@@ -7,8 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::buffer::BufferAccess;
-use crate::buffer::BufferAccessObject;
+use crate::buffer::{BufferAccess, BufferAccessObject};
 use std::sync::Arc;
 
 /// A collection of vertex buffers.
@@ -88,8 +87,6 @@ mod tests {
     use crate::buffer::BufferInner;
     use crate::device::Device;
     use crate::device::DeviceOwned;
-    use crate::device::Queue;
-    use crate::sync::AccessError;
     use crate::DeviceSize;
     use std::sync::Arc;
 
@@ -106,18 +103,6 @@ mod tests {
         }
 
         fn conflict_key(&self) -> (u64, u64) {
-            unimplemented!()
-        }
-
-        fn try_gpu_lock(&self, write: bool, queue: &Queue) -> Result<(), AccessError> {
-            unimplemented!()
-        }
-
-        unsafe fn increase_gpu_lock(&self, write: bool) {
-            unimplemented!()
-        }
-
-        unsafe fn unlock(&self, write: bool) {
             unimplemented!()
         }
     }
@@ -144,18 +129,6 @@ mod tests {
         }
 
         fn conflict_key(&self) -> (u64, u64) {
-            unimplemented!()
-        }
-
-        fn try_gpu_lock(&self, write: bool, queue: &Queue) -> Result<(), AccessError> {
-            unimplemented!()
-        }
-
-        unsafe fn increase_gpu_lock(&self, write: bool) {
-            unimplemented!()
-        }
-
-        unsafe fn unlock(&self, write: bool) {
             unimplemented!()
         }
     }

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -165,3 +165,19 @@ where
     /// The resource is used in multiple queue families. Can be slower than `Exclusive`.
     Concurrent(I),
 }
+
+/// How the memory of a resource is currently being accessed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CurrentAccess {
+    /// The resource is currently being accessed exclusively by the CPU.
+    CpuExclusive,
+
+    /// The resource is currently being accessed exclusively by the GPU.
+    /// The GPU can have multiple exclusive accesses, if they are separated by synchronization.
+    ///
+    /// `gpu_writes` must not be 0. If it's decremented to 0, switch to `Shared`.
+    GpuExclusive { gpu_reads: usize, gpu_writes: usize },
+
+    /// The resource is not currently being accessed, or is being accessed for reading only.
+    Shared { cpu_reads: usize, gpu_reads: usize },
+}


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** Removed the `try_gpu_lock`, `increase_gpu_lock` and `unlock` methods from the `BufferAccess` and `ImageAccess` traits. Locking is now implemented internally in `UnsafeBuffer` and `UnsafeImage`.
```

This adds new and better resource locking for buffers and images. Locking is performed in `UnsafeBuffer` and `UnsafeImage` instead of in the individual "safe" types, so if multiple safe types share a common buffer/image, the locking still works properly. The locks for buffers are now granular at the byte level, so it is possible to lock one range of a buffer while leaving other ranges untouched. For images the same thing applies, but it is granular at the level of aspect/mip level/array layer.

To make this possible, I've had to use an existing crate, `rangemap`, and make changes to it so that it would fit Vulkano's needs. This PR uses a fork of `rangemap` on my personal repository, which is probably ok for now but needs a better solution in the long term (before 0.30 is released anyway). It could be merged fully into Vulkano, but then its git history will be lost. @AustinJ235 proposed making it a repository under the Vulkano project, which is also a possibility.

This PR is the first in what will be a series of PRs tackling different parts of Vulkano's synchronization. For that reason, I have not included all changes in the changelog entries: things are not yet in the final state and will probably change again before the next release. It is also quite likely that some things don't work properly at the moment. The `texture_array` example crashes, but I know what the cause is and it should be fixed in one of the followup PRs.