### PR TITLE
Export enum MemoryMapError

### DIFF
--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -96,7 +96,7 @@ pub use self::{
     device_memory::{
         DeviceMemory, DeviceMemoryAllocationError, DeviceMemoryExportError,
         ExternalMemoryHandleType, ExternalMemoryHandleTypes, MappedDeviceMemory,
-        MemoryAllocateInfo, MemoryImportInfo,
+        MemoryAllocateInfo, MemoryImportInfo, MemoryMapError,
     },
     pool::MemoryPool,
 };


### PR DESCRIPTION
Export MemoryMapError which is required by MappedDeviceMemory::new()
