### PR TITLE
Use range-based state tracking for `SyncCommandBuffer`

### DIFF
--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -119,7 +119,7 @@ where
     A: MemoryPool,
 {
     // Inner content.
-    inner: UnsafeBuffer,
+    inner: Arc<UnsafeBuffer>,
 
     // The memory held by the buffer.
     memory: PotentialDedicatedAllocation<A::Alloc>,

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -54,7 +54,7 @@ where
     T: BufferContents + ?Sized,
 {
     // Inner content.
-    inner: UnsafeBuffer,
+    inner: Arc<UnsafeBuffer>,
 
     // The memory held by the buffer.
     memory: A,
@@ -237,7 +237,7 @@ where
         size: DeviceSize,
         usage: BufferUsage,
         queue_families: &SmallVec<[u32; 4]>,
-    ) -> Result<(UnsafeBuffer, MemoryRequirements), DeviceMemoryAllocationError> {
+    ) -> Result<(Arc<UnsafeBuffer>, MemoryRequirements), DeviceMemoryAllocationError> {
         let buffer = {
             match UnsafeBuffer::new(
                 device.clone(),

--- a/vulkano/src/buffer/immutable.rs
+++ b/vulkano/src/buffer/immutable.rs
@@ -54,7 +54,7 @@ where
     T: BufferContents + ?Sized,
 {
     // Inner content.
-    inner: UnsafeBuffer,
+    inner: Arc<UnsafeBuffer>,
 
     // Memory allocated for the buffer.
     memory: A,

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -128,7 +128,7 @@ impl BufferAccessObject for Arc<dyn BufferAccess> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BufferInner<'a> {
     /// The underlying buffer object.
-    pub buffer: &'a UnsafeBuffer,
+    pub buffer: &'a Arc<UnsafeBuffer>,
     /// The offset in bytes from the start of the underlying buffer object to the start of the
     /// buffer we're describing.
     pub offset: DeviceSize,

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -45,12 +45,13 @@ use super::{
     SubpassContents,
 };
 use crate::{
-    buffer::{BufferAccess, BufferContents, TypedBufferAccess},
+    buffer::{sys::UnsafeBuffer, BufferAccess, BufferContents, TypedBufferAccess},
     descriptor_set::{check_descriptor_write, DescriptorSetsCollection, WriteDescriptorSet},
     device::{physical::QueueFamily, Device, DeviceOwned, Queue},
     format::{ClearValue, NumericType},
     image::{
         attachment::{ClearAttachment, ClearRect},
+        sys::UnsafeImage,
         ImageAccess, ImageAspect, ImageAspects, ImageLayout,
     },
     pipeline::{
@@ -3684,23 +3685,26 @@ where
     #[inline]
     fn check_buffer_access(
         &self,
-        buffer: &dyn BufferAccess,
+        buffer: &UnsafeBuffer,
+        range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        self.inner.check_buffer_access(buffer, exclusive, queue)
+        self.inner
+            .check_buffer_access(buffer, range, exclusive, queue)
     }
 
     #[inline]
     fn check_image_access(
         &self,
-        image: &dyn ImageAccess,
-        layout: ImageLayout,
+        image: &UnsafeImage,
+        range: Range<DeviceSize>,
         exclusive: bool,
+        expected_layout: ImageLayout,
         queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
         self.inner
-            .check_image_access(image, layout, exclusive, queue)
+            .check_image_access(image, range, exclusive, expected_layout, queue)
     }
 }
 

--- a/vulkano/src/command_buffer/synced/commands.rs
+++ b/vulkano/src/command_buffer/synced/commands.rs
@@ -11,7 +11,7 @@ use super::{SyncCommandBufferBuilder, SyncCommandBufferBuilderError};
 use crate::{
     buffer::{BufferAccess, BufferContents, TypedBufferAccess},
     command_buffer::{
-        synced::{Command, KeyTy, ResourceKey, SetOrPush},
+        synced::{Command, KeyTy, SetOrPush},
         sys::{
             RenderPassBeginInfo, UnsafeCommandBufferBuilder,
             UnsafeCommandBufferBuilderBindVertexBuffer, UnsafeCommandBufferBuilderBufferImageCopy,
@@ -322,8 +322,16 @@ impl SyncCommandBufferBuilder {
         let mut resources: SmallVec<[_; 2]> = SmallVec::new();
 
         // if its the same image in source and destination, we need to lock it once
-        let source_key = ResourceKey::from(source.as_ref());
-        let destination_key = ResourceKey::from(destination.as_ref());
+        let source_key = (
+            source.conflict_key(),
+            source.current_mip_levels_access(),
+            source.current_array_layers_access(),
+        );
+        let destination_key = (
+            destination.conflict_key(),
+            destination.current_mip_levels_access(),
+            destination.current_array_layers_access(),
+        );
         if source_key == destination_key {
             resources.push((
                 KeyTy::Image(source.clone()),
@@ -455,8 +463,16 @@ impl SyncCommandBufferBuilder {
         let mut resources: SmallVec<[_; 2]> = SmallVec::new();
 
         // if its the same image in source and destination, we need to lock it once
-        let source_key = ResourceKey::from(source.as_ref());
-        let destination_key = ResourceKey::from(destination.as_ref());
+        let source_key = (
+            source.conflict_key(),
+            source.current_mip_levels_access(),
+            source.current_array_layers_access(),
+        );
+        let destination_key = (
+            destination.conflict_key(),
+            destination.current_mip_levels_access(),
+            destination.current_array_layers_access(),
+        );
         if source_key == destination_key {
             resources.push((
                 KeyTy::Image(source.clone()),

--- a/vulkano/src/image/aspect.rs
+++ b/vulkano/src/image/aspect.rs
@@ -199,3 +199,47 @@ impl From<ash::vk::ImageAspectFlags> for ImageAspects {
         }
     }
 }
+
+impl From<ImageAspect> for ImageAspects {
+    fn from(aspect: ImageAspect) -> Self {
+        let mut result = Self::none();
+
+        match aspect {
+            ImageAspect::Color => result.color = true,
+            ImageAspect::Depth => result.depth = true,
+            ImageAspect::Stencil => result.stencil = true,
+            ImageAspect::Metadata => result.metadata = true,
+            ImageAspect::Plane0 => result.plane0 = true,
+            ImageAspect::Plane1 => result.plane1 = true,
+            ImageAspect::Plane2 => result.plane2 = true,
+            ImageAspect::MemoryPlane0 => result.memory_plane0 = true,
+            ImageAspect::MemoryPlane1 => result.memory_plane1 = true,
+            ImageAspect::MemoryPlane2 => result.memory_plane2 = true,
+        }
+
+        result
+    }
+}
+
+impl FromIterator<ImageAspect> for ImageAspects {
+    fn from_iter<T: IntoIterator<Item = ImageAspect>>(iter: T) -> Self {
+        let mut result = Self::none();
+
+        for aspect in iter {
+            match aspect {
+                ImageAspect::Color => result.color = true,
+                ImageAspect::Depth => result.depth = true,
+                ImageAspect::Stencil => result.stencil = true,
+                ImageAspect::Metadata => result.metadata = true,
+                ImageAspect::Plane0 => result.plane0 = true,
+                ImageAspect::Plane1 => result.plane1 = true,
+                ImageAspect::Plane2 => result.plane2 = true,
+                ImageAspect::MemoryPlane0 => result.memory_plane0 = true,
+                ImageAspect::MemoryPlane1 => result.memory_plane1 = true,
+                ImageAspect::MemoryPlane2 => result.memory_plane2 = true,
+            }
+        }
+
+        result
+    }
+}

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -30,6 +30,7 @@ use crate::{
 use std::{
     fs::File,
     hash::{Hash, Hasher},
+    ops::Range,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
@@ -68,7 +69,7 @@ use std::{
 #[derive(Debug)]
 pub struct AttachmentImage<A = PotentialDedicatedAllocation<StdMemoryPoolAlloc>> {
     // Inner implementation.
-    image: UnsafeImage,
+    image: Arc<UnsafeImage>,
 
     // Memory used to back the image.
     memory: A,
@@ -602,12 +603,12 @@ where
     }
 
     #[inline]
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
+    fn current_mip_levels_access(&self) -> Range<u32> {
         0..self.mip_levels()
     }
 
     #[inline]
-    fn current_array_layers_access(&self) -> std::ops::Range<u32> {
+    fn current_array_layers_access(&self) -> Range<u32> {
         0..self.dimensions().array_layers()
     }
 }

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -42,7 +42,7 @@ use std::{
 // TODO: type (2D, 3D, array, etc.) as template parameter
 #[derive(Debug)]
 pub struct ImmutableImage<A = PotentialDedicatedAllocation<StdMemoryPoolAlloc>> {
-    image: UnsafeImage,
+    image: Arc<UnsafeImage>,
     dimensions: ImageDimensions,
     memory: A,
     format: Format,
@@ -92,8 +92,8 @@ impl SubImage {
 // Must not implement Clone, as that would lead to multiple `used` values.
 pub struct ImmutableImageInitialization<A = PotentialDedicatedAllocation<StdMemoryPoolAlloc>> {
     image: Arc<ImmutableImage<A>>,
-    mip_levels_access: std::ops::Range<u32>,
-    array_layers_access: std::ops::Range<u32>,
+    mip_levels_access: Range<u32>,
+    array_layers_access: Range<u32>,
 }
 
 fn has_mipmaps(mipmaps: MipmapsCount) -> bool {
@@ -432,12 +432,12 @@ where
     }
 
     #[inline]
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
+    fn current_mip_levels_access(&self) -> Range<u32> {
         0..self.mip_levels()
     }
 
     #[inline]
-    fn current_array_layers_access(&self) -> std::ops::Range<u32> {
+    fn current_array_layers_access(&self) -> Range<u32> {
         0..self.dimensions().array_layers()
     }
 }
@@ -473,11 +473,11 @@ unsafe impl ImageAccess for SubImage {
         None
     }
 
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
+    fn current_mip_levels_access(&self) -> Range<u32> {
         self.mip_levels_access.clone()
     }
 
-    fn current_array_layers_access(&self) -> std::ops::Range<u32> {
+    fn current_array_layers_access(&self) -> Range<u32> {
         self.array_layers_access.clone()
     }
 
@@ -539,12 +539,12 @@ where
     }
 
     #[inline]
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
+    fn current_mip_levels_access(&self) -> Range<u32> {
         self.mip_levels_access.clone()
     }
 
     #[inline]
-    fn current_array_layers_access(&self) -> std::ops::Range<u32> {
+    fn current_array_layers_access(&self) -> Range<u32> {
         self.array_layers_access.clone()
     }
 }

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -65,6 +65,7 @@ use crate::memory::ExternalMemoryHandleType;
 use crate::memory::ExternalMemoryProperties;
 use crate::DeviceSize;
 use std::cmp;
+use std::ops::Range;
 
 mod aspect;
 pub mod attachment; // TODO: make private
@@ -551,6 +552,38 @@ impl ImageDimensions {
                 }
             }
         })
+    }
+}
+
+/// One or more subresources of an image that should be accessed by a command.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct ImageSubresourceRange {
+    /// Selects the aspects that will be included.
+    ///
+    /// The value must not be empty, and must not include any of the `memory_plane` aspects.
+    /// The `color` aspect cannot be selected together any of with the `plane` aspects.
+    pub aspects: ImageAspects,
+
+    /// Selects the range of the mip levels that will be included.
+    ///
+    /// The range must not be empty.
+    pub mip_levels: Range<u32>,
+
+    /// Selects the range of array layers that will be included.
+    ///
+    /// The range must not be empty.
+    pub array_layers: Range<u32>,
+}
+
+impl From<ImageSubresourceRange> for ash::vk::ImageSubresourceRange {
+    fn from(val: ImageSubresourceRange) -> Self {
+        Self {
+            aspect_mask: val.aspects.into(),
+            base_mip_level: val.mip_levels.start,
+            level_count: val.mip_levels.end - val.mip_levels.start,
+            base_array_layer: val.array_layers.start,
+            layer_count: val.array_layers.end - val.array_layers.start,
+        }
     }
 }
 

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -32,6 +32,7 @@ use smallvec::SmallVec;
 use std::{
     fs::File,
     hash::{Hash, Hasher},
+    ops::Range,
     sync::Arc,
 };
 
@@ -43,7 +44,7 @@ where
     A: MemoryPool,
 {
     // Inner implementation.
-    image: UnsafeImage,
+    image: Arc<UnsafeImage>,
 
     // Memory used to back the image.
     memory: PotentialDedicatedAllocation<A::Alloc>,
@@ -280,12 +281,12 @@ where
     }
 
     #[inline]
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
+    fn current_mip_levels_access(&self) -> Range<u32> {
         0..self.mip_levels()
     }
 
     #[inline]
-    fn current_array_layers_access(&self) -> std::ops::Range<u32> {
+    fn current_array_layers_access(&self) -> Range<u32> {
         0..self.dimensions().array_layers()
     }
 }

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::{format::ClearValue, swapchain::Swapchain, OomError};
 use std::{
     hash::{Hash, Hasher},
+    ops::Range,
     sync::Arc,
 };
 
@@ -120,12 +121,12 @@ where
     }
 
     #[inline]
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
+    fn current_mip_levels_access(&self) -> Range<u32> {
         0..self.mip_levels()
     }
 
     #[inline]
-    fn current_array_layers_access(&self) -> std::ops::Range<u32> {
+    fn current_array_layers_access(&self) -> Range<u32> {
         0..1
     }
 }

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use std::{
     hash::{Hash, Hasher},
+    ops::Range,
     sync::Arc,
 };
 
@@ -132,17 +133,17 @@ pub unsafe trait ImageAccess: Send + Sync {
     fn conflict_key(&self) -> u64;
 
     /// Returns the current mip level that is accessed by the gpu
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32>;
+    fn current_mip_levels_access(&self) -> Range<u32>;
 
     /// Returns the current array layer that is accessed by the gpu
-    fn current_array_layers_access(&self) -> std::ops::Range<u32>;
+    fn current_array_layers_access(&self) -> Range<u32>;
 }
 
 /// Inner information about an image.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ImageInner<'a> {
     /// The underlying image object.
-    pub image: &'a UnsafeImage,
+    pub image: &'a Arc<UnsafeImage>,
 
     /// The first layer of `image` to consider.
     pub first_layer: usize,
@@ -214,11 +215,11 @@ where
         self.image.conflict_key()
     }
 
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
+    fn current_mip_levels_access(&self) -> Range<u32> {
         self.image.current_mip_levels_access()
     }
 
-    fn current_array_layers_access(&self) -> std::ops::Range<u32> {
+    fn current_array_layers_access(&self) -> Range<u32> {
         self.image.current_array_layers_access()
     }
 }
@@ -297,11 +298,11 @@ where
         (**self).is_layout_initialized()
     }
 
-    fn current_mip_levels_access(&self) -> std::ops::Range<u32> {
+    fn current_mip_levels_access(&self) -> Range<u32> {
         (**self).current_mip_levels_access()
     }
 
-    fn current_array_layers_access(&self) -> std::ops::Range<u32> {
+    fn current_array_layers_access(&self) -> Range<u32> {
         (**self).current_array_layers_access()
     }
 }

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -234,7 +234,7 @@ pipeline_stages! {
 
 macro_rules! access_flags {
     ($($elem:ident => $val:expr,)+) => (
-        #[derive(Debug, Copy, Clone)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
         #[allow(missing_docs)]
         pub struct AccessFlags {
             $(
@@ -325,7 +325,7 @@ access_flags! {
 }
 
 /// The full specification of memory access by the pipeline for a particular resource.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PipelineMemoryAccess {
     /// The pipeline stages the resource will be accessed in.
     pub stages: PipelineStages,


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** All `check_buffer_access` and `check_image_access` functions now take an `UnsafeBuffer`/`UnsafeImage` and a `Range<DeviceSize>`.
```

Like the previous PR, not many actual user-visible changes here. The major change here is that `SyncCommandBuffer` now tracks the state of resources as subranges too when building the command buffer or when checking for access. This means that the access state is tracked individually for each byte of a buffer and each subresource of an image, and pipeline barriers are applied to these subpieces instead of to the whole thing.

The buffer and image types themselves may not yet make full use of this capability; for example, an image view can select a subresource range from its parent image, but it's still treated in the command buffer as if it covers its whole parent. This is work for a future PR; the groundwork has been laid so the capability is now there. I'm happy to say that the `texture_array` example is working again, however.