### PR TITLE
Re-export `UnsafeCommandPoolCreateInfo` and `UnsafeCommandPoolCreationError`

### DIFF
--- a/vulkano/src/command_buffer/pool/mod.rs
+++ b/vulkano/src/command_buffer/pool/mod.rs
@@ -18,7 +18,10 @@
 
 pub use self::{
     standard::StandardCommandPool,
-    sys::{CommandPoolTrimError, UnsafeCommandPool, UnsafeCommandPoolAlloc},
+    sys::{
+        CommandPoolTrimError, UnsafeCommandPool, UnsafeCommandPoolAlloc,
+        UnsafeCommandPoolCreateInfo, UnsafeCommandPoolCreationError,
+    },
 };
 use super::CommandBufferLevel;
 use crate::{


### PR DESCRIPTION
Fixes #1865.