### PR TITLE
Redundant unsafe block removed

### DIFF
--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -634,7 +634,7 @@ impl<W> Swapchain<W> {
                     array_layers: image_array_layers,
                 };
 
-                let img = unsafe {
+                let img = {
                     UnsafeImage::from_raw(
                         device.clone(),
                         handle,


### PR DESCRIPTION
This `unsafe` block is nested inside another `unsafe` block, so it's not needed. This PR just cleans up a compiler's warning, no user-facing changes introduced.
