### PR TITLE
Use only the selected range of buffer and image views in synchronization

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -35,7 +35,7 @@ use super::{
 use crate::{
     buffer::{sys::UnsafeBuffer, BufferAccess},
     device::{physical::QueueFamily, Device, DeviceOwned, Queue},
-    image::{sys::UnsafeImage, ImageAccess, ImageLayout},
+    image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
     pipeline::GraphicsPipeline,
     query::{QueryControlFlags, QueryPipelineStatisticFlags, QueryType},
     render_pass::Subpass,
@@ -684,7 +684,14 @@ where
     }
 
     #[inline]
-    fn buffer(&self, index: usize) -> Option<(&Arc<dyn BufferAccess>, PipelineMemoryAccess)> {
+    fn buffer(
+        &self,
+        index: usize,
+    ) -> Option<(
+        &Arc<dyn BufferAccess>,
+        Range<DeviceSize>,
+        PipelineMemoryAccess,
+    )> {
         self.inner.buffer(index)
     }
 
@@ -699,6 +706,7 @@ where
         index: usize,
     ) -> Option<(
         &Arc<dyn ImageAccess>,
+        &ImageSubresourceRange,
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -23,7 +23,7 @@ use crate::{
     format::{ClearValue, NumericType},
     image::{
         attachment::{ClearAttachment, ClearRect},
-        ImageAspects, ImageSubresourceRange,
+        ImageAspects,
     },
     pipeline::GraphicsPipeline,
     render_pass::{Framebuffer, LoadOp},
@@ -402,19 +402,13 @@ impl SyncCommandBufferBuilder {
             .iter()
             .enumerate()
             .map(|(num, desc)| {
-                let image = render_pass_begin_info.framebuffer.attachments()[num].image();
-                let subresource_range = ImageSubresourceRange {
-                    // TODO:
-                    aspects: image.format().aspects(),
-                    mip_levels: image.current_mip_levels_access(),
-                    array_layers: image.current_array_layers_access(),
-                };
+                let image_view = &render_pass_begin_info.framebuffer.attachments()[num];
 
                 (
                     format!("attachment {}", num).into(),
                     Resource::Image {
-                        image,
-                        subresource_range,
+                        image: image_view.image(),
+                        subresource_range: image_view.subresource_range().clone(),
                         memory: PipelineMemoryAccess {
                             stages: PipelineStages {
                                 all_commands: true,

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -16,7 +16,6 @@ use crate::{
         CommandBufferInheritanceRenderPassInfo, CommandBufferUsage, ExecuteCommandsError,
         PrimaryAutoCommandBuffer, SecondaryCommandBuffer, SubpassContents,
     },
-    image::ImageSubresourceRange,
     query::QueryType,
     SafeDeref, VulkanObject,
 };
@@ -248,28 +247,24 @@ impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
             let mut resources = Vec::new();
             for (cbuf_num, cbuf) in self.inner.iter().enumerate() {
                 for buf_num in 0..cbuf.num_buffers() {
-                    let (buffer, memory) = cbuf.buffer(buf_num).unwrap();
+                    let (buffer, range, memory) = cbuf.buffer(buf_num).unwrap();
                     resources.push((
                         format!("Buffer bound to secondary command buffer {}", cbuf_num).into(),
                         Resource::Buffer {
                             buffer: buffer.clone(),
-                            range: 0..buffer.size(), // TODO:
+                            range,
                             memory,
                         },
                     ));
                 }
                 for img_num in 0..cbuf.num_images() {
-                    let (image, memory, start_layout, end_layout) = cbuf.image(img_num).unwrap();
+                    let (image, subresource_range, memory, start_layout, end_layout) =
+                        cbuf.image(img_num).unwrap();
                     resources.push((
                         format!("Image bound to secondary command buffer {}", cbuf_num).into(),
                         Resource::Image {
                             image: image.clone(),
-                            subresource_range: ImageSubresourceRange {
-                                // TODO:
-                                aspects: image.format().aspects(),
-                                mip_levels: image.current_mip_levels_access(),
-                                array_layers: image.current_array_layers_access(),
-                            },
+                            subresource_range: subresource_range.clone(),
                             memory,
                             start_layout,
                             end_layout,

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -107,9 +107,14 @@ pub struct SyncCommandBuffer {
     images2: HashMap<Arc<UnsafeImage>, RangeMap<DeviceSize, ImageFinalState>>,
 
     // Resources and their accesses. Used for executing secondary command buffers in a primary.
-    buffers: Vec<(Arc<dyn BufferAccess>, PipelineMemoryAccess)>,
+    buffers: Vec<(
+        Arc<dyn BufferAccess>,
+        Range<DeviceSize>,
+        PipelineMemoryAccess,
+    )>,
     images: Vec<(
         Arc<dyn ImageAccess>,
+        ImageSubresourceRange,
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
@@ -381,10 +386,17 @@ impl SyncCommandBuffer {
     }
 
     #[inline]
-    pub fn buffer(&self, index: usize) -> Option<(&Arc<dyn BufferAccess>, PipelineMemoryAccess)> {
+    pub fn buffer(
+        &self,
+        index: usize,
+    ) -> Option<(
+        &Arc<dyn BufferAccess>,
+        Range<DeviceSize>,
+        PipelineMemoryAccess,
+    )> {
         self.buffers
             .get(index)
-            .map(|(buffer, memory)| (buffer, *memory))
+            .map(|(buffer, range, memory)| (buffer, range.clone(), *memory))
     }
 
     #[inline]
@@ -398,14 +410,15 @@ impl SyncCommandBuffer {
         index: usize,
     ) -> Option<(
         &Arc<dyn ImageAccess>,
+        &ImageSubresourceRange,
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
     )> {
         self.images
             .get(index)
-            .map(|(image, memory, start_layout, end_layout)| {
-                (image, *memory, *start_layout, *end_layout)
+            .map(|(image, range, memory, start_layout, end_layout)| {
+                (image, range, *memory, *start_layout, *end_layout)
             })
     }
 }

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     buffer::{sys::UnsafeBuffer, BufferAccess},
     device::{Device, DeviceOwned, Queue},
-    image::{sys::UnsafeImage, ImageAccess, ImageLayout},
+    image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
     sync::{
         now, AccessCheckError, AccessError, AccessFlags, FlushError, GpuFuture, NowFuture,
         PipelineMemoryAccess, PipelineStages,
@@ -229,7 +229,14 @@ pub unsafe trait SecondaryCommandBuffer: DeviceOwned + Send + Sync {
     /// Returns the `index`th buffer of this command buffer, or `None` if out of range.
     ///
     /// The valid range is between 0 and `num_buffers()`.
-    fn buffer(&self, index: usize) -> Option<(&Arc<dyn BufferAccess>, PipelineMemoryAccess)>;
+    fn buffer(
+        &self,
+        index: usize,
+    ) -> Option<(
+        &Arc<dyn BufferAccess>,
+        Range<DeviceSize>,
+        PipelineMemoryAccess,
+    )>;
 
     /// Returns the number of images accessed by this command buffer.
     fn num_images(&self) -> usize;
@@ -242,6 +249,7 @@ pub unsafe trait SecondaryCommandBuffer: DeviceOwned + Send + Sync {
         index: usize,
     ) -> Option<(
         &Arc<dyn ImageAccess>,
+        &ImageSubresourceRange,
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,
@@ -279,7 +287,14 @@ where
     }
 
     #[inline]
-    fn buffer(&self, index: usize) -> Option<(&Arc<dyn BufferAccess>, PipelineMemoryAccess)> {
+    fn buffer(
+        &self,
+        index: usize,
+    ) -> Option<(
+        &Arc<dyn BufferAccess>,
+        Range<DeviceSize>,
+        PipelineMemoryAccess,
+    )> {
         (**self).buffer(index)
     }
 
@@ -294,6 +309,7 @@ where
         index: usize,
     ) -> Option<(
         &Arc<dyn ImageAccess>,
+        &ImageSubresourceRange,
         PipelineMemoryAccess,
         ImageLayout,
         ImageLayout,

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -7,19 +7,16 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::buffer::view::BufferViewAbstract;
-use crate::buffer::{BufferAccess, BufferInner};
-use crate::descriptor_set::layout::{DescriptorSetLayoutBinding, DescriptorType};
-use crate::descriptor_set::DescriptorSetLayout;
-use crate::device::DeviceOwned;
-use crate::image::view::{ImageViewAbstract, ImageViewType};
-use crate::image::ImageType;
-use crate::sampler::{Sampler, SamplerImageViewIncompatibleError};
-use crate::DeviceSize;
-use crate::VulkanObject;
+use super::layout::{DescriptorSetLayout, DescriptorSetLayoutBinding, DescriptorType};
+use crate::{
+    buffer::{view::BufferViewAbstract, BufferAccess, BufferInner},
+    device::DeviceOwned,
+    image::{view::ImageViewType, ImageType, ImageViewAbstract},
+    sampler::{Sampler, SamplerImageViewIncompatibleError},
+    DeviceSize, VulkanObject,
+};
 use smallvec::SmallVec;
-use std::ptr;
-use std::sync::Arc;
+use std::{ptr, sync::Arc};
 
 /// Represents a single write operation to the binding of a descriptor set.
 ///
@@ -585,7 +582,9 @@ pub(crate) fn check_descriptor_write<'a>(
                     }
 
                     // VUID-VkDescriptorImageInfo-imageView-01976
-                    if image_view.aspects().depth && image_view.aspects().stencil {
+                    if image_view.subresource_range().aspects.depth
+                        && image_view.subresource_range().aspects.stencil
+                    {
                         return Err(DescriptorSetUpdateError::ImageViewDepthAndStencil {
                             binding: write.binding(),
                             index: descriptor_range_start + index as u32,
@@ -631,7 +630,9 @@ pub(crate) fn check_descriptor_write<'a>(
                     }
 
                     // VUID-VkDescriptorImageInfo-imageView-01976
-                    if image_view.aspects().depth && image_view.aspects().stencil {
+                    if image_view.subresource_range().aspects.depth
+                        && image_view.subresource_range().aspects.stencil
+                    {
                         return Err(DescriptorSetUpdateError::ImageViewDepthAndStencil {
                             binding: write.binding(),
                             index: descriptor_range_start + index as u32,
@@ -679,7 +680,9 @@ pub(crate) fn check_descriptor_write<'a>(
                     }
 
                     // VUID-VkDescriptorImageInfo-imageView-01976
-                    if image_view.aspects().depth && image_view.aspects().stencil {
+                    if image_view.subresource_range().aspects.depth
+                        && image_view.subresource_range().aspects.stencil
+                    {
                         return Err(DescriptorSetUpdateError::ImageViewDepthAndStencil {
                             binding: write.binding(),
                             index: descriptor_range_start + index as u32,
@@ -735,7 +738,9 @@ pub(crate) fn check_descriptor_write<'a>(
                     }
 
                     // VUID-VkDescriptorImageInfo-imageView-01976
-                    if image_view.aspects().depth && image_view.aspects().stencil {
+                    if image_view.subresource_range().aspects.depth
+                        && image_view.subresource_range().aspects.stencil
+                    {
                         return Err(DescriptorSetUpdateError::ImageViewDepthAndStencil {
                             binding: write.binding(),
                             index: descriptor_range_start + index as u32,
@@ -818,7 +823,9 @@ pub(crate) fn check_descriptor_write<'a>(
                     }
 
                     // VUID-VkDescriptorImageInfo-imageView-01976
-                    if image_view.aspects().depth && image_view.aspects().stencil {
+                    if image_view.subresource_range().aspects.depth
+                        && image_view.subresource_range().aspects.stencil
+                    {
                         return Err(DescriptorSetUpdateError::ImageViewDepthAndStencil {
                             binding: write.binding(),
                             index: descriptor_range_start + index as u32,

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -30,7 +30,6 @@ use crate::{
 use std::{
     fs::File,
     hash::{Hash, Hasher},
-    ops::Range,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
@@ -595,16 +594,6 @@ where
     #[inline]
     fn is_layout_initialized(&self) -> bool {
         self.initialized.load(Ordering::SeqCst)
-    }
-
-    #[inline]
-    fn current_mip_levels_access(&self) -> Range<u32> {
-        0..self.mip_levels()
-    }
-
-    #[inline]
-    fn current_array_layers_access(&self) -> Range<u32> {
-        0..self.dimensions().array_layers()
     }
 }
 

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -373,16 +373,6 @@ where
             input_attachment: self.layout,
         })
     }
-
-    #[inline]
-    fn current_mip_levels_access(&self) -> Range<u32> {
-        0..self.mip_levels()
-    }
-
-    #[inline]
-    fn current_array_layers_access(&self) -> Range<u32> {
-        0..self.dimensions().array_layers()
-    }
 }
 
 unsafe impl<P, A> ImageContent<P> for ImmutableImage<A>
@@ -452,16 +442,6 @@ where
     #[inline]
     fn descriptor_layouts(&self) -> Option<ImageDescriptorLayouts> {
         None
-    }
-
-    #[inline]
-    fn current_mip_levels_access(&self) -> Range<u32> {
-        self.mip_levels_access.clone()
-    }
-
-    #[inline]
-    fn current_array_layers_access(&self) -> Range<u32> {
-        self.array_layers_access.clone()
     }
 }
 

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -32,7 +32,6 @@ use smallvec::SmallVec;
 use std::{
     fs::File,
     hash::{Hash, Hasher},
-    ops::Range,
     sync::Arc,
 };
 
@@ -282,16 +281,6 @@ where
             sampled_image: ImageLayout::General,
             input_attachment: ImageLayout::General,
         })
-    }
-
-    #[inline]
-    fn current_mip_levels_access(&self) -> Range<u32> {
-        0..self.mip_levels()
-    }
-
-    #[inline]
-    fn current_array_layers_access(&self) -> Range<u32> {
-        0..self.dimensions().array_layers()
     }
 }
 

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 use std::{
     hash::{Hash, Hasher},
-    ops::Range,
     sync::Arc,
 };
 
@@ -36,7 +35,7 @@ use std::{
 /// method on the swapchain), which will have the effect of showing the content of the image to
 /// the screen. Once an image has been presented, it can no longer be used unless it is acquired
 /// again.
-// TODO: #[derive(Debug)]
+#[derive(Debug)]
 pub struct SwapchainImage<W> {
     swapchain: Arc<Swapchain<W>>,
     image_offset: usize,
@@ -124,16 +123,6 @@ where
     #[inline]
     fn is_layout_initialized(&self) -> bool {
         self.is_layout_initialized()
-    }
-
-    #[inline]
-    fn current_mip_levels_access(&self) -> Range<u32> {
-        0..self.mip_levels()
-    }
-
-    #[inline]
-    fn current_array_layers_access(&self) -> Range<u32> {
-        0..1
     }
 }
 

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -188,8 +188,8 @@ impl Framebuffer {
                 }
 
                 let image_view_extent = image_view.image().dimensions().width_height();
-                let image_view_array_layers =
-                    image_view.array_layers().end - attachments[0].array_layers().start;
+                let image_view_array_layers = image_view.subresource_range().array_layers.end
+                    - attachments[0].subresource_range().array_layers.start;
 
                 // VUID-VkFramebufferCreateInfo-renderPass-04536
                 if image_view_array_layers < render_pass.views_used() {
@@ -227,7 +227,10 @@ impl Framebuffer {
                 }
 
                 // VUID-VkFramebufferCreateInfo-pAttachments-00883
-                if image_view.mip_levels().end - image_view.mip_levels().start != 1 {
+                if image_view.subresource_range().mip_levels.end
+                    - image_view.subresource_range().mip_levels.start
+                    != 1
+                {
                     return Err(FramebufferCreationError::AttachmentMultipleMipLevels {
                         attachment: attachment_num,
                     });
@@ -357,7 +360,7 @@ impl Framebuffer {
     pub fn attached_layers_ranges(&self) -> SmallVec<[Range<u32>; 4]> {
         self.attachments
             .iter()
-            .map(|img| img.array_layers())
+            .map(|img| img.subresource_range().array_layers.clone())
             .collect()
     }
 }

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -447,7 +447,7 @@ impl Sampler {
             // The SPIR-V instruction is one of the OpImage*Dref* instructions, the image
             // view format is one of the depth/stencil formats, and the image view aspect
             // is not VK_IMAGE_ASPECT_DEPTH_BIT.
-            if !image_view.aspects().depth {
+            if !image_view.subresource_range().aspects.depth {
                 return Err(SamplerImageViewIncompatibleError::DepthComparisonWrongAspect);
             }
         } else {
@@ -486,7 +486,7 @@ impl Sampler {
         }
 
         if let Some(border_color) = self.border_color {
-            let aspects = image_view.aspects();
+            let aspects = image_view.subresource_range().aspects;
             let view_scalar_type = ShaderScalarType::from(
                 if aspects.color || aspects.plane0 || aspects.plane1 || aspects.plane2 {
                     image_view.format().unwrap().type_color().unwrap()
@@ -566,7 +566,10 @@ impl Sampler {
             }
 
             // The image view must have a single layer and a single mip level.
-            if image_view.mip_levels().end - image_view.mip_levels().start != 1 {
+            if image_view.subresource_range().mip_levels.end
+                - image_view.subresource_range().mip_levels.start
+                != 1
+            {
                 return Err(
                     SamplerImageViewIncompatibleError::UnnormalizedCoordinatesMultipleMipLevels,
                 );


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** `ImageViewCreateInfo` now has a single `subresource_range` field instead of separate fields for aspect, mip levels and array layers.
- **Breaking** The `aspects`, `mip_levels` and `array_layers` methods of `ImageViewAbstract` are removed, and replaced with a single `subresource_range` method.
- **Breaking** The `current_mip_levels_access` and `current_array_layers_access` methods of `ImageAccess` are removed.
```

```markdown
- `BufferViewAbstract` now has a `range` method that returns the byte range of the underlying buffer that the view covers.
```

Command buffer synchronization now uses the specified ranges of buffer and image views instead of the whole buffer/image. I've also made it so that buffer and image ranges are passed correctly from a secondary command buffer to a primary one.