### PR TITLE
Disallow dispatch calls with dimensions of zero-length

### DIFF
--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1611,6 +1611,10 @@ fn check_dispatch(device: &Device, dimensions: [u32; 3]) -> Result<(), CheckDisp
         });
     }
 
+    if dimensions.contains(&0) {
+        return Err(CheckDispatchError::ZeroLengthDimensions);
+    }
+
     Ok(())
 }
 
@@ -1624,6 +1628,9 @@ pub enum CheckDispatchError {
         /// The actual supported dimensions.
         max_supported: [u32; 3],
     },
+
+    /// At least one of the dimensions requested were zero.
+    ZeroLengthDimensions,
 }
 
 impl error::Error for CheckDispatchError {}
@@ -1637,6 +1644,9 @@ impl fmt::Display for CheckDispatchError {
             match *self {
                 CheckDispatchError::UnsupportedDimensions { .. } => {
                     "the dimensions are too large for the device's limits"
+                }
+                CheckDispatchError::ZeroLengthDimensions => {
+                    "at least one of the dimensions requested were 0"
                 }
             }
         )
@@ -2362,6 +2372,28 @@ mod tests {
             Err(CheckDispatchError::UnsupportedDimensions { requested, .. }) => {
                 assert_eq!(requested, attempted);
             }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn zero_dimension_checked() {
+        let (device, _) = gfx_dev_and_queue!();
+
+        let attempted = [128, 1, 0];
+
+        // Just in case the device is some kind of software implementation.
+        if device
+            .physical_device()
+            .properties()
+            .max_compute_work_group_count
+            == attempted
+        {
+            return;
+        }
+
+        match check_dispatch(&device, attempted) {
+            Err(CheckDispatchError::ZeroLengthDimensions) => {}
             _ => panic!(),
         }
     }

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1629,7 +1629,7 @@ pub enum CheckDispatchError {
         max_supported: [u32; 3],
     },
 
-    /// At least one of the dimensions requested were zero.
+    /// At least one of the requested dimensions were zero.
     ZeroLengthDimensions,
 }
 
@@ -1646,7 +1646,7 @@ impl fmt::Display for CheckDispatchError {
                     "the dimensions are too large for the device's limits"
                 }
                 CheckDispatchError::ZeroLengthDimensions => {
-                    "at least one of the dimensions requested were 0"
+                    "at least one of the requested dimensions were zero"
                 }
             }
         )
@@ -2381,16 +2381,6 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let attempted = [128, 1, 0];
-
-        // Just in case the device is some kind of software implementation.
-        if device
-            .physical_device()
-            .properties()
-            .max_compute_work_group_count
-            == attempted
-        {
-            return;
-        }
 
         match check_dispatch(&device, attempted) {
             Err(CheckDispatchError::ZeroLengthDimensions) => {}


### PR DESCRIPTION
1. [x] This is meant to address #1219 by adding an additional check to `check_dispatch()` for a zero-length dimension

2. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   files(`CHANGELOG_VULKANO.md` and `CHANGELOG_VK_SYS.md`)
   by maintainers right after the Pull Request merge.

    * Entries for Vulkano changelog:
        - Added new enum value `CheckDispatchError::ZeroLengthDimensions` to be returned when `dispatch()` is called with dimension(s) of length zero.

3. [x] Run `cargo fmt` on the changes.

4. [x] Make sure that the changes are covered by unit-tests.

5. [x] Update documentation to reflect any user-facing changes - in this repository.

Let me know if there are any concerns! (and yes, this issue is pretty low-hanging fruit :P )