### PR TITLE
Fixing Module comments that were accidentally changed

### DIFF
--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -7,12 +7,13 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-/// Buffer whose content is read-written by the GPU only.
-///
-/// Each access from the CPU or from the GPU locks the whole buffer for either reading or writing.
-/// You can read the buffer multiple times simultaneously from multiple queues. Trying to read and
-/// write simultaneously, or write and write simultaneously will block with a semaphore.
-///
+//! Buffer whose content is read-written by the GPU only.
+//!
+//! Each access from the CPU or from the GPU locks the whole buffer for either reading or writing.
+//! You can read the buffer multiple times simultaneously from multiple queues. Trying to read and
+//! write simultaneously, or write and write simultaneously will block with a semaphore.
+//!
+
 use super::{
     sys::{UnsafeBuffer, UnsafeBufferCreateInfo},
     BufferAccess, BufferAccessObject, BufferContents, BufferCreationError, BufferInner,


### PR DESCRIPTION
Whoops. I appreciate the speed with-which https://github.com/vulkano-rs/vulkano/pull/1890 was merged, but I notice now that I had accidentally changed the leading module comments to be outer-line doc comments.

This is a simple commit to fix those comments again.