### PR TITLE
Image extent zero length

### DIFF
--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -234,12 +234,17 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
+                let dimensions = surface.window().inner_size();
+                if dimensions.width == 0 || dimensions.height == 0 {
+                    return;
+                }
+
                 previous_frame_end.as_mut().unwrap().cleanup_finished();
 
                 if recreate_swapchain {
                     let (new_swapchain, new_images) =
                         match swapchain.recreate(SwapchainCreateInfo {
-                            image_extent: surface.window().inner_size().into(),
+                            image_extent: dimensions.into(),
                             ..swapchain.create_info()
                         }) {
                             Ok(r) => r,

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -195,11 +195,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -163,11 +163,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -346,11 +346,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -266,11 +266,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -275,11 +275,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -297,12 +297,17 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
+                let dimensions = surface.window().inner_size();
+                if dimensions.width == 0 || dimensions.height == 0 {
+                    return;
+                }
+
                 previous_frame_end.as_mut().unwrap().cleanup_finished();
 
                 if recreate_swapchain {
                     let (new_swapchain, new_images) =
                         match swapchain.recreate(SwapchainCreateInfo {
-                            image_extent: surface.window().inner_size().into(),
+                            image_extent: dimensions.into(),
                             ..swapchain.create_info()
                         }) {
                             Ok(r) => r,

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -293,12 +293,17 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
+                let dimensions = surface.window().inner_size();
+                if dimensions.width == 0 || dimensions.height == 0 {
+                    return;
+                }
+
                 previous_frame_end.as_mut().unwrap().cleanup_finished();
 
                 if recreate_swapchain {
                     let (new_swapchain, new_images) =
                         match swapchain.recreate(SwapchainCreateInfo {
-                            image_extent: surface.window().inner_size().into(),
+                            image_extent: dimensions.into(),
                             ..swapchain.create_info()
                         }) {
                             Ok(r) => r,

--- a/examples/src/bin/interactive_fractal/main.rs
+++ b/examples/src/bin/interactive_fractal/main.rs
@@ -63,6 +63,16 @@ fn main() {
         if !handle_events(&mut event_loop, &mut renderer, &mut app) {
             break;
         }
+
+        match renderer.window_size() {
+            [w, h] => {
+                // Skip this frame when minimized
+                if w == 0 || h == 0 {
+                    continue;
+                }
+            }
+        }
+
         app.update_state_after_inputs(&mut renderer);
         compute_then_render(&mut renderer, &mut app, render_target_id);
         app.reset_input_state();

--- a/examples/src/bin/interactive_fractal/renderer.rs
+++ b/examples/src/bin/interactive_fractal/renderer.rs
@@ -271,7 +271,6 @@ impl Renderer {
     }
 
     /// Winit window size
-    #[allow(unused)]
     pub fn window_size(&self) -> [u32; 2] {
         let size = self.window().inner_size();
         [size.width, size.height]

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -352,11 +352,16 @@ fn main() {
                 ref mut previous_frame_end,
             } = window_surfaces.get_mut(&window_id).unwrap();
 
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if *recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/multi_window_game_of_life/main.rs
+++ b/examples/src/bin/multi_window_game_of_life/main.rs
@@ -197,6 +197,15 @@ fn compute_then_render(
     life_color: [f32; 4],
     dead_color: [f32; 4],
 ) {
+    // Skip this window when minimized
+    match vulkano_window.window_size() {
+        [w, h] => {
+            if w == 0 || h == 0 {
+                return;
+            }
+        }
+    }
+
     // Start frame
     let before_pipeline_future = match vulkano_window.start_frame() {
         Err(e) => {

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -312,11 +312,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -258,11 +258,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -243,11 +243,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -395,11 +395,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -412,8 +412,8 @@ fn main() {
             }
             Event::RedrawEventsCleared => {
                 let dimensions = surface.window().inner_size();
-                if dimensions.width == 0 && dimensions.height == 0 {
-                    return; // On Windows, minimizing sets surface to 0x0. Do not draw frame.
+                if dimensions.width == 0 || dimensions.height == 0 {
+                    return;
                 }
 
                 // Update per-frame variables.

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -189,12 +189,17 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
+                let dimensions = surface.window().inner_size();
+                if dimensions.width == 0 || dimensions.height == 0 {
+                    return;
+                }
+
                 previous_frame_end.as_mut().unwrap().cleanup_finished();
 
                 if recreate_swapchain {
                     let (new_swapchain, new_images) =
                         match swapchain.recreate(SwapchainCreateInfo {
-                            image_extent: surface.window().inner_size().into(),
+                            image_extent: dimensions.into(),
                             ..swapchain.create_info()
                         }) {
                             Ok(r) => r,

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -349,11 +349,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -267,11 +267,16 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
+            let dimensions = surface.window().inner_size();
+            if dimensions.width == 0 || dimensions.height == 0 {
+                return;
+            }
+
             previous_frame_end.as_mut().unwrap().cleanup_finished();
 
             if recreate_swapchain {
                 let (new_swapchain, new_images) = match swapchain.recreate(SwapchainCreateInfo {
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: dimensions.into(),
                     ..swapchain.create_info()
                 }) {
                     Ok(r) => r,

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -416,6 +416,13 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
+                // Do not draw frame when screen dimensions are zero.
+                // On Windows, this can occur from minimizing the application.
+                let dimensions = surface.window().inner_size();
+                if dimensions.width == 0 || dimensions.height == 0 {
+                    return;
+                }
+
                 // It is important to call this function from time to time, otherwise resources will keep
                 // accumulating and you will eventually reach an out of memory error.
                 // Calling this function polls various fences in order to determine what the GPU has
@@ -425,11 +432,11 @@ fn main() {
                 // Whenever the window resizes we need to recreate everything dependent on the window size.
                 // In this example that includes the swapchain, the framebuffers and the dynamic state viewport.
                 if recreate_swapchain {
-                    // Get the new dimensions of the window.
+                    // Use the new dimensions of the window.
 
                     let (new_swapchain, new_images) =
                         match swapchain.recreate(SwapchainCreateInfo {
-                            image_extent: surface.window().inner_size().into(),
+                            image_extent: dimensions.into(),
                             ..swapchain.create_info()
                         }) {
                             Ok(r) => r,

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -393,7 +393,9 @@ impl<W> Swapchain<W> {
 
         // VUID-VkSwapchainCreateInfoKHR-imageExtent-01689
         // On some platforms, dimensions of zero-length can occur by minimizing the surface.
-        if image_extent.contains(&0) { return Err(SwapchainCreationError::ImageExtentZeroLengthDimensions)}
+        if image_extent.contains(&0) {
+            return Err(SwapchainCreationError::ImageExtentZeroLengthDimensions);
+        }
 
         // VUID-VkSwapchainCreateInfoKHR-imageArrayLayers-01275
         if image_array_layers == 0
@@ -1059,7 +1061,10 @@ pub enum SwapchainCreationError {
     /// The provided `image_extent` contained at least one dimension of zero length.
     /// This is prohibited by [VUID-VkSwapchainCreateInfoKHR-imageExtent-01689](https://khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSwapchainCreateInfoKHR.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01689)
     /// which requires both the width and height be non-zero.
-    ImageExtentZeroLengthDimensions, 
+    ///
+    /// This error is distinct from `ImageExtentNotSupported` because a surface's minimum supported
+    /// length may not enforce this rule.
+    ImageExtentZeroLengthDimensions,
 
     /// The provided image parameters are not supported as queried from `image_format_properties`.
     ImageFormatPropertiesNotSupported,


### PR DESCRIPTION
This PR was initially set to resolve issue #1892 for all examples. Namely, the goal was to ensure the examples did not crash when minimized. The cause of the crashes is that Windows sets the surface size to zero by zero when minimized. Coincidentally, the swapchain creation code was incorrectly validating [VUID-VkSwapchainCreateInfoKHR-imageExtent-01689](https://khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSwapchainCreateInfoKHR.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01689) by asserting that at least one dimension was non-zero.

* Entries for Vulkano changelog:
     - Added new enum value `SwapchainCreationError ::ImageExtentZeroLengthDimensions` to be returned when at least one of the image extent's dimensions are zero.
