### PR TITLE
Remove `Default` from `NonExhaustive`

### DIFF
--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -281,10 +281,17 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
         /// let features_to_request = optimal_features.intersection(physical_device.supported_features());
         /// ```
         ///
-        #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+        #[derive(Clone, Debug, PartialEq, Eq, Hash)]
         pub struct Features {
             #(#struct_items)*
             pub _ne: crate::NonExhaustive,
+        }
+
+        impl Default for Features {
+            #[inline]
+            fn default() -> Self {
+                Self::none()
+            }
         }
 
         impl Features {

--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -69,6 +69,12 @@ fn properties_output(members: &[PropertiesMember]) -> TokenStream {
         },
     );
 
+    let default_items = members.iter().map(|PropertiesMember { name, .. }| {
+        quote! {
+            #name: Default::default(),
+        }
+    });
+
     let from_items = members.iter().map(
         |PropertiesMember {
              name,
@@ -108,10 +114,19 @@ fn properties_output(members: &[PropertiesMember]) -> TokenStream {
         /// Depending on the highest version of Vulkan supported by the physical device, and the
         /// available extensions, not every property may be available. For that reason, some
         /// properties are wrapped in an `Option`.
-        #[derive(Clone, Debug, Default)]
+        #[derive(Clone, Debug)]
         pub struct Properties {
             #(#struct_items)*
             pub _ne: crate::NonExhaustive,
+        }
+
+        impl Default for Properties {
+            fn default() -> Self {
+                Properties {
+                    #(#default_items)*
+                    _ne: crate::NonExhaustive(()),
+                }
+            }
         }
 
         impl From<&PropertiesFfi> for Properties {

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -507,11 +507,22 @@ impl From<Error> for BufferCreationError {
 }
 
 /// The level of sparse binding that a buffer should be created with.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct SparseLevel {
     pub sparse_residency: bool,
     pub sparse_aliased: bool,
     pub _ne: crate::NonExhaustive,
+}
+
+impl Default for SparseLevel {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            sparse_residency: false,
+            sparse_aliased: false,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
 }
 
 impl SparseLevel {

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -15,7 +15,7 @@ use std::ops::BitOr;
 ///
 /// Some methods are provided to build `BufferUsage` structs for some common situations. However
 /// there is no restriction in the combination of BufferUsages that can be enabled.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BufferUsage {
     pub transfer_src: bool,
     pub transfer_dst: bool,
@@ -28,6 +28,25 @@ pub struct BufferUsage {
     pub indirect_buffer: bool,
     pub device_address: bool,
     pub _ne: crate::NonExhaustive,
+}
+
+impl Default for BufferUsage {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            transfer_src: false,
+            transfer_dst: false,
+            uniform_texel_buffer: false,
+            storage_texel_buffer: false,
+            uniform_buffer: false,
+            storage_buffer: false,
+            index_buffer: false,
+            vertex_buffer: false,
+            indirect_buffer: false,
+            device_address: false,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
 }
 
 impl BufferUsage {

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -702,7 +702,7 @@ impl From<(f32, u32)> for ClearDepthStencilValue {
 }
 
 /// The properties of a format that are supported by a physical device.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct FormatProperties {
     /// Features available for images with linear tiling.
     pub linear_tiling_features: FormatFeatures,
@@ -716,6 +716,18 @@ pub struct FormatProperties {
     pub _ne: crate::NonExhaustive,
 }
 
+impl Default for FormatProperties {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            linear_tiling_features: Default::default(),
+            optimal_tiling_features: Default::default(),
+            buffer_features: Default::default(),
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+}
+
 impl FormatProperties {
     /// Returns the potential format features, following the definition of
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/chap43.html#potential-format-features>.
@@ -726,7 +738,7 @@ impl FormatProperties {
 }
 
 /// The features supported by a device for an image or buffer with a particular format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub struct FormatFeatures {
     // Image usage
@@ -823,6 +835,49 @@ pub struct FormatFeatures {
     pub acceleration_structure_vertex_buffer: bool,
 
     pub _ne: crate::NonExhaustive,
+}
+
+impl Default for FormatFeatures {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            sampled_image: false,
+            storage_image: false,
+            storage_image_atomic: false,
+            storage_read_without_format: false,
+            storage_write_without_format: false,
+            color_attachment: false,
+            color_attachment_blend: false,
+            depth_stencil_attachment: false,
+            fragment_density_map: false,
+            fragment_shading_rate_attachment: false,
+            transfer_src: false,
+            transfer_dst: false,
+            blit_src: false,
+            blit_dst: false,
+            sampled_image_filter_linear: false,
+            sampled_image_filter_cubic: false,
+            sampled_image_filter_minmax: false,
+            midpoint_chroma_samples: false,
+            cosited_chroma_samples: false,
+            sampled_image_ycbcr_conversion_linear_filter: false,
+            sampled_image_ycbcr_conversion_separate_reconstruction_filter: false,
+            sampled_image_ycbcr_conversion_chroma_reconstruction_explicit: false,
+            sampled_image_ycbcr_conversion_chroma_reconstruction_explicit_forceable: false,
+            sampled_image_depth_comparison: false,
+            video_decode_output: false,
+            video_decode_dpb: false,
+            video_encode_input: false,
+            video_encode_dpb: false,
+            disjoint: false,
+            uniform_texel_buffer: false,
+            storage_texel_buffer: false,
+            storage_texel_buffer_atomic: false,
+            vertex_buffer: false,
+            acceleration_structure_vertex_buffer: false,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
 }
 
 impl BitOr for &FormatFeatures {

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -244,8 +244,8 @@ fn check_errors(result: ash::vk::Result) -> Result<Success, Error> {
 /// A helper type for non-exhaustive structs.
 ///
 /// This type cannot be constructed outside Vulkano. Structures with a field of this type can only
-/// be constructed by calling a function such as `Default::default()`. The effect is similar to the
-/// standard Rust `#[non_exhaustive]` attribute, except that it does not prevent update syntax from
-/// being used.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)] // add traits as needed
+/// be constructed by calling a constructor function or `Default::default()`. The effect is similar
+/// to the standard Rust `#[non_exhaustive]` attribute, except that it does not prevent update
+/// syntax from being used.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)] // add traits as needed
 pub struct NonExhaustive(pub(crate) ());

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -580,7 +580,7 @@ impl ImageMemoryBarrier {
                 mip_levels: 0..0,
                 array_layers: 0..0,
             },
-            _ne: Default::default(),
+            _ne: crate::NonExhaustive(()),
         }
     }
 }


### PR DESCRIPTION
Changelog:
```markdown
- Fixed a bug where `NonExhaustive` implemented the `Default` trait and was therefore still constructable by the user.
```

A small bug that I missed in the previous release.