### PR TITLE
Refactor query commands

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -8,16 +8,10 @@
 // according to those terms.
 
 use super::{
-    commands::{
-        pipeline::{
-            CheckDescriptorSetsValidityError, CheckDispatchError, CheckDynamicStateValidityError,
-            CheckIndexBufferError, CheckIndirectBufferError, CheckPipelineError,
-            CheckPushConstantsValidityError, CheckVertexBufferError,
-        },
-        query::{
-            CheckBeginQueryError, CheckCopyQueryPoolResultsError, CheckEndQueryError,
-            CheckResetQueryPoolError, CheckWriteTimestampError,
-        },
+    commands::pipeline::{
+        CheckDescriptorSetsValidityError, CheckDispatchError, CheckDynamicStateValidityError,
+        CheckIndexBufferError, CheckIndirectBufferError, CheckPipelineError,
+        CheckPushConstantsValidityError, CheckVertexBufferError,
     },
     pool::{
         standard::{StandardCommandPoolAlloc, StandardCommandPoolBuilder},
@@ -1015,12 +1009,6 @@ err_gen!(BuildError {
     OomError,
 });
 
-err_gen!(CopyQueryPoolResultsError {
-    AutoCommandBufferBuilderContextError,
-    CheckCopyQueryPoolResultsError,
-    SyncCommandBufferBuilderError,
-});
-
 err_gen!(DispatchError {
     AutoCommandBufferBuilderContextError,
     CheckPipelineError,
@@ -1082,26 +1070,6 @@ err_gen!(DrawIndexedIndirectError {
     CheckIndexBufferError,
     CheckIndirectBufferError,
     SyncCommandBufferBuilderError,
-});
-
-err_gen!(BeginQueryError {
-    AutoCommandBufferBuilderContextError,
-    CheckBeginQueryError,
-});
-
-err_gen!(EndQueryError {
-    AutoCommandBufferBuilderContextError,
-    CheckEndQueryError,
-});
-
-err_gen!(WriteTimestampError {
-    AutoCommandBufferBuilderContextError,
-    CheckWriteTimestampError,
-});
-
-err_gen!(ResetQueryPoolError {
-    AutoCommandBufferBuilderContextError,
-    CheckResetQueryPoolError,
 });
 
 #[derive(Debug, Copy, Clone)]

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -33,7 +33,7 @@ impl<P> AutoCommandBufferBuilder<PrimaryAutoCommandBuffer<P::Alloc>, P>
 where
     P: CommandPoolBuilderAlloc,
 {
-    /// Adds a command that executes a secondary command buffer.
+    /// Executes a secondary command buffer.
     ///
     /// If the `flags` that `command_buffer` was created with are more restrictive than those of
     /// `self`, then `self` will be restricted to match. E.g. executing a secondary command buffer
@@ -63,7 +63,7 @@ where
         Ok(self)
     }
 
-    /// Adds a command that multiple secondary command buffers in a vector.
+    /// Executes multiple secondary command buffers in a vector.
     ///
     /// This requires that the secondary command buffers do not have resource conflicts; an error
     /// will be returned if there are any. Use `execute_commands` if you want to ensure that

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -87,10 +87,7 @@ pub use self::commands::{
         CheckIndexBufferError, CheckIndirectBufferError, CheckPipelineError,
         CheckPushConstantsValidityError, CheckVertexBufferError,
     },
-    query::{
-        CheckBeginQueryError, CheckCopyQueryPoolResultsError, CheckEndQueryError,
-        CheckResetQueryPoolError, CheckWriteTimestampError,
-    },
+    query::QueryError,
     render_pass::{
         ClearAttachment, ClearRect, RenderPassBeginInfo, RenderPassError, RenderingAttachmentInfo,
         RenderingAttachmentResolveInfo, RenderingInfo,
@@ -104,11 +101,10 @@ pub use self::commands::{
 };
 pub use self::{
     auto::{
-        AutoCommandBufferBuilder, AutoCommandBufferBuilderContextError, BeginQueryError,
-        BuildError, CommandBufferBeginError, CopyQueryPoolResultsError, DispatchError,
-        DispatchIndirectError, DrawError, DrawIndexedError, DrawIndexedIndirectError,
-        DrawIndirectError, EndQueryError, PrimaryAutoCommandBuffer, ResetQueryPoolError,
-        SecondaryAutoCommandBuffer, WriteTimestampError,
+        AutoCommandBufferBuilder, AutoCommandBufferBuilderContextError, BuildError,
+        CommandBufferBeginError, DispatchError, DispatchIndirectError, DrawError, DrawIndexedError,
+        DrawIndexedIndirectError, DrawIndirectError, PrimaryAutoCommandBuffer,
+        SecondaryAutoCommandBuffer,
     },
     traits::{
         CommandBufferExecError, CommandBufferExecFuture, PrimaryCommandBuffer,

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -367,6 +367,9 @@ impl<'a> QueriesRange<'a> {
         T: QueryResultElement,
     {
         assert!(buffer_len > 0);
+
+        // VUID-vkGetQueryPoolResults-flags-02828
+        // VUID-vkGetQueryPoolResults-flags-00815
         debug_assert!(buffer_start % std::mem::size_of::<T>() as DeviceSize == 0);
 
         let count = self.range.end - self.range.start;
@@ -374,6 +377,7 @@ impl<'a> QueriesRange<'a> {
             self.pool.query_type.result_len() + flags.with_availability as DeviceSize;
         let required_len = per_query_len * count as DeviceSize;
 
+        // VUID-vkGetQueryPoolResults-dataSize-00817
         if buffer_len < required_len {
             return Err(GetResultsError::BufferTooSmall {
                 required_len: required_len as DeviceSize,
@@ -385,6 +389,7 @@ impl<'a> QueriesRange<'a> {
             QueryType::Occlusion => (),
             QueryType::PipelineStatistics(_) => (),
             QueryType::Timestamp => {
+                // VUID-vkGetQueryPoolResults-queryType-00818
                 if flags.partial {
                     return Err(GetResultsError::InvalidFlags);
                 }


### PR DESCRIPTION
This PR refactors the query commands, in the same way that other command buffer commands have already been done. There are no breaking changes (other than to error types, which I haven't included in changelogs so far). After this, only the bind and the pipeline commands are left.