### PR TITLE
Add `is_signaled` to `FenceSignalFuture`

### DIFF
--- a/vulkano/src/command_buffer/submit/queue_submit.rs
+++ b/vulkano/src/command_buffer/submit/queue_submit.rs
@@ -313,14 +313,14 @@ mod tests {
             let (device, queue) = gfx_dev_and_queue!();
 
             let fence = Fence::new(device.clone(), Default::default()).unwrap();
-            assert!(!fence.ready().unwrap());
+            assert!(!fence.is_signaled().unwrap());
 
             let mut builder = SubmitCommandBufferBuilder::new();
             builder.set_fence_signal(&fence);
 
             builder.submit(&queue).unwrap();
             fence.wait(Some(Duration::from_secs(5))).unwrap();
-            assert!(fence.ready().unwrap());
+            assert!(fence.is_signaled().unwrap());
         }
     }
 


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** Renamed the `ready` method of `Fence` to `is_signaled`.
```

```markdown
- Added an `is_signaled` method to `FenceSignalFuture`.
```

Fixes #1907. I renamed the function to better fit Rust method naming guidelines and Vulkan terminology.