### PR TITLE
Refactor dynamic state commands

### DIFF
--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -17,8 +17,8 @@ use crate::{
     },
     device::{physical::QueueFamily, DeviceOwned},
     query::{
-        GetResultsError, QueriesRange, Query, QueryControlFlags, QueryPool, QueryResultElement,
-        QueryResultFlags, QueryType,
+        QueriesRange, Query, QueryControlFlags, QueryPool, QueryResultElement, QueryResultFlags,
+        QueryType,
     },
     sync::{AccessFlags, PipelineMemoryAccess, PipelineStage, PipelineStages},
     DeviceSize, VulkanObject,
@@ -886,22 +886,5 @@ impl From<SyncCommandBufferBuilderError> for QueryError {
     #[inline]
     fn from(err: SyncCommandBufferBuilderError) -> Self {
         Self::SyncCommandBufferBuilderError(err)
-    }
-}
-
-impl From<GetResultsError> for QueryError {
-    #[inline]
-    fn from(value: GetResultsError) -> Self {
-        match value {
-            GetResultsError::BufferTooSmall {
-                required_len,
-                actual_len,
-            } => Self::BufferTooSmall {
-                required_len,
-                actual_len,
-            },
-            GetResultsError::InvalidFlags => Self::InvalidFlags,
-            GetResultsError::DeviceLost | GetResultsError::OomError(_) => unreachable!(),
-        }
     }
 }

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -48,7 +48,7 @@ use std::{
     borrow::Cow,
     collections::{hash_map::Entry, HashMap},
     error, fmt,
-    ops::Range,
+    ops::{Range, RangeInclusive},
     sync::Arc,
 };
 
@@ -958,7 +958,7 @@ pub(in crate::command_buffer) struct CurrentState {
     pub(in crate::command_buffer) cull_mode: Option<CullMode>,
     pub(in crate::command_buffer) depth_bias: Option<DepthBias>,
     pub(in crate::command_buffer) depth_bias_enable: Option<bool>,
-    pub(in crate::command_buffer) depth_bounds: Option<(f32, f32)>,
+    pub(in crate::command_buffer) depth_bounds: Option<RangeInclusive<f32>>,
     pub(in crate::command_buffer) depth_bounds_test_enable: Option<bool>,
     pub(in crate::command_buffer) depth_compare_op: Option<CompareOp>,
     pub(in crate::command_buffer) depth_test_enable: Option<bool>,
@@ -1223,8 +1223,8 @@ impl<'a> CommandBufferState<'a> {
 
     /// Returns the current depth bounds settings, or `None` if nothing has been set yet.
     #[inline]
-    pub fn depth_bounds(&self) -> Option<(f32, f32)> {
-        self.current_state.depth_bounds
+    pub fn depth_bounds(&self) -> Option<RangeInclusive<f32>> {
+        self.current_state.depth_bounds.clone()
     }
 
     /// Returns whether depth bound testing is enabled, or `None` if nothing has been set yet.


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** The `set_depth_bounds` parameter is now a single `RangeInclusive` instead of two separate `f32`, to match the type used on the `DepthBoundsState` struct.
```

Mostly mechanical work in this one, and one breaking change.