### PR TITLE
 Add from_handle constructors for various Vulkan object types. #1935 

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -182,6 +182,28 @@ impl UnsafeBuffer {
         Ok(Arc::new(buffer))
     }
 
+    /// Creates a new `UnsafeBuffer` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(
+        handle: ash::vk::Buffer,
+        create_info: UnsafeBufferCreateInfo,
+        device: Arc<Device>,
+    ) -> Arc<UnsafeBuffer> {
+        let UnsafeBufferCreateInfo { size, usage, .. } = create_info;
+
+        Arc::new(UnsafeBuffer {
+            handle,
+            device,
+
+            size,
+            usage,
+
+            state: Mutex::new(BufferState::new(size)),
+        })
+    }
+
     /// Returns the memory requirements for this buffer.
     pub fn memory_requirements(&self) -> MemoryRequirements {
         #[inline]

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -72,6 +72,34 @@ impl UnsafeCommandPool {
         })
     }
 
+    /// Creates a new `UnsafeCommandPool` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(
+        handle: ash::vk::CommandPool,
+        create_info: UnsafeCommandPoolCreateInfo,
+        device: Arc<Device>,
+    ) -> UnsafeCommandPool {
+        let UnsafeCommandPoolCreateInfo {
+            queue_family_index,
+            transient,
+            reset_command_buffer,
+            _ne: _,
+        } = create_info;
+
+        UnsafeCommandPool {
+            handle,
+            device,
+            dummy_avoid_sync: PhantomData,
+
+            queue_family_index,
+            transient,
+            reset_command_buffer,
+        }
+    }
+
+
     fn validate(
         device: &Device,
         create_info: &mut UnsafeCommandPoolCreateInfo,

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -99,7 +99,6 @@ impl UnsafeCommandPool {
         }
     }
 
-
     fn validate(
         device: &Device,
         create_info: &mut UnsafeCommandPoolCreateInfo,

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -65,6 +65,41 @@ impl DescriptorSetLayout {
         }))
     }
 
+    /// Creates a new `DescriptorSetLayout` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(
+        handle: ash::vk::DescriptorSetLayout,
+        create_info: DescriptorSetLayoutCreateInfo,
+        device: Arc<Device>,
+    ) -> Arc<DescriptorSetLayout> {
+        let DescriptorSetLayoutCreateInfo {
+            bindings,
+            push_descriptor,
+            _ne: _,
+        } = create_info;
+
+        let mut descriptor_counts = HashMap::default();
+        for (&binding_num, binding) in bindings.iter() {
+            if binding.descriptor_count != 0 {
+                *descriptor_counts
+                    .entry(binding.descriptor_type)
+                    .or_default() += binding.descriptor_count;
+            }
+        }
+
+        Arc::new(DescriptorSetLayout {
+            handle,
+            device,
+
+            bindings,
+            push_descriptor,
+
+            descriptor_counts,
+        })
+    }
+
     fn validate(
         device: &Device,
         create_info: &mut DescriptorSetLayoutCreateInfo,

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -116,6 +116,32 @@ impl UnsafeDescriptorPool {
         })
     }
 
+    /// Creates a new `UnsafeDescriptorPool` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(
+        handle: ash::vk::DescriptorPool,
+        create_info: UnsafeDescriptorPoolCreateInfo,
+        device: Arc<Device>,
+    ) -> UnsafeDescriptorPool {
+        let UnsafeDescriptorPoolCreateInfo {
+            max_sets,
+            pool_sizes,
+            can_free_descriptor_sets,
+            _ne: _,
+        } = create_info;
+
+        UnsafeDescriptorPool {
+            handle,
+            device,
+
+            max_sets,
+            pool_sizes,
+            can_free_descriptor_sets,
+        }
+    }
+
     /// Returns the maximum number of sets that can be allocated from the pool.
     #[inline]
     pub fn max_sets(&self) -> u32 {

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -123,7 +123,18 @@ impl PipelineLayout {
             )
         });
 
-        // Create a list of disjoint ranges.
+        let push_constant_ranges_disjoint = Self::create_push_constant_ranges_disjoint(&push_constant_ranges);
+
+        Ok(Arc::new(PipelineLayout {
+            handle,
+            device,
+            set_layouts,
+            push_constant_ranges,
+            push_constant_ranges_disjoint,
+        }))
+    }
+
+    fn create_push_constant_ranges_disjoint(push_constant_ranges: &Vec<PushConstantRange>) -> Vec<PushConstantRange> {
         let mut push_constant_ranges_disjoint: Vec<PushConstantRange> =
             Vec::with_capacity(push_constant_ranges.len());
 
@@ -159,14 +170,33 @@ impl PipelineLayout {
                 min_offset = max_offset;
             }
         }
+        push_constant_ranges_disjoint
+    }
 
-        Ok(Arc::new(PipelineLayout {
+
+    /// Creates a new `PipelineLayout` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(handle : ash::vk::PipelineLayout,
+                              create_info: PipelineLayoutCreateInfo,
+                              device: Arc<Device>
+    ) -> Arc<PipelineLayout> {
+        let PipelineLayoutCreateInfo {
+            set_layouts,
+            push_constant_ranges,
+            _ne: _,
+        } = create_info;
+
+        let push_constant_ranges_disjoint = Self::create_push_constant_ranges_disjoint(& push_constant_ranges);
+
+        Arc::new(PipelineLayout {
             handle,
             device,
             set_layouts,
             push_constant_ranges,
             push_constant_ranges_disjoint,
-        }))
+        })
     }
 
     fn validate(

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -123,7 +123,8 @@ impl PipelineLayout {
             )
         });
 
-        let push_constant_ranges_disjoint = Self::create_push_constant_ranges_disjoint(&push_constant_ranges);
+        let push_constant_ranges_disjoint =
+            Self::create_push_constant_ranges_disjoint(&push_constant_ranges);
 
         Ok(Arc::new(PipelineLayout {
             handle,
@@ -134,7 +135,9 @@ impl PipelineLayout {
         }))
     }
 
-    fn create_push_constant_ranges_disjoint(push_constant_ranges: &Vec<PushConstantRange>) -> Vec<PushConstantRange> {
+    fn create_push_constant_ranges_disjoint(
+        push_constant_ranges: &Vec<PushConstantRange>,
+    ) -> Vec<PushConstantRange> {
         let mut push_constant_ranges_disjoint: Vec<PushConstantRange> =
             Vec::with_capacity(push_constant_ranges.len());
 
@@ -173,14 +176,14 @@ impl PipelineLayout {
         push_constant_ranges_disjoint
     }
 
-
     /// Creates a new `PipelineLayout` from an ash-handle
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(handle : ash::vk::PipelineLayout,
-                              create_info: PipelineLayoutCreateInfo,
-                              device: Arc<Device>
+    pub unsafe fn from_handle(
+        handle: ash::vk::PipelineLayout,
+        create_info: PipelineLayoutCreateInfo,
+        device: Arc<Device>,
     ) -> Arc<PipelineLayout> {
         let PipelineLayoutCreateInfo {
             set_layouts,
@@ -188,7 +191,8 @@ impl PipelineLayout {
             _ne: _,
         } = create_info;
 
-        let push_constant_ranges_disjoint = Self::create_push_constant_ranges_disjoint(& push_constant_ranges);
+        let push_constant_ranges_disjoint =
+            Self::create_push_constant_ranges_disjoint(&push_constant_ranges);
 
         Arc::new(PipelineLayout {
             handle,

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -106,10 +106,11 @@ impl QueryPool {
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(handle : ash::vk::QueryPool,
-                              create_info: QueryPoolCreateInfo,
-                              device: Arc<Device>
-    ) -> Arc<QueryPool>{
+    pub unsafe fn from_handle(
+        handle: ash::vk::QueryPool,
+        create_info: QueryPoolCreateInfo,
+        device: Arc<Device>,
+    ) -> Arc<QueryPool> {
         let QueryPoolCreateInfo {
             query_type,
             query_count,

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -102,6 +102,27 @@ impl QueryPool {
         }))
     }
 
+    /// Creates a new `QueryPool` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(handle : ash::vk::QueryPool,
+                              create_info: QueryPoolCreateInfo,
+                              device: Arc<Device>
+    ) -> Arc<QueryPool>{
+        let QueryPoolCreateInfo {
+            query_type,
+            query_count,
+            _ne: _,
+        } = create_info;
+        return Arc::new(QueryPool {
+            handle,
+            device,
+            query_type,
+            query_count,
+        });
+    }
+
     /// Returns the query type of the pool.
     #[inline]
     pub fn query_type(&self) -> QueryType {

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -332,9 +332,10 @@ impl Framebuffer {
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(handle : ash::vk::Framebuffer,
-                              create_info: FramebufferCreateInfo,
-                              render_pass: Arc<RenderPass>
+    pub unsafe fn from_handle(
+        handle: ash::vk::Framebuffer,
+        create_info: FramebufferCreateInfo,
+        render_pass: Arc<RenderPass>,
     ) -> Arc<Framebuffer> {
         let FramebufferCreateInfo {
             attachments,

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -328,6 +328,30 @@ impl Framebuffer {
         }))
     }
 
+    /// Creates a new `Framebuffer` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(handle : ash::vk::Framebuffer,
+                              create_info: FramebufferCreateInfo,
+                              render_pass: Arc<RenderPass>
+    ) -> Arc<Framebuffer> {
+        let FramebufferCreateInfo {
+            attachments,
+            extent,
+            layers,
+            _ne: _,
+        } = create_info;
+
+        Arc::new(Framebuffer {
+            handle,
+            render_pass,
+
+            attachments,
+            extent,
+            layers,
+        })
+    }
     /// Returns the renderpass that was used to create this framebuffer.
     #[inline]
     pub fn render_pass(&self) -> &Arc<RenderPass> {

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -181,11 +181,14 @@ impl RenderPass {
     /// the `create_info` must match the info used to create said object
     pub unsafe fn from_handle(
         handle: ash::vk::RenderPass,
-        mut create_info: RenderPassCreateInfo,
+        create_info: RenderPassCreateInfo,
         granularity: [u32; 2],
         device: Arc<Device>,
     ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
-        let views_used = Self::validate(&device, &mut create_info)?;
+        let views_used = create_info.subpasses
+            .iter()
+            .map(|subpass| u32::BITS - subpass.view_mask.leading_zeros())
+            .max().unwrap();
         let granularity = Self::get_granularity(&device, handle);
 
         let RenderPassCreateInfo {

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -185,10 +185,12 @@ impl RenderPass {
         granularity: [u32; 2],
         device: Arc<Device>,
     ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
-        let views_used = create_info.subpasses
+        let views_used = create_info
+            .subpasses
             .iter()
             .map(|subpass| u32::BITS - subpass.view_mask.leading_zeros())
-            .max().unwrap();
+            .max()
+            .unwrap();
         let granularity = Self::get_granularity(&device, handle);
 
         let RenderPassCreateInfo {

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -148,20 +148,56 @@ impl RenderPass {
             _ne: _,
         } = create_info;
 
-        let granularity = unsafe {
-            let fns = device.fns();
-            let mut out = MaybeUninit::uninit();
-            (fns.v1_0.get_render_area_granularity)(
-                device.internal_object(),
-                handle,
-                out.as_mut_ptr(),
-            );
+        let granularity = unsafe { Self::get_granularity(&device, handle) };
 
-            let out = out.assume_init();
-            debug_assert_ne!(out.width, 0);
-            debug_assert_ne!(out.height, 0);
-            [out.width, out.height]
-        };
+        Ok(Arc::new(RenderPass {
+            handle,
+            device,
+
+            attachments,
+            subpasses,
+            dependencies,
+            correlated_view_masks,
+
+            granularity,
+            views_used,
+        }))
+    }
+
+    unsafe fn get_granularity(device: &Arc<Device>, handle: ash::vk::RenderPass) -> [u32; 2] {
+        let fns = device.fns();
+        let mut out = MaybeUninit::uninit();
+        (fns.v1_0.get_render_area_granularity)(
+            device.internal_object(),
+            handle,
+            out.as_mut_ptr(),
+        );
+
+        let out = out.assume_init();
+        debug_assert_ne!(out.width, 0);
+        debug_assert_ne!(out.height, 0);
+        [out.width, out.height]
+    }
+
+    /// Creates a new `RenderPass` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(handle : ash::vk::RenderPass,
+                              mut create_info: RenderPassCreateInfo,
+                              granularity: [u32; 2],
+                              device: Arc<Device>
+    ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
+        let views_used = Self::validate(&device, &mut create_info)?;
+        let granularity =  Self::get_granularity(&device, handle);
+
+        let RenderPassCreateInfo {
+            attachments,
+            subpasses,
+            dependencies,
+            correlated_view_masks,
+            _ne: _,
+        } = create_info;
 
         Ok(Arc::new(RenderPass {
             handle,

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -167,11 +167,7 @@ impl RenderPass {
     unsafe fn get_granularity(device: &Arc<Device>, handle: ash::vk::RenderPass) -> [u32; 2] {
         let fns = device.fns();
         let mut out = MaybeUninit::uninit();
-        (fns.v1_0.get_render_area_granularity)(
-            device.internal_object(),
-            handle,
-            out.as_mut_ptr(),
-        );
+        (fns.v1_0.get_render_area_granularity)(device.internal_object(), handle, out.as_mut_ptr());
 
         let out = out.assume_init();
         debug_assert_ne!(out.width, 0);
@@ -183,13 +179,14 @@ impl RenderPass {
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(handle : ash::vk::RenderPass,
-                              mut create_info: RenderPassCreateInfo,
-                              granularity: [u32; 2],
-                              device: Arc<Device>
+    pub unsafe fn from_handle(
+        handle: ash::vk::RenderPass,
+        mut create_info: RenderPassCreateInfo,
+        granularity: [u32; 2],
+        device: Arc<Device>,
     ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
         let views_used = Self::validate(&device, &mut create_info)?;
-        let granularity =  Self::get_granularity(&device, handle);
+        let granularity = Self::get_granularity(&device, handle);
 
         let RenderPassCreateInfo {
             attachments,

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -428,10 +428,11 @@ impl Sampler {
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(handle : ash::vk::Sampler,
-                              create_info: SamplerCreateInfo,
-                              device: Arc<Device>
-    ) -> Arc<Sampler>{
+    pub unsafe fn from_handle(
+        handle: ash::vk::Sampler,
+        create_info: SamplerCreateInfo,
+        device: Arc<Device>,
+    ) -> Arc<Sampler> {
         let SamplerCreateInfo {
             mag_filter,
             min_filter,
@@ -469,8 +470,6 @@ impl Sampler {
             unnormalized_coordinates,
         })
     }
-
-
 
     /// Checks whether this sampler is compatible with `image_view`.
     pub fn check_can_sample<I>(

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -424,6 +424,54 @@ impl Sampler {
         }))
     }
 
+    /// Creates a new `Sampler` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(handle : ash::vk::Sampler,
+                              create_info: SamplerCreateInfo,
+                              device: Arc<Device>
+    ) -> Arc<Sampler>{
+        let SamplerCreateInfo {
+            mag_filter,
+            min_filter,
+            mipmap_mode,
+            address_mode,
+            mip_lod_bias,
+            anisotropy,
+            compare,
+            lod,
+            border_color,
+            unnormalized_coordinates,
+            reduction_mode,
+            sampler_ycbcr_conversion,
+            _ne: _,
+        } = create_info;
+
+        Arc::new(Sampler {
+            handle,
+            device,
+
+            address_mode,
+            anisotropy,
+            border_color: address_mode
+                .into_iter()
+                .any(|mode| mode == SamplerAddressMode::ClampToBorder)
+                .then(|| border_color),
+            compare,
+            lod,
+            mag_filter,
+            min_filter,
+            mip_lod_bias,
+            mipmap_mode,
+            reduction_mode,
+            sampler_ycbcr_conversion,
+            unnormalized_coordinates,
+        })
+    }
+
+
+
     /// Checks whether this sampler is compatible with `image_view`.
     pub fn check_can_sample<I>(
         &self,

--- a/vulkano/src/sampler/ycbcr.rs
+++ b/vulkano/src/sampler/ycbcr.rs
@@ -316,15 +316,15 @@ impl SamplerYcbcrConversion {
         }))
     }
 
-
     /// Creates a new `SamplerYcbcrConversion` from an ash-handle
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
     /// `create_info.format` must be some -- see `SamplerYcbcrConversion`::new`
-    pub unsafe fn from_handle(handle : ash::vk::SamplerYcbcrConversion,
-                              create_info: SamplerYcbcrConversionCreateInfo,
-                              device: Arc<Device>
+    pub unsafe fn from_handle(
+        handle: ash::vk::SamplerYcbcrConversion,
+        create_info: SamplerYcbcrConversionCreateInfo,
+        device: Arc<Device>,
     ) -> Arc<SamplerYcbcrConversion> {
         let SamplerYcbcrConversionCreateInfo {
             format,

--- a/vulkano/src/sampler/ycbcr.rs
+++ b/vulkano/src/sampler/ycbcr.rs
@@ -316,6 +316,39 @@ impl SamplerYcbcrConversion {
         }))
     }
 
+
+    /// Creates a new `SamplerYcbcrConversion` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    /// `create_info.format` must be some -- see `SamplerYcbcrConversion`::new`
+    pub unsafe fn from_handle(handle : ash::vk::SamplerYcbcrConversion,
+                              create_info: SamplerYcbcrConversionCreateInfo,
+                              device: Arc<Device>
+    ) -> Arc<SamplerYcbcrConversion> {
+        let SamplerYcbcrConversionCreateInfo {
+            format,
+            ycbcr_model,
+            ycbcr_range,
+            component_mapping,
+            chroma_offset,
+            chroma_filter,
+            force_explicit_reconstruction,
+            _ne: _,
+        } = create_info;
+        Arc::new(SamplerYcbcrConversion {
+            handle,
+            device,
+            format,
+            ycbcr_model,
+            ycbcr_range,
+            component_mapping,
+            chroma_offset,
+            chroma_filter,
+            force_explicit_reconstruction,
+        })
+    }
+
     /// Returns the chroma filter used by the conversion.
     #[inline]
     pub fn chroma_filter(&self) -> Filter {

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -99,12 +99,11 @@ impl Event {
         handle: ash::vk::Event,
         create_info: EventCreateInfo,
         device: Arc<Device>,
-        must_put_in_pool: bool,
     ) -> Event {
         Event {
             device,
             handle,
-            must_put_in_pool,
+            must_put_in_pool: false,
         }
     }
 

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -91,6 +91,23 @@ impl Event {
         Ok(event)
     }
 
+
+    /// Creates a new `Event` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(handle : ash::vk::Event,
+                              create_info: EventCreateInfo,
+                              device: Arc<Device>,
+                              must_put_in_pool: bool
+    ) -> Event {
+        Event {
+            device,
+            handle,
+            must_put_in_pool
+        }
+    }
+
     /// Returns true if the event is signaled.
     #[inline]
     pub fn signaled(&self) -> Result<bool, OomError> {

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -91,20 +91,20 @@ impl Event {
         Ok(event)
     }
 
-
     /// Creates a new `Event` from an ash-handle
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(handle : ash::vk::Event,
-                              create_info: EventCreateInfo,
-                              device: Arc<Device>,
-                              must_put_in_pool: bool
+    pub unsafe fn from_handle(
+        handle: ash::vk::Event,
+        create_info: EventCreateInfo,
+        device: Arc<Device>,
+        must_put_in_pool: bool,
     ) -> Event {
         Event {
             device,
             handle,
-            must_put_in_pool
+            must_put_in_pool,
         }
     }
 

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -119,6 +119,8 @@ impl Fence {
         Ok(fence)
     }
 
+
+
     /// Returns true if the fence is signaled.
     #[inline]
     pub fn is_signaled(&self) -> Result<bool, OomError> {

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -120,6 +120,23 @@ impl Fence {
     }
 
 
+    /// Creates a new `Fence` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(handle : ash::vk::Fence,
+                              create_info: FenceCreateInfo,
+                              device: Arc<Device>
+    ) -> Fence {
+        let FenceCreateInfo { signaled, _ne: _ } = create_info;
+
+        Fence {
+            handle,
+            device,
+            is_signaled: AtomicBool::new(signaled),
+            must_put_in_pool: false,
+        }
+    }
 
     /// Returns true if the fence is signaled.
     #[inline]

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -119,15 +119,15 @@ impl Fence {
         Ok(fence)
     }
 
-
     /// Creates a new `Fence` from an ash-handle
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(handle : ash::vk::Fence,
-                              create_info: FenceCreateInfo,
-                              device: Arc<Device>,
-                              must_put_in_pool: bool
+    pub unsafe fn from_handle(
+        handle: ash::vk::Fence,
+        create_info: FenceCreateInfo,
+        device: Arc<Device>,
+        must_put_in_pool: bool,
     ) -> Fence {
         let FenceCreateInfo { signaled, _ne: _ } = create_info;
 
@@ -135,7 +135,7 @@ impl Fence {
             handle,
             device,
             is_signaled: AtomicBool::new(signaled),
-            must_put_in_pool
+            must_put_in_pool,
         }
     }
 

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -127,7 +127,6 @@ impl Fence {
         handle: ash::vk::Fence,
         create_info: FenceCreateInfo,
         device: Arc<Device>,
-        must_put_in_pool: bool,
     ) -> Fence {
         let FenceCreateInfo { signaled, _ne: _ } = create_info;
 
@@ -135,7 +134,7 @@ impl Fence {
             handle,
             device,
             is_signaled: AtomicBool::new(signaled),
-            must_put_in_pool,
+            must_put_in_pool: false,
         }
     }
 

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -126,7 +126,8 @@ impl Fence {
     /// the `create_info` must match the info used to create said object
     pub unsafe fn from_handle(handle : ash::vk::Fence,
                               create_info: FenceCreateInfo,
-                              device: Arc<Device>
+                              device: Arc<Device>,
+                              must_put_in_pool: bool
     ) -> Fence {
         let FenceCreateInfo { signaled, _ne: _ } = create_info;
 
@@ -134,7 +135,7 @@ impl Fence {
             handle,
             device,
             is_signaled: AtomicBool::new(signaled),
-            must_put_in_pool: false,
+            must_put_in_pool
         }
     }
 

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -140,6 +140,28 @@ impl Semaphore {
         Ok(semaphore)
     }
 
+    /// Creates a new `Semaphore` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `create_info` must match the info used to create said object
+    pub unsafe fn from_handle(handle : ash::vk::Semaphore,
+                              create_info: SemaphoreCreateInfo,
+                              device: Arc<Device>
+    ) -> Semaphore {
+        let SemaphoreCreateInfo {
+            export_handle_types,
+            _ne: _,
+        } = create_info;
+
+        Semaphore {
+            device,
+            handle,
+            must_put_in_pool: false,
+
+            export_handle_types,
+        }
+    }
+
     /// # Safety
     ///
     /// - The semaphore must not be used, or have been used, to acquire a swapchain image.

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -146,7 +146,8 @@ impl Semaphore {
     /// the `create_info` must match the info used to create said object
     pub unsafe fn from_handle(handle : ash::vk::Semaphore,
                               create_info: SemaphoreCreateInfo,
-                              device: Arc<Device>
+                              device: Arc<Device>,
+                              must_put_in_pool: bool
     ) -> Semaphore {
         let SemaphoreCreateInfo {
             export_handle_types,
@@ -156,7 +157,7 @@ impl Semaphore {
         Semaphore {
             device,
             handle,
-            must_put_in_pool: false,
+            must_put_in_pool,
 
             export_handle_types,
         }

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -148,7 +148,6 @@ impl Semaphore {
         handle: ash::vk::Semaphore,
         create_info: SemaphoreCreateInfo,
         device: Arc<Device>,
-        must_put_in_pool: bool,
     ) -> Semaphore {
         let SemaphoreCreateInfo {
             export_handle_types,
@@ -158,7 +157,7 @@ impl Semaphore {
         Semaphore {
             device,
             handle,
-            must_put_in_pool,
+            must_put_in_pool: false,
 
             export_handle_types,
         }

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -144,10 +144,11 @@ impl Semaphore {
     /// # Safety
     /// The `handle` has to be a valid vulkan object handle and
     /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(handle : ash::vk::Semaphore,
-                              create_info: SemaphoreCreateInfo,
-                              device: Arc<Device>,
-                              must_put_in_pool: bool
+    pub unsafe fn from_handle(
+        handle: ash::vk::Semaphore,
+        create_info: SemaphoreCreateInfo,
+        device: Arc<Device>,
+        must_put_in_pool: bool,
     ) -> Semaphore {
         let SemaphoreCreateInfo {
             export_handle_types,


### PR DESCRIPTION
Add from_handle functions so there is a way to use ash directly.