### PR TITLE
Make `StandardCommandPool` lockless

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -233,7 +233,7 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
             }
         }
 
-        let pool_builder_alloc = Device::standard_command_pool(&device, queue_family)
+        let pool_builder_alloc = Device::standard_command_pool(&device, queue_family)?
             .allocate(level, 1)?
             .next()
             .expect("Requested one command buffer from the command pool, but got zero.");

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -546,7 +546,7 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let pool = Device::standard_command_pool(&device, queue.family());
+            let pool = Device::standard_command_pool(&device, queue.family()).unwrap();
             let pool_builder_alloc = pool
                 .allocate(CommandBufferLevel::Primary, 1)
                 .unwrap()
@@ -599,7 +599,7 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
 
-            let pool = Device::standard_command_pool(&device, queue.family());
+            let pool = Device::standard_command_pool(&device, queue.family()).unwrap();
             let allocs = pool
                 .allocate(CommandBufferLevel::Primary, 2)
                 .unwrap()
@@ -659,7 +659,7 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let pool = Device::standard_command_pool(&device, queue.family());
+            let pool = Device::standard_command_pool(&device, queue.family()).unwrap();
             let pool_builder_alloc = pool
                 .allocate(CommandBufferLevel::Primary, 1)
                 .unwrap()
@@ -690,7 +690,7 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let pool = Device::standard_command_pool(&device, queue.family());
+            let pool = Device::standard_command_pool(&device, queue.family()).unwrap();
             let pool_builder_alloc = pool
                 .allocate(CommandBufferLevel::Primary, 1)
                 .unwrap()


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** made `StandardCommandPool` lockless
```
In my quest to hopefully improve command buffer performance, I noticed that the tree structure that the command pool is part of is as follows: a `Device` has one `StandardCommandPool` for each queue family, which in turn stores one interior pool for each thread using a `HashMap`.

### Problem
Due to the structure, the `StandardCommandPool`s have to be behind a `Mutex` inside `Device`, because the pools themselves hold a reference to the `Device`. That's a bummer because this `Mutex` is otherwise completely avoidable seeing as the queue families are known at device creation and don't change. Further, this `Mutex` is locked and unlocked every time a command buffer is created. This is in stark contrast to the Vulkan philosophy that threads should never wait on one another when allocating command buffers. Further, the `StandardCommandPool` itself puts the `HashMap` associating a thread with its pool behind a `Mutex`, which nullifies the benefit of having one pool per thread, if only one can access its own pool at a time.

### Solution
Change the structure as follows: a thread stores its pool in thread local storage, one for each device and queue family that it uses. The result is that no locks are needed. Also thread-local storage is practically free on systems that support it, certainly all that support Vulkan.

### Benchmarks
Naturally, as a sanity check, I did some benchmarks which I'm going to share in case you're interested. I did two kinds: `single_thread_N` and `multi_thread_N`. The former consists of retrieving the command pool from the device and allocating `N` command buffers each iteration. The second does the same on all cores in parallel (12 in my case) benching the main thread the same way as the single-threaded test. This contention is not realistic at all, but the point is to measure CPU utilization, as that is the best indicator of time spent in locks.

#### Before
![2022-07-31_21-02](https://user-images.githubusercontent.com/40955683/182041576-054b6775-c458-432a-a47a-91c65b91978e.png)

#### After
![2022-07-31_21-10](https://user-images.githubusercontent.com/40955683/182041586-23ae6e24-a3c2-4c72-8703-c8b833f1447f.png)

(The 9th bench is the same as the one before, just to show the CPU utilization along side the benches)

An unintentional side-effect: I had periodic lag spikes when running any vulkano project before (including the examples) which seems to be fixed now :D