### PR TITLE
Remove unnecessary question mark operator and unsafe block

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -272,14 +272,14 @@ where
             static WORDS: &[u32] = &[ #( #words ),* ];
 
             unsafe {
-                Ok(::vulkano::shader::ShaderModule::from_words_with_data(
+                ::vulkano::shader::ShaderModule::from_words_with_data(
                     device,
                     WORDS,
                     #spirv_version,
                     [#(#spirv_capabilities),*],
                     [#(#spirv_extensions),*],
                     [#(#entry_points),*],
-                )?)
+                )
             }
         }
 

--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -340,10 +340,8 @@ fn write_interface(interface: &ShaderInterface) -> TokenStream {
     );
 
     quote! {
-        unsafe {
-            ::vulkano::shader::ShaderInterface::new_unchecked(vec![
-                #( #items )*
-            ])
-        }
+        ::vulkano::shader::ShaderInterface::new_unchecked(vec![
+            #( #items )*
+        ])
     }
 }


### PR DESCRIPTION
When running clippy on a crate that uses the `shader!` macro.
```
warning: question mark operator is useless here
```

`unsafe` block is unnecessary as it is always nested. Found during macro expansion.