### PR TITLE
Better defaults for vulkano config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - **Breaking** Changes to `StandardCommandPool`:
   - `StandardCommandPool` is now implemented lock-free, using thread-local storage.
   - `StandardCommandPool::new` and `Device::standard_command_pool` now return a `Result`.
+  - Added `khr_portability_enumeration` as a default configuration for MacOS in `vulkano-utils`
 
 # Version 0.30.0 (2022-07-20)
 

--- a/vulkano-util/src/context.rs
+++ b/vulkano-util/src/context.rs
@@ -53,8 +53,14 @@ impl Default for VulkanoConfig {
         };
         VulkanoConfig {
             instance_create_info: InstanceCreateInfo {
-                application_version: Version::V1_2,
-                enabled_extensions: InstanceExtensions::none(),
+                application_version: Version::V1_3,
+                enabled_extensions: InstanceExtensions {
+                    #[cfg(target_os = "macos")]
+                    khr_portability_enumeration: true,
+                    ..InstanceExtensions::none()
+                },
+                #[cfg(target_os = "macos")]
+                enumerate_portability: true,
                 ..Default::default()
             },
             debug_create_info: None,


### PR DESCRIPTION
With new vulkano (1.3), mac fails to unless `khr_portability_enumeration` is used.

```
thread 'main' panicked at 'Failed to create instance: IncompatibleDriver', vulkano-util/src/context.rs:132:14
```

I think the config defaults should `cfg` those for mac os by default. Of course, one can add them when using the `VulkanoContext::new()`, but I think these are better defaults. Also the default `application_version` is updated to `V1_3`.