### PR TITLE
`StdDescriptorPool` rewamp

### DIFF
--- a/vulkano/src/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor_set/persistent.rs
@@ -48,8 +48,12 @@ impl PersistentDescriptorSet {
         layout: Arc<DescriptorSetLayout>,
         descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
     ) -> Result<Arc<PersistentDescriptorSet>, DescriptorSetCreationError> {
-        let mut pool = Device::standard_descriptor_pool(layout.device());
-        Self::new_with_pool(layout, 0, &mut pool, descriptor_writes)
+        layout
+            .device()
+            .clone()
+            .with_standard_descriptor_pool(|pool| {
+                Self::new_with_pool(layout, 0, pool, descriptor_writes)
+            })
     }
 
     /// Creates and returns a new descriptor set with the requested variable descriptor count.
@@ -61,13 +65,12 @@ impl PersistentDescriptorSet {
         variable_descriptor_count: u32,
         descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
     ) -> Result<Arc<PersistentDescriptorSet>, DescriptorSetCreationError> {
-        let mut pool = Device::standard_descriptor_pool(layout.device());
-        Self::new_with_pool(
-            layout,
-            variable_descriptor_count,
-            &mut pool,
-            descriptor_writes,
-        )
+        layout
+            .device()
+            .clone()
+            .with_standard_descriptor_pool(|pool| {
+                Self::new_with_pool(layout, variable_descriptor_count, pool, descriptor_writes)
+            })
     }
 
     /// Creates and returns a new descriptor set with the requested variable descriptor count,
@@ -88,14 +91,16 @@ impl PersistentDescriptorSet {
     {
         assert!(
             !layout.push_descriptor(),
-            "the provided descriptor set layout is for push descriptors, and cannot be used to build a descriptor set object"
+            "the provided descriptor set layout is for push descriptors, and cannot be used to \
+            build a descriptor set object",
         );
 
         let max_count = layout.variable_descriptor_count();
 
         assert!(
             variable_descriptor_count <= max_count,
-            "the provided variable_descriptor_count ({}) is greater than the maximum number of variable count descriptors in the set ({})",
+            "the provided variable_descriptor_count ({}) is greater than the maximum number of \
+            variable count descriptors in the set ({})",
             variable_descriptor_count,
             max_count,
         );

--- a/vulkano/src/descriptor_set/pool/mod.rs
+++ b/vulkano/src/descriptor_set/pool/mod.rs
@@ -18,6 +18,7 @@ pub use self::{
 };
 use super::{layout::DescriptorSetLayout, sys::UnsafeDescriptorSet};
 use crate::{device::DeviceOwned, OomError};
+use std::sync::Arc;
 
 pub mod standard;
 mod sys;
@@ -35,7 +36,7 @@ pub unsafe trait DescriptorPool: DeviceOwned {
     /// Allocates a descriptor set.
     fn allocate(
         &mut self,
-        layout: &DescriptorSetLayout,
+        layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
     ) -> Result<Self::Alloc, OomError>;
 }

--- a/vulkano/src/descriptor_set/pool/mod.rs
+++ b/vulkano/src/descriptor_set/pool/mod.rs
@@ -24,9 +24,6 @@ pub mod standard;
 mod sys;
 
 /// A pool from which descriptor sets can be allocated.
-///
-/// Since the destructor of `Alloc` must free the descriptor set, this trait is usually implemented
-/// on `Arc<T>` or `&'a T` and not `T` directly, so that the `Alloc` object can hold the pool.
 pub unsafe trait DescriptorPool: DeviceOwned {
     /// Object that represented an allocated descriptor set.
     ///

--- a/vulkano/src/descriptor_set/pool/standard.rs
+++ b/vulkano/src/descriptor_set/pool/standard.rs
@@ -73,15 +73,6 @@ unsafe impl DescriptorPool for StdDescriptorPool {
             max_count,
         );
 
-        if !self.pools.contains_key(layout) {
-            let pool = if max_count == 0 {
-                Pool::Fixed(SingleLayoutDescSetPool::new(layout.clone())?)
-            } else {
-                Pool::Variable(SingleLayoutVariableDescSetPool::new(layout.clone())?)
-            };
-            self.pools.insert(layout.clone(), pool);
-        }
-
         // We do this instead of using `HashMap::entry` directly because that would involve cloning
         // an `Arc` every time. `hash_raw_entry` is still not stabilized >:(
         let pool = if let Some(pool) = self.pools.get_mut(layout) {

--- a/vulkano/src/descriptor_set/single_layout_pool.rs
+++ b/vulkano/src/descriptor_set/single_layout_pool.rs
@@ -346,7 +346,7 @@ impl SingleLayoutVariableDescSetPool {
 
             let allocate_info = DescriptorSetAllocateInfo {
                 layout: &self.layout,
-                variable_descriptor_count: 0,
+                variable_descriptor_count,
             };
 
             match unsafe { unsafe_pool.allocate_descriptor_sets([allocate_info]) } {

--- a/vulkano/src/descriptor_set/single_layout_pool.rs
+++ b/vulkano/src/descriptor_set/single_layout_pool.rs
@@ -21,24 +21,33 @@ use crate::{
     device::{Device, DeviceOwned},
     OomError, VulkanObject,
 };
-use crossbeam_queue::SegQueue;
+use crossbeam_queue::ArrayQueue;
 use std::{
+    cell::UnsafeCell,
     hash::{Hash, Hasher},
+    mem::ManuallyDrop,
     sync::Arc,
 };
 
+const MAX_SETS: usize = 32;
+
+const MAX_POOLS: usize = 32;
+
 /// `SingleLayoutDescSetPool` is a convenience wrapper provided by Vulkano not to be confused with
-/// `VkDescriptorPool`. Its function is to provide access to pool(s) to allocate `DescriptorSet`'s
-/// from and optimizes for a specific layout. For a more general purpose pool see `descriptor_set::pool::StdDescriptorPool`.
+/// `VkDescriptorPool`. Its function is to provide access to pool(s) to allocate descriptor sets
+/// from and optimizes for a specific layout which must not have a variable descriptor count. If
+/// you need a variable descriptor count see [`SingleLayoutVariableDescSetPool`]. For a more general
+/// purpose pool see [`StdDescriptorPool`].
+///
+/// [`StdDescriptorPool`]: super::pool::standard::StdDescriptorPool
+#[derive(Debug)]
 pub struct SingleLayoutDescSetPool {
     // The `SingleLayoutPool` struct contains an actual Vulkan pool. Every time it is full we create
     // a new pool and replace the current one with the new one.
-    inner: Option<Arc<SingleLayoutPool>>,
-    // The Vulkan device.
-    device: Arc<Device>,
+    inner: Arc<SingleLayoutPool>,
     // The amount of sets available to use when we create a new Vulkan pool.
     set_count: usize,
-    // The descriptor layout that this pool is for.
+    // The descriptor set layout that this pool is for.
     layout: Arc<DescriptorSetLayout>,
 }
 
@@ -51,22 +60,23 @@ impl SingleLayoutDescSetPool {
     /// - Panics if the provided `layout` is for push descriptors rather than regular descriptor
     ///   sets.
     /// - Panics if the provided `layout` has a binding with a variable descriptor count.
-    pub fn new(layout: Arc<DescriptorSetLayout>) -> Self {
+    pub fn new(layout: Arc<DescriptorSetLayout>) -> Result<Self, OomError> {
         assert!(
             !layout.push_descriptor(),
-            "the provided descriptor set layout is for push descriptors, and cannot be used to build a descriptor set object"
+            "the provided descriptor set layout is for push descriptors, and cannot be used to \
+            build a descriptor set object",
         );
         assert!(
             layout.variable_descriptor_count() == 0,
-            "the provided descriptor set layout has a binding with a variable descriptor count, which cannot be used with SingleLayoutDescSetPool"
+            "the provided descriptor set layout has a binding with a variable descriptor count, \
+            which cannot be used with SingleLayoutDescSetPool",
         );
 
-        Self {
-            inner: None,
-            device: layout.device().clone(),
-            set_count: 4,
+        Ok(Self {
+            inner: SingleLayoutPool::new(&layout, MAX_SETS)?,
+            set_count: MAX_SETS,
             layout,
-        }
+        })
     }
 
     /// Returns a new descriptor set, either by creating a new one or returning an existing one
@@ -87,117 +97,111 @@ impl SingleLayoutDescSetPool {
         Ok(Arc::new(SingleLayoutDescSet { alloc, inner }))
     }
 
-    fn next_alloc(&mut self) -> Result<SingleLayoutPoolAlloc, OomError> {
+    pub(crate) fn next_alloc(&mut self) -> Result<SingleLayoutPoolAlloc, OomError> {
         loop {
-            let mut not_enough_sets = false;
-
-            if let Some(ref mut p_inner) = self.inner {
-                if let Some(existing) = p_inner.reserve.pop() {
-                    return Ok(SingleLayoutPoolAlloc {
-                        pool: p_inner.clone(),
-                        inner: Some(existing),
-                    });
-                } else {
-                    not_enough_sets = true;
-                }
+            if let Some(existing) = self.inner.reserve.pop() {
+                return Ok(SingleLayoutPoolAlloc {
+                    pool: self.inner.clone(),
+                    inner: ManuallyDrop::new(existing),
+                });
             }
 
-            if not_enough_sets {
-                self.set_count *= 2;
-            }
+            self.set_count *= 2;
 
-            let mut unsafe_pool = UnsafeDescriptorPool::new(
-                self.device.clone(),
-                UnsafeDescriptorPoolCreateInfo {
-                    max_sets: self.set_count as u32,
-                    pool_sizes: self
-                        .layout
-                        .descriptor_counts()
-                        .iter()
-                        .map(|(&ty, &count)| (ty, count * self.set_count as u32))
-                        .collect(),
-                    ..Default::default()
-                },
-            )?;
-
-            let reserve = unsafe {
-                match unsafe_pool.allocate_descriptor_sets((0..self.set_count).map(|_| {
-                    DescriptorSetAllocateInfo {
-                        layout: self.layout.as_ref(),
-                        variable_descriptor_count: 0,
-                    }
-                })) {
-                    Ok(alloc_iter) => {
-                        let reserve = SegQueue::new();
-
-                        for alloc in alloc_iter {
-                            reserve.push(alloc);
-                        }
-
-                        reserve
-                    }
-                    Err(DescriptorPoolAllocError::OutOfHostMemory) => {
-                        return Err(OomError::OutOfHostMemory);
-                    }
-                    Err(DescriptorPoolAllocError::OutOfDeviceMemory) => {
-                        return Err(OomError::OutOfDeviceMemory);
-                    }
-                    Err(DescriptorPoolAllocError::FragmentedPool) => {
-                        // This can't happen as we don't free individual sets.
-                        unreachable!()
-                    }
-                    Err(DescriptorPoolAllocError::OutOfPoolMemory) => unreachable!(),
-                }
-            };
-
-            self.inner = Some(Arc::new(SingleLayoutPool {
-                inner: unsafe_pool,
-                reserve,
-            }));
+            self.inner = SingleLayoutPool::new(&self.layout, self.set_count)?;
         }
     }
 }
 
+#[derive(Debug)]
 struct SingleLayoutPool {
     // The actual Vulkan descriptor pool. This field isn't actually used anywhere, but we need to
     // keep the pool alive in order to keep the descriptor sets valid.
     inner: UnsafeDescriptorPool,
-
     // List of descriptor sets. When `alloc` is called, a descriptor will be extracted from this
     // list. When a `SingleLayoutPoolAlloc` is dropped, its descriptor set is put back in this list.
-    reserve: SegQueue<UnsafeDescriptorSet>,
+    reserve: ArrayQueue<UnsafeDescriptorSet>,
 }
 
-struct SingleLayoutPoolAlloc {
-    // The `SingleLayoutPool` were we allocated from. We need to keep a copy of it in each allocation
-    // so that we can put back the allocation in the list in our `Drop` impl.
-    pool: Arc<SingleLayoutPool>,
+impl SingleLayoutPool {
+    fn new(layout: &Arc<DescriptorSetLayout>, set_count: usize) -> Result<Arc<Self>, OomError> {
+        let mut inner = UnsafeDescriptorPool::new(
+            layout.device().clone(),
+            UnsafeDescriptorPoolCreateInfo {
+                max_sets: set_count as u32,
+                pool_sizes: layout
+                    .descriptor_counts()
+                    .iter()
+                    .map(|(&ty, &count)| (ty, count * set_count as u32))
+                    .collect(),
+                ..Default::default()
+            },
+        )?;
 
-    // The actual descriptor set, wrapped inside an `Option` so that we can extract it in our
-    // `Drop` impl.
-    inner: Option<UnsafeDescriptorSet>,
+        let allocate_infos = (0..set_count).map(|_| DescriptorSetAllocateInfo {
+            layout,
+            variable_descriptor_count: 0,
+        });
+
+        let reserve = match unsafe { inner.allocate_descriptor_sets(allocate_infos) } {
+            Ok(alloc_iter) => {
+                let reserve = ArrayQueue::new(set_count);
+
+                for alloc in alloc_iter {
+                    reserve.push(alloc).unwrap();
+                }
+
+                reserve
+            }
+            Err(DescriptorPoolAllocError::OutOfHostMemory) => {
+                return Err(OomError::OutOfHostMemory);
+            }
+            Err(DescriptorPoolAllocError::OutOfDeviceMemory) => {
+                return Err(OomError::OutOfDeviceMemory);
+            }
+            Err(DescriptorPoolAllocError::FragmentedPool) => {
+                // This can't happen as we don't free individual sets.
+                unreachable!();
+            }
+            Err(DescriptorPoolAllocError::OutOfPoolMemory) => {
+                // We created the pool with an exact size.
+                unreachable!();
+            }
+        };
+
+        Ok(Arc::new(Self { inner, reserve }))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SingleLayoutPoolAlloc {
+    // The actual descriptor set.
+    inner: ManuallyDrop<UnsafeDescriptorSet>,
+    // The `SingleLayoutPool` where we allocated from. We need to keep a copy of it in each
+    // allocation so that we can put back the allocation in the list in our `Drop` impl.
+    pool: Arc<SingleLayoutPool>,
 }
 
 impl DescriptorPoolAlloc for SingleLayoutPoolAlloc {
     #[inline]
     fn inner(&self) -> &UnsafeDescriptorSet {
-        self.inner.as_ref().unwrap()
+        &self.inner
     }
 
     #[inline]
     fn inner_mut(&mut self) -> &mut UnsafeDescriptorSet {
-        self.inner.as_mut().unwrap()
+        &mut self.inner
     }
 }
 
 impl Drop for SingleLayoutPoolAlloc {
     fn drop(&mut self) {
-        let inner = self.inner.take().unwrap();
-        self.pool.reserve.push(inner);
+        let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
+        self.pool.reserve.push(inner).unwrap();
     }
 }
 
-/// A descriptor set created from a `SingleLayoutDescSetPool`.
+/// A descriptor set created from a [`SingleLayoutDescSetPool`].
 pub struct SingleLayoutDescSet {
     alloc: SingleLayoutPoolAlloc,
     inner: DescriptorSetInner,
@@ -238,6 +242,253 @@ impl PartialEq for SingleLayoutDescSet {
 impl Eq for SingleLayoutDescSet {}
 
 impl Hash for SingleLayoutDescSet {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner().internal_object().hash(state);
+        self.device().hash(state);
+    }
+}
+
+/// Much like [`SingleLayoutDescSetPool`], except that it allows you to allocate descriptor sets
+/// with a variable descriptor count. As this has more overhead, you should only use this pool if
+/// you need the functionality and prefer [`SingleLayoutDescSetPool`] otherwise. For a more general
+/// purpose pool see [`StdDescriptorPool`].
+///
+/// [`StdDescriptorPool`]: super::pool::standard::StdDescriptorPool
+#[derive(Debug)]
+pub struct SingleLayoutVariableDescSetPool {
+    // The `SingleLayoutVariablePool` struct contains an actual Vulkan pool. Every time it is full
+    // we grab one from the reserve, or create a new pool if there are none.
+    inner: Arc<SingleLayoutVariablePool>,
+    // When a `SingleLayoutVariablePool` is dropped, it returns its Vulkan pool here for reuse.
+    reserve: Arc<ArrayQueue<UnsafeDescriptorPool>>,
+    // The descriptor set layout that this pool is for.
+    layout: Arc<DescriptorSetLayout>,
+    // The number of sets currently allocated from the Vulkan pool.
+    allocated_sets: usize,
+}
+
+impl SingleLayoutVariableDescSetPool {
+    /// Initializes a new pool. The pool is configured to allocate sets that corresponds to the
+    /// parameters passed to this function.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the provided `layout` is for push descriptors rather than regular descriptor
+    ///   sets.
+    pub fn new(layout: Arc<DescriptorSetLayout>) -> Result<Self, OomError> {
+        assert!(
+            !layout.push_descriptor(),
+            "the provided descriptor set layout is for push descriptors, and cannot be used to \
+            build a descriptor set object",
+        );
+
+        let reserve = Arc::new(ArrayQueue::new(MAX_POOLS));
+
+        Ok(Self {
+            inner: SingleLayoutVariablePool::new(&layout, reserve.clone())?,
+            reserve,
+            layout,
+            allocated_sets: 0,
+        })
+    }
+
+    /// Allocates a new descriptor set.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the provided `variable_descriptor_count` exceeds the maximum for the layout.
+    #[inline]
+    pub fn next(
+        &mut self,
+        variable_descriptor_count: u32,
+        descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
+    ) -> Result<SingleLayoutVariableDescSet, DescriptorSetCreationError> {
+        let max_count = self.layout.variable_descriptor_count();
+
+        assert!(
+            variable_descriptor_count <= max_count,
+            "the provided variable_descriptor_count ({}) is greater than the maximum number of \
+            variable count descriptors in the set ({})",
+            variable_descriptor_count,
+            max_count,
+        );
+
+        let alloc = self.next_alloc(variable_descriptor_count)?;
+        let inner = DescriptorSetInner::new(
+            alloc.inner().internal_object(),
+            self.layout.clone(),
+            0,
+            descriptor_writes,
+        )?;
+
+        Ok(SingleLayoutVariableDescSet { inner, alloc })
+    }
+
+    pub(crate) fn next_alloc(
+        &mut self,
+        variable_descriptor_count: u32,
+    ) -> Result<SingleLayoutVariablePoolAlloc, OomError> {
+        if self.allocated_sets >= MAX_SETS {
+            self.inner = if let Some(unsafe_pool) = self.reserve.pop() {
+                Arc::new(SingleLayoutVariablePool {
+                    inner: UnsafeCell::new(ManuallyDrop::new(unsafe_pool)),
+                    reserve: self.reserve.clone(),
+                })
+            } else {
+                SingleLayoutVariablePool::new(&self.layout, self.reserve.clone())?
+            };
+            self.allocated_sets = 0;
+        }
+
+        let inner = {
+            let unsafe_pool = unsafe { &mut *self.inner.inner.get() };
+
+            let allocate_info = DescriptorSetAllocateInfo {
+                layout: &self.layout,
+                variable_descriptor_count: 0,
+            };
+
+            match unsafe { unsafe_pool.allocate_descriptor_sets([allocate_info]) } {
+                Ok(mut sets) => sets.next().unwrap(),
+                Err(DescriptorPoolAllocError::OutOfHostMemory) => {
+                    return Err(OomError::OutOfHostMemory);
+                }
+                Err(DescriptorPoolAllocError::OutOfDeviceMemory) => {
+                    return Err(OomError::OutOfDeviceMemory);
+                }
+                Err(DescriptorPoolAllocError::FragmentedPool) => {
+                    // This can't happen as we don't free individual sets.
+                    unreachable!();
+                }
+                Err(DescriptorPoolAllocError::OutOfPoolMemory) => {
+                    // We created the pool to fit the maximum variable descriptor count.
+                    unreachable!();
+                }
+            }
+        };
+
+        self.allocated_sets += 1;
+
+        Ok(SingleLayoutVariablePoolAlloc {
+            inner,
+            pool: self.inner.clone(),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct SingleLayoutVariablePool {
+    // The actual Vulkan descriptor pool.
+    inner: UnsafeCell<ManuallyDrop<UnsafeDescriptorPool>>,
+    // Where we return the Vulkan descriptor pool in our `Drop` impl.
+    reserve: Arc<ArrayQueue<UnsafeDescriptorPool>>,
+}
+
+impl SingleLayoutVariablePool {
+    fn new(
+        layout: &Arc<DescriptorSetLayout>,
+        reserve: Arc<ArrayQueue<UnsafeDescriptorPool>>,
+    ) -> Result<Arc<Self>, OomError> {
+        let unsafe_pool = UnsafeDescriptorPool::new(
+            layout.device().clone(),
+            UnsafeDescriptorPoolCreateInfo {
+                max_sets: MAX_SETS as u32,
+                pool_sizes: layout
+                    .descriptor_counts()
+                    .iter()
+                    .map(|(&ty, &count)| (ty, count * MAX_SETS as u32))
+                    .collect(),
+                ..Default::default()
+            },
+        )?;
+
+        Ok(Arc::new(Self {
+            inner: UnsafeCell::new(ManuallyDrop::new(unsafe_pool)),
+            reserve,
+        }))
+    }
+}
+
+impl Drop for SingleLayoutVariablePool {
+    fn drop(&mut self) {
+        let mut inner = unsafe { ManuallyDrop::take(&mut *self.inner.get()) };
+        // TODO: This should not return `Result`, resetting a pool can't fail.
+        unsafe { inner.reset() }.unwrap();
+
+        // If there is not enough space in the reserve, we destroy the pool. The only way this can
+        // happen is if something is resource hogging, forcing new pools to be created such that
+        // the number exceeds `MAX_POOLS`, and then drops them all at once.
+        let _ = self.reserve.push(inner);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SingleLayoutVariablePoolAlloc {
+    // The actual descriptor set.
+    inner: UnsafeDescriptorSet,
+    // The `SingleLayoutVariablePool` where we allocated from. We need to keep a copy of it in each
+    // allocation so that we can put back the pool in the reserve once all allocations have been
+    // dropped.
+    pool: Arc<SingleLayoutVariablePool>,
+}
+
+unsafe impl Send for SingleLayoutVariablePoolAlloc {}
+unsafe impl Sync for SingleLayoutVariablePoolAlloc {}
+
+impl DescriptorPoolAlloc for SingleLayoutVariablePoolAlloc {
+    #[inline]
+    fn inner(&self) -> &UnsafeDescriptorSet {
+        &self.inner
+    }
+
+    #[inline]
+    fn inner_mut(&mut self) -> &mut UnsafeDescriptorSet {
+        &mut self.inner
+    }
+}
+
+/// A descriptor set created from a [`SingleLayoutVariableDescSetPool`].
+pub struct SingleLayoutVariableDescSet {
+    alloc: SingleLayoutVariablePoolAlloc,
+    inner: DescriptorSetInner,
+}
+
+unsafe impl DescriptorSet for SingleLayoutVariableDescSet {
+    #[inline]
+    fn inner(&self) -> &UnsafeDescriptorSet {
+        self.alloc.inner()
+    }
+
+    #[inline]
+    fn layout(&self) -> &Arc<DescriptorSetLayout> {
+        self.inner.layout()
+    }
+
+    #[inline]
+    fn resources(&self) -> &DescriptorSetResources {
+        self.inner.resources()
+    }
+}
+
+unsafe impl DeviceOwned for SingleLayoutVariableDescSet {
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        self.inner.layout().device()
+    }
+}
+
+impl PartialEq for SingleLayoutVariableDescSet {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.inner().internal_object() == other.inner().internal_object()
+            && self.device() == other.device()
+    }
+}
+
+impl Eq for SingleLayoutVariableDescSet {}
+
+impl Hash for SingleLayoutVariableDescSet {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner().internal_object().hash(state);


### PR DESCRIPTION
Changelog:
```markdown
- Changes to `StdDescriptorPool`:
  - Now implemented lock-less, using thread-local storage.
  - **Breaking** removed `Device::standard_descriptor_pool` in favor of `Device::with_standard_descriptor_pool`.
- **Breaking** `DescriptorPool::allocate` now takes `&Arc<DescriptorSetLayout>` instead of `&DescriptorSetLayout`.
- **Breaking** `SingleLayoutDescSetPool::new` now returns `Result`.
- Added `SingleLayoutVariableDescSetPool`.
```
Seeing as `StdDescriptorPool` was originally using 3 layers of `Mutex`, and the allocation algorithm wasn't very optimized, I felt the need to address these and some other issues.
- Addressing the locks was the easy part, they got the same treatment as in #1939.
- `DescriptorPool` being implemented on `Arc<StdDescriptorPool>` now made little sense, since the `StdDescriptorPool`s are all thread local and `DescriptorPool` takes `&mut self`. The trait is now implemented on `StdDescriptorPool` directly, and `Device::standard_descriptor_pool` has been removed, since it handed out `Arc` clones previously, which would now be redundant overhead. Instead, `Device::with_standard_descriptor_pool` can be used, which still gives the user full access to the `StdDescriptorPool` without the need for these `Arc` clones. I will be working on consistency with `StandardCommandPool` in an upcoming PR.
- Regarding the allocation strategy, I was pretty sure the amazing work that was done on `SingleLayoutDescSetPool` would perform the best, but I tried some other ideas only to conclude that is the case.
  - To allocate one set, `SingleLayoutDescSetPool` took 58ns on my machine. That is in contrast to the current strategy employed in `StdDescriptorPool` which takes 3800ns with no contention. There's just some small details I thought could maximize the performance of `SingleLayoutDescSetPool`, which reduced the time to 38ns. Not a big difference, but that's what happens when there's not much to improve in the first place!
  - The next question to ask was what to do about variable descriptor counts. Apart from pre-allocating a fixed number of descriptor sets like `SingleLayoutDescSetPool` does and reusing those, I believe the next-best performing strategy is to reuse the Vulkan pools. Allocate from a pool until its full, then yeet it and grab a new one, then once the pool is no longer needed reset it as a whole and put it back in the queue. This of course has the advantage that the Vulkan implementation can use a simple bump allocator, and no pool fragmentation can occur. Also, this saves some cycles since pool creation is expensive. So this is the approach I took for variable descriptor counts, but I think we could absolutely have one pool per count per layout for the performance. If someone wants to do that I'm all for it. This approach clocks in at 104ns for me.
  - Updating `StdDescriptorPool` was now as easy as using the now added `SingleLayoutVariableDescSetPool` together with `SingleLayoutDescSetPool` to support all of the `DescriptorPool` API. The result is that allocating a fixed count descriptor set takes 104ns, and variable count takes 171ns for me. Meaning that the new `StdDescriptorPool` adds about 66ns of overhead on top. I don't like this one bit and I have a good idea where this overhead is coming from, so expect future PRs.