### PR TITLE
Vulkano-shaders struct generation refactor

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -246,13 +246,8 @@ where
     let entry_points = reflect::entry_points(&spirv)
         .map(|(name, model, info)| entry_point::write_entry_point(&name, model, &info));
 
-    let specialization_constants = structs::write_specialization_constants(
-        prefix,
-        &spirv,
-        types_meta,
-        shared_constants,
-        types_registry,
-    );
+    let specialization_constants =
+        structs::write_specialization_constants(prefix, &spirv, shared_constants, types_registry);
 
     let load_name = if prefix.is_empty() {
         format_ident!("load")


### PR DESCRIPTION
Changelog:
```markdown
- Bugs fixed:
  - [#1896](https://github.com/vulkano-rs/vulkano/issues/1896): Vulkano-shaders generates invalid struct definitions when struct field names are stripped out by the compiler.
```

This refactors the code in Vulkano-shaders that generates struct definitions for Rust, to make it easier to read. It also fixes #1896. There are still some problems with the current code, including #1208 and #1530.