### PR TITLE
Use libloading instead of shared_library

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -21,9 +21,9 @@ bytemuck = { version = "1.7", features = ["derive", "extern_crate_std", "min_con
 crossbeam-queue = "0.3"
 half = "1.8"
 lazy_static = "1.4"
+libloading = "0.7"
 nalgebra = { version = "0.31.0", optional = true }
 parking_lot = { version = "0.12", features = ["send_guard"] }
-shared_library = "0.1"
 smallvec = "1.8"
 
 [build-dependencies]

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -125,7 +125,7 @@ use std::{
     fmt,
     fs::File,
     hash::{Hash, Hasher},
-    mem::{self, MaybeUninit},
+    mem::MaybeUninit,
     ops::Deref,
     ptr,
     sync::{Arc, Mutex, MutexGuard, Weak},
@@ -394,7 +394,8 @@ impl Device {
 
         // loading the function pointers of the newly-created device
         let fns = DeviceFunctions::load(|name| unsafe {
-            mem::transmute((fns_i.v1_0.get_device_proc_addr)(handle, name.as_ptr()))
+            (fns_i.v1_0.get_device_proc_addr)(handle, name.as_ptr())
+                .map_or(ptr::null(), |func| func as _)
         });
 
         let device = Arc::new(Device {

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -439,7 +439,11 @@ impl Instance {
 
         // Loading the function pointers of the newly-created instance.
         let fns = {
-            InstanceFunctions::load(|name| library.get_instance_proc_addr(handle, name.as_ptr()))
+            InstanceFunctions::load(|name| {
+                library
+                    .get_instance_proc_addr(handle, name.as_ptr())
+                    .map_or(ptr::null(), |func| func as _)
+            })
         };
 
         let mut instance = Instance {


### PR DESCRIPTION
Changelog (add to existing headers):
```markdown
- **Breaking** Changes to `Instance` and Vulkan initialization:
  - `VulkanLibrary::get_instance_proc_addr` is now `unsafe`, and returns `ash::vk::PFN_vkVoidFunction`.
```

This replaces the `shared_library` crate with `libloading`. The original library was created by Tomaka, but has not been maintained since. The replacement crate is more up to date and much more widely used.