### PR TITLE
Remove an unneccessary `Mutex` layer when accessing `StandardMemoryPool`

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -20,9 +20,9 @@ ash = "0.37"
 bytemuck = { version = "1.7", features = ["derive", "extern_crate_std", "min_const_generics"] }
 crossbeam-queue = "0.3"
 half = "1.8"
-lazy_static = "1.4"
 libloading = "0.7"
 nalgebra = { version = "0.31.0", optional = true }
+once_cell = { version = "1.13", features = ["parking_lot"] }
 parking_lot = { version = "0.12", features = ["send_guard"] }
 smallvec = "1.8"
 

--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -252,7 +252,7 @@ where
         let mem_reqs = buffer.memory_requirements();
 
         let memory = MemoryPool::alloc_from_requirements(
-            &device.standard_memory_pool(),
+            device.standard_memory_pool(),
             &mem_reqs,
             AllocLayout::Linear,
             MappingRequirement::Map,

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -196,7 +196,7 @@ where
     #[inline]
     pub fn new(device: Arc<Device>, usage: BufferUsage) -> CpuBufferPool<T> {
         assert!(size_of::<T>() > 0);
-        let pool = device.standard_memory_pool();
+        let pool = device.standard_memory_pool().clone();
 
         CpuBufferPool {
             device,

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -359,7 +359,7 @@ where
         let (buffer, mem_reqs) = Self::build_buffer(&device, size, usage, &queue_families)?;
 
         let memory = MemoryPool::alloc_from_requirements(
-            &device.standard_memory_pool(),
+            device.standard_memory_pool(),
             &mem_reqs,
             AllocLayout::Linear,
             MappingRequirement::DoNotMap,

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -443,7 +443,7 @@ impl AttachmentImage {
 
         let mem_reqs = image.memory_requirements();
         let memory = MemoryPool::alloc_from_requirements(
-            &device.standard_memory_pool(),
+            device.standard_memory_pool(),
             &mem_reqs,
             AllocLayout::Optimal,
             MappingRequirement::DoNotMap,

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -204,7 +204,7 @@ impl ImmutableImage {
 
         let mem_reqs = image.memory_requirements();
         let memory = MemoryPool::alloc_from_requirements(
-            &device.standard_memory_pool(),
+            device.standard_memory_pool(),
             &mem_reqs,
             AllocLayout::Optimal,
             MappingRequirement::DoNotMap,

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -128,7 +128,7 @@ impl StorageImage {
 
         let mem_reqs = image.memory_requirements();
         let memory = MemoryPool::alloc_from_requirements(
-            &device.standard_memory_pool(),
+            device.standard_memory_pool(),
             &mem_reqs,
             AllocLayout::Optimal,
             MappingRequirement::DoNotMap,


### PR DESCRIPTION
Changelog:
```markdown
- **Breaking** `Device::standard_memory_pool` now returns `&Arc<StandardMemoryPool>`.
```
Avoids a lock and an `Arc`-clone every time the memory pool is accessed. `once_cell` was added as a dependency to accomplish this and will be vital to future optimizations. I just wanted to push this one ASAP because this API has been just broken this realease. `lazy_static` was removed as a dependency because it wasn't needed.