### PR TITLE
Ios fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -->
 - **Breaking** Public dependency updates:
   - Winit 0.27
+  - raw-window-handle 0.5
 - **Breaking** Changes to `Instance` and Vulkan initialization:
   - `FunctionPointers` is renamed to `VulkanLibrary`, and now resides in a separate `library` module. It is re-exported from the crate root.
   - The `Loader` trait is now in the `library` module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 - **Breaking** Changes to memory pools:
   - Renamed `StdMemoryPool[Alloc]`, `StdHostVisibleMemoryTypePool[Alloc]`, `StdNonHostVisibleMemoryTypePool[Alloc]` to `Standard{...}`.
   - Removed `Device::standard_pool` in favor of `Device::standard_memory_pool`, which returns `&Arc<StandardMemoryPool>`.
+- **Potentially Breaking** Fix iOS compilation:
+  - Removed dependency to `cocoa` and `metal`
+  - Fixed iOS compilation errors
+  - Added `winit_to_surface` method for iOS, ensuring we can draw to a sub `CAMetalLayer` layer
+  - Added `Surface::update_ios_sublayer_on_resize` to ensure iOS sublayer is fullscreen if initial window size was not the same as device's
+  - Ensure both iOS and MacOS have `CAMetalLayer` when using `create_surface_from_handle`
 - Bugs fixed:
   - [#1896](https://github.com/vulkano-rs/vulkano/issues/1896): Vulkano-shaders generates invalid struct definitions when struct field names are stripped out by the compiler.
 

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -339,6 +339,10 @@ impl VulkanoWindowRenderer {
             self.remove_additional_image_view(i);
             self.add_additional_image_view(i, format, usage);
         }
+        #[cfg(target_os = "ios")]
+        unsafe {
+            self.surface.update_ios_sublayer_on_resize();
+        }
         self.recreate_swapchain = false;
     }
 }

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -17,7 +17,7 @@ winit_ = ["winit", "objc", "core-graphics-types"]
 raw-window-handle_ = ["raw-window-handle"]
 
 [dependencies]
-raw-window-handle = { version = "0.4", optional = true }
+raw-window-handle = { version = "0.5", optional = true }
 vulkano = { version = "0.30.0", path = "../vulkano" }
 winit = { version = "0.27", optional = true }
 

--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["rendering::graphics-api"]
 
 [features]
 default = ["winit_", "raw-window-handle_"]
-winit_ = ["winit", "metal", "cocoa", "objc"]
+winit_ = ["winit", "objc", "core-graphics-types"]
 raw-window-handle_ = ["raw-window-handle"]
 
 [dependencies]
@@ -21,7 +21,6 @@ raw-window-handle = { version = "0.4", optional = true }
 vulkano = { version = "0.30.0", path = "../vulkano" }
 winit = { version = "0.27", optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-cocoa = { version = "0.24", optional = true }
-metal = { version = "0.23", optional = true }
-objc = { version = "0.2", optional = true }
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+objc = { version = "0.2.5", optional = true }
+core-graphics-types = { version = "0.1", optional = true }

--- a/vulkano-win/src/raw_window_handle.rs
+++ b/vulkano-win/src/raw_window_handle.rs
@@ -2,7 +2,9 @@
 use crate::get_metal_layer_ios;
 #[cfg(target_os = "macos")]
 use crate::get_metal_layer_macos;
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{
+    HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+};
 use std::sync::Arc;
 use vulkano::instance::Instance;
 use vulkano::swapchain::Surface;
@@ -15,7 +17,7 @@ pub fn create_surface_from_handle<W>(
     instance: Arc<Instance>,
 ) -> Result<Arc<Surface<W>>, SurfaceCreationError>
 where
-    W: HasRawWindowHandle,
+    W: HasRawWindowHandle + HasRawDisplayHandle,
 {
     unsafe {
         match window.raw_window_handle() {
@@ -47,11 +49,27 @@ where
                 }
             }
             RawWindowHandle::Wayland(h) => {
-                Surface::from_wayland(instance, h.display, h.surface, window)
+                let d = match window.raw_display_handle() {
+                    RawDisplayHandle::Wayland(d) => d,
+                    _ => panic!("Invalid RawDisplayHandle"),
+                };
+                Surface::from_wayland(instance, d.display, h.surface, window)
             }
             RawWindowHandle::Win32(h) => Surface::from_win32(instance, h.hinstance, h.hwnd, window),
-            RawWindowHandle::Xcb(h) => Surface::from_xcb(instance, h.connection, h.window, window),
-            RawWindowHandle::Xlib(h) => Surface::from_xlib(instance, h.display, h.window, window),
+            RawWindowHandle::Xcb(h) => {
+                let d = match window.raw_display_handle() {
+                    RawDisplayHandle::Xcb(d) => d,
+                    _ => panic!("Invalid RawDisplayHandle"),
+                };
+                Surface::from_xcb(instance, d.connection, h.window, window)
+            }
+            RawWindowHandle::Xlib(h) => {
+                let d = match window.raw_display_handle() {
+                    RawDisplayHandle::Xlib(d) => d,
+                    _ => panic!("Invalid RawDisplayHandle"),
+                };
+                Surface::from_xlib(instance, d.display, h.window, window)
+            }
             RawWindowHandle::Web(_) => unimplemented!(),
             _ => unimplemented!(),
         }

--- a/vulkano-win/src/raw_window_handle.rs
+++ b/vulkano-win/src/raw_window_handle.rs
@@ -43,7 +43,7 @@ where
                 }
                 #[cfg(not(target_os = "macos"))]
                 {
-                    panic!("AppKit handle should only be used when target_os == 'ios'");
+                    panic!("AppKit handle should only be used when target_os == 'macos'");
                 }
             }
             RawWindowHandle::Wayland(h) => {

--- a/vulkano-win/src/raw_window_handle.rs
+++ b/vulkano-win/src/raw_window_handle.rs
@@ -1,3 +1,7 @@
+#[cfg(target_os = "ios")]
+use crate::get_metal_layer_ios;
+#[cfg(target_os = "macos")]
+use crate::get_metal_layer_macos;
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use std::sync::Arc;
 use vulkano::instance::Instance;
@@ -6,9 +10,6 @@ use vulkano::swapchain::SurfaceCreationError;
 
 /// Creates a vulkan surface from a generic window
 /// which implements HasRawWindowHandle and thus can reveal the os-dependent handle.
-/// - Note that if you wish to use this function with MacOS, you will need to ensure that the
-/// `CAMetalLayer` is set to the ns_view. An example of how one might do that can be found in
-/// `vulkano_win::set_ca_metal_layer_to_winit`
 pub fn create_surface_from_handle<W>(
     window: W,
     instance: Arc<Instance>,
@@ -21,8 +22,30 @@ where
             RawWindowHandle::AndroidNdk(h) => {
                 Surface::from_android(instance, h.a_native_window, window)
             }
-            RawWindowHandle::UiKit(h) => Surface::from_ios(instance, h.ui_view, window),
-            RawWindowHandle::AppKit(h) => Surface::from_mac_os(instance, h.ns_view, window),
+            RawWindowHandle::UiKit(_h) => {
+                #[cfg(target_os = "ios")]
+                {
+                    // Ensure the layer is CAMetalLayer
+                    let layer = get_metal_layer_ios(_h.ui_view);
+                    Surface::from_ios(instance, layer, window)
+                }
+                #[cfg(not(target_os = "ios"))]
+                {
+                    panic!("UiKit handle should only be used when target_os == 'ios'");
+                }
+            }
+            RawWindowHandle::AppKit(_h) => {
+                #[cfg(target_os = "macos")]
+                {
+                    // Ensure the layer is CAMetalLayer
+                    let layer = get_metal_layer_macos(_h.ns_view);
+                    Surface::from_mac_os(instance, layer as *const (), window)
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    panic!("AppKit handle should only be used when target_os == 'ios'");
+                }
+            }
             RawWindowHandle::Wayland(h) => {
                 Surface::from_wayland(instance, h.display, h.surface, window)
             }

--- a/vulkano-win/src/winit.rs
+++ b/vulkano-win/src/winit.rs
@@ -179,6 +179,9 @@ pub(crate) unsafe fn get_metal_layer_macos(view: *mut std::ffi::c_void) -> *mut 
     let is_valid_layer: BOOL = msg_send![main_layer, isKindOfClass: class];
     if is_valid_layer == NO {
         let new_layer: *mut Object = msg_send![class, new];
+        let () = msg_send![new_layer, setEdgeAntialiasingMask: 0];
+        let () = msg_send![new_layer, setPresentsWithTransaction: false];
+        let () = msg_send![new_layer, removeAllAnimations];
         let () = msg_send![view, setLayer: new_layer];
         let () = msg_send![view, setWantsLayer: YES];
         let window: *mut Object = msg_send![view, window];

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -26,6 +26,10 @@ once_cell = { version = "1.13", features = ["parking_lot"] }
 parking_lot = { version = "0.12", features = ["send_guard"] }
 smallvec = "1.8"
 
+[target.'cfg(target_os = "ios")'.dependencies]
+objc = "0.2.5"
+core-graphics-types = "0.1"
+
 [build-dependencies]
 heck = "0.4"
 indexmap = "1.8"

--- a/vulkano/src/library.rs
+++ b/vulkano/src/library.rs
@@ -329,7 +329,7 @@ macro_rules! statically_linked_vulkan_loader {
                 instance: ash::vk::Instance,
                 name: *const c_char,
             ) -> ash::vk::PFN_vkVoidFunction {
-                unsafe { vkGetInstanceProcAddr(instance, name) }
+                vkGetInstanceProcAddr(instance, name)
             }
         }
 

--- a/vulkano/src/library.rs
+++ b/vulkano/src/library.rs
@@ -324,12 +324,12 @@ macro_rules! statically_linked_vulkan_loader {
 
         struct StaticallyLinkedVulkanLoader;
         unsafe impl Loader for StaticallyLinkedVulkanLoader {
-            fn get_instance_proc_addr(
+            unsafe fn get_instance_proc_addr(
                 &self,
                 instance: ash::vk::Instance,
                 name: *const c_char,
-            ) -> *const c_void {
-                unsafe { std::mem::transmute(vkGetInstanceProcAddr(instance, name)) }
+            ) -> ash::vk::PFN_vkVoidFunction {
+                unsafe { vkGetInstanceProcAddr(instance, name) }
             }
         }
 

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -330,6 +330,9 @@ pub use self::{
         SwapchainAcquireFuture, SwapchainCreateInfo, SwapchainCreationError, Win32Monitor,
     },
 };
+#[cfg(target_os = "ios")]
+pub use surface::IOSMetalLayer;
+
 use std::sync::atomic::AtomicBool;
 
 pub mod display;

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -612,7 +612,9 @@ impl<W> Surface<W> {
         &self.window
     }
 
-    /// Resizes the sublayer bounds on iOS. This is to be called after resize has occurred.
+    /// Resizes the sublayer bounds on iOS.
+    /// It may not be necessary if original window size matches device's, but often it does not.
+    /// Thus this should be called after a resize has occurred abd swapchain has been recreated.
     ///
     /// On iOS, we've created CAMetalLayer as a sublayer. However, when the view changes size,
     /// its sublayers are not automatically resized, and we must resize


### PR DESCRIPTION
As part of my ongoing desire to also build my current project as an iOS app I discovered that iOS seems to be broken.

I am assuming that not many have been running Vulkano on iOS. So this PR is a result of a bunch of figuring out how to get an iOS app to compile and run on my iPhone 8 plus.

**Error 1:**
```
error[E0782]: trait objects must include the `dyn` keyword
  --> /Users/okkohakola/Programming/Rust/vulkano/vulkano/src/library.rs:45:44
   |
45 |         fn def_loader_impl() -> Result<Box<Loader>, LoadingError> {
```

After fixing above by adding `dyn`

**Error 2:**
```
error: cannot find macro `statically_linked_vulkan_loader` in this scope
  --> /Users/okkohakola/Programming/Rust/vulkano/vulkano/src/library.rs:46:26
   |
46 |             let loader = statically_linked_vulkan_loader!();
```
After fixing above by `crate::statically_linked_vulkan_loader`

**Errors 3:**
```
error[E0053]: method `get_instance_proc_addr` has an incompatible type for trait
   --> /Users/okkohakola/Programming/Rust/vulkano/vulkano/src/library.rs:328:13
    |
46  |               let loader = crate::statically_linked_vulkan_loader!();
    |                            ----------------------------------------- in this macro invocation
...
328 | /             fn get_instance_proc_addr(
329 | |                 &self,
330 | |                 instance: ash::vk::Instance,
331 | |                 name: *const c_char,
332 | |             ) -> extern "system" fn() -> () {
    | |___________________________________________^ expected unsafe fn, found normal fn

46  |             let loader = crate::statically_linked_vulkan_loader!();
    |                          ----------------------------------------- in this macro invocation
...
332 |             ) -> extern "system" fn() -> () {
    |                  -------------------------- expected `extern "system" fn()` because of return type
333 |                 unsafe { vkGetInstanceProcAddr(instance, name) }
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found enum `Option`
```

After fixing that with 
```rust
        unsafe impl Loader for StaticallyLinkedVulkanLoader {
            unsafe fn get_instance_proc_addr(
                &self,
                instance: ash::vk::Instance,
                name: *const c_char,
            ) -> ash::vk::PFN_vkVoidFunction {
                vkGetInstanceProcAddr(instance, name)
            }
        }
```

**Errors 4**
```
// Bunch of
144 |                     win.borrow().xlib_display().unwrap(),
    |                                  ^^^^^^^^^^^^ method not found in `&Window`
```

Fix that with
```
#[cfg(all(unix, not(target_os = "android"), not(target_os = "macos"), not(target_os = "ios")))]
```

**Error 5**
```
41 |     unsafe { winit_to_surface(instance, window) }
   |              ^^^^^^^^^^^^^^^^ not found in this scope
```

Already down the rabbit hole, make one for ios... how? ... Well my eventual investigation & debugging resulted in handling iOS and MacOS similarly to `wgpu` seen in this PR.

I've managed to get this working nicely with resizes etc. following [wgpu's approach](https://github.com/gfx-rs/wgpu/blob/master/wgpu-hal/src/metal/surface.rs)

If you have xcode and apple developer subscription, you should be able to run [bevy_vulkano_ios](https://github.com/hakolao/bevy_vulkano_ios)

There is also a simple `triangle` example in this [branch](https://github.com/hakolao/bevy_vulkano_ios/tree/triangle).

And lastly, to fix `create_surface_from_handle`, testing that in this [branch](https://github.com/hakolao/bevy_vulkano_ios/tree/triangle-raw-window-handle)