### PR TITLE
Switch to `parking_lot`'s `Mutex`es

### DIFF
--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -68,11 +68,8 @@
 pub use ash::vk::Handle;
 pub use half;
 pub use library::VulkanLibrary;
-use std::{
-    error, fmt,
-    ops::Deref,
-    sync::{Arc, MutexGuard},
-};
+use parking_lot::MutexGuard;
+use std::{error, fmt, ops::Deref, sync::Arc};
 pub use version::Version;
 
 #[macro_use]

--- a/vulkano/src/memory/pool/host_visible.rs
+++ b/vulkano/src/memory/pool/host_visible.rs
@@ -16,11 +16,8 @@ use crate::{
     },
     DeviceSize,
 };
-use std::{
-    cmp,
-    ops::Range,
-    sync::{Arc, Mutex},
-};
+use parking_lot::Mutex;
+use std::{cmp, ops::Range, sync::Arc};
 
 /// Memory pool that operates on a given memory type.
 #[derive(Debug)]
@@ -82,7 +79,7 @@ impl StandardHostVisibleMemoryTypePool {
         }
 
         // Find a location.
-        let mut occupied = me.occupied.lock().unwrap();
+        let mut occupied = me.occupied.lock();
 
         // Try finding an entry in already-allocated chunks.
         for &mut (ref dev_mem, ref mut entries) in occupied.iter_mut() {
@@ -183,7 +180,7 @@ impl StandardHostVisibleMemoryTypePoolAlloc {
 
 impl Drop for StandardHostVisibleMemoryTypePoolAlloc {
     fn drop(&mut self) {
-        let mut occupied = self.pool.occupied.lock().unwrap();
+        let mut occupied = self.pool.occupied.lock();
 
         let entries = occupied
             .iter_mut()

--- a/vulkano/src/memory/pool/non_host_visible.rs
+++ b/vulkano/src/memory/pool/non_host_visible.rs
@@ -13,11 +13,8 @@ use crate::{
     memory::{device_memory::MemoryAllocateInfo, DeviceMemory, DeviceMemoryAllocationError},
     DeviceSize,
 };
-use std::{
-    cmp,
-    ops::Range,
-    sync::{Arc, Mutex},
-};
+use parking_lot::Mutex;
+use std::{cmp, ops::Range, sync::Arc};
 
 /// Memory pool that operates on a given memory type.
 #[derive(Debug)]
@@ -77,7 +74,7 @@ impl StandardNonHostVisibleMemoryTypePool {
         }
 
         // Find a location.
-        let mut occupied = me.occupied.lock().unwrap();
+        let mut occupied = me.occupied.lock();
 
         // Try finding an entry in already-allocated chunks.
         for &mut (ref dev_mem, ref mut entries) in occupied.iter_mut() {
@@ -177,7 +174,7 @@ impl StandardNonHostVisibleMemoryTypePoolAlloc {
 
 impl Drop for StandardNonHostVisibleMemoryTypePoolAlloc {
     fn drop(&mut self) {
-        let mut occupied = self.pool.occupied.lock().unwrap();
+        let mut occupied = self.pool.occupied.lock();
 
         let entries = occupied
             .iter_mut()

--- a/vulkano/src/memory/pool/pool.rs
+++ b/vulkano/src/memory/pool/pool.rs
@@ -19,9 +19,10 @@ use crate::{
     },
     DeviceSize,
 };
+use parking_lot::Mutex;
 use std::{
     collections::{hash_map::Entry, HashMap},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 #[derive(Debug)]
@@ -53,7 +54,7 @@ fn generic_allocation(
     layout: AllocLayout,
     map: MappingRequirement,
 ) -> Result<StandardMemoryPoolAlloc, DeviceMemoryAllocationError> {
-    let mut pools = mem_pool.pools.lock().unwrap();
+    let mut pools = mem_pool.pools.lock();
 
     let memory_type_host_visible = memory_type.is_host_visible();
     assert!(memory_type_host_visible || map == MappingRequirement::DoNotMap);

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -66,7 +66,7 @@ impl Event {
     /// For most applications, using the event pool should be preferred,
     /// in order to avoid creating new events every frame.
     pub fn from_pool(device: Arc<Device>) -> Result<Event, OomError> {
-        let handle = device.event_pool().lock().unwrap().pop();
+        let handle = device.event_pool().lock().pop();
         let event = match handle {
             Some(handle) => {
                 unsafe {
@@ -181,7 +181,7 @@ impl Drop for Event {
         unsafe {
             if self.must_put_in_pool {
                 let raw_event = self.handle;
-                self.device.event_pool().lock().unwrap().push(raw_event);
+                self.device.event_pool().lock().push(raw_event);
             } else {
                 let fns = self.device.fns();
                 (fns.v1_0.destroy_event)(self.device.internal_object(), self.handle, ptr::null());
@@ -274,16 +274,16 @@ mod tests {
     fn event_pool() {
         let (device, _) = gfx_dev_and_queue!();
 
-        assert_eq!(device.event_pool().lock().unwrap().len(), 0);
+        assert_eq!(device.event_pool().lock().len(), 0);
         let event1_internal_obj = {
             let event = Event::from_pool(device.clone()).unwrap();
-            assert_eq!(device.event_pool().lock().unwrap().len(), 0);
+            assert_eq!(device.event_pool().lock().len(), 0);
             event.internal_object()
         };
 
-        assert_eq!(device.event_pool().lock().unwrap().len(), 1);
+        assert_eq!(device.event_pool().lock().len(), 1);
         let event2 = Event::from_pool(device.clone()).unwrap();
-        assert_eq!(device.event_pool().lock().unwrap().len(), 0);
+        assert_eq!(device.event_pool().lock().len(), 0);
         assert_eq!(event2.internal_object(), event1_internal_obj);
     }
 }

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -88,7 +88,7 @@ impl Fence {
     /// For most applications, using the fence pool should be preferred,
     /// in order to avoid creating new fences every frame.
     pub fn from_pool(device: Arc<Device>) -> Result<Fence, OomError> {
-        let handle = device.fence_pool().lock().unwrap().pop();
+        let handle = device.fence_pool().lock().pop();
         let fence = match handle {
             Some(handle) => {
                 unsafe {
@@ -332,7 +332,7 @@ impl Drop for Fence {
         unsafe {
             if self.must_put_in_pool {
                 let raw_fence = self.handle;
-                self.device.fence_pool().lock().unwrap().push(raw_fence);
+                self.device.fence_pool().lock().push(raw_fence);
             } else {
                 let fns = self.device.fns();
                 (fns.v1_0.destroy_fence)(self.device.internal_object(), self.handle, ptr::null());
@@ -576,16 +576,16 @@ mod tests {
     fn fence_pool() {
         let (device, _) = gfx_dev_and_queue!();
 
-        assert_eq!(device.fence_pool().lock().unwrap().len(), 0);
+        assert_eq!(device.fence_pool().lock().len(), 0);
         let fence1_internal_obj = {
             let fence = Fence::from_pool(device.clone()).unwrap();
-            assert_eq!(device.fence_pool().lock().unwrap().len(), 0);
+            assert_eq!(device.fence_pool().lock().len(), 0);
             fence.internal_object()
         };
 
-        assert_eq!(device.fence_pool().lock().unwrap().len(), 1);
+        assert_eq!(device.fence_pool().lock().len(), 1);
         let fence2 = Fence::from_pool(device.clone()).unwrap();
-        assert_eq!(device.fence_pool().lock().unwrap().len(), 0);
+        assert_eq!(device.fence_pool().lock().len(), 0);
         assert_eq!(fence2.internal_object(), fence1_internal_obj);
     }
 }

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -120,7 +120,7 @@ impl Semaphore {
     /// For most applications, using the pool should be preferred,
     /// in order to avoid creating new semaphores every frame.
     pub fn from_pool(device: Arc<Device>) -> Result<Semaphore, SemaphoreCreationError> {
-        let handle = device.semaphore_pool().lock().unwrap().pop();
+        let handle = device.semaphore_pool().lock().pop();
         let semaphore = match handle {
             Some(handle) => Semaphore {
                 device,
@@ -216,7 +216,7 @@ impl Drop for Semaphore {
         unsafe {
             if self.must_put_in_pool {
                 let raw_sem = self.handle;
-                self.device.semaphore_pool().lock().unwrap().push(raw_sem);
+                self.device.semaphore_pool().lock().push(raw_sem);
             } else {
                 let fns = self.device.fns();
                 (fns.v1_0.destroy_semaphore)(
@@ -566,16 +566,16 @@ mod tests {
     fn semaphore_pool() {
         let (device, _) = gfx_dev_and_queue!();
 
-        assert_eq!(device.semaphore_pool().lock().unwrap().len(), 0);
+        assert_eq!(device.semaphore_pool().lock().len(), 0);
         let sem1_internal_obj = {
             let sem = Semaphore::from_pool(device.clone()).unwrap();
-            assert_eq!(device.semaphore_pool().lock().unwrap().len(), 0);
+            assert_eq!(device.semaphore_pool().lock().len(), 0);
             sem.internal_object()
         };
 
-        assert_eq!(device.semaphore_pool().lock().unwrap().len(), 1);
+        assert_eq!(device.semaphore_pool().lock().len(), 1);
         let sem2 = Semaphore::from_pool(device.clone()).unwrap();
-        assert_eq!(device.semaphore_pool().lock().unwrap().len(), 0);
+        assert_eq!(device.semaphore_pool().lock().len(), 0);
         assert_eq!(sem2.internal_object(), sem1_internal_obj);
     }
 


### PR DESCRIPTION
Title says all. I didn't bother with `CpuBufferPool` because of discussion on Discord about removing synchronization from it entirely.