### PR TITLE
Fix or allow all Clippy errors, re-enable dead code and unused variable warnings

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -137,7 +137,7 @@ fn main() {
     // We start by creating the buffer that will store the data.
     let data_buffer = {
         // Iterator that produces the data.
-        let data_iter = (0..65536u32).map(|n| n);
+        let data_iter = 0..65536u32;
         // Builds the buffer and fills it with this iterator.
         CpuAccessibleBuffer::from_iter(
             device.clone(),
@@ -186,7 +186,7 @@ fn main() {
             PipelineBindPoint::Compute,
             pipeline.layout().clone(),
             0,
-            set.clone(),
+            set,
         )
         .dispatch([1024, 1, 1])
         .unwrap();
@@ -195,8 +195,8 @@ fn main() {
 
     // Let's execute this command buffer now.
     // To do so, we TODO: this is a bit clumsy, probably needs a shortcut
-    let future = sync::now(device.clone())
-        .then_execute(queue.clone(), command_buffer)
+    let future = sync::now(device)
+        .then_execute(queue, command_buffer)
         .unwrap()
         // This line instructs the GPU to signal a *fence* once the command buffer has finished
         // execution. A fence is a Vulkan object that allows the CPU to know when the GPU has

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -53,8 +53,8 @@ fn main() {
     // and you should verify that list for safety - Vulkano will return an error if you specify
     // any layers that are not installed on this system. That code to do could look like this:
     println!("List of Vulkan debugging layers available to use:");
-    let mut layers = library.layer_properties().unwrap();
-    while let Some(l) = layers.next() {
+    let layers = library.layer_properties().unwrap();
+    for l in layers {
         println!("\t{}", l.name());
     }
 
@@ -140,13 +140,11 @@ fn main() {
     };
     let (physical_device, queue_family) = PhysicalDevice::enumerate(&instance)
         .filter(|&p| p.supported_extensions().is_superset_of(&device_extensions))
-        .filter_map(|p| {
-            Some(
-                p.queue_families()
-                    .next()
-                    .map(|q| (p, q))
-                    .expect("couldn't find a queue family"),
-            )
+        .map(|p| {
+            p.queue_families()
+                .next()
+                .map(|q| (p, q))
+                .expect("couldn't find a queue family")
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,
@@ -181,7 +179,7 @@ fn main() {
         dimensions,
         MipmapsCount::One,
         pixel_format,
-        queue.clone(),
+        queue,
     )
     .unwrap();
 

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -144,7 +144,7 @@ impl AmbientLightingSystem {
         )
         .unwrap();
         builder
-            .set_viewport(0, [viewport.clone()])
+            .set_viewport(0, [viewport])
             .bind_pipeline_graphics(self.pipeline.clone())
             .bind_descriptor_sets(
                 PipelineBindPoint::Graphics,

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -158,7 +158,7 @@ impl DirectionalLightingSystem {
         )
         .unwrap();
         builder
-            .set_viewport(0, [viewport.clone()])
+            .set_viewport(0, [viewport])
             .bind_pipeline_graphics(self.pipeline.clone())
             .bind_descriptor_sets(
                 PipelineBindPoint::Graphics,

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -126,6 +126,7 @@ impl PointLightingSystem {
     /// - `position` is the position of the spot light in world coordinates.
     /// - `color` is the color of the light.
     ///
+    #[allow(clippy::too_many_arguments)]
     pub fn draw(
         &self,
         viewport_dimensions: [u32; 2],
@@ -170,7 +171,7 @@ impl PointLightingSystem {
         )
         .unwrap();
         builder
-            .set_viewport(0, [viewport.clone()])
+            .set_viewport(0, [viewport])
             .bind_pipeline_graphics(self.pipeline.clone())
             .bind_descriptor_sets(
                 PipelineBindPoint::Graphics,

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -141,7 +141,7 @@ fn main() {
         .unwrap();
         let images = images
             .into_iter()
-            .map(|image| ImageView::new_default(image.clone()).unwrap())
+            .map(|image| ImageView::new_default(image).unwrap())
             .collect::<Vec<_>>();
         (swapchain, images)
     };
@@ -186,7 +186,7 @@ fn main() {
                 };
                 let new_images = new_images
                     .into_iter()
-                    .map(|image| ImageView::new_default(image.clone()).unwrap())
+                    .map(|image| ImageView::new_default(image).unwrap())
                     .collect::<Vec<_>>();
 
                 swapchain = new_swapchain;

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -212,9 +212,7 @@ mod linux {
         let set = PersistentDescriptorSet::new(
             layout.clone(),
             [WriteDescriptorSet::image_view_sampler(
-                0,
-                image_view,
-                sampler.clone(),
+                0, image_view, sampler,
             )],
         )
         .unwrap();
@@ -363,6 +361,7 @@ mod linux {
     }
     impl_vertex!(Vertex, position);
 
+    #[allow(clippy::type_complexity)]
     fn vk_setup(
         display: glium::HeadlessRenderer,
     ) -> (

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -319,11 +319,7 @@ fn main() {
     let layout = pipeline.layout().set_layouts().get(0).unwrap();
     let set = PersistentDescriptorSet::new(
         layout.clone(),
-        [WriteDescriptorSet::image_view_sampler(
-            0,
-            texture.clone(),
-            sampler.clone(),
-        )],
+        [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
     )
     .unwrap();
 

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -239,11 +239,7 @@ fn main() {
     let layout = pipeline.layout().set_layouts().get(0).unwrap();
     let set = PersistentDescriptorSet::new(
         layout.clone(),
-        [WriteDescriptorSet::image_view_sampler(
-            0,
-            texture.clone(),
-            sampler.clone(),
-        )],
+        [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
     )
     .unwrap();
 

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -250,11 +250,9 @@ fn main() {
     let layout = pipeline.layout().set_layouts().get(0).unwrap();
 
     // Use `image_view` instead of `image_view_sampler`, since the sampler is already in the layout.
-    let set = PersistentDescriptorSet::new(
-        layout.clone(),
-        [WriteDescriptorSet::image_view(0, texture.clone())],
-    )
-    .unwrap();
+    let set =
+        PersistentDescriptorSet::new(layout.clone(), [WriteDescriptorSet::image_view(0, texture)])
+            .unwrap();
 
     let mut viewport = Viewport {
         origin: [0.0, 0.0],

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -385,7 +385,7 @@ fn main() {
                         PipelineBindPoint::Compute,
                         compute_pipeline.layout().clone(),
                         0,
-                        cs_desciptor_set.clone(),
+                        cs_desciptor_set,
                     )
                     .dispatch([1, 1, 1])
                     .unwrap()
@@ -401,8 +401,8 @@ fn main() {
                     // contain the arguments when the draw is executed on the GPU
                     .set_viewport(0, [viewport.clone()])
                     .bind_pipeline_graphics(render_pipeline.clone())
-                    .bind_vertex_buffers(0, vertices.clone())
-                    .draw_indirect(indirect_buffer.clone())
+                    .bind_vertex_buffers(0, vertices)
+                    .draw_indirect(indirect_buffer)
                     .unwrap()
                     .end_render_pass()
                     .unwrap();

--- a/examples/src/bin/interactive_fractal/app.rs
+++ b/examples/src/bin/interactive_fractal/app.rs
@@ -329,9 +329,8 @@ impl InputState {
 
     /// Update toggle julia state (if right mouse is clicked)
     fn on_mouse_click_event(&mut self, state: ElementState, mouse_btn: winit::event::MouseButton) {
-        match mouse_btn {
-            MouseButton::Right => self.toggle_c = state_is_pressed(state),
-            _ => (),
-        };
+        if mouse_btn == MouseButton::Right {
+            self.toggle_c = state_is_pressed(state)
+        }
     }
 }

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -105,7 +105,7 @@ impl FractalComputePipeline {
         let set = PersistentDescriptorSet::new(
             desc_layout.clone(),
             [
-                WriteDescriptorSet::image_view(0, image.clone()),
+                WriteDescriptorSet::image_view(0, image),
                 WriteDescriptorSet::buffer(1, self.palette.clone()),
             ],
         )

--- a/examples/src/bin/interactive_fractal/main.rs
+++ b/examples/src/bin/interactive_fractal/main.rs
@@ -144,7 +144,7 @@ fn compute_then_render(
     // Start frame
     let before_pipeline_future = match renderer.acquire() {
         Err(e) => {
-            println!("{}", e.to_string());
+            println!("{}", e);
             return;
         }
         Ok(future) => future,

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -296,7 +296,7 @@ fn main() {
             ..
         } => {
             let surface = WindowBuilder::new()
-                .build_vk_surface(&event_loop, instance.clone())
+                .build_vk_surface(event_loop, instance.clone())
                 .unwrap();
             let window_id = surface.window().id();
             let (swapchain, images) = {

--- a/examples/src/bin/multi_window_game_of_life/main.rs
+++ b/examples/src/bin/multi_window_game_of_life/main.rs
@@ -198,7 +198,7 @@ fn compute_then_render(
     // Start frame
     let before_pipeline_future = match window_renderer.acquire() {
         Err(e) => {
-            println!("{}", e.to_string());
+            println!("{}", e);
             return;
         }
         Ok(future) => future,

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -261,7 +261,7 @@ fn main() {
             },
         ]))
         .fragment_shader(fs.entry_point("main").unwrap(), ())
-        .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
+        .render_pass(Subpass::from(render_pass, 0).unwrap())
         .build(device.clone())
         .unwrap();
 
@@ -291,12 +291,12 @@ fn main() {
         .begin_render_pass(
             RenderPassBeginInfo {
                 clear_values: vec![Some([0.0, 0.0, 1.0, 1.0].into())],
-                ..RenderPassBeginInfo::framebuffer(framebuffer.clone())
+                ..RenderPassBeginInfo::framebuffer(framebuffer)
             },
             SubpassContents::Inline,
         )
         .unwrap()
-        .bind_pipeline_graphics(pipeline.clone())
+        .bind_pipeline_graphics(pipeline)
         .bind_vertex_buffers(0, vertex_buffer.clone())
         .draw(vertex_buffer.len() as u32, 1, 0, 0)
         .unwrap()
@@ -335,7 +335,7 @@ fn main() {
     let command_buffer = builder.build().unwrap();
 
     let future = sync::now(device.clone())
-        .then_execute(queue.clone(), command_buffer)
+        .then_execute(queue, command_buffer)
         .unwrap()
         .then_signal_fence_and_flush()
         .unwrap();
@@ -366,7 +366,7 @@ fn write_image_buffer_to_file(
     let buffer_content = buffer.read().unwrap();
     let path = Path::new(path);
     let file = File::create(path).unwrap();
-    let ref mut w = BufWriter::new(file);
+    let w = &mut BufWriter::new(file);
     let mut encoder = png::Encoder::new(w, width, height);
     encoder.set_color(png::ColorType::Rgba);
     encoder.set_depth(png::BitDepth::Eight);

--- a/examples/src/bin/pipeline-caching.rs
+++ b/examples/src/bin/pipeline-caching.rs
@@ -145,7 +145,7 @@ fn main() {
 
     if let Ok(data) = pipeline_cache.get_data() {
         if let Ok(mut file) = File::create("pipeline_cache.bin.tmp") {
-            if let Ok(_) = file.write_all(&data) {
+            if file.write_all(&data).is_ok() {
                 let _ = rename("pipeline_cache.bin.tmp", "pipeline_cache.bin");
             } else {
                 let _ = remove_file("pipeline_cache.bin.tmp");
@@ -163,7 +163,7 @@ fn main() {
     let data = {
         if let Ok(mut file) = File::open("pipeline_cache.bin") {
             let mut data = Vec::new();
-            if let Ok(_) = file.read_to_end(&mut data) {
+            if file.read_to_end(&mut data).is_ok() {
                 Some(data)
             } else {
                 None
@@ -175,9 +175,9 @@ fn main() {
 
     let second_cache = if let Some(data) = data {
         // This is unsafe because there is no way to be sure that the file contains valid data.
-        unsafe { PipelineCache::with_data(device.clone(), &data).unwrap() }
+        unsafe { PipelineCache::with_data(device, &data).unwrap() }
     } else {
-        PipelineCache::empty(device.clone()).unwrap()
+        PipelineCache::empty(device).unwrap()
     };
 
     // As the PipelineCache of the Vulkan implementation saves an opaque blob of data,

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -115,7 +115,7 @@ fn main() {
     .unwrap();
 
     let data_buffer = {
-        let data_iter = (0..65536u32).map(|n| n);
+        let data_iter = 0..65536u32;
         CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), false, data_iter)
             .unwrap()
     };
@@ -151,15 +151,15 @@ fn main() {
             PipelineBindPoint::Compute,
             pipeline.layout().clone(),
             0,
-            set.clone(),
+            set,
         )
         .push_constants(pipeline.layout().clone(), 0, push_constants)
         .dispatch([1024, 1, 1])
         .unwrap();
     let command_buffer = builder.build().unwrap();
 
-    let future = sync::now(device.clone())
-        .then_execute(queue.clone(), command_buffer)
+    let future = sync::now(device)
+        .then_execute(queue, command_buffer)
         .unwrap()
         .then_signal_fence_and_flush()
         .unwrap();
@@ -168,7 +168,7 @@ fn main() {
 
     let data_buffer_content = data_buffer.read().unwrap();
     for n in 0..65536u32 {
-        assert_eq!(data_buffer_content[n as usize], n * 1 + 1);
+        assert_eq!(data_buffer_content[n as usize], n + 1);
     }
     println!("Success");
 }

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -328,7 +328,7 @@ fn main() {
 
         let set_layouts = layout_create_infos
             .into_iter()
-            .map(|desc| Ok(DescriptorSetLayout::new(device.clone(), desc.clone())?))
+            .map(|desc| DescriptorSetLayout::new(device.clone(), desc))
             .collect::<Result<Vec<_>, DescriptorSetLayoutCreationError>>()
             .unwrap();
 
@@ -368,8 +368,8 @@ fn main() {
             0,
             0,
             [
-                (mascot_texture.clone() as _, sampler.clone()),
-                (vulkano_texture.clone() as _, sampler.clone()),
+                (mascot_texture as _, sampler.clone()),
+                (vulkano_texture as _, sampler),
             ],
         )],
     )

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -155,14 +155,14 @@ fn main() {
             PipelineBindPoint::Compute,
             pipeline.layout().clone(),
             0,
-            set.clone(),
+            set,
         )
         .dispatch([1024, 1, 1])
         .unwrap();
     let command_buffer = builder.build().unwrap();
 
-    let future = sync::now(device.clone())
-        .then_execute(queue.clone(), command_buffer)
+    let future = sync::now(device)
+        .then_execute(queue, command_buffer)
         .unwrap()
         .then_signal_fence_and_flush()
         .unwrap();

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -115,7 +115,7 @@ fn main() {
     };
 
     let data_buffer = {
-        let data_iter = (0..65536u32).map(|n| n);
+        let data_iter = 0..65536u32;
         CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), false, data_iter)
             .unwrap()
     };
@@ -139,13 +139,13 @@ fn main() {
             PipelineBindPoint::Compute,
             pipeline.layout().clone(),
             0,
-            set.clone(),
+            set,
         )
         .dispatch([1024, 1, 1])
         .unwrap();
     let command_buffer = builder.build().unwrap();
-    let future = sync::now(device.clone())
-        .then_execute(queue.clone(), command_buffer)
+    let future = sync::now(device)
+        .then_execute(queue, command_buffer)
         .unwrap()
         .then_signal_fence_and_flush()
         .unwrap();

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -186,7 +186,7 @@ fn main() {
         let layout = pipeline.layout().set_layouts().get(0).unwrap();
         let set = PersistentDescriptorSet::new(
             layout.clone(),
-            [WriteDescriptorSet::buffer(0, data_buffer.clone())],
+            [WriteDescriptorSet::buffer(0, data_buffer)],
         )
         .unwrap();
 
@@ -202,7 +202,7 @@ fn main() {
                 PipelineBindPoint::Compute,
                 pipeline.layout().clone(),
                 0,
-                set.clone(),
+                set,
             )
             .push_constants(pipeline.layout().clone(), 0, parameters)
             .dispatch([1024, 1, 1])
@@ -220,7 +220,7 @@ fn main() {
 
     // Preparing test data array `[0, 1, 2, 3....]`
     let data_buffer = {
-        let data_iter = (0..65536u32).map(|n| n);
+        let data_iter = 0..65536u32;
         CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), false, data_iter)
             .unwrap()
     };
@@ -241,7 +241,7 @@ fn main() {
     // Loading the second shader, and creating a Pipeline for the shader
     let add_pipeline = ComputePipeline::new(
         device.clone(),
-        shaders::load_add(device.clone())
+        shaders::load_add(device)
             .unwrap()
             .entry_point("main")
             .unwrap(),
@@ -270,7 +270,7 @@ fn main() {
     // Then multiply each value by 3
     run_shader(
         mult_pipeline,
-        queue.clone(),
+        queue,
         data_buffer.clone(),
         shaders::ty::Parameters { value: 3 },
     );

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -398,7 +398,7 @@ fn main() {
         .input_assembly_state(InputAssemblyState::new().topology(PrimitiveTopology::PointList)) // Vertices will be rendered as a list of points.
         .viewport_state(ViewportState::viewport_fixed_scissor_irrelevant([viewport]))
         .fragment_shader(fs.entry_point("main").unwrap(), ())
-        .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
+        .render_pass(Subpass::from(render_pass, 0).unwrap())
         .build(device.clone())
         .unwrap();
 
@@ -406,7 +406,7 @@ fn main() {
     let mut previous_fence_index = 0;
 
     let start_time = SystemTime::now();
-    let mut last_frame_time = start_time.clone();
+    let mut last_frame_time = start_time;
     event_loop.run(move |event, _, control_flow| {
         match event {
             Event::WindowEvent {
@@ -445,8 +445,8 @@ fn main() {
                     };
 
                 // Since we disallow resizing, assert the swapchain and surface are optimally configured.
-                assert_eq!(
-                    suboptimal, false,
+                assert!(
+                    !suboptimal,
                     "Not handling sub-optimal swapchains in this sample code"
                 );
 

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -116,7 +116,7 @@ fn main() {
     .unwrap();
 
     let data_buffer = {
-        let data_iter = (0..65536u32).map(|n| n);
+        let data_iter = 0..65536u32;
         CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), false, data_iter)
             .unwrap()
     };
@@ -140,14 +140,14 @@ fn main() {
             PipelineBindPoint::Compute,
             pipeline.layout().clone(),
             0,
-            set.clone(),
+            set,
         )
         .dispatch([1024, 1, 1])
         .unwrap();
     let command_buffer = builder.build().unwrap();
 
-    let future = sync::now(device.clone())
-        .then_execute(queue.clone(), command_buffer)
+    let future = sync::now(device)
+        .then_execute(queue, command_buffer)
         .unwrap()
         .then_signal_fence_and_flush()
         .unwrap();
@@ -156,7 +156,7 @@ fn main() {
 
     let data_buffer_content = data_buffer.read().unwrap();
     for n in 0..65536u32 {
-        assert_eq!(data_buffer_content[n as usize], n * 1 + 1);
+        assert_eq!(data_buffer_content[n as usize], n + 1);
     }
     println!("Success");
 }

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -301,7 +301,7 @@ fn main() {
                         PipelineBindPoint::Graphics,
                         pipeline.layout().clone(),
                         0,
-                        set.clone(),
+                        set,
                     )
                     .bind_vertex_buffers(0, (vertex_buffer.clone(), normals_buffer.clone()))
                     .bind_index_buffer(index_buffer.clone())
@@ -390,8 +390,8 @@ fn window_size_dependent_setup(
         ]))
         .fragment_shader(fs.entry_point("main").unwrap(), ())
         .depth_stencil_state(DepthStencilState::simple_depth_test())
-        .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
-        .build(device.clone())
+        .render_pass(Subpass::from(render_pass, 0).unwrap())
+        .build(device)
         .unwrap();
 
     (pipeline, framebuffers)

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -240,11 +240,7 @@ fn main() {
     let layout = pipeline.layout().set_layouts().get(0).unwrap();
     let set = PersistentDescriptorSet::new(
         layout.clone(),
-        [WriteDescriptorSet::image_view_sampler(
-            0,
-            texture.clone(),
-            sampler.clone(),
-        )],
+        [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
     )
     .unwrap();
 

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,6 +1,3 @@
-use bytemuck::{Pod, Zeroable};
-use vulkano::impl_vertex;
-
 // Copyright (c) 2016 The vulkano developers
 // Licensed under the Apache License, Version 2.0
 // <LICENSE-APACHE or
@@ -9,6 +6,9 @@ use vulkano::impl_vertex;
 // at your option. All files in the project carrying such
 // notice may not be copied, modified, or distributed except
 // according to those terms.
+
+use bytemuck::{Pod, Zeroable};
+use vulkano::impl_vertex;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Zeroable, Pod)]

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -32,6 +32,7 @@ pub(super) fn path_to_str(path: &Path) -> &str {
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn include_callback(
     requested_source_path_raw: &str,
     directive_type: IncludeType,
@@ -143,6 +144,7 @@ fn include_callback(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn compile(
     path: Option<String>,
     base_path: &impl AsRef<Path>,
@@ -197,7 +199,7 @@ pub fn compile(
     compile_options.set_generate_debug_info();
 
     let content = compiler
-        .compile_into_spirv(&code, ty, root_source_path, "main", Some(&compile_options))
+        .compile_into_spirv(code, ty, root_source_path, "main", Some(&compile_options))
         .map_err(|e| e.to_string())?;
 
     let includes = includes_tracker.borrow().clone();
@@ -703,7 +705,7 @@ mod tests {
         // Check first entrypoint
         let e1_descriptors = descriptors.get(0).expect("Could not find entrypoint1");
         let mut e1_bindings = Vec::new();
-        for (loc, _reqs) in e1_descriptors {
+        for loc in e1_descriptors.keys() {
             e1_bindings.push(*loc);
         }
         assert_eq!(e1_bindings.len(), 5);
@@ -716,7 +718,7 @@ mod tests {
         // Check second entrypoint
         let e2_descriptors = descriptors.get(1).expect("Could not find entrypoint2");
         let mut e2_bindings = Vec::new();
-        for (loc, _reqs) in e2_descriptors {
+        for loc in e2_descriptors.keys() {
             e2_bindings.push(*loc);
         }
         assert_eq!(e2_bindings.len(), 3);
@@ -767,7 +769,7 @@ mod tests {
         .unwrap();
         let spirv = Spirv::new(comp.as_binary()).unwrap();
 
-        for (_, _, info) in reflect::entry_points(&spirv) {
+        if let Some((_, _, info)) = reflect::entry_points(&spirv).next() {
             let mut bindings = Vec::new();
             for (loc, _reqs) in info.descriptor_requirements {
                 bindings.push(loc);

--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -87,7 +87,7 @@ fn write_shader_execution(execution: &ShaderExecution) -> TokenStream {
 fn write_descriptor_requirements(
     descriptor_requirements: &HashMap<(u32, u32), DescriptorRequirements>,
 ) -> TokenStream {
-    let descriptor_requirements = descriptor_requirements.into_iter().map(|(loc, reqs)| {
+    let descriptor_requirements = descriptor_requirements.iter().map(|(loc, reqs)| {
         let (set_num, binding_num) = loc;
         let DescriptorRequirements {
             descriptor_types,
@@ -106,7 +106,7 @@ fn write_descriptor_requirements(
             storage_write,
         } = reqs;
 
-        let descriptor_types = descriptor_types.into_iter().map(|ty| {
+        let descriptor_types = descriptor_types.iter().map(|ty| {
             let ident = format_ident!("{}", format!("{:?}", ty));
             quote! { ::vulkano::descriptor_set::layout::DescriptorType::#ident }
         });
@@ -286,19 +286,20 @@ fn write_push_constant_requirements(
 fn write_specialization_constant_requirements(
     specialization_constant_requirements: &HashMap<u32, SpecializationConstantRequirements>,
 ) -> TokenStream {
-    let specialization_constant_requirements = specialization_constant_requirements
-        .into_iter()
-        .map(|(&constant_id, reqs)| {
-            let SpecializationConstantRequirements { size } = reqs;
-            quote! {
-                (
-                    #constant_id,
-                    ::vulkano::shader::SpecializationConstantRequirements {
-                        size: #size,
-                    },
-                ),
-            }
-        });
+    let specialization_constant_requirements =
+        specialization_constant_requirements
+            .iter()
+            .map(|(&constant_id, reqs)| {
+                let SpecializationConstantRequirements { size } = reqs;
+                quote! {
+                    (
+                        #constant_id,
+                        ::vulkano::shader::SpecializationConstantRequirements {
+                            size: #size,
+                        },
+                    ),
+                }
+            });
 
     quote! {
         [

--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -64,7 +64,7 @@ pub(super) fn write_structs<'a>(
 
             Some(if is_sized {
                 let derives = write_derives(types_meta);
-                let impls = write_impls(types_meta, &struct_name, &rust_members);
+                let impls = write_impls(types_meta, struct_name, &rust_members);
                 quote! {
                     #derives
                     #struct_body
@@ -414,12 +414,12 @@ pub(super) fn type_from_id(
                     data: i8,
                     after: u8,
                 }
-                return (
+                (
                     quote! {i8},
                     Cow::from("i8"),
                     Some(std::mem::size_of::<i8>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             (8, 0) => {
                 #[repr(C)]
@@ -427,12 +427,12 @@ pub(super) fn type_from_id(
                     data: u8,
                     after: u8,
                 }
-                return (
+                (
                     quote! {u8},
                     Cow::from("u8"),
                     Some(std::mem::size_of::<u8>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             (16, 1) => {
                 #[repr(C)]
@@ -440,12 +440,12 @@ pub(super) fn type_from_id(
                     data: i16,
                     after: u8,
                 }
-                return (
+                (
                     quote! {i16},
                     Cow::from("i16"),
                     Some(std::mem::size_of::<i16>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             (16, 0) => {
                 #[repr(C)]
@@ -453,12 +453,12 @@ pub(super) fn type_from_id(
                     data: u16,
                     after: u8,
                 }
-                return (
+                (
                     quote! {u16},
                     Cow::from("u16"),
                     Some(std::mem::size_of::<u16>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             (32, 1) => {
                 #[repr(C)]
@@ -466,12 +466,12 @@ pub(super) fn type_from_id(
                     data: i32,
                     after: u8,
                 }
-                return (
+                (
                     quote! {i32},
                     Cow::from("i32"),
                     Some(std::mem::size_of::<i32>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             (32, 0) => {
                 #[repr(C)]
@@ -479,12 +479,12 @@ pub(super) fn type_from_id(
                     data: u32,
                     after: u8,
                 }
-                return (
+                (
                     quote! {u32},
                     Cow::from("u32"),
                     Some(std::mem::size_of::<u32>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             (64, 1) => {
                 #[repr(C)]
@@ -492,12 +492,12 @@ pub(super) fn type_from_id(
                     data: i64,
                     after: u8,
                 }
-                return (
+                (
                     quote! {i64},
                     Cow::from("i64"),
                     Some(std::mem::size_of::<i64>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             (64, 0) => {
                 #[repr(C)]
@@ -505,12 +505,12 @@ pub(super) fn type_from_id(
                     data: u64,
                     after: u8,
                 }
-                return (
+                (
                     quote! {u64},
                     Cow::from("u64"),
                     Some(std::mem::size_of::<u64>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             _ => panic!("No Rust equivalent for an integer of width {}", width),
         },
@@ -521,12 +521,12 @@ pub(super) fn type_from_id(
                     data: f32,
                     after: u8,
                 }
-                return (
+                (
                     quote! {f32},
                     Cow::from("f32"),
                     Some(std::mem::size_of::<f32>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             64 => {
                 #[repr(C)]
@@ -534,12 +534,12 @@ pub(super) fn type_from_id(
                     data: f64,
                     after: u8,
                 }
-                return (
+                (
                     quote! {f64},
                     Cow::from("f64"),
                     Some(std::mem::size_of::<f64>()),
                     mem::align_of::<Foo>(),
-                );
+                )
             }
             _ => panic!("No Rust equivalent for a floating-point of width {}", width),
         },
@@ -552,12 +552,12 @@ pub(super) fn type_from_id(
             let (ty, item, t_size, t_align) = type_from_id(shader, spirv, component_type);
             let array_length = component_count as usize;
             let size = t_size.map(|s| s * component_count as usize);
-            return (
+            (
                 quote! { [#ty; #array_length] },
                 Cow::from(format!("[{}; {}]", item, array_length)),
                 size,
                 t_align,
-            );
+            )
         }
         &Instruction::TypeMatrix {
             column_type,
@@ -569,12 +569,12 @@ pub(super) fn type_from_id(
             let (ty, item, t_size, t_align) = type_from_id(shader, spirv, column_type);
             let array_length = column_count as usize;
             let size = t_size.map(|s| s * column_count as usize);
-            return (
+            (
                 quote! { [#ty; #array_length] },
                 Cow::from(format!("[{}; {}]", item, array_length)),
                 size,
                 t_align,
-            );
+            )
         }
         &Instruction::TypeArray {
             element_type,
@@ -611,12 +611,12 @@ pub(super) fn type_from_id(
                             (e.g. increase a vec3 to a vec4)")
             }
 
-            return (
+            (
                 quote! { [#element_type; #array_length] },
                 Cow::from(format!("[{}; {}]", element_type_string, array_length)),
                 Some(element_size * array_length as usize),
                 element_align,
-            );
+            )
         }
         &Instruction::TypeRuntimeArray { element_type, .. } => {
             debug_assert_eq!(mem::align_of::<[u32; 3]>(), mem::align_of::<u32>());
@@ -624,12 +624,12 @@ pub(super) fn type_from_id(
             let (element_type, element_type_string, _, element_align) =
                 type_from_id(shader, spirv, element_type);
 
-            return (
+            (
                 quote! { [#element_type] },
                 Cow::from(format!("[{}]", element_type_string)),
                 None,
                 element_align,
-            );
+            )
         }
         Instruction::TypeStruct { member_types, .. } => {
             // TODO: take the Offset member decorate into account?
@@ -676,13 +676,13 @@ pub(super) fn type_from_id(
                     Instruction::Name { name, .. } => Some(Cow::from(name.clone())),
                     _ => None,
                 })
-                .unwrap_or(Cow::from("__unnamed"));
+                .unwrap_or_else(|| Cow::from("__unnamed"));
             let name = {
                 let name = format_ident!("{}", name_string);
                 quote! { #name }
             };
 
-            return (name, name_string, size, align);
+            (name, name_string, size, align)
         }
         _ => panic!("Type #{} not found", type_id),
     }
@@ -709,18 +709,18 @@ pub(super) fn write_specialization_constants<'a>(
     let mut spec_consts = Vec::new();
 
     for instruction in spirv.iter_global() {
-        let (result_type_id, result_id, default_value) = match instruction {
-            &Instruction::SpecConstantTrue {
+        let (result_type_id, result_id, default_value) = match *instruction {
+            Instruction::SpecConstantTrue {
                 result_type_id,
                 result_id,
             } => (result_type_id, result_id, quote! {1u32}),
 
-            &Instruction::SpecConstantFalse {
+            Instruction::SpecConstantFalse {
                 result_type_id,
                 result_id,
             } => (result_type_id, result_id, quote! {0u32}),
 
-            &Instruction::SpecConstant {
+            Instruction::SpecConstant {
                 result_type_id,
                 result_id,
                 ref value,
@@ -730,7 +730,8 @@ pub(super) fn write_specialization_constants<'a>(
                 };
                 (result_type_id, result_id, def_val)
             }
-            &Instruction::SpecConstantComposite {
+
+            Instruction::SpecConstantComposite {
                 result_type_id,
                 result_id,
                 ref constituents,
@@ -741,6 +742,7 @@ pub(super) fn write_specialization_constants<'a>(
                 };
                 (result_type_id, result_id, def_val)
             }
+
             _ => continue,
         };
 

--- a/vulkano-util/src/context.rs
+++ b/vulkano-util/src/context.rs
@@ -134,19 +134,18 @@ impl VulkanoContext {
             .union(&config.instance_create_info.enabled_extensions);
 
         // Create instance
-        let instance = Instance::new(library.clone(), config.instance_create_info)
-            .expect("Failed to create instance");
+        let instance =
+            Instance::new(library, config.instance_create_info).expect("Failed to create instance");
 
         // Create debug callback
-        let _debug_utils_messenger = if let Some(dbg_create_info) = config.debug_create_info.take()
-        {
-            Some(unsafe {
-                DebugUtilsMessenger::new(instance.clone(), dbg_create_info)
-                    .expect("Failed to create debug callback")
-            })
-        } else {
-            None
-        };
+        let _debug_utils_messenger =
+            config
+                .debug_create_info
+                .take()
+                .map(|dbg_create_info| unsafe {
+                    DebugUtilsMessenger::new(instance.clone(), dbg_create_info)
+                        .expect("Failed to create debug callback")
+                });
 
         // Get prioritized device
         let physical_device = PhysicalDevice::enumerate(&instance)

--- a/vulkano-util/src/lib.rs
+++ b/vulkano-util/src/lib.rs
@@ -7,6 +7,8 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+#![allow(clippy::missing_safety_doc)]
+
 pub mod context;
 pub mod renderer;
 pub mod window;

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -335,7 +335,7 @@ impl VulkanoWindowRenderer {
             .collect::<Vec<usize>>();
         for i in resizable_views {
             let format = self.get_additional_image_view(i).format().unwrap();
-            let usage = self.get_additional_image_view(i).usage().clone();
+            let usage = *self.get_additional_image_view(i).usage();
             self.remove_additional_image_view(i);
             self.add_additional_image_view(i, format, usage);
         }

--- a/vulkano-util/src/window.rs
+++ b/vulkano-util/src/window.rs
@@ -202,19 +202,17 @@ impl VulkanoWindows {
         &mut self,
         id: winit::window::WindowId,
     ) -> Option<&mut VulkanoWindowRenderer> {
-        self.windows.get_mut(&id).and_then(|v| Some(v))
+        self.windows.get_mut(&id)
     }
 
     /// Get a reference to the renderer by winit window id
     pub fn get_renderer(&self, id: winit::window::WindowId) -> Option<&VulkanoWindowRenderer> {
-        self.windows.get(&id).and_then(|v| Some(v))
+        self.windows.get(&id)
     }
 
     /// Get a reference to the winit window by winit window id
     pub fn get_window(&self, id: winit::window::WindowId) -> Option<&winit::window::Window> {
-        self.windows
-            .get(&id)
-            .and_then(|v_window| Some(v_window.window()))
+        self.windows.get(&id).map(|v_window| v_window.window())
     }
 
     /// Return primary window id
@@ -294,7 +292,7 @@ fn get_best_videomode(monitor: &winit::monitor::MonitorHandle) -> winit::monitor
 }
 
 /// Defines the way a window is displayed.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WindowMode {
     /// Creates a window that uses the given size.
     Windowed,

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/vulkano-rs/vulkano/master/logo.png")]
+#![allow(clippy::missing_safety_doc)]
 
 /// Create a surface either using winit or a RawWindowHandle
 /// Its possible to disable either one using features

--- a/vulkano/autogen/fns.rs
+++ b/vulkano/autogen/fns.rs
@@ -90,7 +90,7 @@ fn fns_output(extension_members: &[FnsMember], fns_level: &str, doc: &str) -> To
 
         impl std::fmt::Debug for #struct_name {
             #[inline]
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
                 Ok(())
             }
         }

--- a/vulkano/autogen/formats.rs
+++ b/vulkano/autogen/formats.rs
@@ -475,8 +475,8 @@ fn formats_members(formats: &[&Format]) -> Vec<FormatMember> {
             let name = format_ident!("{}", parts.join("_"));
 
             let mut member = FormatMember {
-                name: name.clone(),
-                ffi_name: ffi_name.clone(),
+                name,
+                ffi_name,
 
                 aspect_color: false,
                 aspect_depth: false,
@@ -489,13 +489,13 @@ fn formats_members(formats: &[&Format]) -> Vec<FormatMember> {
                 block_size: None,
                 compatibility: format_ident!(
                     "Class_{}",
-                    format.class.replace("-", "").replace(" ", "_")
+                    format.class.replace('-', "").replace(' ', "_")
                 ),
                 components: [0u8; 4],
                 compression: format
                     .compressed
                     .as_ref()
-                    .map(|c| format_ident!("{}", c.replace(" ", "_"))),
+                    .map(|c| format_ident!("{}", c.replace(' ', "_"))),
                 planes: vec![],
                 rust_type: None,
                 texels_per_block: format.texelsPerBlock,
@@ -585,7 +585,7 @@ fn formats_members(formats: &[&Format]) -> Vec<FormatMember> {
                     captures.get(3).unwrap().as_str().parse().unwrap(),
                 ];
             } else {
-                match format.chroma.as_ref().map(|s| s.as_str()) {
+                match format.chroma.as_deref() {
                     Some("420") => member.block_extent = [2, 2, 1],
                     Some("422") => member.block_extent = [2, 1, 1],
                     _ => (),

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -202,7 +202,7 @@ where
             device,
             pool,
             current_buffer: Mutex::new(None),
-            usage: usage.clone(),
+            usage,
             marker: PhantomData,
         }
     }
@@ -345,7 +345,7 @@ where
         I: IntoIterator<Item = T>,
         I::IntoIter: ExactSizeIterator,
     {
-        self.chunk_impl(data.into_iter()).map(|ok| Arc::new(ok))
+        self.chunk_impl(data.into_iter()).map(Arc::new)
     }
 
     fn chunk_impl(
@@ -435,7 +435,7 @@ where
                 memory: mem,
                 chunks_in_use: Mutex::new(vec![]),
                 next_index: AtomicU64::new(0),
-                capacity: capacity,
+                capacity,
             }));
 
             Ok(())
@@ -612,7 +612,7 @@ where
             device: self.device.clone(),
             pool: self.pool.clone(),
             current_buffer: Mutex::new(buf.clone()),
-            usage: self.usage.clone(),
+            usage: self.usage,
             marker: PhantomData,
         }
     }

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -140,13 +140,6 @@ where
     marker: PhantomData<Box<T>>,
 }
 
-#[derive(Debug, Copy, Clone)]
-enum GpuAccess {
-    None,
-    NonExclusive { num: u32 },
-    Exclusive { num: u32 },
-}
-
 impl<T> DeviceLocalBuffer<T>
 where
     T: BufferContents,
@@ -408,7 +401,7 @@ where
         let (buffer, mem_reqs) = Self::build_buffer(&device, size, usage, &queue_families)?;
 
         let memory = alloc_dedicated_with_exportable_fd(
-            device.clone(),
+            device,
             &mem_reqs,
             AllocLayout::Linear,
             MappingRequirement::DoNotMap,
@@ -627,7 +620,7 @@ mod tests {
             CpuAccessibleBuffer::from_data(device.clone(), BufferUsage::all(), false, 0).unwrap();
 
         let mut cbb = AutoCommandBufferBuilder::primary(
-            device.clone(),
+            device,
             queue.family(),
             CommandBufferUsage::MultipleSubmit,
         )
@@ -637,7 +630,7 @@ mod tests {
         let _ = cbb
             .build()
             .unwrap()
-            .execute(queue.clone())
+            .execute(queue)
             .unwrap()
             .then_signal_fence_and_flush()
             .unwrap();
@@ -666,7 +659,7 @@ mod tests {
         .unwrap();
 
         let mut cbb = AutoCommandBufferBuilder::primary(
-            device.clone(),
+            device,
             queue.family(),
             CommandBufferUsage::MultipleSubmit,
         )
@@ -676,7 +669,7 @@ mod tests {
         let _ = cbb
             .build()
             .unwrap()
-            .execute(queue.clone())
+            .execute(queue)
             .unwrap()
             .then_signal_fence_and_flush()
             .unwrap();

--- a/vulkano/src/buffer/slice.rs
+++ b/vulkano/src/buffer/slice.rs
@@ -74,7 +74,7 @@ impl<T: ?Sized, B> BufferSlice<T, B> {
             marker: PhantomData,
             resource: r,
             offset: 0,
-            size: size,
+            size,
         })
     }
 

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -502,7 +502,7 @@ impl fmt::Display for BufferCreationError {
                 fmt,
                 "the specified size exceeded the value of the `max_buffer_size` limit"
             ),
-            Self::SharingInvalidQueueFamilyId { id } => {
+            Self::SharingInvalidQueueFamilyId { .. } => {
                 write!(fmt, "the sharing mode was set to `Concurrent`, but one of the specified queue family ids was not valid")
             }
         }

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -475,20 +475,17 @@ mod tests {
     #[test]
     fn create_uniform() {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
 
         let usage = BufferUsage {
             uniform_texel_buffer: true,
             ..BufferUsage::none()
         };
 
-        let (buffer, _) = DeviceLocalBuffer::<[[u8; 4]]>::from_iter(
-            (0..128).map(|_| [0; 4]),
-            usage,
-            queue.clone(),
-        )
-        .unwrap();
-        let view = BufferView::new(
+        let (buffer, _) =
+            DeviceLocalBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]), usage, queue)
+                .unwrap();
+        BufferView::new(
             buffer,
             BufferViewCreateInfo {
                 format: Some(Format::R8G8B8A8_UNORM),
@@ -501,19 +498,16 @@ mod tests {
     #[test]
     fn create_storage() {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
 
         let usage = BufferUsage {
             storage_texel_buffer: true,
             ..BufferUsage::none()
         };
 
-        let (buffer, _) = DeviceLocalBuffer::<[[u8; 4]]>::from_iter(
-            (0..128).map(|_| [0; 4]),
-            usage,
-            queue.clone(),
-        )
-        .unwrap();
+        let (buffer, _) =
+            DeviceLocalBuffer::<[[u8; 4]]>::from_iter((0..128).map(|_| [0; 4]), usage, queue)
+                .unwrap();
         BufferView::new(
             buffer,
             BufferViewCreateInfo {
@@ -527,7 +521,7 @@ mod tests {
     #[test]
     fn create_storage_atomic() {
         // `VK_FORMAT_R32_UINT` guaranteed to be a supported format for atomics
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
 
         let usage = BufferUsage {
             storage_texel_buffer: true,
@@ -535,8 +529,7 @@ mod tests {
         };
 
         let (buffer, _) =
-            DeviceLocalBuffer::<[u32]>::from_iter((0..128).map(|_| 0), usage, queue.clone())
-                .unwrap();
+            DeviceLocalBuffer::<[u32]>::from_iter((0..128).map(|_| 0), usage, queue).unwrap();
         BufferView::new(
             buffer,
             BufferViewCreateInfo {
@@ -550,12 +543,12 @@ mod tests {
     #[test]
     fn wrong_usage() {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
 
         let (buffer, _) = DeviceLocalBuffer::<[[u8; 4]]>::from_iter(
             (0..128).map(|_| [0; 4]),
             BufferUsage::none(),
-            queue.clone(),
+            queue,
         )
         .unwrap();
 
@@ -573,7 +566,7 @@ mod tests {
 
     #[test]
     fn unsupported_format() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
 
         let usage = BufferUsage {
             uniform_texel_buffer: true,
@@ -581,12 +574,9 @@ mod tests {
             ..BufferUsage::none()
         };
 
-        let (buffer, _) = DeviceLocalBuffer::<[[f64; 4]]>::from_iter(
-            (0..128).map(|_| [0.0; 4]),
-            usage,
-            queue.clone(),
-        )
-        .unwrap();
+        let (buffer, _) =
+            DeviceLocalBuffer::<[[f64; 4]]>::from_iter((0..128).map(|_| [0.0; 4]), usage, queue)
+                .unwrap();
 
         // TODO: what if R64G64B64A64_SFLOAT is supported?
         match BufferView::new(

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -658,7 +658,7 @@ impl SyncCommandBufferBuilder {
         let set_resources = match state
             .descriptor_sets
             .entry(set_num)
-            .or_insert(SetOrPush::Push(DescriptorSetResources::new(layout, 0)))
+            .or_insert_with(|| SetOrPush::Push(DescriptorSetResources::new(layout, 0)))
         {
             SetOrPush::Push(set_resources) => set_resources,
             _ => unreachable!(),
@@ -720,8 +720,7 @@ impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
                 let dynamic_offsets = self
                     .descriptor_sets
                     .iter()
-                    .map(|x| x.as_ref().1.iter().copied())
-                    .flatten();
+                    .flat_map(|x| x.as_ref().1.iter().copied());
 
                 out.bind_descriptor_sets(
                     self.pipeline_bind_point,
@@ -775,7 +774,7 @@ impl<'a> SyncCommandBufferBuilderBindVertexBuffer<'a> {
         struct Cmd {
             first_set: u32,
             inner: Mutex<Option<UnsafeCommandBufferBuilderBindVertexBuffer>>,
-            buffers: SmallVec<[Arc<dyn BufferAccess>; 4]>,
+            _buffers: SmallVec<[Arc<dyn BufferAccess>; 4]>,
         }
 
         impl Command for Cmd {
@@ -798,7 +797,7 @@ impl<'a> SyncCommandBufferBuilderBindVertexBuffer<'a> {
         self.builder.commands.push(Box::new(Cmd {
             first_set,
             inner: Mutex::new(Some(self.inner)),
-            buffers: self.buffers,
+            _buffers: self.buffers,
         }));
     }
 }

--- a/vulkano/src/command_buffer/commands/debug.rs
+++ b/vulkano/src/command_buffer/commands/debug.rs
@@ -41,7 +41,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_begin_debug_utils_label(
         &self,
-        label_info: &mut DebugUtilsLabel,
+        _label_info: &mut DebugUtilsLabel,
     ) -> Result<(), DebugUtilsError> {
         if !self
             .device()
@@ -123,7 +123,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_insert_debug_utils_label(
         &self,
-        label_info: &mut DebugUtilsLabel,
+        _label_info: &mut DebugUtilsLabel,
     ) -> Result<(), DebugUtilsError> {
         if !self
             .device()

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -59,7 +59,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_blend_constants(
         &self,
-        constants: [f32; 4],
+        _constants: [f32; 4],
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::BlendConstants) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -162,7 +162,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         self
     }
 
-    fn validate_set_cull_mode(&self, cull_mode: CullMode) -> Result<(), SetDynamicStateError> {
+    fn validate_set_cull_mode(&self, _cull_mode: CullMode) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::CullMode) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
         }
@@ -213,9 +213,9 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_depth_bias(
         &self,
-        constant_factor: f32,
+        _constant_factor: f32,
         clamp: f32,
-        slope_factor: f32,
+        _slope_factor: f32,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::DepthBias) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -257,7 +257,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         self
     }
 
-    fn validate_set_depth_bias_enable(&self, enable: bool) -> Result<(), SetDynamicStateError> {
+    fn validate_set_depth_bias_enable(&self, _enable: bool) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::DepthBiasEnable) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
         }
@@ -352,7 +352,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_depth_bounds_test_enable(
         &self,
-        enable: bool,
+        _enable: bool,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::DepthBoundsTestEnable) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -398,7 +398,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_depth_compare_op(
         &self,
-        compare_op: CompareOp,
+        _compare_op: CompareOp,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::DepthCompareOp) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -442,7 +442,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         self
     }
 
-    fn validate_set_depth_test_enable(&self, enable: bool) -> Result<(), SetDynamicStateError> {
+    fn validate_set_depth_test_enable(&self, _enable: bool) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::DepthTestEnable) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
         }
@@ -485,7 +485,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         self
     }
 
-    fn validate_set_depth_write_enable(&self, enable: bool) -> Result<(), SetDynamicStateError> {
+    fn validate_set_depth_write_enable(&self, _enable: bool) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::DepthWriteEnable) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
         }
@@ -600,7 +600,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         self
     }
 
-    fn validate_set_front_face(&self, face: FrontFace) -> Result<(), SetDynamicStateError> {
+    fn validate_set_front_face(&self, _face: FrontFace) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::FrontFace) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
         }
@@ -646,7 +646,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     fn validate_set_line_stipple(
         &self,
         factor: u32,
-        pattern: u16,
+        _pattern: u16,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::LineStipple) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -731,7 +731,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         self
     }
 
-    fn validate_set_logic_op(&self, logic_op: LogicOp) -> Result<(), SetDynamicStateError> {
+    fn validate_set_logic_op(&self, _logic_op: LogicOp) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::LogicOp) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
         }
@@ -848,7 +848,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_primitive_restart_enable(
         &self,
-        enable: bool,
+        _enable: bool,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::PrimitiveRestartEnable) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -970,7 +970,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_rasterizer_discard_enable(
         &self,
-        enable: bool,
+        _enable: bool,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::RasterizerDiscardEnable) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -1156,8 +1156,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_stencil_compare_mask(
         &self,
-        faces: StencilFaces,
-        compare_mask: u32,
+        _faces: StencilFaces,
+        _compare_mask: u32,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::StencilCompareMask) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -1202,11 +1202,11 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_stencil_op(
         &self,
-        faces: StencilFaces,
-        fail_op: StencilOp,
-        pass_op: StencilOp,
-        depth_fail_op: StencilOp,
-        compare_op: CompareOp,
+        _faces: StencilFaces,
+        _fail_op: StencilOp,
+        _pass_op: StencilOp,
+        _depth_fail_op: StencilOp,
+        _compare_op: CompareOp,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::StencilOp) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -1249,8 +1249,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_stencil_reference(
         &self,
-        faces: StencilFaces,
-        reference: u32,
+        _faces: StencilFaces,
+        _reference: u32,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::StencilReference) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -1284,7 +1284,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         self
     }
 
-    fn validate_set_stencil_test_enable(&self, enable: bool) -> Result<(), SetDynamicStateError> {
+    fn validate_set_stencil_test_enable(&self, _enable: bool) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::StencilTestEnable) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
         }
@@ -1326,8 +1326,8 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
     fn validate_set_stencil_write_mask(
         &self,
-        faces: StencilFaces,
-        write_mask: u32,
+        _faces: StencilFaces,
+        _write_mask: u32,
     ) -> Result<(), SetDynamicStateError> {
         if self.has_fixed_state(DynamicState::StencilWriteMask) {
             return Err(SetDynamicStateError::PipelineHasFixedState);
@@ -1743,9 +1743,7 @@ impl SyncCommandBufferBuilder {
 
         for (num, rectangle) in rectangles.iter().enumerate() {
             let num = num as u32 + first_rectangle;
-            self.current_state
-                .discard_rectangle
-                .insert(num, rectangle.clone());
+            self.current_state.discard_rectangle.insert(num, *rectangle);
         }
 
         self.commands.push(Box::new(Cmd {
@@ -2130,7 +2128,7 @@ impl SyncCommandBufferBuilder {
 
         for (num, scissor) in scissors.iter().enumerate() {
             let num = num as u32 + first_scissor;
-            self.current_state.scissor.insert(num, scissor.clone());
+            self.current_state.scissor.insert(num, *scissor);
         }
 
         self.commands.push(Box::new(Cmd {
@@ -2379,7 +2377,7 @@ impl UnsafeCommandBufferBuilder {
 
         let rectangles = rectangles
             .into_iter()
-            .map(|v| v.clone().into())
+            .map(|v| v.into())
             .collect::<SmallVec<[_; 2]>>();
         if rectangles.is_empty() {
             return;
@@ -2577,7 +2575,7 @@ impl UnsafeCommandBufferBuilder {
     ) {
         let scissors = scissors
             .into_iter()
-            .map(|v| ash::vk::Rect2D::from(v.clone()))
+            .map(ash::vk::Rect2D::from)
             .collect::<SmallVec<[_; 2]>>();
         if scissors.is_empty() {
             return;
@@ -2599,7 +2597,7 @@ impl UnsafeCommandBufferBuilder {
     pub unsafe fn set_scissor_with_count(&mut self, scissors: impl IntoIterator<Item = Scissor>) {
         let scissors = scissors
             .into_iter()
-            .map(|v| ash::vk::Rect2D::from(v.clone()))
+            .map(ash::vk::Rect2D::from)
             .collect::<SmallVec<[_; 2]>>();
         if scissors.is_empty() {
             return;
@@ -2635,7 +2633,7 @@ impl UnsafeCommandBufferBuilder {
     ) {
         let viewports = viewports
             .into_iter()
-            .map(|v| v.clone().into())
+            .map(|v| v.into())
             .collect::<SmallVec<[_; 2]>>();
         if viewports.is_empty() {
             return;
@@ -2660,7 +2658,7 @@ impl UnsafeCommandBufferBuilder {
     ) {
         let viewports = viewports
             .into_iter()
-            .map(|v| v.clone().into())
+            .map(|v| v.into())
             .collect::<SmallVec<[_; 2]>>();
         if viewports.is_empty() {
             return;
@@ -2687,6 +2685,7 @@ impl UnsafeCommandBufferBuilder {
 }
 
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 enum SetDynamicStateError {
     ExtensionNotEnabled {
         extension: &'static str,

--- a/vulkano/src/command_buffer/commands/image.rs
+++ b/vulkano/src/command_buffer/commands/image.rs
@@ -599,7 +599,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         let &mut ClearColorImageInfo {
             ref image,
             image_layout,
-            clear_value,
+            clear_value: _,
             ref regions,
             _ne: _,
         } = clear_info;
@@ -1070,7 +1070,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             assert!(extent[0] != 0 && extent[1] != 0 && extent[2] != 0);
 
             let check_offset_extent = |resource: CopyErrorResource,
-                                       image_type: ImageType,
+                                       _image_type: ImageType,
                                        subresource_extent: [u32; 3],
                                        offset: [u32; 3]|
              -> Result<_, CopyError> {
@@ -1153,7 +1153,7 @@ impl SyncCommandBufferBuilder {
             ref dst_image,
             dst_image_layout,
             ref regions,
-            filter,
+            filter: _,
             _ne: _,
         } = &blit_image_info;
 
@@ -1162,9 +1162,9 @@ impl SyncCommandBufferBuilder {
             .flat_map(|region| {
                 let &ImageBlit {
                     ref src_subresource,
-                    src_offsets,
+                    src_offsets: _,
                     ref dst_subresource,
-                    dst_offsets,
+                    dst_offsets: _,
                     _ne: _,
                 } = region;
 
@@ -1251,7 +1251,7 @@ impl SyncCommandBufferBuilder {
         let &ClearColorImageInfo {
             ref image,
             image_layout,
-            clear_value,
+            clear_value: _,
             ref regions,
             _ne: _,
         } = &clear_info;
@@ -1321,7 +1321,7 @@ impl SyncCommandBufferBuilder {
         let &ClearDepthStencilImageInfo {
             ref image,
             image_layout,
-            clear_value,
+            clear_value: _,
             ref regions,
             _ne: _,
         } = &clear_info;
@@ -1403,10 +1403,10 @@ impl SyncCommandBufferBuilder {
             .flat_map(|region| {
                 let &ImageResolve {
                     ref src_subresource,
-                    src_offset,
+                    src_offset: _,
                     ref dst_subresource,
-                    dst_offset,
-                    extent,
+                    dst_offset: _,
+                    extent: _,
                     _ne: _,
                 } = region;
 

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -391,7 +391,7 @@ fn check_descriptor_sets_validity<'a, P: Pipeline>(
         let layout_binding =
             &pipeline.layout().set_layouts()[set_num as usize].bindings()[&binding_num];
 
-        let check_buffer = |index: u32, buffer: &Arc<dyn BufferAccess>| Ok(());
+        let check_buffer = |_index: u32, _buffer: &Arc<dyn BufferAccess>| Ok(());
 
         let check_buffer_view = |index: u32, buffer_view: &Arc<dyn BufferViewAbstract>| {
             if layout_binding.descriptor_type == DescriptorType::StorageTexelBuffer {
@@ -804,12 +804,7 @@ impl fmt::Display for InvalidDescriptorResource {
             Self::Missing => {
                 write!(fmt, "no resource was bound")
             }
-            Self::SamplerImageViewIncompatible {
-                image_view_set_num,
-                image_view_binding_num,
-                image_view_index,
-                ..
-            } => {
+            Self::SamplerImageViewIncompatible { .. } => {
                 write!(
                     fmt,
                     "the bound sampler samples an image view that is not compatible with it"
@@ -1331,8 +1326,7 @@ fn check_index_buffer(
             return Err(CheckIndexBufferError::TooManyIndices {
                 index_count,
                 max_index_count,
-            }
-            .into());
+            });
         }
     }
 
@@ -1432,10 +1426,7 @@ impl fmt::Display for CheckIndirectBufferError {
                 CheckIndirectBufferError::BufferMissingUsage => {
                     "the indirect buffer usage must be enabled on the indirect buffer"
                 }
-                CheckIndirectBufferError::MaxDrawIndirectCountLimitExceeded {
-                    limit,
-                    requested,
-                } => {
+                CheckIndirectBufferError::MaxDrawIndirectCountLimitExceeded { .. } => {
                     "the maximum number of indirect draws has been exceeded"
                 }
             }
@@ -1511,8 +1502,7 @@ fn check_vertex_buffers(
                 return Err(CheckVertexBufferError::TooManyInstances {
                     instance_count,
                     max_instance_count,
-                }
-                .into());
+                });
             }
         }
 
@@ -1536,8 +1526,7 @@ fn check_vertex_buffers(
                 return Err(CheckVertexBufferError::TooManyInstances {
                     instance_count,
                     max_instance_count: max_instance_index + 1, // TODO: this can overflow
-                }
-                .into());
+                });
             }
         }
     }

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -67,7 +67,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     ) -> Result<(), QueryError> {
         // VUID-vkCmdBeginQuery-commandBuffer-cmdpool
         if !(self.queue_family().supports_graphics() || self.queue_family().supports_compute()) {
-            return Err(QueryError::NotSupportedByQueueFamily.into());
+            return Err(QueryError::NotSupportedByQueueFamily);
         }
 
         let device = self.device();
@@ -175,7 +175,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     fn validate_end_query(&self, query_pool: &QueryPool, query: u32) -> Result<(), QueryError> {
         // VUID-vkCmdEndQuery-commandBuffer-cmdpool
         if !(self.queue_family().supports_graphics() || self.queue_family().supports_compute()) {
-            return Err(QueryError::NotSupportedByQueueFamily.into());
+            return Err(QueryError::NotSupportedByQueueFamily);
         }
 
         let device = self.device();
@@ -191,7 +191,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
                 state.query_pool == query_pool.internal_object() && state.query == query
             })
         {
-            return Err(QueryError::QueryNotActive.into());
+            return Err(QueryError::QueryNotActive);
         }
 
         // VUID-vkCmdEndQuery-query-00810
@@ -256,7 +256,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             || self.queue_family().supports_graphics()
             || self.queue_family().supports_compute())
         {
-            return Err(QueryError::NotSupportedByQueueFamily.into());
+            return Err(QueryError::NotSupportedByQueueFamily);
         }
 
         let device = self.device();
@@ -391,7 +391,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     {
         // VUID-vkCmdCopyQueryPoolResults-commandBuffer-cmdpool
         if !(self.queue_family().supports_graphics() || self.queue_family().supports_compute()) {
-            return Err(QueryError::NotSupportedByQueueFamily.into());
+            return Err(QueryError::NotSupportedByQueueFamily);
         }
 
         // VUID-vkCmdCopyQueryPoolResults-renderpass
@@ -476,7 +476,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
 
         // VUID-vkCmdResetQueryPool-commandBuffer-cmdpool
         if !(self.queue_family().supports_graphics() || self.queue_family().supports_compute()) {
-            return Err(QueryError::NotSupportedByQueueFamily.into());
+            return Err(QueryError::NotSupportedByQueueFamily);
         }
 
         let device = self.device();
@@ -494,7 +494,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         if self.query_state.values().any(|state| {
             state.query_pool == query_pool.internal_object() && queries.contains(&state.query)
         }) {
-            return Err(QueryError::QueryIsActive.into());
+            return Err(QueryError::QueryIsActive);
         }
 
         Ok(())

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -324,12 +324,11 @@ where
             match state.ty {
                 QueryType::Occlusion => {
                     // VUID-vkCmdExecuteCommands-commandBuffer-00102
-                    let inherited_flags = command_buffer
-                        .inheritance_info()
-                        .occlusion_query
-                        .ok_or_else(|| ExecuteCommandsError::OcclusionQueryInheritanceRequired {
+                    let inherited_flags = command_buffer.inheritance_info().occlusion_query.ok_or(
+                        ExecuteCommandsError::OcclusionQueryInheritanceRequired {
                             command_buffer_index,
-                        })?;
+                        },
+                    )?;
 
                     let inherited_flags_vk = ash::vk::QueryControlFlags::from(inherited_flags);
                     let state_flags_vk = ash::vk::QueryControlFlags::from(state.flags);

--- a/vulkano/src/command_buffer/commands/transfer.rs
+++ b/vulkano/src/command_buffer/commands/transfer.rs
@@ -771,7 +771,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
                     for (dst_region_index, dst_region) in regions.iter().enumerate() {
                         let &ImageCopy {
                             ref dst_subresource,
-                            dst_offset,
+                            dst_offset: _,
                             ..
                         } = dst_region;
 
@@ -1729,7 +1729,7 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         }
 
         let &mut FillBufferInfo {
-            data,
+            data: _,
             ref dst_buffer,
             dst_offset,
             size,
@@ -1895,25 +1895,6 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     }
 }
 
-/// Computes the minimum required len in elements for buffer with image data in specified
-/// format of specified size.
-fn required_size_for_format(format: Format, extent: [u32; 3], layer_count: u32) -> DeviceSize {
-    let num_blocks = extent
-        .into_iter()
-        .zip(format.block_extent())
-        .map(|(extent, block_extent)| {
-            let extent = extent as DeviceSize;
-            let block_extent = block_extent as DeviceSize;
-            (extent + block_extent - 1) / block_extent
-        })
-        .product::<DeviceSize>()
-        * layer_count as DeviceSize;
-    let block_size = format
-        .block_size()
-        .expect("this format cannot accept pixels");
-    num_blocks * block_size
-}
-
 impl SyncCommandBufferBuilder {
     /// Calls `vkCmdCopyBuffer` on the builder.
     ///
@@ -2046,10 +2027,10 @@ impl SyncCommandBufferBuilder {
             .flat_map(|region| {
                 let &ImageCopy {
                     ref src_subresource,
-                    src_offset,
+                    src_offset: _,
                     ref dst_subresource,
-                    dst_offset,
-                    extent,
+                    dst_offset: _,
+                    extent: _,
                     _ne: _,
                 } = region;
 
@@ -2147,11 +2128,11 @@ impl SyncCommandBufferBuilder {
             .flat_map(|region| {
                 let &BufferImageCopy {
                     buffer_offset,
-                    buffer_row_length,
-                    buffer_image_height,
+                    buffer_row_length: _,
+                    buffer_image_height: _,
                     ref image_subresource,
-                    image_offset,
-                    image_extent,
+                    image_offset: _,
+                    image_extent: _,
                     _ne: _,
                 } = region;
 
@@ -2250,11 +2231,11 @@ impl SyncCommandBufferBuilder {
             .flat_map(|region| {
                 let &BufferImageCopy {
                     buffer_offset,
-                    buffer_row_length,
-                    buffer_image_height,
+                    buffer_row_length: _,
+                    buffer_image_height: _,
                     ref image_subresource,
-                    image_offset,
-                    image_extent,
+                    image_offset: _,
+                    image_extent: _,
                     _ne: _,
                 } = region;
 
@@ -2338,7 +2319,7 @@ impl SyncCommandBufferBuilder {
         }
 
         let &FillBufferInfo {
-            data,
+            data: _,
             ref dst_buffer,
             dst_offset,
             size,
@@ -3565,6 +3546,25 @@ impl FillBufferInfo {
 mod tests {
     use super::*;
     use crate::format::Format;
+
+    /// Computes the minimum required len in elements for buffer with image data in specified
+    /// format of specified size.
+    fn required_size_for_format(format: Format, extent: [u32; 3], layer_count: u32) -> DeviceSize {
+        let num_blocks = extent
+            .into_iter()
+            .zip(format.block_extent())
+            .map(|(extent, block_extent)| {
+                let extent = extent as DeviceSize;
+                let block_extent = block_extent as DeviceSize;
+                (extent + block_extent - 1) / block_extent
+            })
+            .product::<DeviceSize>()
+            * layer_count as DeviceSize;
+        let block_size = format
+            .block_size()
+            .expect("this format cannot accept pixels");
+        num_blocks * block_size
+    }
 
     #[test]
     fn test_required_len_for_format() {

--- a/vulkano/src/command_buffer/pool/standard.rs
+++ b/vulkano/src/command_buffer/pool/standard.rs
@@ -266,7 +266,7 @@ mod tests {
         let (device, queue) = gfx_dev_and_queue!();
 
         let thread = thread::spawn({
-            let (device, queue) = (device.clone(), queue.clone());
+            let (device, queue) = (device, queue);
             move || {
                 device
                     .with_standard_command_pool(queue.family(), |pool| {

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -39,8 +39,8 @@ pub struct UnsafeCommandPool {
     dummy_avoid_sync: PhantomData<*const u8>,
 
     queue_family_index: u32,
-    transient: bool,
-    reset_command_buffer: bool,
+    _transient: bool,
+    _reset_command_buffer: bool,
 }
 
 unsafe impl Send for UnsafeCommandPool {}
@@ -67,8 +67,8 @@ impl UnsafeCommandPool {
             dummy_avoid_sync: PhantomData,
 
             queue_family_index,
-            transient,
-            reset_command_buffer,
+            _transient: transient,
+            _reset_command_buffer: reset_command_buffer,
         })
     }
 
@@ -94,8 +94,8 @@ impl UnsafeCommandPool {
             dummy_avoid_sync: PhantomData,
 
             queue_family_index,
-            transient,
-            reset_command_buffer,
+            _transient: transient,
+            _reset_command_buffer: reset_command_buffer,
         }
     }
 
@@ -105,8 +105,8 @@ impl UnsafeCommandPool {
     ) -> Result<(), UnsafeCommandPoolCreationError> {
         let &mut UnsafeCommandPoolCreateInfo {
             queue_family_index,
-            transient,
-            reset_command_buffer,
+            transient: _,
+            reset_command_buffer: _,
             _ne: _,
         } = create_info;
 
@@ -615,14 +615,18 @@ mod tests {
         .unwrap();
 
         if device.api_version() >= Version::V1_1 {
-            match pool.trim() {
-                Err(CommandPoolTrimError::Maintenance1ExtensionNotEnabled) => panic!(),
-                _ => (),
+            if matches!(
+                pool.trim(),
+                Err(CommandPoolTrimError::Maintenance1ExtensionNotEnabled)
+            ) {
+                panic!()
             }
         } else {
-            match pool.trim() {
-                Err(CommandPoolTrimError::Maintenance1ExtensionNotEnabled) => (),
-                _ => panic!(),
+            if !matches!(
+                pool.trim(),
+                Err(CommandPoolTrimError::Maintenance1ExtensionNotEnabled)
+            ) {
+                panic!()
             }
         }
     }

--- a/vulkano/src/command_buffer/submit/mod.rs
+++ b/vulkano/src/command_buffer/submit/mod.rs
@@ -43,9 +43,6 @@ impl<'a> SubmitAnyBuilder<'a> {
     /// Returns true if equal to `SubmitAnyBuilder::Empty`.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        match self {
-            &SubmitAnyBuilder::Empty => true,
-            _ => false,
-        }
+        matches!(self, SubmitAnyBuilder::Empty)
     }
 }

--- a/vulkano/src/command_buffer/submit/queue_submit.rs
+++ b/vulkano/src/command_buffer/submit/queue_submit.rs
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn empty_submit() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
         let builder = SubmitCommandBufferBuilder::new();
         builder.submit(&queue).unwrap();
     }
@@ -310,7 +310,7 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let fence = Fence::new(device.clone(), Default::default()).unwrap();
+            let fence = Fence::new(device, Default::default()).unwrap();
             assert!(!fence.is_signaled().unwrap());
 
             let mut builder = SubmitCommandBufferBuilder::new();
@@ -325,9 +325,9 @@ mod tests {
     #[test]
     fn has_fence() {
         unsafe {
-            let (device, queue) = gfx_dev_and_queue!();
+            let (device, _queue) = gfx_dev_and_queue!();
 
-            let fence = Fence::new(device.clone(), Default::default()).unwrap();
+            let fence = Fence::new(device, Default::default()).unwrap();
 
             let mut builder = SubmitCommandBufferBuilder::new();
             assert!(!builder.has_fence());
@@ -342,7 +342,7 @@ mod tests {
             let (device, _) = gfx_dev_and_queue!();
 
             let fence1 = Fence::new(device.clone(), Default::default()).unwrap();
-            let fence2 = Fence::new(device.clone(), Default::default()).unwrap();
+            let fence2 = Fence::new(device, Default::default()).unwrap();
 
             let mut builder1 = SubmitCommandBufferBuilder::new();
             builder1.set_fence_signal(&fence1);

--- a/vulkano/src/command_buffer/submit/semaphores_wait.rs
+++ b/vulkano/src/command_buffer/submit/semaphores_wait.rs
@@ -46,12 +46,12 @@ impl<'a> SubmitSemaphoresWaitBuilder<'a> {
     }
 }
 
-impl<'a> Into<SubmitCommandBufferBuilder<'a>> for SubmitSemaphoresWaitBuilder<'a> {
+impl<'a> From<SubmitSemaphoresWaitBuilder<'a>> for SubmitCommandBufferBuilder<'a> {
     #[inline]
-    fn into(mut self) -> SubmitCommandBufferBuilder<'a> {
+    fn from(mut val: SubmitSemaphoresWaitBuilder<'a>) -> Self {
         unsafe {
             let mut builder = SubmitCommandBufferBuilder::new();
-            for sem in self.semaphores.drain(..) {
+            for sem in val.semaphores.drain(..) {
                 builder.add_wait_semaphore(
                     sem,
                     PipelineStages {
@@ -66,12 +66,12 @@ impl<'a> Into<SubmitCommandBufferBuilder<'a>> for SubmitSemaphoresWaitBuilder<'a
     }
 }
 
-impl<'a> Into<SubmitPresentBuilder<'a>> for SubmitSemaphoresWaitBuilder<'a> {
+impl<'a> From<SubmitSemaphoresWaitBuilder<'a>> for SubmitPresentBuilder<'a> {
     #[inline]
-    fn into(mut self) -> SubmitPresentBuilder<'a> {
+    fn from(mut val: SubmitSemaphoresWaitBuilder<'a>) -> Self {
         unsafe {
             let mut builder = SubmitPresentBuilder::new();
-            for sem in self.semaphores.drain(..) {
+            for sem in val.semaphores.drain(..) {
                 builder.add_wait_semaphore(sem);
             }
             builder

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -198,8 +198,8 @@ impl SyncCommandBufferBuilder {
     ) -> Result<(), SyncCommandBufferBuilderError> {
         let (resource_name, resource) = resource;
 
-        match resource {
-            &Resource::Buffer {
+        match *resource {
+            Resource::Buffer {
                 ref buffer,
                 ref range,
                 ref memory,
@@ -217,7 +217,7 @@ impl SyncCommandBufferBuilder {
                     });
                 }
             }
-            &Resource::Image {
+            Resource::Image {
                 ref image,
                 ref subresource_range,
                 ref memory,
@@ -266,7 +266,7 @@ impl SyncCommandBufferBuilder {
 
         let range_map = self.buffers2.get(inner.buffer)?;
 
-        for (range, state) in range_map
+        for (_range, state) in range_map
             .range(&range)
             .filter(|(_range, state)| !state.resource_uses.is_empty())
         {
@@ -297,7 +297,7 @@ impl SyncCommandBufferBuilder {
         mut subresource_range: ImageSubresourceRange,
         memory: &PipelineMemoryAccess,
         start_layout: ImageLayout,
-        end_layout: ImageLayout,
+        _end_layout: ImageLayout,
     ) -> Option<&ImageUse> {
         // Barriers work differently in render passes, so if we're in one, we can only insert a
         // barrier before the start of the render pass.
@@ -313,7 +313,7 @@ impl SyncCommandBufferBuilder {
         let range_map = self.images2.get(inner.image)?;
 
         for range in inner.image.iter_ranges(subresource_range) {
-            for (range, state) in range_map
+            for (_range, state) in range_map
                 .range(&range)
                 .filter(|(_range, state)| !state.resource_uses.is_empty())
             {
@@ -851,7 +851,7 @@ impl SyncCommandBufferBuilder {
             buffers2,
             images2,
             commands: self.commands,
-            barriers: self.barriers,
+            _barriers: self.barriers,
         })
     }
 }

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -100,7 +100,7 @@ pub struct SyncCommandBuffer {
 
     // Locations within commands that pipeline barriers were inserted. For debugging purposes.
     // TODO: present only in cfg(debug_assertions)?
-    barriers: Vec<usize>,
+    _barriers: Vec<usize>,
 
     // State of all the resources used by this command buffer.
     buffers2: HashMap<Arc<UnsafeBuffer>, RangeMap<DeviceSize, BufferFinalState>>,
@@ -311,7 +311,7 @@ impl SyncCommandBuffer {
         buffer: &UnsafeBuffer,
         range: Range<DeviceSize>,
         exclusive: bool,
-        queue: &Queue,
+        _queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
         let range_map = match self.buffers2.get(buffer) {
             Some(x) => x,
@@ -345,7 +345,7 @@ impl SyncCommandBuffer {
         range: Range<DeviceSize>,
         exclusive: bool,
         expected_layout: ImageLayout,
-        queue: &Queue,
+        _queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
         let range_map = match self.images2.get(image) {
             Some(x) => x,
@@ -556,7 +556,7 @@ mod tests {
                 .unwrap();
 
             SyncCommandBufferBuilder::new(
-                &pool_builder_alloc.inner(),
+                pool_builder_alloc.inner(),
                 CommandBufferBeginInfo {
                     usage: CommandBufferUsage::MultipleSubmit,
                     ..Default::default()
@@ -635,7 +635,7 @@ mod tests {
 
                 // Ensure that the builder added a barrier between the two writes
                 assert_eq!(&names, &["execute_commands", "execute_commands"]);
-                assert_eq!(&primary.barriers, &[0, 1]);
+                assert_eq!(&primary._barriers, &[0, 1]);
             }
 
             {
@@ -672,7 +672,7 @@ mod tests {
                 })
                 .unwrap();
             let mut sync = SyncCommandBufferBuilder::new(
-                &pool_builder_alloc.inner(),
+                pool_builder_alloc.inner(),
                 CommandBufferBeginInfo {
                     usage: CommandBufferUsage::MultipleSubmit,
                     ..Default::default()
@@ -705,7 +705,7 @@ mod tests {
                 })
                 .unwrap();
             let mut sync = SyncCommandBufferBuilder::new(
-                &pool_builder_alloc.inner(),
+                pool_builder_alloc.inner(),
                 CommandBufferBeginInfo {
                     usage: CommandBufferUsage::MultipleSubmit,
                     ..Default::default()
@@ -794,7 +794,7 @@ mod tests {
             .unwrap();
 
             let set = PersistentDescriptorSet::new(
-                set_layout.clone(),
+                set_layout,
                 [WriteDescriptorSet::sampler(
                     0,
                     Sampler::new(device, SamplerCreateInfo::simple_repeat_linear()).unwrap(),

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -101,7 +101,7 @@ impl UnsafeCommandBufferBuilder {
                         ..Default::default()
                     });
 
-                if let Some(flags) = inheritance_info.occlusion_query {
+                if let Some(flags) = occlusion_query {
                     inheritance_info_vk.occlusion_query_enable = ash::vk::TRUE;
 
                     if flags.precise {

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -387,7 +387,7 @@ where
             return Ok(SubmitAnyBuilder::Empty);
         }
 
-        return self.build_submission_impl();
+        self.build_submission_impl()
     }
 
     #[inline]
@@ -416,7 +416,7 @@ where
 
     #[inline]
     unsafe fn signal_finished(&self) {
-        if self.finished.swap(true, Ordering::SeqCst) == false {
+        if !self.finished.swap(true, Ordering::SeqCst) {
             self.command_buffer.unlock();
         }
 

--- a/vulkano/src/descriptor_set/collection.rs
+++ b/vulkano/src/descriptor_set/collection.rs
@@ -48,17 +48,10 @@ macro_rules! impl_collection {
                   $(, $others: Into<DescriptorSetWithOffsets>)*
         {
             #[inline]
+            #[allow(non_snake_case)]
             fn into_vec(self) -> Vec<DescriptorSetWithOffsets> {
-                #![allow(non_snake_case)]
-
                 let ($first, $($others,)*) = self;
-
-                let mut list = Vec::new();
-                list.push($first.into());
-                $(
-                    list.push($others.into());
-                )+
-                list
+                vec![$first.into() $(, $others.into())+]
             }
         }
 

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -81,7 +81,7 @@ impl DescriptorSetLayout {
         } = create_info;
 
         let mut descriptor_counts = HashMap::default();
-        for (&binding_num, binding) in bindings.iter() {
+        for binding in bindings.values() {
             if binding.descriptor_count != 0 {
                 *descriptor_counts
                     .entry(binding.descriptor_type)
@@ -699,18 +699,18 @@ impl DescriptorSetLayoutBinding {
         let DescriptorRequirements {
             descriptor_types,
             descriptor_count,
-            image_format,
-            image_multisampled,
-            image_scalar_type,
-            image_view_type,
-            sampler_compare,
-            sampler_no_unnormalized_coordinates,
-            sampler_no_ycbcr_conversion,
-            sampler_with_images,
+            image_format: _,
+            image_multisampled: _,
+            image_scalar_type: _,
+            image_view_type: _,
+            sampler_compare: _,
+            sampler_no_unnormalized_coordinates: _,
+            sampler_no_ycbcr_conversion: _,
+            sampler_with_images: _,
             stages,
-            storage_image_atomic,
-            storage_read,
-            storage_write,
+            storage_image_atomic: _,
+            storage_read: _,
+            storage_write: _,
         } = descriptor_requirements;
 
         if !descriptor_types.contains(&self.descriptor_type) {
@@ -786,7 +786,7 @@ impl fmt::Display for DescriptorRequirementsNotMet {
                 "the descriptor count ({}) is less than what is required ({})",
                 obtained, required
             ),
-            Self::ShaderStages { required, obtained } => write!(
+            Self::ShaderStages { .. } => write!(
                 fmt,
                 "the descriptor's shader stages do not contain the stages that are required",
             ),
@@ -869,7 +869,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let sl = DescriptorSetLayout::new(
-            device.clone(),
+            device,
             DescriptorSetLayoutCreateInfo {
                 bindings: [(
                     0,

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -148,9 +148,7 @@ impl Hash for dyn DescriptorSet {
 }
 
 pub(crate) struct DescriptorSetInner {
-    handle: ash::vk::DescriptorSet,
     layout: Arc<DescriptorSetLayout>,
-    variable_descriptor_count: u32,
     resources: DescriptorSetResources,
 }
 
@@ -225,20 +223,11 @@ impl DescriptorSetInner {
             );
         }
 
-        Ok(DescriptorSetInner {
-            handle,
-            layout,
-            variable_descriptor_count,
-            resources,
-        })
+        Ok(DescriptorSetInner { layout, resources })
     }
 
     pub(crate) fn layout(&self) -> &Arc<DescriptorSetLayout> {
         &self.layout
-    }
-
-    pub(crate) fn variable_descriptor_count(&self) -> u32 {
-        self.variable_descriptor_count
     }
 
     pub(crate) fn resources(&self) -> &DescriptorSetResources {
@@ -317,7 +306,7 @@ impl DescriptorSetResources {
     ///
     /// - Panics if the binding number of a write does not exist in the resources.
     /// - See also [`DescriptorBindingResources::update`].
-    pub fn update<'a>(&mut self, write: &WriteDescriptorSet) {
+    pub fn update(&mut self, write: &WriteDescriptorSet) {
         self.binding_resources
             .get_mut(&write.binding())
             .expect("descriptor write has invalid binding number")
@@ -460,13 +449,13 @@ impl DescriptorSetWithOffsets {
         }
 
         assert!(
-            !(dynamic_offsets.len() < dynamic_offset_index),
+            dynamic_offsets.len() >= dynamic_offset_index,
             "Too few dynamic offsets: got {}, expected {}",
             dynamic_offsets.len(),
             dynamic_offset_index
         );
         assert!(
-            !(dynamic_offsets.len() > dynamic_offset_index),
+            dynamic_offsets.len() <= dynamic_offset_index,
             "Too many dynamic offsets: got {}, expected {}",
             dynamic_offsets.len(),
             dynamic_offset_index
@@ -519,10 +508,10 @@ impl std::fmt::Display for DescriptorSetCreationError {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::DescriptorSetUpdateError(err) => {
+            Self::DescriptorSetUpdateError(_) => {
                 write!(f, "an error occurred while updating the descriptor set")
             }
-            Self::OomError(err) => write!(f, "out of memory"),
+            Self::OomError(_) => write!(f, "out of memory"),
         }
     }
 }

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -205,7 +205,7 @@ impl UnsafeDescriptorPool {
                 })
                 .unzip();
 
-        let output = if layouts.len() == 0 {
+        let output = if layouts.is_empty() {
             vec![]
         } else {
             let variable_desc_count_alloc_info = if (self.device.api_version() >= Version::V1_2
@@ -265,9 +265,7 @@ impl UnsafeDescriptorPool {
             output
         };
 
-        Ok(output
-            .into_iter()
-            .map(|handle| UnsafeDescriptorSet::new(handle)))
+        Ok(output.into_iter().map(UnsafeDescriptorSet::new))
     }
 
     /// Frees some descriptor sets.

--- a/vulkano/src/descriptor_set/single_layout_pool.rs
+++ b/vulkano/src/descriptor_set/single_layout_pool.rs
@@ -117,7 +117,7 @@ impl SingleLayoutDescSetPool {
 struct SingleLayoutPool {
     // The actual Vulkan descriptor pool. This field isn't actually used anywhere, but we need to
     // keep the pool alive in order to keep the descriptor sets valid.
-    inner: UnsafeDescriptorPool,
+    _inner: UnsafeDescriptorPool,
     // List of descriptor sets. When `alloc` is called, a descriptor will be extracted from this
     // list. When a `SingleLayoutPoolAlloc` is dropped, its descriptor set is put back in this list.
     reserve: ArrayQueue<UnsafeDescriptorSet>,
@@ -169,7 +169,10 @@ impl SingleLayoutPool {
             }
         };
 
-        Ok(Arc::new(Self { inner, reserve }))
+        Ok(Arc::new(Self {
+            _inner: inner,
+            reserve,
+        }))
     }
 }
 
@@ -372,7 +375,7 @@ impl SingleLayoutVariableDescSetPool {
 
         Ok(SingleLayoutVariablePoolAlloc {
             inner,
-            pool: self.inner.clone(),
+            _pool: self.inner.clone(),
         })
     }
 }
@@ -430,7 +433,7 @@ pub(crate) struct SingleLayoutVariablePoolAlloc {
     // The `SingleLayoutVariablePool` where we allocated from. We need to keep a copy of it in each
     // allocation so that we can put back the pool in the reserve once all allocations have been
     // dropped.
-    pool: Arc<SingleLayoutVariablePool>,
+    _pool: Arc<SingleLayoutVariablePool>,
 }
 
 unsafe impl Send for SingleLayoutVariablePoolAlloc {}

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -372,27 +372,6 @@ pub(crate) enum DescriptorWriteInfo {
     BufferView(SmallVec<[ash::vk::BufferView; 1]>),
 }
 
-impl DescriptorWriteInfo {
-    fn set_info(&self, write: &mut ash::vk::WriteDescriptorSet) {
-        match self {
-            DescriptorWriteInfo::Image(info) => {
-                write.descriptor_count = info.len() as u32;
-                write.p_image_info = info.as_ptr();
-            }
-            DescriptorWriteInfo::Buffer(info) => {
-                write.descriptor_count = info.len() as u32;
-                write.p_buffer_info = info.as_ptr();
-            }
-            DescriptorWriteInfo::BufferView(info) => {
-                write.descriptor_count = info.len() as u32;
-                write.p_texel_buffer_view = info.as_ptr();
-            }
-        }
-
-        debug_assert!(write.descriptor_count != 0);
-    }
-}
-
 pub(crate) fn check_descriptor_write<'a>(
     write: &WriteDescriptorSet,
     layout: &'a DescriptorSetLayout,
@@ -429,7 +408,7 @@ pub(crate) fn check_descriptor_write<'a>(
     }
 
     match elements {
-        WriteDescriptorSetElements::None(num_elements) => match layout_binding.descriptor_type {
+        WriteDescriptorSetElements::None(_num_elements) => match layout_binding.descriptor_type {
             DescriptorType::Sampler
                 if layout.push_descriptor() && !layout_binding.immutable_samplers.is_empty() => {}
             _ => {

--- a/vulkano/src/device/extensions.rs
+++ b/vulkano/src/device/extensions.rs
@@ -25,6 +25,6 @@ mod tests {
     #[test]
     fn empty_extensions() {
         let d: Vec<CString> = (&DeviceExtensions::none()).into();
-        assert!(d.iter().next().is_none());
+        assert!(d.get(0).is_none());
     }
 }

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -235,7 +235,7 @@ impl Device {
             // VUID-VkDeviceQueueCreateInfo-pQueuePriorities-00383
             assert!(queues
                 .iter()
-                .all(|&priority| priority >= 0.0 && priority <= 1.0));
+                .all(|&priority| (0.0..=1.0).contains(&priority)));
 
             if queues.len() > family.queues_count() {
                 return Err(DeviceCreationError::TooManyQueuesForFamily);
@@ -491,7 +491,7 @@ impl Device {
     /// > **Note**: Will return `-> impl ExactSizeIterator<Item = QueueFamily>` in the future.
     // TODO: ^
     #[inline]
-    pub fn active_queue_families<'a>(&'a self) -> impl ExactSizeIterator<Item = QueueFamily<'a>> {
+    pub fn active_queue_families(&self) -> impl ExactSizeIterator<Item = QueueFamily> {
         let physical_device = self.physical_device();
         self.active_queue_families
             .iter()
@@ -1058,7 +1058,7 @@ impl Queue {
 
     fn validate_begin_debug_utils_label(
         &self,
-        label_info: &mut DebugUtilsLabel,
+        _label_info: &mut DebugUtilsLabel,
     ) -> Result<(), DebugUtilsError> {
         if !self
             .device()
@@ -1151,7 +1151,7 @@ impl Queue {
 
     fn validate_insert_debug_utils_label(
         &self,
-        label_info: &mut DebugUtilsLabel,
+        _label_info: &mut DebugUtilsLabel,
     ) -> Result<(), DebugUtilsError> {
         if !self
             .device()
@@ -1246,7 +1246,7 @@ mod tests {
         };
 
         let family = physical.queue_families().next().unwrap();
-        let queues = (0..family.queues_count() + 1).map(|_| (family, 1.0));
+        let _queues = (0..family.queues_count() + 1).map(|_| (family, 1.0));
 
         match Device::new(
             physical,
@@ -1258,7 +1258,7 @@ mod tests {
                 ..Default::default()
             },
         ) {
-            Err(DeviceCreationError::TooManyQueuesForFamily) => return, // Success
+            Err(DeviceCreationError::TooManyQueuesForFamily) => (), // Success
             _ => panic!(),
         };
     }
@@ -1290,7 +1290,7 @@ mod tests {
             Err(DeviceCreationError::FeatureRestrictionNotMet(FeatureRestrictionError {
                 restriction: FeatureRestriction::NotSupported,
                 ..
-            })) => return, // Success
+            })) => (), // Success
             _ => panic!(),
         };
     }

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -68,10 +68,10 @@ pub(crate) fn init_physical_devices(
         }
     };
 
-    Ok(handles
+    handles
         .into_iter()
         .enumerate()
-        .map(|(index, handle)| -> Result<_, InstanceCreationError> {
+        .map(|(_index, handle)| -> Result<_, InstanceCreationError> {
             let api_version = unsafe {
                 let mut output = MaybeUninit::uninit();
                 (fns.v1_0.get_physical_device_properties)(handle, output.as_mut_ptr());
@@ -138,7 +138,7 @@ pub(crate) fn init_physical_devices(
 
             Ok(info)
         })
-        .collect::<Result<_, _>>()?)
+        .collect::<Result<_, _>>()
 }
 
 fn init_info(instance: &Instance, info: &mut PhysicalDeviceInfo) {
@@ -391,7 +391,7 @@ impl<'a> PhysicalDevice<'a> {
     /// ```
     #[inline]
     pub fn instance(&self) -> &'a Arc<Instance> {
-        &self.instance
+        self.instance
     }
 
     /// Returns the index of the physical device in the physical devices list.
@@ -1324,11 +1324,8 @@ impl<'a> PhysicalDevice<'a> {
             }
         };
 
-        debug_assert!(modes.len() > 0);
-        debug_assert!(modes
-            .iter()
-            .find(|&&m| m == ash::vk::PresentModeKHR::FIFO)
-            .is_some());
+        debug_assert!(!modes.is_empty());
+        debug_assert!(modes.iter().any(|&m| m == ash::vk::PresentModeKHR::FIFO));
 
         Ok(modes
             .into_iter()
@@ -1564,7 +1561,7 @@ impl<'a> QueueFamily<'a> {
     /// of `[width, height, depth]`
     #[inline]
     pub fn min_image_transfer_granularity(&self) -> [u32; 3] {
-        let ref granularity = self.properties.min_image_transfer_granularity;
+        let granularity = &self.properties.min_image_transfer_granularity;
         [granularity.width, granularity.height, granularity.depth]
     }
 
@@ -1809,7 +1806,7 @@ pub struct ShaderCoreProperties {}
 
 impl From<ash::vk::ShaderCorePropertiesFlagsAMD> for ShaderCoreProperties {
     #[inline]
-    fn from(val: ash::vk::ShaderCorePropertiesFlagsAMD) -> Self {
+    fn from(_val: ash::vk::ShaderCorePropertiesFlagsAMD) -> Self {
         Self {}
     }
 }

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -102,7 +102,10 @@ include!(concat!(env!("OUT_DIR"), "/formats.rs"));
 
 impl Format {
     /// Retrieves the properties of a format when used by a certain device.
-    #[deprecated(since = "0.28", note = "Use PhysicalDevice::format_properties instead")]
+    #[deprecated(
+        since = "0.28.0",
+        note = "Use PhysicalDevice::format_properties instead"
+    )]
     #[inline]
     pub fn properties(&self, physical_device: PhysicalDevice) -> FormatProperties {
         physical_device.format_properties(*self)

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -30,7 +30,7 @@ use std::{
     fs::File,
     hash::{Hash, Hasher},
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, Ordering},
         Arc,
     },
 };
@@ -72,9 +72,6 @@ pub struct AttachmentImage<A = PotentialDedicatedAllocation<StandardMemoryPoolAl
     // Memory used to back the image.
     memory: A,
 
-    // Format.
-    format: Format,
-
     // Layout to use when the image is used as a framebuffer attachment.
     // Must be either "depth-stencil optimal" or "color optimal".
     attachment_layout: ImageLayout,
@@ -82,9 +79,6 @@ pub struct AttachmentImage<A = PotentialDedicatedAllocation<StandardMemoryPoolAl
     // If true, then the image is in the layout of `attachment_layout` (above). If false, then it
     // is still `Undefined`.
     initialized: AtomicBool,
-
-    // Number of times this image is locked on the GPU side.
-    gpu_lock: AtomicUsize,
 }
 
 impl AttachmentImage {
@@ -464,14 +458,12 @@ impl AttachmentImage {
         Ok(Arc::new(AttachmentImage {
             image,
             memory,
-            format,
             attachment_layout: if is_depth {
                 ImageLayout::DepthStencilAttachmentOptimal
             } else {
                 ImageLayout::ColorAttachmentOptimal
             },
             initialized: AtomicBool::new(false),
-            gpu_lock: AtomicUsize::new(0),
         }))
     }
 
@@ -547,14 +539,12 @@ impl AttachmentImage {
         Ok(Arc::new(AttachmentImage {
             image,
             memory,
-            format,
             attachment_layout: if is_depth {
                 ImageLayout::DepthStencilAttachmentOptimal
             } else {
                 ImageLayout::ColorAttachmentOptimal
             },
             initialized: AtomicBool::new(false),
-            gpu_lock: AtomicUsize::new(0),
         }))
     }
 

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -38,7 +38,6 @@ use std::{
     error::Error,
     fmt,
     hash::{Hash, Hasher},
-    ops::Range,
     sync::Arc,
 };
 
@@ -49,8 +48,7 @@ use std::{
 pub struct ImmutableImage<A = PotentialDedicatedAllocation<StandardMemoryPoolAlloc>> {
     image: Arc<UnsafeImage>,
     dimensions: ImageDimensions,
-    memory: A,
-    format: Format,
+    _memory: A,
     layout: ImageLayout,
 }
 
@@ -66,7 +64,7 @@ fn generate_mipmaps<L>(
     cbb: &mut AutoCommandBufferBuilder<L>,
     image: Arc<dyn ImageAccess>,
     dimensions: ImageDimensions,
-    layout: ImageLayout,
+    _layout: ImageLayout,
 ) {
     for level in 1..image.mip_levels() {
         let src_size = dimensions
@@ -225,16 +223,13 @@ impl ImmutableImage {
 
         let image = Arc::new(ImmutableImage {
             image,
-            memory,
+            _memory: memory,
             dimensions,
-            format,
             layout,
         });
 
         let init = Arc::new(ImmutableImageInitialization {
             image: image.clone(),
-            mip_levels_access: 0..image.mip_levels(),
-            array_layers_access: 0..image.dimensions().array_layers(),
         });
 
         Ok((image, init))
@@ -414,8 +409,6 @@ where
 // Must not implement Clone, as that would lead to multiple `used` values.
 pub struct ImmutableImageInitialization<A = PotentialDedicatedAllocation<StandardMemoryPoolAlloc>> {
     image: Arc<ImmutableImage<A>>,
-    mip_levels_access: Range<u32>,
-    array_layers_access: Range<u32>,
 }
 
 unsafe impl<A> DeviceOwned for ImmutableImageInitialization<A> {

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -946,7 +946,7 @@ mod tests {
 
     #[test]
     fn mipmap_working_immutable_image() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
 
         let dimensions = ImageDimensions::Dim2d {
             width: 512,
@@ -978,7 +978,7 @@ mod tests {
                 dimensions,
                 MipmapsCount::Log2,
                 Format::R8_UNORM,
-                queue.clone(),
+                queue,
             )
             .unwrap();
             assert_eq!(image.mip_levels(), 10);

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -48,12 +48,6 @@ where
 
     // Dimensions of the image.
     dimensions: ImageDimensions,
-
-    // Format.
-    format: Format,
-
-    // Queue families allowed to access this image.
-    queue_families: SmallVec<[u32; 4]>,
 }
 
 impl StorageImage {
@@ -150,8 +144,6 @@ impl StorageImage {
             image,
             memory,
             dimensions,
-            format,
-            queue_families,
         }))
     }
 
@@ -196,7 +188,7 @@ impl StorageImage {
 
         let mem_reqs = image.memory_requirements();
         let memory = alloc_dedicated_with_exportable_fd(
-            device.clone(),
+            device,
             &mem_reqs,
             AllocLayout::Optimal,
             MappingRequirement::DoNotMap,
@@ -218,8 +210,6 @@ impl StorageImage {
             image,
             memory,
             dimensions,
-            format,
-            queue_families,
         }))
     }
 
@@ -376,7 +366,7 @@ mod tests {
 
     #[test]
     fn create_general_purpose_image_view() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
         let usage = ImageUsage {
             transfer_src: true,
             transfer_dst: true,
@@ -384,7 +374,7 @@ mod tests {
             ..ImageUsage::none()
         };
         let img_view = StorageImage::general_purpose_image_view(
-            queue.clone(),
+            queue,
             [32, 32],
             Format::R8G8B8A8_UNORM,
             usage,
@@ -395,14 +385,14 @@ mod tests {
 
     #[test]
     fn create_general_purpose_image_view_failed() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (_device, queue) = gfx_dev_and_queue!();
         // Not valid for image view...
         let usage = ImageUsage {
             transfer_src: true,
             ..ImageUsage::none()
         };
         let img_result = StorageImage::general_purpose_image_view(
-            queue.clone(),
+            queue,
             [32, 32],
             Format::R8G8B8A8_UNORM,
             usage,

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -45,10 +45,8 @@ impl<W> SwapchainImage<W> {
         swapchain: Arc<Swapchain<W>>,
         id: usize,
     ) -> Result<Arc<SwapchainImage<W>>, OomError> {
-        let image = swapchain.raw_image(id).unwrap();
-
         Ok(Arc::new(SwapchainImage {
-            swapchain: swapchain.clone(),
+            swapchain,
             image_offset: id,
         }))
     }

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -508,14 +508,13 @@ where
             ..Default::default()
         };
 
-        let mut sampler_ycbcr_conversion_info = if let Some(conversion) = sampler_ycbcr_conversion {
-            Some(ash::vk::SamplerYcbcrConversionInfo {
-                conversion: conversion.internal_object(),
-                ..Default::default()
-            })
-        } else {
-            None
-        };
+        let mut sampler_ycbcr_conversion_info =
+            sampler_ycbcr_conversion.as_ref().map(|conversion| {
+                ash::vk::SamplerYcbcrConversionInfo {
+                    conversion: conversion.internal_object(),
+                    ..Default::default()
+                }
+            });
 
         if let Some(sampler_ycbcr_conversion_info) = sampler_ycbcr_conversion_info.as_mut() {
             sampler_ycbcr_conversion_info.p_next = create_info.p_next;
@@ -811,7 +810,7 @@ impl fmt::Display for ImageViewCreationError {
     #[inline]
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
-            Self::OomError(err) => write!(
+            Self::OomError(_) => write!(
                 fmt,
                 "allocating memory failed",
             ),
@@ -854,7 +853,7 @@ impl fmt::Display for ImageViewCreationError {
                 fmt,
                 "the format requires a sampler YCbCr conversion, but none was provided",
             ),
-            Self::FormatUsageNotSupported { usage } => write!(
+            Self::FormatUsageNotSupported { .. } => write!(
                 fmt,
                 "a requested usage flag was not supported by the given format"
             ),

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -63,7 +63,7 @@ pub(super) type UserCallback = Arc<dyn Fn(&Message) + RefUnwindSafe + Send + Syn
 pub struct DebugUtilsMessenger {
     handle: ash::vk::DebugUtilsMessengerEXT,
     instance: Arc<Instance>,
-    user_callback: Box<UserCallback>,
+    _user_callback: Box<UserCallback>,
 }
 
 impl DebugUtilsMessenger {
@@ -86,7 +86,7 @@ impl DebugUtilsMessenger {
         Ok(DebugUtilsMessenger {
             handle,
             instance,
-            user_callback,
+            _user_callback: user_callback,
         })
     }
 
@@ -97,7 +97,7 @@ impl DebugUtilsMessenger {
         let &mut DebugUtilsMessengerCreateInfo {
             message_type,
             message_severity,
-            ref user_callback,
+            user_callback: _,
             _ne: _,
         } = create_info;
 
@@ -185,7 +185,7 @@ impl fmt::Debug for DebugUtilsMessenger {
         let Self {
             handle,
             instance,
-            user_callback: _,
+            _user_callback: _,
         } = self;
 
         f.debug_struct("DebugUtilsMessenger")

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -27,6 +27,6 @@ mod tests {
     #[test]
     fn empty_extensions() {
         let i: Vec<CString> = (&InstanceExtensions::none()).into();
-        assert!(i.iter().next().is_none());
+        assert!(i.get(0).is_none());
     }
 }

--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -118,11 +118,11 @@ mod tests {
             Err(_) => return,
         };
 
-        let mut list = match library.layer_properties() {
+        let list = match library.layer_properties() {
             Ok(l) => l,
             Err(_) => return,
         };
 
-        while let Some(_) = list.next() {}
+        for _ in list {}
     }
 }

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -241,7 +241,7 @@ pub struct Instance {
     enabled_layers: Vec<String>,
     library: Arc<VulkanLibrary>,
     max_api_version: Version,
-    user_callbacks: Vec<Box<UserCallback>>,
+    _user_callbacks: Vec<Box<UserCallback>>,
 }
 
 // TODO: fix the underlying cause instead
@@ -323,7 +323,7 @@ impl Instance {
         }
 
         // Check if the extensions are correct
-        enabled_extensions.check_requirements(&supported_extensions, api_version)?;
+        enabled_extensions.check_requirements(supported_extensions, api_version)?;
 
         // FIXME: check whether each layer is supported
         let enabled_layers_cstr: Vec<CString> = enabled_layers
@@ -453,7 +453,7 @@ impl Instance {
             enabled_layers,
             library,
             max_api_version,
-            user_callbacks,
+            _user_callbacks: user_callbacks,
         };
 
         // Enumerating all physical devices.
@@ -550,7 +550,7 @@ impl fmt::Debug for Instance {
             enabled_layers,
             library: function_pointers,
             max_api_version,
-            user_callbacks: _,
+            _user_callbacks: _,
         } = self;
 
         f.debug_struct("Instance")

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -62,8 +62,24 @@
 //!
 
 //#![warn(missing_docs)]        // TODO: activate
-#![allow(dead_code)] // TODO: remove
-#![allow(unused_variables)] // TODO: remove
+
+// These lints are a bit too pedantic, so they're disabled here.
+#![allow(
+    clippy::collapsible_else_if,
+    clippy::collapsible_if,
+    clippy::large_enum_variant,
+    clippy::len_without_is_empty,
+    clippy::missing_safety_doc, // TODO: remove
+    clippy::module_inception,
+    clippy::mutable_key_type,
+    clippy::new_without_default,
+    clippy::nonminimal_bool,
+    clippy::op_ref, // Seems to be bugged, the fixed code triggers a compile error
+    clippy::too_many_arguments,
+    clippy::type_complexity,
+    clippy::vec_box,
+    clippy::wrong_self_convention
+)]
 
 pub use ash::vk::Handle;
 pub use half;

--- a/vulkano/src/library.rs
+++ b/vulkano/src/library.rs
@@ -264,14 +264,14 @@ where
 
 impl fmt::Debug for dyn Loader {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Ok(())
     }
 }
 
 /// Implementation of `Loader` that loads Vulkan from a dynamic library.
 pub struct DynamicLibraryLoader {
-    vk_lib: Library,
+    _vk_lib: Library,
     get_instance_proc_addr: ash::vk::PFN_vkGetInstanceProcAddr,
 }
 
@@ -294,7 +294,7 @@ impl DynamicLibraryLoader {
             .map_err(LoadingError::LibraryLoadFailure)?;
 
         Ok(DynamicLibraryLoader {
-            vk_lib,
+            _vk_lib: vk_lib,
             get_instance_proc_addr,
         })
     }

--- a/vulkano/src/memory/pool/host_visible.rs
+++ b/vulkano/src/memory/pool/host_visible.rs
@@ -52,7 +52,7 @@ impl StandardHostVisibleMemoryTypePool {
         assert!(memory_type.is_host_visible());
 
         Arc::new(StandardHostVisibleMemoryTypePool {
-            device: device.clone(),
+            device,
             memory_type: memory_type.id(),
             occupied: Mutex::new(Vec::new()),
         })

--- a/vulkano/src/memory/pool/mod.rs
+++ b/vulkano/src/memory/pool/mod.rs
@@ -60,8 +60,7 @@ where
         first_loop
             .chain(second_loop)
             .filter(|&(t, _)| (requirements.memory_type_bits & (1 << t.id())) != 0)
-            .filter(|&(t, rq)| filter(t) == rq)
-            .next()
+            .find(|&(t, rq)| filter(t) == rq)
             .expect("Couldn't find a memory type to allocate from")
             .0
     };
@@ -73,7 +72,7 @@ where
 pub(crate) fn alloc_dedicated_with_exportable_fd<F>(
     device: Arc<Device>,
     requirements: &MemoryRequirements,
-    layout: AllocLayout,
+    _layout: AllocLayout,
     map: MappingRequirement,
     dedicated_allocation: DedicatedAllocation,
     filter: F,

--- a/vulkano/src/memory/pool/non_host_visible.rs
+++ b/vulkano/src/memory/pool/non_host_visible.rs
@@ -47,7 +47,7 @@ impl StandardNonHostVisibleMemoryTypePool {
         );
 
         Arc::new(StandardNonHostVisibleMemoryTypePool {
-            device: device.clone(),
+            device,
             memory_type: memory_type.id(),
             occupied: Mutex::new(Vec::new()),
         })

--- a/vulkano/src/memory/pool/pool.rs
+++ b/vulkano/src/memory/pool/pool.rs
@@ -40,7 +40,7 @@ impl StandardMemoryPool {
         let cap = device.physical_device().memory_types().len();
 
         Arc::new(StandardMemoryPool {
-            device: device.clone(),
+            device,
             pools: Mutex::new(HashMap::with_capacity(cap)),
         })
     }
@@ -60,21 +60,21 @@ fn generic_allocation(
     assert!(memory_type_host_visible || map == MappingRequirement::DoNotMap);
 
     match pools.entry((memory_type.id(), layout, map)) {
-        Entry::Occupied(entry) => match entry.get() {
-            &Pool::HostVisible(ref pool) => {
+        Entry::Occupied(entry) => match *entry.get() {
+            Pool::HostVisible(ref pool) => {
                 let alloc = pool.alloc(size, alignment)?;
                 let inner = StandardMemoryPoolAllocInner::HostVisible(alloc);
                 Ok(StandardMemoryPoolAlloc {
                     inner,
-                    pool: mem_pool.clone(),
+                    _pool: mem_pool.clone(),
                 })
             }
-            &Pool::NonHostVisible(ref pool) => {
+            Pool::NonHostVisible(ref pool) => {
                 let alloc = pool.alloc(size, alignment)?;
                 let inner = StandardMemoryPoolAllocInner::NonHostVisible(alloc);
                 Ok(StandardMemoryPoolAlloc {
                     inner,
-                    pool: mem_pool.clone(),
+                    _pool: mem_pool.clone(),
                 })
             }
         },
@@ -88,7 +88,7 @@ fn generic_allocation(
                 let inner = StandardMemoryPoolAllocInner::HostVisible(alloc);
                 Ok(StandardMemoryPoolAlloc {
                     inner,
-                    pool: mem_pool.clone(),
+                    _pool: mem_pool.clone(),
                 })
             } else {
                 let pool =
@@ -98,7 +98,7 @@ fn generic_allocation(
                 let inner = StandardMemoryPoolAllocInner::NonHostVisible(alloc);
                 Ok(StandardMemoryPoolAlloc {
                     inner,
-                    pool: mem_pool.clone(),
+                    _pool: mem_pool.clone(),
                 })
             }
         }
@@ -136,7 +136,7 @@ enum Pool {
 #[derive(Debug)]
 pub struct StandardMemoryPoolAlloc {
     inner: StandardMemoryPoolAllocInner,
-    pool: Arc<StandardMemoryPool>,
+    _pool: Arc<StandardMemoryPool>,
 }
 
 impl StandardMemoryPoolAlloc {

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -127,7 +127,7 @@ impl PipelineCache {
 
         Ok(Arc::new(PipelineCache {
             device: device.clone(),
-            cache: cache,
+            cache,
         }))
     }
 
@@ -151,7 +151,7 @@ impl PipelineCache {
             let pipelines = pipelines
                 .into_iter()
                 .map(|pipeline| {
-                    assert!(&***pipeline as *const _ != &*self as *const _);
+                    assert!(&***pipeline as *const _ != self as *const _);
                     pipeline.cache
                 })
                 .collect::<Vec<_>>();
@@ -264,11 +264,10 @@ mod tests {
         pipeline::{cache::PipelineCache, ComputePipeline},
         shader::ShaderModule,
     };
-    use std::sync::Arc;
 
     #[test]
     fn merge_self_forbidden() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
         let pipeline = PipelineCache::empty(device).unwrap();
         assert_should_panic!({
             pipeline.merge(&[&pipeline]).unwrap();
@@ -277,7 +276,7 @@ mod tests {
 
     #[test]
     fn cache_returns_same_data() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let cache = PipelineCache::empty(device.clone()).unwrap();
 
@@ -300,16 +299,14 @@ mod tests {
             ShaderModule::from_bytes(device.clone(), &MODULE).unwrap()
         };
 
-        let pipeline = Arc::new(
-            ComputePipeline::new(
-                device.clone(),
-                module.entry_point("main").unwrap(),
-                &(),
-                Some(cache.clone()),
-                |_| {},
-            )
-            .unwrap(),
-        );
+        let _pipeline = ComputePipeline::new(
+            device,
+            module.entry_point("main").unwrap(),
+            &(),
+            Some(cache.clone()),
+            |_| {},
+        )
+        .unwrap();
 
         let cache_data = cache.get_data().unwrap();
         let second_data = cache.get_data().unwrap();
@@ -319,7 +316,7 @@ mod tests {
 
     #[test]
     fn cache_returns_different_data() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let cache = PipelineCache::empty(device.clone()).unwrap();
 
@@ -373,29 +370,25 @@ mod tests {
             ShaderModule::from_bytes(device.clone(), &SECOND_MODULE).unwrap()
         };
 
-        let pipeline = Arc::new(
-            ComputePipeline::new(
-                device.clone(),
-                first_module.entry_point("main").unwrap(),
-                &(),
-                Some(cache.clone()),
-                |_| {},
-            )
-            .unwrap(),
-        );
+        let _pipeline = ComputePipeline::new(
+            device.clone(),
+            first_module.entry_point("main").unwrap(),
+            &(),
+            Some(cache.clone()),
+            |_| {},
+        )
+        .unwrap();
 
         let cache_data = cache.get_data().unwrap();
 
-        let second_pipeline = Arc::new(
-            ComputePipeline::new(
-                device.clone(),
-                second_module.entry_point("main").unwrap(),
-                &(),
-                Some(cache.clone()),
-                |_| {},
-            )
-            .unwrap(),
-        );
+        let _second_pipeline = ComputePipeline::new(
+            device,
+            second_module.entry_point("main").unwrap(),
+            &(),
+            Some(cache.clone()),
+            |_| {},
+        )
+        .unwrap();
 
         let second_data = cache.get_data().unwrap();
 
@@ -408,7 +401,7 @@ mod tests {
 
     #[test]
     fn cache_data_does_not_change() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let cache = PipelineCache::empty(device.clone()).unwrap();
 
@@ -431,29 +424,25 @@ mod tests {
             ShaderModule::from_bytes(device.clone(), &MODULE).unwrap()
         };
 
-        let pipeline = Arc::new(
-            ComputePipeline::new(
-                device.clone(),
-                module.entry_point("main").unwrap(),
-                &(),
-                Some(cache.clone()),
-                |_| {},
-            )
-            .unwrap(),
-        );
+        let _pipeline = ComputePipeline::new(
+            device.clone(),
+            module.entry_point("main").unwrap(),
+            &(),
+            Some(cache.clone()),
+            |_| {},
+        )
+        .unwrap();
 
         let cache_data = cache.get_data().unwrap();
 
-        let second_pipeline = Arc::new(
-            ComputePipeline::new(
-                device.clone(),
-                module.entry_point("main").unwrap(),
-                &(),
-                Some(cache.clone()),
-                |_| {},
-            )
-            .unwrap(),
-        );
+        let _second_pipeline = ComputePipeline::new(
+            device,
+            module.entry_point("main").unwrap(),
+            &(),
+            Some(cache.clone()),
+            |_| {},
+        )
+        .unwrap();
 
         let second_data = cache.get_data().unwrap();
 

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -512,8 +512,8 @@ mod tests {
             .unwrap();
         let cb = cbb.build().unwrap();
 
-        let future = now(device.clone())
-            .then_execute(queue.clone(), cb)
+        let future = now(device)
+            .then_execute(queue, cb)
             .unwrap()
             .then_signal_fence_and_flush()
             .unwrap();

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -123,7 +123,7 @@ pub struct GraphicsPipeline {
 impl GraphicsPipeline {
     /// Starts the building process of a graphics pipeline. Returns a builder object that you can
     /// fill with the various parameters.
-    pub fn start<'a>() -> GraphicsPipelineBuilder<
+    pub fn start() -> GraphicsPipelineBuilder<
         'static,
         'static,
         'static,

--- a/vulkano/src/pipeline/graphics/render_pass.rs
+++ b/vulkano/src/pipeline/graphics/render_pass.rs
@@ -7,7 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::GraphicsPipelineCreationError;
 use crate::{format::Format, render_pass::Subpass};
 
 /// Selects the type of render pass that a graphics pipeline is created for.
@@ -78,11 +77,5 @@ impl Default for PipelineRenderingCreateInfo {
             stencil_attachment_format: None,
             _ne: crate::NonExhaustive(()),
         }
-    }
-}
-
-impl PipelineRenderingCreateInfo {
-    pub(super) fn validate(&self) -> Result<(), GraphicsPipelineCreationError> {
-        Ok(())
     }
 }

--- a/vulkano/src/pipeline/graphics/vertex_input/collection.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/collection.rs
@@ -56,18 +56,10 @@ macro_rules! impl_collection {
                   $(, $others: BufferAccessObject)*
         {
             #[inline]
+            #[allow(non_snake_case)]
             fn into_vec(self) -> Vec<Arc<dyn BufferAccess>> {
-                #![allow(non_snake_case)]
-
                 let ($first, $($others,)*) = self;
-                let mut list = Vec::new();
-                list.push($first.as_buffer_access_object());
-
-                $(
-                    list.push($others.as_buffer_access_object());
-                )+
-
-                list
+                vec![$first.as_buffer_access_object() $(, $others.as_buffer_access_object())+]
             }
         }
 
@@ -166,12 +158,9 @@ mod tests {
         takes_collection(vec![dynamic_a.clone(), concrete_b.clone()]);
 
         // Arrays are similar to Vecs
-        takes_collection([concrete_a.clone(), concrete_aa.clone()]);
+        takes_collection([concrete_a.clone(), concrete_aa]);
         takes_collection([dynamic_a.clone(), dynamic_b.clone()]);
-        takes_collection([
-            concrete_a.clone() as Arc<dyn BufferAccess>,
-            concrete_b.clone(),
-        ]);
-        takes_collection([dynamic_a.clone(), concrete_b.clone()]);
+        takes_collection([concrete_a as Arc<dyn BufferAccess>, concrete_b.clone()]);
+        takes_collection([dynamic_a.clone(), concrete_b]);
     }
 }

--- a/vulkano/src/pipeline/graphics/vertex_input/definition.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/definition.rs
@@ -71,7 +71,7 @@ pub unsafe trait VertexDefinition {
 unsafe impl VertexDefinition for VertexInputState {
     fn definition(
         &self,
-        interface: &ShaderInterface,
+        _interface: &ShaderInterface,
     ) -> Result<VertexInputState, IncompatibleVertexDefinitionError> {
         Ok(self.clone())
     }

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -244,7 +244,7 @@ impl PipelineLayout {
 
                 if set_layout.push_descriptor() {
                     // VUID-VkPipelineLayoutCreateInfo-pSetLayouts-00293
-                    if let Some(num) = push_descriptor_set {
+                    if push_descriptor_set.is_some() {
                         return Err(PipelineLayoutCreationError::SetLayoutsPushDescriptorMultiple);
                     } else {
                         push_descriptor_set = Some(set_num);

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -117,12 +117,12 @@ impl QueryPool {
             query_count,
             _ne: _,
         } = create_info;
-        return Arc::new(QueryPool {
+        Arc::new(QueryPool {
             handle,
             device,
             query_type,
             query_count,
-        });
+        })
     }
 
     /// Returns the query type of the pool.
@@ -306,7 +306,7 @@ impl<'a> Query<'a> {
     /// Returns a reference to the query pool.
     #[inline]
     pub fn pool(&self) -> &'a QueryPool {
-        &self.pool
+        self.pool
     }
 
     /// Returns the index of the query represented.
@@ -329,7 +329,7 @@ impl<'a> QueriesRange<'a> {
     /// Returns a reference to the query pool.
     #[inline]
     pub fn pool(&self) -> &'a QueryPool {
-        &self.pool
+        self.pool
     }
 
     /// Returns the range of queries represented.

--- a/vulkano/src/range_map.rs
+++ b/vulkano/src/range_map.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::{
     cmp,
     cmp::Ordering,
@@ -72,13 +74,13 @@ where
 
     /// Returns `true` if any part of the provided range overlaps with a range in the map.
     #[inline]
-    pub fn contains_any<'a>(&self, range: &'a Range<K>) -> bool {
+    pub fn contains_any(&self, range: &Range<K>) -> bool {
         self.range(range).next().is_some()
     }
 
     /// Returns `true` if all of the provided range is covered by ranges in the map.
     #[inline]
-    pub fn contains_all<'a>(&self, range: &'a Range<K>) -> bool {
+    pub fn contains_all(&self, range: &Range<K>) -> bool {
         self.gaps(range).next().is_none()
     }
 

--- a/vulkano/src/render_pass/create.rs
+++ b/vulkano/src/render_pass/create.rs
@@ -46,11 +46,11 @@ impl RenderPass {
         for (atch_num, attachment) in attachments.iter().enumerate() {
             let &AttachmentDescription {
                 format,
-                samples,
-                load_op,
-                store_op,
-                stencil_load_op,
-                stencil_store_op,
+                samples: _,
+                load_op: _,
+                store_op: _,
+                stencil_load_op: _,
+                stencil_store_op: _,
                 initial_layout,
                 final_layout,
                 _ne: _,
@@ -175,17 +175,17 @@ impl RenderPass {
             // Common checks for all attachment types
             let mut check_attachment = |atch_ref: &AttachmentReference| {
                 // VUID-VkRenderPassCreateInfo2-attachment-03051
-                let atch = attachments
-                    .get(atch_ref.attachment as usize)
-                    .ok_or_else(|| RenderPassCreationError::SubpassAttachmentOutOfRange {
+                let atch = attachments.get(atch_ref.attachment as usize).ok_or(
+                    RenderPassCreationError::SubpassAttachmentOutOfRange {
                         subpass: subpass_num,
                         attachment: atch_ref.attachment,
-                    })?;
+                    },
+                )?;
 
                 // VUID-VkSubpassDescription2-layout-02528
                 match &mut layouts[atch_ref.attachment as usize] {
                     Some(layout) if *layout == atch_ref.layout => (),
-                    Some(layout) => {
+                    Some(_) => {
                         return Err(RenderPassCreationError::SubpassAttachmentLayoutMismatch {
                             subpass: subpass_num,
                             attachment: atch_ref.attachment,
@@ -486,7 +486,7 @@ impl RenderPass {
                 }
 
                 // VUID-VkSubpassDescription2-pResolveAttachments-03065
-                let color_atch_ref = color_atch_ref.ok_or_else(|| {
+                let color_atch_ref = color_atch_ref.ok_or({
                     RenderPassCreationError::SubpassResolveAttachmentWithoutColorAttachment {
                         subpass: subpass_num,
                     }
@@ -732,6 +732,7 @@ impl RenderPass {
                                 ..
                             } = *source_stages;
 
+                            #[allow(clippy::identity_op)]
                             [
                                 draw_indirect as u8 * 1,
                                 // index_input as u8 * 2,
@@ -772,6 +773,7 @@ impl RenderPass {
                                 ..
                             } = *destination_stages;
 
+                            #[allow(clippy::identity_op)]
                             [
                                 draw_indirect as u8 * 1,
                                 // index_input as u8 * 2,
@@ -933,17 +935,14 @@ impl RenderPass {
             let out: SmallVec<[_; 4]> = subpasses
                 .iter()
                 .map(|subpass| {
-                    let input_attachments =
-                        attachment_references_vk.as_ptr().offset(ref_index as isize);
+                    let input_attachments = attachment_references_vk.as_ptr().add(ref_index);
                     ref_index += subpass.input_attachments.len();
-                    let color_attachments =
-                        attachment_references_vk.as_ptr().offset(ref_index as isize);
+                    let color_attachments = attachment_references_vk.as_ptr().add(ref_index);
                     ref_index += subpass.color_attachments.len();
-                    let resolve_attachments =
-                        attachment_references_vk.as_ptr().offset(ref_index as isize);
+                    let resolve_attachments = attachment_references_vk.as_ptr().add(ref_index);
                     ref_index += subpass.resolve_attachments.len();
                     let depth_stencil = if subpass.depth_stencil_attachment.is_some() {
-                        let a = attachment_references_vk.as_ptr().offset(ref_index as isize);
+                        let a = attachment_references_vk.as_ptr().add(ref_index);
                         ref_index += 1;
                         a
                     } else {
@@ -1132,17 +1131,14 @@ impl RenderPass {
             let out: SmallVec<[_; 4]> = subpasses
                 .iter()
                 .map(|subpass| {
-                    let input_attachments =
-                        attachment_references_vk.as_ptr().offset(ref_index as isize);
+                    let input_attachments = attachment_references_vk.as_ptr().add(ref_index);
                     ref_index += subpass.input_attachments.len();
-                    let color_attachments =
-                        attachment_references_vk.as_ptr().offset(ref_index as isize);
+                    let color_attachments = attachment_references_vk.as_ptr().add(ref_index);
                     ref_index += subpass.color_attachments.len();
-                    let resolve_attachments =
-                        attachment_references_vk.as_ptr().offset(ref_index as isize);
+                    let resolve_attachments = attachment_references_vk.as_ptr().add(ref_index);
                     ref_index += subpass.resolve_attachments.len();
                     let depth_stencil = if subpass.depth_stencil_attachment.is_some() {
-                        let a = attachment_references_vk.as_ptr().offset(ref_index as isize);
+                        let a = attachment_references_vk.as_ptr().add(ref_index);
                         ref_index += 1;
                         a
                     } else {

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -753,7 +753,7 @@ mod tests {
         .unwrap();
 
         let view = ImageView::new_default(
-            AttachmentImage::new(device.clone(), [1024, 768], Format::R8G8B8A8_UNORM).unwrap(),
+            AttachmentImage::new(device, [1024, 768], Format::R8G8B8A8_UNORM).unwrap(),
         )
         .unwrap();
         let _ = Framebuffer::new(
@@ -820,7 +820,7 @@ mod tests {
         .unwrap();
 
         let view = ImageView::new_default(
-            AttachmentImage::new(device.clone(), [1024, 768], Format::R8_UNORM).unwrap(),
+            AttachmentImage::new(device, [1024, 768], Format::R8_UNORM).unwrap(),
         )
         .unwrap();
 
@@ -859,7 +859,7 @@ mod tests {
         .unwrap();
 
         let view = ImageView::new_default(
-            AttachmentImage::new(device.clone(), [600, 600], Format::R8G8B8A8_UNORM).unwrap(),
+            AttachmentImage::new(device, [600, 600], Format::R8G8B8A8_UNORM).unwrap(),
         )
         .unwrap();
 
@@ -896,7 +896,7 @@ mod tests {
         .unwrap();
 
         let view = ImageView::new_default(
-            AttachmentImage::new(device.clone(), [512, 700], Format::R8G8B8A8_UNORM).unwrap(),
+            AttachmentImage::new(device, [512, 700], Format::R8G8B8A8_UNORM).unwrap(),
         )
         .unwrap();
 
@@ -945,7 +945,7 @@ mod tests {
         )
         .unwrap();
         let b = ImageView::new_default(
-            AttachmentImage::new(device.clone(), [512, 128], Format::R8G8B8A8_UNORM).unwrap(),
+            AttachmentImage::new(device, [512, 128], Format::R8G8B8A8_UNORM).unwrap(),
         )
         .unwrap();
 
@@ -991,7 +991,7 @@ mod tests {
         .unwrap();
 
         let view = ImageView::new_default(
-            AttachmentImage::new(device.clone(), [256, 512], Format::R8G8B8A8_UNORM).unwrap(),
+            AttachmentImage::new(device, [256, 512], Format::R8G8B8A8_UNORM).unwrap(),
         )
         .unwrap();
 
@@ -1037,7 +1037,7 @@ mod tests {
         )
         .unwrap();
         let b = ImageView::new_default(
-            AttachmentImage::new(device.clone(), [256, 512], Format::R8G8B8A8_UNORM).unwrap(),
+            AttachmentImage::new(device, [256, 512], Format::R8G8B8A8_UNORM).unwrap(),
         )
         .unwrap();
 

--- a/vulkano/src/render_pass/macros.rs
+++ b/vulkano/src/render_pass/macros.rs
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn single_pass_resolve() {
         let (device, _) = gfx_dev_and_queue!();
-        let _ = single_pass_renderpass!(device.clone(),
+        let _ = single_pass_renderpass!(device,
             attachments: {
                 a: {
                     load: Clear,

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -182,7 +182,6 @@ impl RenderPass {
     pub unsafe fn from_handle(
         handle: ash::vk::RenderPass,
         create_info: RenderPassCreateInfo,
-        granularity: [u32; 2],
         device: Arc<Device>,
     ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
         let views_used = create_info
@@ -495,7 +494,7 @@ impl RenderPass {
                     _ => return false,
                 };
 
-                let attachment_desc = &self.attachments[attachment_id as usize];
+                let _attachment_desc = &self.attachments[attachment_id as usize];
 
                 // FIXME: compare formats depending on the number of components and data type
                 /*if attachment_desc.format != element.format {
@@ -1248,7 +1247,7 @@ mod tests {
         }
 
         let rp = single_pass_renderpass! {
-            device.clone(),
+            device,
             attachments: {
                 a1: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
                 a2: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
@@ -1278,7 +1277,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let rp = single_pass_renderpass! {
-            device.clone(),
+            device,
             attachments: {
                 a: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, }
             },

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -198,8 +198,8 @@ impl Sampler {
                 .any(|filter| filter == Filter::Cubic)
             {
                 return Err(SamplerCreationError::AnisotropyInvalidFilter {
-                    mag_filter: mag_filter,
-                    min_filter: min_filter,
+                    mag_filter,
+                    min_filter,
                 });
             }
 
@@ -235,12 +235,10 @@ impl Sampler {
             }
 
             if lod != (0.0..=0.0) {
-                return Err(SamplerCreationError::UnnormalizedCoordinatesNonzeroLod {
-                    lod: lod.clone(),
-                });
+                return Err(SamplerCreationError::UnnormalizedCoordinatesNonzeroLod { lod });
             }
 
-            if address_mode[0..2].into_iter().any(|mode| {
+            if address_mode[0..2].iter().any(|mode| {
                 !matches!(
                     mode,
                     SamplerAddressMode::ClampToEdge | SamplerAddressMode::ClampToBorder
@@ -366,7 +364,7 @@ impl Sampler {
             address_mode_u: address_mode[0].into(),
             address_mode_v: address_mode[1].into(),
             address_mode_w: address_mode[2].into(),
-            mip_lod_bias: mip_lod_bias,
+            mip_lod_bias,
             anisotropy_enable,
             max_anisotropy,
             compare_enable,
@@ -1491,7 +1489,7 @@ mod tests {
 
     #[test]
     fn create_regular() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let s = Sampler::new(
             device,
@@ -1505,13 +1503,13 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(!s.compare().is_some());
+        assert!(s.compare().is_none());
         assert!(!s.unnormalized_coordinates());
     }
 
     #[test]
     fn create_compare() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let s = Sampler::new(
             device,
@@ -1532,7 +1530,7 @@ mod tests {
 
     #[test]
     fn create_unnormalized() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let s = Sampler::new(
             device,
@@ -1544,25 +1542,25 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(!s.compare().is_some());
+        assert!(s.compare().is_none());
         assert!(s.unnormalized_coordinates());
     }
 
     #[test]
     fn simple_repeat_linear() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
         let _ = Sampler::new(device, SamplerCreateInfo::simple_repeat_linear());
     }
 
     #[test]
     fn simple_repeat_linear_no_mipmap() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
         let _ = Sampler::new(device, SamplerCreateInfo::simple_repeat_linear_no_mipmap());
     }
 
     #[test]
     fn min_lod_inferior() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         assert_should_panic!({
             let _ = Sampler::new(
@@ -1581,7 +1579,7 @@ mod tests {
 
     #[test]
     fn max_anisotropy() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         assert_should_panic!({
             let _ = Sampler::new(
@@ -1601,7 +1599,7 @@ mod tests {
 
     #[test]
     fn anisotropy_feature() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let r = Sampler::new(
             device,
@@ -1627,7 +1625,7 @@ mod tests {
 
     #[test]
     fn anisotropy_limit() {
-        let (device, queue) = gfx_dev_and_queue!(sampler_anisotropy);
+        let (device, _queue) = gfx_dev_and_queue!(sampler_anisotropy);
 
         let r = Sampler::new(
             device,
@@ -1650,7 +1648,7 @@ mod tests {
 
     #[test]
     fn mip_lod_bias_limit() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let r = Sampler::new(
             device,
@@ -1672,7 +1670,7 @@ mod tests {
 
     #[test]
     fn sampler_mirror_clamp_to_edge_extension() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let r = Sampler::new(
             device,
@@ -1703,7 +1701,7 @@ mod tests {
 
     #[test]
     fn sampler_filter_minmax_extension() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let r = Sampler::new(
             device,

--- a/vulkano/src/sampler/ycbcr.rs
+++ b/vulkano/src/sampler/ycbcr.rs
@@ -475,7 +475,7 @@ impl Hash for SamplerYcbcrConversion {
 }
 
 /// Error that can happen when creating a `SamplerYcbcrConversion`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SamplerYcbcrConversionCreationError {
     /// Not enough memory.
     OomError(OomError),
@@ -765,7 +765,7 @@ mod tests {
 
     #[test]
     fn feature_not_enabled() {
-        let (device, queue) = gfx_dev_and_queue!();
+        let (device, _queue) = gfx_dev_and_queue!();
 
         let r = SamplerYcbcrConversion::new(device, Default::default());
 

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -164,7 +164,7 @@ impl ShaderModule {
         let entries = entry_points.into_iter().collect::<Vec<_>>();
         let entry_points = entries
             .iter()
-            .filter_map(|(name, _, _)| Some(name))
+            .map(|(name, _, _)| name)
             .collect::<HashSet<_>>()
             .iter()
             .map(|name| {
@@ -607,7 +607,7 @@ impl DescriptorRequirements {
             .descriptor_types
             .iter()
             .copied()
-            .filter(|ty| other.descriptor_types.contains(&ty))
+            .filter(|ty| other.descriptor_types.contains(ty))
             .collect();
 
         if descriptor_types.is_empty() {

--- a/vulkano/src/shader/spirv.rs
+++ b/vulkano/src/shader/spirv.rs
@@ -396,7 +396,7 @@ impl Spirv {
     /// - Panics if `id` is not defined in this module. This can in theory only happpen if you are
     ///   mixing `Id`s from different modules.
     #[inline]
-    pub fn id<'a>(&'a self, id: Id) -> IdInfo<'a> {
+    pub fn id(&self, id: Id) -> IdInfo {
         IdInfo {
             data_indices: &self.ids[&id],
             instructions: &self.instructions,
@@ -628,11 +628,13 @@ impl<'a> InstructionReader<'a> {
         Ok(word)
     }
 
+    /*
     /// Returns the next two words as a single `u64`.
     #[inline]
     fn next_u64(&mut self) -> Result<u64, ParseError> {
         Ok(self.next_u32()? as u64 | (self.next_u32()? as u64) << 32)
     }
+    */
 
     /// Reads a nul-terminated string.
     fn next_string(&mut self) -> Result<String, ParseError> {
@@ -771,7 +773,7 @@ impl Display for ParseErrors {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::FromUtf8Error(err) => write!(f, "invalid UTF-8 in string literal"),
+            Self::FromUtf8Error(_) => write!(f, "invalid UTF-8 in string literal"),
             Self::LeftoverOperands => write!(f, "unparsed operands remaining"),
             Self::MissingOperands => write!(f, "the instruction and its operands require more words than are present in the instruction"),
             Self::UnexpectedEOF => write!(f, "encountered unexpected end of file"),

--- a/vulkano/src/swapchain/display.rs
+++ b/vulkano/src/swapchain/display.rs
@@ -168,8 +168,7 @@ impl DisplayPlane {
 
         self.supported_displays
             .iter()
-            .find(|&&d| d == display.internal_object())
-            .is_some()
+            .any(|&d| d == display.internal_object())
     }
 }
 
@@ -259,7 +258,7 @@ impl Display {
     /// Returns the physical dimensions of the display in millimeters.
     #[inline]
     pub fn physical_dimensions(&self) -> [u32; 2] {
-        let ref r = self.properties.physical_dimensions;
+        let r = &self.properties.physical_dimensions;
         [r.width, r.height]
     }
 
@@ -269,7 +268,7 @@ impl Display {
     /// > only the "best" resolution.
     #[inline]
     pub fn physical_resolution(&self) -> [u32; 2] {
-        let ref r = self.properties.physical_resolution;
+        let r = &self.properties.physical_resolution;
         [r.width, r.height]
     }
 
@@ -408,7 +407,7 @@ impl DisplayMode {
     /// Returns the dimensions of the region that is visible on the monitor.
     #[inline]
     pub fn visible_region(&self) -> [u32; 2] {
-        let ref d = self.parameters.visible_region;
+        let d = &self.parameters.visible_region;
         [d.width, d.height]
     }
 

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -33,7 +33,7 @@ pub struct Event {
 
 impl Event {
     /// Creates a new `Event`.
-    pub fn new(device: Arc<Device>, create_info: EventCreateInfo) -> Result<Event, OomError> {
+    pub fn new(device: Arc<Device>, _create_info: EventCreateInfo) -> Result<Event, OomError> {
         let create_info = ash::vk::EventCreateInfo {
             flags: ash::vk::EventCreateFlags::empty(),
             ..Default::default()
@@ -100,7 +100,7 @@ impl Event {
     /// the `create_info` must match the info used to create said object
     pub unsafe fn from_handle(
         handle: ash::vk::Event,
-        create_info: EventCreateInfo,
+        _create_info: EventCreateInfo,
         device: Arc<Device>,
     ) -> Event {
         Event {

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -215,8 +215,7 @@ impl Fence {
             .filter_map(|fence| {
                 match &mut device {
                     dev @ &mut None => *dev = Some(&*fence.device),
-                    &mut Some(ref dev)
-                        if &**dev as *const Device == &*fence.device as *const Device => {}
+                    &mut Some(dev) if std::ptr::eq(dev, &*fence.device) => {}
                     _ => panic!(
                         "Tried to wait for multiple fences that didn't belong to the \
                                  same device"
@@ -294,8 +293,7 @@ impl Fence {
             .map(|fence| {
                 match &mut device {
                     dev @ &mut None => *dev = Some(&*fence.device),
-                    &mut Some(ref dev)
-                        if &**dev as *const Device == &*fence.device as *const Device => {}
+                    &mut Some(dev) if std::ptr::eq(dev, &*fence.device) => {}
                     _ => panic!(
                         "Tried to reset multiple fences that didn't belong to the same \
                                  device"
@@ -454,7 +452,7 @@ mod tests {
     fn fence_create() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let fence = Fence::new(device.clone(), Default::default()).unwrap();
+        let fence = Fence::new(device, Default::default()).unwrap();
         assert!(!fence.is_signaled().unwrap());
     }
 
@@ -463,7 +461,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let fence = Fence::new(
-            device.clone(),
+            device,
             FenceCreateInfo {
                 signaled: true,
                 ..Default::default()
@@ -478,7 +476,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let fence = Fence::new(
-            device.clone(),
+            device,
             FenceCreateInfo {
                 signaled: true,
                 ..Default::default()
@@ -493,7 +491,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         let mut fence = Fence::new(
-            device.clone(),
+            device,
             FenceCreateInfo {
                 signaled: true,
                 ..Default::default()

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -43,6 +43,7 @@ pub enum FenceSignalFutureBehavior {
     /// Continue execution on the same queue.
     Continue,
     /// Wait for the fence to be signalled before submitting any further operation.
+    #[allow(dead_code)] // TODO: why is this never constructed?
     Block {
         /// How long to block the current thread.
         timeout: Option<Duration>,
@@ -219,7 +220,7 @@ where
             };
 
             // TODO: meh for unwrap
-            let queue = previous.queue().unwrap().clone();
+            let queue = previous.queue().unwrap();
 
             // There are three possible outcomes for the flush operation: success, partial success
             // in which case `result` will contain `Err(OutcomeErr::Partial)`, or total failure
@@ -365,11 +366,7 @@ where
         match self.behavior {
             FenceSignalFutureBehavior::Continue => {
                 let state = self.state.lock();
-                if state.get_prev().is_some() {
-                    false
-                } else {
-                    true
-                }
+                state.get_prev().is_none()
             }
             FenceSignalFutureBehavior::Block { .. } => true,
         }

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -178,7 +178,7 @@ pub unsafe trait GpuFuture: DeviceOwned {
         Self: Sized,
         Cb: PrimaryCommandBuffer + 'static,
     {
-        let queue = self.queue().unwrap().clone();
+        let queue = self.queue().unwrap();
         command_buffer.execute_after(self, queue)
     }
 

--- a/vulkano/src/sync/future/now.rs
+++ b/vulkano/src/sync/future/now.rs
@@ -59,10 +59,10 @@ unsafe impl GpuFuture for NowFuture {
     #[inline]
     fn check_buffer_access(
         &self,
-        buffer: &UnsafeBuffer,
-        range: Range<DeviceSize>,
-        exclusive: bool,
-        queue: &Queue,
+        _buffer: &UnsafeBuffer,
+        _range: Range<DeviceSize>,
+        _exclusive: bool,
+        _queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
         Err(AccessCheckError::Unknown)
     }
@@ -70,11 +70,11 @@ unsafe impl GpuFuture for NowFuture {
     #[inline]
     fn check_image_access(
         &self,
-        image: &UnsafeImage,
-        range: Range<DeviceSize>,
-        exclusive: bool,
-        expected_layout: ImageLayout,
-        queue: &Queue,
+        _image: &UnsafeImage,
+        _range: Range<DeviceSize>,
+        _exclusive: bool,
+        _expected_layout: ImageLayout,
+        _queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
         Err(AccessCheckError::Unknown)
     }

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -88,7 +88,7 @@ where
                 return Ok(());
             }
 
-            let queue = self.previous.queue().unwrap().clone();
+            let queue = self.previous.queue().unwrap();
 
             match self.previous.build_submission()? {
                 SubmitAnyBuilder::Empty => {

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -144,7 +144,7 @@ pub enum SharingMode {
 
 impl<'a> From<&'a Arc<Queue>> for SharingMode {
     #[inline]
-    fn from(queue: &'a Arc<Queue>) -> SharingMode {
+    fn from(_queue: &'a Arc<Queue>) -> SharingMode {
         SharingMode::Exclusive
     }
 }

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -116,7 +116,7 @@ impl PipelineStages {
         }
 
         let PipelineStages {
-            top_of_pipe,
+            top_of_pipe: _,
             mut draw_indirect,
             mut vertex_input,
             mut vertex_shader,
@@ -129,10 +129,10 @@ impl PipelineStages {
             mut color_attachment_output,
             compute_shader,
             transfer,
-            bottom_of_pipe,
+            bottom_of_pipe: _,
             host,
             all_graphics,
-            all_commands,
+            all_commands: _,
             ray_tracing_shader,
         } = *self;
 

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -567,7 +567,7 @@ mod tests {
     #[test]
     fn semaphore_create() {
         let (device, _) = gfx_dev_and_queue!();
-        let _ = Semaphore::new(device.clone(), Default::default());
+        let _ = Semaphore::new(device, Default::default());
     }
 
     #[test]
@@ -629,13 +629,13 @@ mod tests {
         };
 
         let sem = Semaphore::new(
-            device.clone(),
+            device,
             SemaphoreCreateInfo {
                 export_handle_types: ExternalSemaphoreHandleTypes::posix(),
                 ..Default::default()
             },
         )
         .unwrap();
-        let fd = unsafe { sem.export_opaque_fd().unwrap() };
+        let _fd = unsafe { sem.export_opaque_fd().unwrap() };
     }
 }


### PR DESCRIPTION
Changelog:
```
- Improvements to compiler linting:
  - Most clippy warnings and errors have been fixed, and the remainder is explicitly allowed in each crate root. Some of these may be re-enabled in the future if desired.
  - Warnings for dead code and unused variables have been re-enabled and fixed.
```

A huge number of changed files here, but nothing has been changed semantically (hopefully). This makes clippy actually usable, and also re-enables the warnings for dead code and unused variables, which were disabled but with a note to re-enable them at some point. I explicitly disabled the clippy warnings that I felt were too pedantic or opinionated.

Fixes #1195.