### PR TITLE
Refactor draw/dispatch commands, render pass state, improve validation checks

### DIFF
--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -10,10 +10,10 @@
 use crate::{
     buffer::TypedBufferAccess,
     command_buffer::{
-        auto::{QueryState, RenderPassStateType},
+        auto::QueryState,
         synced::{Command, Resource, SyncCommandBufferBuilder, SyncCommandBufferBuilderError},
         sys::UnsafeCommandBufferBuilder,
-        AutoCommandBufferBuilder, CommandBufferInheritanceRenderPassType,
+        AutoCommandBufferBuilder,
     },
     device::{physical::QueueFamily, DeviceOwned},
     query::{
@@ -121,29 +121,9 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
             return Err(QueryError::QueryIsActive);
         }
 
-        if let Some(state) = &self.render_pass_state {
-            let view_mask = match &state.render_pass {
-                RenderPassStateType::BeginRenderPass(state) => {
-                    state.subpass.subpass_desc().view_mask
-                }
-                RenderPassStateType::BeginRendering(state) => state.view_mask,
-                RenderPassStateType::Inherited => match self
-                    .inheritance_info
-                    .as_ref()
-                    .unwrap()
-                    .render_pass
-                    .as_ref()
-                    .unwrap()
-                {
-                    CommandBufferInheritanceRenderPassType::BeginRenderPass(info) => {
-                        info.subpass.subpass_desc().view_mask
-                    }
-                    CommandBufferInheritanceRenderPassType::BeginRendering(info) => info.view_mask,
-                },
-            };
-
+        if let Some(render_pass_state) = &self.render_pass_state {
             // VUID-vkCmdBeginQuery-query-00808
-            if query + view_mask.count_ones() > query_pool.query_count() {
+            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
                 return Err(QueryError::OutOfRangeMultiview);
             }
         }
@@ -197,29 +177,9 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         // VUID-vkCmdEndQuery-query-00810
         query_pool.query(query).ok_or(QueryError::OutOfRange)?;
 
-        if let Some(state) = &self.render_pass_state {
-            let view_mask = match &state.render_pass {
-                RenderPassStateType::BeginRenderPass(state) => {
-                    state.subpass.subpass_desc().view_mask
-                }
-                RenderPassStateType::BeginRendering(state) => state.view_mask,
-                RenderPassStateType::Inherited => match self
-                    .inheritance_info
-                    .as_ref()
-                    .unwrap()
-                    .render_pass
-                    .as_ref()
-                    .unwrap()
-                {
-                    CommandBufferInheritanceRenderPassType::BeginRenderPass(info) => {
-                        info.subpass.subpass_desc().view_mask
-                    }
-                    CommandBufferInheritanceRenderPassType::BeginRendering(info) => info.view_mask,
-                },
-            };
-
+        if let Some(render_pass_state) = &self.render_pass_state {
             // VUID-vkCmdEndQuery-query-00812
-            if query + view_mask.count_ones() > query_pool.query_count() {
+            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
                 return Err(QueryError::OutOfRangeMultiview);
             }
         }
@@ -306,29 +266,9 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
         // VUID-vkCmdWriteTimestamp-query-04904
         query_pool.query(query).ok_or(QueryError::OutOfRange)?;
 
-        if let Some(state) = &self.render_pass_state {
-            let view_mask = match &state.render_pass {
-                RenderPassStateType::BeginRenderPass(state) => {
-                    state.subpass.subpass_desc().view_mask
-                }
-                RenderPassStateType::BeginRendering(state) => state.view_mask,
-                RenderPassStateType::Inherited => match self
-                    .inheritance_info
-                    .as_ref()
-                    .unwrap()
-                    .render_pass
-                    .as_ref()
-                    .unwrap()
-                {
-                    CommandBufferInheritanceRenderPassType::BeginRenderPass(info) => {
-                        info.subpass.subpass_desc().view_mask
-                    }
-                    CommandBufferInheritanceRenderPassType::BeginRendering(info) => info.view_mask,
-                },
-            };
-
+        if let Some(render_pass_state) = &self.render_pass_state {
             // VUID-vkCmdWriteTimestamp-query-00831
-            if query + view_mask.count_ones() > query_pool.query_count() {
+            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
                 return Err(QueryError::OutOfRangeMultiview);
             }
         }

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -167,7 +167,7 @@ where
 
                     // VUID-vkCmdExecuteCommands-pCommandBuffers-00099
                     if let Some(framebuffer) = &inheritance_info.framebuffer {
-                        if framebuffer != &state.framebuffer {
+                        if framebuffer != state.framebuffer.as_ref().unwrap() {
                             return Err(ExecuteCommandsError::RenderPassFramebufferMismatch {
                                 command_buffer_index,
                             });
@@ -178,35 +178,39 @@ where
                     RenderPassStateType::BeginRendering(state),
                     CommandBufferInheritanceRenderPassType::BeginRendering(inheritance_info),
                 ) => {
+                    let attachments = state.attachments.as_ref().unwrap();
+
                     // VUID-vkCmdExecuteCommands-colorAttachmentCount-06027
                     if inheritance_info.color_attachment_formats.len()
-                        != state.color_attachments.len()
+                        != attachments.color_attachments.len()
                     {
                         return Err(
                             ExecuteCommandsError::RenderPassColorAttachmentCountMismatch {
                                 command_buffer_index,
-                                required_count: state.color_attachments.len() as u32,
+                                required_count: attachments.color_attachments.len() as u32,
                                 inherited_count: inheritance_info.color_attachment_formats.len()
                                     as u32,
                             },
                         );
                     }
 
-                    for (color_attachment_index, image_view, format) in state
+                    for (color_attachment_index, image_view, inherited_format) in attachments
                         .color_attachments
                         .iter()
                         .zip(inheritance_info.color_attachment_formats.iter().copied())
                         .enumerate()
                         .filter_map(|(i, (a, f))| a.as_ref().map(|a| (i as u32, &a.image_view, f)))
                     {
+                        let required_format = image_view.format().unwrap();
+
                         // VUID-vkCmdExecuteCommands-imageView-06028
-                        if Some(image_view.format().unwrap()) != format {
+                        if Some(required_format) != inherited_format {
                             return Err(
                                 ExecuteCommandsError::RenderPassColorAttachmentFormatMismatch {
                                     command_buffer_index,
                                     color_attachment_index,
-                                    required_format: image_view.format().unwrap(),
-                                    inherited_format: format,
+                                    required_format,
+                                    inherited_format,
                                 },
                             );
                         }
@@ -224,7 +228,7 @@ where
                         }
                     }
 
-                    if let Some((image_view, format)) = state
+                    if let Some((image_view, format)) = attachments
                         .depth_attachment
                         .as_ref()
                         .map(|a| (&a.image_view, inheritance_info.depth_attachment_format))
@@ -252,7 +256,7 @@ where
                         }
                     }
 
-                    if let Some((image_view, format)) = state
+                    if let Some((image_view, format)) = attachments
                         .stencil_attachment
                         .as_ref()
                         .map(|a| (&a.image_view, inheritance_info.stencil_attachment_format))
@@ -281,15 +285,14 @@ where
                     }
 
                     // VUID-vkCmdExecuteCommands-viewMask-06031
-                    if inheritance_info.view_mask != state.view_mask {
+                    if inheritance_info.view_mask != render_pass_state.view_mask {
                         return Err(ExecuteCommandsError::RenderPassViewMaskMismatch {
                             command_buffer_index,
-                            required_view_mask: state.view_mask,
+                            required_view_mask: render_pass_state.view_mask,
                             inherited_view_mask: inheritance_info.view_mask,
                         });
                     }
                 }
-                (RenderPassStateType::Inherited, _) => unreachable!(),
                 _ => {
                     // VUID-vkCmdExecuteCommands-pBeginInfo-06025
                     return Err(ExecuteCommandsError::RenderPassTypeMismatch {

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -91,9 +91,7 @@
 
 pub use self::{
     auto::{
-        AutoCommandBufferBuilder, AutoCommandBufferBuilderContextError, BuildError,
-        CommandBufferBeginError, DispatchError, DispatchIndirectError, DrawError, DrawIndexedError,
-        DrawIndexedIndirectError, DrawIndirectError, PrimaryAutoCommandBuffer,
+        AutoCommandBufferBuilder, BuildError, CommandBufferBeginError, PrimaryAutoCommandBuffer,
         SecondaryAutoCommandBuffer,
     },
     commands::{
@@ -102,11 +100,7 @@ pub use self::{
             BlitImageInfo, ClearColorImageInfo, ClearDepthStencilImageInfo, ImageBlit,
             ImageResolve, ResolveImageInfo,
         },
-        pipeline::{
-            CheckDescriptorSetsValidityError, CheckDispatchError, CheckDynamicStateValidityError,
-            CheckIndexBufferError, CheckIndirectBufferError, CheckPipelineError,
-            CheckPushConstantsValidityError, CheckVertexBufferError,
-        },
+        pipeline::PipelineExecutionError,
         query::QueryError,
         render_pass::{
             ClearAttachment, ClearRect, RenderPassBeginInfo, RenderPassError,


### PR DESCRIPTION
No changelog.

This is again a PR with a lot of internal rearranging, but hopefully that's the last of it for command buffers for the moment. I've finished the refactoring of draw/dispatch commands and improved/added validation checks there when needed. I also changed a bit how the render pass state is stored internally, to make these checks a little less messy.