### PR TITLE
Add sparse image querying functions

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -21,7 +21,7 @@ use super::{
 use crate::{
     buffer::{sys::UnsafeBuffer, BufferAccess},
     command_buffer::CommandBufferInheritanceRenderingInfo,
-    device::{physical::QueueFamilyProperties, Device, DeviceOwned, Queue},
+    device::{Device, DeviceOwned, Queue, QueueFamilyProperties},
     format::Format,
     image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
     query::{QueryControlFlags, QueryType},

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -7,19 +7,24 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+use super::QueueFamilyProperties;
 use crate::{
     buffer::{ExternalBufferInfo, ExternalBufferProperties},
     device::{DeviceExtensions, Features, FeaturesFfi, Properties, PropertiesFfi},
     format::{Format, FormatProperties},
-    image::{ImageCreateFlags, ImageFormatInfo, ImageFormatProperties, ImageUsage},
+    image::{
+        ImageCreateFlags, ImageFormatInfo, ImageFormatProperties, ImageUsage,
+        SparseImageFormatInfo, SparseImageFormatProperties,
+    },
     instance::Instance,
     macros::{vulkan_bitflags, vulkan_enum},
+    memory::MemoryProperties,
     swapchain::{
         ColorSpace, FullScreenExclusive, PresentMode, SupportedSurfaceTransforms, Surface,
         SurfaceApi, SurfaceCapabilities, SurfaceInfo,
     },
-    sync::{ExternalSemaphoreInfo, ExternalSemaphoreProperties, PipelineStage},
-    DeviceSize, OomError, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
+    sync::{ExternalSemaphoreInfo, ExternalSemaphoreProperties},
+    OomError, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
 use bytemuck::cast_slice;
 use std::{
@@ -722,6 +727,9 @@ impl PhysicalDevice {
         // VUID-VkPhysicalDeviceImageFormatInfo2-usage-parameter
         usage.validate_physical_device(self)?;
 
+        // VUID-VkPhysicalDeviceImageFormatInfo2-usage-requiredbitmask
+        assert!(!usage.is_empty());
+
         if let Some(handle_type) = external_memory_handle_type {
             if !(self.api_version() >= Version::V1_1
                 || self
@@ -898,6 +906,203 @@ impl PhysicalDevice {
             })),
             Err(VulkanError::FormatNotSupported) => Ok(None),
             Err(err) => Err(err),
+        }
+    }
+
+    /// Returns the properties of sparse images with a given image configuration.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `format_info.format` is `None`.
+    #[inline]
+    pub fn sparse_image_format_properties(
+        &self,
+        format_info: SparseImageFormatInfo,
+    ) -> Result<Vec<SparseImageFormatProperties>, ImageFormatPropertiesError> {
+        self.validate_sparse_image_format_properties(&format_info)?;
+
+        unsafe { Ok(self.sparse_image_format_properties_unchecked(format_info)) }
+    }
+
+    fn validate_sparse_image_format_properties(
+        &self,
+        format_info: &SparseImageFormatInfo,
+    ) -> Result<(), ImageFormatPropertiesError> {
+        let &SparseImageFormatInfo {
+            format: _,
+            image_type,
+            samples,
+            usage,
+            tiling,
+            _ne: _,
+        } = format_info;
+
+        // VUID-VkPhysicalDeviceSparseImageFormatInfo2-format-parameter
+        // TODO: format.validate_physical_device(self)?;
+
+        // VUID-VkPhysicalDeviceSparseImageFormatInfo2-type-parameter
+        image_type.validate_physical_device(self)?;
+
+        // VUID-VkPhysicalDeviceSparseImageFormatInfo2-samples-parameter
+        samples.validate_physical_device(self)?;
+
+        // VUID-VkPhysicalDeviceSparseImageFormatInfo2-usage-parameter
+        usage.validate_physical_device(self)?;
+
+        // VUID-VkPhysicalDeviceSparseImageFormatInfo2-usage-requiredbitmask
+        assert!(!usage.is_empty());
+
+        // VUID-VkPhysicalDeviceSparseImageFormatInfo2-tiling-parameter
+        tiling.validate_physical_device(self)?;
+
+        // VUID-VkPhysicalDeviceSparseImageFormatInfo2-samples-01095
+        // TODO:
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn sparse_image_format_properties_unchecked(
+        &self,
+        format_info: SparseImageFormatInfo,
+    ) -> Vec<SparseImageFormatProperties> {
+        let SparseImageFormatInfo {
+            format,
+            image_type,
+            samples,
+            usage,
+            tiling,
+            _ne: _,
+        } = format_info;
+
+        let format_info2 = ash::vk::PhysicalDeviceSparseImageFormatInfo2 {
+            format: format.unwrap().into(),
+            ty: image_type.into(),
+            samples: samples.into(),
+            usage: usage.into(),
+            tiling: tiling.into(),
+            ..Default::default()
+        };
+
+        let fns = self.instance.fns();
+
+        if self.api_version() >= Version::V1_1
+            || self
+                .instance
+                .enabled_extensions()
+                .khr_get_physical_device_properties2
+        {
+            let mut count = 0;
+
+            if self.api_version() >= Version::V1_1 {
+                (fns.v1_1.get_physical_device_sparse_image_format_properties2)(
+                    self.handle,
+                    &format_info2,
+                    &mut count,
+                    ptr::null_mut(),
+                );
+            } else {
+                (fns.khr_get_physical_device_properties2
+                    .get_physical_device_sparse_image_format_properties2_khr)(
+                    self.handle,
+                    &format_info2,
+                    &mut count,
+                    ptr::null_mut(),
+                );
+            }
+
+            let mut sparse_image_format_properties2 =
+                vec![ash::vk::SparseImageFormatProperties2::default(); count as usize];
+
+            if self.api_version() >= Version::V1_1 {
+                (fns.v1_1.get_physical_device_sparse_image_format_properties2)(
+                    self.handle,
+                    &format_info2,
+                    &mut count,
+                    sparse_image_format_properties2.as_mut_ptr(),
+                );
+            } else {
+                (fns.khr_get_physical_device_properties2
+                    .get_physical_device_sparse_image_format_properties2_khr)(
+                    self.handle,
+                    &format_info2,
+                    &mut count,
+                    sparse_image_format_properties2.as_mut_ptr(),
+                );
+            }
+
+            sparse_image_format_properties2.set_len(count as usize);
+
+            sparse_image_format_properties2
+                .into_iter()
+                .map(
+                    |sparse_image_format_properties2| SparseImageFormatProperties {
+                        aspects: sparse_image_format_properties2
+                            .properties
+                            .aspect_mask
+                            .into(),
+                        image_granularity: [
+                            sparse_image_format_properties2
+                                .properties
+                                .image_granularity
+                                .width,
+                            sparse_image_format_properties2
+                                .properties
+                                .image_granularity
+                                .height,
+                            sparse_image_format_properties2
+                                .properties
+                                .image_granularity
+                                .depth,
+                        ],
+                        flags: sparse_image_format_properties2.properties.flags.into(),
+                    },
+                )
+                .collect()
+        } else {
+            let mut count = 0;
+
+            (fns.v1_0.get_physical_device_sparse_image_format_properties)(
+                self.handle,
+                format_info2.format,
+                format_info2.ty,
+                format_info2.samples,
+                format_info2.usage,
+                format_info2.tiling,
+                &mut count,
+                ptr::null_mut(),
+            );
+
+            let mut sparse_image_format_properties =
+                vec![ash::vk::SparseImageFormatProperties::default(); count as usize];
+
+            (fns.v1_0.get_physical_device_sparse_image_format_properties)(
+                self.handle,
+                format_info2.format,
+                format_info2.ty,
+                format_info2.samples,
+                format_info2.usage,
+                format_info2.tiling,
+                &mut count,
+                sparse_image_format_properties.as_mut_ptr(),
+            );
+
+            sparse_image_format_properties.set_len(count as usize);
+
+            sparse_image_format_properties
+                .into_iter()
+                .map(
+                    |sparse_image_format_properties| SparseImageFormatProperties {
+                        aspects: sparse_image_format_properties.aspect_mask.into(),
+                        image_granularity: [
+                            sparse_image_format_properties.image_granularity.width,
+                            sparse_image_format_properties.image_granularity.height,
+                            sparse_image_format_properties.image_granularity.depth,
+                        ],
+                        flags: sparse_image_format_properties.flags.into(),
+                    },
+                )
+                .collect()
         }
     }
 
@@ -1497,195 +1702,6 @@ impl From<ash::vk::ExtensionProperties> for ExtensionProperties {
             spec_version: val.spec_version,
         }
     }
-}
-
-/// Properties of the memory in a physical device.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct MemoryProperties {
-    /// The available memory types.
-    pub memory_types: Vec<MemoryType>,
-
-    /// The available memory heaps.
-    pub memory_heaps: Vec<MemoryHeap>,
-}
-
-impl From<ash::vk::PhysicalDeviceMemoryProperties> for MemoryProperties {
-    #[inline]
-    fn from(val: ash::vk::PhysicalDeviceMemoryProperties) -> Self {
-        Self {
-            memory_types: val.memory_types[0..val.memory_type_count as usize]
-                .iter()
-                .map(|vk_memory_type| MemoryType {
-                    property_flags: vk_memory_type.property_flags.into(),
-                    heap_index: vk_memory_type.heap_index,
-                })
-                .collect(),
-            memory_heaps: val.memory_heaps[0..val.memory_heap_count as usize]
-                .iter()
-                .map(|vk_memory_heap| MemoryHeap {
-                    size: vk_memory_heap.size,
-                    flags: vk_memory_heap.flags.into(),
-                })
-                .collect(),
-        }
-    }
-}
-
-/// A memory type in a physical device.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct MemoryType {
-    /// The properties of this memory type.
-    pub property_flags: MemoryPropertyFlags,
-
-    /// The index of the memory heap that this memory type corresponds to.
-    pub heap_index: u32,
-}
-
-vulkan_bitflags! {
-    /// Properties of a memory type.
-    #[non_exhaustive]
-    MemoryPropertyFlags = MemoryPropertyFlags(u32);
-
-    /// The memory is located on the device. This usually means that it's efficient for the
-    /// device to access this memory.
-    device_local = DEVICE_LOCAL,
-
-    /// The memory can be accessed by the host.
-    host_visible = HOST_VISIBLE,
-
-    /// Modifications made by the host or the device on this memory type are
-    /// instantaneously visible to the other party. If memory does not have this flag, changes to
-    /// the memory are not visible until they are flushed or invalidated.
-    host_coherent = HOST_COHERENT,
-
-    /// The memory is cached by the host. Host memory accesses to cached memory are faster than for
-    /// uncached memory, but the cache may not be coherent.
-    host_cached = HOST_CACHED,
-
-    /// Allocations made from this memory type are lazy.
-    ///
-    /// This means that no actual allocation is performed. Instead memory is automatically
-    /// allocated by the Vulkan implementation based on need.
-    ///
-    /// Memory of this type can only be used on images created with a certain flag. Memory of this
-    /// type is never host-visible.
-    lazily_allocated = LAZILY_ALLOCATED,
-
-    /// The memory can only be accessed by the device, and allows protected queue access.
-    ///
-    /// Memory of this type is never host visible, host coherent or host cached.
-    protected = PROTECTED {
-        api_version: V1_1,
-    },
-}
-
-/// A memory heap in a physical device.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct MemoryHeap {
-    /// The size of the heap in bytes.
-    pub size: DeviceSize,
-
-    /// Attributes of the heap.
-    pub flags: MemoryHeapFlags,
-}
-
-vulkan_bitflags! {
-    /// Attributes of a memory heap.
-    #[non_exhaustive]
-    MemoryHeapFlags = MemoryHeapFlags(u32);
-
-    /// The heap corresponds to device-local memory.
-    device_local = DEVICE_LOCAL,
-
-    /// If used on a logical device that represents more than one physical device, allocations are
-    /// replicated across each physical device's instance of this heap.
-    multi_instance = MULTI_INSTANCE {
-        api_version: V1_1,
-        instance_extensions: [khr_device_group_creation],
-    },
-}
-
-/// Properties of a queue family in a physical device.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct QueueFamilyProperties {
-    /// Attributes of the queue family.
-    pub queue_flags: QueueFlags,
-
-    /// The number of queues available in this family.
-    ///
-    /// This guaranteed to be at least 1 (or else that family wouldn't exist).
-    pub queue_count: u32,
-
-    /// If timestamps are supported, the number of bits supported by timestamp operations.
-    /// The returned value will be in the range 36..64.
-    ///
-    /// If timestamps are not supported, this is `None`.
-    pub timestamp_valid_bits: Option<u32>,
-
-    /// The minimum granularity supported for image transfers, in terms of `[width, height, depth]`.
-    pub min_image_transfer_granularity: [u32; 3],
-}
-
-impl QueueFamilyProperties {
-    /// Returns whether the queues of this family support a particular pipeline stage.
-    #[inline]
-    pub fn supports_stage(&self, stage: PipelineStage) -> bool {
-        ash::vk::QueueFlags::from(self.queue_flags).contains(stage.required_queue_flags())
-    }
-}
-
-impl From<ash::vk::QueueFamilyProperties> for QueueFamilyProperties {
-    #[inline]
-    fn from(val: ash::vk::QueueFamilyProperties) -> Self {
-        Self {
-            queue_flags: val.queue_flags.into(),
-            queue_count: val.queue_count,
-            timestamp_valid_bits: (val.timestamp_valid_bits != 0)
-                .then_some(val.timestamp_valid_bits),
-            min_image_transfer_granularity: [
-                val.min_image_transfer_granularity.width,
-                val.min_image_transfer_granularity.height,
-                val.min_image_transfer_granularity.depth,
-            ],
-        }
-    }
-}
-
-vulkan_bitflags! {
-    /// Attributes of a queue or queue family.
-    #[non_exhaustive]
-    QueueFlags = QueueFlags(u32);
-
-    /// Queues of this family can execute graphics operations.
-    graphics = GRAPHICS,
-
-    /// Queues of this family can execute compute operations.
-    compute = COMPUTE,
-
-    /// Queues of this family can execute transfer operations.
-    transfer = TRANSFER,
-
-    /// Queues of this family can execute sparse memory management operations.
-    sparse_binding = SPARSE_BINDING,
-
-    /// Queues of this family can be created using the `protected` flag.
-    protected = PROTECTED {
-        api_version: V1_1,
-    },
-
-    /// Queues of this family can execute video decode operations.
-    video_decode = VIDEO_DECODE_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },
-
-    /// Queues of this family can execute video encode operations.
-    video_encode = VIDEO_ENCODE_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },
 }
 
 vulkan_enum! {

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -16,13 +16,16 @@
 use super::{
     ImageAspect, ImageAspects, ImageCreateFlags, ImageDimensions, ImageLayout,
     ImageSubresourceLayers, ImageSubresourceRange, ImageTiling, ImageUsage, SampleCount,
-    SampleCounts,
+    SampleCounts, SparseImageMemoryRequirements,
 };
 use crate::{
     buffer::cpu_access::{ReadLockError, WriteLockError},
     device::{physical::ImageFormatPropertiesError, Device, DeviceOwned},
     format::{ChromaSampling, Format, FormatFeatures, NumericType},
-    image::{view::ImageViewCreationError, ImageFormatInfo, ImageFormatProperties, ImageType},
+    image::{
+        view::ImageViewCreationError, ImageFormatInfo, ImageFormatProperties, ImageType,
+        SparseImageFormatProperties,
+    },
     memory::{
         DeviceMemory, DeviceMemoryAllocationError, ExternalMemoryHandleType,
         ExternalMemoryHandleTypes, MemoryRequirements,
@@ -1008,6 +1011,185 @@ impl UnsafeImage {
             prefer_dedicated: memory_dedicated_requirements
                 .map_or(false, |dreqs| dreqs.prefers_dedicated_allocation != 0),
             ..MemoryRequirements::from(memory_requirements2.memory_requirements)
+        }
+    }
+
+    /// Returns the sparse memory requirements for this image.
+    pub fn sparse_memory_requirements(&self) -> Vec<SparseImageMemoryRequirements> {
+        let device = &self.device;
+
+        unsafe {
+            let fns = self.device.fns();
+
+            if device.api_version() >= Version::V1_1
+                || device.enabled_extensions().khr_get_memory_requirements2
+            {
+                let info2 = ash::vk::ImageSparseMemoryRequirementsInfo2 {
+                    image: self.handle,
+                    ..Default::default()
+                };
+
+                let mut count = 0;
+
+                if device.api_version() >= Version::V1_1 {
+                    (fns.v1_1.get_image_sparse_memory_requirements2)(
+                        device.internal_object(),
+                        &info2,
+                        &mut count,
+                        ptr::null_mut(),
+                    );
+                } else {
+                    (fns.khr_get_memory_requirements2
+                        .get_image_sparse_memory_requirements2_khr)(
+                        device.internal_object(),
+                        &info2,
+                        &mut count,
+                        ptr::null_mut(),
+                    );
+                }
+
+                let mut sparse_image_memory_requirements2 =
+                    vec![ash::vk::SparseImageMemoryRequirements2::default(); count as usize];
+
+                if device.api_version() >= Version::V1_1 {
+                    (fns.v1_1.get_image_sparse_memory_requirements2)(
+                        self.device.internal_object(),
+                        &info2,
+                        &mut count,
+                        sparse_image_memory_requirements2.as_mut_ptr(),
+                    );
+                } else {
+                    (fns.khr_get_memory_requirements2
+                        .get_image_sparse_memory_requirements2_khr)(
+                        self.device.internal_object(),
+                        &info2,
+                        &mut count,
+                        sparse_image_memory_requirements2.as_mut_ptr(),
+                    );
+                }
+
+                sparse_image_memory_requirements2.set_len(count as usize);
+
+                sparse_image_memory_requirements2
+                    .into_iter()
+                    .map(
+                        |sparse_image_memory_requirements2| SparseImageMemoryRequirements {
+                            format_properties: SparseImageFormatProperties {
+                                aspects: sparse_image_memory_requirements2
+                                    .memory_requirements
+                                    .format_properties
+                                    .aspect_mask
+                                    .into(),
+                                image_granularity: [
+                                    sparse_image_memory_requirements2
+                                        .memory_requirements
+                                        .format_properties
+                                        .image_granularity
+                                        .width,
+                                    sparse_image_memory_requirements2
+                                        .memory_requirements
+                                        .format_properties
+                                        .image_granularity
+                                        .height,
+                                    sparse_image_memory_requirements2
+                                        .memory_requirements
+                                        .format_properties
+                                        .image_granularity
+                                        .depth,
+                                ],
+                                flags: sparse_image_memory_requirements2
+                                    .memory_requirements
+                                    .format_properties
+                                    .flags
+                                    .into(),
+                            },
+                            image_mip_tail_first_lod: sparse_image_memory_requirements2
+                                .memory_requirements
+                                .image_mip_tail_first_lod,
+                            image_mip_tail_size: sparse_image_memory_requirements2
+                                .memory_requirements
+                                .image_mip_tail_size,
+                            image_mip_tail_offset: sparse_image_memory_requirements2
+                                .memory_requirements
+                                .image_mip_tail_offset,
+                            image_mip_tail_stride: (!sparse_image_memory_requirements2
+                                .memory_requirements
+                                .format_properties
+                                .flags
+                                .intersects(ash::vk::SparseImageFormatFlags::SINGLE_MIPTAIL))
+                            .then_some(
+                                sparse_image_memory_requirements2
+                                    .memory_requirements
+                                    .image_mip_tail_stride,
+                            ),
+                        },
+                    )
+                    .collect()
+            } else {
+                let mut count = 0;
+
+                (fns.v1_0.get_image_sparse_memory_requirements)(
+                    device.internal_object(),
+                    self.handle,
+                    &mut count,
+                    ptr::null_mut(),
+                );
+
+                let mut sparse_image_memory_requirements =
+                    vec![ash::vk::SparseImageMemoryRequirements::default(); count as usize];
+
+                (fns.v1_0.get_image_sparse_memory_requirements)(
+                    device.internal_object(),
+                    self.handle,
+                    &mut count,
+                    sparse_image_memory_requirements.as_mut_ptr(),
+                );
+
+                sparse_image_memory_requirements.set_len(count as usize);
+
+                sparse_image_memory_requirements
+                    .into_iter()
+                    .map(
+                        |sparse_image_memory_requirements| SparseImageMemoryRequirements {
+                            format_properties: SparseImageFormatProperties {
+                                aspects: sparse_image_memory_requirements
+                                    .format_properties
+                                    .aspect_mask
+                                    .into(),
+                                image_granularity: [
+                                    sparse_image_memory_requirements
+                                        .format_properties
+                                        .image_granularity
+                                        .width,
+                                    sparse_image_memory_requirements
+                                        .format_properties
+                                        .image_granularity
+                                        .height,
+                                    sparse_image_memory_requirements
+                                        .format_properties
+                                        .image_granularity
+                                        .depth,
+                                ],
+                                flags: sparse_image_memory_requirements
+                                    .format_properties
+                                    .flags
+                                    .into(),
+                            },
+                            image_mip_tail_first_lod: sparse_image_memory_requirements
+                                .image_mip_tail_first_lod,
+                            image_mip_tail_size: sparse_image_memory_requirements
+                                .image_mip_tail_size,
+                            image_mip_tail_offset: sparse_image_memory_requirements
+                                .image_mip_tail_offset,
+                            image_mip_tail_stride: (!sparse_image_memory_requirements
+                                .format_properties
+                                .flags
+                                .intersects(ash::vk::SparseImageFormatFlags::SINGLE_MIPTAIL))
+                            .then_some(sparse_image_memory_requirements.image_mip_tail_stride),
+                        },
+                    )
+                    .collect()
+            }
         }
     }
 

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -100,10 +100,121 @@ pub use self::{
     },
     pool::MemoryPool,
 };
-use crate::{buffer::sys::UnsafeBuffer, image::sys::UnsafeImage, DeviceSize};
+use crate::{
+    buffer::sys::UnsafeBuffer, image::sys::UnsafeImage, macros::vulkan_bitflags, DeviceSize,
+};
 
 mod device_memory;
 pub mod pool;
+
+/// Properties of the memory in a physical device.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct MemoryProperties {
+    /// The available memory types.
+    pub memory_types: Vec<MemoryType>,
+
+    /// The available memory heaps.
+    pub memory_heaps: Vec<MemoryHeap>,
+}
+
+impl From<ash::vk::PhysicalDeviceMemoryProperties> for MemoryProperties {
+    #[inline]
+    fn from(val: ash::vk::PhysicalDeviceMemoryProperties) -> Self {
+        Self {
+            memory_types: val.memory_types[0..val.memory_type_count as usize]
+                .iter()
+                .map(|vk_memory_type| MemoryType {
+                    property_flags: vk_memory_type.property_flags.into(),
+                    heap_index: vk_memory_type.heap_index,
+                })
+                .collect(),
+            memory_heaps: val.memory_heaps[0..val.memory_heap_count as usize]
+                .iter()
+                .map(|vk_memory_heap| MemoryHeap {
+                    size: vk_memory_heap.size,
+                    flags: vk_memory_heap.flags.into(),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// A memory type in a physical device.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct MemoryType {
+    /// The properties of this memory type.
+    pub property_flags: MemoryPropertyFlags,
+
+    /// The index of the memory heap that this memory type corresponds to.
+    pub heap_index: u32,
+}
+
+vulkan_bitflags! {
+    /// Properties of a memory type.
+    #[non_exhaustive]
+    MemoryPropertyFlags = MemoryPropertyFlags(u32);
+
+    /// The memory is located on the device. This usually means that it's efficient for the
+    /// device to access this memory.
+    device_local = DEVICE_LOCAL,
+
+    /// The memory can be accessed by the host.
+    host_visible = HOST_VISIBLE,
+
+    /// Modifications made by the host or the device on this memory type are
+    /// instantaneously visible to the other party. If memory does not have this flag, changes to
+    /// the memory are not visible until they are flushed or invalidated.
+    host_coherent = HOST_COHERENT,
+
+    /// The memory is cached by the host. Host memory accesses to cached memory are faster than for
+    /// uncached memory, but the cache may not be coherent.
+    host_cached = HOST_CACHED,
+
+    /// Allocations made from this memory type are lazy.
+    ///
+    /// This means that no actual allocation is performed. Instead memory is automatically
+    /// allocated by the Vulkan implementation based on need.
+    ///
+    /// Memory of this type can only be used on images created with a certain flag. Memory of this
+    /// type is never host-visible.
+    lazily_allocated = LAZILY_ALLOCATED,
+
+    /// The memory can only be accessed by the device, and allows protected queue access.
+    ///
+    /// Memory of this type is never host visible, host coherent or host cached.
+    protected = PROTECTED {
+        api_version: V1_1,
+    },
+}
+
+/// A memory heap in a physical device.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct MemoryHeap {
+    /// The size of the heap in bytes.
+    pub size: DeviceSize,
+
+    /// Attributes of the heap.
+    pub flags: MemoryHeapFlags,
+}
+
+vulkan_bitflags! {
+    /// Attributes of a memory heap.
+    #[non_exhaustive]
+    MemoryHeapFlags = MemoryHeapFlags(u32);
+
+    /// The heap corresponds to device-local memory.
+    device_local = DEVICE_LOCAL,
+
+    /// If used on a logical device that represents more than one physical device, allocations are
+    /// replicated across each physical device's instance of this heap.
+    multi_instance = MULTI_INSTANCE {
+        api_version: V1_1,
+        instance_extensions: [khr_device_group_creation],
+    },
+}
 
 /// Represents requirements expressed by the Vulkan implementation when it comes to binding memory
 /// to a resource.

--- a/vulkano/src/memory/pool/mod.rs
+++ b/vulkano/src/memory/pool/mod.rs
@@ -14,8 +14,9 @@ pub use self::{
     },
     pool::{StandardMemoryPool, StandardMemoryPoolAlloc},
 };
+use super::MemoryType;
 use crate::{
-    device::{physical::MemoryType, Device, DeviceOwned},
+    device::{Device, DeviceOwned},
     memory::{
         device_memory::MemoryAllocateInfo, DedicatedAllocation, DeviceMemory,
         DeviceMemoryAllocationError, ExternalMemoryHandleTypes, MappedDeviceMemory,


### PR DESCRIPTION
Changelog:
```markdown
- Added two missing functions for querying about sparse images: `PhysicalDevice::sparse_image_format_properties` and `UnsafeImage::sparse_memory_requirements`.
```

These functions from Vulkan 1.0 were still missing, so this implements them. They'll be useful if anyone ever wants to implement sparse images properly.

I also moved some of the new types from the `physical` module to more appropriate places.