### PR TITLE
Add `DeviceMemory::commitment`

### DIFF
--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -27,7 +27,7 @@ use crate::{
             AllocFromRequirementsFilter, AllocLayout, MappingRequirement, MemoryPoolAlloc,
             PotentialDedicatedAllocation, StandardMemoryPoolAlloc,
         },
-        DedicatedAllocation, DeviceMemoryAllocationError, MemoryPool,
+        DedicatedAllocation, DeviceMemoryError, MemoryPool,
     },
     sync::Sharing,
     DeviceSize,
@@ -82,7 +82,7 @@ where
         usage: BufferUsage,
         host_cached: bool,
         data: T,
-    ) -> Result<Arc<CpuAccessibleBuffer<T>>, DeviceMemoryAllocationError> {
+    ) -> Result<Arc<CpuAccessibleBuffer<T>>, DeviceMemoryError> {
         unsafe {
             let uninitialized = CpuAccessibleBuffer::raw(
                 device,
@@ -115,7 +115,7 @@ where
         device: Arc<Device>,
         usage: BufferUsage,
         host_cached: bool,
-    ) -> Result<Arc<CpuAccessibleBuffer<T>>, DeviceMemoryAllocationError> {
+    ) -> Result<Arc<CpuAccessibleBuffer<T>>, DeviceMemoryError> {
         CpuAccessibleBuffer::raw(device, size_of::<T>() as DeviceSize, usage, host_cached, [])
     }
 }
@@ -136,7 +136,7 @@ where
         usage: BufferUsage,
         host_cached: bool,
         data: I,
-    ) -> Result<Arc<CpuAccessibleBuffer<[T]>>, DeviceMemoryAllocationError>
+    ) -> Result<Arc<CpuAccessibleBuffer<[T]>>, DeviceMemoryError>
     where
         I: IntoIterator<Item = T>,
         I::IntoIter: ExactSizeIterator,
@@ -179,7 +179,7 @@ where
         len: DeviceSize,
         usage: BufferUsage,
         host_cached: bool,
-    ) -> Result<Arc<CpuAccessibleBuffer<[T]>>, DeviceMemoryAllocationError> {
+    ) -> Result<Arc<CpuAccessibleBuffer<[T]>>, DeviceMemoryError> {
         CpuAccessibleBuffer::raw(
             device,
             len * size_of::<T>() as DeviceSize,
@@ -209,7 +209,7 @@ where
         usage: BufferUsage,
         host_cached: bool,
         queue_family_indices: impl IntoIterator<Item = u32>,
-    ) -> Result<Arc<CpuAccessibleBuffer<T>>, DeviceMemoryAllocationError> {
+    ) -> Result<Arc<CpuAccessibleBuffer<T>>, DeviceMemoryError> {
         let queue_family_indices: SmallVec<[_; 4]> = queue_family_indices.into_iter().collect();
 
         let buffer = {

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -31,7 +31,7 @@ use super::{
 use crate::{
     device::{Device, DeviceOwned},
     macros::vulkan_bitflags,
-    memory::{DeviceMemory, DeviceMemoryAllocationError, MemoryRequirements},
+    memory::{DeviceMemory, DeviceMemoryError, MemoryRequirements},
     range_map::RangeMap,
     sync::{AccessError, CurrentAccess, Sharing},
     DeviceSize, OomError, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
@@ -480,7 +480,7 @@ impl Default for UnsafeBufferCreateInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BufferCreationError {
     /// Allocating memory failed.
-    AllocError(DeviceMemoryAllocationError),
+    AllocError(DeviceMemoryError),
 
     RequirementNotMet {
         required_for: &'static str,
@@ -544,10 +544,10 @@ impl From<VulkanError> for BufferCreationError {
     fn from(err: VulkanError) -> BufferCreationError {
         match err {
             err @ VulkanError::OutOfHostMemory => {
-                BufferCreationError::AllocError(DeviceMemoryAllocationError::from(err))
+                BufferCreationError::AllocError(DeviceMemoryError::from(err))
             }
             err @ VulkanError::OutOfDeviceMemory => {
-                BufferCreationError::AllocError(DeviceMemoryAllocationError::from(err))
+                BufferCreationError::AllocError(DeviceMemoryError::from(err))
             }
             _ => panic!("unexpected error: {:?}", err),
         }

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -21,7 +21,7 @@ use crate::{
             MappingRequirement, MemoryPoolAlloc, PotentialDedicatedAllocation,
             StandardMemoryPoolAlloc,
         },
-        DedicatedAllocation, DeviceMemoryExportError, ExternalMemoryHandleType,
+        DedicatedAllocation, DeviceMemoryError, ExternalMemoryHandleType,
         ExternalMemoryHandleTypes, MemoryPool,
     },
     DeviceSize,
@@ -550,7 +550,7 @@ impl AttachmentImage {
 
     /// Exports posix file descriptor for the allocated memory
     /// requires `khr_external_memory_fd` and `khr_external_memory` extensions to be loaded.
-    pub fn export_posix_fd(&self) -> Result<File, DeviceMemoryExportError> {
+    pub fn export_posix_fd(&self) -> Result<File, DeviceMemoryError> {
         self.memory
             .memory()
             .export_fd(ExternalMemoryHandleType::OpaqueFd)

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -27,7 +27,7 @@ use crate::{
             AllocFromRequirementsFilter, AllocLayout, MappingRequirement, MemoryPoolAlloc,
             PotentialDedicatedAllocation, StandardMemoryPoolAlloc,
         },
-        DedicatedAllocation, DeviceMemoryAllocationError, MemoryPool,
+        DedicatedAllocation, DeviceMemoryError, MemoryPool,
     },
     sampler::Filter,
     sync::{NowFuture, Sharing},
@@ -461,7 +461,7 @@ where
 #[derive(Clone, Debug)]
 pub enum ImmutableImageCreationError {
     ImageCreationError(ImageCreationError),
-    DeviceMemoryAllocationError(DeviceMemoryAllocationError),
+    DeviceMemoryAllocationError(DeviceMemoryError),
     CommandBufferBeginError(CommandBufferBeginError),
 }
 
@@ -494,9 +494,9 @@ impl From<ImageCreationError> for ImmutableImageCreationError {
     }
 }
 
-impl From<DeviceMemoryAllocationError> for ImmutableImageCreationError {
+impl From<DeviceMemoryError> for ImmutableImageCreationError {
     #[inline]
-    fn from(err: DeviceMemoryAllocationError) -> Self {
+    fn from(err: DeviceMemoryError) -> Self {
         Self::DeviceMemoryAllocationError(err)
     }
 }

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -20,7 +20,7 @@ use crate::{
             alloc_dedicated_with_exportable_fd, AllocFromRequirementsFilter, AllocLayout,
             MappingRequirement, MemoryPoolAlloc, PotentialDedicatedAllocation, StandardMemoryPool,
         },
-        DedicatedAllocation, DeviceMemoryExportError, ExternalMemoryHandleType,
+        DedicatedAllocation, DeviceMemoryError, ExternalMemoryHandleType,
         ExternalMemoryHandleTypes, MemoryPool,
     },
     sync::Sharing,
@@ -240,7 +240,7 @@ impl StorageImage {
 
     /// Exports posix file descriptor for the allocated memory
     /// requires `khr_external_memory_fd` and `khr_external_memory` extensions to be loaded.
-    pub fn export_posix_fd(&self) -> Result<File, DeviceMemoryExportError> {
+    pub fn export_posix_fd(&self) -> Result<File, DeviceMemoryError> {
         self.memory
             .memory()
             .export_fd(ExternalMemoryHandleType::OpaqueFd)

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -24,8 +24,8 @@ use crate::{
     format::{ChromaSampling, Format, FormatFeatures, NumericType},
     image::{view::ImageViewCreationError, ImageFormatInfo, ImageFormatProperties, ImageType},
     memory::{
-        DeviceMemory, DeviceMemoryAllocationError, ExternalMemoryHandleType,
-        ExternalMemoryHandleTypes, MemoryRequirements,
+        DeviceMemory, DeviceMemoryError, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
+        MemoryRequirements,
     },
     range_map::RangeMap,
     sync::{AccessError, CurrentAccess, Sharing},
@@ -1548,7 +1548,7 @@ impl Default for UnsafeImageCreateInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ImageCreationError {
     /// Allocating memory failed.
-    AllocError(DeviceMemoryAllocationError),
+    AllocError(DeviceMemoryError),
 
     RequirementNotMet {
         required_for: &'static str,
@@ -1794,13 +1794,13 @@ impl Display for ImageCreationError {
 impl From<OomError> for ImageCreationError {
     #[inline]
     fn from(err: OomError) -> Self {
-        Self::AllocError(DeviceMemoryAllocationError::OomError(err))
+        Self::AllocError(DeviceMemoryError::OomError(err))
     }
 }
 
-impl From<DeviceMemoryAllocationError> for ImageCreationError {
+impl From<DeviceMemoryError> for ImageCreationError {
     #[inline]
-    fn from(err: DeviceMemoryAllocationError) -> Self {
+    fn from(err: DeviceMemoryError) -> Self {
         Self::AllocError(err)
     }
 }
@@ -1831,7 +1831,7 @@ impl From<ImageFormatPropertiesError> for ImageCreationError {
     fn from(err: ImageFormatPropertiesError) -> Self {
         match err {
             ImageFormatPropertiesError::OomError(err) => {
-                Self::AllocError(DeviceMemoryAllocationError::OomError(err))
+                Self::AllocError(DeviceMemoryError::OomError(err))
             }
             ImageFormatPropertiesError::RequirementNotMet {
                 required_for,

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -94,9 +94,8 @@
 
 pub use self::{
     device_memory::{
-        DeviceMemory, DeviceMemoryAllocationError, DeviceMemoryExportError,
-        ExternalMemoryHandleType, ExternalMemoryHandleTypes, MappedDeviceMemory,
-        MemoryAllocateInfo, MemoryImportInfo, MemoryMapError,
+        DeviceMemory, DeviceMemoryError, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
+        MappedDeviceMemory, MemoryAllocateInfo, MemoryImportInfo, MemoryMapError,
     },
     pool::MemoryPool,
 };

--- a/vulkano/src/memory/pool/host_visible.rs
+++ b/vulkano/src/memory/pool/host_visible.rs
@@ -10,8 +10,7 @@
 use crate::{
     device::Device,
     memory::{
-        device_memory::MemoryAllocateInfo, DeviceMemory, DeviceMemoryAllocationError,
-        MappedDeviceMemory,
+        device_memory::MemoryAllocateInfo, DeviceMemory, DeviceMemoryError, MappedDeviceMemory,
     },
     DeviceSize,
 };
@@ -62,7 +61,7 @@ impl StandardHostVisibleMemoryTypePool {
         self: &Arc<Self>,
         size: DeviceSize,
         alignment: DeviceSize,
-    ) -> Result<StandardHostVisibleMemoryTypePoolAlloc, DeviceMemoryAllocationError> {
+    ) -> Result<StandardHostVisibleMemoryTypePoolAlloc, DeviceMemoryError> {
         assert!(size != 0);
         assert!(alignment != 0);
 

--- a/vulkano/src/memory/pool/mod.rs
+++ b/vulkano/src/memory/pool/mod.rs
@@ -17,9 +17,8 @@ pub use self::{
 use crate::{
     device::{physical::MemoryType, Device, DeviceOwned},
     memory::{
-        device_memory::MemoryAllocateInfo, DedicatedAllocation, DeviceMemory,
-        DeviceMemoryAllocationError, ExternalMemoryHandleTypes, MappedDeviceMemory,
-        MemoryRequirements,
+        device_memory::MemoryAllocateInfo, DedicatedAllocation, DeviceMemory, DeviceMemoryError,
+        ExternalMemoryHandleTypes, MappedDeviceMemory, MemoryRequirements,
     },
     DeviceSize,
 };
@@ -82,7 +81,7 @@ pub(crate) fn alloc_dedicated_with_exportable_fd<F>(
     map: MappingRequirement,
     dedicated_allocation: DedicatedAllocation,
     filter: F,
-) -> Result<PotentialDedicatedAllocation<StandardMemoryPoolAlloc>, DeviceMemoryAllocationError>
+) -> Result<PotentialDedicatedAllocation<StandardMemoryPoolAlloc>, DeviceMemoryError>
 where
     F: FnMut(&MemoryType) -> AllocFromRequirementsFilter,
 {
@@ -145,7 +144,7 @@ pub unsafe trait MemoryPool: DeviceOwned {
         alignment: DeviceSize,
         layout: AllocLayout,
         map: MappingRequirement,
-    ) -> Result<Self::Alloc, DeviceMemoryAllocationError>;
+    ) -> Result<Self::Alloc, DeviceMemoryError>;
 
     /// Chooses a memory type and allocates memory from it.
     ///
@@ -183,7 +182,7 @@ pub unsafe trait MemoryPool: DeviceOwned {
         map: MappingRequirement,
         dedicated_allocation: Option<DedicatedAllocation>,
         filter: F,
-    ) -> Result<PotentialDedicatedAllocation<Self::Alloc>, DeviceMemoryAllocationError>
+    ) -> Result<PotentialDedicatedAllocation<Self::Alloc>, DeviceMemoryError>
     where
         F: FnMut(&MemoryType) -> AllocFromRequirementsFilter,
     {

--- a/vulkano/src/memory/pool/non_host_visible.rs
+++ b/vulkano/src/memory/pool/non_host_visible.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     device::Device,
-    memory::{device_memory::MemoryAllocateInfo, DeviceMemory, DeviceMemoryAllocationError},
+    memory::{device_memory::MemoryAllocateInfo, DeviceMemory, DeviceMemoryError},
     DeviceSize,
 };
 use parking_lot::Mutex;
@@ -56,7 +56,7 @@ impl StandardNonHostVisibleMemoryTypePool {
         self: &Arc<Self>,
         size: DeviceSize,
         alignment: DeviceSize,
-    ) -> Result<StandardNonHostVisibleMemoryTypePoolAlloc, DeviceMemoryAllocationError> {
+    ) -> Result<StandardNonHostVisibleMemoryTypePoolAlloc, DeviceMemoryError> {
         assert!(size != 0);
         assert!(alignment != 0);
 

--- a/vulkano/src/memory/pool/pool.rs
+++ b/vulkano/src/memory/pool/pool.rs
@@ -15,7 +15,7 @@ use crate::{
             StandardHostVisibleMemoryTypePool, StandardHostVisibleMemoryTypePoolAlloc,
             StandardNonHostVisibleMemoryTypePool, StandardNonHostVisibleMemoryTypePoolAlloc,
         },
-        DeviceMemory, DeviceMemoryAllocationError, MappedDeviceMemory,
+        DeviceMemory, DeviceMemoryError, MappedDeviceMemory,
     },
     DeviceSize,
 };
@@ -57,14 +57,14 @@ fn generic_allocation(
     alignment: DeviceSize,
     layout: AllocLayout,
     map: MappingRequirement,
-) -> Result<StandardMemoryPoolAlloc, DeviceMemoryAllocationError> {
+) -> Result<StandardMemoryPoolAlloc, DeviceMemoryError> {
     let mut pools = mem_pool.pools.lock();
 
     let memory_properties = mem_pool.device().physical_device().memory_properties();
     let memory_type = memory_properties
         .memory_types
         .get(memory_type_index as usize)
-        .ok_or(DeviceMemoryAllocationError::MemoryTypeIndexOutOfRange {
+        .ok_or(DeviceMemoryError::MemoryTypeIndexOutOfRange {
             memory_type_index,
             memory_type_count: memory_properties.memory_types.len() as u32,
         })?;
@@ -132,7 +132,7 @@ unsafe impl MemoryPool for Arc<StandardMemoryPool> {
         alignment: DeviceSize,
         layout: AllocLayout,
         map: MappingRequirement,
-    ) -> Result<StandardMemoryPoolAlloc, DeviceMemoryAllocationError> {
+    ) -> Result<StandardMemoryPoolAlloc, DeviceMemoryError> {
         generic_allocation(
             self.clone(),
             memory_type_index,


### PR DESCRIPTION
Changelog:

```markdown
- Added a `DeviceMemory::commitment` method to retrieve the current commitment for lazily-allocated memory.
```

Another Vulkan 1.0 function that never got implemented.