### PR TITLE
Add validation to `Format`

### DIFF
--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -43,16 +43,16 @@ struct ExtensionsMember {
     doc: String,
     raw: String,
     required_if_supported: bool,
-    requires: Vec<OneOfDependencies>,
+    requires: Vec<RequiresOneOf>,
     conflicts_device_extensions: Vec<Ident>,
     status: Option<ExtensionStatus>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
-struct OneOfDependencies {
-    api_version: Option<(String, String)>,
-    device_extensions: Vec<Ident>,
-    instance_extensions: Vec<Ident>,
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RequiresOneOf {
+    pub api_version: Option<(String, String)>,
+    pub device_extensions: Vec<Ident>,
+    pub instance_extensions: Vec<Ident>,
 }
 
 #[derive(Clone, Debug)]
@@ -556,7 +556,7 @@ fn extensions_members(ty: &str, extensions: &IndexMap<&str, &Extension>) -> Vec<
 
             if let Some(core) = ext.requires_core.as_ref() {
                 let (major, minor) = core.split_once('.').unwrap();
-                requires.push(OneOfDependencies {
+                requires.push(RequiresOneOf {
                     api_version: Some((major.to_owned(), minor.to_owned())),
                     ..Default::default()
                 });
@@ -564,7 +564,7 @@ fn extensions_members(ty: &str, extensions: &IndexMap<&str, &Extension>) -> Vec<
 
             if let Some(req) = ext.requires.as_ref() {
                 requires.extend(req.split(',').map(|mut vk_name| {
-                    let mut dependencies = OneOfDependencies::default();
+                    let mut dependencies = RequiresOneOf::default();
 
                     loop {
                         if let Some(version) = vk_name.strip_prefix("VK_VERSION_") {

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -335,7 +335,7 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
                             ref color_attachment_formats,
                             depth_attachment_format,
                             stencil_attachment_format,
-                            rasterization_samples: _, // TODO: ?
+                            rasterization_samples,
                         } = rendering_info;
 
                         // VUID-VkCommandBufferInheritanceRenderingInfo-multiview-06008
@@ -366,9 +366,12 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
                         {
                             let attachment_index = attachment_index as u32;
 
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-pColorAttachmentFormats-parameter
+                            format.validate_device(device)?;
+
                             // VUID-VkCommandBufferInheritanceRenderingInfo-pColorAttachmentFormats-06006
-                            if !physical_device
-                                .format_properties(format)
+                            // Use unchecked, because all validation has been done above.
+                            if !unsafe { physical_device.format_properties_unchecked(format) }
                                 .potential_format_features()
                                 .color_attachment
                             {
@@ -381,6 +384,9 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
                         }
 
                         if let Some(format) = depth_attachment_format {
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-parameter
+                            format.validate_device(device)?;
+
                             // VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-06540
                             if !format.aspects().depth {
                                 return Err(
@@ -389,8 +395,8 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
                             }
 
                             // VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-06007
-                            if !physical_device
-                                .format_properties(format)
+                            // Use unchecked, because all validation has been done above.
+                            if !unsafe { physical_device.format_properties_unchecked(format) }
                                 .potential_format_features()
                                 .depth_stencil_attachment
                             {
@@ -401,6 +407,9 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
                         }
 
                         if let Some(format) = stencil_attachment_format {
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-parameter
+                            format.validate_device(device)?;
+
                             // VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-06541
                             if !format.aspects().stencil {
                                 return Err(
@@ -409,8 +418,8 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
                             }
 
                             // VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-06199
-                            if !physical_device
-                                .format_properties(format)
+                            // Use unchecked, because all validation has been done above.
+                            if !unsafe { physical_device.format_properties_unchecked(format) }
                                 .potential_format_features()
                                 .depth_stencil_attachment
                             {
@@ -430,6 +439,9 @@ impl<L> AutoCommandBufferBuilder<L, StandardCommandPoolBuilder> {
                                 );
                             }
                         }
+
+                        // VUID-VkCommandBufferInheritanceRenderingInfo-rasterizationSamples-parameter
+                        rasterization_samples.validate_device(device)?;
                     }
                 }
             }

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -108,7 +108,7 @@ impl Format {
     )]
     #[inline]
     pub fn properties(&self, physical_device: PhysicalDevice) -> FormatProperties {
-        physical_device.format_properties(*self)
+        physical_device.format_properties(*self).unwrap()
     }
 
     /// Returns whether the format can be used with a storage image, without specifying

--- a/vulkano/src/render_pass/create.rs
+++ b/vulkano/src/render_pass/create.rs
@@ -75,12 +75,8 @@ impl RenderPass {
             let format = format.unwrap();
             let aspects = format.aspects();
 
-            attachment_potential_format_features.push(
-                device
-                    .physical_device()
-                    .format_properties(format)
-                    .potential_format_features(),
-            );
+            // VUID-VkAttachmentDescription2-format-parameter
+            format.validate_device(device)?;
 
             // VUID-VkAttachmentDescription2-samples-parameter
             samples.validate_device(device)?;
@@ -125,6 +121,14 @@ impl RenderPass {
                     _ => (),
                 }
             }
+
+            // Use unchecked, because all validation has been done above.
+            attachment_potential_format_features.push(unsafe {
+                device
+                    .physical_device()
+                    .format_properties_unchecked(format)
+                    .potential_format_features()
+            });
         }
 
         /*

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -312,10 +312,13 @@ impl Sampler {
         {
             assert_eq!(&device, sampler_ycbcr_conversion.device());
 
-            let potential_format_features = device
-                .physical_device()
-                .format_properties(sampler_ycbcr_conversion.format().unwrap())
-                .potential_format_features();
+            // Use unchecked, because all validation has been done by the SamplerYcbcrConversion.
+            let potential_format_features = unsafe {
+                device
+                    .physical_device()
+                    .format_properties_unchecked(sampler_ycbcr_conversion.format().unwrap())
+                    .potential_format_features()
+            };
 
             // VUID-VkSamplerCreateInfo-minFilter-01645
             if !potential_format_features

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -16,10 +16,7 @@ use crate::{
     command_buffer::submit::{
         SubmitAnyBuilder, SubmitPresentBuilder, SubmitPresentError, SubmitSemaphoresWaitBuilder,
     },
-    device::{
-        physical::{ImageFormatPropertiesError, SurfacePropertiesError},
-        Device, DeviceOwned, Queue,
-    },
+    device::{Device, DeviceOwned, Queue},
     format::Format,
     image::{
         sys::UnsafeImage, ImageCreateFlags, ImageDimensions, ImageFormatInfo, ImageInner,
@@ -110,21 +107,6 @@ impl<W> Swapchain<W> {
         surface: Arc<Surface<W>>,
         mut create_info: SwapchainCreateInfo,
     ) -> Result<(Arc<Swapchain<W>>, Vec<Arc<SwapchainImage<W>>>), SwapchainCreationError> {
-        assert_eq!(
-            device.instance().internal_object(),
-            surface.instance().internal_object()
-        );
-
-        if !device.enabled_extensions().khr_swapchain {
-            return Err(SwapchainCreationError::RequirementNotMet {
-                required_for: "`Swapchain`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_swapchain"],
-                    ..Default::default()
-                },
-            });
-        }
-
         Self::validate(&device, &surface, &mut create_info)?;
 
         // Checking that the surface doesn't already have a swapchain.
@@ -302,6 +284,18 @@ impl<W> Swapchain<W> {
             _ne: _,
         } = create_info;
 
+        if !device.enabled_extensions().khr_swapchain {
+            return Err(SwapchainCreationError::RequirementNotMet {
+                required_for: "`Swapchain`",
+                requires_one_of: RequiresOneOf {
+                    device_extensions: &["khr_swapchain"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        assert_eq!(device.instance(), surface.instance());
+
         // VUID-VkSwapchainCreateInfoKHR-imageColorSpace-parameter
         image_color_space.validate_device(device)?;
 
@@ -350,18 +344,21 @@ impl<W> Swapchain<W> {
 
         // VUID-VkSwapchainCreateInfoKHR-surface-01270
         *image_format = Some({
-            let surface_formats = device.physical_device().surface_formats(
-                surface,
-                SurfaceInfo {
-                    full_screen_exclusive,
-                    win32_monitor,
-                    ..Default::default()
-                },
-            )?;
+            // Use unchecked, because all validation has been done above.
+            let surface_formats = unsafe {
+                device.physical_device().surface_formats_unchecked(
+                    surface,
+                    SurfaceInfo {
+                        full_screen_exclusive,
+                        win32_monitor,
+                        ..Default::default()
+                    },
+                )?
+            };
 
             if let Some(format) = image_format {
                 // VUID-VkSwapchainCreateInfoKHR-imageFormat-parameter
-                // TODO: format.validate_device(device)?;
+                format.validate_device(device)?;
 
                 // VUID-VkSwapchainCreateInfoKHR-imageFormat-01273
                 if !surface_formats
@@ -383,14 +380,17 @@ impl<W> Swapchain<W> {
             }
         });
 
-        let surface_capabilities = device.physical_device().surface_capabilities(
-            surface,
-            SurfaceInfo {
-                full_screen_exclusive,
-                win32_monitor,
-                ..Default::default()
-            },
-        )?;
+        // Use unchecked, because all validation has been done above.
+        let surface_capabilities = unsafe {
+            device.physical_device().surface_capabilities_unchecked(
+                surface,
+                SurfaceInfo {
+                    full_screen_exclusive,
+                    win32_monitor,
+                    ..Default::default()
+                },
+            )?
+        };
 
         // VUID-VkSwapchainCreateInfoKHR-minImageCount-01272
         // VUID-VkSwapchainCreateInfoKHR-presentMode-02839
@@ -502,25 +502,31 @@ impl<W> Swapchain<W> {
         }
 
         // VUID-VkSwapchainCreateInfoKHR-presentMode-01281
-        if !device
-            .physical_device()
-            .surface_present_modes(surface)?
-            .any(|mode| mode == present_mode)
+        // Use unchecked, because all validation has been done above.
+        if !unsafe {
+            device
+                .physical_device()
+                .surface_present_modes_unchecked(surface)?
+        }
+        .any(|mode| mode == present_mode)
         {
             return Err(SwapchainCreationError::PresentModeNotSupported);
         }
 
         // VUID-VkSwapchainCreateInfoKHR-imageFormat-01778
-        if device
-            .physical_device()
-            .image_format_properties(ImageFormatInfo {
-                format: *image_format,
-                image_type: ImageType::Dim2d,
-                tiling: ImageTiling::Optimal,
-                usage: image_usage,
-                ..Default::default()
-            })?
-            .is_none()
+        // Use unchecked, because all validation has been done above.
+        if unsafe {
+            device
+                .physical_device()
+                .image_format_properties_unchecked(ImageFormatInfo {
+                    format: *image_format,
+                    image_type: ImageType::Dim2d,
+                    tiling: ImageTiling::Optimal,
+                    usage: image_usage,
+                    ..Default::default()
+                })?
+        }
+        .is_none()
         {
             return Err(SwapchainCreationError::ImageFormatPropertiesNotSupported);
         }
@@ -1271,41 +1277,12 @@ impl From<OomError> for SwapchainCreationError {
     }
 }
 
-impl From<SurfacePropertiesError> for SwapchainCreationError {
-    #[inline]
-    fn from(err: SurfacePropertiesError) -> SwapchainCreationError {
-        match err {
-            SurfacePropertiesError::OomError(err) => Self::OomError(err),
-            SurfacePropertiesError::SurfaceLost => Self::SurfaceLost,
-            SurfacePropertiesError::NotSupported => unreachable!(),
-            SurfacePropertiesError::QueueFamilyIndexOutOfRange { .. } => unreachable!(),
-            SurfacePropertiesError::RequirementNotMet { .. } => unreachable!(),
-        }
-    }
-}
-
 impl From<RequirementNotMet> for SwapchainCreationError {
     #[inline]
     fn from(err: RequirementNotMet) -> Self {
         Self::RequirementNotMet {
             required_for: err.required_for,
             requires_one_of: err.requires_one_of,
-        }
-    }
-}
-
-impl From<ImageFormatPropertiesError> for SwapchainCreationError {
-    #[inline]
-    fn from(err: ImageFormatPropertiesError) -> Self {
-        match err {
-            ImageFormatPropertiesError::OomError(err) => Self::OomError(err),
-            ImageFormatPropertiesError::RequirementNotMet {
-                required_for,
-                requires_one_of,
-            } => Self::RequirementNotMet {
-                required_for,
-                requires_one_of,
-            },
         }
     }
 }


### PR DESCRIPTION
This adds validation to the one enum that was missing it, because it was more involved to implement. I also combined all the different error types of `PhysicalDevice` into a single `PhysicalDeviceError` to avoid having tons of them.