### PR TITLE
Fix LayerNotPresent error in debug.rs example

### DIFF
--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -58,10 +58,6 @@ fn main() {
     }
 
     // NOTE: To simplify the example code we won't verify these layer(s) are actually in the layers list:
-    #[cfg(not(target_os = "macos"))]
-    let layers = vec!["VK_LAYER_LUNARG_standard_validation".to_owned()];
-
-    #[cfg(target_os = "macos")]
     let layers = vec!["VK_LAYER_KHRONOS_validation".to_owned()];
 
     // Important: pass the extension(s) and layer(s) when creating the vulkano instance


### PR DESCRIPTION
the example debug.rs doesn't work on my arch Linux machine with the latest **vulkan-validation-layers** package:
```
pacman -Q --info vulkan-validation-layers
Name            : vulkan-validation-layers
Version         : 1.3.224.1-1
Description     : Vulkan Validation Layers
Architecture    : x86_64
URL             : https://www.khronos.org/vulkan/
Licenses        : custom
Groups          : vulkan-devel
Provides        : libVkLayer_khronos_validation.so=libVkLayer_khronos_validation.so-64
Depends On      : gcc-libs  vulkan-icd-loader  vulkan-headers  libx11
Optional Deps   : None
Required By     : vulkan-extra-layers  vulkan-extra-tools
Optional For    : None
Conflicts With  : None
Replaces        : None
Installed Size  : 276.32 MiB
Packager        : Laurent Carlier <lordheavym@archlinux.org>
Build Date      : Thu 08 Sep 2022 08:31:35 AM +01
Install Date    : Tue 13 Sep 2022 12:30:49 PM +01
Install Reason  : Explicitly installed
Install Script  : No
Validated By    : Signature
```
with error:
```
List of Vulkan debugging layers available to use:
        VK_LAYER_NV_optimus
        VK_LAYER_LUNARG_api_dump
        VK_LAYER_LUNARG_monitor
        VK_LAYER_LUNARG_screenshot
        VK_LAYER_KHRONOS_validation
thread 'main' panicked at 'failed to create Vulkan instance: LayerNotPresent', examples/src/bin/debug.rs:78:6
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
am not sure about the mac os validation layer name, but in this case, I just removed the platform-dependent code altogether.