### PR TITLE
Improvements to `from_handle` documentation and parameter order

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -208,14 +208,16 @@ impl UnsafeBuffer {
         Ok(Arc::new(buffer))
     }
 
-    /// Creates a new `UnsafeBuffer` from an ash-handle
+    /// Creates a new `UnsafeBuffer` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::Buffer,
         create_info: UnsafeBufferCreateInfo,
-        device: Arc<Device>,
     ) -> Arc<UnsafeBuffer> {
         let UnsafeBufferCreateInfo { size, usage, .. } = create_info;
 

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -72,14 +72,16 @@ impl UnsafeCommandPool {
         })
     }
 
-    /// Creates a new `UnsafeCommandPool` from an ash-handle
+    /// Creates a new `UnsafeCommandPool` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::CommandPool,
         create_info: UnsafeCommandPoolCreateInfo,
-        device: Arc<Device>,
     ) -> UnsafeCommandPool {
         let UnsafeCommandPoolCreateInfo {
             queue_family_index,

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -66,14 +66,16 @@ impl DescriptorSetLayout {
         }))
     }
 
-    /// Creates a new `DescriptorSetLayout` from an ash-handle
+    /// Creates a new `DescriptorSetLayout` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::DescriptorSetLayout,
         create_info: DescriptorSetLayoutCreateInfo,
-        device: Arc<Device>,
     ) -> Arc<DescriptorSetLayout> {
         let DescriptorSetLayoutCreateInfo {
             bindings,

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -118,14 +118,16 @@ impl UnsafeDescriptorPool {
         })
     }
 
-    /// Creates a new `UnsafeDescriptorPool` from an ash-handle
+    /// Creates a new `UnsafeDescriptorPool` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::DescriptorPool,
         create_info: UnsafeDescriptorPoolCreateInfo,
-        device: Arc<Device>,
     ) -> UnsafeDescriptorPool {
         let UnsafeDescriptorPoolCreateInfo {
             max_sets,

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -76,9 +76,14 @@ pub struct PhysicalDevice {
 }
 
 impl PhysicalDevice {
+    /// Creates a new `PhysicalDevice` from a raw object handle.
+    ///
+    /// # Safety
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `instance`.
     pub unsafe fn from_handle(
-        handle: ash::vk::PhysicalDevice,
         instance: Arc<Instance>,
+        handle: ash::vk::PhysicalDevice,
     ) -> Result<Arc<Self>, VulkanError> {
         let api_version = Self::get_api_version(handle, &instance);
         let extension_properties = Self::get_extension_properties(handle, &instance)?;

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -550,7 +550,7 @@ impl Instance {
 
             let physical_devices: SmallVec<[_; 4]> = handles
                 .into_iter()
-                .map(|handle| PhysicalDevice::from_handle(handle, self.clone()))
+                .map(|handle| PhysicalDevice::from_handle(self.clone(), handle))
                 .collect::<Result<_, _>>()?;
 
             Ok(physical_devices.into_iter())

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -176,33 +176,6 @@ impl PipelineLayout {
         push_constant_ranges_disjoint
     }
 
-    /// Creates a new `PipelineLayout` from an ash-handle
-    /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(
-        handle: ash::vk::PipelineLayout,
-        create_info: PipelineLayoutCreateInfo,
-        device: Arc<Device>,
-    ) -> Arc<PipelineLayout> {
-        let PipelineLayoutCreateInfo {
-            set_layouts,
-            push_constant_ranges,
-            _ne: _,
-        } = create_info;
-
-        let push_constant_ranges_disjoint =
-            Self::create_push_constant_ranges_disjoint(&push_constant_ranges);
-
-        Arc::new(PipelineLayout {
-            handle,
-            device,
-            set_layouts,
-            push_constant_ranges,
-            push_constant_ranges_disjoint,
-        })
-    }
-
     fn validate(
         device: &Device,
         create_info: &mut PipelineLayoutCreateInfo,
@@ -550,6 +523,35 @@ impl PipelineLayout {
         };
 
         Ok(handle)
+    }
+
+    /// Creates a new `PipelineLayout` from a raw object handle.
+    ///
+    /// # Safety
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
+    pub unsafe fn from_handle(
+        device: Arc<Device>,
+        handle: ash::vk::PipelineLayout,
+        create_info: PipelineLayoutCreateInfo,
+    ) -> Arc<PipelineLayout> {
+        let PipelineLayoutCreateInfo {
+            set_layouts,
+            push_constant_ranges,
+            _ne: _,
+        } = create_info;
+
+        let push_constant_ranges_disjoint =
+            Self::create_push_constant_ranges_disjoint(&push_constant_ranges);
+
+        Arc::new(PipelineLayout {
+            handle,
+            device,
+            set_layouts,
+            push_constant_ranges,
+            push_constant_ranges_disjoint,
+        })
     }
 
     /// Returns the descriptor set layouts this pipeline layout was created from.

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -104,14 +104,16 @@ impl QueryPool {
         }))
     }
 
-    /// Creates a new `QueryPool` from an ash-handle
+    /// Creates a new `QueryPool` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::QueryPool,
         create_info: QueryPoolCreateInfo,
-        device: Arc<Device>,
     ) -> Arc<QueryPool> {
         let QueryPoolCreateInfo {
             query_type,

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -330,14 +330,16 @@ impl Framebuffer {
         }))
     }
 
-    /// Creates a new `Framebuffer` from an ash-handle
+    /// Creates a new `Framebuffer` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `render_pass`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        render_pass: Arc<RenderPass>,
         handle: ash::vk::Framebuffer,
         create_info: FramebufferCreateInfo,
-        render_pass: Arc<RenderPass>,
     ) -> Arc<Framebuffer> {
         let FramebufferCreateInfo {
             attachments,

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -176,14 +176,32 @@ impl RenderPass {
         [out.width, out.height]
     }
 
-    /// Creates a new `RenderPass` from an ash-handle
+    /// Builds a render pass with one subpass and no attachment.
+    ///
+    /// This method is useful for quick tests.
+    #[inline]
+    pub fn empty_single_pass(
+        device: Arc<Device>,
+    ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
+        RenderPass::new(
+            device,
+            RenderPassCreateInfo {
+                subpasses: vec![SubpassDescription::default()],
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Creates a new `RenderPass` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::RenderPass,
         create_info: RenderPassCreateInfo,
-        device: Arc<Device>,
     ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
         let views_used = create_info
             .subpasses
@@ -213,22 +231,6 @@ impl RenderPass {
             granularity,
             views_used,
         }))
-    }
-
-    /// Builds a render pass with one subpass and no attachment.
-    ///
-    /// This method is useful for quick tests.
-    #[inline]
-    pub fn empty_single_pass(
-        device: Arc<Device>,
-    ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
-        RenderPass::new(
-            device,
-            RenderPassCreateInfo {
-                subpasses: vec![SubpassDescription::default()],
-                ..Default::default()
-            },
-        )
     }
 
     /// Returns the attachments of the render pass.

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -442,14 +442,16 @@ impl Sampler {
         }))
     }
 
-    /// Creates a new `Sampler` from an ash-handle
+    /// Creates a new `Sampler` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::Sampler,
         create_info: SamplerCreateInfo,
-        device: Arc<Device>,
     ) -> Arc<Sampler> {
         let SamplerCreateInfo {
             mag_filter,

--- a/vulkano/src/sampler/ycbcr.rs
+++ b/vulkano/src/sampler/ycbcr.rs
@@ -355,15 +355,17 @@ impl SamplerYcbcrConversion {
         }))
     }
 
-    /// Creates a new `SamplerYcbcrConversion` from an ash-handle
+    /// Creates a new `SamplerYcbcrConversion` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
-    /// `create_info.format` must be some -- see `SamplerYcbcrConversion`::new`
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
+    /// - `create_info.format` must be `Some`.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::SamplerYcbcrConversion,
         create_info: SamplerYcbcrConversionCreateInfo,
-        device: Arc<Device>,
     ) -> Arc<SamplerYcbcrConversion> {
         let SamplerYcbcrConversionCreateInfo {
             format,

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -51,7 +51,7 @@ impl<W> Surface<W> {
     ///
     /// # Safety
     ///
-    /// - `handle` must be a valid Vulkan surface handle owned by `instance`.
+    /// - `handle` must be a valid Vulkan object handle created from `instance`.
     /// - `handle` must have been created from `api`.
     /// - The window object that `handle` was created from must outlive the created `Surface`.
     ///   The `win` parameter can be used to ensure this.

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -1577,7 +1577,7 @@ pub fn wait_for_present<W>(
         (swapchain.device.fns().khr_present_wait.wait_for_present_khr)(
             swapchain.device.internal_object(),
             swapchain.handle,
-            present_id.into(),
+            present_id,
             timeout_ns,
         )
     };
@@ -1585,7 +1585,7 @@ pub fn wait_for_present<W>(
     match result {
         ash::vk::Result::SUCCESS => Ok(false),
         ash::vk::Result::SUBOPTIMAL_KHR => Ok(true),
-        ash::vk::Result::TIMEOUT => return Err(PresentWaitError::Timeout),
+        ash::vk::Result::TIMEOUT => Err(PresentWaitError::Timeout),
         err => {
             let err = VulkanError::from(err).into();
 

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -94,14 +94,16 @@ impl Event {
         Ok(event)
     }
 
-    /// Creates a new `Event` from an ash-handle
+    /// Creates a new `Event` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::Event,
         _create_info: EventCreateInfo,
-        device: Arc<Device>,
     ) -> Event {
         Event {
             device,

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -147,30 +147,6 @@ impl Fence {
         })
     }
 
-    /// Creates a new `Fence` from an ash-handle
-    /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(
-        handle: ash::vk::Fence,
-        create_info: FenceCreateInfo,
-        device: Arc<Device>,
-    ) -> Fence {
-        let FenceCreateInfo {
-            signaled,
-            export_handle_types,
-            _ne: _,
-        } = create_info;
-
-        Fence {
-            handle,
-            device,
-            _export_handle_types: export_handle_types,
-            is_signaled: AtomicBool::new(signaled),
-            must_put_in_pool: false,
-        }
-    }
-
     /// Takes a fence from the vulkano-provided fence pool.
     /// If the pool is empty, a new fence will be created.
     /// Upon `drop`, the fence is put back into the pool.
@@ -206,6 +182,32 @@ impl Fence {
         };
 
         Ok(fence)
+    }
+
+    /// Creates a new `Fence` from a raw object handle.
+    ///
+    /// # Safety
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
+    pub unsafe fn from_handle(
+        device: Arc<Device>,
+        handle: ash::vk::Fence,
+        create_info: FenceCreateInfo,
+    ) -> Fence {
+        let FenceCreateInfo {
+            signaled,
+            export_handle_types,
+            _ne: _,
+        } = create_info;
+
+        Fence {
+            handle,
+            device,
+            _export_handle_types: export_handle_types,
+            is_signaled: AtomicBool::new(signaled),
+            must_put_in_pool: false,
+        }
     }
 
     /// Returns true if the fence is signaled.

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -134,30 +134,6 @@ impl Semaphore {
         })
     }
 
-    /// Creates a new `Semaphore` from an ash-handle
-    /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `create_info` must match the info used to create said object
-    pub unsafe fn from_handle(
-        handle: ash::vk::Semaphore,
-        create_info: SemaphoreCreateInfo,
-        device: Arc<Device>,
-    ) -> Semaphore {
-        let SemaphoreCreateInfo {
-            export_handle_types,
-            _ne: _,
-        } = create_info;
-
-        Semaphore {
-            device,
-            handle,
-
-            export_handle_types,
-
-            must_put_in_pool: false,
-        }
-    }
-
     /// Takes a semaphore from the vulkano-provided semaphore pool.
     /// If the pool is empty, a new semaphore will be allocated.
     /// Upon `drop`, the semaphore is put back into the pool.
@@ -184,6 +160,32 @@ impl Semaphore {
         };
 
         Ok(semaphore)
+    }
+
+    /// Creates a new `Semaphore` from a raw object handle.
+    ///
+    /// # Safety
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
+    pub unsafe fn from_handle(
+        device: Arc<Device>,
+        handle: ash::vk::Semaphore,
+        create_info: SemaphoreCreateInfo,
+    ) -> Semaphore {
+        let SemaphoreCreateInfo {
+            export_handle_types,
+            _ne: _,
+        } = create_info;
+
+        Semaphore {
+            device,
+            handle,
+
+            export_handle_types,
+
+            must_put_in_pool: false,
+        }
     }
 
     /// Exports the semaphore into a POSIX file descriptor. The caller owns the returned `File`.


### PR DESCRIPTION
This improves the documentation of the new `from_handle` functions a bit. I also put the device/owning object as the first argument, because this is the standard order used across both Vulkan and Vulkano.

No changelog because this only affects functions that haven't been in a stable release yet.