### PR TITLE
Example Tweaks

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,5 +24,4 @@ png = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 ron = "0.7"
 rand = "0.8.4"
-
-glium = { git = "https://github.com/glium/glium.git", rev = "60889a2" }
+glium = "0.32.1"

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -232,4 +232,6 @@ fn main() {
     for n in 0..65536u32 {
         assert_eq!(data_buffer_content[n as usize], n * 12);
     }
+
+    println!("Success");
 }

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -1,6 +1,8 @@
 fn main() {
     #[cfg(target_os = "linux")]
     linux::main();
+    #[cfg(not(target_os = "linux"))]
+    println!("Not Implemented");
 }
 
 // TODO: Can this be demonstrated for other platforms as well?

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -60,18 +60,18 @@ mod linux {
     };
 
     pub fn main() {
-        let event_loop_gl = glutin::event_loop::EventLoop::new();
+        let event_loop = EventLoop::new();
         // For some reason, this must be created before the vulkan window
         let hrb = glutin::ContextBuilder::new()
             .with_gl_debug_flag(true)
             .with_gl(glutin::GlRequest::Latest)
-            .build_surfaceless(&event_loop_gl)
+            .build_surfaceless(&event_loop)
             .unwrap();
 
         let hrb_vk = glutin::ContextBuilder::new()
             .with_gl_debug_flag(true)
             .with_gl(glutin::GlRequest::Latest)
-            .build_surfaceless(&event_loop_gl)
+            .build_surfaceless(&event_loop)
             .unwrap();
 
         let display = glium::HeadlessRenderer::with_debug(
@@ -84,7 +84,6 @@ mod linux {
             _instance,
             mut swapchain,
             surface,
-            event_loop,
             mut viewport,
             queue,
             render_pass,
@@ -92,7 +91,7 @@ mod linux {
             sampler,
             pipeline,
             vertex_buffer,
-        ) = vk_setup(display);
+        ) = vk_setup(display, &event_loop);
 
         let image = StorageImage::new_with_exportable_fd(
             device.clone(),
@@ -388,12 +387,12 @@ mod linux {
     #[allow(clippy::type_complexity)]
     fn vk_setup(
         display: glium::HeadlessRenderer,
+        event_loop: &EventLoop<()>,
     ) -> (
         Arc<vulkano::device::Device>,
         Arc<vulkano::instance::Instance>,
         Arc<Swapchain<winit::window::Window>>,
         Arc<vulkano::swapchain::Surface<winit::window::Window>>,
-        winit::event_loop::EventLoop<()>,
         vulkano::pipeline::graphics::viewport::Viewport,
         Arc<Queue>,
         Arc<RenderPass>,
@@ -442,7 +441,6 @@ mod linux {
             .unwrap()
         };
 
-        let event_loop = EventLoop::new();
         let surface = WindowBuilder::new()
             .build_vk_surface(&event_loop, instance.clone())
             .unwrap();
@@ -630,7 +628,6 @@ mod linux {
             instance,
             swapchain,
             surface,
-            event_loop,
             viewport,
             queue,
             render_pass,

--- a/examples/src/bin/interactive_fractal/main.rs
+++ b/examples/src/bin/interactive_fractal/main.rs
@@ -44,7 +44,7 @@ fn main() {
         &context,
         &WindowDescriptor {
             title: "Fractal".to_string(),
-            present_mode: PresentMode::Immediate,
+            present_mode: PresentMode::Fifo,
             ..Default::default()
         },
         |_| {},

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -367,4 +367,8 @@ fn main() {
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder.write_header().unwrap();
     writer.write_image_data(&buffer_content).unwrap();
+
+    if let Ok(path) = path.canonicalize() {
+        println!("Saved to {}", path.display());
+    }
 }

--- a/examples/src/bin/multi_window_game_of_life/main.rs
+++ b/examples/src/bin/multi_window_game_of_life/main.rs
@@ -86,7 +86,7 @@ fn handle_events(
 ) -> bool {
     let mut is_running = true;
     event_loop.run_return(|event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        *control_flow = ControlFlow::Poll;
         match &event {
             Event::WindowEvent {
                 event, window_id, ..

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -387,4 +387,8 @@ fn write_image_buffer_to_file(
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder.write_header().unwrap();
     writer.write_image_data(&buffer_content).unwrap();
+
+    if let Ok(path) = path.canonicalize() {
+        println!("Saved to {}", path.display());
+    }
 }

--- a/examples/src/bin/pipeline-caching.rs
+++ b/examples/src/bin/pipeline-caching.rs
@@ -191,6 +191,9 @@ fn main() {
     // in the byte blob here, but it should still work.
     // If it doesn't, please check if there is an issue describing this problem, and if
     // not open a new one, on the GitHub page.
-    println!("first : {:?}", pipeline_cache.get_data().unwrap());
-    println!("second: {:?}", second_cache.get_data().unwrap());
+    assert_eq!(
+        pipeline_cache.get_data().unwrap(),
+        second_cache.get_data().unwrap()
+    );
+    println!("Success");
 }

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -183,4 +183,6 @@ fn main() {
         assert_eq!(data_buffer_content[n as usize], n * 12);
         assert_eq!(data_buffer_content[n as usize + 65536 / 2], n * 12);
     }
+
+    println!("Success");
 }

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -170,4 +170,6 @@ fn main() {
     for n in 0..65536u32 {
         assert_eq!(data_buffer_content[n as usize], n * 12);
     }
+
+    println!("Success");
 }


### PR DESCRIPTION
- Print file paths on examples that write to files.
  - `msaa-renderpass`
  - `multiview`
  - `dynamic-local-size`
- Print "Success" on examples that complete successfully but otherwise have no indications.
  - `basic-compute-shader`
  - `pipeline-caching`
  - `self-copy-buffer`
  - `shader-include`
- `gl-interop` now prints "Not implemented" when target isn't linux.
- `gl-interop` now uses the released version of `glium`.
- `interactive_fractal` now uses `PresentMode::Fifo` for better compatibility.
- `multi_window_game_of_life` now uses `ControlFlow::Poll` to allow proper rendering on platforms that don't request redraws.

