### PR TITLE
Treat atomic writes in shaders as write accesses

### DIFF
--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -442,7 +442,7 @@ mod linux {
         };
 
         let surface = WindowBuilder::new()
-            .build_vk_surface(&event_loop, instance.clone())
+            .build_vk_surface(event_loop, instance.clone())
             .unwrap();
 
         let device_extensions = DeviceExtensions {


### PR DESCRIPTION
Changelog (add to existing section):
```markdown
- Bugs fixed: 
  - Atomic writes in shaders are not treated as write access for the purposes of synchronization.
```