### PR TITLE
Fix handling of runtime sized arrays in shaders

### DIFF
--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -110,6 +110,12 @@ fn write_descriptor_requirements(
             let ident = format_ident!("{}", format!("{:?}", ty));
             quote! { ::vulkano::descriptor_set::layout::DescriptorType::#ident }
         });
+        let descriptor_count = match descriptor_count {
+            Some(descriptor_count) => {
+                quote! { Some(#descriptor_count) }
+            }
+            None => quote! { None },
+        };
         let image_format = match image_format {
             Some(image_format) => {
                 let ident = format_ident!("{}", format!("{:?}", image_format));

--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -111,9 +111,7 @@ fn write_descriptor_requirements(
             quote! { ::vulkano::descriptor_set::layout::DescriptorType::#ident }
         });
         let descriptor_count = match descriptor_count {
-            Some(descriptor_count) => {
-                quote! { Some(#descriptor_count) }
-            }
+            Some(descriptor_count) => quote! { Some(#descriptor_count) },
             None => quote! { None },
         };
         let image_format = match image_format {

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -196,7 +196,7 @@ where
     #[inline]
     pub fn new(device: Arc<Device>, usage: BufferUsage) -> CpuBufferPool<T> {
         assert!(size_of::<T>() > 0);
-        let pool = device.standard_memory_pool().clone();
+        let pool = device.standard_memory_pool();
 
         CpuBufferPool {
             device,

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -542,7 +542,10 @@ pub struct DescriptorRequirements {
 
     /// The number of descriptors (array elements) that the shader requires. The descriptor set
     /// layout can declare more than this, but never less.
-    pub descriptor_count: u32,
+    ///
+    /// `None` means that the shader declares this as a runtime-sized array, and could potentially
+    /// access every array element provided in the descriptor set.
+    pub descriptor_count: Option<u32>,
 
     /// The image format that is required for image views bound to this descriptor. If this is
     /// `None`, then any image format is allowed.

--- a/vulkano/src/shader/reflect.rs
+++ b/vulkano/src/shader/reflect.rs
@@ -711,7 +711,7 @@ fn descriptor_requirements_of(spirv: &Spirv, variable_id: Id) -> DescriptorVaria
     let variable_id_info = spirv.id(variable_id);
 
     let mut reqs = DescriptorRequirements {
-        descriptor_count: 1,
+        descriptor_count: Some(1),
         ..Default::default()
     };
 
@@ -878,12 +878,15 @@ fn descriptor_requirements_of(spirv: &Spirv, variable_id: Id) -> DescriptorVaria
                     _ => panic!("failed to find array length"),
                 };
 
-                reqs.descriptor_count *= len as u32;
+                if let Some(count) = reqs.descriptor_count.as_mut() {
+                    *count *= len as u32
+                }
+
                 Some(element_type)
             }
 
             &Instruction::TypeRuntimeArray { element_type, .. } => {
-                reqs.descriptor_count = 0;
+                reqs.descriptor_count = None;
                 Some(element_type)
             }
 


### PR DESCRIPTION
Changelog:
```markdown
- Bugs fixed:
  - Incorrect check for descriptor set validity when the shader declares a runtime-sized array.
```

Reported on Discord by @winterle.