### PR TITLE
Fix clippy warnings with new Rust version

### DIFF
--- a/vulkano/src/image/aspect.rs
+++ b/vulkano/src/image/aspect.rs
@@ -130,16 +130,16 @@ impl ImageAspects {
         } = *self;
 
         [
-            color.then(|| ImageAspect::Color),
-            depth.then(|| ImageAspect::Depth),
-            stencil.then(|| ImageAspect::Stencil),
-            metadata.then(|| ImageAspect::Metadata),
-            plane0.then(|| ImageAspect::Plane0),
-            plane1.then(|| ImageAspect::Plane1),
-            plane2.then(|| ImageAspect::Plane2),
-            memory_plane0.then(|| ImageAspect::MemoryPlane0),
-            memory_plane1.then(|| ImageAspect::MemoryPlane1),
-            memory_plane2.then(|| ImageAspect::MemoryPlane2),
+            color.then_some(ImageAspect::Color),
+            depth.then_some(ImageAspect::Depth),
+            stencil.then_some(ImageAspect::Stencil),
+            metadata.then_some(ImageAspect::Metadata),
+            plane0.then_some(ImageAspect::Plane0),
+            plane1.then_some(ImageAspect::Plane1),
+            plane2.then_some(ImageAspect::Plane2),
+            memory_plane0.then_some(ImageAspect::MemoryPlane0),
+            memory_plane1.then_some(ImageAspect::MemoryPlane1),
+            memory_plane2.then_some(ImageAspect::MemoryPlane2),
         ]
         .into_iter()
         .flatten()

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -879,19 +879,19 @@ impl ExternalMemoryHandleTypes {
         } = *self;
 
         [
-            opaque_fd.then(|| ExternalMemoryHandleType::OpaqueFd),
-            opaque_win32.then(|| ExternalMemoryHandleType::OpaqueWin32),
-            opaque_win32_kmt.then(|| ExternalMemoryHandleType::OpaqueWin32Kmt),
-            d3d11_texture.then(|| ExternalMemoryHandleType::D3D11Texture),
-            d3d11_texture_kmt.then(|| ExternalMemoryHandleType::D3D11TextureKmt),
-            d3d12_heap.then(|| ExternalMemoryHandleType::D3D12Heap),
-            d3d12_resource.then(|| ExternalMemoryHandleType::D3D12Resource),
-            dma_buf.then(|| ExternalMemoryHandleType::DmaBuf),
-            android_hardware_buffer.then(|| ExternalMemoryHandleType::AndroidHardwareBuffer),
-            host_allocation.then(|| ExternalMemoryHandleType::HostAllocation),
-            host_mapped_foreign_memory.then(|| ExternalMemoryHandleType::HostMappedForeignMemory),
-            zircon_vmo.then(|| ExternalMemoryHandleType::HostMappedForeignMemory),
-            rdma_address.then(|| ExternalMemoryHandleType::HostMappedForeignMemory),
+            opaque_fd.then_some(ExternalMemoryHandleType::OpaqueFd),
+            opaque_win32.then_some(ExternalMemoryHandleType::OpaqueWin32),
+            opaque_win32_kmt.then_some(ExternalMemoryHandleType::OpaqueWin32Kmt),
+            d3d11_texture.then_some(ExternalMemoryHandleType::D3D11Texture),
+            d3d11_texture_kmt.then_some(ExternalMemoryHandleType::D3D11TextureKmt),
+            d3d12_heap.then_some(ExternalMemoryHandleType::D3D12Heap),
+            d3d12_resource.then_some(ExternalMemoryHandleType::D3D12Resource),
+            dma_buf.then_some(ExternalMemoryHandleType::DmaBuf),
+            android_hardware_buffer.then_some(ExternalMemoryHandleType::AndroidHardwareBuffer),
+            host_allocation.then_some(ExternalMemoryHandleType::HostAllocation),
+            host_mapped_foreign_memory.then_some(ExternalMemoryHandleType::HostMappedForeignMemory),
+            zircon_vmo.then_some(ExternalMemoryHandleType::HostMappedForeignMemory),
+            rdma_address.then_some(ExternalMemoryHandleType::HostMappedForeignMemory),
         ]
         .into_iter()
         .flatten()

--- a/vulkano/src/pipeline/graphics/builder.rs
+++ b/vulkano/src/pipeline/graphics/builder.rs
@@ -399,15 +399,15 @@ where
 
             vertex_input_state, // Can be None if there's a mesh shader, but we don't support that yet
             input_assembly_state, // Can be None if there's a mesh shader, but we don't support that yet
-            tessellation_state: has.tessellation_state.then(|| tessellation_state),
-            viewport_state: has.viewport_state.then(|| viewport_state),
+            tessellation_state: has.tessellation_state.then_some(tessellation_state),
+            viewport_state: has.viewport_state.then_some(viewport_state),
             discard_rectangle_state: has
                 .pre_rasterization_shader_state
-                .then(|| discard_rectangle_state),
+                .then_some(discard_rectangle_state),
             rasterization_state,
-            multisample_state: has.fragment_output_state.then(|| multisample_state),
-            depth_stencil_state: has.depth_stencil_state.then(|| depth_stencil_state),
-            color_blend_state: has.color_blend_state.then(|| color_blend_state),
+            multisample_state: has.fragment_output_state.then_some(multisample_state),
+            depth_stencil_state: has.depth_stencil_state.then_some(depth_stencil_state),
+            color_blend_state: has.color_blend_state.then_some(color_blend_state),
             dynamic_state,
         }))
     }

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -429,7 +429,7 @@ impl Sampler {
             border_color: address_mode
                 .into_iter()
                 .any(|mode| mode == SamplerAddressMode::ClampToBorder)
-                .then(|| border_color),
+                .then_some(border_color),
             compare,
             lod,
             mag_filter,
@@ -478,7 +478,7 @@ impl Sampler {
             border_color: address_mode
                 .into_iter()
                 .any(|mode| mode == SamplerAddressMode::ClampToBorder)
-                .then(|| border_color),
+                .then_some(border_color),
             compare,
             lod,
             mag_filter,

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -377,7 +377,7 @@ impl<W> Swapchain<W> {
                     .find_map(|(f, c)| {
                         (c == image_color_space
                             && [Format::R8G8B8A8_UNORM, Format::B8G8R8A8_UNORM].contains(&f))
-                        .then(|| f)
+                        .then_some(f)
                     })
                     .ok_or(SwapchainCreationError::FormatColorSpaceNotSupported)?
             }


### PR DESCRIPTION
Rust 1.64, released today, added a new clippy warning that was triggering on the Vulkano code in a few places. This PR fixes those.