### PR TITLE
Updated pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ Changelog:
  
 ### Breaking changes
 Changes to `Foo`:
-- Renamed to `Bar`
+- Renamed to `Bar`.
 
 ### Additions
 - Support for the `khr_foorbar` extension.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,5 +27,5 @@ Changes to `Foo`:
 - Support for the `khr_foorbar` extension.
 
 ### Bugs fixed
-- `bar` no longer panics when calling `foo`.
+- `bar` panics when calling `foo`.
 ````

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,31 @@
-1. [ ] Describe in common words what is the purpose of this change, related
-   Github Issues, and highlight important implementation aspects.
+1. [ ] Update documentation to reflect any user-facing changes - in this repository.
 
-2. [ ] Please put changelog entries **in the description of this Pull Request**
-   if knowledge of this change could be valuable to users. No need to put the
-   entries to the changelog directly, they will be transferred to the changelog
-   files(`CHANGELOG_VULKANO.md` and `CHANGELOG_VK_SYS.md`)
-   by maintainers right after the Pull Request merge.
-
-    * Entries for Vulkano changelog:
-        - `**Breaking** Breaking entry description.`
-        - `Non-breaking entry description.`...
-
-    * Entries for VkSys changelog:
-        - `Entry 1.`
-        - `Entry 2.`...
+2. [ ] Make sure that the changes are covered by unit-tests.
 
 3. [ ] Run `cargo fmt` on the changes.
 
-4. [ ] Make sure that the changes are covered by unit-tests.
+4. [ ] Please put changelog entries **in the description of this Pull Request**
+   if knowledge of this change could be valuable to users. No need to put the
+   entries to the changelog directly, they will be transferred to the changelog
+   file by maintainers right after the Pull Request merge.
+   
+   Please remove any items from the template below that are not applicable.
 
-5. [ ] Update documentation to reflect any user-facing changes - in this repository.
+5. [ ] Describe in common words what is the purpose of this change, related
+   Github Issues, and highlight important implementation aspects.
+
+Changelog:
+```markdown
+### Public dependency updates
+- [some_crate](https://crates.io/crates/some_crate) 1.0
+ 
+### Breaking changes
+Changes to `Foo`:
+- Renamed to `Bar`
+
+### Additions
+- Support for the `khr_foorbar` extension.
+
+### Bugs fixed
+- `bar` no longer panics when calling `foo`.
+````

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Changes to `Foo`:
 - Renamed to `Bar`.
 
 ### Additions
-- Support for the `khr_foorbar` extension.
+- Support for the `khr_foobar` extension.
 
 ### Bugs fixed
 - `bar` panics when calling `foo`.


### PR DESCRIPTION
I placed the changelog template at the bottom, and formatted it the way I usually do, with `markdown` highlighting. The template now has example items for each header.

I also rearranged the other items, so that they appear in roughly the order that the user should perform them in.