### PR TITLE
Fix feature name casing

### DIFF
--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -550,7 +550,7 @@ fn features_members(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<FeaturesMe
                             name: format_ident!("{}", name),
                             doc: String::new(),
                             ffi_name: format_ident!("{}", name),
-                            raw: name,
+                            raw: vulkan_name.to_owned(),
                             ffi_members: vec![ty_name.clone()],
                             requires_features: requires_features
                                 .iter()
@@ -596,7 +596,13 @@ fn features_members(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<FeaturesMe
 
 fn make_doc(feat: &mut FeaturesMember, vulkan_ty_name: &str) {
     let writer = &mut feat.doc;
-    write!(writer, "- [Vulkan documentation](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/{}.html#features-{})", vulkan_ty_name, feat.name).unwrap();
+    write!(
+        writer,
+        "- [Vulkan documentation](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/{}.html#features-{})",
+        vulkan_ty_name,
+        feat.raw
+    )
+    .unwrap();
 
     if !feat.requires_features.is_empty() {
         let links: Vec<_> = feat

--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -41,6 +41,7 @@ struct PropertiesMember {
     name: Ident,
     ty: TokenStream,
     doc: String,
+    raw: String,
     ffi_name: Ident,
     ffi_members: Vec<(Ident, TokenStream)>,
     optional: bool,
@@ -206,6 +207,7 @@ fn properties_members(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<Properti
                             name: format_ident!("{}", vulkano_member),
                             ty: vulkano_ty,
                             doc: String::new(),
+                            raw: name.to_owned(),
                             ffi_name: format_ident!("{}", vulkano_member),
                             ffi_members: vec![ty_name.clone()],
                             optional,
@@ -233,7 +235,13 @@ fn properties_members(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<Properti
 
 fn make_doc(prop: &mut PropertiesMember, vulkan_ty_name: &str) {
     let writer = &mut prop.doc;
-    write!(writer, "- [Vulkan documentation](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/{}.html#limits-{})", vulkan_ty_name, prop.name).unwrap();
+    write!(
+        writer,
+        "- [Vulkan documentation](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/{}.html#limits-{})",
+        vulkan_ty_name,
+        prop.raw
+    )
+    .unwrap();
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This fixes a small issue where all of the fields containing names for a feature would use snake case, which results in the generated link to the specification to not work correctly. This PR addresses that by storing the original (camel case) name of the feature in one of the fields.