### PR TITLE
Cache results of some `PhysicalDevice` methods for faster future retrieval

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -19,7 +19,6 @@ build = "build.rs"
 ash = "0.37"
 bytemuck = { version = "1.7", features = ["derive", "extern_crate_std", "min_const_generics"] }
 crossbeam-queue = "0.3"
-dashmap = "5"
 half = "2"
 libloading = "0.7"
 nalgebra = { version = "0.31.0", optional = true }

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -19,6 +19,7 @@ build = "build.rs"
 ash = "0.37"
 bytemuck = { version = "1.7", features = ["derive", "extern_crate_std", "min_const_generics"] }
 crossbeam-queue = "0.3"
+dashmap = "5"
 half = "2"
 libloading = "0.7"
 nalgebra = { version = "0.31.0", optional = true }

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -173,7 +173,7 @@ where
 
 /// The buffer configuration to query in
 /// [`PhysicalDevice::external_buffer_properties`](crate::device::physical::PhysicalDevice::external_buffer_properties).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ExternalBufferInfo {
     /// The external handle type that will be used with the buffer.
     pub handle_type: ExternalMemoryHandleType,

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -2839,7 +2839,7 @@ pub enum PhysicalDeviceError {
         queue_family_count: u32,
     },
 
-    // The provided `surface` is not supported by the physical device for any queue family.
+    // The provided `surface` is not supported by any of the physical device's queue families.
     SurfaceNotSupported,
 }
 
@@ -2885,7 +2885,7 @@ impl Display for PhysicalDeviceError {
             ),
             Self::SurfaceNotSupported => write!(
                 f,
-                "the provided `surface` is not supported by the physical device for any queue family",
+                "the provided `surface` is not supported by any of the physical device's queue families",
             ),
         }
     }

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -2147,7 +2147,10 @@ impl PhysicalDevice {
         queue_family_index: u32,
         surface: &Surface<W>,
     ) -> Result<bool, VulkanError> {
-        match surface.surface_support.entry(self.handle) {
+        match surface
+            .surface_support
+            .entry((self.handle, queue_family_index))
+        {
             DashMapEntry::Occupied(entry) => Ok(*entry.get()),
             DashMapEntry::Vacant(entry) => {
                 let result = {

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -30,8 +30,10 @@ use crate::{
     RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
 use bytemuck::cast_slice;
-use dashmap::{mapref::entry::Entry as DashMapEntry, DashMap};
+use parking_lot::RwLock;
 use std::{
+    collections::{hash_map::Entry, HashMap},
+    convert::Infallible,
     error::Error,
     fmt::{Debug, Display, Error as FmtError, Formatter},
     hash::{Hash, Hasher},
@@ -61,7 +63,7 @@ use std::{
 ///     println!("Name: {}", dev.properties().device_name);
 /// }
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PhysicalDevice {
     handle: ash::vk::PhysicalDevice,
     instance: Arc<Instance>,
@@ -76,13 +78,14 @@ pub struct PhysicalDevice {
     queue_family_properties: Vec<QueueFamilyProperties>,
 
     // Data queried by the user at runtime, cached for faster lookups.
-    external_buffer_properties: DashMap<ExternalBufferInfo, ExternalBufferProperties>,
-    external_fence_properties: DashMap<ExternalFenceInfo, ExternalFenceProperties>,
-    external_semaphore_properties: DashMap<ExternalSemaphoreInfo, ExternalSemaphoreProperties>,
-    format_properties: DashMap<Format, FormatProperties>,
-    image_format_properties: DashMap<ImageFormatInfo, Option<ImageFormatProperties>>,
+    external_buffer_properties: RwLock<HashMap<ExternalBufferInfo, ExternalBufferProperties>>,
+    external_fence_properties: RwLock<HashMap<ExternalFenceInfo, ExternalFenceProperties>>,
+    external_semaphore_properties:
+        RwLock<HashMap<ExternalSemaphoreInfo, ExternalSemaphoreProperties>>,
+    format_properties: RwLock<HashMap<Format, FormatProperties>>,
+    image_format_properties: RwLock<HashMap<ImageFormatInfo, Option<ImageFormatProperties>>>,
     sparse_image_format_properties:
-        DashMap<SparseImageFormatInfo, Vec<SparseImageFormatProperties>>,
+        RwLock<HashMap<SparseImageFormatInfo, Vec<SparseImageFormatProperties>>>,
 }
 
 impl PhysicalDevice {
@@ -140,12 +143,12 @@ impl PhysicalDevice {
             memory_properties,
             queue_family_properties,
 
-            external_buffer_properties: DashMap::new(),
-            external_fence_properties: DashMap::new(),
-            external_semaphore_properties: DashMap::new(),
-            format_properties: DashMap::new(),
-            image_format_properties: DashMap::new(),
-            sparse_image_format_properties: DashMap::new(),
+            external_buffer_properties: RwLock::new(HashMap::new()),
+            external_fence_properties: RwLock::new(HashMap::new()),
+            external_semaphore_properties: RwLock::new(HashMap::new()),
+            format_properties: RwLock::new(HashMap::new()),
+            image_format_properties: RwLock::new(HashMap::new()),
+            sparse_image_format_properties: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -541,60 +544,53 @@ impl PhysicalDevice {
         &self,
         info: ExternalBufferInfo,
     ) -> ExternalBufferProperties {
-        match self.external_buffer_properties.entry(info) {
-            DashMapEntry::Occupied(entry) => entry.get().clone(),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    /* Input */
+        get_cached(&self.external_buffer_properties, info, |info| {
+            /* Input */
 
-                    let &ExternalBufferInfo {
-                        handle_type,
-                        usage,
-                        sparse,
-                        _ne: _,
-                    } = entry.key();
+            let &ExternalBufferInfo {
+                handle_type,
+                usage,
+                sparse,
+                _ne: _,
+            } = info;
 
-                    let external_buffer_info = ash::vk::PhysicalDeviceExternalBufferInfo {
-                        flags: sparse.map(Into::into).unwrap_or_default(),
-                        usage: usage.into(),
-                        handle_type: handle_type.into(),
-                        ..Default::default()
-                    };
+            let external_buffer_info = ash::vk::PhysicalDeviceExternalBufferInfo {
+                flags: sparse.map(Into::into).unwrap_or_default(),
+                usage: usage.into(),
+                handle_type: handle_type.into(),
+                ..Default::default()
+            };
 
-                    /* Output */
+            /* Output */
 
-                    let mut external_buffer_properties =
-                        ash::vk::ExternalBufferProperties::default();
+            let mut external_buffer_properties = ash::vk::ExternalBufferProperties::default();
 
-                    /* Call */
+            /* Call */
 
-                    let fns = self.instance.fns();
+            let fns = self.instance.fns();
 
-                    if self.instance.api_version() >= Version::V1_1 {
-                        (fns.v1_1.get_physical_device_external_buffer_properties)(
-                            self.handle,
-                            &external_buffer_info,
-                            &mut external_buffer_properties,
-                        )
-                    } else {
-                        (fns.khr_external_memory_capabilities
-                            .get_physical_device_external_buffer_properties_khr)(
-                            self.handle,
-                            &external_buffer_info,
-                            &mut external_buffer_properties,
-                        );
-                    }
-
-                    ExternalBufferProperties {
-                        external_memory_properties: external_buffer_properties
-                            .external_memory_properties
-                            .into(),
-                    }
-                };
-
-                entry.insert(result).clone()
+            if self.instance.api_version() >= Version::V1_1 {
+                (fns.v1_1.get_physical_device_external_buffer_properties)(
+                    self.handle,
+                    &external_buffer_info,
+                    &mut external_buffer_properties,
+                )
+            } else {
+                (fns.khr_external_memory_capabilities
+                    .get_physical_device_external_buffer_properties_khr)(
+                    self.handle,
+                    &external_buffer_info,
+                    &mut external_buffer_properties,
+                );
             }
-        }
+
+            Ok::<_, Infallible>(ExternalBufferProperties {
+                external_memory_properties: external_buffer_properties
+                    .external_memory_properties
+                    .into(),
+            })
+        })
+        .unwrap()
     }
 
     /// Retrieves the external handle properties supported for fences with a given
@@ -652,64 +648,56 @@ impl PhysicalDevice {
         &self,
         info: ExternalFenceInfo,
     ) -> ExternalFenceProperties {
-        match self.external_fence_properties.entry(info) {
-            DashMapEntry::Occupied(entry) => entry.get().clone(),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    /* Input */
+        get_cached(&self.external_fence_properties, info, |info| {
+            /* Input */
 
-                    let &ExternalFenceInfo {
-                        handle_type,
-                        _ne: _,
-                    } = entry.key();
+            let &ExternalFenceInfo {
+                handle_type,
+                _ne: _,
+            } = info;
 
-                    let external_fence_info = ash::vk::PhysicalDeviceExternalFenceInfo {
-                        handle_type: handle_type.into(),
-                        ..Default::default()
-                    };
+            let external_fence_info = ash::vk::PhysicalDeviceExternalFenceInfo {
+                handle_type: handle_type.into(),
+                ..Default::default()
+            };
 
-                    /* Output */
+            /* Output */
 
-                    let mut external_fence_properties = ash::vk::ExternalFenceProperties::default();
+            let mut external_fence_properties = ash::vk::ExternalFenceProperties::default();
 
-                    /* Call */
+            /* Call */
 
-                    let fns = self.instance.fns();
+            let fns = self.instance.fns();
 
-                    if self.instance.api_version() >= Version::V1_1 {
-                        (fns.v1_1.get_physical_device_external_fence_properties)(
-                            self.handle,
-                            &external_fence_info,
-                            &mut external_fence_properties,
-                        )
-                    } else {
-                        (fns.khr_external_fence_capabilities
-                            .get_physical_device_external_fence_properties_khr)(
-                            self.handle,
-                            &external_fence_info,
-                            &mut external_fence_properties,
-                        );
-                    }
-
-                    ExternalFenceProperties {
-                        exportable: external_fence_properties
-                            .external_fence_features
-                            .intersects(ash::vk::ExternalFenceFeatureFlags::EXPORTABLE),
-                        importable: external_fence_properties
-                            .external_fence_features
-                            .intersects(ash::vk::ExternalFenceFeatureFlags::IMPORTABLE),
-                        export_from_imported_handle_types: external_fence_properties
-                            .export_from_imported_handle_types
-                            .into(),
-                        compatible_handle_types: external_fence_properties
-                            .compatible_handle_types
-                            .into(),
-                    }
-                };
-
-                entry.insert(result).clone()
+            if self.instance.api_version() >= Version::V1_1 {
+                (fns.v1_1.get_physical_device_external_fence_properties)(
+                    self.handle,
+                    &external_fence_info,
+                    &mut external_fence_properties,
+                )
+            } else {
+                (fns.khr_external_fence_capabilities
+                    .get_physical_device_external_fence_properties_khr)(
+                    self.handle,
+                    &external_fence_info,
+                    &mut external_fence_properties,
+                );
             }
-        }
+
+            Ok::<_, Infallible>(ExternalFenceProperties {
+                exportable: external_fence_properties
+                    .external_fence_features
+                    .intersects(ash::vk::ExternalFenceFeatureFlags::EXPORTABLE),
+                importable: external_fence_properties
+                    .external_fence_features
+                    .intersects(ash::vk::ExternalFenceFeatureFlags::IMPORTABLE),
+                export_from_imported_handle_types: external_fence_properties
+                    .export_from_imported_handle_types
+                    .into(),
+                compatible_handle_types: external_fence_properties.compatible_handle_types.into(),
+            })
+        })
+        .unwrap()
     }
 
     /// Retrieves the external handle properties supported for semaphores with a given
@@ -767,65 +755,58 @@ impl PhysicalDevice {
         &self,
         info: ExternalSemaphoreInfo,
     ) -> ExternalSemaphoreProperties {
-        match self.external_semaphore_properties.entry(info) {
-            DashMapEntry::Occupied(entry) => entry.get().clone(),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    /* Input */
+        get_cached(&self.external_semaphore_properties, info, |info| {
+            /* Input */
 
-                    let &ExternalSemaphoreInfo {
-                        handle_type,
-                        _ne: _,
-                    } = entry.key();
+            let &ExternalSemaphoreInfo {
+                handle_type,
+                _ne: _,
+            } = info;
 
-                    let external_semaphore_info = ash::vk::PhysicalDeviceExternalSemaphoreInfo {
-                        handle_type: handle_type.into(),
-                        ..Default::default()
-                    };
+            let external_semaphore_info = ash::vk::PhysicalDeviceExternalSemaphoreInfo {
+                handle_type: handle_type.into(),
+                ..Default::default()
+            };
 
-                    /* Output */
+            /* Output */
 
-                    let mut external_semaphore_properties =
-                        ash::vk::ExternalSemaphoreProperties::default();
+            let mut external_semaphore_properties = ash::vk::ExternalSemaphoreProperties::default();
 
-                    /* Call */
+            /* Call */
 
-                    let fns = self.instance.fns();
+            let fns = self.instance.fns();
 
-                    if self.instance.api_version() >= Version::V1_1 {
-                        (fns.v1_1.get_physical_device_external_semaphore_properties)(
-                            self.handle,
-                            &external_semaphore_info,
-                            &mut external_semaphore_properties,
-                        )
-                    } else {
-                        (fns.khr_external_semaphore_capabilities
-                            .get_physical_device_external_semaphore_properties_khr)(
-                            self.handle,
-                            &external_semaphore_info,
-                            &mut external_semaphore_properties,
-                        );
-                    }
-
-                    ExternalSemaphoreProperties {
-                        exportable: external_semaphore_properties
-                            .external_semaphore_features
-                            .intersects(ash::vk::ExternalSemaphoreFeatureFlags::EXPORTABLE),
-                        importable: external_semaphore_properties
-                            .external_semaphore_features
-                            .intersects(ash::vk::ExternalSemaphoreFeatureFlags::IMPORTABLE),
-                        export_from_imported_handle_types: external_semaphore_properties
-                            .export_from_imported_handle_types
-                            .into(),
-                        compatible_handle_types: external_semaphore_properties
-                            .compatible_handle_types
-                            .into(),
-                    }
-                };
-
-                entry.insert(result).clone()
+            if self.instance.api_version() >= Version::V1_1 {
+                (fns.v1_1.get_physical_device_external_semaphore_properties)(
+                    self.handle,
+                    &external_semaphore_info,
+                    &mut external_semaphore_properties,
+                )
+            } else {
+                (fns.khr_external_semaphore_capabilities
+                    .get_physical_device_external_semaphore_properties_khr)(
+                    self.handle,
+                    &external_semaphore_info,
+                    &mut external_semaphore_properties,
+                );
             }
-        }
+
+            Ok::<_, Infallible>(ExternalSemaphoreProperties {
+                exportable: external_semaphore_properties
+                    .external_semaphore_features
+                    .intersects(ash::vk::ExternalSemaphoreFeatureFlags::EXPORTABLE),
+                importable: external_semaphore_properties
+                    .external_semaphore_features
+                    .intersects(ash::vk::ExternalSemaphoreFeatureFlags::IMPORTABLE),
+                export_from_imported_handle_types: external_semaphore_properties
+                    .export_from_imported_handle_types
+                    .into(),
+                compatible_handle_types: external_semaphore_properties
+                    .compatible_handle_types
+                    .into(),
+            })
+        })
+        .unwrap()
     }
 
     /// Retrieves the properties of a format when used by this physical device.
@@ -851,83 +832,70 @@ impl PhysicalDevice {
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn format_properties_unchecked(&self, format: Format) -> FormatProperties {
-        match self.format_properties.entry(format) {
-            DashMapEntry::Occupied(entry) => *entry.get(),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    let mut format_properties2 = ash::vk::FormatProperties2::default();
-                    let mut format_properties3 = if self.api_version() >= Version::V1_3
-                        || self.supported_extensions().khr_format_feature_flags2
-                    {
-                        Some(ash::vk::FormatProperties3KHR::default())
-                    } else {
-                        None
-                    };
+        get_cached(&self.format_properties, format, |&format| {
+            let mut format_properties2 = ash::vk::FormatProperties2::default();
+            let mut format_properties3 = if self.api_version() >= Version::V1_3
+                || self.supported_extensions().khr_format_feature_flags2
+            {
+                Some(ash::vk::FormatProperties3KHR::default())
+            } else {
+                None
+            };
 
-                    if let Some(next) = format_properties3.as_mut() {
-                        next.p_next = format_properties2.p_next;
-                        format_properties2.p_next = next as *mut _ as *mut _;
-                    }
-
-                    let fns = self.instance.fns();
-
-                    if self.api_version() >= Version::V1_1 {
-                        (fns.v1_1.get_physical_device_format_properties2)(
-                            self.handle,
-                            format.into(),
-                            &mut format_properties2,
-                        );
-                    } else if self
-                        .instance
-                        .enabled_extensions()
-                        .khr_get_physical_device_properties2
-                    {
-                        (fns.khr_get_physical_device_properties2
-                            .get_physical_device_format_properties2_khr)(
-                            self.handle,
-                            format.into(),
-                            &mut format_properties2,
-                        );
-                    } else {
-                        (fns.v1_0.get_physical_device_format_properties)(
-                            self.internal_object(),
-                            format.into(),
-                            &mut format_properties2.format_properties,
-                        );
-                    }
-
-                    match format_properties3 {
-                        Some(format_properties3) => FormatProperties {
-                            linear_tiling_features: format_properties3
-                                .linear_tiling_features
-                                .into(),
-                            optimal_tiling_features: format_properties3
-                                .optimal_tiling_features
-                                .into(),
-                            buffer_features: format_properties3.buffer_features.into(),
-                            _ne: crate::NonExhaustive(()),
-                        },
-                        None => FormatProperties {
-                            linear_tiling_features: format_properties2
-                                .format_properties
-                                .linear_tiling_features
-                                .into(),
-                            optimal_tiling_features: format_properties2
-                                .format_properties
-                                .optimal_tiling_features
-                                .into(),
-                            buffer_features: format_properties2
-                                .format_properties
-                                .buffer_features
-                                .into(),
-                            _ne: crate::NonExhaustive(()),
-                        },
-                    }
-                };
-
-                *entry.insert(result)
+            if let Some(next) = format_properties3.as_mut() {
+                next.p_next = format_properties2.p_next;
+                format_properties2.p_next = next as *mut _ as *mut _;
             }
-        }
+
+            let fns = self.instance.fns();
+
+            if self.api_version() >= Version::V1_1 {
+                (fns.v1_1.get_physical_device_format_properties2)(
+                    self.handle,
+                    format.into(),
+                    &mut format_properties2,
+                );
+            } else if self
+                .instance
+                .enabled_extensions()
+                .khr_get_physical_device_properties2
+            {
+                (fns.khr_get_physical_device_properties2
+                    .get_physical_device_format_properties2_khr)(
+                    self.handle,
+                    format.into(),
+                    &mut format_properties2,
+                );
+            } else {
+                (fns.v1_0.get_physical_device_format_properties)(
+                    self.internal_object(),
+                    format.into(),
+                    &mut format_properties2.format_properties,
+                );
+            }
+
+            Ok::<_, Infallible>(match format_properties3 {
+                Some(format_properties3) => FormatProperties {
+                    linear_tiling_features: format_properties3.linear_tiling_features.into(),
+                    optimal_tiling_features: format_properties3.optimal_tiling_features.into(),
+                    buffer_features: format_properties3.buffer_features.into(),
+                    _ne: crate::NonExhaustive(()),
+                },
+                None => FormatProperties {
+                    linear_tiling_features: format_properties2
+                        .format_properties
+                        .linear_tiling_features
+                        .into(),
+                    optimal_tiling_features: format_properties2
+                        .format_properties
+                        .optimal_tiling_features
+                        .into(),
+                    buffer_features: format_properties2.format_properties.buffer_features.into(),
+                    _ne: crate::NonExhaustive(()),
+                },
+            })
+        })
+        .unwrap()
     }
 
     /// Returns the properties supported for images with a given image configuration.
@@ -1075,169 +1043,163 @@ impl PhysicalDevice {
             }
         }
 
-        match self.image_format_properties.entry(image_format_info) {
-            DashMapEntry::Occupied(entry) => Ok(entry.get().clone()),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    /* Input */
-                    let &ImageFormatInfo {
-                        format,
-                        image_type,
-                        tiling,
-                        usage,
-                        stencil_usage,
-                        external_memory_handle_type,
-                        image_view_type,
-                        mutable_format,
-                        cube_compatible,
-                        array_2d_compatible,
-                        block_texel_view_compatible,
-                        _ne: _,
-                    } = entry.key();
+        get_cached(
+            &self.image_format_properties,
+            image_format_info,
+            |image_format_info| {
+                /* Input */
+                let &ImageFormatInfo {
+                    format,
+                    image_type,
+                    tiling,
+                    usage,
+                    stencil_usage,
+                    external_memory_handle_type,
+                    image_view_type,
+                    mutable_format,
+                    cube_compatible,
+                    array_2d_compatible,
+                    block_texel_view_compatible,
+                    _ne: _,
+                } = image_format_info;
 
-                    let has_separate_stencil_usage = stencil_usage == usage;
+                let has_separate_stencil_usage = stencil_usage == usage;
 
-                    let flags = ImageCreateFlags {
-                        mutable_format,
-                        cube_compatible,
-                        array_2d_compatible,
-                        block_texel_view_compatible,
-                        ..ImageCreateFlags::empty()
-                    };
-
-                    let mut info2_vk = ash::vk::PhysicalDeviceImageFormatInfo2 {
-                        format: format.unwrap().into(),
-                        ty: image_type.into(),
-                        tiling: tiling.into(),
-                        usage: usage.into(),
-                        flags: flags.into(),
-                        ..Default::default()
-                    };
-                    let mut external_info_vk = None;
-                    let mut image_view_info_vk = None;
-                    let mut stencil_usage_info_vk = None;
-
-                    if let Some(handle_type) = external_memory_handle_type {
-                        let next = external_info_vk.insert(
-                            ash::vk::PhysicalDeviceExternalImageFormatInfo {
-                                handle_type: handle_type.into(),
-                                ..Default::default()
-                            },
-                        );
-
-                        next.p_next = info2_vk.p_next;
-                        info2_vk.p_next = next as *const _ as *const _;
-                    }
-
-                    if let Some(image_view_type) = image_view_type {
-                        let next = image_view_info_vk.insert(
-                            ash::vk::PhysicalDeviceImageViewImageFormatInfoEXT {
-                                image_view_type: image_view_type.into(),
-                                ..Default::default()
-                            },
-                        );
-
-                        next.p_next = info2_vk.p_next as *mut _;
-                        info2_vk.p_next = next as *const _ as *const _;
-                    }
-
-                    if has_separate_stencil_usage {
-                        let next =
-                            stencil_usage_info_vk.insert(ash::vk::ImageStencilUsageCreateInfo {
-                                stencil_usage: stencil_usage.into(),
-                                ..Default::default()
-                            });
-
-                        next.p_next = info2_vk.p_next as *mut _;
-                        info2_vk.p_next = next as *const _ as *const _;
-                    }
-
-                    /* Output */
-
-                    let mut properties2_vk = ash::vk::ImageFormatProperties2::default();
-                    let mut external_properties_vk = None;
-                    let mut filter_cubic_image_view_properties_vk = None;
-
-                    if external_info_vk.is_some() {
-                        let next = external_properties_vk
-                            .insert(ash::vk::ExternalImageFormatProperties::default());
-
-                        next.p_next = properties2_vk.p_next;
-                        properties2_vk.p_next = next as *mut _ as *mut _;
-                    }
-
-                    if image_view_info_vk.is_some() {
-                        let next = filter_cubic_image_view_properties_vk.insert(
-                            ash::vk::FilterCubicImageViewImageFormatPropertiesEXT::default(),
-                        );
-
-                        next.p_next = properties2_vk.p_next;
-                        properties2_vk.p_next = next as *mut _ as *mut _;
-                    }
-
-                    let result = {
-                        let fns = self.instance.fns();
-
-                        if self.api_version() >= Version::V1_1 {
-                            (fns.v1_1.get_physical_device_image_format_properties2)(
-                                self.handle,
-                                &info2_vk,
-                                &mut properties2_vk,
-                            )
-                        } else if self
-                            .instance
-                            .enabled_extensions()
-                            .khr_get_physical_device_properties2
-                        {
-                            (fns.khr_get_physical_device_properties2
-                                .get_physical_device_image_format_properties2_khr)(
-                                self.handle,
-                                &info2_vk,
-                                &mut properties2_vk,
-                            )
-                        } else {
-                            // Can't query this, return unsupported
-                            if !info2_vk.p_next.is_null() {
-                                return Ok(None);
-                            }
-
-                            (fns.v1_0.get_physical_device_image_format_properties)(
-                                self.handle,
-                                info2_vk.format,
-                                info2_vk.ty,
-                                info2_vk.tiling,
-                                info2_vk.usage,
-                                info2_vk.flags,
-                                &mut properties2_vk.image_format_properties,
-                            )
-                        }
-                        .result()
-                        .map_err(VulkanError::from)
-                    };
-
-                    match result {
-                        Ok(_) => Some(ImageFormatProperties {
-                            external_memory_properties: external_properties_vk
-                                .map(|properties| properties.external_memory_properties.into())
-                                .unwrap_or_default(),
-                            filter_cubic: filter_cubic_image_view_properties_vk
-                                .map_or(false, |properties| {
-                                    properties.filter_cubic != ash::vk::FALSE
-                                }),
-                            filter_cubic_minmax: filter_cubic_image_view_properties_vk
-                                .map_or(false, |properties| {
-                                    properties.filter_cubic_minmax != ash::vk::FALSE
-                                }),
-                            ..properties2_vk.image_format_properties.into()
-                        }),
-                        Err(VulkanError::FormatNotSupported) => None,
-                        Err(err) => return Err(err),
-                    }
+                let flags = ImageCreateFlags {
+                    mutable_format,
+                    cube_compatible,
+                    array_2d_compatible,
+                    block_texel_view_compatible,
+                    ..ImageCreateFlags::empty()
                 };
 
-                Ok(entry.insert(result).clone())
-            }
-        }
+                let mut info2_vk = ash::vk::PhysicalDeviceImageFormatInfo2 {
+                    format: format.unwrap().into(),
+                    ty: image_type.into(),
+                    tiling: tiling.into(),
+                    usage: usage.into(),
+                    flags: flags.into(),
+                    ..Default::default()
+                };
+                let mut external_info_vk = None;
+                let mut image_view_info_vk = None;
+                let mut stencil_usage_info_vk = None;
+
+                if let Some(handle_type) = external_memory_handle_type {
+                    let next =
+                        external_info_vk.insert(ash::vk::PhysicalDeviceExternalImageFormatInfo {
+                            handle_type: handle_type.into(),
+                            ..Default::default()
+                        });
+
+                    next.p_next = info2_vk.p_next;
+                    info2_vk.p_next = next as *const _ as *const _;
+                }
+
+                if let Some(image_view_type) = image_view_type {
+                    let next = image_view_info_vk.insert(
+                        ash::vk::PhysicalDeviceImageViewImageFormatInfoEXT {
+                            image_view_type: image_view_type.into(),
+                            ..Default::default()
+                        },
+                    );
+
+                    next.p_next = info2_vk.p_next as *mut _;
+                    info2_vk.p_next = next as *const _ as *const _;
+                }
+
+                if has_separate_stencil_usage {
+                    let next = stencil_usage_info_vk.insert(ash::vk::ImageStencilUsageCreateInfo {
+                        stencil_usage: stencil_usage.into(),
+                        ..Default::default()
+                    });
+
+                    next.p_next = info2_vk.p_next as *mut _;
+                    info2_vk.p_next = next as *const _ as *const _;
+                }
+
+                /* Output */
+
+                let mut properties2_vk = ash::vk::ImageFormatProperties2::default();
+                let mut external_properties_vk = None;
+                let mut filter_cubic_image_view_properties_vk = None;
+
+                if external_info_vk.is_some() {
+                    let next = external_properties_vk
+                        .insert(ash::vk::ExternalImageFormatProperties::default());
+
+                    next.p_next = properties2_vk.p_next;
+                    properties2_vk.p_next = next as *mut _ as *mut _;
+                }
+
+                if image_view_info_vk.is_some() {
+                    let next = filter_cubic_image_view_properties_vk
+                        .insert(ash::vk::FilterCubicImageViewImageFormatPropertiesEXT::default());
+
+                    next.p_next = properties2_vk.p_next;
+                    properties2_vk.p_next = next as *mut _ as *mut _;
+                }
+
+                let result = {
+                    let fns = self.instance.fns();
+
+                    if self.api_version() >= Version::V1_1 {
+                        (fns.v1_1.get_physical_device_image_format_properties2)(
+                            self.handle,
+                            &info2_vk,
+                            &mut properties2_vk,
+                        )
+                    } else if self
+                        .instance
+                        .enabled_extensions()
+                        .khr_get_physical_device_properties2
+                    {
+                        (fns.khr_get_physical_device_properties2
+                            .get_physical_device_image_format_properties2_khr)(
+                            self.handle,
+                            &info2_vk,
+                            &mut properties2_vk,
+                        )
+                    } else {
+                        // Can't query this, return unsupported
+                        if !info2_vk.p_next.is_null() {
+                            return Ok(None);
+                        }
+
+                        (fns.v1_0.get_physical_device_image_format_properties)(
+                            self.handle,
+                            info2_vk.format,
+                            info2_vk.ty,
+                            info2_vk.tiling,
+                            info2_vk.usage,
+                            info2_vk.flags,
+                            &mut properties2_vk.image_format_properties,
+                        )
+                    }
+                    .result()
+                    .map_err(VulkanError::from)
+                };
+
+                Ok(match result {
+                    Ok(_) => Some(ImageFormatProperties {
+                        external_memory_properties: external_properties_vk
+                            .map(|properties| properties.external_memory_properties.into())
+                            .unwrap_or_default(),
+                        filter_cubic: filter_cubic_image_view_properties_vk
+                            .map_or(false, |properties| {
+                                properties.filter_cubic != ash::vk::FALSE
+                            }),
+                        filter_cubic_minmax: filter_cubic_image_view_properties_vk
+                            .map_or(false, |properties| {
+                                properties.filter_cubic_minmax != ash::vk::FALSE
+                            }),
+                        ..properties2_vk.image_format_properties.into()
+                    }),
+                    Err(VulkanError::FormatNotSupported) => None,
+                    Err(err) => return Err(err),
+                })
+            },
+        )
     }
 
     /// Queries whether the physical device supports presenting to QNX Screen surfaces from queues
@@ -1363,77 +1325,78 @@ impl PhysicalDevice {
         &self,
         format_info: SparseImageFormatInfo,
     ) -> Vec<SparseImageFormatProperties> {
-        match self.sparse_image_format_properties.entry(format_info) {
-            DashMapEntry::Occupied(entry) => entry.get().clone(),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    let &SparseImageFormatInfo {
-                        format,
-                        image_type,
-                        samples,
-                        usage,
-                        tiling,
-                        _ne: _,
-                    } = entry.key();
+        get_cached(
+            &self.sparse_image_format_properties,
+            format_info,
+            |format_info| {
+                let &SparseImageFormatInfo {
+                    format,
+                    image_type,
+                    samples,
+                    usage,
+                    tiling,
+                    _ne: _,
+                } = format_info;
 
-                    let format_info2 = ash::vk::PhysicalDeviceSparseImageFormatInfo2 {
-                        format: format.unwrap().into(),
-                        ty: image_type.into(),
-                        samples: samples.into(),
-                        usage: usage.into(),
-                        tiling: tiling.into(),
-                        ..Default::default()
-                    };
+                let format_info2 = ash::vk::PhysicalDeviceSparseImageFormatInfo2 {
+                    format: format.unwrap().into(),
+                    ty: image_type.into(),
+                    samples: samples.into(),
+                    usage: usage.into(),
+                    tiling: tiling.into(),
+                    ..Default::default()
+                };
 
-                    let fns = self.instance.fns();
+                let fns = self.instance.fns();
 
-                    if self.api_version() >= Version::V1_1
-                        || self
-                            .instance
-                            .enabled_extensions()
-                            .khr_get_physical_device_properties2
-                    {
-                        let mut count = 0;
+                if self.api_version() >= Version::V1_1
+                    || self
+                        .instance
+                        .enabled_extensions()
+                        .khr_get_physical_device_properties2
+                {
+                    let mut count = 0;
 
-                        if self.api_version() >= Version::V1_1 {
-                            (fns.v1_1.get_physical_device_sparse_image_format_properties2)(
-                                self.handle,
-                                &format_info2,
-                                &mut count,
-                                ptr::null_mut(),
-                            );
-                        } else {
-                            (fns.khr_get_physical_device_properties2
-                                .get_physical_device_sparse_image_format_properties2_khr)(
-                                self.handle,
-                                &format_info2,
-                                &mut count,
-                                ptr::null_mut(),
-                            );
-                        }
+                    if self.api_version() >= Version::V1_1 {
+                        (fns.v1_1.get_physical_device_sparse_image_format_properties2)(
+                            self.handle,
+                            &format_info2,
+                            &mut count,
+                            ptr::null_mut(),
+                        );
+                    } else {
+                        (fns.khr_get_physical_device_properties2
+                            .get_physical_device_sparse_image_format_properties2_khr)(
+                            self.handle,
+                            &format_info2,
+                            &mut count,
+                            ptr::null_mut(),
+                        );
+                    }
 
-                        let mut sparse_image_format_properties2 =
-                            vec![ash::vk::SparseImageFormatProperties2::default(); count as usize];
+                    let mut sparse_image_format_properties2 =
+                        vec![ash::vk::SparseImageFormatProperties2::default(); count as usize];
 
-                        if self.api_version() >= Version::V1_1 {
-                            (fns.v1_1.get_physical_device_sparse_image_format_properties2)(
-                                self.handle,
-                                &format_info2,
-                                &mut count,
-                                sparse_image_format_properties2.as_mut_ptr(),
-                            );
-                        } else {
-                            (fns.khr_get_physical_device_properties2
-                                .get_physical_device_sparse_image_format_properties2_khr)(
-                                self.handle,
-                                &format_info2,
-                                &mut count,
-                                sparse_image_format_properties2.as_mut_ptr(),
-                            );
-                        }
+                    if self.api_version() >= Version::V1_1 {
+                        (fns.v1_1.get_physical_device_sparse_image_format_properties2)(
+                            self.handle,
+                            &format_info2,
+                            &mut count,
+                            sparse_image_format_properties2.as_mut_ptr(),
+                        );
+                    } else {
+                        (fns.khr_get_physical_device_properties2
+                            .get_physical_device_sparse_image_format_properties2_khr)(
+                            self.handle,
+                            &format_info2,
+                            &mut count,
+                            sparse_image_format_properties2.as_mut_ptr(),
+                        );
+                    }
 
-                        sparse_image_format_properties2.set_len(count as usize);
+                    sparse_image_format_properties2.set_len(count as usize);
 
+                    Ok::<_, Infallible>(
                         sparse_image_format_properties2
                             .into_iter()
                             .map(
@@ -1459,37 +1422,39 @@ impl PhysicalDevice {
                                     flags: sparse_image_format_properties2.properties.flags.into(),
                                 },
                             )
-                            .collect()
-                    } else {
-                        let mut count = 0;
+                            .collect(),
+                    )
+                } else {
+                    let mut count = 0;
 
-                        (fns.v1_0.get_physical_device_sparse_image_format_properties)(
-                            self.handle,
-                            format_info2.format,
-                            format_info2.ty,
-                            format_info2.samples,
-                            format_info2.usage,
-                            format_info2.tiling,
-                            &mut count,
-                            ptr::null_mut(),
-                        );
+                    (fns.v1_0.get_physical_device_sparse_image_format_properties)(
+                        self.handle,
+                        format_info2.format,
+                        format_info2.ty,
+                        format_info2.samples,
+                        format_info2.usage,
+                        format_info2.tiling,
+                        &mut count,
+                        ptr::null_mut(),
+                    );
 
-                        let mut sparse_image_format_properties =
-                            vec![ash::vk::SparseImageFormatProperties::default(); count as usize];
+                    let mut sparse_image_format_properties =
+                        vec![ash::vk::SparseImageFormatProperties::default(); count as usize];
 
-                        (fns.v1_0.get_physical_device_sparse_image_format_properties)(
-                            self.handle,
-                            format_info2.format,
-                            format_info2.ty,
-                            format_info2.samples,
-                            format_info2.usage,
-                            format_info2.tiling,
-                            &mut count,
-                            sparse_image_format_properties.as_mut_ptr(),
-                        );
+                    (fns.v1_0.get_physical_device_sparse_image_format_properties)(
+                        self.handle,
+                        format_info2.format,
+                        format_info2.ty,
+                        format_info2.samples,
+                        format_info2.usage,
+                        format_info2.tiling,
+                        &mut count,
+                        sparse_image_format_properties.as_mut_ptr(),
+                    );
 
-                        sparse_image_format_properties.set_len(count as usize);
+                    sparse_image_format_properties.set_len(count as usize);
 
+                    Ok::<_, Infallible>(
                         sparse_image_format_properties
                             .into_iter()
                             .map(
@@ -1503,13 +1468,12 @@ impl PhysicalDevice {
                                     flags: sparse_image_format_properties.flags.into(),
                                 },
                             )
-                            .collect()
-                    }
-                };
-
-                entry.insert(result).clone()
-            }
-        }
+                            .collect(),
+                    )
+                }
+            },
+        )
+        .unwrap()
     }
 
     /// Returns the capabilities that are supported by the physical device for the given surface.
@@ -1591,195 +1555,187 @@ impl PhysicalDevice {
         surface: &Surface<W>,
         surface_info: SurfaceInfo,
     ) -> Result<SurfaceCapabilities, VulkanError> {
-        match surface
-            .surface_capabilities
-            .entry((self.handle, surface_info))
-        {
-            DashMapEntry::Occupied(entry) => Ok(entry.get().clone()),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    /* Input */
+        get_cached(
+            &surface.surface_capabilities,
+            (self.handle, surface_info),
+            |(_, surface_info)| {
+                /* Input */
 
-                    let &SurfaceInfo {
-                        full_screen_exclusive,
-                        win32_monitor,
-                        _ne: _,
-                    } = &entry.key().1;
+                let &SurfaceInfo {
+                    full_screen_exclusive,
+                    win32_monitor,
+                    _ne: _,
+                } = surface_info;
 
-                    let mut surface_full_screen_exclusive_info = self
-                        .supported_extensions()
-                        .ext_full_screen_exclusive
-                        .then(|| ash::vk::SurfaceFullScreenExclusiveInfoEXT {
-                            full_screen_exclusive: full_screen_exclusive.into(),
-                            ..Default::default()
-                        });
-
-                    let mut surface_full_screen_exclusive_win32_info =
-                        win32_monitor.map(|win32_monitor| {
-                            ash::vk::SurfaceFullScreenExclusiveWin32InfoEXT {
-                                hmonitor: win32_monitor.0,
-                                ..Default::default()
-                            }
-                        });
-
-                    let mut surface_info2 = ash::vk::PhysicalDeviceSurfaceInfo2KHR {
-                        surface: surface.internal_object(),
+                let mut surface_full_screen_exclusive_info = self
+                    .supported_extensions()
+                    .ext_full_screen_exclusive
+                    .then(|| ash::vk::SurfaceFullScreenExclusiveInfoEXT {
+                        full_screen_exclusive: full_screen_exclusive.into(),
                         ..Default::default()
-                    };
+                    });
 
-                    if let Some(surface_full_screen_exclusive_info) =
-                        surface_full_screen_exclusive_info.as_mut()
-                    {
-                        surface_full_screen_exclusive_info.p_next = surface_info2.p_next as *mut _;
-                        surface_info2.p_next =
-                            surface_full_screen_exclusive_info as *const _ as *const _;
-                    }
+                let mut surface_full_screen_exclusive_win32_info =
+                    win32_monitor.map(|win32_monitor| {
+                        ash::vk::SurfaceFullScreenExclusiveWin32InfoEXT {
+                            hmonitor: win32_monitor.0,
+                            ..Default::default()
+                        }
+                    });
 
-                    if let Some(surface_full_screen_exclusive_win32_info) =
-                        surface_full_screen_exclusive_win32_info.as_mut()
-                    {
-                        surface_full_screen_exclusive_win32_info.p_next =
-                            surface_info2.p_next as *mut _;
-                        surface_info2.p_next =
-                            surface_full_screen_exclusive_win32_info as *const _ as *const _;
-                    }
-
-                    /* Output */
-
-                    let mut surface_capabilities2 = ash::vk::SurfaceCapabilities2KHR::default();
-
-                    let mut surface_capabilities_full_screen_exclusive =
-                        if surface_full_screen_exclusive_info.is_some() {
-                            Some(ash::vk::SurfaceCapabilitiesFullScreenExclusiveEXT::default())
-                        } else {
-                            None
-                        };
-
-                    if let Some(surface_capabilities_full_screen_exclusive) =
-                        surface_capabilities_full_screen_exclusive.as_mut()
-                    {
-                        surface_capabilities_full_screen_exclusive.p_next =
-                            surface_capabilities2.p_next as *mut _;
-                        surface_capabilities2.p_next =
-                            surface_capabilities_full_screen_exclusive as *mut _ as *mut _;
-                    }
-
-                    let fns = self.instance.fns();
-
-                    if self
-                        .instance
-                        .enabled_extensions()
-                        .khr_get_surface_capabilities2
-                    {
-                        (fns.khr_get_surface_capabilities2
-                            .get_physical_device_surface_capabilities2_khr)(
-                            self.internal_object(),
-                            &surface_info2,
-                            &mut surface_capabilities2,
-                        )
-                        .result()
-                        .map_err(VulkanError::from)?;
-                    } else {
-                        (fns.khr_surface.get_physical_device_surface_capabilities_khr)(
-                            self.internal_object(),
-                            surface_info2.surface,
-                            &mut surface_capabilities2.surface_capabilities,
-                        )
-                        .result()
-                        .map_err(VulkanError::from)?;
-                    };
-
-                    SurfaceCapabilities {
-                        min_image_count: surface_capabilities2.surface_capabilities.min_image_count,
-                        max_image_count: if surface_capabilities2
-                            .surface_capabilities
-                            .max_image_count
-                            == 0
-                        {
-                            None
-                        } else {
-                            Some(surface_capabilities2.surface_capabilities.max_image_count)
-                        },
-                        current_extent: if surface_capabilities2
-                            .surface_capabilities
-                            .current_extent
-                            .width
-                            == 0xffffffff
-                            && surface_capabilities2
-                                .surface_capabilities
-                                .current_extent
-                                .height
-                                == 0xffffffff
-                        {
-                            None
-                        } else {
-                            Some([
-                                surface_capabilities2
-                                    .surface_capabilities
-                                    .current_extent
-                                    .width,
-                                surface_capabilities2
-                                    .surface_capabilities
-                                    .current_extent
-                                    .height,
-                            ])
-                        },
-                        min_image_extent: [
-                            surface_capabilities2
-                                .surface_capabilities
-                                .min_image_extent
-                                .width,
-                            surface_capabilities2
-                                .surface_capabilities
-                                .min_image_extent
-                                .height,
-                        ],
-                        max_image_extent: [
-                            surface_capabilities2
-                                .surface_capabilities
-                                .max_image_extent
-                                .width,
-                            surface_capabilities2
-                                .surface_capabilities
-                                .max_image_extent
-                                .height,
-                        ],
-                        max_image_array_layers: surface_capabilities2
-                            .surface_capabilities
-                            .max_image_array_layers,
-                        supported_transforms: surface_capabilities2
-                            .surface_capabilities
-                            .supported_transforms
-                            .into(),
-
-                        current_transform: SupportedSurfaceTransforms::from(
-                            surface_capabilities2.surface_capabilities.current_transform,
-                        )
-                        .iter()
-                        .next()
-                        .unwrap(), // TODO:
-                        supported_composite_alpha: surface_capabilities2
-                            .surface_capabilities
-                            .supported_composite_alpha
-                            .into(),
-                        supported_usage_flags: {
-                            let usage = ImageUsage::from(
-                                surface_capabilities2
-                                    .surface_capabilities
-                                    .supported_usage_flags,
-                            );
-                            debug_assert!(usage.color_attachment); // specs say that this must be true
-                            usage
-                        },
-
-                        full_screen_exclusive_supported: surface_capabilities_full_screen_exclusive
-                            .map_or(false, |c| c.full_screen_exclusive_supported != 0),
-                    }
+                let mut surface_info2 = ash::vk::PhysicalDeviceSurfaceInfo2KHR {
+                    surface: surface.internal_object(),
+                    ..Default::default()
                 };
 
-                Ok(entry.insert(result).clone())
-            }
-        }
+                if let Some(surface_full_screen_exclusive_info) =
+                    surface_full_screen_exclusive_info.as_mut()
+                {
+                    surface_full_screen_exclusive_info.p_next = surface_info2.p_next as *mut _;
+                    surface_info2.p_next =
+                        surface_full_screen_exclusive_info as *const _ as *const _;
+                }
+
+                if let Some(surface_full_screen_exclusive_win32_info) =
+                    surface_full_screen_exclusive_win32_info.as_mut()
+                {
+                    surface_full_screen_exclusive_win32_info.p_next =
+                        surface_info2.p_next as *mut _;
+                    surface_info2.p_next =
+                        surface_full_screen_exclusive_win32_info as *const _ as *const _;
+                }
+
+                /* Output */
+
+                let mut surface_capabilities2 = ash::vk::SurfaceCapabilities2KHR::default();
+
+                let mut surface_capabilities_full_screen_exclusive =
+                    if surface_full_screen_exclusive_info.is_some() {
+                        Some(ash::vk::SurfaceCapabilitiesFullScreenExclusiveEXT::default())
+                    } else {
+                        None
+                    };
+
+                if let Some(surface_capabilities_full_screen_exclusive) =
+                    surface_capabilities_full_screen_exclusive.as_mut()
+                {
+                    surface_capabilities_full_screen_exclusive.p_next =
+                        surface_capabilities2.p_next as *mut _;
+                    surface_capabilities2.p_next =
+                        surface_capabilities_full_screen_exclusive as *mut _ as *mut _;
+                }
+
+                let fns = self.instance.fns();
+
+                if self
+                    .instance
+                    .enabled_extensions()
+                    .khr_get_surface_capabilities2
+                {
+                    (fns.khr_get_surface_capabilities2
+                        .get_physical_device_surface_capabilities2_khr)(
+                        self.internal_object(),
+                        &surface_info2,
+                        &mut surface_capabilities2,
+                    )
+                    .result()
+                    .map_err(VulkanError::from)?;
+                } else {
+                    (fns.khr_surface.get_physical_device_surface_capabilities_khr)(
+                        self.internal_object(),
+                        surface_info2.surface,
+                        &mut surface_capabilities2.surface_capabilities,
+                    )
+                    .result()
+                    .map_err(VulkanError::from)?;
+                };
+
+                Ok(SurfaceCapabilities {
+                    min_image_count: surface_capabilities2.surface_capabilities.min_image_count,
+                    max_image_count: if surface_capabilities2.surface_capabilities.max_image_count
+                        == 0
+                    {
+                        None
+                    } else {
+                        Some(surface_capabilities2.surface_capabilities.max_image_count)
+                    },
+                    current_extent: if surface_capabilities2
+                        .surface_capabilities
+                        .current_extent
+                        .width
+                        == 0xffffffff
+                        && surface_capabilities2
+                            .surface_capabilities
+                            .current_extent
+                            .height
+                            == 0xffffffff
+                    {
+                        None
+                    } else {
+                        Some([
+                            surface_capabilities2
+                                .surface_capabilities
+                                .current_extent
+                                .width,
+                            surface_capabilities2
+                                .surface_capabilities
+                                .current_extent
+                                .height,
+                        ])
+                    },
+                    min_image_extent: [
+                        surface_capabilities2
+                            .surface_capabilities
+                            .min_image_extent
+                            .width,
+                        surface_capabilities2
+                            .surface_capabilities
+                            .min_image_extent
+                            .height,
+                    ],
+                    max_image_extent: [
+                        surface_capabilities2
+                            .surface_capabilities
+                            .max_image_extent
+                            .width,
+                        surface_capabilities2
+                            .surface_capabilities
+                            .max_image_extent
+                            .height,
+                    ],
+                    max_image_array_layers: surface_capabilities2
+                        .surface_capabilities
+                        .max_image_array_layers,
+                    supported_transforms: surface_capabilities2
+                        .surface_capabilities
+                        .supported_transforms
+                        .into(),
+
+                    current_transform: SupportedSurfaceTransforms::from(
+                        surface_capabilities2.surface_capabilities.current_transform,
+                    )
+                    .iter()
+                    .next()
+                    .unwrap(), // TODO:
+                    supported_composite_alpha: surface_capabilities2
+                        .surface_capabilities
+                        .supported_composite_alpha
+                        .into(),
+                    supported_usage_flags: {
+                        let usage = ImageUsage::from(
+                            surface_capabilities2
+                                .surface_capabilities
+                                .supported_usage_flags,
+                        );
+                        debug_assert!(usage.color_attachment); // specs say that this must be true
+                        usage
+                    },
+
+                    full_screen_exclusive_supported: surface_capabilities_full_screen_exclusive
+                        .map_or(false, |c| c.full_screen_exclusive_supported != 0),
+                })
+            },
+        )
     }
 
     /// Returns the combinations of format and color space that are supported by the physical device
@@ -1876,143 +1832,140 @@ impl PhysicalDevice {
         surface: &Surface<W>,
         surface_info: SurfaceInfo,
     ) -> Result<Vec<(Format, ColorSpace)>, VulkanError> {
-        match surface.surface_formats.entry((self.handle, surface_info)) {
-            DashMapEntry::Occupied(entry) => Ok(entry.get().clone()),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    let &SurfaceInfo {
-                        full_screen_exclusive,
-                        win32_monitor,
-                        _ne: _,
-                    } = &entry.key().1;
+        get_cached(
+            &surface.surface_formats,
+            (self.handle, surface_info),
+            |(_, surface_info)| {
+                let &SurfaceInfo {
+                    full_screen_exclusive,
+                    win32_monitor,
+                    _ne: _,
+                } = surface_info;
 
-                    let mut surface_full_screen_exclusive_info = (full_screen_exclusive
-                        != FullScreenExclusive::Default)
-                        .then(|| ash::vk::SurfaceFullScreenExclusiveInfoEXT {
-                            full_screen_exclusive: full_screen_exclusive.into(),
-                            ..Default::default()
-                        });
-
-                    let mut surface_full_screen_exclusive_win32_info =
-                        win32_monitor.map(|win32_monitor| {
-                            ash::vk::SurfaceFullScreenExclusiveWin32InfoEXT {
-                                hmonitor: win32_monitor.0,
-                                ..Default::default()
-                            }
-                        });
-
-                    let mut surface_info2 = ash::vk::PhysicalDeviceSurfaceInfo2KHR {
-                        surface: surface.internal_object(),
+                let mut surface_full_screen_exclusive_info = (full_screen_exclusive
+                    != FullScreenExclusive::Default)
+                    .then(|| ash::vk::SurfaceFullScreenExclusiveInfoEXT {
+                        full_screen_exclusive: full_screen_exclusive.into(),
                         ..Default::default()
-                    };
+                    });
 
-                    if let Some(surface_full_screen_exclusive_info) =
-                        surface_full_screen_exclusive_info.as_mut()
-                    {
-                        surface_full_screen_exclusive_info.p_next = surface_info2.p_next as *mut _;
-                        surface_info2.p_next =
-                            surface_full_screen_exclusive_info as *const _ as *const _;
-                    }
+                let mut surface_full_screen_exclusive_win32_info =
+                    win32_monitor.map(|win32_monitor| {
+                        ash::vk::SurfaceFullScreenExclusiveWin32InfoEXT {
+                            hmonitor: win32_monitor.0,
+                            ..Default::default()
+                        }
+                    });
 
-                    if let Some(surface_full_screen_exclusive_win32_info) =
-                        surface_full_screen_exclusive_win32_info.as_mut()
-                    {
-                        surface_full_screen_exclusive_win32_info.p_next =
-                            surface_info2.p_next as *mut _;
-                        surface_info2.p_next =
-                            surface_full_screen_exclusive_win32_info as *const _ as *const _;
-                    }
-
-                    let fns = self.instance.fns();
-
-                    if self
-                        .instance
-                        .enabled_extensions()
-                        .khr_get_surface_capabilities2
-                    {
-                        let surface_format2s = loop {
-                            let mut count = 0;
-                            (fns.khr_get_surface_capabilities2
-                                .get_physical_device_surface_formats2_khr)(
-                                self.internal_object(),
-                                &surface_info2,
-                                &mut count,
-                                ptr::null_mut(),
-                            )
-                            .result()
-                            .map_err(VulkanError::from)?;
-
-                            let mut surface_format2s =
-                                vec![ash::vk::SurfaceFormat2KHR::default(); count as usize];
-                            let result = (fns
-                                .khr_get_surface_capabilities2
-                                .get_physical_device_surface_formats2_khr)(
-                                self.internal_object(),
-                                &surface_info2,
-                                &mut count,
-                                surface_format2s.as_mut_ptr(),
-                            );
-
-                            match result {
-                                ash::vk::Result::SUCCESS => {
-                                    surface_format2s.set_len(count as usize);
-                                    break surface_format2s;
-                                }
-                                ash::vk::Result::INCOMPLETE => (),
-                                err => return Err(VulkanError::from(err)),
-                            }
-                        };
-
-                        surface_format2s
-                            .into_iter()
-                            .filter_map(|surface_format2| {
-                                (surface_format2.surface_format.format.try_into().ok())
-                                    .zip(surface_format2.surface_format.color_space.try_into().ok())
-                            })
-                            .collect()
-                    } else {
-                        let surface_formats = loop {
-                            let mut count = 0;
-                            (fns.khr_surface.get_physical_device_surface_formats_khr)(
-                                self.internal_object(),
-                                surface.internal_object(),
-                                &mut count,
-                                ptr::null_mut(),
-                            )
-                            .result()
-                            .map_err(VulkanError::from)?;
-
-                            let mut surface_formats = Vec::with_capacity(count as usize);
-                            let result = (fns.khr_surface.get_physical_device_surface_formats_khr)(
-                                self.internal_object(),
-                                surface.internal_object(),
-                                &mut count,
-                                surface_formats.as_mut_ptr(),
-                            );
-
-                            match result {
-                                ash::vk::Result::SUCCESS => {
-                                    surface_formats.set_len(count as usize);
-                                    break surface_formats;
-                                }
-                                ash::vk::Result::INCOMPLETE => (),
-                                err => return Err(VulkanError::from(err)),
-                            }
-                        };
-
-                        surface_formats
-                            .into_iter()
-                            .filter_map(|surface_format| {
-                                (surface_format.format.try_into().ok())
-                                    .zip(surface_format.color_space.try_into().ok())
-                            })
-                            .collect()
-                    }
+                let mut surface_info2 = ash::vk::PhysicalDeviceSurfaceInfo2KHR {
+                    surface: surface.internal_object(),
+                    ..Default::default()
                 };
 
-                Ok(entry.insert(result).clone())
-            }
-        }
+                if let Some(surface_full_screen_exclusive_info) =
+                    surface_full_screen_exclusive_info.as_mut()
+                {
+                    surface_full_screen_exclusive_info.p_next = surface_info2.p_next as *mut _;
+                    surface_info2.p_next =
+                        surface_full_screen_exclusive_info as *const _ as *const _;
+                }
+
+                if let Some(surface_full_screen_exclusive_win32_info) =
+                    surface_full_screen_exclusive_win32_info.as_mut()
+                {
+                    surface_full_screen_exclusive_win32_info.p_next =
+                        surface_info2.p_next as *mut _;
+                    surface_info2.p_next =
+                        surface_full_screen_exclusive_win32_info as *const _ as *const _;
+                }
+
+                let fns = self.instance.fns();
+
+                if self
+                    .instance
+                    .enabled_extensions()
+                    .khr_get_surface_capabilities2
+                {
+                    let surface_format2s = loop {
+                        let mut count = 0;
+                        (fns.khr_get_surface_capabilities2
+                            .get_physical_device_surface_formats2_khr)(
+                            self.internal_object(),
+                            &surface_info2,
+                            &mut count,
+                            ptr::null_mut(),
+                        )
+                        .result()
+                        .map_err(VulkanError::from)?;
+
+                        let mut surface_format2s =
+                            vec![ash::vk::SurfaceFormat2KHR::default(); count as usize];
+                        let result = (fns
+                            .khr_get_surface_capabilities2
+                            .get_physical_device_surface_formats2_khr)(
+                            self.internal_object(),
+                            &surface_info2,
+                            &mut count,
+                            surface_format2s.as_mut_ptr(),
+                        );
+
+                        match result {
+                            ash::vk::Result::SUCCESS => {
+                                surface_format2s.set_len(count as usize);
+                                break surface_format2s;
+                            }
+                            ash::vk::Result::INCOMPLETE => (),
+                            err => return Err(VulkanError::from(err)),
+                        }
+                    };
+
+                    Ok(surface_format2s
+                        .into_iter()
+                        .filter_map(|surface_format2| {
+                            (surface_format2.surface_format.format.try_into().ok())
+                                .zip(surface_format2.surface_format.color_space.try_into().ok())
+                        })
+                        .collect())
+                } else {
+                    let surface_formats = loop {
+                        let mut count = 0;
+                        (fns.khr_surface.get_physical_device_surface_formats_khr)(
+                            self.internal_object(),
+                            surface.internal_object(),
+                            &mut count,
+                            ptr::null_mut(),
+                        )
+                        .result()
+                        .map_err(VulkanError::from)?;
+
+                        let mut surface_formats = Vec::with_capacity(count as usize);
+                        let result = (fns.khr_surface.get_physical_device_surface_formats_khr)(
+                            self.internal_object(),
+                            surface.internal_object(),
+                            &mut count,
+                            surface_formats.as_mut_ptr(),
+                        );
+
+                        match result {
+                            ash::vk::Result::SUCCESS => {
+                                surface_formats.set_len(count as usize);
+                                break surface_formats;
+                            }
+                            ash::vk::Result::INCOMPLETE => (),
+                            err => return Err(VulkanError::from(err)),
+                        }
+                    };
+
+                    Ok(surface_formats
+                        .into_iter()
+                        .filter_map(|surface_format| {
+                            (surface_format.format.try_into().ok())
+                                .zip(surface_format.color_space.try_into().ok())
+                        })
+                        .collect())
+                }
+            },
+        )
     }
 
     /// Returns the present modes that are supported by the physical device for the given surface.
@@ -2066,53 +2019,47 @@ impl PhysicalDevice {
         &self,
         surface: &Surface<W>,
     ) -> Result<impl Iterator<Item = PresentMode>, VulkanError> {
-        match surface.surface_present_modes.entry(self.handle) {
-            DashMapEntry::Occupied(entry) => Ok(entry.get().clone().into_iter()),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    let fns = self.instance.fns();
+        get_cached(&surface.surface_present_modes, self.handle, |_| {
+            let fns = self.instance.fns();
 
-                    let modes = loop {
-                        let mut count = 0;
-                        (fns.khr_surface
-                            .get_physical_device_surface_present_modes_khr)(
-                            self.internal_object(),
-                            surface.internal_object(),
-                            &mut count,
-                            ptr::null_mut(),
-                        )
-                        .result()
-                        .map_err(VulkanError::from)?;
+            let modes = loop {
+                let mut count = 0;
+                (fns.khr_surface
+                    .get_physical_device_surface_present_modes_khr)(
+                    self.internal_object(),
+                    surface.internal_object(),
+                    &mut count,
+                    ptr::null_mut(),
+                )
+                .result()
+                .map_err(VulkanError::from)?;
 
-                        let mut modes = Vec::with_capacity(count as usize);
-                        let result = (fns
-                            .khr_surface
-                            .get_physical_device_surface_present_modes_khr)(
-                            self.internal_object(),
-                            surface.internal_object(),
-                            &mut count,
-                            modes.as_mut_ptr(),
-                        );
+                let mut modes = Vec::with_capacity(count as usize);
+                let result = (fns
+                    .khr_surface
+                    .get_physical_device_surface_present_modes_khr)(
+                    self.internal_object(),
+                    surface.internal_object(),
+                    &mut count,
+                    modes.as_mut_ptr(),
+                );
 
-                        match result {
-                            ash::vk::Result::SUCCESS => {
-                                modes.set_len(count as usize);
-                                break modes;
-                            }
-                            ash::vk::Result::INCOMPLETE => (),
-                            err => return Err(VulkanError::from(err)),
-                        }
-                    };
+                match result {
+                    ash::vk::Result::SUCCESS => {
+                        modes.set_len(count as usize);
+                        break modes;
+                    }
+                    ash::vk::Result::INCOMPLETE => (),
+                    err => return Err(VulkanError::from(err)),
+                }
+            };
 
-                    modes
-                        .into_iter()
-                        .filter_map(|mode_vk| mode_vk.try_into().ok())
-                        .collect()
-                };
-
-                Ok(entry.insert(result).clone().into_iter())
-            }
-        }
+            Ok(modes
+                .into_iter()
+                .filter_map(|mode_vk| mode_vk.try_into().ok())
+                .collect())
+        })
+        .map(IntoIterator::into_iter)
     }
 
     /// Returns whether queues of the given queue family can draw on the given surface.
@@ -2162,31 +2109,25 @@ impl PhysicalDevice {
         queue_family_index: u32,
         surface: &Surface<W>,
     ) -> Result<bool, VulkanError> {
-        match surface
-            .surface_support
-            .entry((self.handle, queue_family_index))
-        {
-            DashMapEntry::Occupied(entry) => Ok(*entry.get()),
-            DashMapEntry::Vacant(entry) => {
-                let result = {
-                    let fns = self.instance.fns();
+        get_cached(
+            &surface.surface_support,
+            (self.handle, queue_family_index),
+            |_| {
+                let fns = self.instance.fns();
 
-                    let mut output = MaybeUninit::uninit();
-                    (fns.khr_surface.get_physical_device_surface_support_khr)(
-                        self.handle,
-                        queue_family_index,
-                        surface.internal_object(),
-                        output.as_mut_ptr(),
-                    )
-                    .result()
-                    .map_err(VulkanError::from)?;
+                let mut output = MaybeUninit::uninit();
+                (fns.khr_surface.get_physical_device_surface_support_khr)(
+                    self.handle,
+                    queue_family_index,
+                    surface.internal_object(),
+                    output.as_mut_ptr(),
+                )
+                .result()
+                .map_err(VulkanError::from)?;
 
-                    output.assume_init() != 0
-                };
-
-                Ok(*entry.insert(result))
-            }
-        }
+                Ok(output.assume_init() != 0)
+            },
+        )
     }
 
     /// Retrieves the properties of tools that are currently active on the physical device.
@@ -2555,6 +2496,37 @@ impl Hash for PhysicalDevice {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.handle.hash(state);
         self.instance.hash(state);
+    }
+}
+
+unsafe fn get_cached<K, V, E>(
+    cache: &RwLock<HashMap<K, V>>,
+    key: K,
+    func: impl FnOnce(&K) -> Result<V, E>,
+) -> Result<V, E>
+where
+    K: Eq + Hash,
+    V: Clone,
+{
+    {
+        let read_lock = cache.read();
+        if let Some(result) = read_lock.get(&key) {
+            return Ok(result.clone());
+        }
+    }
+
+    let mut write_lock = cache.write();
+    match write_lock.entry(key) {
+        Entry::Occupied(entry) => {
+            // This can happen if someone else inserted an entry between when we released
+            // the read lock and acquired the write lock.
+            Ok(entry.get().clone())
+        }
+        Entry::Vacant(entry) => {
+            let result = func(entry.key())?;
+            entry.insert(result.clone());
+            Ok(result)
+        }
     }
 }
 

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -605,7 +605,7 @@ pub struct SubresourceLayout {
 
 /// The image configuration to query in
 /// [`PhysicalDevice::image_format_properties`](crate::device::physical::PhysicalDevice::image_format_properties).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ImageFormatInfo {
     /// The `format` that the image will have.
     ///
@@ -762,7 +762,7 @@ impl From<ash::vk::ImageFormatProperties> for ImageFormatProperties {
 
 /// The image configuration to query in
 /// [`PhysicalDevice::sparse_image_format_properties`](crate::device::physical::PhysicalDevice::sparse_image_format_properties).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SparseImageFormatInfo {
     /// The `format` that the image will have.
     ///

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -9,6 +9,7 @@
 
 use super::{FullScreenExclusive, Win32Monitor};
 use crate::{
+    format::Format,
     image::ImageUsage,
     instance::Instance,
     macros::{vulkan_bitflags, vulkan_enum},
@@ -22,6 +23,7 @@ use crate::{
 #[cfg(target_os = "ios")]
 use objc::{class, msg_send, runtime::Object, sel, sel_impl};
 
+use dashmap::DashMap;
 use std::{
     error::Error,
     fmt::{Debug, Display, Error as FmtError, Formatter},
@@ -44,6 +46,16 @@ pub struct Surface<W> {
     has_swapchain: AtomicBool,
     #[cfg(target_os = "ios")]
     metal_layer: IOSMetalLayer,
+
+    // Data queried by the user at runtime, cached for faster lookups.
+    // This is stored here rather than on `PhysicalDevice` to ensure that it's freed when the
+    // `Surface` is destroyed.
+    pub(crate) surface_capabilities:
+        DashMap<(ash::vk::PhysicalDevice, SurfaceInfo), SurfaceCapabilities>,
+    pub(crate) surface_formats:
+        DashMap<(ash::vk::PhysicalDevice, SurfaceInfo), Vec<(Format, ColorSpace)>>,
+    pub(crate) surface_present_modes: DashMap<ash::vk::PhysicalDevice, Vec<PresentMode>>,
+    pub(crate) surface_support: DashMap<ash::vk::PhysicalDevice, bool>,
 }
 
 impl<W> Surface<W> {
@@ -71,6 +83,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }
     }
 
@@ -132,6 +149,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -226,6 +248,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -302,6 +329,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -386,6 +418,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -467,6 +504,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -548,6 +590,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -786,6 +833,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -872,6 +924,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -948,6 +1005,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -1036,6 +1098,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -1122,6 +1189,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -1208,6 +1280,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -1294,6 +1371,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -1881,7 +1963,7 @@ vulkan_enum! {
 /// [`PhysicalDevice::surface_capabilities`](crate::device::physical::PhysicalDevice::surface_capabilities)
 /// and
 /// [`PhysicalDevice::surface_formats`](crate::device::physical::PhysicalDevice::surface_formats).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SurfaceInfo {
     pub full_screen_exclusive: FullScreenExclusive,
     pub win32_monitor: Option<Win32Monitor>,

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -55,7 +55,7 @@ pub struct Surface<W> {
     pub(crate) surface_formats:
         DashMap<(ash::vk::PhysicalDevice, SurfaceInfo), Vec<(Format, ColorSpace)>>,
     pub(crate) surface_present_modes: DashMap<ash::vk::PhysicalDevice, Vec<PresentMode>>,
-    pub(crate) surface_support: DashMap<ash::vk::PhysicalDevice, bool>,
+    pub(crate) surface_support: DashMap<(ash::vk::PhysicalDevice, u32), bool>,
 }
 
 impl<W> Surface<W> {

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -677,6 +677,11 @@ impl<W> Surface<W> {
 
             has_swapchain: AtomicBool::new(false),
             metal_layer,
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 
@@ -760,6 +765,11 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
+
+            surface_capabilities: DashMap::new(),
+            surface_formats: DashMap::new(),
+            surface_present_modes: DashMap::new(),
+            surface_support: DashMap::new(),
         }))
     }
 

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -23,8 +23,9 @@ use crate::{
 #[cfg(target_os = "ios")]
 use objc::{class, msg_send, runtime::Object, sel, sel_impl};
 
-use dashmap::DashMap;
+use parking_lot::RwLock;
 use std::{
+    collections::HashMap,
     error::Error,
     fmt::{Debug, Display, Error as FmtError, Formatter},
     hash::{Hash, Hasher},
@@ -51,11 +52,11 @@ pub struct Surface<W> {
     // This is stored here rather than on `PhysicalDevice` to ensure that it's freed when the
     // `Surface` is destroyed.
     pub(crate) surface_capabilities:
-        DashMap<(ash::vk::PhysicalDevice, SurfaceInfo), SurfaceCapabilities>,
+        RwLock<HashMap<(ash::vk::PhysicalDevice, SurfaceInfo), SurfaceCapabilities>>,
     pub(crate) surface_formats:
-        DashMap<(ash::vk::PhysicalDevice, SurfaceInfo), Vec<(Format, ColorSpace)>>,
-    pub(crate) surface_present_modes: DashMap<ash::vk::PhysicalDevice, Vec<PresentMode>>,
-    pub(crate) surface_support: DashMap<(ash::vk::PhysicalDevice, u32), bool>,
+        RwLock<HashMap<(ash::vk::PhysicalDevice, SurfaceInfo), Vec<(Format, ColorSpace)>>>,
+    pub(crate) surface_present_modes: RwLock<HashMap<ash::vk::PhysicalDevice, Vec<PresentMode>>>,
+    pub(crate) surface_support: RwLock<HashMap<(ash::vk::PhysicalDevice, u32), bool>>,
 }
 
 impl<W> Surface<W> {
@@ -84,10 +85,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }
     }
 
@@ -150,10 +151,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -249,10 +250,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -330,10 +331,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -419,10 +420,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -505,10 +506,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -591,10 +592,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -678,10 +679,10 @@ impl<W> Surface<W> {
             has_swapchain: AtomicBool::new(false),
             metal_layer,
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -766,10 +767,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -844,10 +845,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -935,10 +936,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -1016,10 +1017,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -1109,10 +1110,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -1200,10 +1201,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -1291,10 +1292,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 
@@ -1382,10 +1383,10 @@ impl<W> Surface<W> {
             #[cfg(target_os = "ios")]
             metal_layer: IOSMetalLayer::new(std::ptr::null_mut(), std::ptr::null_mut()),
 
-            surface_capabilities: DashMap::new(),
-            surface_formats: DashMap::new(),
-            surface_present_modes: DashMap::new(),
-            surface_support: DashMap::new(),
+            surface_capabilities: RwLock::new(HashMap::new()),
+            surface_formats: RwLock::new(HashMap::new()),
+            surface_present_modes: RwLock::new(HashMap::new()),
+            surface_support: RwLock::new(HashMap::new()),
         }))
     }
 

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -346,6 +346,21 @@ where
         }
 
         // VUID-VkSwapchainCreateInfoKHR-surface-01270
+        if !device
+            .active_queue_family_indices()
+            .iter()
+            .copied()
+            .any(|index| unsafe {
+                // Use unchecked, because all validation has been done above.
+                device
+                    .physical_device()
+                    .surface_support_unchecked(index, surface)
+                    .unwrap_or_default()
+            })
+        {
+            return Err(SwapchainCreationError::SurfaceNotSupported);
+        }
+
         *image_format = Some({
             // Use unchecked, because all validation has been done above.
             let surface_formats = unsafe {
@@ -1206,7 +1221,10 @@ pub enum SwapchainCreationError {
 
     /// The provided `image_array_layers` is greater than what is supported by the surface for this
     /// device.
-    ImageArrayLayersNotSupported { provided: u32, max_supported: u32 },
+    ImageArrayLayersNotSupported {
+        provided: u32,
+        max_supported: u32,
+    },
 
     /// The provided `image_extent` is not within the range supported by the surface for this
     /// device.
@@ -1258,6 +1276,9 @@ pub enum SwapchainCreationError {
         supported: SupportedSurfaceTransforms,
     },
 
+    // The provided `surface` is not supported by any of the device's queue families.
+    SurfaceNotSupported,
+
     /// The swapchain has already been used to create a new one.
     SwapchainAlreadyRetired,
 
@@ -1278,7 +1299,7 @@ impl Error for SwapchainCreationError {
 impl Display for SwapchainCreationError {
     #[inline]
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-        match *self {
+        match self {
             Self::OomError(_) => write!(f, "not enough memory available",),
             Self::DeviceLost => write!(f, "the device was lost",),
             Self::SurfaceLost => write!(f, "the surface was lost",),
@@ -1345,6 +1366,10 @@ impl Display for SwapchainCreationError {
             Self::PreTransformNotSupported { .. } => write!(
                 f,
                 "the provided `pre_transform` is not supported by the surface for this device",
+            ),
+            Self::SurfaceNotSupported => write!(
+                f,
+                "the provided `surface` is not supported by any of the device's queue families",
             ),
             Self::SwapchainAlreadyRetired => write!(
                 f,

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -529,7 +529,7 @@ vulkan_bitflags! {
 
 /// The fence configuration to query in
 /// [`PhysicalDevice::external_fence_properties`](crate::device::physical::PhysicalDevice::external_fence_properties).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ExternalFenceInfo {
     /// The external handle type that will be used with the fence.
     pub handle_type: ExternalFenceHandleType,

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -446,7 +446,7 @@ vulkan_bitflags! {
 
 /// The semaphore configuration to query in
 /// [`PhysicalDevice::external_semaphore_properties`](crate::device::physical::PhysicalDevice::external_semaphore_properties).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ExternalSemaphoreInfo {
     /// The external handle type that will be used with the semaphore.
     pub handle_type: ExternalSemaphoreHandleType,


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Some methods of `PhysicalDevice` now cache their results, so that another call with the same arguments will retrieve them faster.
````

While some of these Vulkan API functions may be relatively fast to call on some drivers, we can't know for sure. I expect that looking up and cloning a hashmap entry is probably going to be faster as it does not depend on the driver implementation.