### PR TITLE
#2007 fixes

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -41,7 +41,7 @@ fn include_callback(
     include_directories: &[impl AsRef<Path>],
     root_source_has_path: bool,
     base_path: &impl AsRef<Path>,
-    mut includes_tracker: RefMut<Vec<String>>,
+    mut includes_tracker: RefMut<'_, Vec<String>>,
 ) -> Result<ResolvedInclude, String> {
     let file_to_include = match directive_type {
         IncludeType::Relative => {

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -217,12 +217,12 @@
 
 #![doc(html_logo_url = "https://raw.githubusercontent.com/vulkano-rs/vulkano/master/logo.png")]
 #![recursion_limit = "1024"]
+#![warn(rust_2018_idioms, rust_2021_compatibility)]
 
 #[macro_use]
 extern crate quote;
 #[macro_use]
 extern crate syn;
-extern crate proc_macro;
 
 use crate::codegen::ShaderKind;
 use shaderc::{EnvVersion, SpirvVersion};
@@ -367,7 +367,7 @@ struct MacroInput {
 }
 
 impl Parse for MacroInput {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let mut dump = None;
         let mut exact_entrypoint_interface = None;
         let mut include_directories = Vec::new();
@@ -381,7 +381,7 @@ impl Parse for MacroInput {
         fn parse_shader_fields<'k>(
             output: &mut (Option<ShaderKind>, Option<SourceKind>),
             name: &'k str,
-            input: ParseStream,
+            input: ParseStream<'_>,
         ) -> Result<()> {
             match name {
                 "ty" => {

--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -286,7 +286,7 @@ fn write_impls<'a>(
 
         quote! {
             impl std::fmt::Debug for #struct_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
                     f
                         .debug_struct(#struct_name)
                         #( #fields )*
@@ -306,7 +306,7 @@ fn write_impls<'a>(
 
         quote! {
             impl std::fmt::Display for #struct_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
                     f
                         .debug_struct(#struct_name)
                         #( #fields )*

--- a/vulkano-util/src/lib.rs
+++ b/vulkano-util/src/lib.rs
@@ -8,6 +8,7 @@
 // according to those terms.
 
 #![allow(clippy::missing_safety_doc)]
+#![warn(rust_2018_idioms, rust_2021_compatibility)]
 
 pub mod context;
 pub mod renderer;

--- a/vulkano-util/src/window.rs
+++ b/vulkano-util/src/window.rs
@@ -231,12 +231,12 @@ impl VulkanoWindows {
     }
 
     /// Return iterator over window renderers
-    pub fn iter(&self) -> Iter<WindowId, VulkanoWindowRenderer> {
+    pub fn iter(&self) -> Iter<'_, WindowId, VulkanoWindowRenderer> {
         self.windows.iter()
     }
 
     /// Return iterator over mutable window renderers
-    pub fn iter_mut(&mut self) -> IterMut<WindowId, VulkanoWindowRenderer> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, WindowId, VulkanoWindowRenderer> {
         self.windows.iter_mut()
     }
 }

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/vulkano-rs/vulkano/master/logo.png")]
 #![allow(clippy::missing_safety_doc)]
+#![warn(rust_2018_idioms, rust_2021_compatibility)]
 
 /// Create a surface either using winit or a RawWindowHandle
 /// Its possible to disable either one using features

--- a/vulkano-win/src/winit.rs
+++ b/vulkano-win/src/winit.rs
@@ -88,7 +88,7 @@ impl Error for CreationError {
 
 impl Display for CreationError {
     #[inline]
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(
             f,
             "{}",

--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -509,7 +509,7 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
 
         impl std::fmt::Debug for #struct_name {
             #[allow(unused_assignments)]
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
                 write!(f, "[")?;
 
                 let mut first = true;

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -486,7 +486,7 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
 
         impl std::fmt::Debug for Features {
             #[allow(unused_assignments)]
-            fn fmt(&self, f: &mut std::fmt:: Formatter) -> Result<(), std::fmt::Error> {
+            fn fmt(&self, f: &mut std::fmt:: Formatter<'_>) -> Result<(), std::fmt::Error> {
                 write!(f, "[")?;
 
                 let mut first = true;

--- a/vulkano/autogen/fns.rs
+++ b/vulkano/autogen/fns.rs
@@ -90,7 +90,7 @@ fn fns_output(extension_members: &[FnsMember], fns_level: &str, doc: &str) -> To
 
         impl std::fmt::Debug for #struct_name {
             #[inline]
-            fn fmt(&self, _f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+            fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
                 Ok(())
             }
         }

--- a/vulkano/autogen/spirv_parse.rs
+++ b/vulkano/autogen/spirv_parse.rs
@@ -229,7 +229,7 @@ fn instruction_output(members: &[InstructionMember], spec_constant: bool) -> Tok
 
         impl #enum_name {
             #[allow(dead_code)]
-            fn parse(reader: &mut InstructionReader) -> Result<Self, ParseError> {
+            fn parse(reader: &mut InstructionReader<'_>) -> Result<Self, ParseError> {
                 let opcode = (reader.next_u32()? & 0xffff) as u16;
 
                 Ok(match opcode {
@@ -392,7 +392,7 @@ fn bit_enum_output(enums: &[(Ident, Vec<KindEnumMember>)]) -> TokenStream {
 
             impl #name {
                 #[allow(dead_code)]
-                fn parse(reader: &mut InstructionReader) -> Result<#name, ParseError> {
+                fn parse(reader: &mut InstructionReader<'_>) -> Result<#name, ParseError> {
                     let value = reader.next_u32()?;
 
                     Ok(Self {
@@ -536,7 +536,7 @@ fn value_enum_output(enums: &[(Ident, Vec<KindEnumMember>)]) -> TokenStream {
 
             impl #name {
                 #[allow(dead_code)]
-                fn parse(reader: &mut InstructionReader) -> Result<#name, ParseError> {
+                fn parse(reader: &mut InstructionReader<'_>) -> Result<#name, ParseError> {
                     Ok(match reader.next_u32()? {
                         #(#parse_items)*
                         value => return Err(reader.map_err(ParseErrors::UnknownEnumerant(#name_string, value))),

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -431,18 +431,45 @@ impl Default for DebugUtilsLabel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        instance::{InstanceCreateInfo, InstanceExtensions},
+        VulkanLibrary,
+    };
     use std::thread;
 
     #[test]
     fn ensure_sendable() {
         // It's useful to be able to initialize a DebugUtilsMessenger on one thread
         // and keep it alive on another thread.
-        let instance = instance!();
+        let instance = {
+            let library = match VulkanLibrary::new() {
+                Ok(x) => x,
+                Err(_) => return,
+            };
+
+            match Instance::new(
+                library,
+                InstanceCreateInfo {
+                    enabled_extensions: InstanceExtensions {
+                        ext_debug_utils: true,
+                        ..InstanceExtensions::empty()
+                    },
+                    ..Default::default()
+                },
+            ) {
+                Ok(x) => x,
+                Err(_) => return,
+            }
+        };
+
         let callback = unsafe {
             DebugUtilsMessenger::new(
                 instance,
                 DebugUtilsMessengerCreateInfo {
-                    message_severity: DebugUtilsMessageSeverity::empty(),
+                    message_severity: DebugUtilsMessageSeverity {
+                        error: true,
+                        ..DebugUtilsMessageSeverity::empty()
+                    },
                     message_type: DebugUtilsMessageType {
                         general: true,
                         validation: true,


### PR DESCRIPTION
This fixes some issues that were left over after #2007:
- The `ensure_sendable` test was failing.
- The auto-generated code was triggering idiom warnings.
- Idiom warnings weren't enabled on the other crates in Vulkano, I did that now and fixed any warnings.