### PR TITLE
Swapchain acquisition checks

### DIFF
--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -39,8 +39,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -37,8 +37,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -46,8 +46,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -50,8 +50,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     single_pass_renderpass,
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -36,8 +36,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     single_pass_renderpass,
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -38,8 +38,8 @@ use vulkano::{
     query::{QueryControlFlags, QueryPool, QueryPoolCreateInfo, QueryResultFlags, QueryType},
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -37,8 +37,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -44,8 +44,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     shader::ShaderModule,
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -43,8 +43,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -34,8 +34,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     shader::ShaderModule,
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -44,8 +44,8 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -37,8 +37,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Sampler, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -46,8 +46,8 @@ use vulkano::{
     },
     render_pass::{LoadOp, StoreOp},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     Version, VulkanLibrary,

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -39,8 +39,8 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract,
-        SwapchainCreateInfo, SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
+        SwapchainCreationError, SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -594,8 +594,8 @@ fn main() {
                         previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                     Err(e) => {
-                        println!("Failed to flush future: {:?}", e);
-                        previous_frame_end = Some(sync::now(device.clone()).boxed());
+                        panic!("Failed to flush future: {:?}", e);
+                        // previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                 }
             }

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -497,6 +497,15 @@ where
             }
         }
     }
+
+    #[inline]
+    fn check_swapchain_image_acquired(
+        &self,
+        image: &UnsafeImage,
+        _before: bool,
+    ) -> Result<(), AccessCheckError> {
+        self.previous.check_swapchain_image_acquired(image, false)
+    }
 }
 
 unsafe impl<F> DeviceOwned for CommandBufferExecFuture<F>

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -1774,6 +1774,25 @@ where
 
         Ok(None)
     }
+
+    #[inline]
+    fn check_swapchain_image_acquired(
+        &self,
+        image: &UnsafeImage,
+        before: bool,
+    ) -> Result<(), AccessCheckError> {
+        if before {
+            Ok(())
+        } else {
+            let swapchain_image = self.swapchain.raw_image(self.image_index).unwrap();
+
+            if swapchain_image.image.internal_object() == image.internal_object() {
+                Ok(())
+            } else {
+                Err(AccessCheckError::Unknown)
+            }
+        }
+    }
 }
 
 impl<W> Drop for SwapchainAcquireFuture<W> {
@@ -2124,6 +2143,21 @@ where
                         }
                     }
 
+                    match self.previous.check_swapchain_image_acquired(
+                        self.swapchain_info
+                            .swapchain
+                            .raw_image(self.swapchain_info.image_index)
+                            .unwrap()
+                            .image,
+                        true,
+                    ) {
+                        Ok(_) => (),
+                        Err(AccessCheckError::Unknown) => {
+                            return Err(AccessError::SwapchainImageNotAcquired.into())
+                        }
+                        Err(AccessCheckError::Denied(e)) => return Err(e.into()),
+                    }
+
                     let mut queue_guard = self.queue.lock();
                     Ok(queue_guard
                         .present_unchecked(present_info)
@@ -2193,6 +2227,27 @@ where
         } else {
             self.previous
                 .check_image_access(image, range, exclusive, expected_layout, queue)
+        }
+    }
+
+    #[inline]
+    fn check_swapchain_image_acquired(
+        &self,
+        image: &UnsafeImage,
+        before: bool,
+    ) -> Result<(), AccessCheckError> {
+        let swapchain_image = self
+            .swapchain_info
+            .swapchain
+            .raw_image(self.swapchain_info.image_index)
+            .unwrap();
+
+        if before {
+            self.previous.check_swapchain_image_acquired(image, false)
+        } else if swapchain_image.image.internal_object() == image.internal_object() {
+            Err(AccessError::SwapchainImageNotAcquired.into())
+        } else {
+            self.previous.check_swapchain_image_acquired(image, false)
         }
     }
 }

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -1786,7 +1786,7 @@ where
         } else {
             let swapchain_image = self.swapchain.raw_image(self.image_index).unwrap();
 
-            if swapchain_image.image.internal_object() == image.internal_object() {
+            if **swapchain_image.image == *image {
                 Ok(())
             } else {
                 Err(AccessCheckError::Unknown)
@@ -2244,7 +2244,7 @@ where
 
         if before {
             self.previous.check_swapchain_image_acquired(image, false)
-        } else if swapchain_image.image.internal_object() == image.internal_object() {
+        } else if **swapchain_image.image == *image {
             Err(AccessError::SwapchainImageNotAcquired.into())
         } else {
             self.previous.check_swapchain_image_acquired(image, false)

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -13,7 +13,7 @@ use crate::{
     command_buffer::{SemaphoreSubmitInfo, SubmitInfo},
     device::{Device, DeviceOwned, Queue},
     image::{sys::UnsafeImage, ImageLayout},
-    sync::{AccessFlags, Fence, PipelineStages, SubmitAnyBuilder},
+    sync::{AccessError, AccessFlags, Fence, PipelineStages, SubmitAnyBuilder},
     DeviceSize, OomError,
 };
 use parking_lot::{Mutex, MutexGuard};
@@ -311,6 +311,19 @@ where
                             }) {
                                 return Err(FlushError::PresentIdLessThanOrEqual);
                             }
+
+                            match previous.check_swapchain_image_acquired(
+                                swapchain_info
+                                    .swapchain
+                                    .raw_image(swapchain_info.image_index)
+                                    .unwrap()
+                                    .image,
+                                true,
+                            ) {
+                                Ok(_) => (),
+                                Err(AccessCheckError::Unknown) => return Err(AccessError::SwapchainImageNotAcquired.into()),
+                                Err(AccessCheckError::Denied(e)) => return Err(e.into()),
+                            }
                         }
 
                         let mut queue_guard = queue.lock();
@@ -464,6 +477,19 @@ where
             Err(AccessCheckError::Unknown)
         }
     }
+
+    #[inline]
+    fn check_swapchain_image_acquired(
+        &self,
+        image: &UnsafeImage,
+        _before: bool,
+    ) -> Result<(), AccessCheckError> {
+        if let Some(previous) = self.state.lock().get_prev() {
+            previous.check_swapchain_image_acquired(image, false)
+        } else {
+            Err(AccessCheckError::Unknown)
+        }
+    }
 }
 
 unsafe impl<F> DeviceOwned for FenceSignalFuture<F>
@@ -571,5 +597,14 @@ where
         queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
         (**self).check_image_access(image, range, exclusive, expected_layout, queue)
+    }
+
+    #[inline]
+    fn check_swapchain_image_acquired(
+        &self,
+        image: &UnsafeImage,
+        before: bool,
+    ) -> Result<(), AccessCheckError> {
+        (**self).check_swapchain_image_acquired(image, before)
     }
 }

--- a/vulkano/src/sync/future/now.rs
+++ b/vulkano/src/sync/future/now.rs
@@ -77,6 +77,15 @@ unsafe impl GpuFuture for NowFuture {
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
         Err(AccessCheckError::Unknown)
     }
+
+    #[inline]
+    fn check_swapchain_image_acquired(
+        &self,
+        _image: &UnsafeImage,
+        _before: bool,
+    ) -> Result<(), AccessCheckError> {
+        Err(AccessCheckError::Unknown)
+    }
 }
 
 unsafe impl DeviceOwned for NowFuture {

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -13,7 +13,7 @@ use crate::{
     command_buffer::{SemaphoreSubmitInfo, SubmitInfo},
     device::{Device, DeviceOwned, Queue},
     image::{sys::UnsafeImage, ImageLayout},
-    sync::{AccessFlags, PipelineStages, Semaphore},
+    sync::{AccessError, AccessFlags, PipelineStages, Semaphore},
     DeviceSize,
 };
 use parking_lot::Mutex;
@@ -150,6 +150,21 @@ where
                         }) {
                             return Err(FlushError::PresentIdLessThanOrEqual);
                         }
+
+                        match self.previous.check_swapchain_image_acquired(
+                            swapchain_info
+                                .swapchain
+                                .raw_image(swapchain_info.image_index)
+                                .unwrap()
+                                .image,
+                            true,
+                        ) {
+                            Ok(_) => (),
+                            Err(AccessCheckError::Unknown) => {
+                                return Err(AccessError::SwapchainImageNotAcquired.into())
+                            }
+                            Err(AccessCheckError::Denied(e)) => return Err(e.into()),
+                        }
                     }
 
                     let mut queue_guard = queue.lock();
@@ -219,6 +234,15 @@ where
         self.previous
             .check_image_access(image, range, exclusive, expected_layout, queue)
             .map(|_| None)
+    }
+
+    #[inline]
+    fn check_swapchain_image_acquired(
+        &self,
+        image: &UnsafeImage,
+        _before: bool,
+    ) -> Result<(), AccessCheckError> {
+        self.previous.check_swapchain_image_acquired(image, false)
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/vulkano-rs/vulkano/issues/2004

This provides a solution for checking to make sure when presenting that the swapchain image has been acquired and has not already been presented. There may be some short comings to this yet, but my initial tests it is working as intended.

- `SwapchainImageAcquireOnly` was renamed to `SwapchainImageNotAcquired` to be less confusing.
- This does not address accessing images via commands.

Changelog:
```markdown
### Breaking changes
Changes to `GpuFuture`:
- Added required method `check_swapchain_image_acquired`.
- `AccessError::SwapchainImageAcquireOnly` has been renamed to `SwapchainImageNotAcquired`.

### Bugs fixed
- Fix bug where a swapchain image could be presented without being acquired. #2004 
````
