### PR TITLE
Add state tracking and validation to `Fence`

### DIFF
--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -254,10 +254,9 @@ mod linux {
                     recreate_swapchain = true;
                 }
                 Event::RedrawEventsCleared => {
-                    unsafe {
-                        let mut queue_guard = queue.lock();
-                        queue_guard
-                            .submit_unchecked(
+                    queue
+                        .with(|mut q| unsafe {
+                            q.submit_unchecked(
                                 [SubmitInfo {
                                     signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
                                         acquire_sem.clone(),
@@ -266,16 +265,15 @@ mod linux {
                                 }],
                                 None,
                             )
-                            .unwrap();
-                    };
+                        })
+                        .unwrap();
 
                     barrier.wait();
                     barrier_2.wait();
 
-                    unsafe {
-                        let mut queue_guard = queue.lock();
-                        queue_guard
-                            .submit_unchecked(
+                    queue
+                        .with(|mut q| unsafe {
+                            q.submit_unchecked(
                                 [SubmitInfo {
                                     wait_semaphores: vec![SemaphoreSubmitInfo::semaphore(
                                         release_sem.clone(),
@@ -284,8 +282,8 @@ mod linux {
                                 }],
                                 None,
                             )
-                            .unwrap();
-                    };
+                        })
+                        .unwrap();
 
                     previous_frame_end.as_mut().unwrap().cleanup_finished();
 

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -425,8 +425,7 @@ where
             match self.build_submission_impl()? {
                 SubmitAnyBuilder::Empty => {}
                 SubmitAnyBuilder::CommandBuffer(submit_info, fence) => {
-                    let mut queue_guard = queue.lock();
-                    queue_guard.submit_unchecked([submit_info], fence)?;
+                    queue.with(|mut q| q.submit_unchecked([submit_info], fence))?;
                 }
                 _ => unreachable!(),
             };
@@ -519,7 +518,7 @@ where
                 // TODO: handle errors?
                 self.flush().unwrap();
                 // Block until the queue finished.
-                self.queue.lock().wait_idle().unwrap();
+                self.queue.with(|mut q| q.wait_idle()).unwrap();
                 self.previous.signal_finished();
             }
         }

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -18,7 +18,7 @@ use crate::{
         BindSparseInfo, SparseBufferMemoryBind, SparseImageMemoryBind, SparseImageOpaqueMemoryBind,
     },
     swapchain::{PresentInfo, SwapchainPresentInfo},
-    sync::{Fence, PipelineStage},
+    sync::{Fence, FenceState, PipelineStage},
     OomError, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};
@@ -81,21 +81,22 @@ impl Queue {
         self.id
     }
 
-    /// Locks the queue, making it possible to perform operations on the queue, such as submissions.
+    /// Locks the queue and then calls the provided closure, providing it with an object that
+    /// can be used to perform operations on the queue, such as command buffer submissions.
     #[inline]
-    pub fn lock(&self) -> QueueGuard<'_> {
-        QueueGuard {
+    pub fn with<'a, R>(self: &'a Arc<Self>, func: impl FnOnce(QueueGuard<'a>) -> R) -> R {
+        func(QueueGuard {
             queue: self,
             state: self.state.lock(),
-        }
+        })
     }
 }
 
 impl Drop for Queue {
     #[inline]
     fn drop(&mut self) {
-        let mut queue_guard = self.lock();
-        queue_guard.wait_idle().unwrap();
+        let state = self.state.get_mut();
+        let _ = state.wait_idle(&self.device, self.handle);
     }
 }
 
@@ -134,26 +135,13 @@ impl Hash for Queue {
 }
 
 pub struct QueueGuard<'a> {
-    queue: &'a Queue,
+    queue: &'a Arc<Queue>,
     state: MutexGuard<'a, QueueState>,
 }
 
 impl<'a> QueueGuard<'a> {
-    /// Releases ownership of resources belonging to queue operations that have completed.
-    ///
-    /// This is implemented by checking for operations that have a signaled fence, and then
-    /// releasing the resources of that operation and all preceding ones. If you execute an
-    /// operation without a fence, it will not be cleaned up until you execute another operation
-    /// with a fence after it, as a fence is the only way for the CPU to know that the queue has
-    /// reached a certain point in its execution.
-    ///
-    /// It is highly recommended to call `cleanup_finished` from time to time, for example once
-    /// every frame. Otherwise, the queue will hold onto resources indefinitely (using up memory)
-    /// and resource locks will not be released, which may cause errors when submitting future
-    /// queue operations.
-    #[inline]
-    pub fn cleanup_finished(&mut self) {
-        self.state.cleanup_finished();
+    pub(crate) unsafe fn fence_signaled(&mut self, fence: &Fence) {
+        self.state.fence_signaled(fence)
     }
 
     /// Waits until all work on this queue has finished, then releases ownership of all resources
@@ -166,20 +154,7 @@ impl<'a> QueueGuard<'a> {
     /// program.
     #[inline]
     pub fn wait_idle(&mut self) -> Result<(), OomError> {
-        unsafe {
-            let fns = self.queue.device.fns();
-            (fns.v1_0.queue_wait_idle)(self.queue.handle)
-                .result()
-                .map_err(VulkanError::from)?;
-
-            // Since we now know that the queue is finished with all work,
-            // we can safely release all resources.
-            for (operation, _) in take(&mut self.state.operations) {
-                operation.unlock();
-            }
-
-            Ok(())
-        }
+        self.state.wait_idle(&self.queue.device, self.queue.handle)
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
@@ -586,8 +561,20 @@ impl<'a> QueueGuard<'a> {
         submit_infos: impl IntoIterator<Item = SubmitInfo>,
         fence: Option<Arc<Fence>>,
     ) -> Result<(), VulkanError> {
-        let submit_infos: SmallVec<[_; 4]> = submit_infos.into_iter().collect();
+        self.submit_unchecked_locked(
+            submit_infos.into_iter().collect(),
+            fence.as_ref().map(|fence| {
+                let state = fence.lock();
+                (fence, state)
+            }),
+        )
+    }
 
+    unsafe fn submit_unchecked_locked(
+        &mut self,
+        submit_infos: SmallVec<[SubmitInfo; 4]>,
+        fence: Option<(&Arc<Fence>, MutexGuard<'_, FenceState>)>,
+    ) -> Result<(), VulkanError> {
         if self.queue.device.enabled_features().synchronization2 {
             struct PerSubmitInfo {
                 wait_semaphore_infos_vk: SmallVec<[ash::vk::SemaphoreSubmitInfo; 4]>,
@@ -702,7 +689,7 @@ impl<'a> QueueGuard<'a> {
                     submit_info_vk.as_ptr(),
                     fence
                         .as_ref()
-                        .map_or_else(Default::default, |fence| fence.internal_object()),
+                        .map_or_else(Default::default, |(fence, _)| fence.internal_object()),
                 )
             } else {
                 debug_assert!(self.queue.device.enabled_extensions().khr_synchronization2);
@@ -712,7 +699,7 @@ impl<'a> QueueGuard<'a> {
                     submit_info_vk.as_ptr(),
                     fence
                         .as_ref()
-                        .map_or_else(Default::default, |fence| fence.internal_object()),
+                        .map_or_else(Default::default, |(fence, _)| fence.internal_object()),
                 )
             }
             .result()
@@ -817,11 +804,16 @@ impl<'a> QueueGuard<'a> {
                 submit_info_vk.as_ptr(),
                 fence
                     .as_ref()
-                    .map_or_else(Default::default, |fence| fence.internal_object()),
+                    .map_or_else(Default::default, |(fence, _)| fence.internal_object()),
             )
             .result()
             .map_err(VulkanError::from)?;
         }
+
+        let fence = fence.map(|(fence, mut state)| {
+            state.add_to_queue(self.queue);
+            fence.clone()
+        });
 
         self.state
             .operations
@@ -1136,26 +1128,44 @@ struct QueueState {
 }
 
 impl QueueState {
-    fn cleanup_finished(&mut self) {
-        // Find the most recent operation that has a signaled fence.
-        let last_signaled_fence_index =
-            self.operations
-                .iter()
-                .enumerate()
-                .rev()
-                .find_map(|(index, (_, fence))| {
-                    fence
-                        .as_ref()
-                        // If `is_signaled` returns an error, treat it as not signaled.
-                        .map_or(false, |fence| fence.is_signaled().unwrap_or(false))
-                        .then_some(index)
-                });
+    fn wait_idle(&mut self, device: &Device, handle: ash::vk::Queue) -> Result<(), OomError> {
+        unsafe {
+            let fns = device.fns();
+            (fns.v1_0.queue_wait_idle)(handle)
+                .result()
+                .map_err(VulkanError::from)?;
 
-        if let Some(index) = last_signaled_fence_index {
+            // Since we now know that the queue is finished with all work,
+            // we can safely release all resources.
+            for (operation, _) in take(&mut self.operations) {
+                operation.unlock();
+            }
+
+            Ok(())
+        }
+    }
+
+    /// Called by `fence` when it finds that it is signaled.
+    fn fence_signaled(&mut self, fence: &Fence) {
+        // Find the most recent operation that uses `fence`.
+        let fence_index = self
+            .operations
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(index, (_, f))| {
+                f.as_ref().map_or(false, |f| **f == *fence).then_some(index)
+            });
+
+        if let Some(index) = fence_index {
             // Remove all operations up to this index, and perform cleanup if needed.
-            for (operation, _) in self.operations.drain(..index + 1) {
+            for (operation, fence) in self.operations.drain(..index + 1) {
                 unsafe {
                     operation.unlock();
+
+                    if let Some(fence) = fence {
+                        fence.lock().set_finished();
+                    }
                 }
             }
         }
@@ -1217,12 +1227,9 @@ mod tests {
     fn empty_submit() {
         let (_device, queue) = gfx_dev_and_queue!();
 
-        unsafe {
-            let mut queue_guard = queue.lock();
-            queue_guard
-                .submit_unchecked([Default::default()], None)
-                .unwrap();
-        }
+        queue
+            .with(|mut q| unsafe { q.submit_unchecked([Default::default()], None) })
+            .unwrap();
     }
 
     #[test]
@@ -1233,9 +1240,8 @@ mod tests {
             let fence = Arc::new(Fence::new(device, Default::default()).unwrap());
             assert!(!fence.is_signaled().unwrap());
 
-            let mut queue_guard = queue.lock();
-            queue_guard
-                .submit_unchecked([Default::default()], Some(fence.clone()))
+            queue
+                .with(|mut q| q.submit_unchecked([Default::default()], Some(fence.clone())))
                 .unwrap();
 
             fence.wait(Some(Duration::from_secs(5))).unwrap();

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -2124,9 +2124,9 @@ where
                         }
                     }
 
-                    let mut queue_guard = self.queue.lock();
-                    Ok(queue_guard
-                        .present_unchecked(present_info)
+                    Ok(self
+                        .queue
+                        .with(|mut q| q.present_unchecked(present_info))
                         .map(|r| r.map(|_| ()))
                         .fold(Ok(()), Result::and)?)
                 }
@@ -2221,7 +2221,7 @@ where
 
             if !*self.finished.get_mut() {
                 // Block until the queue finished.
-                self.queue().unwrap().lock().wait_idle().unwrap();
+                self.queue().unwrap().with(|mut q| q.wait_idle()).unwrap();
                 self.previous.signal_finished();
             }
         }

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -153,11 +153,6 @@ where
                 unsafe {
                     previous.signal_finished();
                 }
-
-                if let Some(queue) = previous.queue() {
-                    queue.lock().cleanup_finished();
-                }
-
                 Ok(())
             }
             FenceSignalFutureState::Cleaned => Ok(()),
@@ -181,11 +176,6 @@ where
                 match fence.wait(Some(Duration::from_secs(0))) {
                     Ok(()) => {
                         unsafe { prev.signal_finished() }
-
-                        if let Some(queue) = prev.queue() {
-                            queue.lock().cleanup_finished();
-                        }
-
                         *state = FenceSignalFutureState::Cleaned;
                     }
                     Err(_) => {
@@ -239,35 +229,37 @@ where
                 SubmitAnyBuilder::Empty => {
                     debug_assert!(!partially_flushed);
 
-                    let mut queue_guard = queue.lock();
-                    queue_guard
-                        .submit_unchecked([Default::default()], Some(new_fence.clone()))
+                    queue
+                        .with(|mut q| {
+                            q.submit_unchecked([Default::default()], Some(new_fence.clone()))
+                        })
                         .map_err(|err| OutcomeErr::Full(err.into()))
                 }
                 SubmitAnyBuilder::SemaphoresWait(semaphores) => {
                     debug_assert!(!partially_flushed);
 
-                    let mut queue_guard = queue.lock();
-                    queue_guard
-                        .submit_unchecked(
-                            [SubmitInfo {
-                                wait_semaphores: semaphores
-                                    .into_iter()
-                                    .map(|semaphore| {
-                                        SemaphoreSubmitInfo {
-                                            stages: PipelineStages {
-                                                // TODO: correct stages ; hard
-                                                all_commands: true,
-                                                ..PipelineStages::empty()
-                                            },
-                                            ..SemaphoreSubmitInfo::semaphore(semaphore)
-                                        }
-                                    })
-                                    .collect(),
-                                ..Default::default()
-                            }],
-                            None,
-                        )
+                    queue
+                        .with(|mut q| {
+                            q.submit_unchecked(
+                                [SubmitInfo {
+                                    wait_semaphores: semaphores
+                                        .into_iter()
+                                        .map(|semaphore| {
+                                            SemaphoreSubmitInfo {
+                                                stages: PipelineStages {
+                                                    // TODO: correct stages ; hard
+                                                    all_commands: true,
+                                                    ..PipelineStages::empty()
+                                                },
+                                                ..SemaphoreSubmitInfo::semaphore(semaphore)
+                                            }
+                                        })
+                                        .collect(),
+                                    ..Default::default()
+                                }],
+                                None,
+                            )
+                        })
                         .map_err(|err| OutcomeErr::Full(err.into()))
                 }
                 SubmitAnyBuilder::CommandBuffer(submit_info, fence) => {
@@ -279,9 +271,8 @@ where
                     // assertion.
                     assert!(fence.is_none());
 
-                    let mut queue_guard = queue.lock();
-                    queue_guard
-                        .submit_unchecked([submit_info], Some(new_fence.clone()))
+                    queue
+                        .with(|mut q| q.submit_unchecked([submit_info], Some(new_fence.clone())))
                         .map_err(|err| OutcomeErr::Full(err.into()))
                 }
                 SubmitAnyBuilder::BindSparse(bind_infos, fence) => {
@@ -295,9 +286,8 @@ where
                             .sparse_binding
                     );
 
-                    let mut queue_guard = queue.lock();
-                    queue_guard
-                        .bind_sparse_unchecked(bind_infos, Some(new_fence.clone()))
+                    queue
+                        .with(|mut q| q.bind_sparse_unchecked(bind_infos, Some(new_fence.clone())))
                         .map_err(|err| OutcomeErr::Full(err.into()))
                 }
                 SubmitAnyBuilder::QueuePresent(present_info) => {
@@ -313,20 +303,18 @@ where
                             }
                         }
 
-                        let mut queue_guard = queue.lock();
-                        queue_guard
-                            .present_unchecked(present_info)
+                        queue
+                            .with(|mut q| q.present_unchecked(present_info))
                             .map(|r| r.map(|_| ()))
                             .fold(Ok(()), Result::and)
                     };
 
                     match intermediary_result {
-                        Ok(()) => {
-                            let mut queue_guard = queue.lock();
-                            queue_guard
-                                .submit_unchecked([Default::default()], Some(new_fence.clone()))
-                                .map_err(|err| OutcomeErr::Partial(err.into()))
-                        }
+                        Ok(()) => queue
+                            .with(|mut q| {
+                                q.submit_unchecked([Default::default()], Some(new_fence.clone()))
+                            })
+                            .map_err(|err| OutcomeErr::Partial(err.into())),
                         Err(err) => Err(OutcomeErr::Full(err.into())),
                     }
                 }
@@ -493,10 +481,6 @@ where
                 fence.wait(None).unwrap();
                 unsafe {
                     previous.signal_finished();
-
-                    if let Some(queue) = previous.queue() {
-                        queue.lock().cleanup_finished();
-                    }
                 }
             }
             FenceSignalFutureState::Cleaned => {

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -572,7 +572,7 @@ impl From<FenceError> for FlushError {
             FenceError::OomError(err) => FlushError::OomError(err),
             FenceError::Timeout => FlushError::Timeout,
             FenceError::DeviceLost => FlushError::DeviceLost,
-            FenceError::RequirementNotMet { .. } => unreachable!(),
+            FenceError::RequirementNotMet { .. } | FenceError::InUse => unreachable!(),
         }
     }
 }

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -90,41 +90,43 @@ where
 
             match self.previous.build_submission()? {
                 SubmitAnyBuilder::Empty => {
-                    let mut queue_guard = queue.lock();
-                    queue_guard.submit_unchecked(
-                        [SubmitInfo {
-                            signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
-                                self.semaphore.clone(),
-                            )],
-                            ..Default::default()
-                        }],
-                        None,
-                    )?;
+                    queue.with(|mut q| {
+                        q.submit_unchecked(
+                            [SubmitInfo {
+                                signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
+                                    self.semaphore.clone(),
+                                )],
+                                ..Default::default()
+                            }],
+                            None,
+                        )
+                    })?;
                 }
                 SubmitAnyBuilder::SemaphoresWait(semaphores) => {
-                    let mut queue_guard = queue.lock();
-                    queue_guard.submit_unchecked(
-                        [SubmitInfo {
-                            wait_semaphores: semaphores
-                                .into_iter()
-                                .map(|semaphore| {
-                                    SemaphoreSubmitInfo {
-                                        stages: PipelineStages {
-                                            // TODO: correct stages ; hard
-                                            all_commands: true,
-                                            ..PipelineStages::empty()
-                                        },
-                                        ..SemaphoreSubmitInfo::semaphore(semaphore)
-                                    }
-                                })
-                                .collect(),
-                            signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
-                                self.semaphore.clone(),
-                            )],
-                            ..Default::default()
-                        }],
-                        None,
-                    )?;
+                    queue.with(|mut q| {
+                        q.submit_unchecked(
+                            [SubmitInfo {
+                                wait_semaphores: semaphores
+                                    .into_iter()
+                                    .map(|semaphore| {
+                                        SemaphoreSubmitInfo {
+                                            stages: PipelineStages {
+                                                // TODO: correct stages ; hard
+                                                all_commands: true,
+                                                ..PipelineStages::empty()
+                                            },
+                                            ..SemaphoreSubmitInfo::semaphore(semaphore)
+                                        }
+                                    })
+                                    .collect(),
+                                signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
+                                    self.semaphore.clone(),
+                                )],
+                                ..Default::default()
+                            }],
+                            None,
+                        )
+                    })?;
                 }
                 SubmitAnyBuilder::CommandBuffer(mut submit_info, fence) => {
                     debug_assert!(submit_info.signal_semaphores.is_empty());
@@ -133,8 +135,7 @@ where
                         .signal_semaphores
                         .push(SemaphoreSubmitInfo::semaphore(self.semaphore.clone()));
 
-                    let mut queue_guard = queue.lock();
-                    queue_guard.submit_unchecked([submit_info], fence)?;
+                    queue.with(|mut q| q.submit_unchecked([submit_info], fence))?;
                 }
                 SubmitAnyBuilder::BindSparse(_, _) => {
                     unimplemented!() // TODO: how to do that?
@@ -152,22 +153,22 @@ where
                         }
                     }
 
-                    let mut queue_guard = queue.lock();
-                    queue_guard
-                        .present_unchecked(present_info)
-                        .map(|r| r.map(|_| ()))
-                        .fold(Ok(()), Result::and)?;
-
-                    // FIXME: problematic because if we return an error and flush() is called again, then we'll submit the present twice
-                    queue_guard.submit_unchecked(
-                        [SubmitInfo {
-                            signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
-                                self.semaphore.clone(),
-                            )],
-                            ..Default::default()
-                        }],
-                        None,
-                    )?;
+                    queue.with(|mut q| {
+                        q.present_unchecked(present_info)
+                            .map(|r| r.map(|_| ()))
+                            .fold(Ok(()), Result::and)?;
+                        // FIXME: problematic because if we return an error and flush() is called again, then we'll submit the present twice
+                        q.submit_unchecked(
+                            [SubmitInfo {
+                                signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
+                                    self.semaphore.clone(),
+                                )],
+                                ..Default::default()
+                            }],
+                            None,
+                        )?;
+                        Ok::<_, FlushError>(())
+                    })?;
                 }
             };
 
@@ -242,7 +243,7 @@ where
                 // TODO: handle errors?
                 self.flush().unwrap();
                 // Block until the queue finished.
-                self.queue().unwrap().lock().wait_idle().unwrap();
+                self.queue().unwrap().with(|mut q| q.wait_idle()).unwrap();
                 self.previous.signal_finished();
             }
         }

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -103,6 +103,7 @@
 //! TODO: talk about fence + semaphore simultaneously
 //! TODO: talk about using fences to clean up
 
+pub(crate) use self::fence::FenceState;
 pub use self::{
     event::{Event, EventCreateInfo},
     fence::{


### PR DESCRIPTION
Changelog:
Remove this line
```markdown
- When doing operations on a queue, you must now first call `lock()` on the queue, which prevents concurrent access.
```
and replace with

```markdown
- To do operations on a queue, you must now call `with` to gain access.
```

Remove this line
```markdown
- `QueueGuard` now has a `cleanup_finished` method, which does the same thing as on futures. Calling this method on a future will automatically forward it to its queue.
```

Add
```markdown
### Additions
- Fence methods are now validated and synchronized, so they take `&self`.
- When calling `Fence::is_signaled` or `Fence::wait`, if the fence is associated with a queue, any resources of the associated queue operation will be released.
````
This makes changes that allow `Fence` to be used safely, and also adds convenience by automatically signaling a queue.