### PR TITLE
#1935 add from_handle to DeviceMemory

### DIFF
--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -75,17 +75,34 @@ impl DeviceMemory {
         Self::validate(&device, &mut allocate_info, None)?;
         let handle = unsafe { Self::create(&device, &allocate_info, None)? };
 
-        unsafe { Ok(DeviceMemory::from_handle(handle, allocate_info, device)) }
+        let MemoryAllocateInfo {
+            allocation_size,
+            memory_type_index,
+            dedicated_allocation: _,
+            export_handle_types,
+            _ne: _,
+        } = allocate_info;
+
+        Ok(DeviceMemory {
+            handle,
+            device,
+
+            allocation_size,
+            memory_type_index,
+            export_handle_types,
+        })
     }
 
-    /// Creates a new `DeviceMemory` from an ash-handle
+    /// Creates a new `DeviceMemory` from a raw object handle.
+    ///
     /// # Safety
-    /// The `handle` has to be a valid vulkan object handle and
-    /// the `allocate_info` must match the info used to create said object
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `allocate_info` must match the info used to create the object.
     pub unsafe fn from_handle(
+        device: Arc<Device>,
         handle: ash::vk::DeviceMemory,
         allocate_info: MemoryAllocateInfo<'_>,
-        device: Arc<Device>,
     ) -> DeviceMemory {
         let MemoryAllocateInfo {
             allocation_size,

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -75,6 +75,18 @@ impl DeviceMemory {
         Self::validate(&device, &mut allocate_info, None)?;
         let handle = unsafe { Self::create(&device, &allocate_info, None)? };
 
+        unsafe { Ok(DeviceMemory::from_handle(handle, allocate_info, device)) }
+    }
+
+    /// Creates a new `DeviceMemory` from an ash-handle
+    /// # Safety
+    /// The `handle` has to be a valid vulkan object handle and
+    /// the `allocate_info` must match the info used to create said object
+    pub unsafe fn from_handle(
+        handle: ash::vk::DeviceMemory,
+        allocate_info: MemoryAllocateInfo<'_>,
+        device: Arc<Device>,
+    ) -> DeviceMemory {
         let MemoryAllocateInfo {
             allocation_size,
             memory_type_index,
@@ -83,14 +95,14 @@ impl DeviceMemory {
             _ne: _,
         } = allocate_info;
 
-        Ok(DeviceMemory {
+        DeviceMemory {
             handle,
             device,
 
             allocation_size,
             memory_type_index,
             export_handle_types,
-        })
+        }
     }
 
     /// Imports a block of memory from an external source.


### PR DESCRIPTION
Added `from_handle` constructor to `DeviceMemory`, see #1938.

I also tried to add the constructor to `Instance` and `Device` but I couldn't find a nice solution without refactoring too much.
If you could maybe provide a suggestion or hint, I might be able to add it for those too.

