### PR TITLE
Add support for layer extensions to `VulkanLibrary`

### DIFF
--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -27,7 +27,7 @@ use crate::{
         ExternalFenceInfo, ExternalFenceProperties, ExternalSemaphoreInfo,
         ExternalSemaphoreProperties,
     },
-    RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
+    ExtensionProperties, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
 use bytemuck::cast_slice;
 use parking_lot::RwLock;
@@ -2526,30 +2526,6 @@ where
             let result = func(entry.key())?;
             entry.insert(result.clone());
             Ok(result)
-        }
-    }
-}
-
-/// Properties of an extension in the loader or a physical device.
-#[derive(Clone, Debug)]
-pub struct ExtensionProperties {
-    /// The name of the extension.
-    pub extension_name: String,
-
-    /// The version of the extension.
-    pub spec_version: u32,
-}
-
-impl From<ash::vk::ExtensionProperties> for ExtensionProperties {
-    #[inline]
-    fn from(val: ash::vk::ExtensionProperties) -> Self {
-        Self {
-            extension_name: {
-                let bytes = cast_slice(val.extension_name.as_slice());
-                let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
-                String::from_utf8_lossy(&bytes[0..end]).into()
-            },
-            spec_version: val.spec_version,
         }
     }
 }

--- a/vulkano/src/extensions.rs
+++ b/vulkano/src/extensions.rs
@@ -8,10 +8,35 @@
 // according to those terms.
 
 use crate::RequiresOneOf;
+use bytemuck::cast_slice;
 use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
 };
+
+/// Properties of an extension in the loader or a physical device.
+#[derive(Clone, Debug)]
+pub struct ExtensionProperties {
+    /// The name of the extension.
+    pub extension_name: String,
+
+    /// The version of the extension.
+    pub spec_version: u32,
+}
+
+impl From<ash::vk::ExtensionProperties> for ExtensionProperties {
+    #[inline]
+    fn from(val: ash::vk::ExtensionProperties) -> Self {
+        Self {
+            extension_name: {
+                let bytes = cast_slice(val.extension_name.as_slice());
+                let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+                String::from_utf8_lossy(&bytes[0..end]).into()
+            },
+            spec_version: val.spec_version,
+        }
+    }
+}
 
 /// An error that can happen when enabling an extension on an instance or device.
 #[derive(Clone, Copy, Debug)]

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -312,7 +312,8 @@ impl Instance {
 
         // VUID-VkApplicationInfo-apiVersion-04010
         assert!(max_api_version >= Version::V1_0);
-        let supported_extensions = library.supported_extensions();
+        let supported_extensions =
+            library.supported_extensions_with_layers(enabled_layers.iter().map(String::as_str))?;
         let mut flags = ash::vk::InstanceCreateFlags::empty();
 
         if enumerate_portability && supported_extensions.khr_portability_enumeration {
@@ -321,7 +322,7 @@ impl Instance {
         }
 
         // Check if the extensions are correct
-        enabled_extensions.check_requirements(supported_extensions, api_version)?;
+        enabled_extensions.check_requirements(&supported_extensions, api_version)?;
 
         // FIXME: check whether each layer is supported
         let enabled_layers_cstr: Vec<CString> = enabled_layers

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -90,7 +90,7 @@ use std::{
     ops::Deref,
     sync::Arc,
 };
-pub use version::Version;
+pub use {extensions::ExtensionProperties, version::Version};
 
 #[macro_use]
 mod tests;


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- `VulkanLibrary::extension_properties`, to mirror the equivalent function on `PhysicalDevice`.
- `VulkanLibrary` methods `layer_extension_properties`, `supported_layer_extensions` and `supported_extensions_with_layers`, to query the extensions supported by layers.

### Bugs fixed
- [#1871](https://github.com/vulkano-rs/vulkano/issues/1871): Layer extensions are not included when validating extensions to enable on an instance.
````

Fixes #1871.