### PR TITLE
Add support for `khr_surface_protected_capabilities` extension

### DIFF
--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -2064,6 +2064,9 @@ pub struct SurfaceCapabilities {
     /// the `color_attachment` usage is guaranteed to be supported.
     pub supported_usage_flags: ImageUsage,
 
+    /// Whether creating a protected swapchain is supported.
+    pub supports_protected: bool,
+
     /// Whether full-screen exclusivity is supported.
     pub full_screen_exclusive_supported: bool,
 }


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Added a `supports_protected` member to `SurfaceCapabilities` for the `khr_surface_protected_capabilities` extension.
````

Another relatively low effort extension that we can mark off.