### PR TITLE
Replace generics with `impl Trait` in function arguments

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -207,17 +207,14 @@ pub fn compile(
     Ok((content, includes))
 }
 
-pub(super) fn reflect<'a, I>(
+pub(super) fn reflect<'a>(
     prefix: &'a str,
     words: &[u32],
     types_meta: &TypesMeta,
-    input_paths: I,
+    input_paths: impl IntoIterator<Item = &'a str>,
     shared_constants: bool,
     types_registry: &'a mut HashMap<String, RegisteredType>,
-) -> Result<(TokenStream, TokenStream), Error>
-where
-    I: IntoIterator<Item = &'a str>,
-{
+) -> Result<(TokenStream, TokenStream), Error> {
     let spirv = Spirv::new(words)?;
 
     let include_bytes = input_paths.into_iter().map(|s| {

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -323,10 +323,11 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     /// - Panics if `self` and any element of `vertex_buffers` do not belong to the same device.
     /// - Panics if any element of `vertex_buffers` does not have the
     ///   [`vertex_buffer`](crate::buffer::BufferUsage::vertex_buffer) usage enabled.
-    pub fn bind_vertex_buffers<V>(&mut self, first_binding: u32, vertex_buffers: V) -> &mut Self
-    where
-        V: VertexBuffersCollection,
-    {
+    pub fn bind_vertex_buffers(
+        &mut self,
+        first_binding: u32,
+        vertex_buffers: impl VertexBuffersCollection,
+    ) -> &mut Self {
         let vertex_buffers = vertex_buffers.into_vec();
         self.validate_bind_vertex_buffers(first_binding, &vertex_buffers)
             .unwrap();
@@ -838,10 +839,7 @@ pub struct SyncCommandBufferBuilderBindDescriptorSets<'b> {
 impl<'b> SyncCommandBufferBuilderBindDescriptorSets<'b> {
     /// Adds a descriptor set to the list.
     #[inline]
-    pub fn add<S>(&mut self, descriptor_set: S)
-    where
-        S: Into<DescriptorSetWithOffsets>,
-    {
+    pub fn add(&mut self, descriptor_set: impl Into<DescriptorSetWithOffsets>) {
         self.descriptor_sets.push(descriptor_set.into());
     }
 

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -571,10 +571,11 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     /// - Panics if the highest discard rectangle slot being set is greater than the
     ///   [`max_discard_rectangles`](crate::device::Properties::max_discard_rectangles) device
     ///   property.
-    pub fn set_discard_rectangle<I>(&mut self, first_rectangle: u32, rectangles: I) -> &mut Self
-    where
-        I: IntoIterator<Item = Scissor>,
-    {
+    pub fn set_discard_rectangle(
+        &mut self,
+        first_rectangle: u32,
+        rectangles: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
         let rectangles: SmallVec<[Scissor; 2]> = rectangles.into_iter().collect();
         self.validate_set_discard_rectangle(first_rectangle, &rectangles)
             .unwrap();
@@ -1101,10 +1102,11 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     ///   [`max_viewports`](crate::device::Properties::max_viewports) device property.
     /// - If the [`multi_viewport`](crate::device::Features::multi_viewport) feature is not enabled,
     ///   panics if `first_scissor` is not 0, or if more than 1 scissor is provided.
-    pub fn set_scissor<I>(&mut self, first_scissor: u32, scissors: I) -> &mut Self
-    where
-        I: IntoIterator<Item = Scissor>,
-    {
+    pub fn set_scissor(
+        &mut self,
+        first_scissor: u32,
+        scissors: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
         let scissors: SmallVec<[Scissor; 2]> = scissors.into_iter().collect();
         self.validate_set_scissor(first_scissor, &scissors).unwrap();
 
@@ -1180,10 +1182,10 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     /// - If the [`multi_viewport`](crate::device::Features::multi_viewport) feature is not enabled,
     ///   panics if more than 1 scissor is provided.
     #[inline]
-    pub fn set_scissor_with_count<I>(&mut self, scissors: I) -> &mut Self
-    where
-        I: IntoIterator<Item = Scissor>,
-    {
+    pub fn set_scissor_with_count(
+        &mut self,
+        scissors: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
         let scissors: SmallVec<[Scissor; 2]> = scissors.into_iter().collect();
         self.validate_set_scissor_with_count(&scissors).unwrap();
 
@@ -1493,10 +1495,11 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     ///   [`max_viewports`](crate::device::Properties::max_viewports) device property.
     /// - If the [`multi_viewport`](crate::device::Features::multi_viewport) feature is not enabled,
     ///   panics if `first_viewport` is not 0, or if more than 1 viewport is provided.
-    pub fn set_viewport<I>(&mut self, first_viewport: u32, viewports: I) -> &mut Self
-    where
-        I: IntoIterator<Item = Viewport>,
-    {
+    pub fn set_viewport(
+        &mut self,
+        first_viewport: u32,
+        viewports: impl IntoIterator<Item = Viewport>,
+    ) -> &mut Self {
         let viewports: SmallVec<[Viewport; 2]> = viewports.into_iter().collect();
         self.validate_set_viewport(first_viewport, &viewports)
             .unwrap();
@@ -1573,10 +1576,10 @@ impl<L, P> AutoCommandBufferBuilder<L, P> {
     /// - If the [`multi_viewport`](crate::device::Features::multi_viewport) feature is not enabled,
     ///   panics if more than 1 viewport is provided.
     #[inline]
-    pub fn set_viewport_with_count<I>(&mut self, viewports: I) -> &mut Self
-    where
-        I: IntoIterator<Item = Viewport>,
-    {
+    pub fn set_viewport_with_count(
+        &mut self,
+        viewports: impl IntoIterator<Item = Viewport>,
+    ) -> &mut Self {
         let viewports: SmallVec<[Viewport; 2]> = viewports.into_iter().collect();
         self.validate_set_viewport_with_count(&viewports).unwrap();
 
@@ -1663,10 +1666,7 @@ impl SyncCommandBufferBuilder {
     ///
     /// If the list is empty then the command is automatically ignored.
     #[inline]
-    pub unsafe fn set_color_write_enable<I>(&mut self, enables: I)
-    where
-        I: IntoIterator<Item = bool>,
-    {
+    pub unsafe fn set_color_write_enable(&mut self, enables: impl IntoIterator<Item = bool>) {
         struct Cmd<I> {
             enables: Mutex<Option<I>>,
         }
@@ -1875,10 +1875,11 @@ impl SyncCommandBufferBuilder {
     ///
     /// If the list is empty then the command is automatically ignored.
     #[inline]
-    pub unsafe fn set_discard_rectangle<I>(&mut self, first_rectangle: u32, rectangles: I)
-    where
-        I: IntoIterator<Item = Scissor>,
-    {
+    pub unsafe fn set_discard_rectangle(
+        &mut self,
+        first_rectangle: u32,
+        rectangles: impl IntoIterator<Item = Scissor>,
+    ) {
         struct Cmd {
             first_rectangle: u32,
             rectangles: Mutex<SmallVec<[Scissor; 2]>>,
@@ -2260,10 +2261,11 @@ impl SyncCommandBufferBuilder {
     ///
     /// If the list is empty then the command is automatically ignored.
     #[inline]
-    pub unsafe fn set_scissor<I>(&mut self, first_scissor: u32, scissors: I)
-    where
-        I: IntoIterator<Item = Scissor>,
-    {
+    pub unsafe fn set_scissor(
+        &mut self,
+        first_scissor: u32,
+        scissors: impl IntoIterator<Item = Scissor>,
+    ) {
         struct Cmd {
             first_scissor: u32,
             scissors: Mutex<SmallVec<[Scissor; 2]>>,
@@ -2296,10 +2298,7 @@ impl SyncCommandBufferBuilder {
     ///
     /// If the list is empty then the command is automatically ignored.
     #[inline]
-    pub unsafe fn set_scissor_with_count<I>(&mut self, scissors: I)
-    where
-        I: IntoIterator<Item = Scissor>,
-    {
+    pub unsafe fn set_scissor_with_count(&mut self, scissors: impl IntoIterator<Item = Scissor>) {
         struct Cmd {
             scissors: Mutex<SmallVec<[Scissor; 2]>>,
         }
@@ -2325,10 +2324,11 @@ impl SyncCommandBufferBuilder {
     ///
     /// If the list is empty then the command is automatically ignored.
     #[inline]
-    pub unsafe fn set_viewport<I>(&mut self, first_viewport: u32, viewports: I)
-    where
-        I: IntoIterator<Item = Viewport>,
-    {
+    pub unsafe fn set_viewport(
+        &mut self,
+        first_viewport: u32,
+        viewports: impl IntoIterator<Item = Viewport>,
+    ) {
         struct Cmd {
             first_viewport: u32,
             viewports: Mutex<SmallVec<[Viewport; 2]>>,
@@ -2361,10 +2361,10 @@ impl SyncCommandBufferBuilder {
     ///
     /// If the list is empty then the command is automatically ignored.
     #[inline]
-    pub unsafe fn set_viewport_with_count<I>(&mut self, viewports: I)
-    where
-        I: IntoIterator<Item = Viewport>,
-    {
+    pub unsafe fn set_viewport_with_count(
+        &mut self,
+        viewports: impl IntoIterator<Item = Viewport>,
+    ) {
         struct Cmd {
             viewports: Mutex<SmallVec<[Viewport; 2]>>,
         }

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -412,10 +412,7 @@ pub struct SyncCommandBufferBuilderExecuteCommands<'a> {
 impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
     /// Adds a command buffer to the list.
     #[inline]
-    pub fn add<C>(&mut self, command_buffer: C)
-    where
-        C: SecondaryCommandBuffer + 'static,
-    {
+    pub fn add(&mut self, command_buffer: impl SecondaryCommandBuffer + 'static) {
         self.inner.push(Box::new(command_buffer));
     }
 
@@ -545,10 +542,7 @@ impl UnsafeCommandBufferBuilderExecuteCommands {
 
     /// Adds a command buffer to the list.
     #[inline]
-    pub fn add<C>(&mut self, cb: &C)
-    where
-        C: ?Sized + SecondaryCommandBuffer,
-    {
+    pub fn add(&mut self, cb: &(impl SecondaryCommandBuffer + ?Sized)) {
         // TODO: debug assert that it is a secondary command buffer?
         self.raw_cbs.push(cb.inner().internal_object());
     }

--- a/vulkano/src/command_buffer/pool/sys.rs
+++ b/vulkano/src/command_buffer/pool/sys.rs
@@ -244,10 +244,10 @@ impl UnsafeCommandPool {
     ///
     /// - The `command_buffers` must have been allocated from this pool.
     /// - The `command_buffers` must not be in the pending state.
-    pub unsafe fn free_command_buffers<I>(&self, command_buffers: I)
-    where
-        I: IntoIterator<Item = UnsafeCommandPoolAlloc>,
-    {
+    pub unsafe fn free_command_buffers(
+        &self,
+        command_buffers: impl IntoIterator<Item = UnsafeCommandPoolAlloc>,
+    ) {
         let command_buffers: SmallVec<[_; 4]> =
             command_buffers.into_iter().map(|cb| cb.handle).collect();
         let fns = self.device.fns();

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -118,10 +118,12 @@ pub unsafe trait DescriptorSet: DeviceOwned + Send + Sync {
     fn layout(&self) -> &Arc<DescriptorSetLayout>;
 
     /// Creates a [`DescriptorSetWithOffsets`] with the given dynamic offsets.
-    fn offsets<I>(self: Arc<Self>, dynamic_offsets: I) -> DescriptorSetWithOffsets
+    fn offsets(
+        self: Arc<Self>,
+        dynamic_offsets: impl IntoIterator<Item = u32>,
+    ) -> DescriptorSetWithOffsets
     where
         Self: Sized + 'static,
-        I: IntoIterator<Item = u32>,
     {
         DescriptorSetWithOffsets::new(self, dynamic_offsets)
     }
@@ -405,10 +407,10 @@ pub struct DescriptorSetWithOffsets {
 
 impl DescriptorSetWithOffsets {
     #[inline]
-    pub fn new<O>(descriptor_set: Arc<dyn DescriptorSet>, dynamic_offsets: O) -> Self
-    where
-        O: IntoIterator<Item = u32>,
-    {
+    pub fn new(
+        descriptor_set: Arc<dyn DescriptorSet>,
+        dynamic_offsets: impl IntoIterator<Item = u32>,
+    ) -> Self {
         let dynamic_offsets: SmallVec<_> = dynamic_offsets.into_iter().collect();
         let layout = descriptor_set.layout();
         let properties = layout.device().physical_device().properties();

--- a/vulkano/src/descriptor_set/pool/sys.rs
+++ b/vulkano/src/descriptor_set/pool/sys.rs
@@ -282,10 +282,10 @@ impl UnsafeDescriptorPool {
     /// - The descriptor sets must not be free'd twice.
     /// - The descriptor sets must not be in use by the GPU.
     ///
-    pub unsafe fn free_descriptor_sets<I>(&mut self, descriptor_sets: I) -> Result<(), OomError>
-    where
-        I: IntoIterator<Item = UnsafeDescriptorSet>,
-    {
+    pub unsafe fn free_descriptor_sets(
+        &mut self,
+        descriptor_sets: impl IntoIterator<Item = UnsafeDescriptorSet>,
+    ) -> Result<(), OomError> {
         let sets: SmallVec<[_; 8]> = descriptor_sets
             .into_iter()
             .map(|s| s.internal_object())

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -859,10 +859,7 @@ impl ImageViewCreateInfo {
     /// Returns an `ImageViewCreateInfo` with the `view_type` determined from the image type and
     /// array layers, and `subresource_range` determined from the image format and covering the
     /// whole image.
-    pub fn from_image<I>(image: &I) -> Self
-    where
-        I: ImageAccess + ?Sized,
-    {
+    pub fn from_image(image: &(impl ImageAccess + ?Sized)) -> Self {
         Self {
             view_type: match image.dimensions() {
                 ImageDimensions::Dim1d {

--- a/vulkano/src/library.rs
+++ b/vulkano/src/library.rs
@@ -84,10 +84,7 @@ impl VulkanLibrary {
     }
 
     /// Loads a custom Vulkan library.
-    pub fn with_loader<L>(loader: L) -> Result<Arc<Self>, LoadingError>
-    where
-        L: Loader + 'static,
-    {
+    pub fn with_loader(loader: impl Loader + 'static) -> Result<Arc<Self>, LoadingError> {
         let fns = EntryFunctions::load(|name| unsafe {
             loader
                 .get_instance_proc_addr(ash::vk::Instance::null(), name.as_ptr())
@@ -110,10 +107,7 @@ impl VulkanLibrary {
         }))
     }
 
-    unsafe fn get_api_version<L>(loader: &L) -> Result<Version, VulkanError>
-    where
-        L: Loader,
-    {
+    unsafe fn get_api_version(loader: &impl Loader) -> Result<Version, VulkanError> {
         // Per the Vulkan spec:
         // If the vkGetInstanceProcAddr returns NULL for vkEnumerateInstanceVersion, it is a
         // Vulkan 1.0 implementation. Otherwise, the application can call vkEnumerateInstanceVersion
@@ -352,10 +346,7 @@ impl DynamicLibraryLoader {
     ///
     /// - The dynamic library must be a valid Vulkan implementation.
     ///
-    pub unsafe fn new<P>(path: P) -> Result<DynamicLibraryLoader, LoadingError>
-    where
-        P: AsRef<Path>,
-    {
+    pub unsafe fn new(path: impl AsRef<Path>) -> Result<DynamicLibraryLoader, LoadingError> {
         let vk_lib = Library::new(path.as_ref()).map_err(LoadingError::LibraryLoadFailure)?;
 
         let get_instance_proc_addr = *vk_lib

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -141,10 +141,10 @@ impl PipelineCache {
     ///
     // FIXME: vkMergePipelineCaches is not thread safe for the destination cache
     // TODO: write example
-    pub fn merge<'a, I>(&self, pipelines: I) -> Result<(), OomError>
-    where
-        I: IntoIterator<Item = &'a &'a Arc<PipelineCache>>,
-    {
+    pub fn merge<'a>(
+        &self,
+        pipelines: impl IntoIterator<Item = &'a &'a Arc<PipelineCache>>,
+    ) -> Result<(), OomError> {
         unsafe {
             let fns = self.device.fns();
 

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -492,13 +492,10 @@ impl Sampler {
     }
 
     /// Checks whether this sampler is compatible with `image_view`.
-    pub fn check_can_sample<I>(
+    pub fn check_can_sample(
         &self,
-        image_view: &I,
-    ) -> Result<(), SamplerImageViewIncompatibleError>
-    where
-        I: ImageViewAbstract + ?Sized,
-    {
+        image_view: &(impl ImageViewAbstract + ?Sized),
+    ) -> Result<(), SamplerImageViewIncompatibleError> {
         /*
             Note: Most of these checks come from the Instruction/Sampler/Image View Validation
             section, and are not strictly VUIDs.


### PR DESCRIPTION
This removes generic function arguments that were left over from The Before Times™ where argument-position `impl Trait` wasn't a thing.