### PR TITLE
Fix checks from #2009

### DIFF
--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -309,7 +309,9 @@ where
                                 true,
                             ) {
                                 Ok(_) => (),
-                                Err(AccessCheckError::Unknown) => return Err(AccessError::SwapchainImageNotAcquired.into()),
+                                Err(AccessCheckError::Unknown) => {
+                                    return Err(AccessError::SwapchainImageNotAcquired.into())
+                                }
                                 Err(AccessCheckError::Denied(e)) => return Err(e.into()),
                             }
                         }

--- a/vulkano/src/sync/future/join.rs
+++ b/vulkano/src/sync/future/join.rs
@@ -287,9 +287,7 @@ where
                 Err(AccessCheckError::Denied(e1))
             } // TODO: which one?
             (Ok(_), Err(AccessCheckError::Denied(_)))
-            | (Err(AccessCheckError::Denied(_)), Ok(_)) => {
-                panic!("Contradictory information between two futures")
-            }
+            | (Err(AccessCheckError::Denied(_)), Ok(_)) => Ok(()),
             (Ok(_), Ok(_)) => Ok(()), // TODO: Double Acquired?
         }
     }


### PR DESCRIPTION
``JoinFuture::check_swapchain_image_acquired`` if either future returns ``Ok(())`` then return `Ok(())`.

This seems to pass my testing in catching, acquire errors.

Tests Used:
- Acquire image but always use image index of zero.
  - Sometimes (1 in 20 for me) panics ``thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: AccessError { error: AlreadyInUse, command_name: "begin_render_pass", command_param: "attachment 0", command_offset: 0 }', examples\src\bin\triangle.rs:588:22``, but that is to be expected as command execution doesn't have a check for this. Most of the time present will still return the ``SwapchainNotAcquired`` error.
- Always presenting to zero.
- Presenting twice in a row.
