### PR TITLE
Buffer and image uploads take a command buffer instead of making one

### DIFF
--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -9,7 +9,9 @@
 
 use std::sync::Arc;
 use vulkano::{
-    command_buffer::allocator::StandardCommandBufferAllocator,
+    command_buffer::{
+        allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
+    },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
     },
@@ -174,6 +176,12 @@ fn main() {
     let queue = queues.next().unwrap();
 
     let command_buffer_allocator = StandardCommandBufferAllocator::new(device);
+    let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
+        &command_buffer_allocator,
+        queue.queue_family_index(),
+        CommandBufferUsage::OneTimeSubmit,
+    )
+    .unwrap();
 
     // Create an image in order to generate some additional logging:
     let pixel_format = Format::R8G8B8A8_UINT;
@@ -188,8 +196,7 @@ fn main() {
         dimensions,
         MipmapsCount::One,
         pixel_format,
-        &command_buffer_allocator,
-        queue,
+        &mut command_buffer_builder,
     )
     .unwrap();
 

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -22,7 +22,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        RenderPassBeginInfo, SubpassContents,
+        PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,
@@ -216,8 +216,14 @@ fn main() {
 
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let mut uploads = AutoCommandBufferBuilder::primary(
+        &command_buffer_allocator,
+        queue.queue_family_index(),
+        CommandBufferUsage::OneTimeSubmit,
+    )
+    .unwrap();
 
-    let (texture, tex_future) = {
+    let texture = {
         let png_bytes = include_bytes!("image_img.png").to_vec();
         let cursor = Cursor::new(png_bytes);
         let decoder = png::Decoder::new(cursor);
@@ -232,16 +238,15 @@ fn main() {
         image_data.resize((info.width * info.height * 4) as usize, 0);
         reader.next_frame(&mut image_data).unwrap();
 
-        let (image, future) = ImmutableImage::from_iter(
+        let image = ImmutableImage::from_iter(
             image_data,
             dimensions,
             MipmapsCount::One,
             Format::R8G8B8A8_SRGB,
-            &command_buffer_allocator,
-            queue.clone(),
+            &mut uploads,
         )
         .unwrap();
-        (ImageView::new_default(image).unwrap(), future)
+        ImageView::new_default(image).unwrap()
     };
 
     let sampler = Sampler::new(
@@ -290,7 +295,14 @@ fn main() {
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(tex_future.boxed());
+    let mut previous_frame_end = Some(
+        uploads
+            .build()
+            .unwrap()
+            .execute(queue.clone())
+            .unwrap()
+            .boxed(),
+    );
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -13,7 +13,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        RenderPassBeginInfo, SubpassContents,
+        PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::WriteDescriptorSet,
     device::{
@@ -205,8 +205,14 @@ fn main() {
     .unwrap();
 
     let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let mut uploads = AutoCommandBufferBuilder::primary(
+        &command_buffer_allocator,
+        queue.queue_family_index(),
+        CommandBufferUsage::OneTimeSubmit,
+    )
+    .unwrap();
 
-    let (texture, tex_future) = {
+    let texture = {
         let png_bytes = include_bytes!("image_img.png").to_vec();
         let cursor = Cursor::new(png_bytes);
         let decoder = png::Decoder::new(cursor);
@@ -221,16 +227,15 @@ fn main() {
         image_data.resize((info.width * info.height * 4) as usize, 0);
         reader.next_frame(&mut image_data).unwrap();
 
-        let (image, future) = ImmutableImage::from_iter(
+        let image = ImmutableImage::from_iter(
             image_data,
             dimensions,
             MipmapsCount::One,
             Format::R8G8B8A8_SRGB,
-            &command_buffer_allocator,
-            queue.clone(),
+            &mut uploads,
         )
         .unwrap();
-        (ImageView::new_default(image).unwrap(), future)
+        ImageView::new_default(image).unwrap()
     };
 
     let sampler = Sampler::new(
@@ -269,7 +274,14 @@ fn main() {
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(tex_future.boxed());
+    let mut previous_frame_end = Some(
+        uploads
+            .build()
+            .unwrap()
+            .execute(queue.clone())
+            .unwrap()
+            .boxed(),
+    );
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -22,9 +22,9 @@ use super::{
 use crate::{
     command_buffer::{
         allocator::CommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferBeginError,
-        CommandBufferExecFuture, CommandBufferUsage, CopyBufferInfo, PrimaryCommandBuffer,
+        CopyBufferInfo,
     },
-    device::{Device, DeviceOwned, Queue},
+    device::{Device, DeviceOwned},
     memory::{
         pool::{
             alloc_dedicated_with_exportable_fd, AllocFromRequirementsFilter, AllocLayout,
@@ -34,7 +34,7 @@ use crate::{
         DedicatedAllocation, DeviceMemoryError, ExternalMemoryHandleType, MemoryPool,
         MemoryRequirements,
     },
-    sync::{NowFuture, Sharing},
+    sync::Sharing,
     DeviceSize,
 };
 use smallvec::SmallVec;
@@ -181,20 +181,14 @@ where
     /// the initial upload operation. In order to be allowed to use the `DeviceLocalBuffer`, you
     /// must either submit your operation after this future, or execute this future and wait for it
     /// to be finished before submitting your own operation.
-    pub fn from_buffer<B>(
+    pub fn from_buffer<B, L, A>(
         source: Arc<B>,
         usage: BufferUsage,
-        command_buffer_allocator: &impl CommandBufferAllocator,
-        queue: Arc<Queue>,
-    ) -> Result<
-        (
-            Arc<DeviceLocalBuffer<T>>,
-            CommandBufferExecFuture<NowFuture>,
-        ),
-        DeviceLocalBufferCreationError,
-    >
+        command_buffer_builder: &mut AutoCommandBufferBuilder<L, A>,
+    ) -> Result<Arc<DeviceLocalBuffer<T>>, DeviceLocalBufferCreationError>
     where
         B: TypedBufferAccess<Content = T> + 'static,
+        A: CommandBufferAllocator,
     {
         unsafe {
             // We automatically set `transfer_dst` to true in order to avoid annoying errors.
@@ -214,21 +208,11 @@ where
                     .copied(),
             )?;
 
-            let mut cbb = AutoCommandBufferBuilder::primary(
-                command_buffer_allocator,
-                queue.queue_family_index(),
-                CommandBufferUsage::MultipleSubmit,
-            )?;
-            cbb.copy_buffer(CopyBufferInfo::buffers(source, buffer.clone()))
+            command_buffer_builder
+                .copy_buffer(CopyBufferInfo::buffers(source, buffer.clone()))
                 .unwrap(); // TODO: return error?
-            let cb = cbb.build().unwrap(); // TODO: return OomError
 
-            let future = match cb.execute(queue) {
-                Ok(f) => f,
-                Err(_) => unreachable!(),
-            };
-
-            Ok((buffer, future))
+            Ok(buffer)
         }
     }
 }
@@ -251,20 +235,16 @@ where
     /// # Panics
     ///
     /// - Panics if `T` has zero size.
-    pub fn from_data(
+    pub fn from_data<L, A>(
         data: T,
         usage: BufferUsage,
-        command_buffer_allocator: &impl CommandBufferAllocator,
-        queue: Arc<Queue>,
-    ) -> Result<
-        (
-            Arc<DeviceLocalBuffer<T>>,
-            CommandBufferExecFuture<NowFuture>,
-        ),
-        DeviceLocalBufferCreationError,
-    > {
+        command_buffer_builder: &mut AutoCommandBufferBuilder<L, A>,
+    ) -> Result<Arc<DeviceLocalBuffer<T>>, DeviceLocalBufferCreationError>
+    where
+        A: CommandBufferAllocator,
+    {
         let source = CpuAccessibleBuffer::from_data(
-            queue.device().clone(),
+            command_buffer_builder.device().clone(),
             BufferUsage {
                 transfer_src: true,
                 ..BufferUsage::empty()
@@ -272,7 +252,7 @@ where
             false,
             data,
         )?;
-        DeviceLocalBuffer::from_buffer(source, usage, command_buffer_allocator, queue)
+        DeviceLocalBuffer::from_buffer(source, usage, command_buffer_builder)
     }
 }
 
@@ -284,24 +264,18 @@ where
     ///
     /// - Panics if `T` has zero size.
     /// - Panics if `data` is empty.
-    pub fn from_iter<D>(
+    pub fn from_iter<D, L, A>(
         data: D,
         usage: BufferUsage,
-        command_buffer_allocator: &impl CommandBufferAllocator,
-        queue: Arc<Queue>,
-    ) -> Result<
-        (
-            Arc<DeviceLocalBuffer<[T]>>,
-            CommandBufferExecFuture<NowFuture>,
-        ),
-        DeviceLocalBufferCreationError,
-    >
+        command_buffer_builder: &mut AutoCommandBufferBuilder<L, A>,
+    ) -> Result<Arc<DeviceLocalBuffer<[T]>>, DeviceLocalBufferCreationError>
     where
         D: IntoIterator<Item = T>,
         D::IntoIter: ExactSizeIterator,
+        A: CommandBufferAllocator,
     {
         let source = CpuAccessibleBuffer::from_iter(
-            queue.device().clone(),
+            command_buffer_builder.device().clone(),
             BufferUsage {
                 transfer_src: true,
                 ..BufferUsage::empty()
@@ -309,7 +283,7 @@ where
             false,
             data,
         )?;
-        DeviceLocalBuffer::from_buffer(source, usage, command_buffer_allocator, queue)
+        DeviceLocalBuffer::from_buffer(source, usage, command_buffer_builder)
     }
 }
 
@@ -594,22 +568,32 @@ impl From<CommandBufferBeginError> for DeviceLocalBufferCreationError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{command_buffer::allocator::StandardCommandBufferAllocator, sync::GpuFuture};
+    use crate::{
+        command_buffer::{
+            allocator::StandardCommandBufferAllocator, CommandBufferUsage, PrimaryCommandBuffer,
+        },
+        sync::GpuFuture,
+    };
 
     #[test]
     fn from_data_working() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
+            &command_buffer_allocator,
+            queue.queue_family_index(),
+            CommandBufferUsage::OneTimeSubmit,
+        )
+        .unwrap();
 
-        let (buffer, _) = DeviceLocalBuffer::from_data(
+        let buffer = DeviceLocalBuffer::from_data(
             12u32,
             BufferUsage {
                 transfer_src: true,
                 ..BufferUsage::empty()
             },
-            &cb_allocator,
-            queue.clone(),
+            &mut command_buffer_builder,
         )
         .unwrap();
 
@@ -624,15 +608,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut cbb = AutoCommandBufferBuilder::primary(
-            &cb_allocator,
-            queue.queue_family_index(),
-            CommandBufferUsage::MultipleSubmit,
-        )
-        .unwrap();
-        cbb.copy_buffer(CopyBufferInfo::buffers(buffer, destination.clone()))
+        command_buffer_builder
+            .copy_buffer(CopyBufferInfo::buffers(buffer, destination.clone()))
             .unwrap();
-        let _ = cbb
+        let _ = command_buffer_builder
             .build()
             .unwrap()
             .execute(queue)
@@ -648,16 +627,21 @@ mod tests {
     fn from_iter_working() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
+            &command_buffer_allocator,
+            queue.queue_family_index(),
+            CommandBufferUsage::OneTimeSubmit,
+        )
+        .unwrap();
 
-        let (buffer, _) = DeviceLocalBuffer::from_iter(
+        let buffer = DeviceLocalBuffer::from_iter(
             (0..512u32).map(|n| n * 2),
             BufferUsage {
                 transfer_src: true,
                 ..BufferUsage::empty()
             },
-            &cb_allocator,
-            queue.clone(),
+            &mut command_buffer_builder,
         )
         .unwrap();
 
@@ -672,15 +656,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut cbb = AutoCommandBufferBuilder::primary(
-            &cb_allocator,
-            queue.queue_family_index(),
-            CommandBufferUsage::MultipleSubmit,
-        )
-        .unwrap();
-        cbb.copy_buffer(CopyBufferInfo::buffers(buffer, destination.clone()))
+        command_buffer_builder
+            .copy_buffer(CopyBufferInfo::buffers(buffer, destination.clone()))
             .unwrap();
-        let _ = cbb
+        let _ = command_buffer_builder
             .build()
             .unwrap()
             .execute(queue)
@@ -699,7 +678,13 @@ mod tests {
     fn create_buffer_zero_size_data() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
+        let command_buffer_allocator = StandardCommandBufferAllocator::new(device);
+        let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
+            &command_buffer_allocator,
+            queue.queue_family_index(),
+            CommandBufferUsage::OneTimeSubmit,
+        )
+        .unwrap();
 
         assert_should_panic!({
             DeviceLocalBuffer::from_data(
@@ -708,8 +693,7 @@ mod tests {
                     transfer_dst: true,
                     ..BufferUsage::empty()
                 },
-                &cb_allocator,
-                queue.clone(),
+                &mut command_buffer_builder,
             )
             .unwrap();
         });

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -26,17 +26,16 @@
 //!
 //! # let device: Arc<vulkano::device::Device> = return;
 //! # let queue: Arc<vulkano::device::Queue> = return;
-//! # let command_buffer_allocator: vulkano::command_buffer::allocator::StandardCommandBufferAllocator = return;
 //! let usage = BufferUsage {
 //!     storage_texel_buffer: true,
 //!     ..BufferUsage::empty()
 //! };
 //!
-//! let (buffer, _future) = DeviceLocalBuffer::<[u32]>::from_iter(
-//!     (0..128).map(|n| n),
+//! let buffer = DeviceLocalBuffer::<[u32]>::array(
+//!     device.clone(),
+//!     128,
 //!     usage,
-//!     &command_buffer_allocator,
-//!     queue.clone()
+//!     [queue.queue_family_index()],
 //! ).unwrap();
 //! let _view = BufferView::new(
 //!     buffer,
@@ -483,7 +482,6 @@ mod tests {
             view::{BufferView, BufferViewCreateInfo, BufferViewCreationError},
             BufferUsage, DeviceLocalBuffer,
         },
-        command_buffer::allocator::StandardCommandBufferAllocator,
         format::Format,
     };
 
@@ -497,15 +495,9 @@ mod tests {
             ..BufferUsage::empty()
         };
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
-
-        let (buffer, _) = DeviceLocalBuffer::<[[u8; 4]]>::from_iter(
-            (0..128).map(|_| [0; 4]),
-            usage,
-            &cb_allocator,
-            queue,
-        )
-        .unwrap();
+        let buffer =
+            DeviceLocalBuffer::<[[u8; 4]]>::array(device, 128, usage, [queue.queue_family_index()])
+                .unwrap();
         BufferView::new(
             buffer,
             BufferViewCreateInfo {
@@ -526,15 +518,9 @@ mod tests {
             ..BufferUsage::empty()
         };
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
-
-        let (buffer, _) = DeviceLocalBuffer::<[[u8; 4]]>::from_iter(
-            (0..128).map(|_| [0; 4]),
-            usage,
-            &cb_allocator,
-            queue,
-        )
-        .unwrap();
+        let buffer =
+            DeviceLocalBuffer::<[[u8; 4]]>::array(device, 128, usage, [queue.queue_family_index()])
+                .unwrap();
         BufferView::new(
             buffer,
             BufferViewCreateInfo {
@@ -555,10 +541,8 @@ mod tests {
             ..BufferUsage::empty()
         };
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
-
-        let (buffer, _) =
-            DeviceLocalBuffer::<[u32]>::from_iter((0..128).map(|_| 0), usage, &cb_allocator, queue)
+        let buffer =
+            DeviceLocalBuffer::<[u32]>::array(device, 128, usage, [queue.queue_family_index()])
                 .unwrap();
         BufferView::new(
             buffer,
@@ -575,13 +559,14 @@ mod tests {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
         let (device, queue) = gfx_dev_and_queue!();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
-
-        let (buffer, _) = DeviceLocalBuffer::<[[u8; 4]]>::from_iter(
-            (0..128).map(|_| [0; 4]),
-            BufferUsage::empty(),
-            &cb_allocator,
-            queue,
+        let buffer = DeviceLocalBuffer::<[[u8; 4]]>::array(
+            device,
+            128,
+            BufferUsage {
+                transfer_dst: true, // Dummy value
+                ..BufferUsage::empty()
+            },
+            [queue.queue_family_index()],
         )
         .unwrap();
 
@@ -607,13 +592,11 @@ mod tests {
             ..BufferUsage::empty()
         };
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
-
-        let (buffer, _) = DeviceLocalBuffer::<[[f64; 4]]>::from_iter(
-            (0..128).map(|_| [0.0; 4]),
+        let buffer = DeviceLocalBuffer::<[[f64; 4]]>::array(
+            device,
+            128,
             usage,
-            &cb_allocator,
-            queue,
+            [queue.queue_family_index()],
         )
         .unwrap();
 

--- a/vulkano/src/sampler/ycbcr.rs
+++ b/vulkano/src/sampler/ycbcr.rs
@@ -26,8 +26,8 @@
 //! # let device: std::sync::Arc<vulkano::device::Device> = return;
 //! # let image_data: Vec<u8> = return;
 //! # let queue: std::sync::Arc<vulkano::device::Queue> = return;
-//! # let command_buffer_allocator: vulkano::command_buffer::allocator::StandardCommandBufferAllocator = return;
 //! # let descriptor_set_allocator: vulkano::descriptor_set::allocator::StandardDescriptorSetAllocator = return;
+//! # let mut command_buffer_builder: vulkano::command_buffer::AutoCommandBufferBuilder<vulkano::command_buffer::PrimaryAutoCommandBuffer> = return;
 //! use vulkano::descriptor_set::{PersistentDescriptorSet, WriteDescriptorSet};
 //! use vulkano::descriptor_set::layout::{DescriptorSetLayout, DescriptorSetLayoutBinding, DescriptorSetLayoutCreateInfo, DescriptorType};
 //! use vulkano::format::Format;
@@ -66,13 +66,12 @@
 //!     },
 //! ).unwrap();
 //!
-//! let (image, future) = ImmutableImage::from_iter(
+//! let image = ImmutableImage::from_iter(
 //!     image_data,
 //!     ImageDimensions::Dim2d { width: 1920, height: 1080, array_layers: 1 },
 //!     MipmapsCount::One,
 //!     Format::G8_B8_R8_3PLANE_420_UNORM,
-//!     &command_buffer_allocator,
-//!     queue.clone(),
+//!     &mut command_buffer_builder,
 //! ).unwrap();
 //!
 //! let create_info = ImageViewCreateInfo {


### PR DESCRIPTION
Changelog:

Remove this line (and remove the bullet from the previous one to merge it into the line above):
```markdown
- `DeviceLocalBuffer::{from_buffer, from_data, from_iter}` and `ImmutableImage::{from_iter, from_buffer}` now take an implementation of `CommandBufferAllocator`.
```

Add:
```markdown
### Breaking changes
Changes to buffer and image uploads:
- `DeviceLocalBuffer::{from_buffer, from_data, from_iter}` and `ImmutableImage::{from_iter, from_buffer}` now take a mutable reference to an `AutoCommandBufferBuilder` instead of a queue, and no longer return a future. The upload command will be recorded into the provided command buffer, which should be executed later.
````

Creating a new command buffer builder, recording a single copy command onto it, and then building and submitting a single queue command with just the one tiny command buffer is not very efficient. If a lot of things are uploaded, this can also lead to stack overflows when you try to flush this giant pile of futures all at once, as discovered on Discord. With these changes, the user has the freedom to manage this a bit better themselves, and they can group all uploads into a single command buffer if they wish.