### PR TITLE
Fix missing validation when binding memory to buffers with the  `shader_device_address` usage

### DIFF
--- a/vulkano/src/buffer/cpu_access.rs
+++ b/vulkano/src/buffer/cpu_access.rs
@@ -77,6 +77,8 @@ where
     /// # Panics
     ///
     /// - Panics if `T` has zero size.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub fn from_data(
         device: Arc<Device>,
         usage: BufferUsage,
@@ -130,6 +132,8 @@ where
     ///
     /// - Panics if `T` has zero size.
     /// - Panics if `data` is empty.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub fn from_iter<I>(
         device: Arc<Device>,
         usage: BufferUsage,
@@ -172,6 +176,8 @@ where
     ///
     /// - Panics if `T` has zero size.
     /// - Panics if `len` is zero.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub unsafe fn uninitialized_array(
         device: Arc<Device>,
         len: DeviceSize,
@@ -201,6 +207,8 @@ where
     /// # Panics
     ///
     /// - Panics if `size` is zero.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub unsafe fn raw(
         device: Arc<Device>,
         size: DeviceSize,

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -197,9 +197,12 @@ where
     /// # Panics
     ///
     /// - Panics if `T` has zero size.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     #[inline]
     pub fn new(device: Arc<Device>, usage: BufferUsage) -> CpuBufferPool<T> {
         assert!(size_of::<T>() > 0);
+        assert!(!usage.shader_device_address);
         let pool = device.standard_memory_pool();
 
         CpuBufferPool {

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -181,6 +181,11 @@ where
     /// the initial upload operation. In order to be allowed to use the `DeviceLocalBuffer`, you
     /// must either submit your operation after this future, or execute this future and wait for it
     /// to be finished before submitting your own operation.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub fn from_buffer<B>(
         source: Arc<B>,
         usage: BufferUsage,
@@ -251,6 +256,8 @@ where
     /// # Panics
     ///
     /// - Panics if `T` has zero size.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub fn from_data(
         data: T,
         usage: BufferUsage,
@@ -284,6 +291,8 @@ where
     ///
     /// - Panics if `T` has zero size.
     /// - Panics if `data` is empty.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub fn from_iter<D>(
         data: D,
         usage: BufferUsage,
@@ -323,6 +332,8 @@ where
     ///
     /// - Panics if `T` has zero size.
     /// - Panics if `len` is zero.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub fn array(
         device: Arc<Device>,
         len: DeviceSize,
@@ -353,6 +364,8 @@ where
     /// # Panics
     ///
     /// - Panics if `size` is zero.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub unsafe fn raw(
         device: Arc<Device>,
         size: DeviceSize,
@@ -393,6 +406,8 @@ where
     /// # Panics
     ///
     /// - Panics if `size` is zero.
+    /// - Panics if `usage.shader_device_address` is `true`.
+    // TODO: ^
     pub unsafe fn raw_with_exportable_fd(
         device: Arc<Device>,
         size: DeviceSize,

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -403,8 +403,8 @@ impl UnsafeBuffer {
     /// # Panics
     ///
     /// - Panics if `self.usage.shader_device_address` is `true` and the `memory` was not allocated
-    ///   with the [`device_address`] flag set and the [`ext_buffer_device_address`] device
-    ///   extension is not used.
+    ///   with the [`device_address`] flag set and the [`ext_buffer_device_address`] extension is
+    ///   not enabled on the device.
     ///
     /// [`device_address`]: crate::memory::MemoryAllocateFlags::device_address
     /// [`ext_buffer_device_address`]: crate::device::DeviceExtensions::ext_buffer_device_address

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -403,9 +403,11 @@ impl UnsafeBuffer {
     /// # Panics
     ///
     /// - Panics if `self.usage.shader_device_address` is `true` and the `memory` was not allocated
-    ///   with the [`device_address`] flag set.
+    ///   with the [`device_address`] flag set and the [`ext_buffer_device_address`] device
+    ///   extension is not used.
     ///
     /// [`device_address`]: crate::memory::MemoryAllocateFlags::device_address
+    /// [`ext_buffer_device_address`]: crate::device::DeviceExtensions::ext_buffer_device_address
     pub unsafe fn bind_memory(
         &self,
         memory: &DeviceMemory,
@@ -443,7 +445,9 @@ impl UnsafeBuffer {
         }
 
         // VUID-vkBindBufferMemory-bufferDeviceAddress-03339
-        if self.usage.shader_device_address {
+        if self.usage.shader_device_address
+            && !self.device.enabled_extensions().ext_buffer_device_address
+        {
             assert!(memory.flags().device_address);
         }
 

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -399,6 +399,13 @@ impl UnsafeBuffer {
     }
 
     /// Binds device memory to this buffer.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `self.usage.shader_device_address` is `true` and the `memory` was not allocated
+    ///   with the [`device_address`] flag set.
+    ///
+    /// [`device_address`]: crate::memory::MemoryAllocateFlags::device_address
     pub unsafe fn bind_memory(
         &self,
         memory: &DeviceMemory,
@@ -433,6 +440,11 @@ impl UnsafeBuffer {
             if self.usage().uniform_buffer {
                 debug_assert!(offset % properties.min_uniform_buffer_offset_alignment == 0);
             }
+        }
+
+        // VUID-vkBindBufferMemory-bufferDeviceAddress-03339
+        if self.usage.shader_device_address {
+            assert!(memory.flags().device_address);
         }
 
         (fns.v1_0.bind_buffer_memory)(

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use super::{sys::UnsafeBuffer, BufferContents, BufferSlice, BufferUsage};
-use crate::{device::DeviceOwned, DeviceSize, RequiresOneOf, SafeDeref, VulkanObject};
+use crate::{device::DeviceOwned, DeviceSize, RequiresOneOf, SafeDeref, Version, VulkanObject};
 use std::{
     error::Error,
     fmt::{Debug, Display, Error as FmtError, Formatter},
@@ -100,10 +100,12 @@ pub unsafe trait BufferAccess: DeviceOwned + Send + Sync {
                 ..Default::default()
             };
             let fns = device.fns();
-            let f = if device.enabled_extensions().ext_buffer_device_address {
-                fns.ext_buffer_device_address.get_buffer_device_address_ext
-            } else {
+            let f = if device.api_version() >= Version::V1_2 {
+                fns.v1_2.get_buffer_device_address
+            } else if device.enabled_extensions().khr_buffer_device_address {
                 fns.khr_buffer_device_address.get_buffer_device_address_khr
+            } else {
+                fns.ext_buffer_device_address.get_buffer_device_address_ext
             };
             let ptr = f(device.internal_object(), &info);
 

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -100,13 +100,15 @@ pub unsafe trait BufferAccess: DeviceOwned + Send + Sync {
                 ..Default::default()
             };
             let fns = device.fns();
-            let ptr = (fns.ext_buffer_device_address.get_buffer_device_address_ext)(
-                device.internal_object(),
-                &info,
-            );
+            let f = if device.enabled_extensions().ext_buffer_device_address {
+                fns.ext_buffer_device_address.get_buffer_device_address_ext
+            } else {
+                fns.khr_buffer_device_address.get_buffer_device_address_khr
+            };
+            let ptr = f(device.internal_object(), &info);
 
             if ptr == 0 {
-                panic!("got null ptr from a valid GetBufferDeviceAddressEXT call");
+                panic!("got null ptr from a valid GetBufferDeviceAddress call");
             }
 
             Ok(NonZeroU64::new_unchecked(ptr + inner.offset))

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -49,6 +49,7 @@ vulkan_bitflags! {
     /// [`device_address`] flag set unless the [`ext_buffer_device_address`] extension is used.
     ///
     /// [`device_address`]: crate::memory::MemoryAllocateFlags::device_address
+    /// [`ext_buffer_device_address`]: crate::device::DeviceExtensions::ext_buffer_device_address
     shader_device_address = SHADER_DEVICE_ADDRESS {
         api_version: V1_2,
         device_extensions: [khr_buffer_device_address, ext_buffer_device_address],

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -46,7 +46,8 @@ vulkan_bitflags! {
     /// The buffer's device address can be retrieved.
     ///
     /// A buffer created with this usage can only be bound to device memory allocated with the
-    /// [`device_address`] flag set unless the [`ext_buffer_device_address`] extension is used.
+    /// [`device_address`] flag set unless the [`ext_buffer_device_address`] extension is enabled
+    /// on the device.
     ///
     /// [`device_address`]: crate::memory::MemoryAllocateFlags::device_address
     /// [`ext_buffer_device_address`]: crate::device::DeviceExtensions::ext_buffer_device_address

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -46,7 +46,7 @@ vulkan_bitflags! {
     /// The buffer's device address can be retrieved.
     ///
     /// A buffer created with this usage can only be bound to device memory allocated with the
-    /// [`device_address`] flag set.
+    /// [`device_address`] flag set unless the [`ext_buffer_device_address`] extension is used.
     ///
     /// [`device_address`]: crate::memory::MemoryAllocateFlags::device_address
     shader_device_address = SHADER_DEVICE_ADDRESS {

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -44,6 +44,11 @@ vulkan_bitflags! {
     indirect_buffer = INDIRECT_BUFFER,
 
     /// The buffer's device address can be retrieved.
+    ///
+    /// A buffer created with this usage can only be bound to device memory allocated with the
+    /// [`device_address`] flag set.
+    ///
+    /// [`device_address`]: crate::memory::MemoryAllocateFlags::device_address
     shader_device_address = SHADER_DEVICE_ADDRESS {
         api_version: V1_2,
         device_extensions: [khr_buffer_device_address, ext_buffer_device_address],

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -1020,6 +1020,7 @@ vulkan_bitflags! {
     /// is enabled on the device and the [`ext_buffer_device_address`] extensions is not used.
     ///
     /// [`shader_device_address`]: crate::buffer::BufferUsage::shader_device_address
+    /// [`buffer_device_address`]: crate::device::Features::buffer_device_address
     /// [`ext_buffer_device_address`]: crate::device::DeviceExtensions::ext_buffer_device_address
     device_address = DEVICE_ADDRESS,
 

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -1017,7 +1017,8 @@ vulkan_bitflags! {
 
     /// Specifies that the allocated device memory can be bound to a buffer created with the
     /// [`shader_device_address`] usage. This requires that the [`buffer_device_address`] feature
-    /// is enabled on the device and the [`ext_buffer_device_address`] extensions is not used.
+    /// is enabled on the device and the [`ext_buffer_device_address`] extension is not enabled on
+    /// the device.
     ///
     /// [`shader_device_address`]: crate::buffer::BufferUsage::shader_device_address
     /// [`buffer_device_address`]: crate::device::Features::buffer_device_address

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -95,7 +95,8 @@
 pub use self::{
     device_memory::{
         DeviceMemory, DeviceMemoryError, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
-        MappedDeviceMemory, MemoryAllocateInfo, MemoryImportInfo, MemoryMapError,
+        MappedDeviceMemory, MemoryAllocateFlags, MemoryAllocateInfo, MemoryImportInfo,
+        MemoryMapError,
     },
     pool::MemoryPool,
 };


### PR DESCRIPTION
Required for #1997.

Adds support for passing the `device_address` flag when allocating `DeviceMemory`, which is required when binding memory to a buffer with the `shader_device_address` usage in the `VK_KHR_buffer_device_address` extension (and core 1.2 which it was promoted to), but not its predecessor `VK_EXT_buffer_device_address`. Fixes the bug where `UnsafeBuffer::bind_memory` wasn't validating if the memory is allocated with the `device_address` flag, and also fixes the wrong function pointer in `BufferAccess::raw_device_address` when not using the outdated  `VK_EXT_buffer_device_address` extension.

Changelog:
```markdown
### Breaking changes
Changes to buffers:
- When binding memory to a buffer with the `shader_device_address` usage, the memory must now have been allocated with the `MemoryAllocateFlags::device_address` flag set.

### Additions
- Added `MemoryAllocateFlags`.

### Bugs fixed
- Fixed missing validation when binding memory to a buffer with the `shader_device_address` usage.
````
