### PR TITLE
Switch to an atomic counter for `DeviceMemory` allocations

### DIFF
--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -22,7 +22,7 @@ use std::{
     mem::MaybeUninit,
     ops::Range,
     ptr, slice,
-    sync::Arc,
+    sync::{atomic::Ordering, Arc},
 };
 
 /// Represents memory that has been allocated from the device.
@@ -466,7 +466,7 @@ impl DeviceMemory {
             allocate_info = allocate_info.push_next(info);
         }
 
-        let mut allocation_count = device.allocation_count().lock();
+        let mut allocation_count = device.allocation_count_mutex.lock();
 
         // VUID-vkAllocateMemory-maxMemoryAllocationCount-04101
         // This is technically validation, but it must be atomic with the `allocate_memory` call.
@@ -494,6 +494,7 @@ impl DeviceMemory {
         };
 
         *allocation_count += 1;
+        device.allocation_count.fetch_add(1, Ordering::Relaxed);
 
         Ok(handle)
     }
@@ -630,8 +631,9 @@ impl Drop for DeviceMemory {
         unsafe {
             let fns = self.device.fns();
             (fns.v1_0.free_memory)(self.device.internal_object(), self.handle, ptr::null());
-            let mut allocation_count = self.device.allocation_count().lock();
+            let mut allocation_count = self.device.allocation_count_mutex.lock();
             *allocation_count -= 1;
+            self.device.allocation_count.fetch_sub(1, Ordering::Relaxed);
         }
     }
 }
@@ -1660,7 +1662,7 @@ mod tests {
     #[test]
     fn allocation_count() {
         let (device, _) = gfx_dev_and_queue!();
-        assert_eq!(*device.allocation_count().lock(), 0);
+        assert_eq!(device.allocation_count(), 0);
         let _mem1 = DeviceMemory::allocate(
             device.clone(),
             MemoryAllocateInfo {
@@ -1670,7 +1672,7 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(*device.allocation_count().lock(), 1);
+        assert_eq!(device.allocation_count(), 1);
         {
             let _mem2 = DeviceMemory::allocate(
                 device.clone(),
@@ -1681,8 +1683,8 @@ mod tests {
                 },
             )
             .unwrap();
-            assert_eq!(*device.allocation_count().lock(), 2);
+            assert_eq!(device.allocation_count(), 2);
         }
-        assert_eq!(*device.allocation_count().lock(), 1);
+        assert_eq!(device.allocation_count(), 1);
     }
 }


### PR DESCRIPTION
This replaces the `Mutex<u32>` that was used to keep track of the allocation count for validation with an `AtomicU32`. The purpose is that this atomic is going to give us wait-free reads of the value, which I would like to use in #1997. I've also made the count public if a user would like to write their own allocator and use the value for heuristics much the way the library is going to.

Changelog:
```markdown
### Additions
- Added `Device::allocation_count`.
```