### PR TITLE
Fixed queue family index count not being set in buffers and images

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -226,10 +226,11 @@ impl UnsafeBuffer {
             flags |= sparse_level.into();
         }
 
-        let (sharing_mode, p_queue_family_indices) = match sharing {
-            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, &[] as _),
+        let (sharing_mode, queue_family_index_count, p_queue_family_indices) = match sharing {
+            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, &[] as _),
             Sharing::Concurrent(queue_family_indices) => (
                 ash::vk::SharingMode::CONCURRENT,
+                queue_family_indices.len() as u32,
                 queue_family_indices.as_ptr(),
             ),
         };
@@ -239,6 +240,7 @@ impl UnsafeBuffer {
             size,
             usage: usage.into(),
             sharing_mode,
+            queue_family_index_count,
             p_queue_family_indices,
             ..Default::default()
         };

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -860,10 +860,11 @@ impl UnsafeImage {
             } => (ImageType::Dim3d, [width, height, depth], 1),
         };
 
-        let (sharing_mode, p_queue_family_indices) = match sharing {
-            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, &[] as _),
+        let (sharing_mode, queue_family_index_count, p_queue_family_indices) = match sharing {
+            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, &[] as _),
             Sharing::Concurrent(queue_family_indices) => (
                 ash::vk::SharingMode::CONCURRENT,
+                queue_family_indices.len() as u32,
                 queue_family_indices.as_ptr(),
             ),
         };
@@ -883,6 +884,7 @@ impl UnsafeImage {
             tiling: tiling.into(),
             usage: usage.into(),
             sharing_mode,
+            queue_family_index_count,
             p_queue_family_indices,
             initial_layout: initial_layout.into(),
             ..Default::default()


### PR DESCRIPTION
1. [X] Update documentation to reflect any user-facing changes - in this repository.

2. [X] Make sure that the changes are covered by unit-tests.

3. [X] Run `cargo fmt` on the changes.

4. [X] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.
   
   Please remove any items from the template below that are not applicable.

5. [X] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Bugs fixed
- Queue family count isn't being set in either `ash::vk::BufferCreateInfo` or `ash::vk::ImageCreateInfo`
````

In either case of buffers or images, the bug occurred when using more than 1 queue family (not exclusive use). `queue_family_index_count` in the `ash` structs was not being explicitly set and was left as `Default::default()`, which is 0, making it in violation of the Vulkan spec (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkBufferCreateInfo-sharingMode-00914, https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageCreateInfo-sharingMode-00942) and potentially causing undefined behavior.