### PR TITLE
Add safety checks to semaphores, add importing and exporting

### DIFF
--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -153,16 +153,12 @@ mod linux {
             .unwrap(),
         );
 
-        let acquire_fd = unsafe {
-            acquire_sem
-                .export_fd(ExternalSemaphoreHandleType::OpaqueFd)
-                .unwrap()
-        };
-        let release_fd = unsafe {
-            release_sem
-                .export_fd(ExternalSemaphoreHandleType::OpaqueFd)
-                .unwrap()
-        };
+        let acquire_fd = acquire_sem
+            .export_fd(ExternalSemaphoreHandleType::OpaqueFd)
+            .unwrap();
+        let release_fd = release_sem
+            .export_fd(ExternalSemaphoreHandleType::OpaqueFd)
+            .unwrap();
 
         let barrier_clone = barrier.clone();
         let barrier_2_clone = barrier_2.clone();

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -2145,7 +2145,7 @@ where
 
                     Ok(self
                         .queue
-                        .with(|mut q| q.present_unchecked(present_info))
+                        .with(|mut q| q.present_unchecked(present_info))?
                         .map(|r| r.map(|_| ()))
                         .fold(Ok(()), Result::and)?)
                 }
@@ -2312,6 +2312,11 @@ pub unsafe fn acquire_next_image_raw<W>(
         ash::vk::Result::TIMEOUT => return Err(AcquireError::Timeout),
         err => return Err(VulkanError::from(err).into()),
     };
+
+    if let Some(semaphore) = semaphore {
+        let mut state = semaphore.state();
+        state.swapchain_acquire();
+    }
 
     if let Some(fence) = fence {
         let mut state = fence.state();

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -317,7 +317,7 @@ where
                         }
 
                         queue
-                            .with(|mut q| q.present_unchecked(present_info))
+                            .with(|mut q| q.present_unchecked(present_info))?
                             .map(|r| r.map(|_| ()))
                             .fold(Ok(()), Result::and)
                     };

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -166,7 +166,7 @@ where
                     }
 
                     queue.with(|mut q| {
-                        q.present_unchecked(present_info)
+                        q.present_unchecked(present_info)?
                             .map(|r| r.map(|_| ()))
                             .fold(Ok(()), Result::and)?;
                         // FIXME: problematic because if we return an error and flush() is called again, then we'll submit the present twice

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -103,7 +103,6 @@
 //! TODO: talk about fence + semaphore simultaneously
 //! TODO: talk about using fences to clean up
 
-pub(crate) use self::fence::FenceState;
 #[cfg(unix)]
 pub use self::fence::ImportFenceFdInfo;
 #[cfg(windows)]
@@ -128,6 +127,7 @@ pub use self::{
         SemaphoreImportFlags,
     },
 };
+pub(crate) use self::{fence::FenceState, semaphore::SemaphoreState};
 use crate::device::Queue;
 use std::sync::Arc;
 

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -1103,15 +1103,16 @@ impl SemaphoreState {
     /// Called when a queue is unlocking resources.
     #[inline]
     pub(crate) unsafe fn set_signal_finished(&mut self) {
-        self.is_signaled = true;
         self.pending_signal = None;
+        self.is_signaled = true;
     }
 
     /// Called when a queue is unlocking resources.
     #[inline]
     pub(crate) unsafe fn set_wait_finished(&mut self) {
-        self.is_signaled = false;
         self.pending_wait = None;
+        self.current_import = self.permanent_import.map(Into::into);
+        self.is_signaled = false;
     }
 
     #[allow(dead_code)]

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -1696,7 +1696,8 @@ mod tests {
     }
 
     #[test]
-    fn semaphore_export() {
+    #[cfg(unix)]
+    fn semaphore_export_fd() {
         let library = match VulkanLibrary::new() {
             Ok(x) => x,
             Err(_) => return,


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Support for the `khr_external_semaphore_fd`, `khr_external_semaphore_win32` and `fuchsia_external_semaphore` extensions.
- `Semaphore::export_fd` is no longer unsafe.
````

This adds checks to make semaphores safe to use, but only in a very limited fashion for now. To keep the checks simple, there can't be more than one signal operation and one wait operation pending at any given time. This limitation will hopefully be lifted in the future.