### PR TITLE
Remove type parameter from `Surface`

### DIFF
--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -46,8 +46,8 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -145,6 +145,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -152,7 +153,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -257,7 +258,8 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
-                let dimensions = surface.window().inner_size();
+                let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+                let dimensions = window.inner_size();
                 if dimensions.width == 0 || dimensions.height == 0 {
                     return;
                 }
@@ -392,7 +394,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -20,8 +20,8 @@ use vulkano::{
     instance::{Instance, InstanceCreateInfo},
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -114,6 +114,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -121,7 +122,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -176,7 +177,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -298,7 +300,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
 ) -> Vec<Arc<Framebuffer>> {
     images

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -39,8 +39,8 @@ use vulkano::{
     image::{view::ImageView, ImageUsage},
     instance::{Instance, InstanceCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -49,7 +49,7 @@ use vulkano_win::VkSurfaceBuild;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::WindowBuilder,
+    window::{Window, WindowBuilder},
 };
 
 mod frame;
@@ -135,6 +135,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         let (swapchain, images) = Swapchain::new(
             device.clone(),
@@ -142,7 +143,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -194,7 +195,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -47,8 +47,8 @@ mod linux {
         render_pass::{Framebuffer, RenderPass, Subpass},
         sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
         swapchain::{
-            AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-            SwapchainCreationError, SwapchainPresentInfo,
+            AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+            SwapchainPresentInfo,
         },
         sync::{
             now, ExternalSemaphoreHandleType, ExternalSemaphoreHandleTypes, FlushError, GpuFuture,
@@ -291,9 +291,10 @@ mod linux {
                     previous_frame_end.as_mut().unwrap().cleanup_finished();
 
                     if recreate_swapchain {
+                        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
                         let (new_swapchain, new_images) =
                             match swapchain.recreate(SwapchainCreateInfo {
-                                image_extent: surface.window().inner_size().into(),
+                                image_extent: window.inner_size().into(),
                                 ..swapchain.create_info()
                             }) {
                                 Ok(r) => r,
@@ -407,8 +408,8 @@ mod linux {
     ) -> (
         Arc<vulkano::device::Device>,
         Arc<vulkano::instance::Instance>,
-        Arc<Swapchain<winit::window::Window>>,
-        Arc<vulkano::swapchain::Surface<winit::window::Window>>,
+        Arc<Swapchain>,
+        Arc<vulkano::swapchain::Surface>,
         vulkano::pipeline::graphics::viewport::Viewport,
         Arc<Queue>,
         Arc<RenderPass>,
@@ -536,6 +537,7 @@ mod linux {
                     .unwrap()[0]
                     .0,
             );
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
             Swapchain::new(
                 device.clone(),
@@ -543,7 +545,7 @@ mod linux {
                 SwapchainCreateInfo {
                     min_image_count: surface_capabilities.min_image_count,
                     image_format,
-                    image_extent: surface.window().inner_size().into(),
+                    image_extent: window.inner_size().into(),
                     image_usage: ImageUsage {
                         color_attachment: true,
                         ..ImageUsage::empty()
@@ -673,7 +675,7 @@ mod linux {
     }
 
     fn window_size_dependent_setup(
-        images: &[Arc<SwapchainImage<Window>>],
+        images: &[Arc<SwapchainImage>],
         render_pass: Arc<RenderPass>,
         viewport: &mut Viewport,
     ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -42,8 +42,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -136,6 +136,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -143,7 +144,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -378,7 +379,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -479,7 +481,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -40,8 +40,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -134,6 +134,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -141,7 +142,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -305,7 +306,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -406,7 +408,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -49,8 +49,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -140,6 +140,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -147,7 +148,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -318,7 +319,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -419,7 +421,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -52,8 +52,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     single_pass_renderpass,
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -154,6 +154,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -161,7 +162,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -335,7 +336,8 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
-                let dimensions = surface.window().inner_size();
+                let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+                let dimensions = window.inner_size();
                 if dimensions.width == 0 || dimensions.height == 0 {
                     return;
                 }
@@ -477,7 +479,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -37,8 +37,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     single_pass_renderpass,
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -151,6 +151,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -158,7 +159,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -332,7 +333,8 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
-                let dimensions = surface.window().inner_size();
+                let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+                let dimensions = window.inner_size();
                 if dimensions.width == 0 || dimensions.height == 0 {
                     return;
                 }
@@ -438,7 +440,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -39,8 +39,8 @@ use vulkano::{
     query::{QueryControlFlags, QueryPool, QueryPoolCreateInfo, QueryResultFlags, QueryType},
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -130,6 +130,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -137,7 +138,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -343,7 +344,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -537,7 +539,7 @@ fn main() {
 }
 
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -38,8 +38,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -130,6 +130,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -137,7 +138,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -297,7 +298,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -398,7 +400,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -45,8 +45,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     shader::ShaderModule,
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -145,6 +145,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -152,7 +153,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -273,7 +274,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -368,7 +370,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -45,8 +45,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -146,6 +146,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -153,7 +154,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -435,7 +436,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -536,7 +538,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -39,9 +39,7 @@ use vulkano::{
         GraphicsPipeline, PipelineBindPoint,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, Subpass},
-    swapchain::{
-        PresentMode, Swapchain, SwapchainAbstract, SwapchainCreateInfo, SwapchainPresentInfo,
-    },
+    swapchain::{PresentMode, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo},
     sync::{FenceSignalFuture, GpuFuture},
     VulkanLibrary,
 };
@@ -49,7 +47,7 @@ use vulkano_win::VkSurfaceBuild;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::WindowBuilder,
+    window::{Window, WindowBuilder},
 };
 
 const WINDOW_WIDTH: u32 = 800;
@@ -453,7 +451,8 @@ fn main() {
                 *control_flow = ControlFlow::Exit;
             }
             Event::RedrawEventsCleared => {
-                let dimensions = surface.window().inner_size();
+                let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+                let dimensions = window.inner_size();
                 if dimensions.width == 0 || dimensions.height == 0 {
                     return;
                 }

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -37,8 +37,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     shader::ShaderModule,
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -132,6 +132,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -139,7 +140,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -244,7 +245,8 @@ fn main() {
                 recreate_swapchain = true;
             }
             Event::RedrawEventsCleared => {
-                let dimensions = surface.window().inner_size();
+                let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+                let dimensions = window.inner_size();
                 if dimensions.width == 0 || dimensions.height == 0 {
                     return;
                 }
@@ -400,7 +402,7 @@ fn window_size_dependent_setup(
     device: Arc<Device>,
     vs: &ShaderModule,
     fs: &ShaderModule,
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
 ) -> (Arc<GraphicsPipeline>, Vec<Arc<Framebuffer>>) {
     let dimensions = images[0].dimensions().width_height();

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -45,8 +45,8 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -238,6 +238,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -245,7 +246,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -380,7 +381,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -475,7 +477,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -40,8 +40,8 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Sampler, SamplerCreateInfo},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -136,6 +136,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
             device.clone(),
@@ -143,7 +144,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
                 image_usage: ImageUsage {
                     color_attachment: true,
                     ..ImageUsage::empty()
@@ -306,7 +307,8 @@ fn main() {
             recreate_swapchain = true;
         }
         Event::RedrawEventsCleared => {
-            let dimensions = surface.window().inner_size();
+            let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+            let dimensions = window.inner_size();
             if dimensions.width == 0 || dimensions.height == 0 {
                 return;
             }
@@ -407,7 +409,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -47,8 +47,8 @@ use vulkano::{
     },
     render_pass::{LoadOp, StoreOp},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     Version, VulkanLibrary,
@@ -234,6 +234,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         // Please take a look at the docs for the meaning of the parameters we didn't mention.
         Swapchain::new(
@@ -257,7 +258,7 @@ fn main() {
                 //
                 // Both of these cases need the swapchain to use the window dimensions, so we just
                 // use that.
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
 
                 image_usage: ImageUsage {
                     color_attachment: true,
@@ -460,10 +461,11 @@ fn main() {
                 // In this example that includes the swapchain, the framebuffers and the dynamic state viewport.
                 if recreate_swapchain {
                     // Get the new dimensions of the window.
+                    let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
                     let (new_swapchain, new_images) =
                         match swapchain.recreate(SwapchainCreateInfo {
-                            image_extent: surface.window().inner_size().into(),
+                            image_extent: window.inner_size().into(),
                             ..swapchain.create_info()
                         }) {
                             Ok(r) => r,
@@ -605,9 +607,9 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     viewport: &mut Viewport,
-) -> Vec<Arc<ImageView<SwapchainImage<Window>>>> {
+) -> Vec<Arc<ImageView<SwapchainImage>>> {
     let dimensions = images[0].dimensions().width_height();
     viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
 

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -40,8 +40,8 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Swapchain, SwapchainAbstract, SwapchainCreateInfo,
-        SwapchainCreationError, SwapchainPresentInfo,
+        acquire_next_image, AcquireError, Swapchain, SwapchainCreateInfo, SwapchainCreationError,
+        SwapchainPresentInfo,
     },
     sync::{self, FlushError, GpuFuture},
     VulkanLibrary,
@@ -214,6 +214,7 @@ fn main() {
                 .unwrap()[0]
                 .0,
         );
+        let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         // Please take a look at the docs for the meaning of the parameters we didn't mention.
         Swapchain::new(
@@ -237,7 +238,7 @@ fn main() {
                 //
                 // Both of these cases need the swapchain to use the window dimensions, so we just
                 // use that.
-                image_extent: surface.window().inner_size().into(),
+                image_extent: window.inner_size().into(),
 
                 image_usage: ImageUsage {
                     color_attachment: true,
@@ -459,7 +460,8 @@ fn main() {
             Event::RedrawEventsCleared => {
                 // Do not draw frame when screen dimensions are zero.
                 // On Windows, this can occur from minimizing the application.
-                let dimensions = surface.window().inner_size();
+                let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
+                let dimensions = window.inner_size();
                 if dimensions.width == 0 || dimensions.height == 0 {
                     return;
                 }
@@ -615,7 +617,7 @@ fn main() {
 
 /// This method is called once during initialization, then again whenever the window is resized
 fn window_size_dependent_setup(
-    images: &[Arc<SwapchainImage<Window>>],
+    images: &[Arc<SwapchainImage>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -1478,9 +1478,9 @@ impl PhysicalDevice {
     /// # Panics
     ///
     /// - Panics if the physical device and the surface don't belong to the same instance.
-    pub fn surface_capabilities<W>(
+    pub fn surface_capabilities(
         &self,
-        surface: &Surface<W>,
+        surface: &Surface,
         surface_info: SurfaceInfo,
     ) -> Result<SurfaceCapabilities, PhysicalDeviceError> {
         self.validate_surface_capabilities(surface, &surface_info)?;
@@ -1488,9 +1488,9 @@ impl PhysicalDevice {
         unsafe { Ok(self.surface_capabilities_unchecked(surface, surface_info)?) }
     }
 
-    fn validate_surface_capabilities<W>(
+    fn validate_surface_capabilities(
         &self,
-        surface: &Surface<W>,
+        surface: &Surface,
         surface_info: &SurfaceInfo,
     ) -> Result<(), PhysicalDeviceError> {
         if !(self
@@ -1543,9 +1543,9 @@ impl PhysicalDevice {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn surface_capabilities_unchecked<W>(
+    pub unsafe fn surface_capabilities_unchecked(
         &self,
-        surface: &Surface<W>,
+        surface: &Surface,
         surface_info: SurfaceInfo,
     ) -> Result<SurfaceCapabilities, VulkanError> {
         /* Input */
@@ -1701,9 +1701,9 @@ impl PhysicalDevice {
     /// # Panics
     ///
     /// - Panics if the physical device and the surface don't belong to the same instance.
-    pub fn surface_formats<W>(
+    pub fn surface_formats(
         &self,
-        surface: &Surface<W>,
+        surface: &Surface,
         surface_info: SurfaceInfo,
     ) -> Result<Vec<(Format, ColorSpace)>, PhysicalDeviceError> {
         self.validate_surface_formats(surface, &surface_info)?;
@@ -1711,9 +1711,9 @@ impl PhysicalDevice {
         unsafe { Ok(self.surface_formats_unchecked(surface, surface_info)?) }
     }
 
-    fn validate_surface_formats<W>(
+    fn validate_surface_formats(
         &self,
-        surface: &Surface<W>,
+        surface: &Surface,
         surface_info: &SurfaceInfo,
     ) -> Result<(), PhysicalDeviceError> {
         if !(self
@@ -1780,9 +1780,9 @@ impl PhysicalDevice {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn surface_formats_unchecked<W>(
+    pub unsafe fn surface_formats_unchecked(
         &self,
-        surface: &Surface<W>,
+        surface: &Surface,
         surface_info: SurfaceInfo,
     ) -> Result<Vec<(Format, ColorSpace)>, VulkanError> {
         surface.surface_formats.get_or_try_insert(
@@ -1928,19 +1928,16 @@ impl PhysicalDevice {
     /// # Panics
     ///
     /// - Panics if the physical device and the surface don't belong to the same instance.
-    pub fn surface_present_modes<W>(
+    pub fn surface_present_modes(
         &self,
-        surface: &Surface<W>,
+        surface: &Surface,
     ) -> Result<impl Iterator<Item = PresentMode>, PhysicalDeviceError> {
         self.validate_surface_present_modes(surface)?;
 
         unsafe { Ok(self.surface_present_modes_unchecked(surface)?) }
     }
 
-    fn validate_surface_present_modes<W>(
-        &self,
-        surface: &Surface<W>,
-    ) -> Result<(), PhysicalDeviceError> {
+    fn validate_surface_present_modes(&self, surface: &Surface) -> Result<(), PhysicalDeviceError> {
         if !self.instance.enabled_extensions().khr_surface {
             return Err(PhysicalDeviceError::RequirementNotMet {
                 required_for: "`surface_present_modes`",
@@ -1966,9 +1963,9 @@ impl PhysicalDevice {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn surface_present_modes_unchecked<W>(
+    pub unsafe fn surface_present_modes_unchecked(
         &self,
-        surface: &Surface<W>,
+        surface: &Surface,
     ) -> Result<impl Iterator<Item = PresentMode>, VulkanError> {
         surface
             .surface_present_modes
@@ -2020,20 +2017,20 @@ impl PhysicalDevice {
     /// The results of this function are cached, so that future calls with the same arguments
     /// do not need to make a call to the Vulkan API again.
     #[inline]
-    pub fn surface_support<W>(
+    pub fn surface_support(
         &self,
         queue_family_index: u32,
-        surface: &Surface<W>,
+        surface: &Surface,
     ) -> Result<bool, PhysicalDeviceError> {
         self.validate_surface_support(queue_family_index, surface)?;
 
         unsafe { Ok(self.surface_support_unchecked(queue_family_index, surface)?) }
     }
 
-    fn validate_surface_support<W>(
+    fn validate_surface_support(
         &self,
         queue_family_index: u32,
-        _surface: &Surface<W>,
+        _surface: &Surface,
     ) -> Result<(), PhysicalDeviceError> {
         if !self.instance.enabled_extensions().khr_surface {
             return Err(PhysicalDeviceError::RequirementNotMet {
@@ -2057,10 +2054,10 @@ impl PhysicalDevice {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn surface_support_unchecked<W>(
+    pub unsafe fn surface_support_unchecked(
         &self,
         queue_family_index: u32,
-        surface: &Surface<W>,
+        surface: &Surface,
     ) -> Result<bool, VulkanError> {
         surface
             .surface_support

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -10,7 +10,7 @@
 use super::{traits::ImageContent, ImageAccess, ImageDescriptorLayouts, ImageInner, ImageLayout};
 use crate::{
     device::{Device, DeviceOwned},
-    swapchain::{Swapchain, SwapchainAbstract},
+    swapchain::Swapchain,
     OomError,
 };
 use std::{
@@ -32,22 +32,19 @@ use std::{
 /// the screen. Once an image has been presented, it can no longer be used unless it is acquired
 /// again.
 #[derive(Debug)]
-pub struct SwapchainImage<W> {
-    swapchain: Arc<Swapchain<W>>,
+pub struct SwapchainImage {
+    swapchain: Arc<Swapchain>,
     image_index: u32,
 }
 
-impl<W> SwapchainImage<W>
-where
-    W: Send + Sync,
-{
+impl SwapchainImage {
     /// Builds a `SwapchainImage` from raw components.
     ///
     /// This is an internal method that you shouldn't call.
     pub unsafe fn from_raw(
-        swapchain: Arc<Swapchain<W>>,
+        swapchain: Arc<Swapchain>,
         image_index: u32,
-    ) -> Result<Arc<SwapchainImage<W>>, OomError> {
+    ) -> Result<Arc<SwapchainImage>, OomError> {
         Ok(Arc::new(SwapchainImage {
             swapchain,
             image_index,
@@ -55,7 +52,7 @@ where
     }
 
     /// Returns the swapchain this image belongs to.
-    pub fn swapchain(&self) -> &Arc<Swapchain<W>> {
+    pub fn swapchain(&self) -> &Arc<Swapchain> {
         &self.swapchain
     }
 
@@ -72,16 +69,13 @@ where
     }
 }
 
-unsafe impl<W> DeviceOwned for SwapchainImage<W> {
+unsafe impl DeviceOwned for SwapchainImage {
     fn device(&self) -> &Arc<Device> {
         self.swapchain.device()
     }
 }
 
-unsafe impl<W> ImageAccess for SwapchainImage<W>
-where
-    W: Send + Sync,
-{
+unsafe impl ImageAccess for SwapchainImage {
     fn inner(&self) -> ImageInner<'_> {
         self.my_image()
     }
@@ -112,30 +106,21 @@ where
     }
 }
 
-unsafe impl<P, W> ImageContent<P> for SwapchainImage<W>
-where
-    W: Send + Sync,
-{
+unsafe impl<P> ImageContent<P> for SwapchainImage {
     fn matches_format(&self) -> bool {
         true // FIXME:
     }
 }
 
-impl<W> PartialEq for SwapchainImage<W>
-where
-    W: Send + Sync,
-{
+impl PartialEq for SwapchainImage {
     fn eq(&self, other: &Self) -> bool {
         self.inner() == other.inner()
     }
 }
 
-impl<W> Eq for SwapchainImage<W> where W: Send + Sync {}
+impl Eq for SwapchainImage {}
 
-impl<W> Hash for SwapchainImage<W>
-where
-    W: Send + Sync,
-{
+impl Hash for SwapchainImage {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner().hash(state);
     }


### PR DESCRIPTION
Changelog (rename the existing section):
```markdown
### Breaking changes
Changes to `Surface`, `Swapchain` and swapchain operations:
- `Surface`, `Swapchain`, `SwapchainImage` and `SwapchainAcquireFuture` and related functions no longer have a `W` type parameter.
- All constructors of `Surface` now take `Option<Arc<dyn Any + Send + Sync>>` instead of a generic `W`. The `window` function has been renamed to `object` and likewise returns `Option<&Arc<dyn Any + Send + Sync>>`.
- Vulkano-win: `create_surface_from_handle` takes an `Arc<impl Any + Send + Sync + HasRawWindowHandle + HasRawDisplayHandle>`, `create_surface_from_winit` takes an `Arc<Window>`.
- `PresentInfo` has been renamed to `SwapchainPresentInfo` and has differently named members and constructor.
- `acquire_next_image` returns an `u32` index to match Vulkan.
````

Following yesterday's Discord discussion. No longer having to deal with the W parameter will simplify the design of Vulkano a lot, because we will no longer need `*Abstract` traits to represent these types.