### PR TITLE
Rename `internal_object` to `handle`

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -262,7 +262,7 @@ impl UnsafeBuffer {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_buffer)(
-                device.internal_object(),
+                device.handle(),
                 &create_info_vk,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -344,21 +344,21 @@ impl UnsafeBuffer {
             {
                 if self.device.api_version() >= Version::V1_1 {
                     (fns.v1_1.get_buffer_memory_requirements2)(
-                        self.device.internal_object(),
+                        self.device.handle(),
                         &buffer_memory_requirements_info2,
                         &mut memory_requirements2,
                     );
                 } else {
                     (fns.khr_get_memory_requirements2
                         .get_buffer_memory_requirements2_khr)(
-                        self.device.internal_object(),
+                        self.device.handle(),
                         &buffer_memory_requirements_info2,
                         &mut memory_requirements2,
                     );
                 }
             } else {
                 (fns.v1_0.get_buffer_memory_requirements)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     self.handle,
                     &mut memory_requirements2.memory_requirements,
                 );
@@ -421,7 +421,7 @@ impl UnsafeBuffer {
         debug_assert!({
             let mut mem_reqs = MaybeUninit::uninit();
             (fns.v1_0.get_buffer_memory_requirements)(
-                self.device.internal_object(),
+                self.device.handle(),
                 self.handle,
                 mem_reqs.as_mut_ptr(),
             );
@@ -453,14 +453,9 @@ impl UnsafeBuffer {
             assert!(memory.flags().device_address);
         }
 
-        (fns.v1_0.bind_buffer_memory)(
-            self.device.internal_object(),
-            self.handle,
-            memory.internal_object(),
-            offset,
-        )
-        .result()
-        .map_err(VulkanError::from)?;
+        (fns.v1_0.bind_buffer_memory)(self.device.handle(), self.handle, memory.handle(), offset)
+            .result()
+            .map_err(VulkanError::from)?;
 
         Ok(())
     }
@@ -499,16 +494,16 @@ impl Drop for UnsafeBuffer {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_buffer)(self.device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.destroy_buffer)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for UnsafeBuffer {
-    type Object = ash::vk::Buffer;
+    type Handle = ash::vk::Buffer;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Buffer {
+    fn handle(&self) -> ash::vk::Buffer {
         self.handle
     }
 }

--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -96,7 +96,7 @@ pub unsafe trait BufferAccess: DeviceOwned + Send + Sync {
 
         unsafe {
             let info = ash::vk::BufferDeviceAddressInfo {
-                buffer: inner.buffer.internal_object(),
+                buffer: inner.buffer.handle(),
                 ..Default::default()
             };
             let fns = device.fns();
@@ -107,7 +107,7 @@ pub unsafe trait BufferAccess: DeviceOwned + Send + Sync {
             } else {
                 fns.ext_buffer_device_address.get_buffer_device_address_ext
             };
-            let ptr = f(device.internal_object(), &info);
+            let ptr = f(device.handle(), &info);
 
             if ptr == 0 {
                 panic!("got null ptr from a valid GetBufferDeviceAddress call");

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -207,7 +207,7 @@ where
 
         let create_info = ash::vk::BufferViewCreateInfo {
             flags: ash::vk::BufferViewCreateFlags::empty(),
-            buffer: inner_buffer.internal_object(),
+            buffer: inner_buffer.handle(),
             format: format.into(),
             offset,
             range: size,
@@ -218,7 +218,7 @@ where
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_buffer_view)(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -252,7 +252,7 @@ where
         unsafe {
             let fns = self.buffer.inner().buffer.device().fns();
             (fns.v1_0.destroy_buffer_view)(
-                self.buffer.inner().buffer.device().internal_object(),
+                self.buffer.inner().buffer.device().handle(),
                 self.handle,
                 ptr::null(),
             );
@@ -264,9 +264,9 @@ unsafe impl<B> VulkanObject for BufferView<B>
 where
     B: BufferAccess + ?Sized,
 {
-    type Object = ash::vk::BufferView;
+    type Handle = ash::vk::BufferView;
 
-    fn internal_object(&self) -> ash::vk::BufferView {
+    fn handle(&self) -> ash::vk::BufferView {
         self.handle
     }
 }
@@ -422,7 +422,7 @@ impl From<RequirementNotMet> for BufferViewCreationError {
 }
 
 pub unsafe trait BufferViewAbstract:
-    VulkanObject<Object = ash::vk::BufferView> + DeviceOwned + Send + Sync
+    VulkanObject<Handle = ash::vk::BufferView> + DeviceOwned + Send + Sync
 {
     /// Returns the wrapped buffer that this buffer view was created from.
     fn buffer(&self) -> Arc<dyn BufferAccess>;
@@ -462,7 +462,7 @@ where
 impl PartialEq for dyn BufferViewAbstract {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.internal_object() == other.internal_object() && self.device() == other.device()
+        self.handle() == other.handle() && self.device() == other.device()
     }
 }
 
@@ -470,7 +470,7 @@ impl Eq for dyn BufferViewAbstract {}
 
 impl Hash for dyn BufferViewAbstract {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.internal_object().hash(state);
+        self.handle().hash(state);
         self.device().hash(state);
     }
 }

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -356,7 +356,7 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        let raw = cb.inner().internal_object();
+        let raw = cb.inner().handle();
         drop(cb);
 
         let cb2 = allocator
@@ -364,6 +364,6 @@ mod tests {
             .unwrap()
             .next()
             .unwrap();
-        assert_eq!(raw, cb2.inner().internal_object());
+        assert_eq!(raw, cb2.inner().handle());
     }
 }

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -971,7 +971,7 @@ impl UnsafeCommandBufferBuilder {
     ) {
         let fns = self.device.fns();
 
-        let sets: SmallVec<[_; 12]> = sets.into_iter().map(|s| s.internal_object()).collect();
+        let sets: SmallVec<[_; 12]> = sets.into_iter().map(|s| s.handle()).collect();
         if sets.is_empty() {
             return;
         }
@@ -983,7 +983,7 @@ impl UnsafeCommandBufferBuilder {
         (fns.v1_0.cmd_bind_descriptor_sets)(
             self.handle,
             pipeline_bind_point.into(),
-            pipeline_layout.internal_object(),
+            pipeline_layout.handle(),
             first_set,
             num_bindings,
             sets.as_ptr(),
@@ -1003,7 +1003,7 @@ impl UnsafeCommandBufferBuilder {
 
         (fns.v1_0.cmd_bind_index_buffer)(
             self.handle,
-            inner.buffer.internal_object(),
+            inner.buffer.handle(),
             inner.offset,
             index_type.into(),
         );
@@ -1016,7 +1016,7 @@ impl UnsafeCommandBufferBuilder {
         (fns.v1_0.cmd_bind_pipeline)(
             self.handle,
             ash::vk::PipelineBindPoint::COMPUTE,
-            pipeline.internal_object(),
+            pipeline.handle(),
         );
     }
 
@@ -1027,7 +1027,7 @@ impl UnsafeCommandBufferBuilder {
         (fns.v1_0.cmd_bind_pipeline)(
             self.handle,
             ash::vk::PipelineBindPoint::GRAPHICS,
-            pipeline.internal_object(),
+            pipeline.handle(),
         );
     }
 
@@ -1091,7 +1091,7 @@ impl UnsafeCommandBufferBuilder {
 
         (fns.v1_0.cmd_push_constants)(
             self.handle,
-            pipeline_layout.internal_object(),
+            pipeline_layout.handle(),
             stages.into(),
             offset as u32,
             size as u32,
@@ -1153,7 +1153,7 @@ impl UnsafeCommandBufferBuilder {
         (fns.khr_push_descriptor.cmd_push_descriptor_set_khr)(
             self.handle,
             pipeline_bind_point.into(),
-            pipeline_layout.internal_object(),
+            pipeline_layout.handle(),
             set_num,
             writes.len() as u32,
             writes.as_ptr(),
@@ -1185,7 +1185,7 @@ impl UnsafeCommandBufferBuilderBindVertexBuffer {
     pub fn add(&mut self, buffer: &dyn BufferAccess) {
         let inner = buffer.inner();
         debug_assert!(inner.buffer.usage().vertex_buffer);
-        self.raw_buffers.push(inner.buffer.internal_object());
+        self.raw_buffers.push(inner.buffer.handle());
         self.offsets.push(inner.offset);
     }
 }

--- a/vulkano/src/command_buffer/commands/image.rs
+++ b/vulkano/src/command_buffer/commands/image.rs
@@ -1595,9 +1595,9 @@ impl UnsafeCommandBufferBuilder {
                 .collect();
 
             let blit_image_info = ash::vk::BlitImageInfo2 {
-                src_image: src_image_inner.image.internal_object(),
+                src_image: src_image_inner.image.handle(),
                 src_image_layout: src_image_layout.into(),
-                dst_image: dst_image_inner.image.internal_object(),
+                dst_image: dst_image_inner.image.handle(),
                 dst_image_layout: dst_image_layout.into(),
                 region_count: regions.len() as u32,
                 p_regions: regions.as_ptr(),
@@ -1665,9 +1665,9 @@ impl UnsafeCommandBufferBuilder {
 
             (fns.v1_0.cmd_blit_image)(
                 self.handle,
-                src_image_inner.image.internal_object(),
+                src_image_inner.image.handle(),
                 src_image_layout.into(),
-                dst_image_inner.image.internal_object(),
+                dst_image_inner.image.handle(),
                 dst_image_layout.into(),
                 regions.len() as u32,
                 regions.as_ptr(),
@@ -1704,7 +1704,7 @@ impl UnsafeCommandBufferBuilder {
         let fns = self.device.fns();
         (fns.v1_0.cmd_clear_color_image)(
             self.handle,
-            image.inner().image.internal_object(),
+            image.inner().image.handle(),
             image_layout.into(),
             &clear_value,
             ranges.len() as u32,
@@ -1740,7 +1740,7 @@ impl UnsafeCommandBufferBuilder {
         let fns = self.device.fns();
         (fns.v1_0.cmd_clear_depth_stencil_image)(
             self.handle,
-            image.inner().image.internal_object(),
+            image.inner().image.handle(),
             image_layout.into(),
             &clear_value,
             ranges.len() as u32,
@@ -1821,9 +1821,9 @@ impl UnsafeCommandBufferBuilder {
                 .collect();
 
             let resolve_image_info = ash::vk::ResolveImageInfo2 {
-                src_image: src_image_inner.image.internal_object(),
+                src_image: src_image_inner.image.handle(),
                 src_image_layout: src_image_layout.into(),
-                dst_image: dst_image_inner.image.internal_object(),
+                dst_image: dst_image_inner.image.handle(),
                 dst_image_layout: dst_image_layout.into(),
                 region_count: regions.len() as u32,
                 p_regions: regions.as_ptr(),
@@ -1882,9 +1882,9 @@ impl UnsafeCommandBufferBuilder {
 
             (fns.v1_0.cmd_resolve_image)(
                 self.handle,
-                src_image_inner.image.internal_object(),
+                src_image_inner.image.handle(),
                 src_image_layout.into(),
-                dst_image_inner.image.internal_object(),
+                dst_image_inner.image.handle(),
                 dst_image_layout.into(),
                 regions.len() as u32,
                 regions.as_ptr(),

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -934,7 +934,7 @@ where
         };
 
         // VUID-vkCmdDispatch-maintenance4-06425
-        if pipeline_layout.internal_object() != constants_pipeline_layout.internal_object()
+        if pipeline_layout.handle() != constants_pipeline_layout.handle()
             && pipeline_layout.push_constant_ranges()
                 != constants_pipeline_layout.push_constant_ranges()
         {
@@ -2177,7 +2177,7 @@ impl UnsafeCommandBufferBuilder {
         debug_assert!(inner.buffer.usage().indirect_buffer);
         debug_assert_eq!(inner.offset % 4, 0);
 
-        (fns.v1_0.cmd_dispatch_indirect)(self.handle, inner.buffer.internal_object(), inner.offset);
+        (fns.v1_0.cmd_dispatch_indirect)(self.handle, inner.buffer.handle(), inner.offset);
     }
 
     /// Calls `vkCmdDraw` on the builder.
@@ -2242,7 +2242,7 @@ impl UnsafeCommandBufferBuilder {
 
         (fns.v1_0.cmd_draw_indirect)(
             self.handle,
-            inner.buffer.internal_object(),
+            inner.buffer.handle(),
             inner.offset,
             draw_count,
             stride,
@@ -2265,7 +2265,7 @@ impl UnsafeCommandBufferBuilder {
 
         (fns.v1_0.cmd_draw_indexed_indirect)(
             self.handle,
-            inner.buffer.internal_object(),
+            inner.buffer.handle(),
             inner.offset,
             draw_count,
             stride,

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -1967,8 +1967,8 @@ impl UnsafeCommandBufferBuilder {
             .collect();
 
         let render_pass_begin_info = ash::vk::RenderPassBeginInfo {
-            render_pass: render_pass.internal_object(),
-            framebuffer: framebuffer.internal_object(),
+            render_pass: render_pass.handle(),
+            framebuffer: framebuffer.handle(),
             render_area: ash::vk::Rect2D {
                 offset: ash::vk::Offset2D {
                     x: render_area_offset[0] as i32,
@@ -2110,11 +2110,7 @@ impl UnsafeCommandBufferBuilder {
                             image_layout,
                         } = resolve;
 
-                        (
-                            mode.into(),
-                            image_view.internal_object(),
-                            image_layout.into(),
-                        )
+                        (mode.into(), image_view.handle(), image_layout.into())
                     } else {
                         (
                             ash::vk::ResolveModeFlags::NONE,
@@ -2124,7 +2120,7 @@ impl UnsafeCommandBufferBuilder {
                     };
 
                 ash::vk::RenderingAttachmentInfo {
-                    image_view: image_view.internal_object(),
+                    image_view: image_view.handle(),
                     image_layout: image_layout.into(),
                     resolve_mode,
                     resolve_image_view,

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -448,7 +448,7 @@ impl<'a> SyncCommandBufferBuilderExecuteCommands<'a> {
                 let mut execute = UnsafeCommandBufferBuilderExecuteCommands::new();
                 self.0
                     .iter()
-                    .for_each(|cbuf| execute.add_raw(cbuf.inner().internal_object()));
+                    .for_each(|cbuf| execute.add_raw(cbuf.inner().handle()));
                 out.execute_commands(execute);
             }
         }
@@ -544,7 +544,7 @@ impl UnsafeCommandBufferBuilderExecuteCommands {
     /// Adds a command buffer to the list.
     pub fn add(&mut self, cb: &(impl SecondaryCommandBuffer + ?Sized)) {
         // TODO: debug assert that it is a secondary command buffer?
-        self.raw_cbs.push(cb.inner().internal_object());
+        self.raw_cbs.push(cb.inner().handle());
     }
 
     /// Adds a command buffer to the list.

--- a/vulkano/src/command_buffer/commands/sync.rs
+++ b/vulkano/src/command_buffer/commands/sync.rs
@@ -143,7 +143,7 @@ impl UnsafeCommandBufferBuilder {
                             .map_or(ash::vk::QUEUE_FAMILY_IGNORED, |transfer| {
                                 transfer.destination_index
                             }),
-                        buffer: buffer.internal_object(),
+                        buffer: buffer.handle(),
                         offset: range.start,
                         size: range.end - range.start,
                         ..Default::default()
@@ -202,7 +202,7 @@ impl UnsafeCommandBufferBuilder {
                             .map_or(ash::vk::QUEUE_FAMILY_IGNORED, |transfer| {
                                 transfer.destination_index
                             }),
-                        image: image.internal_object(),
+                        image: image.handle(),
                         subresource_range: subresource_range.clone().into(),
                         ..Default::default()
                     }
@@ -293,7 +293,7 @@ impl UnsafeCommandBufferBuilder {
                             .map_or(ash::vk::QUEUE_FAMILY_IGNORED, |transfer| {
                                 transfer.destination_index
                             }),
-                        buffer: buffer.internal_object(),
+                        buffer: buffer.handle(),
                         offset: range.start,
                         size: range.end - range.start,
                         ..Default::default()
@@ -353,7 +353,7 @@ impl UnsafeCommandBufferBuilder {
                             .map_or(ash::vk::QUEUE_FAMILY_IGNORED, |transfer| {
                                 transfer.destination_index
                             }),
-                        image: image.internal_object(),
+                        image: image.handle(),
                         subresource_range: subresource_range.clone().into(),
                         ..Default::default()
                     }
@@ -394,7 +394,7 @@ impl UnsafeCommandBufferBuilder {
         debug_assert!(!stages.host);
         debug_assert_ne!(stages, PipelineStages::empty());
         let fns = self.device.fns();
-        (fns.v1_0.cmd_set_event)(self.handle, event.internal_object(), stages.into());
+        (fns.v1_0.cmd_set_event)(self.handle, event.handle(), stages.into());
     }
 
     /// Calls `vkCmdResetEvent` on the builder.
@@ -405,6 +405,6 @@ impl UnsafeCommandBufferBuilder {
         debug_assert!(!stages.host);
         debug_assert_ne!(stages, PipelineStages::empty());
 
-        (fns.v1_0.cmd_reset_event)(self.handle, event.internal_object(), stages.into());
+        (fns.v1_0.cmd_reset_event)(self.handle, event.handle(), stages.into());
     }
 }

--- a/vulkano/src/command_buffer/commands/transfer.rs
+++ b/vulkano/src/command_buffer/commands/transfer.rs
@@ -2521,8 +2521,8 @@ impl UnsafeCommandBufferBuilder {
                 .collect();
 
             let copy_buffer_info = ash::vk::CopyBufferInfo2 {
-                src_buffer: src_buffer_inner.buffer.internal_object(),
-                dst_buffer: dst_buffer_inner.buffer.internal_object(),
+                src_buffer: src_buffer_inner.buffer.handle(),
+                dst_buffer: dst_buffer_inner.buffer.handle(),
                 region_count: regions.len() as u32,
                 p_regions: regions.as_ptr(),
                 ..Default::default()
@@ -2554,8 +2554,8 @@ impl UnsafeCommandBufferBuilder {
 
             (fns.v1_0.cmd_copy_buffer)(
                 self.handle,
-                src_buffer_inner.buffer.internal_object(),
-                dst_buffer_inner.buffer.internal_object(),
+                src_buffer_inner.buffer.handle(),
+                dst_buffer_inner.buffer.handle(),
                 regions.len() as u32,
                 regions.as_ptr(),
             );
@@ -2635,9 +2635,9 @@ impl UnsafeCommandBufferBuilder {
                 .collect();
 
             let copy_image_info = ash::vk::CopyImageInfo2 {
-                src_image: src_image_inner.image.internal_object(),
+                src_image: src_image_inner.image.handle(),
                 src_image_layout: src_image_layout.into(),
-                dst_image: dst_image_inner.image.internal_object(),
+                dst_image: dst_image_inner.image.handle(),
                 dst_image_layout: dst_image_layout.into(),
                 region_count: regions.len() as u32,
                 p_regions: regions.as_ptr(),
@@ -2696,9 +2696,9 @@ impl UnsafeCommandBufferBuilder {
 
             (fns.v1_0.cmd_copy_image)(
                 self.handle,
-                src_image_inner.image.internal_object(),
+                src_image_inner.image.handle(),
                 src_image_layout.into(),
-                dst_image_inner.image.internal_object(),
+                dst_image_inner.image.handle(),
                 dst_image_layout.into(),
                 regions.len() as u32,
                 regions.as_ptr(),
@@ -2774,8 +2774,8 @@ impl UnsafeCommandBufferBuilder {
                 .collect();
 
             let copy_buffer_to_image_info = ash::vk::CopyBufferToImageInfo2 {
-                src_buffer: src_buffer_inner.buffer.internal_object(),
-                dst_image: dst_image_inner.image.internal_object(),
+                src_buffer: src_buffer_inner.buffer.handle(),
+                dst_image: dst_image_inner.image.handle(),
                 dst_image_layout: dst_image_layout.into(),
                 region_count: regions.len() as u32,
                 p_regions: regions.as_ptr(),
@@ -2830,8 +2830,8 @@ impl UnsafeCommandBufferBuilder {
 
             (fns.v1_0.cmd_copy_buffer_to_image)(
                 self.handle,
-                src_buffer_inner.buffer.internal_object(),
-                dst_image_inner.image.internal_object(),
+                src_buffer_inner.buffer.handle(),
+                dst_image_inner.image.handle(),
                 dst_image_layout.into(),
                 regions.len() as u32,
                 regions.as_ptr(),
@@ -2907,9 +2907,9 @@ impl UnsafeCommandBufferBuilder {
                 .collect();
 
             let copy_image_to_buffer_info = ash::vk::CopyImageToBufferInfo2 {
-                src_image: src_image_inner.image.internal_object(),
+                src_image: src_image_inner.image.handle(),
                 src_image_layout: src_image_layout.into(),
-                dst_buffer: dst_buffer_inner.buffer.internal_object(),
+                dst_buffer: dst_buffer_inner.buffer.handle(),
                 region_count: regions.len() as u32,
                 p_regions: regions.as_ptr(),
                 ..Default::default()
@@ -2962,9 +2962,9 @@ impl UnsafeCommandBufferBuilder {
 
             (fns.v1_0.cmd_copy_image_to_buffer)(
                 self.handle,
-                src_image_inner.image.internal_object(),
+                src_image_inner.image.handle(),
                 src_image_layout.into(),
-                dst_buffer_inner.buffer.internal_object(),
+                dst_buffer_inner.buffer.handle(),
                 regions.len() as u32,
                 regions.as_ptr(),
             );
@@ -2987,7 +2987,7 @@ impl UnsafeCommandBufferBuilder {
         let fns = self.device.fns();
         (fns.v1_0.cmd_fill_buffer)(
             self.handle,
-            dst_buffer_inner.buffer.internal_object(),
+            dst_buffer_inner.buffer.handle(),
             dst_offset,
             size,
             data,
@@ -3008,7 +3008,7 @@ impl UnsafeCommandBufferBuilder {
         let fns = self.device.fns();
         (fns.v1_0.cmd_update_buffer)(
             self.handle,
-            dst_buffer_inner.buffer.internal_object(),
+            dst_buffer_inner.buffer.handle(),
             dst_buffer_inner.offset + dst_offset,
             size_of_val(data) as DeviceSize,
             data.as_bytes().as_ptr() as *const _,

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -151,7 +151,7 @@ impl CommandPool {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_command_pool)(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -181,7 +181,7 @@ impl CommandPool {
         };
 
         let fns = self.device.fns();
-        (fns.v1_0.reset_command_pool)(self.device.internal_object(), self.handle, flags)
+        (fns.v1_0.reset_command_pool)(self.device.handle(), self.handle, flags)
             .result()
             .map_err(VulkanError::from)?;
 
@@ -215,7 +215,7 @@ impl CommandPool {
                 let fns = self.device.fns();
                 let mut out = Vec::with_capacity(command_buffer_count as usize);
                 (fns.v1_0.allocate_command_buffers)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     &allocate_info,
                     out.as_mut_ptr(),
                 )
@@ -250,7 +250,7 @@ impl CommandPool {
             command_buffers.into_iter().map(|cb| cb.handle).collect();
         let fns = self.device.fns();
         (fns.v1_0.free_command_buffers)(
-            self.device.internal_object(),
+            self.device.handle(),
             self.handle,
             command_buffers.len() as u32,
             command_buffers.as_ptr(),
@@ -287,13 +287,13 @@ impl CommandPool {
 
             if self.device.api_version() >= Version::V1_1 {
                 (fns.v1_1.trim_command_pool)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     self.handle,
                     ash::vk::CommandPoolTrimFlags::empty(),
                 );
             } else {
                 (fns.khr_maintenance1.trim_command_pool_khr)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     self.handle,
                     ash::vk::CommandPoolTrimFlagsKHR::empty(),
                 );
@@ -315,20 +315,16 @@ impl Drop for CommandPool {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_command_pool)(
-                self.device.internal_object(),
-                self.handle,
-                ptr::null(),
-            );
+            (fns.v1_0.destroy_command_pool)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for CommandPool {
-    type Object = ash::vk::CommandPool;
+    type Handle = ash::vk::CommandPool;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::CommandPool {
+    fn handle(&self) -> ash::vk::CommandPool {
         self.handle
     }
 }
@@ -484,10 +480,10 @@ impl CommandPoolAlloc {
 }
 
 unsafe impl VulkanObject for CommandPoolAlloc {
-    type Object = ash::vk::CommandBuffer;
+    type Handle = ash::vk::CommandBuffer;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::CommandBuffer {
+    fn handle(&self) -> ash::vk::CommandBuffer {
         self.handle
     }
 }

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -1046,8 +1046,7 @@ impl CurrentState {
             Entry::Occupied(entry) => {
                 let state = entry.into_mut();
 
-                let invalidate_from = if state.pipeline_layout.internal_object()
-                    == pipeline_layout.internal_object()
+                let invalidate_from = if state.pipeline_layout.handle() == pipeline_layout.handle()
                 {
                     // If we're still using the exact same layout, then of course it's compatible.
                     None

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -121,12 +121,11 @@ impl UnsafeCommandBufferBuilder {
                                 ref framebuffer,
                             } = render_pass_info;
 
-                            inheritance_info_vk.render_pass =
-                                subpass.render_pass().internal_object();
+                            inheritance_info_vk.render_pass = subpass.render_pass().handle();
                             inheritance_info_vk.subpass = subpass.index();
                             inheritance_info_vk.framebuffer = framebuffer
                                 .as_ref()
-                                .map(|fb| fb.internal_object())
+                                .map(|fb| fb.handle())
                                 .unwrap_or_default();
                         }
                         CommandBufferInheritanceRenderPassType::BeginRendering(rendering_info) => {
@@ -177,13 +176,13 @@ impl UnsafeCommandBufferBuilder {
 
             let fns = device.fns();
 
-            (fns.v1_0.begin_command_buffer)(pool_alloc.internal_object(), &begin_info_vk)
+            (fns.v1_0.begin_command_buffer)(pool_alloc.handle(), &begin_info_vk)
                 .result()
                 .map_err(VulkanError::from)?;
         }
 
         Ok(UnsafeCommandBufferBuilder {
-            handle: pool_alloc.internal_object(),
+            handle: pool_alloc.handle(),
             device,
             usage,
         })
@@ -208,10 +207,10 @@ impl UnsafeCommandBufferBuilder {
 }
 
 unsafe impl VulkanObject for UnsafeCommandBufferBuilder {
-    type Object = ash::vk::CommandBuffer;
+    type Handle = ash::vk::CommandBuffer;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::CommandBuffer {
+    fn handle(&self) -> ash::vk::CommandBuffer {
         self.handle
     }
 }
@@ -280,10 +279,10 @@ unsafe impl DeviceOwned for UnsafeCommandBuffer {
 }
 
 unsafe impl VulkanObject for UnsafeCommandBuffer {
-    type Object = ash::vk::CommandBuffer;
+    type Handle = ash::vk::CommandBuffer;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::CommandBuffer {
+    fn handle(&self) -> ash::vk::CommandBuffer {
         self.command_buffer
     }
 }

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -114,10 +114,7 @@ pub unsafe trait PrimaryCommandBuffer: DeviceOwned + Send + Sync {
         Self: Sized + 'static,
         F: GpuFuture,
     {
-        assert_eq!(
-            self.device().internal_object(),
-            future.device().internal_object()
-        );
+        assert_eq!(self.device().handle(), future.device().handle());
 
         if !future.queue_change_allowed() {
             assert!(future.queue().unwrap() == queue);

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -305,7 +305,7 @@ impl DescriptorSetLayout {
                 let sampler_handles = binding
                     .immutable_samplers
                     .iter()
-                    .map(|s| s.internal_object())
+                    .map(|s| s.handle())
                     .collect::<Vec<_>>()
                     .into_boxed_slice();
                 let p_immutable_samplers = sampler_handles.as_ptr();
@@ -360,7 +360,7 @@ impl DescriptorSetLayout {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_descriptor_set_layout)(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -429,7 +429,7 @@ impl Drop for DescriptorSetLayout {
         unsafe {
             let fns = self.device.fns();
             (fns.v1_0.destroy_descriptor_set_layout)(
-                self.device.internal_object(),
+                self.device.handle(),
                 self.handle,
                 ptr::null(),
             );
@@ -438,10 +438,10 @@ impl Drop for DescriptorSetLayout {
 }
 
 unsafe impl VulkanObject for DescriptorSetLayout {
-    type Object = ash::vk::DescriptorSetLayout;
+    type Handle = ash::vk::DescriptorSetLayout;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::DescriptorSetLayout {
+    fn handle(&self) -> ash::vk::DescriptorSetLayout {
         self.handle
     }
 }

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -141,8 +141,7 @@ pub unsafe trait DescriptorSet: DeviceOwned + Send + Sync {
 impl PartialEq for dyn DescriptorSet {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner().internal_object() == other.inner().internal_object()
-            && self.device() == other.device()
+        self.inner().handle() == other.inner().handle() && self.device() == other.device()
     }
 }
 
@@ -150,7 +149,7 @@ impl Eq for dyn DescriptorSet {}
 
 impl Hash for dyn DescriptorSet {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().internal_object().hash(state);
+        self.inner().handle().hash(state);
         self.device().hash(state);
     }
 }
@@ -225,7 +224,7 @@ impl DescriptorSetInner {
             let fns = layout.device().fns();
 
             (fns.v1_0.update_descriptor_sets)(
-                layout.device().internal_object(),
+                layout.device().handle(),
                 write_descriptor_set.len() as u32,
                 write_descriptor_set.as_ptr(),
                 0,

--- a/vulkano/src/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor_set/persistent.rs
@@ -92,7 +92,7 @@ impl PersistentDescriptorSet {
 
         let alloc = allocator.allocate(&layout, variable_descriptor_count)?;
         let inner = DescriptorSetInner::new(
-            alloc.inner().internal_object(),
+            alloc.inner().handle(),
             layout,
             variable_descriptor_count,
             descriptor_writes,
@@ -133,8 +133,7 @@ where
     P: DescriptorSetAlloc,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.inner().internal_object() == other.inner().internal_object()
-            && self.device() == other.device()
+        self.inner().handle() == other.inner().handle() && self.device() == other.device()
     }
 }
 
@@ -145,7 +144,7 @@ where
     P: DescriptorSetAlloc,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().internal_object().hash(state);
+        self.inner().handle().hash(state);
         self.device().hash(state);
     }
 }

--- a/vulkano/src/descriptor_set/single_layout_pool.rs
+++ b/vulkano/src/descriptor_set/single_layout_pool.rs
@@ -93,7 +93,7 @@ impl SingleLayoutDescriptorSetPool {
     ) -> Result<Arc<SingleLayoutDescSet>, DescriptorSetCreationError> {
         let alloc = self.next_alloc()?;
         let inner = DescriptorSetInner::new(
-            alloc.inner().internal_object(),
+            alloc.inner().handle(),
             self.layout.clone(),
             0,
             descriptor_writes,
@@ -246,8 +246,7 @@ unsafe impl DeviceOwned for SingleLayoutDescSet {
 impl PartialEq for SingleLayoutDescSet {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner().internal_object() == other.inner().internal_object()
-            && self.device() == other.device()
+        self.inner().handle() == other.inner().handle() && self.device() == other.device()
     }
 }
 
@@ -255,7 +254,7 @@ impl Eq for SingleLayoutDescSet {}
 
 impl Hash for SingleLayoutDescSet {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().internal_object().hash(state);
+        self.inner().handle().hash(state);
         self.device().hash(state);
     }
 }
@@ -331,7 +330,7 @@ impl SingleLayoutVariableDescriptorSetPool {
 
         let alloc = self.next_alloc(variable_descriptor_count)?;
         let inner = DescriptorSetInner::new(
-            alloc.inner().internal_object(),
+            alloc.inner().handle(),
             self.layout.clone(),
             0,
             descriptor_writes,
@@ -491,8 +490,7 @@ unsafe impl DeviceOwned for SingleLayoutVariableDescSet {
 impl PartialEq for SingleLayoutVariableDescSet {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner().internal_object() == other.inner().internal_object()
-            && self.device() == other.device()
+        self.inner().handle() == other.inner().handle() && self.device() == other.device()
     }
 }
 
@@ -500,7 +498,7 @@ impl Eq for SingleLayoutVariableDescSet {}
 
 impl Hash for SingleLayoutVariableDescSet {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().internal_object().hash(state);
+        self.inner().handle().hash(state);
         self.device().hash(state);
     }
 }

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -94,7 +94,7 @@ impl UnsafeDescriptorSet {
         let fns = layout.device().fns();
 
         (fns.v1_0.update_descriptor_sets)(
-            layout.device().internal_object(),
+            layout.device().handle(),
             writes.len() as u32,
             writes.as_ptr(),
             0,
@@ -108,10 +108,10 @@ impl UnsafeDescriptorSet {
 }
 
 unsafe impl VulkanObject for UnsafeDescriptorSet {
-    type Object = ash::vk::DescriptorSet;
+    type Handle = ash::vk::DescriptorSet;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::DescriptorSet {
+    fn handle(&self) -> ash::vk::DescriptorSet {
         self.handle
     }
 }

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -239,7 +239,7 @@ impl WriteDescriptorSet {
                                     as DeviceSize
                             );
                             ash::vk::DescriptorBufferInfo {
-                                buffer: buffer.internal_object(),
+                                buffer: buffer.handle(),
                                 offset,
                                 range: size,
                             }
@@ -255,7 +255,7 @@ impl WriteDescriptorSet {
                 DescriptorWriteInfo::BufferView(
                     elements
                         .iter()
-                        .map(|buffer_view| buffer_view.internal_object())
+                        .map(|buffer_view| buffer_view.handle())
                         .collect(),
                 )
             }
@@ -277,7 +277,7 @@ impl WriteDescriptorSet {
                             );
                             ash::vk::DescriptorImageInfo {
                                 sampler: ash::vk::Sampler::null(),
-                                image_view: image_view.internal_object(),
+                                image_view: image_view.handle(),
                                 image_layout: layouts.layout_for(descriptor_type).into(),
                             }
                         })
@@ -297,8 +297,8 @@ impl WriteDescriptorSet {
                                 "descriptor_layouts must return Some when used in an image view",
                             );
                             ash::vk::DescriptorImageInfo {
-                                sampler: sampler.internal_object(),
-                                image_view: image_view.internal_object(),
+                                sampler: sampler.handle(),
+                                image_view: image_view.handle(),
                                 image_layout: layouts.layout_for(descriptor_type).into(),
                             }
                         })
@@ -311,7 +311,7 @@ impl WriteDescriptorSet {
                     elements
                         .iter()
                         .map(|sampler| ash::vk::DescriptorImageInfo {
-                            sampler: sampler.internal_object(),
+                            sampler: sampler.handle(),
                             image_view: ash::vk::ImageView::null(),
                             image_layout: ash::vk::ImageLayout::UNDEFINED,
                         })
@@ -421,10 +421,7 @@ pub(crate) fn check_descriptor_write<'a>(
             match layout_binding.descriptor_type {
                 DescriptorType::StorageBuffer | DescriptorType::StorageBufferDynamic => {
                     for (index, buffer) in elements.iter().enumerate() {
-                        assert_eq!(
-                            buffer.device().internal_object(),
-                            layout.device().internal_object(),
-                        );
+                        assert_eq!(buffer.device().handle(), layout.device().handle(),);
 
                         if !buffer.inner().buffer.usage().storage_buffer {
                             return Err(DescriptorSetUpdateError::MissingUsage {
@@ -437,10 +434,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 }
                 DescriptorType::UniformBuffer | DescriptorType::UniformBufferDynamic => {
                     for (index, buffer) in elements.iter().enumerate() {
-                        assert_eq!(
-                            buffer.device().internal_object(),
-                            layout.device().internal_object(),
-                        );
+                        assert_eq!(buffer.device().handle(), layout.device().handle(),);
 
                         if !buffer.inner().buffer.usage().uniform_buffer {
                             return Err(DescriptorSetUpdateError::MissingUsage {
@@ -473,10 +467,7 @@ pub(crate) fn check_descriptor_write<'a>(
             match layout_binding.descriptor_type {
                 DescriptorType::StorageTexelBuffer => {
                     for (index, buffer_view) in elements.iter().enumerate() {
-                        assert_eq!(
-                            buffer_view.device().internal_object(),
-                            layout.device().internal_object(),
-                        );
+                        assert_eq!(buffer_view.device().handle(), layout.device().handle(),);
 
                         // TODO: storage_texel_buffer_atomic
                         if !buffer_view
@@ -496,10 +487,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 }
                 DescriptorType::UniformTexelBuffer => {
                     for (index, buffer_view) in elements.iter().enumerate() {
-                        assert_eq!(
-                            buffer_view.device().internal_object(),
-                            layout.device().internal_object(),
-                        );
+                        assert_eq!(buffer_view.device().handle(), layout.device().handle(),);
 
                         if !buffer_view
                             .buffer()
@@ -533,10 +521,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 for (index, (image_view, sampler)) in
                     elements.iter().zip(immutable_samplers).enumerate()
                 {
-                    assert_eq!(
-                        image_view.device().internal_object(),
-                        layout.device().internal_object(),
-                    );
+                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00337
                     if !image_view.usage().sampled {
@@ -581,10 +566,7 @@ pub(crate) fn check_descriptor_write<'a>(
             }
             DescriptorType::SampledImage => {
                 for (index, image_view) in elements.iter().enumerate() {
-                    assert_eq!(
-                        image_view.device().internal_object(),
-                        layout.device().internal_object(),
-                    );
+                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00337
                     if !image_view.usage().sampled {
@@ -631,10 +613,7 @@ pub(crate) fn check_descriptor_write<'a>(
             }
             DescriptorType::StorageImage => {
                 for (index, image_view) in elements.iter().enumerate() {
-                    assert_eq!(
-                        image_view.device().internal_object(),
-                        layout.device().internal_object(),
-                    );
+                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00339
                     if !image_view.usage().storage {
@@ -689,10 +668,7 @@ pub(crate) fn check_descriptor_write<'a>(
             }
             DescriptorType::InputAttachment => {
                 for (index, image_view) in elements.iter().enumerate() {
-                    assert_eq!(
-                        image_view.device().internal_object(),
-                        layout.device().internal_object(),
-                    );
+                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00338
                     if !image_view.usage().input_attachment {
@@ -770,14 +746,8 @@ pub(crate) fn check_descriptor_write<'a>(
                 }
 
                 for (index, (image_view, sampler)) in elements.iter().enumerate() {
-                    assert_eq!(
-                        image_view.device().internal_object(),
-                        layout.device().internal_object(),
-                    );
-                    assert_eq!(
-                        sampler.device().internal_object(),
-                        layout.device().internal_object(),
-                    );
+                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
+                    assert_eq!(sampler.device().handle(), layout.device().handle(),);
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00337
                     if !image_view.usage().sampled {
@@ -851,10 +821,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 }
 
                 for (index, sampler) in elements.iter().enumerate() {
-                    assert_eq!(
-                        sampler.device().internal_object(),
-                        layout.device().internal_object(),
-                    );
+                    assert_eq!(sampler.device().handle(), layout.device().handle(),);
 
                     if sampler.sampler_ycbcr_conversion().is_some() {
                         return Err(DescriptorSetUpdateError::SamplerHasSamplerYcbcrConversion {

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -389,7 +389,7 @@ impl Device {
         let handle = unsafe {
             let mut output = MaybeUninit::uninit();
             (fns_i.v1_0.create_device)(
-                physical_device.internal_object(),
+                physical_device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -591,12 +591,12 @@ impl Device {
         object: &T,
         object_name: Option<&str>,
     ) -> Result<(), OomError> {
-        assert!(object.device().internal_object() == self.internal_object());
+        assert!(object.device().handle() == self.handle());
 
         let object_name_vk = object_name.map(|object_name| CString::new(object_name).unwrap());
         let info = ash::vk::DebugUtilsObjectNameInfoEXT {
-            object_type: T::Object::TYPE,
-            object_handle: object.internal_object().as_raw(),
+            object_type: T::Handle::TYPE,
+            object_handle: object.handle().as_raw(),
             p_object_name: object_name_vk.map_or(ptr::null(), |object_name| object_name.as_ptr()),
             ..Default::default()
         };
@@ -653,10 +653,10 @@ impl Drop for Device {
 }
 
 unsafe impl VulkanObject for Device {
-    type Object = ash::vk::Device;
+    type Handle = ash::vk::Device;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Device {
+    fn handle(&self) -> ash::vk::Device {
         self.handle
     }
 }

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -872,7 +872,7 @@ impl PhysicalDevice {
                 );
             } else {
                 (fns.v1_0.get_physical_device_format_properties)(
-                    self.internal_object(),
+                    self.handle(),
                     format.into(),
                     &mut format_properties2.format_properties,
                 );
@@ -1557,7 +1557,7 @@ impl PhysicalDevice {
         } = surface_info;
 
         let mut info2 = ash::vk::PhysicalDeviceSurfaceInfo2KHR {
-            surface: surface.internal_object(),
+            surface: surface.handle(),
             ..Default::default()
         };
         let mut full_screen_exclusive_info = None;
@@ -1621,7 +1621,7 @@ impl PhysicalDevice {
         {
             (fns.khr_get_surface_capabilities2
                 .get_physical_device_surface_capabilities2_khr)(
-                self.internal_object(),
+                self.handle(),
                 &info2,
                 &mut capabilities2,
             )
@@ -1629,7 +1629,7 @@ impl PhysicalDevice {
             .map_err(VulkanError::from)?;
         } else {
             (fns.khr_surface.get_physical_device_surface_capabilities_khr)(
-                self.internal_object(),
+                self.handle(),
                 info2.surface,
                 &mut capabilities2.surface_capabilities,
             )
@@ -1810,7 +1810,7 @@ impl PhysicalDevice {
                     });
 
                 let mut surface_info2 = ash::vk::PhysicalDeviceSurfaceInfo2KHR {
-                    surface: surface.internal_object(),
+                    surface: surface.handle(),
                     ..Default::default()
                 };
 
@@ -1842,7 +1842,7 @@ impl PhysicalDevice {
                         let mut count = 0;
                         (fns.khr_get_surface_capabilities2
                             .get_physical_device_surface_formats2_khr)(
-                            self.internal_object(),
+                            self.handle(),
                             &surface_info2,
                             &mut count,
                             ptr::null_mut(),
@@ -1855,7 +1855,7 @@ impl PhysicalDevice {
                         let result = (fns
                             .khr_get_surface_capabilities2
                             .get_physical_device_surface_formats2_khr)(
-                            self.internal_object(),
+                            self.handle(),
                             &surface_info2,
                             &mut count,
                             surface_format2s.as_mut_ptr(),
@@ -1882,8 +1882,8 @@ impl PhysicalDevice {
                     let surface_formats = loop {
                         let mut count = 0;
                         (fns.khr_surface.get_physical_device_surface_formats_khr)(
-                            self.internal_object(),
-                            surface.internal_object(),
+                            self.handle(),
+                            surface.handle(),
                             &mut count,
                             ptr::null_mut(),
                         )
@@ -1892,8 +1892,8 @@ impl PhysicalDevice {
 
                         let mut surface_formats = Vec::with_capacity(count as usize);
                         let result = (fns.khr_surface.get_physical_device_surface_formats_khr)(
-                            self.internal_object(),
-                            surface.internal_object(),
+                            self.handle(),
+                            surface.handle(),
                             &mut count,
                             surface_formats.as_mut_ptr(),
                         );
@@ -1979,8 +1979,8 @@ impl PhysicalDevice {
                     let mut count = 0;
                     (fns.khr_surface
                         .get_physical_device_surface_present_modes_khr)(
-                        self.internal_object(),
-                        surface.internal_object(),
+                        self.handle(),
+                        surface.handle(),
                         &mut count,
                         ptr::null_mut(),
                     )
@@ -1991,8 +1991,8 @@ impl PhysicalDevice {
                     let result = (fns
                         .khr_surface
                         .get_physical_device_surface_present_modes_khr)(
-                        self.internal_object(),
-                        surface.internal_object(),
+                        self.handle(),
+                        surface.handle(),
                         &mut count,
                         modes.as_mut_ptr(),
                     );
@@ -2071,7 +2071,7 @@ impl PhysicalDevice {
                 (fns.khr_surface.get_physical_device_surface_support_khr)(
                     self.handle,
                     queue_family_index,
-                    surface.internal_object(),
+                    surface.handle(),
                     output.as_mut_ptr(),
                 )
                 .result()
@@ -2121,13 +2121,13 @@ impl PhysicalDevice {
 
             if self.api_version() >= Version::V1_3 {
                 (fns.v1_3.get_physical_device_tool_properties)(
-                    self.internal_object(),
+                    self.handle(),
                     &mut count,
                     ptr::null_mut(),
                 )
             } else {
                 (fns.ext_tooling_info.get_physical_device_tool_properties_ext)(
-                    self.internal_object(),
+                    self.handle(),
                     &mut count,
                     ptr::null_mut(),
                 )
@@ -2138,13 +2138,13 @@ impl PhysicalDevice {
             let mut tool_properties = Vec::with_capacity(count as usize);
             let result = if self.api_version() >= Version::V1_3 {
                 (fns.v1_3.get_physical_device_tool_properties)(
-                    self.internal_object(),
+                    self.handle(),
                     &mut count,
                     tool_properties.as_mut_ptr(),
                 )
             } else {
                 (fns.ext_tooling_info.get_physical_device_tool_properties_ext)(
-                    self.internal_object(),
+                    self.handle(),
                     &mut count,
                     tool_properties.as_mut_ptr(),
                 )
@@ -2424,10 +2424,10 @@ impl PhysicalDevice {
 }
 
 unsafe impl VulkanObject for PhysicalDevice {
-    type Object = ash::vk::PhysicalDevice;
+    type Handle = ash::vk::PhysicalDevice;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::PhysicalDevice {
+    fn handle(&self) -> ash::vk::PhysicalDevice {
         self.handle
     }
 }

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -102,10 +102,10 @@ impl Drop for Queue {
 }
 
 unsafe impl VulkanObject for Queue {
-    type Object = ash::vk::Queue;
+    type Handle = ash::vk::Queue;
 
     #[inline]
-    fn internal_object(&self) -> Self::Object {
+    fn handle(&self) -> Self::Handle {
         self.handle
     }
 }
@@ -230,7 +230,7 @@ impl<'a> QueueGuard<'a> {
 
                 let wait_semaphores_vk: SmallVec<[_; 4]> = wait_semaphores
                     .iter()
-                    .map(|semaphore| semaphore.internal_object())
+                    .map(|semaphore| semaphore.handle())
                     .collect();
 
                 let (buffer_bind_infos_vk, buffer_binds_vk): (SmallVec<[_; 4]>, SmallVec<[_; 4]>) =
@@ -239,7 +239,7 @@ impl<'a> QueueGuard<'a> {
                         .map(|(buffer, memory_binds)| {
                             (
                                 ash::vk::SparseBufferMemoryBindInfo {
-                                    buffer: buffer.inner().buffer.internal_object(),
+                                    buffer: buffer.inner().buffer.handle(),
                                     bind_count: 0,
                                     p_binds: ptr::null(),
                                 },
@@ -255,7 +255,7 @@ impl<'a> QueueGuard<'a> {
                                         let (memory, memory_offset) = memory.as_ref().map_or_else(
                                             Default::default,
                                             |(memory, memory_offset)| {
-                                                (memory.internal_object(), *memory_offset)
+                                                (memory.handle(), *memory_offset)
                                             },
                                         );
 
@@ -280,7 +280,7 @@ impl<'a> QueueGuard<'a> {
                     .map(|(image, memory_binds)| {
                         (
                             ash::vk::SparseImageOpaqueMemoryBindInfo {
-                                image: image.inner().image.internal_object(),
+                                image: image.inner().image.handle(),
                                 bind_count: 0,
                                 p_binds: ptr::null(),
                             },
@@ -296,9 +296,7 @@ impl<'a> QueueGuard<'a> {
 
                                     let (memory, memory_offset) = memory.as_ref().map_or_else(
                                         Default::default,
-                                        |(memory, memory_offset)| {
-                                            (memory.internal_object(), *memory_offset)
-                                        },
+                                        |(memory, memory_offset)| (memory.handle(), *memory_offset),
                                     );
 
                                     ash::vk::SparseMemoryBind {
@@ -324,7 +322,7 @@ impl<'a> QueueGuard<'a> {
                         .map(|(image, memory_binds)| {
                             (
                                 ash::vk::SparseImageMemoryBindInfo {
-                                    image: image.inner().image.internal_object(),
+                                    image: image.inner().image.handle(),
                                     bind_count: 0,
                                     p_binds: ptr::null(),
                                 },
@@ -343,7 +341,7 @@ impl<'a> QueueGuard<'a> {
                                         let (memory, memory_offset) = memory.as_ref().map_or_else(
                                             Default::default,
                                             |(memory, memory_offset)| {
-                                                (memory.internal_object(), *memory_offset)
+                                                (memory.handle(), *memory_offset)
                                             },
                                         );
 
@@ -375,7 +373,7 @@ impl<'a> QueueGuard<'a> {
 
                 let signal_semaphores_vk: SmallVec<[_; 4]> = signal_semaphores
                     .iter()
-                    .map(|semaphore| semaphore.internal_object())
+                    .map(|semaphore| semaphore.handle())
                     .collect();
 
                 (
@@ -460,7 +458,7 @@ impl<'a> QueueGuard<'a> {
             bind_infos_vk.as_ptr(),
             fence
                 .as_ref()
-                .map_or_else(Default::default, |(fence, _)| fence.internal_object()),
+                .map_or_else(Default::default, |(fence, _)| fence.handle()),
         )
         .result()
         .map_err(VulkanError::from)?;
@@ -514,7 +512,7 @@ impl<'a> QueueGuard<'a> {
 
         let wait_semaphores_vk: SmallVec<[_; 4]> = wait_semaphores
             .iter()
-            .map(|semaphore| semaphore.internal_object())
+            .map(|semaphore| semaphore.handle())
             .collect();
 
         let mut swapchains_vk: SmallVec<[_; 4]> = SmallVec::with_capacity(swapchain_infos.len());
@@ -536,7 +534,7 @@ impl<'a> QueueGuard<'a> {
                 _ne: _,
             } = swapchain_info;
 
-            swapchains_vk.push(swapchain.internal_object());
+            swapchains_vk.push(swapchain.handle());
             image_indices_vk.push(image_index);
             present_ids_vk.push(present_id.map_or(0, u64::from));
             present_regions_vk.push(ash::vk::PresentRegionKHR::default());
@@ -718,7 +716,7 @@ impl<'a> QueueGuard<'a> {
                                 } = semaphore_submit_info;
 
                                 ash::vk::SemaphoreSubmitInfo {
-                                    semaphore: semaphore.internal_object(),
+                                    semaphore: semaphore.handle(),
                                     value: 0, // TODO:
                                     stage_mask: stages.into(),
                                     device_index: 0, // TODO:
@@ -730,7 +728,7 @@ impl<'a> QueueGuard<'a> {
                         let command_buffer_infos_vk = command_buffers
                             .iter()
                             .map(|cb| ash::vk::CommandBufferSubmitInfo {
-                                command_buffer: cb.inner().internal_object(),
+                                command_buffer: cb.inner().handle(),
                                 device_mask: 0, // TODO:
                                 ..Default::default()
                             })
@@ -746,7 +744,7 @@ impl<'a> QueueGuard<'a> {
                                 } = semaphore_submit_info;
 
                                 ash::vk::SemaphoreSubmitInfo {
-                                    semaphore: semaphore.internal_object(),
+                                    semaphore: semaphore.handle(),
                                     value: 0, // TODO:
                                     stage_mask: stages.into(),
                                     device_index: 0, // TODO:
@@ -804,7 +802,7 @@ impl<'a> QueueGuard<'a> {
                     submit_info_vk.as_ptr(),
                     fence
                         .as_ref()
-                        .map_or_else(Default::default, |(fence, _)| fence.internal_object()),
+                        .map_or_else(Default::default, |(fence, _)| fence.handle()),
                 )
             } else {
                 debug_assert!(self.queue.device.enabled_extensions().khr_synchronization2);
@@ -814,7 +812,7 @@ impl<'a> QueueGuard<'a> {
                     submit_info_vk.as_ptr(),
                     fence
                         .as_ref()
-                        .map_or_else(Default::default, |(fence, _)| fence.internal_object()),
+                        .map_or_else(Default::default, |(fence, _)| fence.handle()),
                 )
             }
             .result()
@@ -847,13 +845,13 @@ impl<'a> QueueGuard<'a> {
                                     _ne: _,
                                 } = semaphore_submit_info;
 
-                                (semaphore.internal_object(), stages.into())
+                                (semaphore.handle(), stages.into())
                             })
                             .unzip();
 
                         let command_buffers_vk = command_buffers
                             .iter()
-                            .map(|cb| cb.inner().internal_object())
+                            .map(|cb| cb.inner().handle())
                             .collect();
 
                         let signal_semaphores_vk = signal_semaphores
@@ -865,7 +863,7 @@ impl<'a> QueueGuard<'a> {
                                     _ne: _,
                                 } = semaphore_submit_info;
 
-                                semaphore.internal_object()
+                                semaphore.handle()
                             })
                             .collect();
 
@@ -919,7 +917,7 @@ impl<'a> QueueGuard<'a> {
                 submit_info_vk.as_ptr(),
                 fence
                     .as_ref()
-                    .map_or_else(Default::default, |(fence, _)| fence.internal_object()),
+                    .map_or_else(Default::default, |(fence, _)| fence.handle()),
             )
             .result()
             .map_err(VulkanError::from)?;

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -915,14 +915,9 @@ impl UnsafeImage {
         let handle = {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
-            (fns.v1_0.create_image)(
-                device.internal_object(),
-                &info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
-            .result()
-            .map_err(VulkanError::from)?;
+            (fns.v1_0.create_image)(device.handle(), &info_vk, ptr::null(), output.as_mut_ptr())
+                .result()
+                .map_err(VulkanError::from)?;
             output.assume_init()
         };
 
@@ -1115,21 +1110,21 @@ impl UnsafeImage {
             {
                 if self.device.api_version() >= Version::V1_1 {
                     (fns.v1_1.get_image_memory_requirements2)(
-                        self.device.internal_object(),
+                        self.device.handle(),
                         &image_memory_requirements_info2,
                         &mut memory_requirements2,
                     );
                 } else {
                     (fns.khr_get_memory_requirements2
                         .get_image_memory_requirements2_khr)(
-                        self.device.internal_object(),
+                        self.device.handle(),
                         &image_memory_requirements_info2,
                         &mut memory_requirements2,
                     );
                 }
             } else {
                 (fns.v1_0.get_image_memory_requirements)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     self.handle,
                     &mut memory_requirements2.memory_requirements,
                 );
@@ -1163,7 +1158,7 @@ impl UnsafeImage {
 
                 if device.api_version() >= Version::V1_1 {
                     (fns.v1_1.get_image_sparse_memory_requirements2)(
-                        device.internal_object(),
+                        device.handle(),
                         &info2,
                         &mut count,
                         ptr::null_mut(),
@@ -1171,7 +1166,7 @@ impl UnsafeImage {
                 } else {
                     (fns.khr_get_memory_requirements2
                         .get_image_sparse_memory_requirements2_khr)(
-                        device.internal_object(),
+                        device.handle(),
                         &info2,
                         &mut count,
                         ptr::null_mut(),
@@ -1183,7 +1178,7 @@ impl UnsafeImage {
 
                 if device.api_version() >= Version::V1_1 {
                     (fns.v1_1.get_image_sparse_memory_requirements2)(
-                        self.device.internal_object(),
+                        self.device.handle(),
                         &info2,
                         &mut count,
                         sparse_image_memory_requirements2.as_mut_ptr(),
@@ -1191,7 +1186,7 @@ impl UnsafeImage {
                 } else {
                     (fns.khr_get_memory_requirements2
                         .get_image_sparse_memory_requirements2_khr)(
-                        self.device.internal_object(),
+                        self.device.handle(),
                         &info2,
                         &mut count,
                         sparse_image_memory_requirements2.as_mut_ptr(),
@@ -1259,7 +1254,7 @@ impl UnsafeImage {
                 let mut count = 0;
 
                 (fns.v1_0.get_image_sparse_memory_requirements)(
-                    device.internal_object(),
+                    device.handle(),
                     self.handle,
                     &mut count,
                     ptr::null_mut(),
@@ -1269,7 +1264,7 @@ impl UnsafeImage {
                     vec![ash::vk::SparseImageMemoryRequirements::default(); count as usize];
 
                 (fns.v1_0.get_image_sparse_memory_requirements)(
-                    device.internal_object(),
+                    device.handle(),
                     self.handle,
                     &mut count,
                     sparse_image_memory_requirements.as_mut_ptr(),
@@ -1335,7 +1330,7 @@ impl UnsafeImage {
         debug_assert!({
             let mut mem_reqs = MaybeUninit::uninit();
             (fns.v1_0.get_image_memory_requirements)(
-                self.device.internal_object(),
+                self.device.handle(),
                 self.handle,
                 mem_reqs.as_mut_ptr(),
             );
@@ -1346,14 +1341,9 @@ impl UnsafeImage {
                 && mem_reqs.memory_type_bits & (1 << memory.memory_type_index()) != 0
         });
 
-        (fns.v1_0.bind_image_memory)(
-            self.device.internal_object(),
-            self.handle,
-            memory.internal_object(),
-            offset,
-        )
-        .result()
-        .map_err(VulkanError::from)?;
+        (fns.v1_0.bind_image_memory)(self.device.handle(), self.handle, memory.handle(), offset)
+            .result()
+            .map_err(VulkanError::from)?;
 
         Ok(())
     }
@@ -1687,7 +1677,7 @@ impl UnsafeImage {
 
         let mut out = MaybeUninit::uninit();
         (fns.v1_0.get_image_subresource_layout)(
-            self.device.internal_object(),
+            self.device.handle(),
             self.handle,
             &subresource,
             out.as_mut_ptr(),
@@ -1713,16 +1703,16 @@ impl Drop for UnsafeImage {
 
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_image)(self.device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.destroy_image)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for UnsafeImage {
-    type Object = ash::vk::Image;
+    type Handle = ash::vk::Image;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Image {
+    fn handle(&self) -> ash::vk::Image {
         self.handle
     }
 }

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -511,7 +511,7 @@ where
 
         let mut info_vk = ash::vk::ImageViewCreateInfo {
             flags: ash::vk::ImageViewCreateFlags::empty(),
-            image: image_inner.internal_object(),
+            image: image_inner.handle(),
             view_type: view_type.into(),
             format: format.unwrap().into(),
             components: component_mapping.into(),
@@ -534,7 +534,7 @@ where
         if let Some(conversion) = sampler_ycbcr_conversion {
             let next =
                 sampler_ycbcr_conversion_info_vk.insert(ash::vk::SamplerYcbcrConversionInfo {
-                    conversion: conversion.internal_object(),
+                    conversion: conversion.handle(),
                     ..Default::default()
                 });
 
@@ -546,7 +546,7 @@ where
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_image_view)(
-                device.internal_object(),
+                device.handle(),
                 &info_vk,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -725,7 +725,7 @@ where
         unsafe {
             let device = self.device();
             let fns = device.fns();
-            (fns.v1_0.destroy_image_view)(device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.destroy_image_view)(device.handle(), self.handle, ptr::null());
         }
     }
 }
@@ -734,9 +734,9 @@ unsafe impl<I> VulkanObject for ImageView<I>
 where
     I: ImageAccess + ?Sized,
 {
-    type Object = ash::vk::ImageView;
+    type Handle = ash::vk::ImageView;
 
-    fn internal_object(&self) -> ash::vk::ImageView {
+    fn handle(&self) -> ash::vk::ImageView {
         self.handle
     }
 }
@@ -1187,7 +1187,7 @@ impl ImageViewType {
 
 /// Trait for types that represent the GPU can access an image view.
 pub unsafe trait ImageViewAbstract:
-    VulkanObject<Object = ash::vk::ImageView> + DeviceOwned + Debug + Send + Sync
+    VulkanObject<Handle = ash::vk::ImageView> + DeviceOwned + Debug + Send + Sync
 {
     /// Returns the wrapped image that this image view was created from.
     fn image(&self) -> Arc<dyn ImageAccess>;
@@ -1353,7 +1353,7 @@ unsafe impl ImageViewAbstract for ImageView<dyn ImageAccess> {
 impl PartialEq for dyn ImageViewAbstract {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.internal_object() == other.internal_object() && self.device() == other.device()
+        self.handle() == other.handle() && self.device() == other.device()
     }
 }
 
@@ -1361,7 +1361,7 @@ impl Eq for dyn ImageViewAbstract {}
 
 impl Hash for dyn ImageViewAbstract {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.internal_object().hash(state);
+        self.handle().hash(state);
         self.device().hash(state);
     }
 }

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -163,7 +163,7 @@ impl DebugUtilsMessenger {
         let handle = {
             let mut output = MaybeUninit::uninit();
             (fns.ext_debug_utils.create_debug_utils_messenger_ext)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -183,7 +183,7 @@ impl Drop for DebugUtilsMessenger {
         unsafe {
             let fns = self.instance.fns();
             (fns.ext_debug_utils.destroy_debug_utils_messenger_ext)(
-                self.instance.internal_object(),
+                self.instance.handle(),
                 self.handle,
                 ptr::null(),
             );

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -623,10 +623,10 @@ impl Drop for Instance {
 }
 
 unsafe impl VulkanObject for Instance {
-    type Object = ash::vk::Instance;
+    type Handle = ash::vk::Instance;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Instance {
+    fn handle(&self) -> ash::vk::Instance {
         self.handle
     }
 }

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -133,10 +133,10 @@ unsafe impl<T: ?Sized> SafeDeref for Box<T> {}
 /// Gives access to the internal identifier of an object.
 pub unsafe trait VulkanObject {
     /// The type of the object.
-    type Object: ash::vk::Handle;
+    type Handle: ash::vk::Handle;
 
-    /// Returns a reference to the object.
-    fn internal_object(&self) -> Self::Object;
+    /// Returns the raw Vulkan handle of the object.
+    fn handle(&self) -> Self::Handle;
 }
 
 /// Error type returned by most Vulkan functions.

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -448,11 +448,11 @@ impl DeviceMemory {
         let mut dedicated_allocate_info =
             dedicated_allocation.map(|dedicated_allocation| match dedicated_allocation {
                 DedicatedAllocation::Buffer(buffer) => ash::vk::MemoryDedicatedAllocateInfo {
-                    buffer: buffer.internal_object(),
+                    buffer: buffer.handle(),
                     ..Default::default()
                 },
                 DedicatedAllocation::Image(image) => ash::vk::MemoryDedicatedAllocateInfo {
-                    image: image.internal_object(),
+                    image: image.handle(),
                     ..Default::default()
                 },
             });
@@ -536,7 +536,7 @@ impl DeviceMemory {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.allocate_memory)(
-                device.internal_object(),
+                device.handle(),
                 &allocate_info.build(),
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -613,11 +613,7 @@ impl DeviceMemory {
         let mut output: DeviceSize = 0;
 
         let fns = self.device.fns();
-        (fns.v1_0.get_device_memory_commitment)(
-            self.device.internal_object(),
-            self.handle,
-            &mut output,
-        );
+        (fns.v1_0.get_device_memory_commitment)(self.device.handle(), self.handle, &mut output);
 
         output
     }
@@ -669,7 +665,7 @@ impl DeviceMemory {
 
                 let mut output = MaybeUninit::uninit();
                 (fns.khr_external_memory_fd.get_memory_fd_khr)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     &info,
                     output.as_mut_ptr(),
                 )
@@ -690,17 +686,17 @@ impl Drop for DeviceMemory {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.free_memory)(self.device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.free_memory)(self.device.handle(), self.handle, ptr::null());
             self.device.allocation_count.fetch_sub(1, Ordering::Release);
         }
     }
 }
 
 unsafe impl VulkanObject for DeviceMemory {
-    type Object = ash::vk::DeviceMemory;
+    type Handle = ash::vk::DeviceMemory;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::DeviceMemory {
+    fn handle(&self) -> ash::vk::DeviceMemory {
         self.handle
     }
 }
@@ -1326,7 +1322,7 @@ impl MappedDeviceMemory {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.map_memory)(
-                device.internal_object(),
+                device.handle(),
                 memory.handle,
                 range.start,
                 range.end - range.start,
@@ -1354,7 +1350,7 @@ impl MappedDeviceMemory {
         unsafe {
             let device = self.memory.device();
             let fns = device.fns();
-            (fns.v1_0.unmap_memory)(device.internal_object(), self.memory.handle);
+            (fns.v1_0.unmap_memory)(device.handle(), self.memory.handle);
         }
 
         self.memory
@@ -1392,20 +1388,16 @@ impl MappedDeviceMemory {
         // Guaranteed because `self` owns the memory and it's mapped during our lifetime.
 
         let range = ash::vk::MappedMemoryRange {
-            memory: self.memory.internal_object(),
+            memory: self.memory.handle(),
             offset: range.start,
             size: range.end - range.start,
             ..Default::default()
         };
 
         let fns = self.memory.device().fns();
-        (fns.v1_0.invalidate_mapped_memory_ranges)(
-            self.memory.device().internal_object(),
-            1,
-            &range,
-        )
-        .result()
-        .map_err(VulkanError::from)?;
+        (fns.v1_0.invalidate_mapped_memory_ranges)(self.memory.device().handle(), 1, &range)
+            .result()
+            .map_err(VulkanError::from)?;
 
         Ok(())
     }
@@ -1442,14 +1434,14 @@ impl MappedDeviceMemory {
         // Guaranteed because `self` owns the memory and it's mapped during our lifetime.
 
         let range = ash::vk::MappedMemoryRange {
-            memory: self.memory.internal_object(),
+            memory: self.memory.handle(),
             offset: range.start,
             size: range.end - range.start,
             ..Default::default()
         };
 
         let fns = self.device().fns();
-        (fns.v1_0.flush_mapped_memory_ranges)(self.memory.device().internal_object(), 1, &range)
+        (fns.v1_0.flush_mapped_memory_ranges)(self.memory.device().handle(), 1, &range)
             .result()
             .map_err(VulkanError::from)?;
 

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -119,7 +119,7 @@ impl PipelineCache {
 
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_pipeline_cache)(
-                device.internal_object(),
+                device.handle(),
                 &infos,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -161,7 +161,7 @@ impl PipelineCache {
                 .collect::<Vec<_>>();
 
             (fns.v1_0.merge_pipeline_caches)(
-                self.device.internal_object(),
+                self.device.handle(),
                 self.cache,
                 pipelines.len() as u32,
                 pipelines.as_ptr(),
@@ -209,7 +209,7 @@ impl PipelineCache {
             loop {
                 let mut count = 0;
                 (fns.v1_0.get_pipeline_cache_data)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     self.cache,
                     &mut count,
                     ptr::null_mut(),
@@ -219,7 +219,7 @@ impl PipelineCache {
 
                 let mut data: Vec<u8> = Vec::with_capacity(count as usize);
                 let result = (fns.v1_0.get_pipeline_cache_data)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     self.cache,
                     &mut count,
                     data.as_mut_ptr() as *mut _,
@@ -241,10 +241,10 @@ impl PipelineCache {
 }
 
 unsafe impl VulkanObject for PipelineCache {
-    type Object = ash::vk::PipelineCache;
+    type Handle = ash::vk::PipelineCache;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::PipelineCache {
+    fn handle(&self) -> ash::vk::PipelineCache {
         self.cache
     }
 }
@@ -254,11 +254,7 @@ impl Drop for PipelineCache {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_pipeline_cache)(
-                self.device.internal_object(),
-                self.cache,
-                ptr::null(),
-            );
+            (fns.v1_0.destroy_pipeline_cache)(self.device.handle(), self.cache, ptr::null());
         }
     }
 }

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -180,7 +180,7 @@ impl ComputePipeline {
             let stage = ash::vk::PipelineShaderStageCreateInfo {
                 flags: ash::vk::PipelineShaderStageCreateFlags::empty(),
                 stage: ash::vk::ShaderStageFlags::COMPUTE,
-                module: shader.module().internal_object(),
+                module: shader.module().handle(),
                 p_name: shader.name().as_ptr(),
                 p_specialization_info: if specialization.data_size == 0 {
                     ptr::null()
@@ -193,20 +193,20 @@ impl ComputePipeline {
             let infos = ash::vk::ComputePipelineCreateInfo {
                 flags: ash::vk::PipelineCreateFlags::empty(),
                 stage,
-                layout: layout.internal_object(),
+                layout: layout.handle(),
                 base_pipeline_handle: ash::vk::Pipeline::null(),
                 base_pipeline_index: 0,
                 ..Default::default()
             };
 
             let cache_handle = match cache {
-                Some(ref cache) => cache.internal_object(),
+                Some(ref cache) => cache.handle(),
                 None => ash::vk::PipelineCache::null(),
             };
 
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_compute_pipelines)(
-                device.internal_object(),
+                device.handle(),
                 cache_handle,
                 1,
                 &infos,
@@ -281,17 +281,17 @@ impl Debug for ComputePipeline {
 impl PartialEq for ComputePipeline {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.internal_object() == other.internal_object()
+        self.handle() == other.handle()
     }
 }
 
 impl Eq for ComputePipeline {}
 
 unsafe impl VulkanObject for ComputePipeline {
-    type Object = ash::vk::Pipeline;
+    type Handle = ash::vk::Pipeline;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Pipeline {
+    fn handle(&self) -> ash::vk::Pipeline {
         self.handle
     }
 }
@@ -308,7 +308,7 @@ impl Drop for ComputePipeline {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_pipeline)(self.device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.destroy_pipeline)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }

--- a/vulkano/src/pipeline/graphics/builder.rs
+++ b/vulkano/src/pipeline/graphics/builder.rs
@@ -2398,7 +2398,7 @@ where
 
         match render_pass {
             PipelineRenderPassType::BeginRenderPass(subpass) => {
-                render_pass_vk = subpass.render_pass().internal_object();
+                render_pass_vk = subpass.render_pass().handle();
                 subpass_vk = subpass.index();
             }
             PipelineRenderPassType::BeginRendering(rendering_info) => {
@@ -2602,7 +2602,7 @@ where
                 stages_vk.push(ash::vk::PipelineShaderStageCreateInfo {
                     flags: ash::vk::PipelineShaderStageCreateFlags::empty(),
                     stage: ash::vk::ShaderStageFlags::VERTEX,
-                    module: entry_point.module().internal_object(),
+                    module: entry_point.module().handle(),
                     p_name: entry_point.name().as_ptr(),
                     p_specialization_info: specialization_info_vk as *const _,
                     ..Default::default()
@@ -2643,7 +2643,7 @@ where
                     stages_vk.push(ash::vk::PipelineShaderStageCreateInfo {
                         flags: ash::vk::PipelineShaderStageCreateFlags::empty(),
                         stage: ash::vk::ShaderStageFlags::TESSELLATION_CONTROL,
-                        module: entry_point.module().internal_object(),
+                        module: entry_point.module().handle(),
                         p_name: entry_point.name().as_ptr(),
                         p_specialization_info: specialization_info_vk as *const _,
                         ..Default::default()
@@ -2682,7 +2682,7 @@ where
                     stages_vk.push(ash::vk::PipelineShaderStageCreateInfo {
                         flags: ash::vk::PipelineShaderStageCreateFlags::empty(),
                         stage: ash::vk::ShaderStageFlags::TESSELLATION_EVALUATION,
-                        module: entry_point.module().internal_object(),
+                        module: entry_point.module().handle(),
                         p_name: entry_point.name().as_ptr(),
                         p_specialization_info: specialization_info_vk as *const _,
                         ..Default::default()
@@ -2722,7 +2722,7 @@ where
                 stages_vk.push(ash::vk::PipelineShaderStageCreateInfo {
                     flags: ash::vk::PipelineShaderStageCreateFlags::empty(),
                     stage: ash::vk::ShaderStageFlags::GEOMETRY,
-                    module: entry_point.module().internal_object(),
+                    module: entry_point.module().handle(),
                     p_name: entry_point.name().as_ptr(),
                     p_specialization_info: specialization_info_vk as *const _,
                     ..Default::default()
@@ -3063,7 +3063,7 @@ where
                 stages_vk.push(ash::vk::PipelineShaderStageCreateInfo {
                     flags: ash::vk::PipelineShaderStageCreateFlags::empty(),
                     stage: ash::vk::ShaderStageFlags::FRAGMENT,
-                    module: entry_point.module().internal_object(),
+                    module: entry_point.module().handle(),
                     p_name: entry_point.name().as_ptr(),
                     p_specialization_info: specialization_info_vk as *const _,
                     ..Default::default()
@@ -3467,7 +3467,7 @@ where
                 .as_ref()
                 .map(|s| s as *const _)
                 .unwrap_or(ptr::null()),
-            layout: pipeline_layout.internal_object(),
+            layout: pipeline_layout.handle(),
             render_pass: render_pass_vk,
             subpass: subpass_vk,
             base_pipeline_handle: ash::vk::Pipeline::null(), // TODO:
@@ -3486,7 +3486,7 @@ where
         }
 
         let cache_handle = match cache.as_ref() {
-            Some(cache) => cache.internal_object(),
+            Some(cache) => cache.handle(),
             None => ash::vk::PipelineCache::null(),
         };
 
@@ -3494,7 +3494,7 @@ where
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_graphics_pipelines)(
-                device.internal_object(),
+                device.handle(),
                 cache_handle,
                 1,
                 &create_info,

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -275,10 +275,10 @@ impl Debug for GraphicsPipeline {
 }
 
 unsafe impl VulkanObject for GraphicsPipeline {
-    type Object = ash::vk::Pipeline;
+    type Handle = ash::vk::Pipeline;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Pipeline {
+    fn handle(&self) -> ash::vk::Pipeline {
         self.handle
     }
 }
@@ -288,7 +288,7 @@ impl Drop for GraphicsPipeline {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_pipeline)(self.device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.destroy_pipeline)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -487,8 +487,7 @@ impl PipelineLayout {
             _ne: _,
         } = create_info;
 
-        let set_layouts: SmallVec<[_; 4]> =
-            set_layouts.iter().map(|l| l.internal_object()).collect();
+        let set_layouts: SmallVec<[_; 4]> = set_layouts.iter().map(|l| l.handle()).collect();
 
         let push_constant_ranges: SmallVec<[_; 4]> = push_constant_ranges
             .iter()
@@ -512,7 +511,7 @@ impl PipelineLayout {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_pipeline_layout)(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -670,20 +669,16 @@ impl Drop for PipelineLayout {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_pipeline_layout)(
-                self.device.internal_object(),
-                self.handle,
-                ptr::null(),
-            );
+            (fns.v1_0.destroy_pipeline_layout)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for PipelineLayout {
-    type Object = ash::vk::PipelineLayout;
+    type Handle = ash::vk::PipelineLayout;
 
     #[inline]
-    fn internal_object(&self) -> Self::Object {
+    fn handle(&self) -> Self::Handle {
         self.handle
     }
 }

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -85,7 +85,7 @@ impl QueryPool {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_query_pool)(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -174,16 +174,16 @@ impl Drop for QueryPool {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_query_pool)(self.device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.destroy_query_pool)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for QueryPool {
-    type Object = ash::vk::QueryPool;
+    type Handle = ash::vk::QueryPool;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::QueryPool {
+    fn handle(&self) -> ash::vk::QueryPool {
         self.handle
     }
 }
@@ -367,8 +367,8 @@ impl<'a> QueriesRange<'a> {
         let result = unsafe {
             let fns = self.pool.device.fns();
             (fns.v1_0.get_query_pool_results)(
-                self.pool.device.internal_object(),
-                self.pool.internal_object(),
+                self.pool.device.handle(),
+                self.pool.handle(),
                 self.range.start,
                 self.range.end - self.range.start,
                 size_of_val(destination),

--- a/vulkano/src/render_pass/create.rs
+++ b/vulkano/src/render_pass/create.rs
@@ -1133,14 +1133,14 @@ impl RenderPass {
 
             if device.api_version() >= Version::V1_2 {
                 (fns.v1_2.create_render_pass2)(
-                    device.internal_object(),
+                    device.handle(),
                     &create_info,
                     ptr::null(),
                     output.as_mut_ptr(),
                 )
             } else {
                 (fns.khr_create_renderpass2.create_render_pass2_khr)(
-                    device.internal_object(),
+                    device.handle(),
                     &create_info,
                     ptr::null(),
                     output.as_mut_ptr(),
@@ -1398,7 +1398,7 @@ impl RenderPass {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_render_pass)(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -265,7 +265,7 @@ impl Framebuffer {
                     });
                 }
 
-                Ok(image_view.internal_object())
+                Ok(image_view.handle())
             })
             .collect::<Result<SmallVec<[_; 4]>, _>>()?;
 
@@ -297,7 +297,7 @@ impl Framebuffer {
 
         let create_info = ash::vk::FramebufferCreateInfo {
             flags: ash::vk::FramebufferCreateFlags::empty(),
-            render_pass: render_pass.internal_object(),
+            render_pass: render_pass.handle(),
             attachment_count: attachments_vk.len() as u32,
             p_attachments: attachments_vk.as_ptr(),
             width: extent[0],
@@ -310,7 +310,7 @@ impl Framebuffer {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_framebuffer)(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -397,20 +397,16 @@ impl Drop for Framebuffer {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device().fns();
-            (fns.v1_0.destroy_framebuffer)(
-                self.device().internal_object(),
-                self.handle,
-                ptr::null(),
-            );
+            (fns.v1_0.destroy_framebuffer)(self.device().handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for Framebuffer {
-    type Object = ash::vk::Framebuffer;
+    type Handle = ash::vk::Framebuffer;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Framebuffer {
+    fn handle(&self) -> ash::vk::Framebuffer {
         self.handle
     }
 }

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -168,7 +168,7 @@ impl RenderPass {
     unsafe fn get_granularity(device: &Arc<Device>, handle: ash::vk::RenderPass) -> [u32; 2] {
         let fns = device.fns();
         let mut out = MaybeUninit::uninit();
-        (fns.v1_0.get_render_area_granularity)(device.internal_object(), handle, out.as_mut_ptr());
+        (fns.v1_0.get_render_area_granularity)(device.handle(), handle, out.as_mut_ptr());
 
         let out = out.assume_init();
         debug_assert_ne!(out.width, 0);
@@ -516,16 +516,16 @@ impl Drop for RenderPass {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_render_pass)(self.device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.destroy_render_pass)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for RenderPass {
-    type Object = ash::vk::RenderPass;
+    type Handle = ash::vk::RenderPass;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::RenderPass {
+    fn handle(&self) -> ash::vk::RenderPass {
         self.handle
     }
 }

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -367,7 +367,7 @@ impl Sampler {
             }
 
             Some(ash::vk::SamplerYcbcrConversionInfo {
-                conversion: sampler_ycbcr_conversion.internal_object(),
+                conversion: sampler_ycbcr_conversion.handle(),
                 ..Default::default()
             })
         } else {
@@ -410,7 +410,7 @@ impl Sampler {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_sampler)(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -722,16 +722,16 @@ impl Drop for Sampler {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_sampler)(self.device.internal_object(), self.handle, ptr::null());
+            (fns.v1_0.destroy_sampler)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for Sampler {
-    type Object = ash::vk::Sampler;
+    type Handle = ash::vk::Sampler;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Sampler {
+    fn handle(&self) -> ash::vk::Sampler {
         self.handle
     }
 }

--- a/vulkano/src/sampler/ycbcr.rs
+++ b/vulkano/src/sampler/ycbcr.rs
@@ -335,7 +335,7 @@ impl SamplerYcbcrConversion {
 
             let mut output = MaybeUninit::uninit();
             create_sampler_ycbcr_conversion(
-                device.internal_object(),
+                device.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -476,20 +476,16 @@ impl Drop for SamplerYcbcrConversion {
                     .destroy_sampler_ycbcr_conversion_khr
             };
 
-            destroy_sampler_ycbcr_conversion(
-                self.device.internal_object(),
-                self.handle,
-                ptr::null(),
-            );
+            destroy_sampler_ycbcr_conversion(self.device.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl VulkanObject for SamplerYcbcrConversion {
-    type Object = ash::vk::SamplerYcbcrConversion;
+    type Handle = ash::vk::SamplerYcbcrConversion;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::SamplerYcbcrConversion {
+    fn handle(&self) -> ash::vk::SamplerYcbcrConversion {
         self.handle
     }
 }

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -153,7 +153,7 @@ impl ShaderModule {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_shader_module)(
-                device.internal_object(),
+                device.handle(),
                 &infos,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -258,10 +258,10 @@ impl ShaderModule {
 }
 
 unsafe impl VulkanObject for ShaderModule {
-    type Object = ash::vk::ShaderModule;
+    type Handle = ash::vk::ShaderModule;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::ShaderModule {
+    fn handle(&self) -> ash::vk::ShaderModule {
         self.handle
     }
 }
@@ -271,11 +271,7 @@ impl Drop for ShaderModule {
     fn drop(&mut self) {
         unsafe {
             let fns = self.device.fns();
-            (fns.v1_0.destroy_shader_module)(
-                self.device.internal_object(),
-                self.handle,
-                ptr::null(),
-            );
+            (fns.v1_0.destroy_shader_module)(self.device.handle(), self.handle, ptr::null());
         }
     }
 }

--- a/vulkano/src/swapchain/display.rs
+++ b/vulkano/src/swapchain/display.rs
@@ -66,7 +66,7 @@ impl DisplayPlane {
                 let mut count = 0;
                 (fns.khr_display
                     .get_physical_device_display_plane_properties_khr)(
-                    physical_device.internal_object(),
+                    physical_device.handle(),
                     &mut count,
                     ptr::null_mut(),
                 )
@@ -77,7 +77,7 @@ impl DisplayPlane {
                 let result = (fns
                     .khr_display
                     .get_physical_device_display_plane_properties_khr)(
-                    physical_device.internal_object(),
+                    physical_device.handle(),
                     &mut count,
                     properties.as_mut_ptr(),
                 );
@@ -101,7 +101,7 @@ impl DisplayPlane {
                     loop {
                         let mut count = 0;
                         (fns.khr_display.get_display_plane_supported_displays_khr)(
-                            physical_device.internal_object(),
+                            physical_device.handle(),
                             index as u32,
                             &mut count,
                             ptr::null_mut(),
@@ -112,7 +112,7 @@ impl DisplayPlane {
 
                         let mut displays = Vec::with_capacity(count as usize);
                         let result = (fns.khr_display.get_display_plane_supported_displays_khr)(
-                            physical_device.internal_object(),
+                            physical_device.handle(),
                             index as u32,
                             &mut count,
                             displays.as_mut_ptr(),
@@ -167,13 +167,13 @@ impl DisplayPlane {
     #[inline]
     pub fn supports(&self, display: &Display) -> bool {
         // making sure that the physical device is the same
-        if self.physical_device().internal_object() != display.physical_device().internal_object() {
+        if self.physical_device().handle() != display.physical_device().handle() {
             return false;
         }
 
         self.supported_displays
             .iter()
-            .any(|&d| d == display.internal_object())
+            .any(|&d| d == display.handle())
     }
 }
 
@@ -197,7 +197,7 @@ impl Display {
             loop {
                 let mut count = 0;
                 (fns.khr_display.get_physical_device_display_properties_khr)(
-                    physical_device.internal_object(),
+                    physical_device.handle(),
                     &mut count,
                     ptr::null_mut(),
                 )
@@ -206,7 +206,7 @@ impl Display {
 
                 let mut properties = Vec::with_capacity(count as usize);
                 let result = (fns.khr_display.get_physical_device_display_properties_khr)(
-                    physical_device.internal_object(),
+                    physical_device.handle(),
                     &mut count,
                     properties.as_mut_ptr(),
                 );
@@ -302,7 +302,7 @@ impl Display {
             loop {
                 let mut count = 0;
                 (fns.khr_display.get_display_mode_properties_khr)(
-                    self.physical_device().internal_object(),
+                    self.physical_device().handle(),
                     self.properties.display,
                     &mut count,
                     ptr::null_mut(),
@@ -312,7 +312,7 @@ impl Display {
 
                 let mut properties = Vec::with_capacity(count as usize);
                 let result = (fns.khr_display.get_display_mode_properties_khr)(
-                    self.physical_device().internal_object(),
+                    self.physical_device().handle(),
                     self.properties.display,
                     &mut count,
                     properties.as_mut_ptr(),
@@ -353,10 +353,10 @@ impl Display {
 }
 
 unsafe impl VulkanObject for Display {
-    type Object = ash::vk::DisplayKHR;
+    type Handle = ash::vk::DisplayKHR;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::DisplayKHR {
+    fn handle(&self) -> ash::vk::DisplayKHR {
         self.properties.display
     }
 }
@@ -388,7 +388,7 @@ impl DisplayMode {
             };
 
             let mut output = mem::uninitialized();
-            (fns.v1_0.CreateDisplayModeKHR)(display.device.internal_object(),
+            (fns.v1_0.CreateDisplayModeKHR)(display.device.handle(),
                                                       display.display, &infos, ptr::null(),
                                                       &mut output).result().map_err(VulkanError::from)?;
             output
@@ -441,10 +441,10 @@ impl FmtDisplay for DisplayMode {
 }
 
 unsafe impl VulkanObject for DisplayMode {
-    type Object = ash::vk::DisplayModeKHR;
+    type Handle = ash::vk::DisplayModeKHR;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::DisplayModeKHR {
+    fn handle(&self) -> ash::vk::DisplayModeKHR {
         self.display_mode
     }
 }

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -125,7 +125,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.ext_headless_surface.create_headless_surface_ext)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -204,7 +204,7 @@ impl<W> Surface<W> {
 
         let create_info = ash::vk::DisplaySurfaceCreateInfoKHR {
             flags: ash::vk::DisplaySurfaceCreateFlagsKHR::empty(),
-            display_mode: display_mode.internal_object(),
+            display_mode: display_mode.handle(),
             plane_index: plane.index(),
             plane_stack_index: 0, // FIXME: plane.properties.currentStackIndex,
             transform: ash::vk::SurfaceTransformFlagsKHR::IDENTITY, // TODO: let user choose
@@ -222,7 +222,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.khr_display.create_display_plane_surface_khr)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -301,7 +301,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.khr_android_surface.create_android_surface_khr)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -388,7 +388,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.ext_directfb_surface.create_direct_fb_surface_ext)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -472,7 +472,7 @@ impl<W> Surface<W> {
             let mut output = MaybeUninit::uninit();
             (fns.fuchsia_imagepipe_surface
                 .create_image_pipe_surface_fuchsia)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -556,7 +556,7 @@ impl<W> Surface<W> {
             let mut output = MaybeUninit::uninit();
             (fns.ggp_stream_descriptor_surface
                 .create_stream_descriptor_surface_ggp)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -642,7 +642,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.mvk_ios_surface.create_ios_surface_mvk)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -727,7 +727,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.mvk_macos_surface.create_mac_os_surface_mvk)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -803,7 +803,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.ext_metal_surface.create_metal_surface_ext)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -892,7 +892,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.qnx_screen_surface.create_screen_surface_qnx)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -971,7 +971,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.nn_vi_surface.create_vi_surface_nn)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -1062,7 +1062,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.khr_wayland_surface.create_wayland_surface_khr)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -1151,7 +1151,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.khr_win32_surface.create_win32_surface_khr)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -1240,7 +1240,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.khr_xcb_surface.create_xcb_surface_khr)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -1329,7 +1329,7 @@ impl<W> Surface<W> {
             let fns = instance.fns();
             let mut output = MaybeUninit::uninit();
             (fns.khr_xlib_surface.create_xlib_surface_khr)(
-                instance.internal_object(),
+                instance.handle(),
                 &create_info,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -1392,19 +1392,15 @@ impl<W> Drop for Surface<W> {
     fn drop(&mut self) {
         unsafe {
             let fns = self.instance.fns();
-            (fns.khr_surface.destroy_surface_khr)(
-                self.instance.internal_object(),
-                self.handle,
-                ptr::null(),
-            );
+            (fns.khr_surface.destroy_surface_khr)(self.instance.handle(), self.handle, ptr::null());
         }
     }
 }
 
 unsafe impl<W> VulkanObject for Surface<W> {
-    type Object = ash::vk::SurfaceKHR;
+    type Handle = ash::vk::SurfaceKHR;
 
-    fn internal_object(&self) -> ash::vk::SurfaceKHR {
+    fn handle(&self) -> ash::vk::SurfaceKHR {
         self.handle
     }
 }

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -158,7 +158,7 @@ impl Fence {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_fence)(
-                device.internal_object(),
+                device.handle(),
                 &create_info_vk,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -197,7 +197,7 @@ impl Fence {
                 unsafe {
                     // Make sure the fence isn't signaled
                     let fns = device.fns();
-                    (fns.v1_0.reset_fences)(device.internal_object(), 1, &handle)
+                    (fns.v1_0.reset_fences)(device.handle(), 1, &handle)
                         .result()
                         .map_err(VulkanError::from)?;
                 }
@@ -270,7 +270,7 @@ impl Fence {
             // We must ask Vulkan for the state.
             let result = unsafe {
                 let fns = self.device.fns();
-                (fns.v1_0.get_fence_status)(self.device.internal_object(), self.handle)
+                (fns.v1_0.get_fence_status)(self.device.handle(), self.handle)
             };
 
             match result {
@@ -315,7 +315,7 @@ impl Fence {
             let result = unsafe {
                 let fns = self.device.fns();
                 (fns.v1_0.wait_for_fences)(
-                    self.device.internal_object(),
+                    self.device.handle(),
                     1,
                     &self.handle,
                     ash::vk::TRUE,
@@ -413,7 +413,7 @@ impl Fence {
             let result = {
                 let fns = device.fns();
                 (fns.v1_0.wait_for_fences)(
-                    device.internal_object(),
+                    device.handle(),
                     fences_vk.len() as u32,
                     fences_vk.as_ptr(),
                     ash::vk::TRUE, // TODO: let the user choose false here?
@@ -471,7 +471,7 @@ impl Fence {
 
     unsafe fn reset_unchecked_locked(&self, state: &mut FenceState) -> Result<(), VulkanError> {
         let fns = self.device.fns();
-        (fns.v1_0.reset_fences)(self.device.internal_object(), 1, &self.handle)
+        (fns.v1_0.reset_fences)(self.device.handle(), 1, &self.handle)
             .result()
             .map_err(VulkanError::from)?;
 
@@ -550,13 +550,9 @@ impl Fence {
         let fences_vk: SmallVec<[_; 8]> = fences.iter().map(|fence| fence.handle).collect();
 
         let fns = device.fns();
-        (fns.v1_0.reset_fences)(
-            device.internal_object(),
-            fences_vk.len() as u32,
-            fences_vk.as_ptr(),
-        )
-        .result()
-        .map_err(VulkanError::from)?;
+        (fns.v1_0.reset_fences)(device.handle(), fences_vk.len() as u32, fences_vk.as_ptr())
+            .result()
+            .map_err(VulkanError::from)?;
 
         for state in states {
             state.reset();
@@ -675,7 +671,7 @@ impl Fence {
         let mut output = MaybeUninit::uninit();
         let fns = self.device.fns();
         (fns.khr_external_fence_fd.get_fence_fd_khr)(
-            self.device.internal_object(),
+            self.device.handle(),
             &info_vk,
             output.as_mut_ptr(),
         )
@@ -805,7 +801,7 @@ impl Fence {
         let mut output = MaybeUninit::uninit();
         let fns = self.device.fns();
         (fns.khr_external_fence_win32.get_fence_win32_handle_khr)(
-            self.device.internal_object(),
+            self.device.handle(),
             &info_vk,
             output.as_mut_ptr(),
         )
@@ -927,7 +923,7 @@ impl Fence {
         };
 
         let fns = self.device.fns();
-        (fns.khr_external_fence_fd.import_fence_fd_khr)(self.device.internal_object(), &info_vk)
+        (fns.khr_external_fence_fd.import_fence_fd_khr)(self.device.handle(), &info_vk)
             .result()
             .map_err(VulkanError::from)?;
 
@@ -1046,7 +1042,7 @@ impl Fence {
 
         let fns = self.device.fns();
         (fns.khr_external_fence_win32.import_fence_win32_handle_khr)(
-            self.device.internal_object(),
+            self.device.handle(),
             &info_vk,
         )
         .result()
@@ -1071,17 +1067,17 @@ impl Drop for Fence {
                 self.device.fence_pool().lock().push(raw_fence);
             } else {
                 let fns = self.device.fns();
-                (fns.v1_0.destroy_fence)(self.device.internal_object(), self.handle, ptr::null());
+                (fns.v1_0.destroy_fence)(self.device.handle(), self.handle, ptr::null());
             }
         }
     }
 }
 
 unsafe impl VulkanObject for Fence {
-    type Object = ash::vk::Fence;
+    type Handle = ash::vk::Fence;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Fence {
+    fn handle(&self) -> ash::vk::Fence {
         self.handle
     }
 }
@@ -1778,12 +1774,12 @@ mod tests {
         let fence1_internal_obj = {
             let fence = Fence::from_pool(device.clone()).unwrap();
             assert_eq!(device.fence_pool().lock().len(), 0);
-            fence.internal_object()
+            fence.handle()
         };
 
         assert_eq!(device.fence_pool().lock().len(), 1);
         let fence2 = Fence::from_pool(device.clone()).unwrap();
         assert_eq!(device.fence_pool().lock().len(), 0);
-        assert_eq!(fence2.internal_object(), fence1_internal_obj);
+        assert_eq!(fence2.handle(), fence1_internal_obj);
     }
 }

--- a/vulkano/src/sync/future/join.rs
+++ b/vulkano/src/sync/future/join.rs
@@ -24,10 +24,7 @@ where
     F: GpuFuture,
     S: GpuFuture,
 {
-    assert_eq!(
-        first.device().internal_object(),
-        second.device().internal_object()
-    );
+    assert_eq!(first.device().handle(), second.device().handle());
 
     if !first.queue_change_allowed() && !second.queue_change_allowed() {
         assert!(first.queue().unwrap() == second.queue().unwrap());
@@ -50,10 +47,7 @@ where
 {
     fn device(&self) -> &Arc<Device> {
         let device = self.first.device();
-        debug_assert_eq!(
-            self.second.device().internal_object(),
-            device.internal_object()
-        );
+        debug_assert_eq!(self.second.device().handle(), device.handle());
         device
     }
 }

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -135,7 +135,7 @@ impl Semaphore {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_semaphore)(
-                device.internal_object(),
+                device.handle(),
                 &create_info_vk,
                 ptr::null(),
                 output.as_mut_ptr(),
@@ -330,7 +330,7 @@ impl Semaphore {
         let mut output = MaybeUninit::uninit();
         let fns = self.device.fns();
         (fns.khr_external_semaphore_fd.get_semaphore_fd_khr)(
-            self.device.internal_object(),
+            self.device.handle(),
             &info,
             output.as_mut_ptr(),
         )
@@ -474,9 +474,7 @@ impl Semaphore {
         let fns = self.device.fns();
         (fns.khr_external_semaphore_win32
             .get_semaphore_win32_handle_khr)(
-            self.device.internal_object(),
-            &info_vk,
-            output.as_mut_ptr(),
+            self.device.handle(), &info_vk, output.as_mut_ptr()
         )
         .result()
         .map_err(VulkanError::from)?;
@@ -597,9 +595,7 @@ impl Semaphore {
         let fns = self.device.fns();
         (fns.fuchsia_external_semaphore
             .get_semaphore_zircon_handle_fuchsia)(
-            self.device.internal_object(),
-            &info,
-            output.as_mut_ptr(),
+            self.device.handle(), &info, output.as_mut_ptr()
         )
         .result()
         .map_err(VulkanError::from)?;
@@ -721,12 +717,9 @@ impl Semaphore {
         };
 
         let fns = self.device.fns();
-        (fns.khr_external_semaphore_fd.import_semaphore_fd_khr)(
-            self.device.internal_object(),
-            &info_vk,
-        )
-        .result()
-        .map_err(VulkanError::from)?;
+        (fns.khr_external_semaphore_fd.import_semaphore_fd_khr)(self.device.handle(), &info_vk)
+            .result()
+            .map_err(VulkanError::from)?;
 
         state.import(handle_type, flags.temporary);
 
@@ -850,7 +843,7 @@ impl Semaphore {
 
         let fns = self.device.fns();
         (fns.khr_external_semaphore_win32
-            .import_semaphore_win32_handle_khr)(self.device.internal_object(), &info_vk)
+            .import_semaphore_win32_handle_khr)(self.device.handle(), &info_vk)
         .result()
         .map_err(VulkanError::from)?;
 
@@ -967,9 +960,7 @@ impl Semaphore {
 
         let fns = self.device.fns();
         (fns.fuchsia_external_semaphore
-            .import_semaphore_zircon_handle_fuchsia)(
-            self.device.internal_object(), &info_vk
-        )
+            .import_semaphore_zircon_handle_fuchsia)(self.device.handle(), &info_vk)
         .result()
         .map_err(VulkanError::from)?;
 
@@ -992,21 +983,17 @@ impl Drop for Semaphore {
                 self.device.semaphore_pool().lock().push(raw_sem);
             } else {
                 let fns = self.device.fns();
-                (fns.v1_0.destroy_semaphore)(
-                    self.device.internal_object(),
-                    self.handle,
-                    ptr::null(),
-                );
+                (fns.v1_0.destroy_semaphore)(self.device.handle(), self.handle, ptr::null());
             }
         }
     }
 }
 
 unsafe impl VulkanObject for Semaphore {
-    type Object = ash::vk::Semaphore;
+    type Handle = ash::vk::Semaphore;
 
     #[inline]
-    fn internal_object(&self) -> ash::vk::Semaphore {
+    fn handle(&self) -> ash::vk::Semaphore {
         self.handle
     }
 }
@@ -1686,13 +1673,13 @@ mod tests {
         let sem1_internal_obj = {
             let sem = Semaphore::from_pool(device.clone()).unwrap();
             assert_eq!(device.semaphore_pool().lock().len(), 0);
-            sem.internal_object()
+            sem.handle()
         };
 
         assert_eq!(device.semaphore_pool().lock().len(), 1);
         let sem2 = Semaphore::from_pool(device.clone()).unwrap();
         assert_eq!(device.semaphore_pool().lock().len(), 0);
-        assert_eq!(sem2.internal_object(), sem1_internal_obj);
+        assert_eq!(sem2.handle(), sem1_internal_obj);
     }
 
     #[test]


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to the `VulkanObject` trait:
- The method `internal_object` is renamed to `handle`, and the associated type `Object` is renamed to `Handle`.
````

This is something I've been wanting to do for a while. In Vulkan terminology these are "handles" and we already use that terminology elsewhere: the private variables holding them are called `handle` and we have `from_handle` constructors now too.