### PR TITLE
Minor tweaks to `DeviceMemory`

### DIFF
--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -70,6 +70,7 @@ impl DeviceMemory {
     /// - Panics if `allocate_info.allocation_size` is 0.
     /// - Panics if `allocate_info.dedicated_allocation` is `Some` and the contained buffer or
     ///   image does not belong to `device`.
+    #[inline]
     pub fn allocate(
         device: Arc<Device>,
         mut allocate_info: MemoryAllocateInfo<'_>,
@@ -121,6 +122,7 @@ impl DeviceMemory {
     /// - Panics if `allocate_info.allocation_size` is 0.
     /// - Panics if `allocate_info.dedicated_allocation` is `Some` and the contained buffer or
     ///   image does not belong to `device`.
+    #[inline]
     pub unsafe fn import(
         device: Arc<Device>,
         mut allocate_info: MemoryAllocateInfo<'_>,

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -131,7 +131,7 @@ impl DeviceMemory {
         Self::allocate_unchecked(device, allocate_info, Some(import_info)).map_err(Into::into)
     }
 
-    #[cold]
+    #[inline(never)]
     fn validate(
         device: &Device,
         allocate_info: &mut MemoryAllocateInfo<'_>,
@@ -395,7 +395,7 @@ impl DeviceMemory {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    #[cold]
+    #[inline(never)]
     pub unsafe fn allocate_unchecked(
         device: Arc<Device>,
         allocate_info: MemoryAllocateInfo<'_>,

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -146,7 +146,7 @@ impl From<ash::vk::PhysicalDeviceMemoryProperties> for MemoryProperties {
 }
 
 /// A memory type in a physical device.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub struct MemoryType {
     /// The properties of this memory type.
@@ -255,7 +255,7 @@ vulkan_bitflags! {
 }
 
 /// A memory heap in a physical device.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub struct MemoryHeap {
     /// The size of the heap in bytes.
@@ -283,7 +283,7 @@ vulkan_bitflags! {
 
 /// Represents requirements expressed by the Vulkan implementation when it comes to binding memory
 /// to a resource.
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct MemoryRequirements {
     /// Number of bytes of memory required.
     pub size: DeviceSize,
@@ -326,7 +326,7 @@ impl From<ash::vk::MemoryRequirements> for MemoryRequirements {
 ///
 /// If a dedicated allocation is performed, it must not be bound to any resource other than the
 /// one that was passed with the enumeration.
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub enum DedicatedAllocation<'a> {
     /// Allocation dedicated to a buffer.
     Buffer(&'a UnsafeBuffer),
@@ -336,7 +336,7 @@ pub enum DedicatedAllocation<'a> {
 
 /// The properties for exporting or importing external memory, when a buffer or image is created
 /// with a specific configuration.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 #[non_exhaustive]
 pub struct ExternalMemoryProperties {
     /// Whether a dedicated memory allocation is required for the queried external handle type.

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -146,7 +146,7 @@ impl From<ash::vk::PhysicalDeviceMemoryProperties> for MemoryProperties {
 }
 
 /// A memory type in a physical device.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct MemoryType {
     /// The properties of this memory type.
@@ -255,7 +255,7 @@ vulkan_bitflags! {
 }
 
 /// A memory heap in a physical device.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct MemoryHeap {
     /// The size of the heap in bytes.
@@ -336,7 +336,7 @@ pub enum DedicatedAllocation<'a> {
 
 /// The properties for exporting or importing external memory, when a buffer or image is created
 /// with a specific configuration.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct ExternalMemoryProperties {
     /// Whether a dedicated memory allocation is required for the queried external handle type.


### PR DESCRIPTION
Renamed `DeviceMemory::create` to `DeviceMemory::allocate_unchecked` and made it public. It also now returns `Result<DeviceMemory, VulkanError>`, so it's a bit more in-line to the new way of doing things. I also added `Copy` to some memory-related structs. This is useful for me to use in #1997.