### PR TITLE
Move resource locking to `submit` function

### DIFF
--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -17,7 +17,8 @@ use std::{rc::Rc, sync::Arc};
 use vulkano::{
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        PrimaryAutoCommandBuffer, RenderPassBeginInfo, SecondaryCommandBuffer, SubpassContents,
+        PrimaryAutoCommandBuffer, RenderPassBeginInfo, SecondaryCommandBufferAbstract,
+        SubpassContents,
     },
     descriptor_set::allocator::StandardDescriptorSetAllocator,
     device::Queue,
@@ -471,7 +472,7 @@ impl<'f, 's: 'f> DrawPass<'f, 's> {
     #[inline]
     pub fn execute<C>(&mut self, command_buffer: C)
     where
-        C: SecondaryCommandBuffer + 'static,
+        C: SecondaryCommandBufferAbstract + 'static,
     {
         self.frame
             .command_buffer_builder

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -14,7 +14,7 @@ use vulkano::{
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, BlitImageInfo,
         BufferImageCopy, ClearColorImageInfo, CommandBufferUsage, CopyBufferToImageInfo,
-        CopyImageInfo, ImageBlit, ImageCopy, PrimaryCommandBuffer, RenderPassBeginInfo,
+        CopyImageInfo, ImageBlit, ImageCopy, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
         SubpassContents,
     },
     descriptor_set::{

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -13,7 +13,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
+        PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -22,7 +22,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
+        PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -14,7 +14,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        PrimaryCommandBuffer,
+        PrimaryCommandBufferAbstract,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -70,7 +70,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyImageToBufferInfo, PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
+        CopyImageToBufferInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -13,7 +13,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
+        PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::WriteDescriptorSet,
     device::{

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -13,7 +13,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
+        PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator,

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -19,7 +19,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, DeviceLocalBuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyBufferInfo, PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
+        CopyBufferInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -13,7 +13,7 @@ use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        PrimaryCommandBuffer, RenderPassBeginInfo, SubpassContents,
+        PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,

--- a/vulkano/src/buffer/cpu_pool.rs
+++ b/vulkano/src/buffer/cpu_pool.rs
@@ -63,7 +63,7 @@ use std::{
 /// use vulkano::buffer::CpuBufferPool;
 /// use vulkano::command_buffer::AutoCommandBufferBuilder;
 /// use vulkano::command_buffer::CommandBufferUsage;
-/// use vulkano::command_buffer::PrimaryCommandBuffer;
+/// use vulkano::command_buffer::PrimaryCommandBufferAbstract;
 /// use vulkano::sync::GpuFuture;
 /// # let device: std::sync::Arc<vulkano::device::Device> = return;
 /// # let queue: std::sync::Arc<vulkano::device::Queue> = return;

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -75,7 +75,7 @@ use std::{
 ///
 /// ```
 /// use vulkano::buffer::{BufferUsage, CpuAccessibleBuffer, DeviceLocalBuffer};
-/// use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage, CopyBufferInfo, PrimaryCommandBuffer};
+/// use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage, CopyBufferInfo, PrimaryCommandBufferAbstract};
 /// use vulkano::sync::GpuFuture;
 /// # let device: std::sync::Arc<vulkano::device::Device> = return;
 /// # let queue: std::sync::Arc<vulkano::device::Queue> = return;
@@ -588,7 +588,8 @@ mod tests {
     use super::*;
     use crate::{
         command_buffer::{
-            allocator::StandardCommandBufferAllocator, CommandBufferUsage, PrimaryCommandBuffer,
+            allocator::StandardCommandBufferAllocator, CommandBufferUsage,
+            PrimaryCommandBufferAbstract,
         },
         sync::GpuFuture,
     };

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -738,10 +738,7 @@ impl BufferState {
         }
     }
 
-    pub(crate) fn check_cpu_write(
-        &mut self,
-        range: Range<DeviceSize>,
-    ) -> Result<(), WriteLockError> {
+    pub(crate) fn check_cpu_write(&self, range: Range<DeviceSize>) -> Result<(), WriteLockError> {
         for (_range, state) in self.ranges.range(&range) {
             match &state.current_access {
                 CurrentAccess::CpuExclusive => return Err(WriteLockError::CpuLocked),
@@ -786,7 +783,7 @@ impl BufferState {
         }
     }
 
-    pub(crate) fn check_gpu_read(&mut self, range: Range<DeviceSize>) -> Result<(), AccessError> {
+    pub(crate) fn check_gpu_read(&self, range: Range<DeviceSize>) -> Result<(), AccessError> {
         for (_range, state) in self.ranges.range(&range) {
             match &state.current_access {
                 CurrentAccess::Shared { .. } => (),
@@ -823,7 +820,7 @@ impl BufferState {
         }
     }
 
-    pub(crate) fn check_gpu_write(&mut self, range: Range<DeviceSize>) -> Result<(), AccessError> {
+    pub(crate) fn check_gpu_write(&self, range: Range<DeviceSize>) -> Result<(), AccessError> {
         for (_range, state) in self.ranges.range(&range) {
             match &state.current_access {
                 CurrentAccess::Shared {

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -12,11 +12,12 @@ use super::{
         CommandBufferAlloc, CommandBufferAllocator, CommandBufferBuilderAlloc,
         StandardCommandBufferAlloc, StandardCommandBufferAllocator,
     },
-    synced::{CommandBufferState, SyncCommandBuffer, SyncCommandBufferBuilder},
-    sys::{CommandBufferBeginInfo, UnsafeCommandBuffer},
+    synced::{CommandBufferBuilderState, SyncCommandBuffer, SyncCommandBufferBuilder},
+    sys::CommandBufferBeginInfo,
     CommandBufferExecError, CommandBufferInheritanceInfo, CommandBufferInheritanceRenderPassInfo,
-    CommandBufferInheritanceRenderPassType, CommandBufferLevel, CommandBufferUsage,
-    PrimaryCommandBuffer, RenderingAttachmentInfo, SecondaryCommandBuffer, SubpassContents,
+    CommandBufferInheritanceRenderPassType, CommandBufferLevel, CommandBufferResourcesUsage,
+    CommandBufferState, CommandBufferUsage, PrimaryCommandBufferAbstract, RenderingAttachmentInfo,
+    SecondaryCommandBufferAbstract, SubpassContents,
 };
 use crate::{
     buffer::{sys::UnsafeBuffer, BufferAccess},
@@ -26,10 +27,11 @@ use crate::{
     image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
     query::{QueryControlFlags, QueryType},
     render_pass::{Framebuffer, Subpass},
-    sync::{AccessCheckError, AccessFlags, GpuFuture, PipelineMemoryAccess, PipelineStages},
-    DeviceSize, OomError, RequirementNotMet, RequiresOneOf,
+    sync::{AccessCheckError, AccessFlags, PipelineMemoryAccess, PipelineStages},
+    DeviceSize, OomError, RequirementNotMet, RequiresOneOf, VulkanObject,
 };
 use ahash::HashMap;
+use parking_lot::{Mutex, MutexGuard};
 use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
@@ -615,20 +617,12 @@ where
             return Err(BuildError::QueryActive);
         }
 
-        let submit_state = match self.usage {
-            CommandBufferUsage::MultipleSubmit => SubmitState::ExclusiveUse {
-                in_use: AtomicBool::new(false),
-            },
-            CommandBufferUsage::SimultaneousUse => SubmitState::Concurrent,
-            CommandBufferUsage::OneTimeSubmit => SubmitState::OneTime {
-                already_submitted: AtomicBool::new(false),
-            },
-        };
-
         Ok(PrimaryAutoCommandBuffer {
             inner: self.inner.build()?,
             _alloc: self.builder_alloc.into_alloc(),
-            submit_state,
+            usage: self.usage,
+
+            state: Mutex::new(Default::default()),
         })
     }
 }
@@ -656,6 +650,7 @@ where
         Ok(SecondaryAutoCommandBuffer {
             inner: self.inner.build()?,
             _alloc: self.builder_alloc.into_alloc(),
+            usage: self.usage,
             inheritance_info: self.inheritance_info.unwrap(),
             submit_state,
         })
@@ -710,7 +705,7 @@ where
     }
 
     /// Returns the binding/setting state.
-    pub fn state(&self) -> CommandBufferState<'_> {
+    pub fn state(&self) -> CommandBufferBuilderState<'_> {
         self.inner.state()
     }
 }
@@ -727,85 +722,31 @@ where
 pub struct PrimaryAutoCommandBuffer<A = StandardCommandBufferAlloc> {
     inner: SyncCommandBuffer,
     _alloc: A, // Safety: must be dropped after `inner`
+    usage: CommandBufferUsage,
 
-    // Tracks usage of the command buffer on the GPU.
-    submit_state: SubmitState,
+    state: Mutex<CommandBufferState>,
 }
 
-unsafe impl<P> DeviceOwned for PrimaryAutoCommandBuffer<P> {
+unsafe impl<A> VulkanObject for PrimaryAutoCommandBuffer<A> {
+    type Handle = ash::vk::CommandBuffer;
+
+    fn handle(&self) -> Self::Handle {
+        self.inner.as_ref().handle()
+    }
+}
+
+unsafe impl<A> DeviceOwned for PrimaryAutoCommandBuffer<A> {
     fn device(&self) -> &Arc<Device> {
         self.inner.device()
     }
 }
 
-unsafe impl<A> PrimaryCommandBuffer for PrimaryAutoCommandBuffer<A>
+unsafe impl<A> PrimaryCommandBufferAbstract for PrimaryAutoCommandBuffer<A>
 where
     A: CommandBufferAlloc,
 {
-    fn inner(&self) -> &UnsafeCommandBuffer {
-        self.inner.as_ref()
-    }
-
-    fn lock_submit(
-        &self,
-        future: &dyn GpuFuture,
-        queue: &Queue,
-    ) -> Result<(), CommandBufferExecError> {
-        match self.submit_state {
-            SubmitState::OneTime {
-                ref already_submitted,
-            } => {
-                let was_already_submitted = already_submitted.swap(true, Ordering::SeqCst);
-                if was_already_submitted {
-                    return Err(CommandBufferExecError::OneTimeSubmitAlreadySubmitted);
-                }
-            }
-            SubmitState::ExclusiveUse { ref in_use } => {
-                let already_in_use = in_use.swap(true, Ordering::SeqCst);
-                if already_in_use {
-                    return Err(CommandBufferExecError::ExclusiveAlreadyInUse);
-                }
-            }
-            SubmitState::Concurrent => (),
-        };
-
-        let err = match self.inner.lock_submit(future, queue) {
-            Ok(()) => return Ok(()),
-            Err(err) => err,
-        };
-
-        // If `self.inner.lock_submit()` failed, we revert action.
-        match self.submit_state {
-            SubmitState::OneTime {
-                ref already_submitted,
-            } => {
-                already_submitted.store(false, Ordering::SeqCst);
-            }
-            SubmitState::ExclusiveUse { ref in_use } => {
-                in_use.store(false, Ordering::SeqCst);
-            }
-            SubmitState::Concurrent => (),
-        };
-
-        Err(err)
-    }
-
-    unsafe fn unlock(&self) {
-        // Because of panic safety, we unlock the inner command buffer first.
-        self.inner.unlock();
-
-        match self.submit_state {
-            SubmitState::OneTime {
-                ref already_submitted,
-            } => {
-                debug_assert!(already_submitted.load(Ordering::SeqCst));
-            }
-            SubmitState::ExclusiveUse { ref in_use } => {
-                let old_val = in_use.swap(false, Ordering::SeqCst);
-                debug_assert!(old_val);
-            }
-            SubmitState::Concurrent => (),
-        };
+    fn usage(&self) -> CommandBufferUsage {
+        self.usage
     }
 
     fn check_buffer_access(
@@ -830,15 +771,32 @@ where
         self.inner
             .check_image_access(image, range, exclusive, expected_layout, queue)
     }
+
+    fn state(&self) -> MutexGuard<'_, CommandBufferState> {
+        self.state.lock()
+    }
+
+    fn resources_usage(&self) -> &CommandBufferResourcesUsage {
+        self.inner.resources_usage()
+    }
 }
 
 pub struct SecondaryAutoCommandBuffer<A = StandardCommandBufferAlloc> {
     inner: SyncCommandBuffer,
     _alloc: A, // Safety: must be dropped after `inner`
+    usage: CommandBufferUsage,
     inheritance_info: CommandBufferInheritanceInfo,
 
     // Tracks usage of the command buffer on the GPU.
     submit_state: SubmitState,
+}
+
+unsafe impl<A> VulkanObject for SecondaryAutoCommandBuffer<A> {
+    type Handle = ash::vk::CommandBuffer;
+
+    fn handle(&self) -> Self::Handle {
+        self.inner.as_ref().handle()
+    }
 }
 
 unsafe impl<A> DeviceOwned for SecondaryAutoCommandBuffer<A> {
@@ -847,12 +805,16 @@ unsafe impl<A> DeviceOwned for SecondaryAutoCommandBuffer<A> {
     }
 }
 
-unsafe impl<A> SecondaryCommandBuffer for SecondaryAutoCommandBuffer<A>
+unsafe impl<A> SecondaryCommandBufferAbstract for SecondaryAutoCommandBuffer<A>
 where
     A: CommandBufferAlloc,
 {
-    fn inner(&self) -> &UnsafeCommandBuffer {
-        self.inner.as_ref()
+    fn usage(&self) -> CommandBufferUsage {
+        self.usage
+    }
+
+    fn inheritance_info(&self) -> &CommandBufferInheritanceInfo {
+        &self.inheritance_info
     }
 
     fn lock_record(&self) -> Result<(), CommandBufferExecError> {
@@ -890,10 +852,6 @@ where
             }
             SubmitState::Concurrent => (),
         };
-    }
-
-    fn inheritance_info(&self) -> &CommandBufferInheritanceInfo {
-        &self.inheritance_info
     }
 
     fn num_buffers(&self) -> usize {
@@ -960,6 +918,7 @@ mod tests {
             ExecuteCommandsError,
         },
         device::{DeviceCreateInfo, QueueCreateInfo},
+        sync::GpuFuture,
     };
 
     #[test]

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -65,23 +65,20 @@
 //! queue with a fresh new barrier prototype.
 
 pub use self::builder::{
-    CommandBufferState, SetOrPush, StencilOpStateDynamic, StencilStateDynamic,
+    CommandBufferBuilderState, SetOrPush, StencilOpStateDynamic, StencilStateDynamic,
     SyncCommandBufferBuilder, SyncCommandBufferBuilderBindDescriptorSets,
     SyncCommandBufferBuilderBindVertexBuffer, SyncCommandBufferBuilderError,
     SyncCommandBufferBuilderExecuteCommands,
 };
 use super::{
     sys::{UnsafeCommandBuffer, UnsafeCommandBufferBuilder},
-    CommandBufferExecError,
+    CommandBufferResourcesUsage,
 };
 use crate::{
     buffer::{sys::UnsafeBuffer, BufferAccess},
     device::{Device, DeviceOwned, Queue},
     image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
-    range_map::RangeMap,
-    sync::{
-        AccessCheckError, AccessError, AccessFlags, GpuFuture, PipelineMemoryAccess, PipelineStages,
-    },
+    sync::{AccessCheckError, AccessError, AccessFlags, PipelineMemoryAccess, PipelineStages},
     DeviceSize,
 };
 use ahash::HashMap;
@@ -102,15 +99,16 @@ pub struct SyncCommandBuffer {
 
     // List of commands used by the command buffer. Used to hold the various resources that are
     // being used.
-    commands: Vec<Box<dyn Command>>,
+    _commands: Vec<Box<dyn Command>>,
 
     // Locations within commands that pipeline barriers were inserted. For debugging purposes.
     // TODO: present only in cfg(debug_assertions)?
     _barriers: Vec<usize>,
 
-    // State of all the resources used by this command buffer.
-    buffers2: HashMap<Arc<UnsafeBuffer>, RangeMap<DeviceSize, BufferFinalState>>,
-    images2: HashMap<Arc<UnsafeImage>, RangeMap<DeviceSize, ImageFinalState>>,
+    // Resources accessed by this command buffer.
+    resources_usage: CommandBufferResourcesUsage,
+    buffer_indices: HashMap<Arc<UnsafeBuffer>, usize>,
+    image_indices: HashMap<Arc<UnsafeImage>, usize>,
 
     // Resources and their accesses. Used for executing secondary command buffers in a primary.
     buffers: Vec<(
@@ -128,185 +126,9 @@ pub struct SyncCommandBuffer {
 }
 
 impl SyncCommandBuffer {
-    /// Tries to lock the resources used by the command buffer.
-    ///
-    /// > **Note**: You should call this in the implementation of the `CommandBuffer` trait.
     #[inline]
-    pub fn lock_submit(
-        &self,
-        future: &dyn GpuFuture,
-        queue: &Queue,
-    ) -> Result<(), CommandBufferExecError> {
-        /*
-            Acquire the state mutexes and check if the resources can be locked.
-        */
-
-        let buffer_state_mutexes = self
-            .buffers2
-            .iter()
-            .map(|(buffer, range_map)| {
-                let mut buffer_state = buffer.state();
-
-                for (range, state) in range_map.iter() {
-                    match future.check_buffer_access(buffer, range.clone(), state.exclusive, queue)
-                    {
-                        Err(AccessCheckError::Denied(err)) => {
-                            let resource_use = &state.resource_uses[0];
-
-                            return Err(CommandBufferExecError::AccessError {
-                                error: err,
-                                command_name: self.commands[resource_use.command_index]
-                                    .name()
-                                    .into(),
-                                command_param: resource_use.name.clone(),
-                                command_offset: resource_use.command_index,
-                            });
-                        }
-                        Err(AccessCheckError::Unknown) => {
-                            let result = if state.exclusive {
-                                buffer_state.check_gpu_write(range.clone())
-                            } else {
-                                buffer_state.check_gpu_read(range.clone())
-                            };
-
-                            if let Err(err) = result {
-                                let resource_use = &state.resource_uses[0];
-
-                                return Err(CommandBufferExecError::AccessError {
-                                    error: err,
-                                    command_name: self.commands[resource_use.command_index]
-                                        .name()
-                                        .into(),
-                                    command_param: resource_use.name.clone(),
-                                    command_offset: resource_use.command_index,
-                                });
-                            }
-                        }
-                        _ => (),
-                    }
-                }
-
-                Ok((buffer.as_ref(), buffer_state))
-            })
-            .collect::<Result<Vec<(_, _)>, _>>()?;
-
-        let image_state_mutexes = self
-            .images2
-            .iter()
-            .map(|(image, range_map)| {
-                let mut image_state = image.state();
-
-                for (range, state) in range_map.iter() {
-                    match future.check_image_access(
-                        image,
-                        range.clone(),
-                        state.exclusive,
-                        state.initial_layout,
-                        queue,
-                    ) {
-                        Err(AccessCheckError::Denied(err)) => {
-                            let resource_use = &state.resource_uses[0];
-
-                            return Err(CommandBufferExecError::AccessError {
-                                error: err,
-                                command_name: self.commands[resource_use.command_index]
-                                    .name()
-                                    .into(),
-                                command_param: resource_use.name.clone(),
-                                command_offset: resource_use.command_index,
-                            });
-                        }
-                        Err(AccessCheckError::Unknown) => {
-                            let result = if state.exclusive {
-                                image_state.check_gpu_write(range.clone(), state.initial_layout)
-                            } else {
-                                image_state.check_gpu_read(range.clone(), state.initial_layout)
-                            };
-
-                            if let Err(err) = result {
-                                let resource_use = &state.resource_uses[0];
-
-                                return Err(CommandBufferExecError::AccessError {
-                                    error: err,
-                                    command_name: self.commands[resource_use.command_index]
-                                        .name()
-                                        .into(),
-                                    command_param: resource_use.name.clone(),
-                                    command_offset: resource_use.command_index,
-                                });
-                            }
-                        }
-                        _ => (),
-                    };
-                }
-
-                Ok((image.as_ref(), image_state))
-            })
-            .collect::<Result<Vec<(_, _)>, _>>()?;
-
-        /*
-            We verified that the resources can be locked, so while still holding the mutexes,
-            lock them now.
-        */
-        unsafe {
-            for (buffer, mut buffer_state) in buffer_state_mutexes {
-                for (range, state) in self.buffers2[buffer].iter() {
-                    if state.exclusive {
-                        buffer_state.gpu_write_lock(range.clone());
-                    } else {
-                        buffer_state.gpu_read_lock(range.clone());
-                    }
-                }
-            }
-
-            for (image, mut image_state) in image_state_mutexes {
-                for (range, state) in self.images2[image].iter() {
-                    if state.exclusive {
-                        image_state.gpu_write_lock(range.clone(), state.final_layout);
-                    } else {
-                        image_state.gpu_read_lock(range.clone());
-                    }
-                }
-            }
-        }
-
-        // TODO: pipeline barriers if necessary?
-
-        Ok(())
-    }
-
-    /// Unlocks the resources used by the command buffer.
-    ///
-    /// > **Note**: You should call this in the implementation of the `CommandBuffer` trait.
-    ///
-    /// # Safety
-    ///
-    /// The command buffer must have been successfully locked with `lock_submit()`.
-    #[inline]
-    pub unsafe fn unlock(&self) {
-        for (buffer, range_map) in &self.buffers2 {
-            let mut buffer_state = buffer.state();
-
-            for (range, state) in range_map.iter() {
-                if state.exclusive {
-                    buffer_state.gpu_write_unlock(range.clone());
-                } else {
-                    buffer_state.gpu_read_unlock(range.clone());
-                }
-            }
-        }
-
-        for (image, range_map) in &self.images2 {
-            let mut image_state = image.state();
-
-            for (range, state) in range_map.iter() {
-                if state.exclusive {
-                    image_state.gpu_write_unlock(range.clone());
-                } else {
-                    image_state.gpu_read_unlock(range.clone());
-                }
-            }
-        }
+    pub(super) fn resources_usage(&self) -> &CommandBufferResourcesUsage {
+        &self.resources_usage
     }
 
     /// Checks whether this command buffer has access to a buffer.
@@ -320,22 +142,26 @@ impl SyncCommandBuffer {
         exclusive: bool,
         _queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        let range_map = match self.buffers2.get(buffer) {
-            Some(x) => x,
+        let usage = match self.buffer_indices.get(buffer) {
+            Some(&index) => &self.resources_usage.buffers[index],
             None => return Err(AccessCheckError::Unknown),
         };
 
         // TODO: check the queue family
 
-        range_map
+        usage
+            .ranges
             .range(&range)
             .try_fold(
                 (PipelineStages::empty(), AccessFlags::empty()),
-                |(stages, access), (_range, state)| {
-                    if !state.exclusive && exclusive {
+                |(stages, access), (_range, range_usage)| {
+                    if !range_usage.mutable && exclusive {
                         Err(AccessCheckError::Unknown)
                     } else {
-                        Ok((stages | state.final_stages, access | state.final_access))
+                        Ok((
+                            stages | range_usage.final_stages,
+                            access | range_usage.final_access,
+                        ))
                     }
                 },
             )
@@ -354,33 +180,37 @@ impl SyncCommandBuffer {
         expected_layout: ImageLayout,
         _queue: &Queue,
     ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        let range_map = match self.images2.get(image) {
-            Some(x) => x,
+        let usage = match self.image_indices.get(image) {
+            Some(&index) => &self.resources_usage.images[index],
             None => return Err(AccessCheckError::Unknown),
         };
 
         // TODO: check the queue family
 
-        range_map
+        usage
+            .ranges
             .range(&range)
             .try_fold(
                 (PipelineStages::empty(), AccessFlags::empty()),
-                |(stages, access), (_range, state)| {
+                |(stages, access), (_range, range_usage)| {
                     if expected_layout != ImageLayout::Undefined
-                        && state.final_layout != expected_layout
+                        && range_usage.final_layout != expected_layout
                     {
                         return Err(AccessCheckError::Denied(
                             AccessError::UnexpectedImageLayout {
-                                allowed: state.final_layout,
+                                allowed: range_usage.final_layout,
                                 requested: expected_layout,
                             },
                         ));
                     }
 
-                    if !state.exclusive && exclusive {
+                    if !range_usage.mutable && exclusive {
                         Err(AccessCheckError::Unknown)
                     } else {
-                        Ok((stages | state.final_stages, access | state.final_access))
+                        Ok((
+                            stages | range_usage.final_stages,
+                            access | range_usage.final_access,
+                        ))
                     }
                 },
             )
@@ -537,7 +367,7 @@ mod tests {
             },
             sys::CommandBufferBeginInfo,
             AutoCommandBufferBuilder, CommandBufferLevel, CommandBufferUsage, FillBufferInfo,
-            PrimaryCommandBuffer,
+            PrimaryCommandBufferAbstract,
         },
         descriptor_set::{
             allocator::StandardDescriptorSetAllocator,
@@ -550,6 +380,7 @@ mod tests {
         pipeline::{layout::PipelineLayoutCreateInfo, PipelineBindPoint, PipelineLayout},
         sampler::{Sampler, SamplerCreateInfo},
         shader::ShaderStages,
+        sync::GpuFuture,
     };
 
     #[test]
@@ -654,7 +485,7 @@ mod tests {
 
                 let primary = builder.build().unwrap();
                 let names = primary
-                    .commands
+                    ._commands
                     .iter()
                     .map(|c| c.name())
                     .collect::<Vec<_>>();

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -2206,7 +2206,7 @@ impl ImageState {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn check_cpu_read(&mut self, range: Range<DeviceSize>) -> Result<(), ReadLockError> {
+    pub(crate) fn check_cpu_read(&self, range: Range<DeviceSize>) -> Result<(), ReadLockError> {
         for (_range, state) in self.ranges.range(&range) {
             match &state.current_access {
                 CurrentAccess::CpuExclusive { .. } => return Err(ReadLockError::CpuWriteLocked),
@@ -2247,10 +2247,7 @@ impl ImageState {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn check_cpu_write(
-        &mut self,
-        range: Range<DeviceSize>,
-    ) -> Result<(), WriteLockError> {
+    pub(crate) fn check_cpu_write(&self, range: Range<DeviceSize>) -> Result<(), WriteLockError> {
         for (_range, state) in self.ranges.range(&range) {
             match &state.current_access {
                 CurrentAccess::CpuExclusive => return Err(WriteLockError::CpuLocked),
@@ -2298,7 +2295,7 @@ impl ImageState {
     }
 
     pub(crate) fn check_gpu_read(
-        &mut self,
+        &self,
         range: Range<DeviceSize>,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {
@@ -2346,7 +2343,7 @@ impl ImageState {
     }
 
     pub(crate) fn check_gpu_write(
-        &mut self,
+        &self,
         range: Range<DeviceSize>,
         expected_layout: ImageLayout,
     ) -> Result<(), AccessError> {

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -139,6 +139,19 @@ pub unsafe trait VulkanObject {
     fn handle(&self) -> Self::Handle;
 }
 
+unsafe impl<T, U> VulkanObject for T
+where
+    T: SafeDeref<Target = U>,
+    U: VulkanObject + ?Sized,
+{
+    type Handle = U::Handle;
+
+    #[inline]
+    fn handle(&self) -> Self::Handle {
+        (**self).handle()
+    }
+}
+
 /// Error type returned by most Vulkan functions.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum OomError {

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -439,7 +439,7 @@ pub struct SparseBufferMemoryBind {
     /// The offset in bytes from the start of the buffer's memory, where memory is to be (un)bound.
     ///
     /// The default value is `0`.
-    pub resource_offset: DeviceSize,
+    pub offset: DeviceSize,
 
     /// The size in bytes of the memory to be (un)bound.
     ///
@@ -464,7 +464,7 @@ pub struct SparseImageOpaqueMemoryBind {
     /// The offset in bytes from the start of the image's memory, where memory is to be (un)bound.
     ///
     /// The default value is `0`.
-    pub resource_offset: DeviceSize,
+    pub offset: DeviceSize,
 
     /// The size in bytes of the memory to be (un)bound.
     ///

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -270,8 +270,15 @@ where
                     assert!(fence.is_none());
 
                     queue
-                        .with(|mut q| q.submit_unchecked([submit_info], Some(new_fence.clone())))
-                        .map_err(|err| OutcomeErr::Full(err.into()))
+                        .with(|mut q| {
+                            q.submit_with_future(
+                                submit_info,
+                                Some(new_fence.clone()),
+                                &previous,
+                                &queue,
+                            )
+                        })
+                        .map_err(OutcomeErr::Full)
                 }
                 SubmitAnyBuilder::BindSparse(bind_infos, fence) => {
                     debug_assert!(!partially_flushed);

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -132,7 +132,9 @@ where
                         .signal_semaphores
                         .push(SemaphoreSubmitInfo::semaphore(self.semaphore.clone()));
 
-                    queue.with(|mut q| q.submit_unchecked([submit_info], fence))?;
+                    queue.with(|mut q| {
+                        q.submit_with_future(submit_info, fence, &self.previous, &queue)
+                    })?;
                 }
                 SubmitAnyBuilder::BindSparse(_, _) => {
                     unimplemented!() // TODO: how to do that?


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to command buffers:
- The `PrimaryCommandBuffer` and `SecondaryCommandBuffer` traits are renamed to `PrimaryCommandBufferAbstract` and `SecondaryCommandBufferAbstract`.
````

The resource locking code that was previously implemented in the `lock_submit` function of the `PrimaryCommandBuffer` trait, is now moved to the `Queue::submit` function. It's also implemented now as a mutex-guarded `CommandBufferState` type, similar to how state was already implemented for buffers, images, fences and semaphores.