### PR TITLE
Add checks for `khr_portability_subset`

### DIFF
--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -1007,8 +1007,8 @@ where
                 {
                     return Err(SetDynamicStateError::RequirementNotMet {
                         required_for:
-                            "the `khr_portability_subset` extension is enabled on the device, and \
-                            `topology` is `PrimitiveTopology::TriangleFan`",
+                            "this device is a portability subset device, and `topology` is \
+                            `PrimitiveTopology::TriangleFan`",
                         requires_one_of: RequiresOneOf {
                             features: &["triangle_fans"],
                             ..Default::default()

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -791,9 +791,8 @@ pub(crate) fn check_descriptor_write<'a>(
                         return Err(DescriptorSetUpdateError::RequirementNotMet {
                             binding: write.binding(),
                             index: descriptor_range_start + index as u32,
-                            required_for:
-                                "the `khr_portability_subset` extension is enabled on the device, \
-                                and `sampler.compare()` is `Some`",
+                            required_for: "this device is a portability subset device, and \
+                                `sampler.compare()` is `Some`",
                             requires_one_of: RequiresOneOf {
                                 features: &["mutable_comparison_samplers"],
                                 ..Default::default()

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -13,7 +13,7 @@ use crate::{
     device::DeviceOwned,
     image::{view::ImageViewType, ImageType, ImageViewAbstract},
     sampler::{Sampler, SamplerImageViewIncompatibleError},
-    DeviceSize, VulkanObject,
+    DeviceSize, RequiresOneOf, VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{
@@ -377,6 +377,8 @@ pub(crate) fn check_descriptor_write<'a>(
     layout: &'a DescriptorSetLayout,
     variable_descriptor_count: u32,
 ) -> Result<&'a DescriptorSetLayoutBinding, DescriptorSetUpdateError> {
+    let device = layout.device();
+
     let layout_binding = match layout.bindings().get(&write.binding()) {
         Some(binding) => binding,
         None => {
@@ -421,7 +423,7 @@ pub(crate) fn check_descriptor_write<'a>(
             match layout_binding.descriptor_type {
                 DescriptorType::StorageBuffer | DescriptorType::StorageBufferDynamic => {
                     for (index, buffer) in elements.iter().enumerate() {
-                        assert_eq!(buffer.device().handle(), layout.device().handle(),);
+                        assert_eq!(device, buffer.device());
 
                         if !buffer.inner().buffer.usage().storage_buffer {
                             return Err(DescriptorSetUpdateError::MissingUsage {
@@ -434,7 +436,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 }
                 DescriptorType::UniformBuffer | DescriptorType::UniformBufferDynamic => {
                     for (index, buffer) in elements.iter().enumerate() {
-                        assert_eq!(buffer.device().handle(), layout.device().handle(),);
+                        assert_eq!(device, buffer.device());
 
                         if !buffer.inner().buffer.usage().uniform_buffer {
                             return Err(DescriptorSetUpdateError::MissingUsage {
@@ -461,13 +463,13 @@ pub(crate) fn check_descriptor_write<'a>(
             // TODO: eventually shouldn't be an assert ; for now robust_buffer_access is always
             //       enabled so this assert should never fail in practice, but we put it anyway
             //       in case we forget to adjust this code
-            assert!(layout.device().enabled_features().robust_buffer_access);
+            assert!(device.enabled_features().robust_buffer_access);
         }
         WriteDescriptorSetElements::BufferView(elements) => {
             match layout_binding.descriptor_type {
                 DescriptorType::StorageTexelBuffer => {
                     for (index, buffer_view) in elements.iter().enumerate() {
-                        assert_eq!(buffer_view.device().handle(), layout.device().handle(),);
+                        assert_eq!(device, buffer_view.device());
 
                         // TODO: storage_texel_buffer_atomic
                         if !buffer_view
@@ -487,7 +489,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 }
                 DescriptorType::UniformTexelBuffer => {
                     for (index, buffer_view) in elements.iter().enumerate() {
-                        assert_eq!(buffer_view.device().handle(), layout.device().handle(),);
+                        assert_eq!(device, buffer_view.device());
 
                         if !buffer_view
                             .buffer()
@@ -521,7 +523,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 for (index, (image_view, sampler)) in
                     elements.iter().zip(immutable_samplers).enumerate()
                 {
-                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
+                    assert_eq!(device, image_view.device());
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00337
                     if !image_view.usage().sampled {
@@ -566,7 +568,7 @@ pub(crate) fn check_descriptor_write<'a>(
             }
             DescriptorType::SampledImage => {
                 for (index, image_view) in elements.iter().enumerate() {
-                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
+                    assert_eq!(device, image_view.device());
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00337
                     if !image_view.usage().sampled {
@@ -613,7 +615,7 @@ pub(crate) fn check_descriptor_write<'a>(
             }
             DescriptorType::StorageImage => {
                 for (index, image_view) in elements.iter().enumerate() {
-                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
+                    assert_eq!(device, image_view.device());
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00339
                     if !image_view.usage().storage {
@@ -668,7 +670,7 @@ pub(crate) fn check_descriptor_write<'a>(
             }
             DescriptorType::InputAttachment => {
                 for (index, image_view) in elements.iter().enumerate() {
-                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
+                    assert_eq!(device, image_view.device());
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00338
                     if !image_view.usage().input_attachment {
@@ -746,8 +748,8 @@ pub(crate) fn check_descriptor_write<'a>(
                 }
 
                 for (index, (image_view, sampler)) in elements.iter().enumerate() {
-                    assert_eq!(image_view.device().handle(), layout.device().handle(),);
-                    assert_eq!(sampler.device().handle(), layout.device().handle(),);
+                    assert_eq!(device, image_view.device());
+                    assert_eq!(device, sampler.device());
 
                     // VUID-VkWriteDescriptorSet-descriptorType-00337
                     if !image_view.usage().sampled {
@@ -778,6 +780,24 @@ pub(crate) fn check_descriptor_write<'a>(
                         return Err(DescriptorSetUpdateError::ImageViewDepthAndStencil {
                             binding: write.binding(),
                             index: descriptor_range_start + index as u32,
+                        });
+                    }
+
+                    // VUID-VkDescriptorImageInfo-mutableComparisonSamplers-04450
+                    if device.enabled_extensions().khr_portability_subset
+                        && !device.enabled_features().mutable_comparison_samplers
+                        && sampler.compare().is_some()
+                    {
+                        return Err(DescriptorSetUpdateError::RequirementNotMet {
+                            binding: write.binding(),
+                            index: descriptor_range_start + index as u32,
+                            required_for:
+                                "the `khr_portability_subset` extension is enabled on the device, \
+                                and `sampler.compare()` is `Some`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["mutable_comparison_samplers"],
+                                ..Default::default()
+                            },
                         });
                     }
 
@@ -821,7 +841,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 }
 
                 for (index, sampler) in elements.iter().enumerate() {
-                    assert_eq!(sampler.device().handle(), layout.device().handle(),);
+                    assert_eq!(device, sampler.device());
 
                     if sampler.sampler_ycbcr_conversion().is_some() {
                         return Err(DescriptorSetUpdateError::SamplerHasSamplerYcbcrConversion {
@@ -844,6 +864,13 @@ pub(crate) fn check_descriptor_write<'a>(
 
 #[derive(Clone, Copy, Debug)]
 pub enum DescriptorSetUpdateError {
+    RequirementNotMet {
+        binding: u32,
+        index: u32,
+        required_for: &'static str,
+        requires_one_of: RequiresOneOf,
+    },
+
     /// Tried to write more elements than were available in a binding.
     ArrayIndexOutOfBounds {
         /// Binding that is affected.
@@ -913,6 +940,17 @@ impl Error for DescriptorSetUpdateError {
 impl Display for DescriptorSetUpdateError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         match self {
+            Self::RequirementNotMet {
+                binding,
+                index,
+                required_for,
+                requires_one_of,
+            } => write!(
+                f,
+                "a requirement on binding {} index {} was not met for: {}; requires one of: {}",
+                binding, index, required_for, requires_one_of,
+            ),
+
             Self::ArrayIndexOutOfBounds {
                 binding,
                 available_count,

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -777,6 +777,12 @@ impl From<FeatureRestrictionError> for DeviceCreationError {
 pub struct DeviceCreateInfo {
     /// The extensions to enable on the device.
     ///
+    /// If the [`khr_portability_subset`](DeviceExtensions::khr_portability_subset) extension is
+    /// available, it will be enabled automatically, so you do not have to do this yourself.
+    /// You are responsible for ensuring that your program can work correctly on such devices.
+    /// See [the documentation of the `instance` module](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// for more information.
+    ///
     /// The default value is [`DeviceExtensions::empty()`].
     pub enabled_extensions: DeviceExtensions,
 

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -294,9 +294,9 @@ impl UnsafeImage {
             {
                 return Err(ImageCreationError::RequirementNotMet {
                     required_for:
-                        "the `khr_portability_subset` extension is enabled on the device, \
-                        `create_info.samples` is not `SampleCount::Sample1` and \
-                        `create_info.dimensions.array_layers()` is greater than `1`",
+                        "this device is a portability subset device, `create_info.samples` is not \
+                        `SampleCount::Sample1` and `create_info.dimensions.array_layers()` is \
+                        greater than `1`",
                     requires_one_of: RequiresOneOf {
                         features: &["multisample_array_image"],
                         ..Default::default()
@@ -515,8 +515,8 @@ impl UnsafeImage {
             {
                 return Err(ImageCreationError::RequirementNotMet {
                     required_for:
-                        "the `khr_portability_subset` extension is enabled on the device, and the \
-                        `array_2d_compatible` flag is enabled",
+                        "this device is a portability subset device, and the `array_2d_compatible`
+                        flag is enabled",
                     requires_one_of: RequiresOneOf {
                         features: &["image_view2_d_on3_d_image"],
                         ..Default::default()
@@ -1777,6 +1777,11 @@ impl Hash for UnsafeImage {
 pub struct UnsafeImageCreateInfo {
     /// The type, extent and number of array layers to create the image with.
     ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if `samples` is not [`SampleCount::Sample1`] and `dimensions.array_layers()` is
+    /// not 1, the [`multisample_array_image`](crate::device::Features::multisample_array_image)
+    /// feature must be enabled on the device.
+    ///
     /// The default value is `ImageDimensions::Dim2d { width: 0, height: 0, array_layers: 1 }`,
     /// which must be overridden.
     pub dimensions: ImageDimensions,
@@ -1792,6 +1797,11 @@ pub struct UnsafeImageCreateInfo {
     pub mip_levels: u32,
 
     /// The number of samples per texel that the image should use.
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if `samples` is not [`SampleCount::Sample1`] and `dimensions.array_layers()` is
+    /// not 1, the [`multisample_array_image`](crate::device::Features::multisample_array_image)
+    /// feature must be enabled on the device.
     ///
     /// The default value is [`SampleCount::Sample1`].
     pub samples: SampleCount,
@@ -1860,6 +1870,10 @@ pub struct UnsafeImageCreateInfo {
     /// [`ImageViewType::Dim2d`](crate::image::view::ImageViewType::Dim2d) or
     /// [`ImageViewType::Dim2dArray`](crate::image::view::ImageViewType::Dim2dArray) can be created
     /// from the image.
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, the [`image_view2_d_on3_d_image`](crate::device::Features::image_view2_d_on3_d_image)
+    /// feature must be enabled on the device.
     ///
     /// The default value is `false`.
     pub array_2d_compatible: bool,

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -286,6 +286,23 @@ impl UnsafeImage {
             if tiling == ImageTiling::Linear {
                 return Err(ImageCreationError::MultisampleLinearTiling);
             }
+
+            // VUID-VkImageCreateInfo-multisampleArrayImage-04460
+            if device.enabled_extensions().khr_portability_subset
+                && !device.enabled_features().multisample_array_image
+                && array_layers != 1
+            {
+                return Err(ImageCreationError::RequirementNotMet {
+                    required_for:
+                        "the `khr_portability_subset` extension is enabled on the device, \
+                        `create_info.samples` is not `SampleCount::Sample1` and \
+                        `create_info.dimensions.array_layers()` is greater than `1`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["multisample_array_image"],
+                        ..Default::default()
+                    },
+                });
+            }
         }
 
         // Check limits for YCbCr formats
@@ -490,6 +507,21 @@ impl UnsafeImage {
             // VUID-VkImageCreateInfo-flags-00950
             if image_type != ImageType::Dim3d {
                 return Err(ImageCreationError::Array2dCompatibleNot3d);
+            }
+
+            // VUID-VkImageCreateInfo-imageView2DOn3DImage-04459
+            if device.enabled_extensions().khr_portability_subset
+                && !device.enabled_features().image_view2_d_on3_d_image
+            {
+                return Err(ImageCreationError::RequirementNotMet {
+                    required_for:
+                        "the `khr_portability_subset` extension is enabled on the device, and the \
+                        `array_2d_compatible` flag is enabled",
+                    requires_one_of: RequiresOneOf {
+                        features: &["image_view2_d_on3_d_image"],
+                        ..Default::default()
+                    },
+                });
             }
         }
 

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -370,9 +370,9 @@ where
             {
                 return Err(ImageViewCreationError::RequirementNotMet {
                     required_for:
-                        "the `khr_portability_subset` extension is enabled on the device, \
-                        and the format of the image view does not have the same components and \
-                        number of bits per component as the parent image",
+                        "this device is a portability subset device, and the format of the image \
+                        view does not have the same components and number of bits per component as \
+                        the parent image",
                     requires_one_of: RequiresOneOf {
                         features: &["image_view_format_reinterpretation"],
                         ..Default::default()
@@ -452,8 +452,8 @@ where
             && !component_mapping.is_identity()
         {
             return Err(ImageViewCreationError::RequirementNotMet {
-                required_for: "the `khr_portability_subset` extension is enabled on the device, \
-                    and `create_info.component_mapping` is not the identity mapping",
+                required_for: "this device is a portability subset device, and \
+                    `create_info.component_mapping` is not the identity mapping",
                 requires_one_of: RequiresOneOf {
                     features: &["image_view_format_swizzle"],
                     ..Default::default()
@@ -823,10 +823,21 @@ pub struct ImageViewCreateInfo {
     /// If this is set to a format that is different from the image, the image must be created with
     /// the `mutable_format` flag.
     ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if `format` does not have the same number of components and bits per component as
+    /// the parent image's format, the
+    /// [`image_view_format_reinterpretation`](crate::device::Features::image_view_format_reinterpretation)
+    /// feature must be enabled on the device.
+    ///
     /// The default value is `None`, which must be overridden.
     pub format: Option<Format>,
 
     /// How to map components of each pixel.
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if `component_mapping` is not the identity mapping, the
+    /// [`image_view_format_swizzle`](crate::device::Features::image_view_format_swizzle)
+    /// feature must be enabled on the device.
     ///
     /// The default value is [`ComponentMapping::identity()`].
     pub component_mapping: ComponentMapping,

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -736,7 +736,8 @@ pub struct InstanceCreateInfo {
     /// supported instance version is 1.0, then it will be 1.0.
     pub max_api_version: Option<Version>,
 
-    /// Include portability subset devices when enumerating physical devices.
+    /// Include [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices when enumerating physical devices.
     ///
     /// If you enable this flag, you must ensure that your program is prepared to handle the
     /// non-conformant aspects of these devices.
@@ -748,9 +749,10 @@ pub struct InstanceCreateInfo {
     ///
     /// # Notes
     ///
-    /// If this flag is enabled, and the `khr_portability_enumeration` extension is supported, it
-    /// will be enabled automatically when creating the instance. If the extension is not supported,
-    /// this flag will be ignored.
+    /// If this flag is enabled, and the
+    /// [`khr_portability_enumeration`](crate::instance::InstanceExtensions::khr_portability_enumeration)
+    /// extension is supported, it will be enabled automatically when creating the instance.
+    /// If the extension is not supported, this flag will be ignored.
     pub enumerate_portability: bool,
 
     /// Features of the validation layer to enable.

--- a/vulkano/src/pipeline/graphics/builder.rs
+++ b/vulkano/src/pipeline/graphics/builder.rs
@@ -772,9 +772,9 @@ where
                             > binding_desc.stride as DeviceSize
                     {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
-                            required_for: "the `khr_portability_subset` extension is enabled on \
-                                the device, and `vertex_input_state.attributes` has an element \
-                                where `offset + format.block_size()` is greater than the stride of \
+                            required_for: "this device is a portability subset device, and \
+                                `vertex_input_state.attributes` has an element where \
+                                `offset + format.block_size()` is greater than the `stride` of \
                                 `binding`",
                             requires_one_of: RequiresOneOf {
                                 features: &["vertex_attribute_access_beyond_stride"],
@@ -806,8 +806,8 @@ where
                                 {
                                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                         required_for:
-                                            "the `khr_portability_subset` extension is enabled on \
-                                            the device, and `input_assembly_state.topology` is \
+                                            "this device is a portability subset device, and \
+                                            `input_assembly_state.topology` is \
                                             `StateMode::Fixed(PrimitiveTopology::TriangleFan)`",
                                         requires_one_of: RequiresOneOf {
                                             features: &["triangle_fans"],
@@ -1225,10 +1225,9 @@ where
                             && polygon_mode == PolygonMode::Point
                         {
                             return Err(GraphicsPipelineCreationError::RequirementNotMet {
-                                required_for:
-                                    "the `khr_portability_subset` extension is enabled on the \
-                                    device, `rasterization_state.rasterizer_discard_enable` is
-                                    `StateMode::Fixed(false)` and
+                                required_for: "this device is a portability subset device, \
+                                    `rasterization_state.rasterizer_discard_enable` is \
+                                    `StateMode::Fixed(false)` and \
                                     `rasterization_state.polygon_mode` is `PolygonMode::Point`",
                                 requires_one_of: RequiresOneOf {
                                     features: &["point_polygons"],
@@ -2084,9 +2083,8 @@ where
                             && front_reference != back_reference
                         {
                             return Err(GraphicsPipelineCreationError::RequirementNotMet {
-                                required_for:
-                                    "the `khr_portability_subset` extension is enabled on the \
-                                    device, `rasterization_state.cull_mode` is \
+                                required_for: "this device is a portability subset device, \
+                                    `rasterization_state.cull_mode` is \
                                     `StateMode::Fixed(CullMode::None)`, and \
                                     `depth_stencil_state.stencil` is `Some(stencil_state)`, \
                                     where `stencil_state.front.reference` does not equal \
@@ -2368,10 +2366,9 @@ where
                         ))
                     {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
-                            required_for:
-                                "the `khr_portability_subset` extension is enabled on the device, \
-                                and `color_blend_state.attachments` has an element where `blend` \
-                                is `Some(blend)`, where \
+                            required_for: "this device is a portability subset device, and \
+                                `color_blend_state.attachments` has an element where `blend` is \
+                                `Some(blend)`, where \
                                 `blend.color_source` or `blend.color_destination` is \
                                 `BlendFactor::ConstantAlpha` or \
                                 `BlendFactor::OneMinusConstantAlpha`",

--- a/vulkano/src/pipeline/graphics/builder.rs
+++ b/vulkano/src/pipeline/graphics/builder.rs
@@ -639,6 +639,22 @@ where
                         );
                     }
 
+                    // VUID-VkVertexInputBindingDescription-stride-04456
+                    if device.enabled_extensions().khr_portability_subset
+                        && (stride == 0
+                            || stride
+                                % properties
+                                    .min_vertex_input_binding_stride_alignment
+                                    .unwrap()
+                                != 0)
+                    {
+                        return Err(GraphicsPipelineCreationError::MinVertexInputBindingStrideAlignmentExceeded {
+                            binding,
+                            max: properties.min_vertex_input_binding_stride_alignment.unwrap(),
+                            obtained: binding,
+                        });
+                    }
+
                     match input_rate {
                         VertexInputRate::Instance { divisor } if divisor != 1 => {
                             // VUID-VkVertexInputBindingDivisorDescriptionEXT-vertexAttributeInstanceRateDivisor-02229
@@ -712,14 +728,12 @@ where
                     // VUID-VkVertexInputAttributeDescription-location-00620
 
                     // VUID-VkPipelineVertexInputStateCreateInfo-binding-00615
-                    if !bindings.contains_key(&binding) {
-                        return Err(
-                            GraphicsPipelineCreationError::VertexInputAttributeInvalidBinding {
-                                location,
-                                binding,
-                            },
-                        );
-                    }
+                    let binding_desc = bindings.get(&binding).ok_or(
+                        GraphicsPipelineCreationError::VertexInputAttributeInvalidBinding {
+                            location,
+                            binding,
+                        },
+                    )?;
 
                     // VUID-VkVertexInputAttributeDescription-offset-00622
                     if offset > properties.max_vertex_input_attribute_offset {
@@ -748,6 +762,26 @@ where
                             },
                         );
                     }
+
+                    // VUID-VkVertexInputAttributeDescription-vertexAttributeAccessBeyondStride-04457
+                    if device.enabled_extensions().khr_portability_subset
+                        && !device
+                            .enabled_features()
+                            .vertex_attribute_access_beyond_stride
+                        && offset as DeviceSize + format.block_size().unwrap()
+                            > binding_desc.stride as DeviceSize
+                    {
+                        return Err(GraphicsPipelineCreationError::RequirementNotMet {
+                            required_for: "the `khr_portability_subset` extension is enabled on \
+                                the device, and `vertex_input_state.attributes` has an element \
+                                where `offset + format.block_size()` is greater than the stride of \
+                                `binding`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["vertex_attribute_access_beyond_stride"],
+                                ..Default::default()
+                            },
+                        });
+                    }
                 }
             }
 
@@ -765,6 +799,23 @@ where
                         topology.validate_device(device)?;
 
                         match topology {
+                            PrimitiveTopology::TriangleFan => {
+                                // VUID-VkPipelineInputAssemblyStateCreateInfo-triangleFans-04452
+                                if device.enabled_extensions().khr_portability_subset
+                                    && !device.enabled_features().triangle_fans
+                                {
+                                    return Err(GraphicsPipelineCreationError::RequirementNotMet {
+                                        required_for:
+                                            "the `khr_portability_subset` extension is enabled on \
+                                            the device, and `input_assembly_state.topology` is \
+                                            `StateMode::Fixed(PrimitiveTopology::TriangleFan)`",
+                                        requires_one_of: RequiresOneOf {
+                                            features: &["triangle_fans"],
+                                            ..Default::default()
+                                        },
+                                    });
+                                }
+                            }
                             PrimitiveTopology::LineListWithAdjacency
                             | PrimitiveTopology::LineStripWithAdjacency
                             | PrimitiveTopology::TriangleListWithAdjacency
@@ -1151,19 +1202,42 @@ where
                     });
                 }
 
-                // VUID?
-                if matches!(rasterizer_discard_enable, StateMode::Dynamic)
-                    && !(device.api_version() >= Version::V1_3
-                        || device.enabled_features().extended_dynamic_state2)
-                {
-                    return Err(GraphicsPipelineCreationError::RequirementNotMet {
-                        required_for: "`rasterization_state.rasterizer_discard_enable` is `StateMode::Dynamic`",
-                        requires_one_of: RequiresOneOf {
-                            api_version: Some(Version::V1_3),
-                            features: &["extended_dynamic_state"],
-                            ..Default::default()
-                        },
-                    });
+                match rasterizer_discard_enable {
+                    StateMode::Dynamic => {
+                        // VUID?
+                        if !(device.api_version() >= Version::V1_3
+                            || device.enabled_features().extended_dynamic_state2)
+                        {
+                            return Err(GraphicsPipelineCreationError::RequirementNotMet {
+                                required_for: "`rasterization_state.rasterizer_discard_enable` is `StateMode::Dynamic`",
+                                requires_one_of: RequiresOneOf {
+                                    api_version: Some(Version::V1_3),
+                                    features: &["extended_dynamic_state"],
+                                    ..Default::default()
+                                },
+                            });
+                        }
+                    }
+                    StateMode::Fixed(false) => {
+                        // VUID-VkPipelineRasterizationStateCreateInfo-pointPolygons-04458
+                        if device.enabled_extensions().khr_portability_subset
+                            && !device.enabled_features().point_polygons
+                            && polygon_mode == PolygonMode::Point
+                        {
+                            return Err(GraphicsPipelineCreationError::RequirementNotMet {
+                                required_for:
+                                    "the `khr_portability_subset` extension is enabled on the \
+                                    device, `rasterization_state.rasterizer_discard_enable` is
+                                    `StateMode::Fixed(false)` and
+                                    `rasterization_state.polygon_mode` is `PolygonMode::Point`",
+                                requires_one_of: RequiresOneOf {
+                                    features: &["point_polygons"],
+                                    ..Default::default()
+                                },
+                            });
+                        }
+                    }
+                    _ => (),
                 }
 
                 // VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01507
@@ -1998,12 +2072,34 @@ where
                     return Err(GraphicsPipelineCreationError::WrongStencilState);
                 }
 
-                if !matches!(
-                    (front.reference, back.reference),
-                    (StateMode::Fixed(_), StateMode::Fixed(_))
-                        | (StateMode::Dynamic, StateMode::Dynamic)
-                ) {
-                    return Err(GraphicsPipelineCreationError::WrongStencilState);
+                match (front.reference, back.reference) {
+                    (StateMode::Fixed(front_reference), StateMode::Fixed(back_reference)) => {
+                        // VUID-VkPipelineDepthStencilStateCreateInfo-separateStencilMaskRef-04453
+                        if device.enabled_extensions().khr_portability_subset
+                            && !device.enabled_features().separate_stencil_mask_ref
+                            && matches!(
+                                rasterization_state.cull_mode,
+                                StateMode::Fixed(CullMode::None)
+                            )
+                            && front_reference != back_reference
+                        {
+                            return Err(GraphicsPipelineCreationError::RequirementNotMet {
+                                required_for:
+                                    "the `khr_portability_subset` extension is enabled on the \
+                                    device, `rasterization_state.cull_mode` is \
+                                    `StateMode::Fixed(CullMode::None)`, and \
+                                    `depth_stencil_state.stencil` is `Some(stencil_state)`, \
+                                    where `stencil_state.front.reference` does not equal \
+                                    `stencil_state.back.reference`",
+                                requires_one_of: RequiresOneOf {
+                                    features: &["separate_stencil_mask_ref"],
+                                    ..Default::default()
+                                },
+                            });
+                        }
+                    }
+                    (StateMode::Dynamic, StateMode::Dynamic) => (),
+                    _ => return Err(GraphicsPipelineCreationError::WrongStencilState),
                 }
 
                 // TODO:
@@ -2217,7 +2313,10 @@ where
                         })
                     {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
-                            required_for: "`color_blend_state.attachments` has an element where `blend` is `Some(blend)`, where `blend.color_source`, `blend.color_destination`, `blend.alpha_source` or `blend.alpha_destination` is `BlendFactor::Src1*`",
+                            required_for: "`color_blend_state.attachments` has an element where \
+                            `blend` is `Some(blend)`, where `blend.color_source`, \
+                            `blend.color_destination`, `blend.alpha_source` or \
+                            `blend.alpha_destination` is `BlendFactor::Src1*`",
                             requires_one_of: RequiresOneOf {
                                 features: &["dual_src_blend"],
                                 ..Default::default()
@@ -2254,6 +2353,33 @@ where
                                 attachment_index: attachment_index as u32,
                             },
                         );
+                    }
+
+                    // VUID-VkPipelineColorBlendAttachmentState-constantAlphaColorBlendFactors-04454
+                    // VUID-VkPipelineColorBlendAttachmentState-constantAlphaColorBlendFactors-04455
+                    if device.enabled_extensions().khr_portability_subset
+                        && !device.enabled_features().constant_alpha_color_blend_factors
+                        && (matches!(
+                            color_source,
+                            BlendFactor::ConstantAlpha | BlendFactor::OneMinusConstantAlpha
+                        ) || matches!(
+                            color_destination,
+                            BlendFactor::ConstantAlpha | BlendFactor::OneMinusConstantAlpha
+                        ))
+                    {
+                        return Err(GraphicsPipelineCreationError::RequirementNotMet {
+                            required_for:
+                                "the `khr_portability_subset` extension is enabled on the device, \
+                                and `color_blend_state.attachments` has an element where `blend` \
+                                is `Some(blend)`, where \
+                                `blend.color_source` or `blend.color_destination` is \
+                                `BlendFactor::ConstantAlpha` or \
+                                `BlendFactor::OneMinusConstantAlpha`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["constant_alpha_color_blend_factors"],
+                                ..Default::default()
+                            },
+                        });
                     }
                 }
 

--- a/vulkano/src/pipeline/graphics/color_blend.rs
+++ b/vulkano/src/pipeline/graphics/color_blend.rs
@@ -365,9 +365,21 @@ vulkan_enum! {
     OneMinusConstantColor = ONE_MINUS_CONSTANT_COLOR,
 
     /// `blend_constants.a` for all components.
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if this value is used for the `color_source` or `color_destination` blend factors,
+    /// then the
+    /// [`constant_alpha_color_blend_factors`](crate::device::Features::constant_alpha_color_blend_factors)
+    /// feature must be enabled on the device.
     ConstantAlpha = CONSTANT_ALPHA,
 
     /// `1 - blend_constants.a` for all components.
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if this value is used for the `color_source` or `color_destination` blend factors,
+    /// then the
+    /// [`constant_alpha_color_blend_factors`](crate::device::Features::constant_alpha_color_blend_factors)
+    /// feature must be enabled on the device.
     OneMinusConstantAlpha = ONE_MINUS_CONSTANT_ALPHA,
 
     /// For the alpha component, always `1`. For the color components,

--- a/vulkano/src/pipeline/graphics/creation_error.rs
+++ b/vulkano/src/pipeline/graphics/creation_error.rs
@@ -125,6 +125,16 @@ pub enum GraphicsPipelineCreationError {
         obtained: u32,
     },
 
+    /// The `min_vertex_input_binding_stride_alignment` limit was exceeded.
+    MinVertexInputBindingStrideAlignmentExceeded {
+        /// Index of the faulty binding.
+        binding: u32,
+        /// Maximum allowed value.
+        max: u32,
+        /// Value that was passed.
+        obtained: u32,
+    },
+
     /// The maximum dimensions of viewports has been exceeded.
     MaxViewportDimensionsExceeded,
 
@@ -299,6 +309,10 @@ impl Display for GraphicsPipelineCreationError {
             Self::MaxViewportDimensionsExceeded => {
                 write!(f, "the maximum dimensions of viewports has been exceeded")
             }
+            Self::MinVertexInputBindingStrideAlignmentExceeded { .. } => write!(
+                f,
+                "the `min_vertex_input_binding_stride_alignment` limit has been exceeded",
+            ),
             Self::MismatchBlendingAttachmentsCount => write!(
                 f,
                 "the number of attachments specified in the blending does not match the number of \

--- a/vulkano/src/pipeline/graphics/depth_stencil.rs
+++ b/vulkano/src/pipeline/graphics/depth_stencil.rs
@@ -197,6 +197,12 @@ pub struct StencilOpState {
     /// Reference value that is used in the unsigned stencil comparison. The stencil test is
     /// considered to pass if the `compare_op` between the stencil buffer value and this reference
     /// value yields true.
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if culling is disabled, and the `reference` values of the front and back face
+    /// are not equal, then the
+    /// [`separate_stencil_mask_ref`](crate::device::Features::separate_stencil_mask_ref)
+    /// feature must be enabled on the device.
     pub reference: StateMode<u32>,
 }
 

--- a/vulkano/src/pipeline/graphics/input_assembly.rs
+++ b/vulkano/src/pipeline/graphics/input_assembly.rs
@@ -119,6 +119,10 @@ vulkan_enum! {
     TriangleStrip = TRIANGLE_STRIP,
 
     /// A series of consecutive triangle primitives, with all triangles sharing a common vertex (the first).
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, the [`triangle_fans`](crate::device::Features::triangle_fans)
+    /// feature must be enabled on the device.
     TriangleFan = TRIANGLE_FAN,
 
     /// As `LineList, but with adjacency, used in combination with geometry shaders. Requires the

--- a/vulkano/src/pipeline/graphics/rasterization.rs
+++ b/vulkano/src/pipeline/graphics/rasterization.rs
@@ -239,7 +239,11 @@ vulkan_enum! {
     // TODO: document
     Line = LINE,
 
-    // TODO: document
+    // TODO: document further
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, unless `rasterizer_discard_enable` is active, the
+    /// [`point_polygons`](crate::device::Features::point_polygons)
+    /// feature must be enabled on the device.
     Point = POINT,
 
     /*

--- a/vulkano/src/pipeline/graphics/vertex_input/mod.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/mod.rs
@@ -194,6 +194,12 @@ pub struct VertexInputAttributeDescription {
     pub format: Format,
 
     /// Number of bytes between the start of a vertex buffer element and the location of attribute.
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if the sum of `offset + format.block_size()` is greater than the `stride` of
+    /// `binding`, the
+    /// [`vertex_attribute_access_beyond_stride`](crate::device::Features::vertex_attribute_access_beyond_stride)
+    /// feature must be enabled on the device.
     pub offset: u32,
 }
 

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -196,7 +196,7 @@ impl Sampler {
                 required_for: "this device is a portability subset device, and \
                     `create_info.mip_lod_bias` is not zero",
                 requires_one_of: RequiresOneOf {
-                    features: &["sampker_mip_lod_bias"],
+                    features: &["sampler_mip_lod_bias"],
                     ..Default::default()
                 },
             });

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -187,6 +187,21 @@ impl Sampler {
             }
         }
 
+        // VUID-VkSamplerCreateInfo-samplerMipLodBias-04467
+        if device.enabled_extensions().khr_portability_subset
+            && !device.enabled_features().sampler_mip_lod_bias
+            && mip_lod_bias != 0.0
+        {
+            return Err(SamplerCreationError::RequirementNotMet {
+                required_for: "the `khr_portability_subset` extension is enabled on the device, \
+                    and `create_info.mip_lod_bias` is not zero",
+                requires_one_of: RequiresOneOf {
+                    features: &["sampker_mip_lod_bias"],
+                    ..Default::default()
+                },
+            });
+        }
+
         let (anisotropy_enable, max_anisotropy) = if let Some(max_anisotropy) = anisotropy {
             assert!(max_anisotropy >= 1.0);
 

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -193,8 +193,8 @@ impl Sampler {
             && mip_lod_bias != 0.0
         {
             return Err(SamplerCreationError::RequirementNotMet {
-                required_for: "the `khr_portability_subset` extension is enabled on the device, \
-                    and `create_info.mip_lod_bias` is not zero",
+                required_for: "this device is a portability subset device, and \
+                    `create_info.mip_lod_bias` is not zero",
                 requires_one_of: RequiresOneOf {
                     features: &["sampker_mip_lod_bias"],
                     ..Default::default()
@@ -1013,6 +1013,11 @@ pub struct SamplerCreateInfo {
     /// [`max_sampler_lod_bias`](crate::device::Properties::max_sampler_lod_bias) limit of the
     /// device.
     ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if `mip_lod_bias` is not `0.0`, the
+    /// [`sampler_mip_lod_bias`](crate::device::Features::sampler_mip_lod_bias)
+    /// feature must be enabled on the device.
+    ///
     /// The default value is `0.0`.
     pub mip_lod_bias: f32,
 
@@ -1041,6 +1046,12 @@ pub struct SamplerCreateInfo {
     ///
     /// If set to `Some`, the `reduction_mode` must be set to
     /// [`WeightedAverage`](SamplerReductionMode::WeightedAverage).
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, if the sampler is going to be used as a mutable sampler (written to descriptor sets
+    /// rather than being an immutable part of a descriptor set layout), the
+    /// [`mutable_comparison_samplers`](crate::device::Features::mutable_comparison_samplers)
+    /// feature must be enabled on the device.
     ///
     /// The default value is `None`.
     pub compare: Option<CompareOp>,

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -9,9 +9,11 @@
 
 use crate::{
     device::{Device, DeviceOwned},
-    OomError, VulkanError, VulkanObject,
+    OomError, RequiresOneOf, VulkanError, VulkanObject,
 };
 use std::{
+    error::Error,
+    fmt::{Display, Error as FmtError, Formatter},
     hash::{Hash, Hasher},
     mem::MaybeUninit,
     ptr,
@@ -34,7 +36,19 @@ pub struct Event {
 impl Event {
     /// Creates a new `Event`.
     #[inline]
-    pub fn new(device: Arc<Device>, _create_info: EventCreateInfo) -> Result<Event, OomError> {
+    pub fn new(device: Arc<Device>, _create_info: EventCreateInfo) -> Result<Event, EventError> {
+        // VUID-vkCreateEvent-events-04468
+        if device.enabled_extensions().khr_portability_subset && !device.enabled_features().events {
+            return Err(EventError::RequirementNotMet {
+                required_for: "the `khr_portability_subset` extension is enabled on the device, \
+                    and `Event::new` was called",
+                requires_one_of: RequiresOneOf {
+                    features: &["events"],
+                    ..Default::default()
+                },
+            });
+        }
+
         let create_info = ash::vk::EventCreateInfo {
             flags: ash::vk::EventCreateFlags::empty(),
             ..Default::default()
@@ -68,7 +82,7 @@ impl Event {
     /// For most applications, using the event pool should be preferred,
     /// in order to avoid creating new events every frame.
     #[inline]
-    pub fn from_pool(device: Arc<Device>) -> Result<Event, OomError> {
+    pub fn from_pool(device: Arc<Device>) -> Result<Event, EventError> {
         let handle = device.event_pool().lock().pop();
         let event = match handle {
             Some(handle) => {
@@ -234,6 +248,53 @@ impl Default for EventCreateInfo {
     fn default() -> Self {
         Self {
             _ne: crate::NonExhaustive(()),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EventError {
+    /// Not enough memory available.
+    OomError(OomError),
+
+    RequirementNotMet {
+        required_for: &'static str,
+        requires_one_of: RequiresOneOf,
+    },
+}
+
+impl Error for EventError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::OomError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl Display for EventError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        match self {
+            Self::OomError(_) => write!(f, "not enough memory available"),
+            Self::RequirementNotMet {
+                required_for,
+                requires_one_of,
+            } => write!(
+                f,
+                "a requirement was not met for: {}; requires one of: {}",
+                required_for, requires_one_of,
+            ),
+        }
+    }
+}
+
+impl From<VulkanError> for EventError {
+    fn from(err: VulkanError) -> Self {
+        match err {
+            e @ VulkanError::OutOfHostMemory | e @ VulkanError::OutOfDeviceMemory => {
+                Self::OomError(e.into())
+            }
+            _ => panic!("unexpected error: {:?}", err),
         }
     }
 }

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -35,13 +35,18 @@ pub struct Event {
 
 impl Event {
     /// Creates a new `Event`.
+    ///
+    /// On [portability subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
+    /// devices, the
+    /// [`events`](crate::device::Features::events)
+    /// feature must be enabled on the device.
     #[inline]
     pub fn new(device: Arc<Device>, _create_info: EventCreateInfo) -> Result<Event, EventError> {
         // VUID-vkCreateEvent-events-04468
         if device.enabled_extensions().khr_portability_subset && !device.enabled_features().events {
             return Err(EventError::RequirementNotMet {
-                required_for: "the `khr_portability_subset` extension is enabled on the device, \
-                    and `Event::new` was called",
+                required_for: "this device is a portability subset device, and `Event::new` was \
+                    called",
                 requires_one_of: RequiresOneOf {
                     features: &["events"],
                     ..Default::default()


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- Validation checks for `khr_portability_subset` devices.
````

This adds the missing validation checks for devices that expose the `khr_portability_subset` extension. This concerns MacOS and iOS devices, which do not fully conform to the Vulkan spec, and therefore do not support all the features that a conformant Vulkan implementation is expected to support. For such devices, certain features must be enabled on the device (if they are available) in order to use them.