### PR TITLE
Make command buffer/descriptor set allocators `Sync` again

### DIFF
--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use bytemuck::{Pod, Zeroable};
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
@@ -40,8 +40,8 @@ pub struct AmbientLightingSystem {
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
     subpass: Subpass,
     pipeline: Arc<GraphicsPipeline>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-    descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+    descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
 }
 
 impl AmbientLightingSystem {
@@ -50,8 +50,8 @@ impl AmbientLightingSystem {
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
         memory_allocator: &impl MemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> AmbientLightingSystem {
         // TODO: vulkano doesn't allow us to draw without a vertex buffer, otherwise we could
         //       hard-code these values in the shader

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -9,7 +9,7 @@
 
 use bytemuck::{Pod, Zeroable};
 use cgmath::Vector3;
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
@@ -41,8 +41,8 @@ pub struct DirectionalLightingSystem {
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
     subpass: Subpass,
     pipeline: Arc<GraphicsPipeline>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-    descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+    descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
 }
 
 impl DirectionalLightingSystem {
@@ -51,8 +51,8 @@ impl DirectionalLightingSystem {
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
         memory_allocator: &impl MemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> DirectionalLightingSystem {
         // TODO: vulkano doesn't allow us to draw without a vertex buffer, otherwise we could
         //       hard-code these values in the shader

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -9,7 +9,7 @@
 
 use bytemuck::{Pod, Zeroable};
 use cgmath::{Matrix4, Vector3};
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
@@ -40,8 +40,8 @@ pub struct PointLightingSystem {
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
     subpass: Subpass,
     pipeline: Arc<GraphicsPipeline>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-    descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+    descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
 }
 
 impl PointLightingSystem {
@@ -50,8 +50,8 @@ impl PointLightingSystem {
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
         memory_allocator: &impl MemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> PointLightingSystem {
         // TODO: vulkano doesn't allow us to draw without a vertex buffer, otherwise we could
         //       hard-code these values in the shader

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -13,7 +13,7 @@ use super::{
     point_lighting_system::PointLightingSystem,
 };
 use cgmath::{Matrix4, SquareMatrix, Vector3};
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
@@ -40,7 +40,7 @@ pub struct FrameSystem {
     render_pass: Arc<RenderPass>,
 
     memory_allocator: Arc<StandardMemoryAllocator>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
 
     // Intermediate render target that will contain the albedo of each pixel of the scene.
     diffuse_buffer: Arc<ImageView<AttachmentImage>>,
@@ -74,7 +74,7 @@ impl FrameSystem {
         gfx_queue: Arc<Queue>,
         final_output_format: Format,
         memory_allocator: Arc<StandardMemoryAllocator>,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
     ) -> FrameSystem {
         // Creating the render pass.
         //
@@ -196,7 +196,7 @@ impl FrameSystem {
         )
         .unwrap();
 
-        let descriptor_set_allocator = Rc::new(StandardDescriptorSetAllocator::new(
+        let descriptor_set_allocator = Arc::new(StandardDescriptorSetAllocator::new(
             gfx_queue.device().clone(),
         ));
 

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -30,7 +30,7 @@ use crate::{
     triangle_draw_system::TriangleDrawSystem,
 };
 use cgmath::{Matrix4, SquareMatrix, Vector3};
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     command_buffer::allocator::StandardCommandBufferAllocator,
     device::{
@@ -166,7 +166,7 @@ fn main() {
     };
 
     let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
-    let command_buffer_allocator = Rc::new(StandardCommandBufferAllocator::new(device.clone()));
+    let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(device.clone()));
 
     // Here is the basic initialization for the deferred system.
     let mut frame_system = FrameSystem::new(

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use bytemuck::{Pod, Zeroable};
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
@@ -35,7 +35,7 @@ pub struct TriangleDrawSystem {
     vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
     subpass: Subpass,
     pipeline: Arc<GraphicsPipeline>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
 }
 
 impl TriangleDrawSystem {
@@ -44,7 +44,7 @@ impl TriangleDrawSystem {
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
         memory_allocator: &StandardMemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
     ) -> TriangleDrawSystem {
         let vertices = [
             Vertex {

--- a/examples/src/bin/interactive_fractal/app.rs
+++ b/examples/src/bin/interactive_fractal/app.rs
@@ -10,8 +10,8 @@
 use crate::fractal_compute_pipeline::FractalComputePipeline;
 use crate::place_over_frame::RenderPassPlaceOverFrame;
 use cgmath::Vector2;
+use std::sync::Arc;
 use std::time::Instant;
-use std::{rc::Rc, sync::Arc};
 use vulkano::command_buffer::allocator::StandardCommandBufferAllocator;
 use vulkano::descriptor_set::allocator::StandardDescriptorSetAllocator;
 use vulkano::device::Queue;
@@ -64,10 +64,10 @@ impl FractalApp {
         let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(
             gfx_queue.device().clone(),
         ));
-        let command_buffer_allocator = Rc::new(StandardCommandBufferAllocator::new(
+        let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(
             gfx_queue.device().clone(),
         ));
-        let descriptor_set_allocator = Rc::new(StandardDescriptorSetAllocator::new(
+        let descriptor_set_allocator = Arc::new(StandardDescriptorSetAllocator::new(
             gfx_queue.device().clone(),
         ));
 

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -9,7 +9,7 @@
 
 use cgmath::Vector2;
 use rand::Rng;
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer},
     command_buffer::{
@@ -31,8 +31,8 @@ pub struct FractalComputePipeline {
     queue: Arc<Queue>,
     pipeline: Arc<ComputePipeline>,
     memory_allocator: Arc<StandardMemoryAllocator>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-    descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+    descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     palette: Arc<CpuAccessibleBuffer<[[f32; 4]]>>,
     palette_size: i32,
     end_color: [f32; 4],
@@ -42,8 +42,8 @@ impl FractalComputePipeline {
     pub fn new(
         queue: Arc<Queue>,
         memory_allocator: Arc<StandardMemoryAllocator>,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> FractalComputePipeline {
         // Initial colors
         let colors = vec![

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use bytemuck::{Pod, Zeroable};
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
@@ -72,8 +72,8 @@ pub struct PixelsDrawPipeline {
     gfx_queue: Arc<Queue>,
     subpass: Subpass,
     pipeline: Arc<GraphicsPipeline>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-    descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+    descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     vertices: Arc<CpuAccessibleBuffer<[TexturedVertex]>>,
     indices: Arc<CpuAccessibleBuffer<[u32]>>,
 }
@@ -83,8 +83,8 @@ impl PixelsDrawPipeline {
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
         memory_allocator: &impl MemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> PixelsDrawPipeline {
         let (vertices, indices) = textured_quad(2.0, 2.0);
         let vertex_buffer = CpuAccessibleBuffer::<[TexturedVertex]>::from_iter(

--- a/examples/src/bin/interactive_fractal/place_over_frame.rs
+++ b/examples/src/bin/interactive_fractal/place_over_frame.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use crate::pixels_draw_pipeline::PixelsDrawPipeline;
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
@@ -29,15 +29,15 @@ pub struct RenderPassPlaceOverFrame {
     gfx_queue: Arc<Queue>,
     render_pass: Arc<RenderPass>,
     pixels_draw_pipeline: PixelsDrawPipeline,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
 }
 
 impl RenderPassPlaceOverFrame {
     pub fn new(
         gfx_queue: Arc<Queue>,
         memory_allocator: &impl MemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
         output_format: Format,
     ) -> RenderPassPlaceOverFrame {
         let render_pass = vulkano::single_pass_renderpass!(gfx_queue.device().clone(),

--- a/examples/src/bin/multi_window_game_of_life/app.rs
+++ b/examples/src/bin/multi_window_game_of_life/app.rs
@@ -11,7 +11,7 @@ use crate::{
     game_of_life::GameOfLifeComputePipeline, render_pass::RenderPassPlaceOverFrame, SCALING,
     WINDOW2_HEIGHT, WINDOW2_WIDTH, WINDOW_HEIGHT, WINDOW_WIDTH,
 };
-use std::{collections::HashMap, rc::Rc, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 use vulkano::command_buffer::allocator::StandardCommandBufferAllocator;
 use vulkano::descriptor_set::allocator::StandardDescriptorSetAllocator;
 use vulkano::memory::allocator::StandardMemoryAllocator;
@@ -33,10 +33,10 @@ impl RenderPipeline {
         swapchain_format: Format,
     ) -> RenderPipeline {
         let memory_allocator = StandardMemoryAllocator::new_default(gfx_queue.device().clone());
-        let command_buffer_allocator = Rc::new(StandardCommandBufferAllocator::new(
+        let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(
             gfx_queue.device().clone(),
         ));
-        let descriptor_set_allocator = Rc::new(StandardDescriptorSetAllocator::new(
+        let descriptor_set_allocator = Arc::new(StandardDescriptorSetAllocator::new(
             gfx_queue.device().clone(),
         ));
 

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -9,7 +9,7 @@
 
 use cgmath::Vector2;
 use rand::Rng;
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::command_buffer::allocator::StandardCommandBufferAllocator;
 use vulkano::descriptor_set::allocator::StandardDescriptorSetAllocator;
 use vulkano::image::{ImageUsage, StorageImage};
@@ -34,8 +34,8 @@ use vulkano_util::renderer::DeviceImageView;
 pub struct GameOfLifeComputePipeline {
     compute_queue: Arc<Queue>,
     compute_life_pipeline: Arc<ComputePipeline>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-    descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+    descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     life_in: Arc<CpuAccessibleBuffer<[u32]>>,
     life_out: Arc<CpuAccessibleBuffer<[u32]>>,
     image: DeviceImageView,
@@ -63,8 +63,8 @@ impl GameOfLifeComputePipeline {
     pub fn new(
         compute_queue: Arc<Queue>,
         memory_allocator: &impl MemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
         size: [u32; 2],
     ) -> GameOfLifeComputePipeline {
         let life_in = rand_grid(memory_allocator, size);

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use bytemuck::{Pod, Zeroable};
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     buffer::{BufferUsage, CpuAccessibleBuffer, TypedBufferAccess},
     command_buffer::{
@@ -72,8 +72,8 @@ pub struct PixelsDrawPipeline {
     gfx_queue: Arc<Queue>,
     subpass: Subpass,
     pipeline: Arc<GraphicsPipeline>,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-    descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+    descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     vertices: Arc<CpuAccessibleBuffer<[TexturedVertex]>>,
     indices: Arc<CpuAccessibleBuffer<[u32]>>,
 }
@@ -83,8 +83,8 @@ impl PixelsDrawPipeline {
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
         memory_allocator: &impl MemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> PixelsDrawPipeline {
         let (vertices, indices) = textured_quad(2.0, 2.0);
         let vertex_buffer = CpuAccessibleBuffer::<[TexturedVertex]>::from_iter(

--- a/examples/src/bin/multi_window_game_of_life/render_pass.rs
+++ b/examples/src/bin/multi_window_game_of_life/render_pass.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use crate::pixels_draw::PixelsDrawPipeline;
-use std::{rc::Rc, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
@@ -29,15 +29,15 @@ pub struct RenderPassPlaceOverFrame {
     gfx_queue: Arc<Queue>,
     render_pass: Arc<RenderPass>,
     pixels_draw_pipeline: PixelsDrawPipeline,
-    command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
+    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
 }
 
 impl RenderPassPlaceOverFrame {
     pub fn new(
         gfx_queue: Arc<Queue>,
         memory_allocator: &impl MemoryAllocator,
-        command_buffer_allocator: Rc<StandardCommandBufferAllocator>,
-        descriptor_set_allocator: Rc<StandardDescriptorSetAllocator>,
+        command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
+        descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
         output_format: Format,
     ) -> RenderPassPlaceOverFrame {
         let render_pass = vulkano::single_pass_renderpass!(gfx_queue.device().clone(),

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -25,6 +25,7 @@ libloading = "0.7"
 nalgebra = { version = "0.31.0", optional = true }
 parking_lot = { version = "0.12", features = ["send_guard"] }
 smallvec = "1.8"
+thread_local = "1.1"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 objc = "0.2.5"

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -106,7 +106,7 @@ pub unsafe trait CommandBufferAlloc: DeviceOwned + Send + Sync + 'static {
 ///
 /// Internally, this allocator keeps one `CommandPool` per queue family index per thread, using
 /// Thread-Local Storage. When a thread first allocates, an entry is reserved for it in the TLS.
-/// After a thread exists and the allocator wasn't dropped yet, its entry is freed, but the pools
+/// After a thread exits and the allocator wasn't dropped yet, its entry is freed, but the pools
 /// it used are not dropped. The next time a new thread allocates for the first time, the entry is
 /// reused along with the pools. If all threads drop their reference to the allocator, all entries
 /// along with the allocator are dropped, even if the threads didn't exit yet, which is why you
@@ -132,7 +132,7 @@ struct Pool {
 
 // This is needed because of the blanket impl of `Send` on `Arc<T>`, which requires that `T` is
 // `Send + Sync`. `PoolInner` is `Send + !Sync` because `CommandPool` is `!Sync`. That's fine
-// however hecause we never access the `CommandPool` concurrently, only drop it once the `Arc`
+// however because we never access the `CommandPool` concurrently, only drop it once the `Arc`
 // containing it is dropped.
 unsafe impl Send for Pool {}
 

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -77,7 +77,7 @@ pub trait DescriptorSetAlloc: Send + Sync {
 /// Internally, this allocator uses one [`SingleLayoutDescriptorSetPool`] /
 /// [`SingleLayoutVariableDescriptorSetPool`] per descriptor set layout per thread, using
 /// Thread-Local Storage. When a thread first allocates, an entry is reserved for it in the TLS.
-/// After a thread exists and the allocator wasn't dropped yet, its entry is freed, but the pools
+/// After a thread exits and the allocator wasn't dropped yet, its entry is freed, but the pools
 /// it used are not dropped. The next time a new thread allocates for the first time, the entry is
 /// reused along with the pools. If all threads drop their reference to the allocator, all entries
 /// along with the allocator are dropped, even if the threads didn't exit yet, which is why you

--- a/vulkano/src/descriptor_set/single_layout_pool.rs
+++ b/vulkano/src/descriptor_set/single_layout_pool.rs
@@ -54,7 +54,7 @@ pub struct SingleLayoutDescriptorSetPool {
 
 // This is needed because of the blanket impl of `Send` on `Arc<T>`, which requires that `T` is
 // `Send + Sync`. `SingleLayoutPool` is `Send + !Sync` because `DescriptorPool` is `!Sync`. That's
-// fine however hecause we never access the pool.
+// fine however because we never access the `DescriptorPool`.
 unsafe impl Send for SingleLayoutDescriptorSetPool {}
 
 impl SingleLayoutDescriptorSetPool {
@@ -288,8 +288,8 @@ pub struct SingleLayoutVariableDescriptorSetPool {
 
 // This is needed because of the blanket impl of `Send` on `Arc<T>`, which requires that `T` is
 // `Send + Sync`. `SingleLayoutVariablePool` is `Send + !Sync` because `DescriptorPool` is `!Sync`.
-// That's fine however hecause we never access the pool concurrently, only drop the `Arc`
-// containing it.
+// That's fine however because we never access the `DescriptorPool` concurrently, only drop it once
+// the `Arc` containing it is dropped.
 unsafe impl Send for SingleLayoutVariableDescriptorSetPool {}
 
 impl SingleLayoutVariableDescriptorSetPool {

--- a/vulkano/src/descriptor_set/single_layout_pool.rs
+++ b/vulkano/src/descriptor_set/single_layout_pool.rs
@@ -52,8 +52,9 @@ pub struct SingleLayoutDescriptorSetPool {
     layout: Arc<DescriptorSetLayout>,
 }
 
-// This is needed because of the blanket impl on `Arc<T>`, which requires that `T` is `Send + Sync`.
-// `SingleLayoutPool` is `Send + !Sync`.
+// This is needed because of the blanket impl of `Send` on `Arc<T>`, which requires that `T` is
+// `Send + Sync`. `SingleLayoutPool` is `Send + !Sync` because `DescriptorPool` is `!Sync`. That's
+// fine however hecause we never access the pool.
 unsafe impl Send for SingleLayoutDescriptorSetPool {}
 
 impl SingleLayoutDescriptorSetPool {
@@ -191,6 +192,13 @@ pub(crate) struct SingleLayoutPoolAlloc {
     pool: Arc<SingleLayoutPool>,
 }
 
+impl SingleLayoutPoolAlloc {
+    #[cfg(test)]
+    pub(crate) fn pool(&self) -> &DescriptorPool {
+        &self.pool._inner
+    }
+}
+
 // This is required for the same reason as for `SingleLayoutDescriptorSetPool`.
 unsafe impl Send for SingleLayoutPoolAlloc {}
 // `DescriptorPool` is `!Sync`, but we never access it, only keep it alive.
@@ -278,8 +286,10 @@ pub struct SingleLayoutVariableDescriptorSetPool {
     allocated_sets: Cell<usize>,
 }
 
-// This is needed because of the blanket impl on `Arc<T>`, which requires that `T` is `Send + Sync`.
-// `SingleLayoutVariablePool` is `Send + !Sync`.
+// This is needed because of the blanket impl of `Send` on `Arc<T>`, which requires that `T` is
+// `Send + Sync`. `SingleLayoutVariablePool` is `Send + !Sync` because `DescriptorPool` is `!Sync`.
+// That's fine however hecause we never access the pool concurrently, only drop the `Arc`
+// containing it.
 unsafe impl Send for SingleLayoutVariableDescriptorSetPool {}
 
 impl SingleLayoutVariableDescriptorSetPool {


### PR DESCRIPTION
Made `StandardCommandBufferAllocator` and `StandardDescriptorSetAllocator` thread-safe using TLS.

At first I wanted to implement the TLS myself, using a simple `RwLock<HashMap<ThreadId, T>>`, but I noticed that Windows kept getting into deadlocks with that for some reason. So instead I opted for an established library, `thread_local`, which was added to the private dependencies. It's a very light-weight library and also more optimized than what I had in mind. For one it doesn't need acquiring any read locks, and also the entries in the TLS can be reused. This would not have been the case with what I have tried, as threads would always drop their allocator on exit and when a new thread would allocate it would create a brand new allocator for itself. This way those reentrant threads can reuse the allocators.

Another good thing that came from trying this library is that after benchmarking, there's almost no overhead to using this TLS over none at all. It's 6ns of overhead on my CPU, granted I also have a very dated CPU. Therefore, I think it makes no sense to have a non-`Sync` version at all, if we're going to use this library. The only performance implication this has is when a lot of threads need to access the TLS concurrently, which would lead to CPU-level contention on the `AtomicPtr`s that the TLS uses. But even with unreasonably high contention that I tested it with (all of my threads going at it) the times for allocation only doubled. If this is an issue the user still has the option to quite simply not share the allocators between threads.