### PR TITLE
Add new safe `Buffer` and `Image` types containing bound memory

### DIFF
--- a/vulkano/src/buffer/traits.rs
+++ b/vulkano/src/buffer/traits.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::{sys::UnsafeBuffer, BufferContents, BufferSlice, BufferUsage};
+use super::{sys::Buffer, BufferContents, BufferSlice, BufferUsage};
 use crate::{device::DeviceOwned, DeviceSize, RequiresOneOf, SafeDeref, Version, VulkanObject};
 use std::{
     error::Error,
@@ -133,7 +133,7 @@ impl BufferAccessObject for Arc<dyn BufferAccess> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BufferInner<'a> {
     /// The underlying buffer object.
-    pub buffer: &'a Arc<UnsafeBuffer>,
+    pub buffer: &'a Arc<Buffer>,
     /// The offset in bytes from the start of the underlying buffer object to the start of the
     /// buffer we're describing.
     pub offset: DeviceSize,

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -20,11 +20,11 @@ use super::{
     SecondaryCommandBufferAbstract, SubpassContents,
 };
 use crate::{
-    buffer::{sys::UnsafeBuffer, BufferAccess},
+    buffer::{sys::Buffer, BufferAccess},
     command_buffer::CommandBufferInheritanceRenderingInfo,
     device::{Device, DeviceOwned, Queue, QueueFamilyProperties},
     format::Format,
-    image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
+    image::{sys::Image, ImageAccess, ImageLayout, ImageSubresourceRange},
     query::{QueryControlFlags, QueryType},
     render_pass::{Framebuffer, Subpass},
     sync::{AccessCheckError, AccessFlags, PipelineMemoryAccess, PipelineStages},
@@ -751,7 +751,7 @@ where
 
     fn check_buffer_access(
         &self,
-        buffer: &UnsafeBuffer,
+        buffer: &Buffer,
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
@@ -762,7 +762,7 @@ where
 
     fn check_image_access(
         &self,
-        image: &UnsafeImage,
+        image: &Image,
         range: Range<DeviceSize>,
         exclusive: bool,
         expected_layout: ImageLayout,

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -41,8 +41,8 @@
 //! When you are done adding commands, build it to obtain either a `PrimaryAutoCommandBuffer` or
 //! `SecondAutoCommandBuffer`.
 //!
-//! Once built, use [the `PrimaryCommandBuffer` trait](crate::command_buffer::PrimaryCommandBuffer) to submit the
-//! command buffer. Submitting a command buffer returns an object that implements the `GpuFuture` trait
+//! Once built, use the [`PrimaryCommandBufferAbstract`] trait to submit the command buffer.
+//! Submitting a command buffer returns an object that implements the `GpuFuture` trait
 //! and that represents the moment when the execution will end on the GPU.
 //!
 //! ```
@@ -120,9 +120,9 @@ pub use self::{
     },
 };
 use crate::{
-    buffer::sys::UnsafeBuffer,
+    buffer::sys::Buffer,
     format::Format,
-    image::{sys::UnsafeImage, ImageLayout, SampleCount},
+    image::{sys::Image, ImageLayout, SampleCount},
     macros::vulkan_enum,
     query::{QueryControlFlags, QueryPipelineStatisticFlags},
     range_map::RangeMap,
@@ -507,7 +507,7 @@ pub struct CommandBufferResourcesUsage {
 
 #[derive(Debug)]
 pub(crate) struct CommandBufferBufferUsage {
-    pub(crate) buffer: Arc<UnsafeBuffer>,
+    pub(crate) buffer: Arc<Buffer>,
     pub(crate) ranges: RangeMap<DeviceSize, CommandBufferBufferRangeUsage>,
 }
 
@@ -521,7 +521,7 @@ pub(crate) struct CommandBufferBufferRangeUsage {
 
 #[derive(Debug)]
 pub(crate) struct CommandBufferImageUsage {
-    pub(crate) image: Arc<UnsafeImage>,
+    pub(crate) image: Arc<Image>,
     pub(crate) ranges: RangeMap<DeviceSize, CommandBufferImageRangeUsage>,
 }
 

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -15,7 +15,7 @@ pub use crate::command_buffer::commands::{
     secondary::SyncCommandBufferBuilderExecuteCommands,
 };
 use crate::{
-    buffer::{sys::UnsafeBuffer, BufferAccess},
+    buffer::{sys::Buffer, BufferAccess},
     command_buffer::{
         pool::CommandPoolAlloc,
         synced::{BufferUse, ImageUse},
@@ -26,7 +26,7 @@ use crate::{
     },
     descriptor_set::{DescriptorSetResources, DescriptorSetWithOffsets},
     device::{Device, DeviceOwned},
-    image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
+    image::{sys::Image, ImageAccess, ImageLayout, ImageSubresourceRange},
     pipeline::{
         graphics::{
             color_blend::LogicOp,
@@ -93,8 +93,8 @@ pub struct SyncCommandBufferBuilder {
     pub(in crate::command_buffer) latest_render_pass_enter: Option<usize>,
 
     // Stores the current state of buffers and images that are in use by the command buffer.
-    buffers2: HashMap<Arc<UnsafeBuffer>, RangeMap<DeviceSize, BufferState>>,
-    images2: HashMap<Arc<UnsafeImage>, RangeMap<DeviceSize, ImageState>>,
+    buffers2: HashMap<Arc<Buffer>, RangeMap<DeviceSize, BufferState>>,
+    images2: HashMap<Arc<Image>, RangeMap<DeviceSize, ImageState>>,
 
     // Resources and their accesses. Used for executing secondary command buffers in a primary.
     buffers: Vec<(

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -75,9 +75,9 @@ use super::{
     CommandBufferResourcesUsage,
 };
 use crate::{
-    buffer::{sys::UnsafeBuffer, BufferAccess},
+    buffer::{sys::Buffer, BufferAccess},
     device::{Device, DeviceOwned, Queue},
-    image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
+    image::{sys::Image, ImageAccess, ImageLayout, ImageSubresourceRange},
     sync::{AccessCheckError, AccessError, AccessFlags, PipelineMemoryAccess, PipelineStages},
     DeviceSize,
 };
@@ -107,8 +107,8 @@ pub struct SyncCommandBuffer {
 
     // Resources accessed by this command buffer.
     resources_usage: CommandBufferResourcesUsage,
-    buffer_indices: HashMap<Arc<UnsafeBuffer>, usize>,
-    image_indices: HashMap<Arc<UnsafeImage>, usize>,
+    buffer_indices: HashMap<Arc<Buffer>, usize>,
+    image_indices: HashMap<Arc<Image>, usize>,
 
     // Resources and their accesses. Used for executing secondary command buffers in a primary.
     buffers: Vec<(
@@ -137,7 +137,7 @@ impl SyncCommandBuffer {
     #[inline]
     pub fn check_buffer_access(
         &self,
-        buffer: &UnsafeBuffer,
+        buffer: &Buffer,
         range: Range<DeviceSize>,
         exclusive: bool,
         _queue: &Queue,
@@ -174,7 +174,7 @@ impl SyncCommandBuffer {
     #[inline]
     pub fn check_image_access(
         &self,
-        image: &UnsafeImage,
+        image: &Image,
         range: Range<DeviceSize>,
         exclusive: bool,
         expected_layout: ImageLayout,

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -12,9 +12,10 @@ use super::{
     CommandBufferUsage, SemaphoreSubmitInfo, SubmitInfo,
 };
 use crate::{
-    buffer::{sys::UnsafeBuffer, BufferAccess},
+    buffer::{sys::Buffer, BufferAccess},
     device::{Device, DeviceOwned, Queue},
-    image::{sys::UnsafeImage, ImageAccess, ImageLayout, ImageSubresourceRange},
+    image::{sys::Image, ImageAccess, ImageLayout, ImageSubresourceRange},
+    swapchain::Swapchain,
     sync::{
         now, AccessCheckError, AccessError, AccessFlags, FlushError, GpuFuture, NowFuture,
         PipelineMemoryAccess, PipelineStages, SubmitAnyBuilder,
@@ -117,7 +118,7 @@ pub unsafe trait PrimaryCommandBufferAbstract:
 
     fn check_buffer_access(
         &self,
-        buffer: &UnsafeBuffer,
+        buffer: &Buffer,
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
@@ -125,7 +126,7 @@ pub unsafe trait PrimaryCommandBufferAbstract:
 
     fn check_image_access(
         &self,
-        image: &UnsafeImage,
+        image: &Image,
         range: Range<DeviceSize>,
         exclusive: bool,
         expected_layout: ImageLayout,
@@ -156,7 +157,7 @@ where
 
     fn check_buffer_access(
         &self,
-        buffer: &UnsafeBuffer,
+        buffer: &Buffer,
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
@@ -166,7 +167,7 @@ where
 
     fn check_image_access(
         &self,
-        image: &UnsafeImage,
+        image: &Image,
         range: Range<DeviceSize>,
         exclusive: bool,
         expected_layout: ImageLayout,
@@ -421,7 +422,7 @@ where
 
     fn check_buffer_access(
         &self,
-        buffer: &UnsafeBuffer,
+        buffer: &Buffer,
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
@@ -440,7 +441,7 @@ where
 
     fn check_image_access(
         &self,
-        image: &UnsafeImage,
+        image: &Image,
         range: Range<DeviceSize>,
         exclusive: bool,
         expected_layout: ImageLayout,
@@ -465,10 +466,12 @@ where
     #[inline]
     fn check_swapchain_image_acquired(
         &self,
-        image: &UnsafeImage,
+        swapchain: &Swapchain,
+        image_index: u32,
         _before: bool,
     ) -> Result<(), AccessCheckError> {
-        self.previous.check_swapchain_image_acquired(image, false)
+        self.previous
+            .check_swapchain_image_acquired(swapchain, image_index, false)
     }
 }
 

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -86,6 +86,8 @@ pub trait DescriptorSetAlloc: Send + Sync {
 ///
 /// This allocator only needs to lock when a thread first allocates or when a thread that
 /// previously allocated exits. In all other cases, allocation is lock-free.
+///
+/// [`DescriptorPool`]: crate::descriptor_set::pool::DescriptorPool
 #[derive(Debug)]
 pub struct StandardDescriptorSetAllocator {
     device: Arc<Device>,

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -14,8 +14,8 @@ use crate::{
     device::{properties::Properties, DeviceExtensions, Features, FeaturesFfi, PropertiesFfi},
     format::{Format, FormatProperties},
     image::{
-        ImageCreateFlags, ImageFormatInfo, ImageFormatProperties, ImageUsage,
-        SparseImageFormatInfo, SparseImageFormatProperties,
+        ImageFormatInfo, ImageFormatProperties, ImageUsage, SparseImageFormatInfo,
+        SparseImageFormatProperties,
     },
     instance::Instance,
     macros::{vulkan_bitflags, vulkan_enum},
@@ -927,6 +927,7 @@ impl PhysicalDevice {
         image_format_info: &ImageFormatInfo,
     ) -> Result<(), PhysicalDeviceError> {
         let &ImageFormatInfo {
+            flags: _,
             format,
             image_type,
             tiling,
@@ -934,10 +935,6 @@ impl PhysicalDevice {
             mut stencil_usage,
             external_memory_handle_type,
             image_view_type,
-            mutable_format: _,
-            cube_compatible: _,
-            array_2d_compatible: _,
-            block_texel_view_compatible: _,
             _ne: _,
         } = image_format_info;
 
@@ -1052,6 +1049,7 @@ impl PhysicalDevice {
             .get_or_try_insert(image_format_info, |image_format_info| {
                 /* Input */
                 let &ImageFormatInfo {
+                    flags,
                     format,
                     image_type,
                     tiling,
@@ -1059,22 +1057,10 @@ impl PhysicalDevice {
                     stencil_usage,
                     external_memory_handle_type,
                     image_view_type,
-                    mutable_format,
-                    cube_compatible,
-                    array_2d_compatible,
-                    block_texel_view_compatible,
                     _ne: _,
                 } = image_format_info;
 
                 let has_separate_stencil_usage = stencil_usage == usage;
-
-                let flags = ImageCreateFlags {
-                    mutable_format,
-                    cube_compatible,
-                    array_2d_compatible,
-                    block_texel_view_compatible,
-                    ..ImageCreateFlags::empty()
-                };
 
                 let mut info2_vk = ash::vk::PhysicalDeviceImageFormatInfo2 {
                     format: format.unwrap().into(),

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -1985,7 +1985,7 @@ pub enum ImageMemory {
     /// The image is backed by sparse memory, bound with [`bind_sparse`].
     ///
     /// [`bind_sparse`]: crate::device::QueueGuard::bind_sparse
-    Sparse,
+    Sparse(Vec<SparseImageMemoryRequirements>),
 
     /// The image is backed by memory owned by a [`Swapchain`].
     Swapchain {

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -8,7 +8,7 @@
 // according to those terms.
 
 use super::{
-    sys::UnsafeImage, ImageAspects, ImageDescriptorLayouts, ImageDimensions, ImageLayout,
+    sys::Image, ImageAspects, ImageDescriptorLayouts, ImageDimensions, ImageLayout,
     ImageSubresourceLayers, ImageSubresourceRange, ImageUsage, SampleCount,
 };
 use crate::{
@@ -199,7 +199,7 @@ pub unsafe trait ImageAccess: DeviceOwned + Send + Sync {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ImageInner<'a> {
     /// The underlying image object.
-    pub image: &'a Arc<UnsafeImage>,
+    pub image: &'a Arc<Image>,
 
     /// The first layer of `image` to consider.
     pub first_layer: u32,

--- a/vulkano/src/macros.rs
+++ b/vulkano/src/macros.rs
@@ -253,7 +253,7 @@ macro_rules! vulkan_bitflags {
                 $(instance_extensions: [$($instance_extension:ident),+ $(,)?],)?
             })?
             ,
-        )+
+        )*
     } => {
         $(#[doc = $ty_doc])*
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -261,7 +261,7 @@ macro_rules! vulkan_bitflags {
             $(
                 $(#[doc = $flag_doc])*
                 pub $flag_name: bool,
-            )+
+            )*
             pub _ne: crate::NonExhaustive,
         }
 
@@ -272,7 +272,7 @@ macro_rules! vulkan_bitflags {
                 Self {
                     $(
                         $flag_name: false,
-                    )+
+                    )*
                     _ne: crate::NonExhaustive(()),
                 }
             }
@@ -288,68 +288,72 @@ macro_rules! vulkan_bitflags {
             #[inline]
             pub const fn is_empty(&self) -> bool {
                 !(
+                    false
                     $(
-                        self.$flag_name
-                    )||+
+                        || self.$flag_name
+                    )*
+
                 )
             }
 
             /// Returns whether any flags are set in both `self` and `other`.
             #[inline]
-            pub const fn intersects(&self, other: &Self) -> bool {
+            pub const fn intersects(&self, #[allow(unused_variables)] other: &Self) -> bool {
+                false
                 $(
-                    (self.$flag_name && other.$flag_name)
-                )||+
+                    || (self.$flag_name && other.$flag_name)
+                )*
             }
 
             /// Returns whether all flags in `other` are set in `self`.
             #[inline]
-            pub const fn contains(&self, other: &Self) -> bool {
+            pub const fn contains(&self, #[allow(unused_variables)] other: &Self) -> bool {
+                true
                 $(
-                    (self.$flag_name || !other.$flag_name)
-                )&&+
+                    && (self.$flag_name || !other.$flag_name)
+                )*
             }
 
             /// Returns the union of `self` and `other`.
             #[inline]
-            pub const fn union(&self, other: &Self) -> Self {
+            pub const fn union(&self, #[allow(unused_variables)] other: &Self) -> Self {
                 Self {
                     $(
                         $flag_name: (self.$flag_name || other.$flag_name),
-                    )+
+                    )*
                     _ne: crate::NonExhaustive(()),
                 }
             }
 
             /// Returns the intersection of `self` and `other`.
             #[inline]
-            pub const fn intersection(&self, other: &Self) -> Self {
+            pub const fn intersection(&self, #[allow(unused_variables)] other: &Self) -> Self {
                 Self {
                     $(
                         $flag_name: (self.$flag_name && other.$flag_name),
-                    )+
+                    )*
                     _ne: crate::NonExhaustive(()),
                 }
             }
 
             /// Returns `self` without the flags set in `other`.
             #[inline]
-            pub const fn difference(&self, other: &Self) -> Self {
+            pub const fn difference(&self, #[allow(unused_variables)] other: &Self) -> Self {
                 Self {
                     $(
                         $flag_name: (self.$flag_name ^ other.$flag_name),
-                    )+
+                    )*
                     _ne: crate::NonExhaustive(()),
                 }
             }
 
             /// Returns the flags set in `self` or `other`, but not both.
             #[inline]
-            pub const fn symmetric_difference(&self, other: &Self) -> Self {
+            pub const fn symmetric_difference(&self, #[allow(unused_variables)] other: &Self) -> Self {
                 Self {
                     $(
                         $flag_name: (self.$flag_name ^ other.$flag_name),
-                    )+
+                    )*
                     _ne: crate::NonExhaustive(()),
                 }
             }
@@ -387,7 +391,7 @@ macro_rules! vulkan_bitflags {
                             });
                         }
                     )?
-                )+
+                )*
 
                 Ok(())
             }
@@ -425,7 +429,7 @@ macro_rules! vulkan_bitflags {
                             });
                         }
                     )?
-                )+
+                )*
 
                 Ok(())
             }
@@ -455,7 +459,7 @@ macro_rules! vulkan_bitflags {
                             });
                         }
                     )?
-                )+
+                )*
 
                 Ok(())
             }
@@ -463,22 +467,23 @@ macro_rules! vulkan_bitflags {
 
         impl From<$ty> for ash::vk::$ty_ffi {
             #[inline]
-            fn from(val: $ty) -> Self {
+            fn from(#[allow(unused_variables)] val: $ty) -> Self {
+                #[allow(unused_mut)]
                 let mut result = ash::vk::$ty_ffi::empty();
                 $(
                     if val.$flag_name { result |= ash::vk::$ty_ffi::$flag_name_ffi }
-                )+
+                )*
                 result
             }
         }
 
         impl From<ash::vk::$ty_ffi> for $ty {
             #[inline]
-            fn from(val: ash::vk::$ty_ffi) -> Self {
+            fn from(#[allow(unused_variables)] val: ash::vk::$ty_ffi) -> Self {
                 Self {
                     $(
                         $flag_name: val.intersects(ash::vk::$ty_ffi::$flag_name_ffi),
-                    )+
+                    )*
                     _ne: crate::NonExhaustive(()),
                 }
             }
@@ -490,7 +495,7 @@ macro_rules! vulkan_bitflags {
                 Self {
                     $(
                         $flag_name: false,
-                    )+
+                    )*
                     _ne: crate::NonExhaustive(()),
                 }
             }

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -131,9 +131,15 @@ impl MemoryAlloc {
                 )
                 .result()
                 .map_err(|err| match err.into() {
-                    VulkanError::OutOfHostMemory => AllocationCreationError::OutOfHostMemory,
-                    VulkanError::OutOfDeviceMemory => AllocationCreationError::OutOfDeviceMemory,
-                    VulkanError::MemoryMapFailed => AllocationCreationError::MemoryMapFailed,
+                    VulkanError::OutOfHostMemory => {
+                        AllocationCreationError::VulkanError(VulkanError::OutOfHostMemory)
+                    }
+                    VulkanError::OutOfDeviceMemory => {
+                        AllocationCreationError::VulkanError(VulkanError::OutOfDeviceMemory)
+                    }
+                    VulkanError::MemoryMapFailed => {
+                        AllocationCreationError::VulkanError(VulkanError::MemoryMapFailed)
+                    }
                     _ => unreachable!(),
                 })?;
 

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -1562,7 +1562,7 @@ vulkan_enum! {
     /// Only `Fifo` is guaranteed to be supported on every device. For the others, you must call
     /// [`surface_present_modes`] to see if they are supported.
     ///
-    /// [`surface_present_modes`]: crate::device::physical_device::PhysicalDevice::surface_present_modes
+    /// [`surface_present_modes`]: crate::device::physical::PhysicalDevice::surface_present_modes
     #[non_exhaustive]
     PresentMode = PresentModeKHR(i32);
 

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -1544,28 +1544,75 @@ pub enum SurfaceApi {
 }
 
 vulkan_enum! {
-    /// The way presenting a swapchain is accomplished.
+    /// The mode of action when a swapchain image is presented.
+    ///
+    /// Swapchain images can be in one of three possible states:
+    /// - Exactly one image is currently displayed on the screen.
+    /// - Zero or more are acquired by the application, or available to be acquired.
+    /// - Some may be held inside the presentation engine waiting to be displayed. The present mode
+    ///   concerns the behaviour of this category, and by extension, which images are left over for
+    ///   acquiring.
+    ///
+    /// The present mode affects what is commonly known as "vertical sync" or "vsync" for short.
+    /// The `Immediate` mode is equivalent to disabling vertical sync, while the others enable
+    /// vertical sync in various forms. An important aspect of the present modes is their potential
+    /// *latency*: the time between when an image is presented, and when it actually appears on
+    /// the display.
+    ///
+    /// Only `Fifo` is guaranteed to be supported on every device. For the others, you must call
+    /// [`surface_present_modes`] to see if they are supported.
+    ///
+    /// [`surface_present_modes`]: crate::device::physical_device::PhysicalDevice::surface_present_modes
     #[non_exhaustive]
     PresentMode = PresentModeKHR(i32);
 
-    /// Immediately shows the image to the user. May result in visible tearing.
+    /// The presentation engine holds only the currently displayed image. When presenting an image,
+    /// the currently displayed image is immediately replaced with the presented image. The old
+    /// image will be available for future acquire operations.
+    ///
+    /// This mode has the lowest latency of all present modes, but if the display is not in a
+    /// vertical blanking period when the image is replaced, a tear will be visible.
     Immediate = IMMEDIATE,
 
-    /// The action of presenting an image puts it in wait. When the next vertical blanking period
-    /// happens, the waiting image is effectively shown to the user. If an image is presented while
-    /// another one is waiting, it is replaced.
+    /// The presentation engine holds the currently displayed image, and optionally another in a
+    /// waiting slot. The presentation engine waits until the next vertical blanking period, then
+    /// removes any image from the waiting slot and displays it. Tearing will never be visible.
+    /// When presenting an image, it is stored in the waiting slot. Any previous entry
+    /// in the slot is discarded, and will be available for future acquire operations.
+    ///
+    /// Latency is relatively low with this mode, and will never be longer than the time between
+    /// vertical blanking periods. However, if a previous image in the waiting slot is discarded,
+    /// the work that went into producing that image was wasted.
+    ///
+    /// With two swapchain images, this mode behaves essentially identical to `Fifo`: once both
+    /// images are held in the presentation engine, no images can be acquired until one is finished
+    /// displaying. But with three or more swapchain images, any images beyond those two are always
+    /// available to acquire.
     Mailbox = MAILBOX,
 
-    /// The action of presenting an image adds it to a queue of images. At each vertical blanking
-    /// period, the queue is popped and an image is presented.
+    /// The presentation engine holds the currently displayed image, and a queue of waiting images.
+    /// When presenting an image, it is added to the tail of the queue, after previously presented
+    /// images. The presentation engine waits until the next vertical blanking period, then removes
+    /// an image from the head of the queue and displays it. Tearing will never be visible. Images
+    /// become available for future acquire operations only after they have been displayed.
     ///
-    /// Guaranteed to be always supported.
+    /// This mode is guaranteed to be always supported. It is possible for all swapchain images to
+    /// end up being held by the presentation engine, either being displayed or in the queue. When
+    /// that happens, no images can be acquired until one is finished displaying. This can be used
+    /// to limit the presentation rate to the display frame rate. Latency is bounded only by the
+    /// number of images in the swapchain.
     ///
     /// This is the equivalent of OpenGL's `SwapInterval` with a value of 1.
     Fifo = FIFO,
 
-    /// Same as `Fifo`, except that if the queue was empty during the previous vertical blanking
-    /// period then it is equivalent to `Immediate`.
+    /// Similar to `Fifo`, but with the ability for images to "skip the queue" if presentation is
+    /// lagging behind the display frame rate. If the queue is empty and a vertical blanking period
+    /// has already passed since the previous image was displayed, then the currently displayed
+    /// image is immediately replaced with the presented image, as in `Immediate`.
+    ///
+    /// This mode has high latency if images are presented faster than the display frame rate,
+    /// as they will accumulate in the queue. But the latency is low if images are presented slower
+    /// than the display frame rate. However, slower presentation can result in visible tearing.
     ///
     /// This is the equivalent of OpenGL's `SwapInterval` with a value of -1.
     FifoRelaxed = FIFO_RELAXED,

--- a/vulkano/src/sync/future/join.rs
+++ b/vulkano/src/sync/future/join.rs
@@ -9,9 +9,10 @@
 
 use super::{AccessCheckError, FlushError, GpuFuture, SubmitAnyBuilder};
 use crate::{
-    buffer::sys::UnsafeBuffer,
+    buffer::sys::Buffer,
     device::{Device, DeviceOwned, Queue},
-    image::{sys::UnsafeImage, ImageLayout},
+    image::{sys::Image, ImageLayout},
+    swapchain::Swapchain,
     sync::{AccessFlags, PipelineStages},
     DeviceSize, VulkanObject,
 };
@@ -199,7 +200,7 @@ where
 
     fn check_buffer_access(
         &self,
-        buffer: &UnsafeBuffer,
+        buffer: &Buffer,
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
@@ -233,7 +234,7 @@ where
 
     fn check_image_access(
         &self,
-        image: &UnsafeImage,
+        image: &Image,
         range: Range<DeviceSize>,
         exclusive: bool,
         expected_layout: ImageLayout,
@@ -268,11 +269,16 @@ where
     #[inline]
     fn check_swapchain_image_acquired(
         &self,
-        image: &UnsafeImage,
+        swapchain: &Swapchain,
+        image_index: u32,
         _before: bool,
     ) -> Result<(), AccessCheckError> {
-        let first = self.first.check_swapchain_image_acquired(image, false);
-        let second = self.second.check_swapchain_image_acquired(image, false);
+        let first = self
+            .first
+            .check_swapchain_image_acquired(swapchain, image_index, false);
+        let second = self
+            .second
+            .check_swapchain_image_acquired(swapchain, image_index, false);
 
         match (first, second) {
             (v, Err(AccessCheckError::Unknown)) => v,

--- a/vulkano/src/sync/future/now.rs
+++ b/vulkano/src/sync/future/now.rs
@@ -9,9 +9,10 @@
 
 use super::{AccessCheckError, FlushError, GpuFuture, SubmitAnyBuilder};
 use crate::{
-    buffer::sys::UnsafeBuffer,
+    buffer::sys::Buffer,
     device::{Device, DeviceOwned, Queue},
-    image::{sys::UnsafeImage, ImageLayout},
+    image::{sys::Image, ImageLayout},
+    swapchain::Swapchain,
     sync::{AccessFlags, PipelineStages},
     DeviceSize,
 };
@@ -58,7 +59,7 @@ unsafe impl GpuFuture for NowFuture {
     #[inline]
     fn check_buffer_access(
         &self,
-        _buffer: &UnsafeBuffer,
+        _buffer: &Buffer,
         _range: Range<DeviceSize>,
         _exclusive: bool,
         _queue: &Queue,
@@ -69,7 +70,7 @@ unsafe impl GpuFuture for NowFuture {
     #[inline]
     fn check_image_access(
         &self,
-        _image: &UnsafeImage,
+        _image: &Image,
         _range: Range<DeviceSize>,
         _exclusive: bool,
         _expected_layout: ImageLayout,
@@ -81,7 +82,8 @@ unsafe impl GpuFuture for NowFuture {
     #[inline]
     fn check_swapchain_image_acquired(
         &self,
-        _image: &UnsafeImage,
+        _swapchain: &Swapchain,
+        _image_index: u32,
         _before: bool,
     ) -> Result<(), AccessCheckError> {
         Err(AccessCheckError::Unknown)

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -8,8 +8,8 @@
 // according to those terms.
 
 use crate::{
-    buffer::sys::UnsafeBuffer,
-    image::{sys::UnsafeImage, ImageAspects, ImageLayout, ImageSubresourceRange},
+    buffer::sys::Buffer,
+    image::{sys::Image, ImageAspects, ImageLayout, ImageSubresourceRange},
     macros::{vulkan_bitflags, vulkan_enum},
     DeviceSize,
 };
@@ -1333,7 +1333,7 @@ pub struct BufferMemoryBarrier {
     pub queue_family_transfer: Option<QueueFamilyTransfer>,
 
     /// The buffer to apply the barrier to.
-    pub buffer: Arc<UnsafeBuffer>,
+    pub buffer: Arc<Buffer>,
 
     /// The byte range of `buffer` to apply the barrier to.
     pub range: Range<DeviceSize>,
@@ -1343,7 +1343,7 @@ pub struct BufferMemoryBarrier {
 
 impl BufferMemoryBarrier {
     #[inline]
-    pub fn buffer(buffer: Arc<UnsafeBuffer>) -> Self {
+    pub fn buffer(buffer: Arc<Buffer>) -> Self {
         Self {
             src_stages: PipelineStages::empty(),
             src_access: AccessFlags::empty(),
@@ -1392,7 +1392,7 @@ pub struct ImageMemoryBarrier {
     pub queue_family_transfer: Option<QueueFamilyTransfer>,
 
     /// The image to apply the barrier to.
-    pub image: Arc<UnsafeImage>,
+    pub image: Arc<Image>,
 
     /// The subresource range of `image` to apply the barrier to.
     pub subresource_range: ImageSubresourceRange,
@@ -1402,7 +1402,7 @@ pub struct ImageMemoryBarrier {
 
 impl ImageMemoryBarrier {
     #[inline]
-    pub fn image(image: Arc<UnsafeImage>) -> Self {
+    pub fn image(image: Arc<Image>) -> Self {
         Self {
             src_stages: PipelineStages::empty(),
             src_access: AccessFlags::empty(),


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to buffers and images:
- `UnsafeBuffer` and `UnsafeImage` are renamed to `RawBuffer` and `RawImage`.
- `UnsafeBufferCreateInfo` and `UnsafeImageCreateInfo` are renamed to `BufferCreateInfo` and `ImageCreateInfo`.
- `ImageCreateInfo` now takes a `flags` instead of separate booleans.
- Replaced the various unsafe `*_linear_layout` methods of `UnsafeImage` with a safe `subresource_layout` method. The `LinearLayout` struct is renamed to `SubresourceLayout` to match.
- Added mostly-safe `bind_memory` methods to these two types. These take `self` by value, and return `Buffer` and `Image` on success.
- Added `Buffer` and `Image` types, which represent buffers and images that have had memory bound to them. This memory can be retrieved using the `memory()` method.
- Most previous uses of `UnsafeBuffer` and `UnsafeImage` now use `Buffer` and `Image` instead.

### Additions
- Added a `flags` field to `BufferCreateInfo`. This contains no flags yet, but will in the future.
- Added the `disjoint` flag to `ImageCreateFlags`. This flag is used in combination with multi-planar images, to bind separate memory to each plane of the image. It is not yet supported for the higher-level image types.
````

This is another step towards reducing the number of buffer and image types that are needed, and also makes binding memory mostly safe. Type safety is used to ensure that `Buffer` and `Image` always have memory bound to them. Once sparse binding is introduced, this will not fully be the case, since bindings can be made and unmade at any time; sparse resources will therefore require runtime checks.

@marc0246 There are some considerations in this PR that may affect your memory allocator code:
- The `disjoint` flag is added, which never allows dedicated allocations ([VUID-VkMemoryDedicatedAllocateInfo-image-01797](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkMemoryDedicatedAllocateInfo.html#VUID-VkMemoryDedicatedAllocateInfo-image-01797)). Images that were created with this flag don't have one single `MemoryRequirements`, but rather two or three (for each plane). The `memory_requirements` method for images therefore now returns a slice. The newly introduced `ImageMemory` type also has a vector to hold all the allocations.
- `MemoryRequirements` was missing the `requires_dedicated_allocation` flag, which this PR adds. The allocator needs to ensure that when this flag is set, either a dedicated allocation is made or it errors out.