### PR TITLE
Fix depth and stencil attachment check when building pipeline

### DIFF
--- a/vulkano/src/pipeline/graphics/builder.rs
+++ b/vulkano/src/pipeline/graphics/builder.rs
@@ -1852,7 +1852,7 @@ where
                 let has_depth_attachment = match render_pass {
                     PipelineRenderPassType::BeginRenderPass(subpass) => subpass.has_depth(),
                     PipelineRenderPassType::BeginRendering(rendering_info) => {
-                        rendering_info.depth_attachment_format.is_none()
+                        rendering_info.depth_attachment_format.is_some()
                     }
                 };
 
@@ -1990,12 +1990,12 @@ where
                 let has_stencil_attachment = match render_pass {
                     PipelineRenderPassType::BeginRenderPass(subpass) => subpass.has_stencil(),
                     PipelineRenderPassType::BeginRendering(rendering_info) => {
-                        rendering_info.stencil_attachment_format.is_none()
+                        rendering_info.stencil_attachment_format.is_some()
                     }
                 };
 
                 if !has_stencil_attachment {
-                    return Err(GraphicsPipelineCreationError::NoDepthAttachment);
+                    return Err(GraphicsPipelineCreationError::NoStencilAttachment);
                 }
 
                 // VUID?


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- Depth and stencil attachments are now properly checked when using dynamic rendering.
- Proper error (`NoStencilAttachment`) is now being returned if stencil attachment format is missing.
````

I've noticed these issues when tinkering with secondary buffers and dynamic rendering - there was no way to declare inheritance for depth attachments for secondary buffers, as it would result in pipeline validation error with or without it.
