### PR TITLE
Further improvements to command buffer allocation

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -147,7 +147,8 @@ fn main() {
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     // We start by creating the buffer that will store the data.
     let data_buffer = {

--- a/examples/src/bin/buffer-pool.rs
+++ b/examples/src/bin/buffer-pool.rs
@@ -244,7 +244,8 @@ fn main() {
     let mut recreate_swapchain = false;
     let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     event_loop.run(move |event, _, control_flow| {
         match event {

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -154,7 +154,8 @@ fn main() {
     )
     .unwrap();
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let mut width = swapchain.image_extent()[0];
     let mut height = swapchain.image_extent()[1];

--- a/examples/src/bin/debug.rs
+++ b/examples/src/bin/debug.rs
@@ -176,7 +176,8 @@ fn main() {
     .expect("failed to create device");
     let queue = queues.next().unwrap();
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
         &command_buffer_allocator,
         queue.queue_family_index(),

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -166,7 +166,10 @@ fn main() {
     };
 
     let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
-    let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(device.clone()));
+    let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(
+        device.clone(),
+        Default::default(),
+    ));
 
     // Here is the basic initialization for the deferred system.
     let mut frame_system = FrameSystem::new(

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -134,7 +134,8 @@ fn main() {
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     // Declare input buffer.
     // Data in a dynamic buffer **MUST** be aligned to min_uniform_buffer_offset_align

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -201,7 +201,8 @@ fn main() {
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let image = StorageImage::new(
         &memory_allocator,

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -227,7 +227,8 @@ mod linux {
         });
 
         let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-        let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let command_buffer_allocator =
+            StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
         let layout = pipeline.layout().set_layouts().get(0).unwrap();
 

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -215,7 +215,8 @@ fn main() {
     .unwrap();
 
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let mut uploads = AutoCommandBufferBuilder::primary(
         &command_buffer_allocator,
         queue.queue_family_index(),

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -213,7 +213,8 @@ fn main() {
     .unwrap();
 
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let mut uploads = AutoCommandBufferBuilder::primary(
         &command_buffer_allocator,
         queue.queue_family_index(),

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -219,7 +219,8 @@ fn main() {
     .unwrap();
 
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let mut uploads = AutoCommandBufferBuilder::primary(
         &command_buffer_allocator,
         queue.queue_family_index(),

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -324,7 +324,8 @@ fn main() {
     let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     event_loop.run(move |event, _, control_flow| {
         match event {

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -319,7 +319,8 @@ fn main() {
     let mut recreate_swapchain = false;
     let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     event_loop.run(move |event, _, control_flow| {
         match event {

--- a/examples/src/bin/interactive_fractal/app.rs
+++ b/examples/src/bin/interactive_fractal/app.rs
@@ -66,6 +66,7 @@ impl FractalApp {
         ));
         let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(
             gfx_queue.device().clone(),
+            Default::default(),
         ));
         let descriptor_set_allocator = Arc::new(StandardDescriptorSetAllocator::new(
             gfx_queue.device().clone(),

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -317,7 +317,8 @@ fn main() {
         depth_range: 0.0..1.0,
     };
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device);
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let buf = CpuAccessibleBuffer::from_iter(
         &memory_allocator,

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -278,7 +278,8 @@ fn main() {
         depth_range: 0.0..1.0,
     };
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     window_surfaces.insert(
         window_id,

--- a/examples/src/bin/multi_window_game_of_life/app.rs
+++ b/examples/src/bin/multi_window_game_of_life/app.rs
@@ -35,6 +35,7 @@ impl RenderPipeline {
         let memory_allocator = StandardMemoryAllocator::new_default(gfx_queue.device().clone());
         let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(
             gfx_queue.device().clone(),
+            Default::default(),
         ));
         let descriptor_set_allocator = Arc::new(StandardDescriptorSetAllocator::new(
             gfx_queue.device().clone(),

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -280,7 +280,8 @@ fn main() {
         .build(device.clone())
         .unwrap();
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let create_buffer = || {
         CpuAccessibleBuffer::from_iter(

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -325,7 +325,8 @@ fn main() {
         depth_range: 0.0..1.0,
     };
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let mut framebuffers = window_size_dependent_setup(
         &images,

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -132,7 +132,8 @@ fn main() {
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let data_buffer = {
         let data_iter = 0..65536u32;

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -208,7 +208,8 @@ fn main() {
     )
     .unwrap();
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let mut uploads = AutoCommandBufferBuilder::primary(
         &command_buffer_allocator,
         queue.queue_family_index(),

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -261,7 +261,8 @@ fn main() {
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
     let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -275,7 +275,8 @@ fn main() {
     .unwrap();
 
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let mut uploads = AutoCommandBufferBuilder::primary(
         &command_buffer_allocator,
         queue.queue_family_index(),

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -119,7 +119,8 @@ fn main() {
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let data_buffer = {
         // we intitialize half of the array and leave the other half to 0, we will use copy later to fill it

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -127,7 +127,8 @@ fn main() {
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let data_buffer = {
         let data_iter = 0..65536u32;

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -239,7 +239,8 @@ fn main() {
     }
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
 
     // Preparing test data array `[0, 1, 2, 3....]`

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -320,7 +320,8 @@ fn main() {
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     #[repr(C)]
     #[derive(Clone, Copy, Debug, Default, Zeroable, Pod)]

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -128,7 +128,8 @@ fn main() {
 
     let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let data_buffer = {
         let data_iter = 0..65536u32;

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -233,7 +233,8 @@ fn main() {
     let rotation_start = Instant::now();
 
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     event_loop.run(move |event, _, control_flow| {
         match event {

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -368,7 +368,8 @@ fn main() {
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -215,7 +215,8 @@ fn main() {
     .unwrap();
 
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let mut uploads = AutoCommandBufferBuilder::primary(
         &command_buffer_allocator,
         queue.queue_family_index(),

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -416,7 +416,8 @@ fn main() {
     //
     // A Vulkan command pool only works for one queue family, and vulkano's command buffer allocator
     // reflects that, therefore we need to pass the queue family during creation.
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     // Initialization is finally finished!
 

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -423,7 +423,8 @@ fn main() {
     //
     // A Vulkan command pool only works for one queue family, and vulkano's command buffer allocator
     // reflects that, therefore we need to pass the queue family during creation.
-    let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+    let command_buffer_allocator =
+        StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     // Initialization is finally finished!
 

--- a/vulkano/src/buffer/device_local.rs
+++ b/vulkano/src/buffer/device_local.rs
@@ -567,7 +567,8 @@ mod tests {
     fn from_data_working() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let command_buffer_allocator =
+            StandardCommandBufferAllocator::new(device.clone(), Default::default());
         let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
             &command_buffer_allocator,
             queue.queue_family_index(),
@@ -617,7 +618,8 @@ mod tests {
     fn from_iter_working() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let command_buffer_allocator =
+            StandardCommandBufferAllocator::new(device.clone(), Default::default());
         let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
             &command_buffer_allocator,
             queue.queue_family_index(),
@@ -670,7 +672,8 @@ mod tests {
     fn create_buffer_zero_size_data() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let command_buffer_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let command_buffer_allocator =
+            StandardCommandBufferAllocator::new(device.clone(), Default::default());
         let mut command_buffer_builder = AutoCommandBufferBuilder::primary(
             &command_buffer_allocator,
             queue.queue_family_index(),

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -968,7 +968,7 @@ mod tests {
         )
         .unwrap();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
+        let cb_allocator = StandardCommandBufferAllocator::new(device, Default::default());
         let mut cbb = AutoCommandBufferBuilder::primary(
             &cb_allocator,
             queue.queue_family_index(),
@@ -1006,7 +1006,7 @@ mod tests {
     fn secondary_nonconcurrent_conflict() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
+        let cb_allocator = StandardCommandBufferAllocator::new(device, Default::default());
 
         // Make a secondary CB that doesn't support simultaneous use.
         let builder = AutoCommandBufferBuilder::secondary(
@@ -1093,7 +1093,7 @@ mod tests {
         )
         .unwrap();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
+        let cb_allocator = StandardCommandBufferAllocator::new(device, Default::default());
         let mut builder = AutoCommandBufferBuilder::primary(
             &cb_allocator,
             queue.queue_family_index(),
@@ -1145,7 +1145,7 @@ mod tests {
         )
         .unwrap();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device);
+        let cb_allocator = StandardCommandBufferAllocator::new(device, Default::default());
         let mut builder = AutoCommandBufferBuilder::primary(
             &cb_allocator,
             queue.queue_family_index(),

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -389,7 +389,7 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let allocator = StandardCommandBufferAllocator::new(device);
+            let allocator = StandardCommandBufferAllocator::new(device, Default::default());
 
             let builder_alloc = allocator
                 .allocate(queue.queue_family_index(), CommandBufferLevel::Primary, 1)
@@ -413,7 +413,8 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let cb_allocator = StandardCommandBufferAllocator::new(device.clone());
+            let cb_allocator =
+                StandardCommandBufferAllocator::new(device.clone(), Default::default());
             let mut cbb = AutoCommandBufferBuilder::primary(
                 &cb_allocator,
                 queue.queue_family_index(),
@@ -522,7 +523,8 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let cb_allocator = StandardCommandBufferAllocator::new(device.clone());
+            let cb_allocator =
+                StandardCommandBufferAllocator::new(device.clone(), Default::default());
             let builder_alloc = cb_allocator
                 .allocate(queue.queue_family_index(), CommandBufferLevel::Primary, 1)
                 .unwrap()
@@ -563,7 +565,8 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let cb_allocator = StandardCommandBufferAllocator::new(device.clone());
+            let cb_allocator =
+                StandardCommandBufferAllocator::new(device.clone(), Default::default());
             let builder_alloc = cb_allocator
                 .allocate(queue.queue_family_index(), CommandBufferLevel::Primary, 1)
                 .unwrap()

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -1022,7 +1022,7 @@ mod tests {
     fn mipmap_working_immutable_image() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let cb_allocator = StandardCommandBufferAllocator::new(device.clone(), Default::default());
         let mut cbb = AutoCommandBufferBuilder::primary(
             &cb_allocator,
             queue.queue_family_index(),

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -512,7 +512,7 @@ mod tests {
         )
         .unwrap();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device.clone());
+        let cb_allocator = StandardCommandBufferAllocator::new(device.clone(), Default::default());
         let mut cbb = AutoCommandBufferBuilder::primary(
             &cb_allocator,
             queue.queue_family_index(),


### PR DESCRIPTION
Improved command buffer allocation performance by 21% (on my system, the precise benchmarks went from 90ns down to 71ns/alloc) by always resetting the command pool as a whole instead of resetting command buffers individually. Other than that some additional methods were added to `StandardCommandBufferAllocator` as well as configuration options for more flexibility.

Changelog:
```markdown
### Additions
- Added `StandardCommandBufferAllocatorCreateInfo`.
- Added `StandardCommandBufferAllocator::{try_reset_pool, clear}`.
````