### PR TITLE
Add homegrown IDs for Vulkan objects

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -34,6 +34,7 @@ use std::{
     fmt::{Display, Error as FmtError, Formatter},
     hash::{Hash, Hasher},
     mem::{size_of_val, MaybeUninit},
+    num::NonZeroU64,
     ops::{Deref, DerefMut, Range},
     ptr,
     sync::Arc,
@@ -48,6 +49,7 @@ use std::{
 pub struct RawBuffer {
     handle: ash::vk::Buffer,
     device: Arc<Device>,
+    id: NonZeroU64,
 
     flags: BufferCreateFlags,
     size: DeviceSize,
@@ -324,13 +326,12 @@ impl RawBuffer {
         RawBuffer {
             handle,
             device,
-
+            id: Self::next_id(),
             flags,
             size,
             usage,
             sharing,
             external_memory_handle_types,
-
             memory_requirements,
         }
     }
@@ -629,21 +630,7 @@ unsafe impl DeviceOwned for RawBuffer {
     }
 }
 
-impl PartialEq for RawBuffer {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device == other.device
-    }
-}
-
-impl Eq for RawBuffer {}
-
-impl Hash for RawBuffer {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device.hash(state);
-    }
-}
+crate::impl_id_counter!(RawBuffer);
 
 /// Parameters to create a new `Buffer`.
 #[derive(Clone, Debug)]

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -59,6 +59,7 @@ use std::{
     fmt::{Display, Error as FmtError, Formatter},
     hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     ops::Range,
     ptr,
     sync::Arc,
@@ -73,6 +74,7 @@ where
 {
     handle: ash::vk::BufferView,
     buffer: Arc<B>,
+    id: NonZeroU64,
 
     format: Option<Format>,
     format_features: FormatFeatures,
@@ -233,7 +235,7 @@ where
         Ok(Arc::new(BufferView {
             handle,
             buffer,
-
+            id: Self::next_id(),
             format: Some(format),
             format_features,
             range: 0..size,
@@ -282,26 +284,7 @@ where
     }
 }
 
-impl<B> PartialEq for BufferView<B>
-where
-    B: BufferAccess + ?Sized,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl<B> Eq for BufferView<B> where B: BufferAccess + ?Sized {}
-
-impl<B> Hash for BufferView<B>
-where
-    B: BufferAccess + ?Sized,
-{
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(BufferView<B: BufferAccess + ?Sized>);
 
 /// Parameters to create a new `BufferView`.
 #[derive(Clone, Debug)]

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -23,8 +23,8 @@ use std::{
     collections::BTreeMap,
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     ptr,
     sync::Arc,
 };
@@ -34,6 +34,7 @@ use std::{
 pub struct DescriptorSetLayout {
     handle: ash::vk::DescriptorSetLayout,
     device: Arc<Device>,
+    id: NonZeroU64,
 
     bindings: BTreeMap<u32, DescriptorSetLayoutBinding>,
     push_descriptor: bool,
@@ -60,10 +61,9 @@ impl DescriptorSetLayout {
         Ok(Arc::new(DescriptorSetLayout {
             handle,
             device,
-
+            id: Self::next_id(),
             bindings,
             push_descriptor,
-
             descriptor_counts,
         }))
     }
@@ -98,10 +98,9 @@ impl DescriptorSetLayout {
         Arc::new(DescriptorSetLayout {
             handle,
             device,
-
+            id: Self::next_id(),
             bindings,
             push_descriptor,
-
             descriptor_counts,
         })
     }
@@ -453,21 +452,7 @@ unsafe impl DeviceOwned for DescriptorSetLayout {
     }
 }
 
-impl PartialEq for DescriptorSetLayout {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl Eq for DescriptorSetLayout {}
-
-impl Hash for DescriptorSetLayout {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(DescriptorSetLayout);
 
 /// Error related to descriptor set layout.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -141,7 +141,7 @@ pub unsafe trait DescriptorSet: DeviceOwned + Send + Sync {
 impl PartialEq for dyn DescriptorSet {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner().handle() == other.inner().handle() && self.device() == other.device()
+        self.inner() == other.inner()
     }
 }
 
@@ -149,8 +149,7 @@ impl Eq for dyn DescriptorSet {}
 
 impl Hash for dyn DescriptorSet {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().handle().hash(state);
-        self.device().hash(state);
+        self.inner().hash(state);
     }
 }
 

--- a/vulkano/src/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor_set/persistent.rs
@@ -133,7 +133,7 @@ where
     P: DescriptorSetAlloc,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.inner().handle() == other.inner().handle() && self.device() == other.device()
+        self.inner() == other.inner()
     }
 }
 
@@ -144,7 +144,6 @@ where
     P: DescriptorSetAlloc,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().handle().hash(state);
-        self.device().hash(state);
+        self.inner().hash(state);
     }
 }

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -21,9 +21,9 @@ use std::{
     cell::Cell,
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
     marker::PhantomData,
     mem::MaybeUninit,
+    num::NonZeroU64,
     ptr,
     sync::Arc,
 };
@@ -36,6 +36,7 @@ use std::{
 pub struct DescriptorPool {
     handle: ash::vk::DescriptorPool,
     device: Arc<Device>,
+    id: NonZeroU64,
 
     max_sets: u32,
     pool_sizes: HashMap<DescriptorType, u32>,
@@ -115,6 +116,7 @@ impl DescriptorPool {
         Ok(DescriptorPool {
             handle,
             device,
+            id: Self::next_id(),
             max_sets,
             pool_sizes,
             can_free_descriptor_sets,
@@ -144,6 +146,7 @@ impl DescriptorPool {
         DescriptorPool {
             handle,
             device,
+            id: Self::next_id(),
             max_sets,
             pool_sizes,
             can_free_descriptor_sets,
@@ -343,21 +346,7 @@ unsafe impl DeviceOwned for DescriptorPool {
     }
 }
 
-impl PartialEq for DescriptorPool {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl Eq for DescriptorPool {}
-
-impl Hash for DescriptorPool {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(DescriptorPool);
 
 /// Parameters to create a new `UnsafeDescriptorPool`.
 #[derive(Clone, Debug)]

--- a/vulkano/src/descriptor_set/single_layout_pool.rs
+++ b/vulkano/src/descriptor_set/single_layout_pool.rs
@@ -254,7 +254,7 @@ unsafe impl DeviceOwned for SingleLayoutDescSet {
 impl PartialEq for SingleLayoutDescSet {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner().handle() == other.inner().handle() && self.device() == other.device()
+        self.inner() == other.inner()
     }
 }
 
@@ -262,8 +262,7 @@ impl Eq for SingleLayoutDescSet {}
 
 impl Hash for SingleLayoutDescSet {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().handle().hash(state);
-        self.device().hash(state);
+        self.inner().hash(state);
     }
 }
 
@@ -500,7 +499,7 @@ unsafe impl DeviceOwned for SingleLayoutVariableDescSet {
 impl PartialEq for SingleLayoutVariableDescSet {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner().handle() == other.inner().handle() && self.device() == other.device()
+        self.inner() == other.inner()
     }
 }
 
@@ -508,7 +507,6 @@ impl Eq for SingleLayoutVariableDescSet {}
 
 impl Hash for SingleLayoutVariableDescSet {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().handle().hash(state);
-        self.device().hash(state);
+        self.inner().hash(state);
     }
 }

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -20,6 +20,7 @@ use crate::{
 use smallvec::SmallVec;
 use std::{
     fmt::{Debug, Error as FmtError, Formatter},
+    num::NonZeroU64,
     ptr,
 };
 
@@ -27,14 +28,20 @@ use std::{
 ///
 /// Contrary to most other objects in this library, this one doesn't free itself automatically and
 /// doesn't hold the pool or the device it is associated to.
-/// Instead it is an object meant to be used with the `UnsafeDescriptorPool`.
+/// Instead it is an object meant to be used with the [`DescriptorPool`].
+///
+/// [`DescriptorPool`]: super::pool::DescriptorPool
 pub struct UnsafeDescriptorSet {
     handle: ash::vk::DescriptorSet,
+    id: NonZeroU64,
 }
 
 impl UnsafeDescriptorSet {
     pub(crate) fn new(handle: ash::vk::DescriptorSet) -> Self {
-        Self { handle }
+        Self {
+            handle,
+            id: Self::next_id(),
+        }
     }
 
     /// Modifies a descriptor set. Doesn't check that the writes or copies are correct, and
@@ -121,3 +128,5 @@ impl Debug for UnsafeDescriptorSet {
         write!(f, "<Vulkan descriptor set {:?}>", self.handle)
     }
 }
+
+crate::impl_id_counter!(UnsafeDescriptorSet);

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -125,8 +125,8 @@ use std::{
     ffi::CString,
     fmt::{Display, Error as FmtError, Formatter},
     fs::File,
-    hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     ops::Deref,
     ptr,
     sync::{
@@ -146,6 +146,7 @@ mod queue;
 pub struct Device {
     handle: ash::vk::Device,
     physical_device: Arc<PhysicalDevice>,
+    id: NonZeroU64,
 
     // The highest version that is supported for this device.
     // This is the minimum of Instance::max_api_version and PhysicalDevice::api_version.
@@ -406,6 +407,7 @@ impl Device {
         let device = Arc::new(Device {
             handle,
             physical_device,
+            id: Self::next_id(),
             api_version,
             fns,
             enabled_extensions,
@@ -643,21 +645,7 @@ unsafe impl VulkanObject for Device {
     }
 }
 
-impl PartialEq for Device {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.physical_device == other.physical_device
-    }
-}
-
-impl Eq for Device {}
-
-impl Hash for Device {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.physical_device.hash(state);
-    }
-}
+crate::impl_id_counter!(Device);
 
 /// Error that can be returned when creating a device.
 #[derive(Copy, Clone, Debug)]

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -29,6 +29,7 @@ use std::{
     fmt::{Debug, Display, Error as FmtError, Formatter},
     hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     ptr,
     sync::Arc,
 };
@@ -41,6 +42,7 @@ where
 {
     handle: ash::vk::ImageView,
     image: Arc<I>,
+    id: NonZeroU64,
 
     component_mapping: ComponentMapping,
     format: Option<Format>,
@@ -672,7 +674,7 @@ where
         Ok(Arc::new(ImageView {
             handle,
             image,
-
+            id: Self::next_id(),
             view_type,
             format,
             format_features,
@@ -680,7 +682,6 @@ where
             subresource_range,
             usage,
             sampler_ycbcr_conversion,
-
             filter_cubic,
             filter_cubic_minmax,
         }))
@@ -782,26 +783,7 @@ where
     }
 }
 
-impl<I> PartialEq for ImageView<I>
-where
-    I: ImageAccess + ?Sized,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl<I> Eq for ImageView<I> where I: ImageAccess + ?Sized {}
-
-impl<I> Hash for ImageView<I>
-where
-    I: ImageAccess + ?Sized,
-{
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(ImageView<I: ImageAccess + ?Sized>);
 
 /// Parameters to create a new `ImageView`.
 #[derive(Debug)]

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -97,8 +97,8 @@ use std::{
     error::Error,
     ffi::{c_void, CString},
     fmt::{Debug, Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     panic::{RefUnwindSafe, UnwindSafe},
     ptr,
     sync::Arc,
@@ -260,6 +260,7 @@ mod layers;
 pub struct Instance {
     handle: ash::vk::Instance,
     fns: InstanceFunctions,
+    id: NonZeroU64,
 
     api_version: Version,
     enabled_extensions: InstanceExtensions,
@@ -531,7 +532,7 @@ impl Instance {
         Ok(Arc::new(Instance {
             handle,
             fns,
-
+            id: Self::next_id(),
             api_version,
             enabled_extensions,
             enabled_layers,
@@ -656,26 +657,14 @@ unsafe impl VulkanObject for Instance {
     }
 }
 
-impl PartialEq for Instance {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle
-    }
-}
-
-impl Eq for Instance {}
-
-impl Hash for Instance {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-    }
-}
+crate::impl_id_counter!(Instance);
 
 impl Debug for Instance {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         let Self {
             handle,
             fns,
+            id: _,
             api_version,
             enabled_extensions,
             enabled_layers,

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -381,3 +381,47 @@ pub(crate) struct RequirementNotMet {
 /// syntax from being used.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)] // add traits as needed
 pub struct NonExhaustive(pub(crate) ());
+
+macro_rules! impl_id_counter {
+    ($type:ident $(< $($param:ident $(: $bound:ident $(+ $bounds:ident)* )?),+ >)?) => {
+        $crate::impl_id_counter!(
+            @inner $type $(< $($param),+ >)?, $( $($param $(: $bound $(+ $bounds)* )?),+)?
+        );
+    };
+    ($type:ident $(< $($param:ident $(: $bound:ident $(+ $bounds:ident)* )? + ?Sized),+ >)?) => {
+        $crate::impl_id_counter!(
+            @inner $type $(< $($param),+ >)?, $( $($param $(: $bound $(+ $bounds)* )? + ?Sized),+)?
+        );
+    };
+    (@inner $type:ident $(< $($param:ident),+ >)?, $($bounds:tt)*) => {
+        impl< $($bounds)* > $type $(< $($param),+ >)? {
+            fn next_id() -> std::num::NonZeroU64 {
+                use std::{
+                    num::NonZeroU64,
+                    sync::atomic::{AtomicU64, Ordering},
+                };
+
+                static COUNTER: AtomicU64 = AtomicU64::new(1);
+
+                NonZeroU64::new(COUNTER.fetch_add(1, Ordering::Relaxed)).expect("ID overflow")
+            }
+        }
+
+        impl< $($bounds)* > PartialEq for $type $(< $($param),+ >)? {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                self.id == other.id
+            }
+        }
+
+        impl< $($bounds)* > Eq for $type $(< $($param),+ >)? {}
+
+        impl< $($bounds)* > std::hash::Hash for $type $(< $($param),+ >)? {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.id.hash(state);
+            }
+        }
+    };
+}
+
+pub(crate) use impl_id_counter;

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -42,6 +42,7 @@ use std::{
     fmt::{Debug, Display, Error as FmtError, Formatter},
     mem,
     mem::MaybeUninit,
+    num::NonZeroU64,
     ptr,
     sync::Arc,
 };
@@ -57,6 +58,7 @@ use std::{
 pub struct ComputePipeline {
     handle: ash::vk::Pipeline,
     device: Arc<Device>,
+    id: NonZeroU64,
     layout: Arc<PipelineLayout>,
     descriptor_requirements: HashMap<(u32, u32), DescriptorRequirements>,
     num_used_descriptor_sets: u32,
@@ -232,6 +234,7 @@ impl ComputePipeline {
         Ok(Arc::new(ComputePipeline {
             handle,
             device: device.clone(),
+            id: Self::next_id(),
             layout,
             descriptor_requirements,
             num_used_descriptor_sets,
@@ -278,14 +281,7 @@ impl Debug for ComputePipeline {
     }
 }
 
-impl PartialEq for ComputePipeline {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle() == other.handle()
-    }
-}
-
-impl Eq for ComputePipeline {}
+crate::impl_id_counter!(ComputePipeline);
 
 unsafe impl VulkanObject for ComputePipeline {
     type Handle = ash::vk::Pipeline;

--- a/vulkano/src/pipeline/graphics/builder.rs
+++ b/vulkano/src/pipeline/graphics/builder.rs
@@ -394,12 +394,12 @@ where
         Ok(Arc::new(GraphicsPipeline {
             handle,
             device,
+            id: GraphicsPipeline::next_id(),
             layout: pipeline_layout,
             render_pass: render_pass.take().expect("Missing render pass"),
             shaders,
             descriptor_requirements,
             num_used_descriptor_sets,
-
             vertex_input_state, // Can be None if there's a mesh shader, but we don't support that yet
             input_assembly_state, // Can be None if there's a mesh shader, but we don't support that yet
             tessellation_state: has.tessellation_state.then_some(tessellation_state),

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -73,7 +73,7 @@ use crate::{
 use ahash::HashMap;
 use std::{
     fmt::{Debug, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
+    num::NonZeroU64,
     ptr,
     sync::Arc,
 };
@@ -100,6 +100,7 @@ pub mod viewport;
 pub struct GraphicsPipeline {
     handle: ash::vk::Pipeline,
     device: Arc<Device>,
+    id: NonZeroU64,
     layout: Arc<PipelineLayout>,
     render_pass: PipelineRenderPassType,
 
@@ -293,18 +294,4 @@ impl Drop for GraphicsPipeline {
     }
 }
 
-impl PartialEq for GraphicsPipeline {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.device == other.device && self.handle == other.handle
-    }
-}
-
-impl Eq for GraphicsPipeline {}
-
-impl Hash for GraphicsPipeline {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device.hash(state);
-    }
-}
+crate::impl_id_counter!(GraphicsPipeline);

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -73,8 +73,8 @@ use smallvec::SmallVec;
 use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     ptr,
     sync::Arc,
 };
@@ -84,6 +84,7 @@ use std::{
 pub struct PipelineLayout {
     handle: ash::vk::PipelineLayout,
     device: Arc<Device>,
+    id: NonZeroU64,
 
     set_layouts: Vec<Arc<DescriptorSetLayout>>,
     push_constant_ranges: Vec<PushConstantRange>,
@@ -129,6 +130,7 @@ impl PipelineLayout {
         Ok(Arc::new(PipelineLayout {
             handle,
             device,
+            id: Self::next_id(),
             set_layouts,
             push_constant_ranges,
             push_constant_ranges_disjoint,
@@ -548,6 +550,7 @@ impl PipelineLayout {
         Arc::new(PipelineLayout {
             handle,
             device,
+            id: Self::next_id(),
             set_layouts,
             push_constant_ranges,
             push_constant_ranges_disjoint,
@@ -690,21 +693,7 @@ unsafe impl DeviceOwned for PipelineLayout {
     }
 }
 
-impl PartialEq for PipelineLayout {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl Eq for PipelineLayout {}
-
-impl Hash for PipelineLayout {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(PipelineLayout);
 
 /// Error that can happen when creating a pipeline layout.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -22,8 +22,8 @@ use std::{
     error::Error,
     ffi::c_void,
     fmt::{Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
     mem::{size_of_val, MaybeUninit},
+    num::NonZeroU64,
     ops::Range,
     ptr,
     sync::Arc,
@@ -34,6 +34,7 @@ use std::{
 pub struct QueryPool {
     handle: ash::vk::QueryPool,
     device: Arc<Device>,
+    id: NonZeroU64,
 
     query_type: QueryType,
     query_count: u32,
@@ -98,7 +99,7 @@ impl QueryPool {
         Ok(Arc::new(QueryPool {
             handle,
             device,
-
+            id: Self::next_id(),
             query_type,
             query_count,
         }))
@@ -125,6 +126,7 @@ impl QueryPool {
         Arc::new(QueryPool {
             handle,
             device,
+            id: Self::next_id(),
             query_type,
             query_count,
         })
@@ -195,21 +197,7 @@ unsafe impl DeviceOwned for QueryPool {
     }
 }
 
-impl PartialEq for QueryPool {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl Eq for QueryPool {}
-
-impl Hash for QueryPool {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(QueryPool);
 
 /// Parameters to create a new `QueryPool`.
 #[derive(Clone, Debug)]

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -18,8 +18,8 @@ use smallvec::SmallVec;
 use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     ops::Range,
     ptr,
     sync::Arc,
@@ -53,6 +53,7 @@ use std::{
 pub struct Framebuffer {
     handle: ash::vk::Framebuffer,
     render_pass: Arc<RenderPass>,
+    id: NonZeroU64,
 
     attachments: Vec<Arc<dyn ImageViewAbstract>>,
     extent: [u32; 2],
@@ -323,7 +324,7 @@ impl Framebuffer {
         Ok(Arc::new(Framebuffer {
             handle,
             render_pass,
-
+            id: Self::next_id(),
             attachments,
             extent,
             layers,
@@ -352,7 +353,7 @@ impl Framebuffer {
         Arc::new(Framebuffer {
             handle,
             render_pass,
-
+            id: Self::next_id(),
             attachments,
             extent,
             layers,
@@ -418,21 +419,7 @@ unsafe impl DeviceOwned for Framebuffer {
     }
 }
 
-impl PartialEq for Framebuffer {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl Eq for Framebuffer {}
-
-impl Hash for Framebuffer {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(Framebuffer);
 
 /// Parameters to create a new `Framebuffer`.
 #[derive(Clone, Debug)]

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -38,13 +38,7 @@ use crate::{
     sync::{AccessFlags, PipelineStages},
     Version, VulkanObject,
 };
-use std::{
-    cmp::max,
-    hash::{Hash, Hasher},
-    mem::MaybeUninit,
-    ptr,
-    sync::Arc,
-};
+use std::{cmp::max, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
 
 #[macro_use]
 mod macros;
@@ -108,6 +102,7 @@ mod framebuffer;
 pub struct RenderPass {
     handle: ash::vk::RenderPass,
     device: Arc<Device>,
+    id: NonZeroU64,
 
     attachments: Vec<AttachmentDescription>,
     subpasses: Vec<SubpassDescription>,
@@ -154,12 +149,11 @@ impl RenderPass {
         Ok(Arc::new(RenderPass {
             handle,
             device,
-
+            id: Self::next_id(),
             attachments,
             subpasses,
             dependencies,
             correlated_view_masks,
-
             granularity,
             views_used,
         }))
@@ -223,12 +217,11 @@ impl RenderPass {
         Ok(Arc::new(RenderPass {
             handle,
             device,
-
+            id: Self::next_id(),
             attachments,
             subpasses,
             dependencies,
             correlated_view_masks,
-
             granularity,
             views_used,
         }))
@@ -294,6 +287,7 @@ impl RenderPass {
         let Self {
             handle: _,
             device: _,
+            id: _,
             attachments: attachments1,
             subpasses: subpasses1,
             dependencies: dependencies1,
@@ -304,6 +298,7 @@ impl RenderPass {
         let Self {
             handle: _,
             device: _,
+            id: _,
             attachments: attachments2,
             subpasses: subpasses2,
             dependencies: dependencies2,
@@ -537,21 +532,7 @@ unsafe impl DeviceOwned for RenderPass {
     }
 }
 
-impl PartialEq for RenderPass {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl Eq for RenderPass {}
-
-impl Hash for RenderPass {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device.hash(state);
-    }
-}
+crate::impl_id_counter!(RenderPass);
 
 /// Represents a subpass within a `RenderPass` object.
 ///

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -58,8 +58,8 @@ use crate::{
 use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     ops::RangeInclusive,
     ptr,
     sync::Arc,
@@ -98,6 +98,7 @@ use std::{
 pub struct Sampler {
     handle: ash::vk::Sampler,
     device: Arc<Device>,
+    id: NonZeroU64,
 
     address_mode: [SamplerAddressMode; 3],
     anisotropy: Option<f32>,
@@ -438,7 +439,7 @@ impl Sampler {
         Ok(Arc::new(Sampler {
             handle,
             device,
-
+            id: Self::next_id(),
             address_mode,
             anisotropy,
             border_color: address_mode
@@ -488,7 +489,7 @@ impl Sampler {
         Arc::new(Sampler {
             handle,
             device,
-
+            id: Self::next_id(),
             address_mode,
             anisotropy,
             border_color: address_mode
@@ -758,21 +759,7 @@ unsafe impl DeviceOwned for Sampler {
     }
 }
 
-impl PartialEq for Sampler {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl Eq for Sampler {}
-
-impl Hash for Sampler {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(Sampler);
 
 /// Error that can happen when creating an instance.
 #[derive(Clone, Debug, PartialEq)]

--- a/vulkano/src/sampler/ycbcr.rs
+++ b/vulkano/src/sampler/ycbcr.rs
@@ -99,8 +99,8 @@ use crate::{
 use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
-    hash::{Hash, Hasher},
     mem::MaybeUninit,
+    num::NonZeroU64,
     ptr,
     sync::Arc,
 };
@@ -110,6 +110,7 @@ use std::{
 pub struct SamplerYcbcrConversion {
     handle: ash::vk::SamplerYcbcrConversion,
     device: Arc<Device>,
+    id: NonZeroU64,
 
     format: Option<Format>,
     ycbcr_model: SamplerYcbcrModelConversion,
@@ -350,6 +351,7 @@ impl SamplerYcbcrConversion {
         Ok(Arc::new(SamplerYcbcrConversion {
             handle,
             device,
+            id: Self::next_id(),
             format: Some(format),
             ycbcr_model,
             ycbcr_range,
@@ -387,6 +389,7 @@ impl SamplerYcbcrConversion {
         Arc::new(SamplerYcbcrConversion {
             handle,
             device,
+            id: Self::next_id(),
             format,
             ycbcr_model,
             ycbcr_range,
@@ -446,6 +449,7 @@ impl SamplerYcbcrConversion {
             let &Self {
                 handle: _,
                 device: _,
+                id: _,
                 format,
                 ycbcr_model,
                 ycbcr_range,
@@ -499,21 +503,7 @@ unsafe impl DeviceOwned for SamplerYcbcrConversion {
     }
 }
 
-impl PartialEq for SamplerYcbcrConversion {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle && self.device() == other.device()
-    }
-}
-
-impl Eq for SamplerYcbcrConversion {}
-
-impl Hash for SamplerYcbcrConversion {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.handle.hash(state);
-        self.device().hash(state);
-    }
-}
+crate::impl_id_counter!(SamplerYcbcrConversion);
 
 /// Error that can happen when creating a `SamplerYcbcrConversion`.
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Adds our own IDs to Vulkan objects, since nothing is stopping a handle from being reused. I can see how a pool/slab allocator in the driver would easily reuse the same handle, which could lead to two different resources testing equal and having the same hash, while they are in fact different. The IDs can also come in handy for other things in the library, I can think of at least a few.