### PR TITLE
Update render pass checks for new VUID

### DIFF
--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -317,8 +317,7 @@ fn main() {
         depth_range: 0.0..1.0,
     };
 
-    let command_buffer_allocator =
-        StandardCommandBufferAllocator::new(device.clone(), Default::default());
+    let command_buffer_allocator = StandardCommandBufferAllocator::new(device, Default::default());
 
     let buf = CpuAccessibleBuffer::from_iter(
         &memory_allocator,


### PR DESCRIPTION
Per https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4236, a VUID for render pass creation was removed, and replaced with a simpler one. This PR implements the simpler one.