### PR TITLE
Add validation for binding dedicated allocations

### DIFF
--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::DedicatedAllocation;
+use super::{DedicatedAllocation, DedicatedTo};
 use crate::{
     device::{Device, DeviceOwned},
     macros::{vulkan_bitflags, vulkan_enum},
@@ -56,6 +56,7 @@ pub struct DeviceMemory {
 
     allocation_size: DeviceSize,
     memory_type_index: u32,
+    dedicated_to: Option<DedicatedTo>,
     export_handle_types: ExternalMemoryHandleTypes,
     imported_handle_type: Option<ExternalMemoryHandleType>,
     flags: MemoryAllocateFlags,
@@ -97,7 +98,7 @@ impl DeviceMemory {
         let MemoryAllocateInfo {
             allocation_size,
             memory_type_index,
-            dedicated_allocation: _,
+            dedicated_allocation,
             export_handle_types,
             flags,
             _ne: _,
@@ -109,6 +110,7 @@ impl DeviceMemory {
             id: Self::next_id(),
             allocation_size,
             memory_type_index,
+            dedicated_to: dedicated_allocation.map(Into::into),
             export_handle_types,
             imported_handle_type: None,
             flags,
@@ -537,6 +539,7 @@ impl DeviceMemory {
             id: Self::next_id(),
             allocation_size,
             memory_type_index,
+            dedicated_to: dedicated_allocation.map(Into::into),
             export_handle_types,
             imported_handle_type,
             flags,
@@ -553,6 +556,18 @@ impl DeviceMemory {
     #[inline]
     pub fn allocation_size(&self) -> DeviceSize {
         self.allocation_size
+    }
+
+    /// Returns `true` if the memory is a [dedicated] to a resource.
+    ///
+    /// [dedicated]: MemoryAllocateInfo#structfield.dedicated_allocation
+    #[inline]
+    pub fn is_dedicated(&self) -> bool {
+        self.dedicated_to.is_some()
+    }
+
+    pub(crate) fn dedicated_to(&self) -> Option<DedicatedTo> {
+        self.dedicated_to
     }
 
     /// Returns the handle types that can be exported from the memory allocation.

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -103,7 +103,7 @@ use crate::{
     sync::Semaphore,
     DeviceSize,
 };
-use std::sync::Arc;
+use std::{num::NonZeroU64, sync::Arc};
 
 pub mod allocator;
 mod device_memory;
@@ -321,6 +321,21 @@ pub enum DedicatedAllocation<'a> {
     Buffer(&'a RawBuffer),
     /// Allocation dedicated to an image.
     Image(&'a RawImage),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DedicatedTo {
+    Buffer(NonZeroU64),
+    Image(NonZeroU64),
+}
+
+impl From<DedicatedAllocation<'_>> for DedicatedTo {
+    fn from(dedicated_allocation: DedicatedAllocation<'_>) -> Self {
+        match dedicated_allocation {
+            DedicatedAllocation::Buffer(buffer) => Self::Buffer(buffer.id()),
+            DedicatedAllocation::Image(image) => Self::Image(image.id()),
+        }
+    }
 }
 
 /// The properties for exporting or importing external memory, when a buffer or image is created


### PR DESCRIPTION
Adds the validation that was missing when binding a dedicated allocation, using the IDs introduced in #2054.