### PR TITLE
Fix unused import warnings on Windows

### DIFF
--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -25,7 +25,7 @@ use std::{
     pin::Pin,
     ptr,
     sync::{Arc, Weak},
-    task::{Context, Pool},
+    task::{Context, Poll},
     time::Duration,
 };
 

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -18,10 +18,15 @@ use crate::{
     DeviceSize, OomError,
 };
 use parking_lot::{Mutex, MutexGuard};
-use std::{mem::replace, ops::Range, sync::Arc, time::Duration};
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    mem::replace,
+    ops::Range,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 /// Builds a new fence signal future.
 pub fn then_signal_fence<F>(future: F, behavior: FenceSignalFutureBehavior) -> FenceSignalFuture<F>
@@ -366,8 +371,8 @@ where
 }
 
 impl<F> Future for FenceSignalFuture<F>
-    where
-        F: GpuFuture,
+where
+    F: GpuFuture,
 {
     type Output = Result<(), OomError>;
 

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -1636,13 +1636,14 @@ impl From<RequirementNotMet> for SemaphoreError {
 
 #[cfg(test)]
 mod tests {
-    use super::ExternalSemaphoreHandleType;
+    #[cfg(unix)]
     use crate::{
         device::{Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo},
         instance::{Instance, InstanceCreateInfo, InstanceExtensions},
-        sync::{ExternalSemaphoreHandleTypes, Semaphore, SemaphoreCreateInfo},
-        VulkanLibrary, VulkanObject,
+        sync::{ExternalSemaphoreHandleType, ExternalSemaphoreHandleTypes, SemaphoreCreateInfo},
+        VulkanLibrary,
     };
+    use crate::{sync::Semaphore, VulkanObject};
 
     #[test]
     fn semaphore_create() {

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -13,10 +13,11 @@ use crate::{
     OomError, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};
+#[cfg(unix)]
+use std::fs::File;
 use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
-    fs::File,
     mem::MaybeUninit,
     num::NonZeroU64,
     ptr,


### PR DESCRIPTION
Fixes the unused import warning for `File` on Windows. Some other changes from ``cargo fmt`` left over from #2051.