### PR TITLE
Update SwapchainCreateInfo image_extent doc

### DIFF
--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -1014,10 +1014,10 @@ pub struct SwapchainCreateInfo {
 
     /// The extent of the created images.
     ///
-    /// If set to `None`, the value of
+    /// If any of the values is 0, the value of
     /// [`SurfaceCapabilities::current_extent`](crate::swapchain::SurfaceCapabilities) will be used.
     ///
-    /// The default value is `None`.
+    /// The default value is `[0, 0]`.
     pub image_extent: [u32; 2],
 
     /// The number of array layers of the created images.


### PR DESCRIPTION
There was an outdated mention of `None` in image_extent doc comment.

Changelog:
```markdown
### Bugs fixed
- SwapchainCreateInfo documentation correction
````
