### PR TITLE
Allow waiting on SwapchainAcquireFuture

### DIFF
--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -1633,6 +1633,18 @@ impl SwapchainAcquireFuture {
     pub fn swapchain(&self) -> &Arc<Swapchain> {
         &self.swapchain
     }
+
+    /// Blocks the current thread until the swapchain image has been acquired, or timeout
+    ///
+    /// If timeout is `None`, will potentially block forever
+    ///
+    /// You still need to join with this future for present to work
+    pub fn wait(&self, timeout: Option<Duration>) -> Result<(), FenceError> {
+        match &self.fence {
+            Some(fence) => fence.wait(timeout),
+            None => Ok(()),
+        }
+    }
 }
 
 unsafe impl GpuFuture for SwapchainAcquireFuture {


### PR DESCRIPTION

Changelog:
````md
### Additions
- Allow waiting on `SwapchainAcquireFuture`
````

Fixes: #1218

It was previously theoretically possible to wait on `SwapchainAcquireFuture` by dropping it.

But if you dropped it, it became impossible to actually present the image, as `then_swapchain_present` requires `acquire_future` to have been joined.



#### Why might you want to wait for the swapchain acquire?

 * Because my machine (Nvidia on Linux) pegs the cpu at 100% if you don't (like, wtf???)
 * Because that's what Sascha Willems' samples do
 * Because it allows you to lower input latency when running vsynced. 

#### Is this the best design?

There was some discussion on discord about making acquire_next_image return some opaque object that did more things automatically. Or perhaps tracking the acquire state on the image instead of with this future. 

But this approach achieve much the same result, and doesn't require invasive refactoring. 

