### PR TITLE
Fix black screen on some devices in interactive examples

### DIFF
--- a/examples/src/bin/interactive_fractal/main.rs
+++ b/examples/src/bin/interactive_fractal/main.rs
@@ -57,10 +57,7 @@ fn main() {
     primary_window_renderer.add_additional_image_view(
         render_target_id,
         DEFAULT_IMAGE_FORMAT,
-        ImageUsage::SAMPLED
-            | ImageUsage::STORAGE
-            | ImageUsage::COLOR_ATTACHMENT
-            | ImageUsage::TRANSFER_DST,
+        ImageUsage::SAMPLED | ImageUsage::STORAGE | ImageUsage::TRANSFER_DST,
     );
 
     // Create app to hold the logic of our fractal explorer

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -84,10 +84,7 @@ impl GameOfLifeComputePipeline {
             compute_queue.clone(),
             size,
             Format::R8G8B8A8_UNORM,
-            ImageUsage::SAMPLED
-                | ImageUsage::STORAGE
-                | ImageUsage::COLOR_ATTACHMENT
-                | ImageUsage::TRANSFER_DST,
+            ImageUsage::SAMPLED | ImageUsage::STORAGE | ImageUsage::TRANSFER_DST,
         )
         .unwrap();
 


### PR DESCRIPTION
To fix #1979, removing the color attachment that actuall was unnecessary in these examples should work. I only know this due to some rather old debugging from the spring, but I don't know **why** this is the case.

The black images only occur on some GPUs.

Maybe someone else knows, perhaps this is an invalid usage combo...