### PR TITLE
Remove allocator from window renderer inputs

### DIFF
--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -66,7 +66,6 @@ impl VulkanoWindowRenderer {
         window: winit::window::Window,
         descriptor: &WindowDescriptor,
         swapchain_create_info_modify: fn(&mut SwapchainCreateInfo),
-        memory_allocator: Arc<StandardMemoryAllocator>,
     ) -> VulkanoWindowRenderer {
         // Create rendering surface from window
         let surface =
@@ -89,7 +88,7 @@ impl VulkanoWindowRenderer {
             compute_queue: vulkano_context.compute_queue().clone(),
             swapchain: swap_chain,
             final_views,
-            memory_allocator,
+            memory_allocator: vulkano_context.memory_allocator().clone(),
             additional_image_views: HashMap::default(),
             recreate_swapchain: false,
             previous_frame_end,

--- a/vulkano-util/src/window.rs
+++ b/vulkano-util/src/window.rs
@@ -168,7 +168,6 @@ impl VulkanoWindows {
                 winit_window,
                 window_descriptor,
                 swapchain_create_info_modify,
-                vulkano_context.memory_allocator().clone(),
             ),
         );
 


### PR DESCRIPTION
Unnecessary input had been added to the window renderer. Just removing it ;)