### PR TITLE
Split `sync` module into multiple submodules, other changes to sync

### DIFF
--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -52,8 +52,12 @@ mod linux {
             SwapchainPresentInfo,
         },
         sync::{
-            now, ExternalSemaphoreHandleType, ExternalSemaphoreHandleTypes, FlushError, GpuFuture,
-            Semaphore, SemaphoreCreateInfo,
+            now,
+            semaphore::{
+                ExternalSemaphoreHandleType, ExternalSemaphoreHandleTypes, Semaphore,
+                SemaphoreCreateInfo,
+            },
+            FlushError, GpuFuture,
         },
         VulkanLibrary,
     };

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -42,7 +42,7 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, Subpass},
     swapchain::{PresentMode, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo},
-    sync::{FenceSignalFuture, GpuFuture},
+    sync::{future::FenceSignalFuture, GpuFuture},
     VulkanLibrary,
 };
 use vulkano_win::VkSurfaceBuild;

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -25,7 +25,7 @@ use crate::{
         MemoryPropertyFlags, MemoryRequirements,
     },
     range_map::RangeMap,
-    sync::{AccessError, CurrentAccess, Sharing},
+    sync::{future::AccessError, CurrentAccess, Sharing},
     DeviceSize, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -27,7 +27,7 @@ use crate::{
     image::{sys::Image, ImageAccess, ImageAspects, ImageLayout, ImageSubresourceRange},
     query::{QueryControlFlags, QueryType},
     render_pass::{Framebuffer, Subpass},
-    sync::{AccessCheckError, AccessFlags, PipelineMemoryAccess, PipelineStages},
+    sync::{future::AccessCheckError, AccessFlags, PipelineMemoryAccess, PipelineStages},
     DeviceSize, OomError, RequirementNotMet, RequiresOneOf, VulkanObject,
 };
 use ahash::HashMap;

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -328,6 +328,7 @@ where
         }
 
         // VUID-vkCmdBindPipeline-pipeline-00781
+        // TODO:
 
         Ok(())
     }
@@ -1218,7 +1219,7 @@ impl UnsafeCommandBufferBuilderBindVertexBuffer {
 }
 
 #[derive(Clone, Debug)]
-enum BindPushError {
+pub(in super::super) enum BindPushError {
     DescriptorSetUpdateError(DescriptorSetUpdateError),
 
     RequirementNotMet {

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -2912,7 +2912,7 @@ impl UnsafeCommandBufferBuilder {
 
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
-enum SetDynamicStateError {
+pub(in super::super) enum SetDynamicStateError {
     RequirementNotMet {
         required_for: &'static str,
         requires_one_of: RequiresOneOf,

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -285,7 +285,7 @@ where
         assert_eq!(device, query_pool.device());
 
         // VUID-vkCmdWriteTimestamp2-stage-03860
-        if !queue_family_properties.supports_stage(stage) {
+        if !PipelineStages::from(queue_family_properties.queue_flags).contains_enum(stage) {
             return Err(QueryError::StageNotSupported);
         }
 

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -127,7 +127,7 @@ use crate::{
     query::{QueryControlFlags, QueryPipelineStatisticFlags},
     range_map::RangeMap,
     render_pass::{Framebuffer, Subpass},
-    sync::{AccessFlags, PipelineStages, Semaphore},
+    sync::{semaphore::Semaphore, AccessFlags, PipelineStages},
     DeviceSize,
 };
 use bytemuck::{Pod, Zeroable};

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -205,7 +205,7 @@ impl SyncCommandBufferBuilder {
                 ref range,
                 ref memory,
             } => {
-                debug_assert!(memory.stages.supported_access().contains(memory.access));
+                debug_assert!(AccessFlags::from(memory.stages).contains(memory.access));
 
                 if let Some(conflicting_use) =
                     self.find_buffer_conflict(buffer, range.clone(), memory)
@@ -226,7 +226,7 @@ impl SyncCommandBufferBuilder {
                 end_layout,
             } => {
                 debug_assert!(memory.exclusive || start_layout == end_layout);
-                debug_assert!(memory.stages.supported_access().contains(memory.access));
+                debug_assert!(AccessFlags::from(memory.stages).contains(memory.access));
                 debug_assert!(end_layout != ImageLayout::Undefined);
                 debug_assert!(end_layout != ImageLayout::Preinitialized);
 

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -78,7 +78,10 @@ use crate::{
     buffer::{sys::Buffer, BufferAccess},
     device::{Device, DeviceOwned, Queue},
     image::{sys::Image, ImageAccess, ImageLayout, ImageSubresourceRange},
-    sync::{AccessCheckError, AccessError, AccessFlags, PipelineMemoryAccess, PipelineStages},
+    sync::{
+        future::{AccessCheckError, AccessError},
+        AccessFlags, PipelineMemoryAccess, PipelineStages,
+    },
     DeviceSize,
 };
 use ahash::HashMap;

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -17,8 +17,10 @@ use crate::{
     image::{sys::Image, ImageAccess, ImageLayout, ImageSubresourceRange},
     swapchain::Swapchain,
     sync::{
-        now, AccessCheckError, AccessError, AccessFlags, FlushError, GpuFuture, NowFuture,
-        PipelineMemoryAccess, PipelineStages, SubmitAnyBuilder,
+        future::{
+            now, AccessCheckError, AccessError, FlushError, GpuFuture, NowFuture, SubmitAnyBuilder,
+        },
+        AccessFlags, PipelineMemoryAccess, PipelineStages,
     },
     DeviceSize, SafeDeref, VulkanObject,
 };

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -25,8 +25,8 @@ use crate::{
         SurfaceInfo, SurfaceTransforms,
     },
     sync::{
-        ExternalFenceInfo, ExternalFenceProperties, ExternalSemaphoreInfo,
-        ExternalSemaphoreProperties,
+        fence::{ExternalFenceInfo, ExternalFenceProperties},
+        semaphore::{ExternalSemaphoreInfo, ExternalSemaphoreProperties},
     },
     ExtensionProperties, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -22,7 +22,9 @@ use crate::{
     },
     swapchain::{PresentInfo, SwapchainPresentInfo},
     sync::{
-        AccessCheckError, Fence, FenceState, FlushError, GpuFuture, PipelineStage, SemaphoreState,
+        fence::{Fence, FenceState},
+        future::{AccessCheckError, FlushError, GpuFuture},
+        semaphore::SemaphoreState,
     },
     OomError, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
@@ -1588,14 +1590,6 @@ pub struct QueueFamilyProperties {
     pub min_image_transfer_granularity: [u32; 3],
 }
 
-impl QueueFamilyProperties {
-    /// Returns whether the queues of this family support a particular pipeline stage.
-    #[inline]
-    pub fn supports_stage(&self, stage: PipelineStage) -> bool {
-        self.queue_flags.contains(stage.required_queue_flags())
-    }
-}
-
 impl From<ash::vk::QueueFamilyProperties> for QueueFamilyProperties {
     #[inline]
     fn from(val: ash::vk::QueueFamilyProperties) -> Self {
@@ -1645,6 +1639,13 @@ vulkan_bitflags! {
     VIDEO_ENCODE = VIDEO_ENCODE_KHR {
         device_extensions: [khr_video_encode_queue],
     },
+
+    /*
+    /// Queues of this family can execute optical flow operations.
+    OPTICAL_FLOW = OPTICAL_FLOW_NV {
+        device_extensions: [nv_optical_flow],
+    },
+     */
 }
 
 /// Error that can happen when submitting work to a queue.
@@ -1700,7 +1701,7 @@ impl From<RequirementNotMet> for QueueError {
 
 #[cfg(test)]
 mod tests {
-    use crate::sync::Fence;
+    use crate::sync::fence::Fence;
     use std::{sync::Arc, time::Duration};
 
     #[test]

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     range_map::RangeMap,
     swapchain::Swapchain,
-    sync::{AccessError, CurrentAccess, Sharing},
+    sync::{future::AccessError, CurrentAccess, Sharing},
     DeviceSize, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -99,7 +99,7 @@ use crate::{
     buffer::{sys::RawBuffer, BufferAccess},
     image::{sys::RawImage, ImageAccess, ImageAspects},
     macros::vulkan_bitflags,
-    sync::Semaphore,
+    sync::semaphore::Semaphore,
     DeviceSize,
 };
 use std::{num::NonZeroU64, sync::Arc};

--- a/vulkano/src/render_pass/create.rs
+++ b/vulkano/src/render_pass/create.rs
@@ -15,7 +15,7 @@ use crate::{
     device::Device,
     format::FormatFeatures,
     image::{ImageAspects, ImageLayout, SampleCount},
-    sync::PipelineStages,
+    sync::{AccessFlags, DependencyFlags, PipelineStages},
     OomError, RequirementNotMet, RequiresOneOf, Version, VulkanError, VulkanObject,
 };
 use smallvec::SmallVec;
@@ -633,8 +633,8 @@ impl RenderPass {
                 dst_stages,
                 src_access,
                 dst_access,
-                by_region,
-                view_local,
+                dependency_flags,
+                view_offset,
                 _ne: _,
             } = dependency;
             let dependency_num = dependency_num as u32;
@@ -875,7 +875,7 @@ impl RenderPass {
 
                 // VUID-VkSubpassDependency2-srcAccessMask-03088
                 // VUID-VkSubpassDependency2-dstAccessMask-03089
-                if !stages.supported_access().contains(access) {
+                if !AccessFlags::from(stages).contains(access) {
                     return Err(
                         RenderPassCreationError::DependencyAccessNotSupportedByStages {
                             dependency: dependency_num,
@@ -884,13 +884,24 @@ impl RenderPass {
                 }
             }
 
-            // VUID-VkRenderPassCreateInfo2-viewMask-03059
-            if view_local.is_some() && !is_multiview {
-                return Err(
-                    RenderPassCreationError::DependencyViewLocalMultiviewNotEnabled {
-                        dependency: dependency_num,
-                    },
-                );
+            if dependency_flags.intersects(DependencyFlags::VIEW_LOCAL) {
+                // VUID-VkRenderPassCreateInfo2-viewMask-03059
+                if !is_multiview {
+                    return Err(
+                        RenderPassCreationError::DependencyViewLocalMultiviewNotEnabled {
+                            dependency: dependency_num,
+                        },
+                    );
+                }
+            } else {
+                // VUID-VkSubpassDependency2-dependencyFlags-03092
+                if view_offset != 0 {
+                    return Err(
+                        RenderPassCreationError::DependencyViewOffzetNonzeroWithoutViewLocal {
+                            dependency: dependency_num,
+                        },
+                    );
+                }
             }
 
             // VUID-VkSubpassDependency2-srcSubpass-03085
@@ -937,7 +948,7 @@ impl RenderPass {
                 } else {
                     // VUID-VkSubpassDependency2-dependencyFlags-03090
                     // VUID-VkSubpassDependency2-dependencyFlags-03091
-                    if view_local.is_some() {
+                    if dependency_flags.intersects(DependencyFlags::VIEW_LOCAL) {
                         return Err(
                             RenderPassCreationError::DependencyViewLocalExternalDependency {
                                 dependency: dependency_num,
@@ -977,7 +988,7 @@ impl RenderPass {
                     // VUID-VkSubpassDependency2-srcSubpass-02245
                     if src_stages.intersects(framebuffer_stages)
                         && dst_stages.intersects(framebuffer_stages)
-                        && !by_region
+                        && !dependency_flags.intersects(DependencyFlags::BY_REGION)
                     {
                         return Err(
                             RenderPassCreationError::DependencySelfDependencyFramebufferStagesWithoutByRegion {
@@ -986,11 +997,11 @@ impl RenderPass {
                         );
                     }
 
-                    if let Some(view_offset) = view_local {
+                    if dependency_flags.intersects(DependencyFlags::VIEW_LOCAL) {
                         // VUID-VkSubpassDependency2-viewOffset-02530
                         if view_offset != 0 {
                             return Err(
-                                RenderPassCreationError::DependencySelfDependencyViewLocalNonzeroOffset {
+                                RenderPassCreationError::DependencySelfDependencyViewLocalNonzeroViewOffset {
                                     dependency: dependency_num,
                                 },
                             );
@@ -1172,16 +1183,6 @@ impl RenderPass {
             .iter()
             .enumerate()
             .map(|(index, dependency)| {
-                let mut dependency_flags = ash::vk::DependencyFlags::empty();
-
-                if dependency.by_region {
-                    dependency_flags |= ash::vk::DependencyFlags::BY_REGION;
-                }
-
-                if dependency.view_local.is_some() {
-                    dependency_flags |= ash::vk::DependencyFlags::VIEW_LOCAL;
-                }
-
                 ash::vk::SubpassDependency2 {
                     p_next: memory_barriers_vk
                         .get(index)
@@ -1192,9 +1193,9 @@ impl RenderPass {
                     dst_stage_mask: dependency.dst_stages.into(),
                     src_access_mask: dependency.src_access.into(),
                     dst_access_mask: dependency.dst_access.into(),
-                    dependency_flags,
+                    dependency_flags: dependency.dependency_flags.into(),
                     // VUID-VkSubpassDependency2-dependencyFlags-03092
-                    view_offset: dependency.view_local.unwrap_or(0),
+                    view_offset: dependency.view_offset,
                     ..Default::default()
                 }
             })
@@ -1371,11 +1372,7 @@ impl RenderPass {
                 dst_stage_mask: dependency.dst_stages.into(),
                 src_access_mask: dependency.src_access.into(),
                 dst_access_mask: dependency.dst_access.into(),
-                dependency_flags: if dependency.by_region {
-                    ash::vk::DependencyFlags::BY_REGION
-                } else {
-                    ash::vk::DependencyFlags::empty()
-                },
+                dependency_flags: dependency.dependency_flags.into(),
             })
             .collect::<SmallVec<[_; 4]>>();
 
@@ -1427,7 +1424,7 @@ impl RenderPass {
                     subpasses.iter().map(|subpass| subpass.view_mask).collect(),
                     dependencies
                         .iter()
-                        .map(|dependency| dependency.view_local.unwrap_or(0))
+                        .map(|dependency| dependency.view_offset)
                         .collect(),
                 )
             } else {
@@ -1549,7 +1546,7 @@ pub enum RenderPassCreationError {
 
     /// A subpass dependency specifies a subpass self-dependency and has the `view_local` dependency
     /// enabled, but the inner offset value was not 0.
-    DependencySelfDependencyViewLocalNonzeroOffset { dependency: u32 },
+    DependencySelfDependencyViewLocalNonzeroViewOffset { dependency: u32 },
 
     /// A subpass dependency specifies a subpass self-dependency without the `view_local`
     /// dependency, but the referenced subpass has more than one bit set in its `view_mask`.
@@ -1566,13 +1563,23 @@ pub enum RenderPassCreationError {
     /// render pass.
     DependencySubpassOutOfRange { dependency: u32, subpass: u32 },
 
-    /// A subpass dependency has the `view_local` dependency enabled, but `src_subpass` or
+    /// In a subpass dependency, `dependency_flags` contains [`VIEW_LOCAL`], but `src_subpass` or
     /// `dst_subpass` were set to `None`.
+    ///
+    /// [`VIEW_LOCAL`]: crate::sync::DependencyFlags::VIEW_LOCAL
     DependencyViewLocalExternalDependency { dependency: u32 },
 
-    /// A subpass dependency has the `view_local` dependency enabled, but multiview is not enabled
-    /// on the render pass.
+    /// In a subpass dependency, `dependency_flags` contains [`VIEW_LOCAL`], but multiview is not
+    /// enabled on the render pass.
+    ///
+    /// [`VIEW_LOCAL`]: crate::sync::DependencyFlags::VIEW_LOCAL
     DependencyViewLocalMultiviewNotEnabled { dependency: u32 },
+
+    /// In a subpass dependency, `view_offset` is not zero, but `dependency_flags` does not contain
+    /// [`VIEW_LOCAL`].
+    ///
+    /// [`VIEW_LOCAL`]: crate::sync::DependencyFlags::VIEW_LOCAL
+    DependencyViewOffzetNonzeroWithoutViewLocal { dependency: u32 },
 
     /// A reference to an attachment used other than as an input attachment in a subpass has
     /// one or more aspects selected.
@@ -1740,7 +1747,7 @@ impl Display for RenderPassCreationError {
                     dependency,
                 )
             }
-            Self::DependencySelfDependencyViewLocalNonzeroOffset { dependency } => write!(
+            Self::DependencySelfDependencyViewLocalNonzeroViewOffset { dependency } => write!(
                 f,
                 "subpass dependency {} specifies a subpass self-dependency and has the \
                 `view_local` dependency enabled, but the inner offset value was not 0",
@@ -1785,14 +1792,20 @@ impl Display for RenderPassCreationError {
             ),
             Self::DependencyViewLocalExternalDependency { dependency } => write!(
                 f,
-                "subpass dependency {} has the `view_local` dependency enabled, but \
+                "in subpass dependency {}, `dependency_flags` contains `VIEW_LOCAL`, but \
                 `src_subpass` or `dst_subpass` were set to `None`",
                 dependency,
             ),
             Self::DependencyViewLocalMultiviewNotEnabled { dependency } => write!(
                 f,
-                "subpass dependency {} has the `view_local` dependency enabled, but multiview is \
-                not enabled on the render pass",
+                "in subpass dependency {}, `dependency_flags` contains `VIEW_LOCAL`, but \
+                multiview is not enabled on the render pass",
+                dependency,
+            ),
+            Self::DependencyViewOffzetNonzeroWithoutViewLocal { dependency } => write!(
+                f,
+                "in subpass dependency {}, `view_offset` is not zero, but `dependency_flags` does \
+                not contain `VIEW_LOCAL`",
                 dependency,
             ),
             Self::SubpassAttachmentAspectsNotEmpty {

--- a/vulkano/src/render_pass/macros.rs
+++ b/vulkano/src/render_pass/macros.rs
@@ -168,7 +168,8 @@ macro_rules! ordered_passes_renderpass {
                         dst_stages,
                         src_access,
                         dst_access,
-                        by_region: true,                      // TODO: correct values
+                        // TODO: correct values
+                        dependency_flags: $crate::sync::DependencyFlags::BY_REGION,
                         ..Default::default()
                     }
                 })

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -337,7 +337,7 @@ pub use self::{
 #[cfg(target_os = "ios")]
 pub use surface::IOSMetalLayer;
 
-use crate::sync::Semaphore;
+use crate::sync::semaphore::Semaphore;
 use std::{
     num::NonZeroU64,
     sync::{atomic::AtomicBool, Arc},

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -22,8 +22,10 @@ use crate::{
     macros::vulkan_enum,
     swapchain::{PresentInfo, SurfaceApi, SurfaceInfo, SurfaceSwapchainLock},
     sync::{
-        AccessCheckError, AccessError, AccessFlags, Fence, FenceError, FlushError, GpuFuture,
-        PipelineStages, Semaphore, SemaphoreError, Sharing, SubmitAnyBuilder,
+        fence::{Fence, FenceError},
+        future::{AccessCheckError, AccessError, FlushError, GpuFuture, SubmitAnyBuilder},
+        semaphore::{Semaphore, SemaphoreError},
+        AccessFlags, PipelineStages, Sharing,
     },
     DeviceSize, OomError, RequirementNotMet, RequiresOneOf, VulkanError, VulkanObject,
 };

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -7,6 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+//! An event provides fine-grained synchronization within a single queue, or from the host to a
+//! queue.
+
 use crate::{
     device::{Device, DeviceOwned},
     OomError, RequiresOneOf, VulkanError, VulkanObject,
@@ -296,7 +299,7 @@ impl From<VulkanError> for EventError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{sync::Event, VulkanObject};
+    use crate::{sync::event::Event, VulkanObject};
 
     #[test]
     fn event_create() {

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -7,6 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+//! A fence provides synchronization between the device and the host, or between an external source
+//! and the host.
+
 use crate::{
     device::{Device, DeviceOwned, Queue},
     macros::{vulkan_bitflags, vulkan_bitflags_enum},
@@ -1608,7 +1611,7 @@ impl From<RequirementNotMet> for FenceError {
 #[cfg(test)]
 mod tests {
     use crate::{
-        sync::{fence::FenceCreateInfo, Fence},
+        sync::fence::{Fence, FenceCreateInfo},
         VulkanObject,
     };
     use std::time::Duration;

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -14,7 +14,11 @@ use crate::{
     device::{Device, DeviceOwned, Queue, QueueFlags},
     image::{sys::Image, ImageLayout},
     swapchain::Swapchain,
-    sync::{AccessError, AccessFlags, Fence, PipelineStages, SubmitAnyBuilder},
+    sync::{
+        fence::Fence,
+        future::{AccessError, SubmitAnyBuilder},
+        AccessFlags, PipelineStages,
+    },
     DeviceSize, OomError,
 };
 use parking_lot::{Mutex, MutexGuard};

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -7,13 +7,100 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+//! Represents an event that will happen on the GPU in the future.
+//!
+//! Whenever you ask the GPU to start an operation by using a function of the vulkano library (for
+//! example executing a command buffer), this function will return a *future*. A future is an
+//! object that implements [the `GpuFuture` trait](crate::sync::GpuFuture) and that represents the
+//! point in time when this operation is over.
+//!
+//! No function in vulkano immediately sends an operation to the GPU (with the exception of some
+//! unsafe low-level functions). Instead they return a future that is in the pending state. Before
+//! the GPU actually starts doing anything, you have to *flush* the future by calling the `flush()`
+//! method or one of its derivatives.
+//!
+//! Futures serve several roles:
+//!
+//! - Futures can be used to build dependencies between operations and makes it possible to ask
+//!   that an operation starts only after a previous operation is finished.
+//! - Submitting an operation to the GPU is a costly operation. By chaining multiple operations
+//!   with futures you will submit them all at once instead of one by one, thereby reducing this
+//!   cost.
+//! - Futures keep alive the resources and objects used by the GPU so that they don't get destroyed
+//!   while they are still in use.
+//!
+//! The last point means that you should keep futures alive in your program for as long as their
+//! corresponding operation is potentially still being executed by the GPU. Dropping a future
+//! earlier will block the current thread (after flushing, if necessary) until the GPU has finished
+//! the operation, which is usually not what you want.
+//!
+//! If you write a function that submits an operation to the GPU in your program, you are
+//! encouraged to let this function return the corresponding future and let the caller handle it.
+//! This way the caller will be able to chain multiple futures together and decide when it wants to
+//! keep the future alive or drop it.
+//!
+//! # Executing an operation after a future
+//!
+//! Respecting the order of operations on the GPU is important, as it is what *proves* vulkano that
+//! what you are doing is indeed safe. For example if you submit two operations that modify the
+//! same buffer, then you need to execute one after the other instead of submitting them
+//! independently. Failing to do so would mean that these two operations could potentially execute
+//! simultaneously on the GPU, which would be unsafe.
+//!
+//! This is done by calling one of the methods of the `GpuFuture` trait. For example calling
+//! `prev_future.then_execute(command_buffer)` takes ownership of `prev_future` and will make sure
+//! to only start executing `command_buffer` after the moment corresponding to `prev_future`
+//! happens. The object returned by the `then_execute` function is itself a future that corresponds
+//! to the moment when the execution of `command_buffer` ends.
+//!
+//! ## Between two different GPU queues
+//!
+//! When you want to perform an operation after another operation on two different queues, you
+//! **must** put a *semaphore* between them. Failure to do so would result in a runtime error.
+//! Adding a semaphore is a simple as replacing `prev_future.then_execute(...)` with
+//! `prev_future.then_signal_semaphore().then_execute(...)`.
+//!
+//! > **Note**: A common use-case is using a transfer queue (ie. a queue that is only capable of
+//! > performing transfer operations) to write data to a buffer, then read that data from the
+//! > rendering queue.
+//!
+//! What happens when you do so is that the first queue will execute the first set of operations
+//! (represented by `prev_future` in the example), then put a semaphore in the signalled state.
+//! Meanwhile the second queue blocks (if necessary) until that same semaphore gets signalled, and
+//! then only will execute the second set of operations.
+//!
+//! Since you want to avoid blocking the second queue as much as possible, you probably want to
+//! flush the operation to the first queue as soon as possible. This can easily be done by calling
+//! `then_signal_semaphore_and_flush()` instead of `then_signal_semaphore()`.
+//!
+//! ## Between several different GPU queues
+//!
+//! The `then_signal_semaphore()` method is appropriate when you perform an operation in one queue,
+//! and want to see the result in another queue. However in some situations you want to start
+//! multiple operations on several different queues.
+//!
+//! TODO: this is not yet implemented
+//!
+//! # Fences
+//!
+//! A `Fence` is an object that is used to signal the CPU when an operation on the GPU is finished.
+//!
+//! Signalling a fence is done by calling `then_signal_fence()` on a future. Just like semaphores,
+//! you are encouraged to use `then_signal_fence_and_flush()` instead.
+//!
+//! Signalling a fence is kind of a "terminator" to a chain of futures
+
 pub use self::{
     fence_signal::{FenceSignalFuture, FenceSignalFutureBehavior},
     join::JoinFuture,
     now::{now, NowFuture},
     semaphore_signal::SemaphoreSignalFuture,
 };
-use super::{AccessFlags, Fence, FenceError, PipelineStages, Semaphore};
+use super::{
+    fence::{Fence, FenceError},
+    semaphore::Semaphore,
+    AccessFlags, PipelineStages,
+};
 use crate::{
     buffer::sys::Buffer,
     command_buffer::{

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -14,7 +14,7 @@ use crate::{
     device::{Device, DeviceOwned, Queue},
     image::{sys::Image, ImageLayout},
     swapchain::Swapchain,
-    sync::{AccessError, AccessFlags, PipelineStages, Semaphore},
+    sync::{future::AccessError, semaphore::Semaphore, AccessFlags, PipelineStages},
     DeviceSize,
 };
 use parking_lot::Mutex;

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -15,127 +15,23 @@
 //!
 //! This safety is enforced at runtime by vulkano but it is not magic and you will require some
 //! knowledge if you want to avoid errors.
-//!
-//! # Futures
-//!
-//! Whenever you ask the GPU to start an operation by using a function of the vulkano library (for
-//! example executing a command buffer), this function will return a *future*. A future is an
-//! object that implements [the `GpuFuture` trait](crate::sync::GpuFuture) and that represents the
-//! point in time when this operation is over.
-//!
-//! No function in vulkano immediately sends an operation to the GPU (with the exception of some
-//! unsafe low-level functions). Instead they return a future that is in the pending state. Before
-//! the GPU actually starts doing anything, you have to *flush* the future by calling the `flush()`
-//! method or one of its derivatives.
-//!
-//! Futures serve several roles:
-//!
-//! - Futures can be used to build dependencies between operations and makes it possible to ask
-//!   that an operation starts only after a previous operation is finished.
-//! - Submitting an operation to the GPU is a costly operation. By chaining multiple operations
-//!   with futures you will submit them all at once instead of one by one, thereby reducing this
-//!   cost.
-//! - Futures keep alive the resources and objects used by the GPU so that they don't get destroyed
-//!   while they are still in use.
-//!
-//! The last point means that you should keep futures alive in your program for as long as their
-//! corresponding operation is potentially still being executed by the GPU. Dropping a future
-//! earlier will block the current thread (after flushing, if necessary) until the GPU has finished
-//! the operation, which is usually not what you want.
-//!
-//! If you write a function that submits an operation to the GPU in your program, you are
-//! encouraged to let this function return the corresponding future and let the caller handle it.
-//! This way the caller will be able to chain multiple futures together and decide when it wants to
-//! keep the future alive or drop it.
-//!
-//! # Executing an operation after a future
-//!
-//! Respecting the order of operations on the GPU is important, as it is what *proves* vulkano that
-//! what you are doing is indeed safe. For example if you submit two operations that modify the
-//! same buffer, then you need to execute one after the other instead of submitting them
-//! independently. Failing to do so would mean that these two operations could potentially execute
-//! simultaneously on the GPU, which would be unsafe.
-//!
-//! This is done by calling one of the methods of the `GpuFuture` trait. For example calling
-//! `prev_future.then_execute(command_buffer)` takes ownership of `prev_future` and will make sure
-//! to only start executing `command_buffer` after the moment corresponding to `prev_future`
-//! happens. The object returned by the `then_execute` function is itself a future that corresponds
-//! to the moment when the execution of `command_buffer` ends.
-//!
-//! ## Between two different GPU queues
-//!
-//! When you want to perform an operation after another operation on two different queues, you
-//! **must** put a *semaphore* between them. Failure to do so would result in a runtime error.
-//! Adding a semaphore is a simple as replacing `prev_future.then_execute(...)` with
-//! `prev_future.then_signal_semaphore().then_execute(...)`.
-//!
-//! > **Note**: A common use-case is using a transfer queue (ie. a queue that is only capable of
-//! > performing transfer operations) to write data to a buffer, then read that data from the
-//! > rendering queue.
-//!
-//! What happens when you do so is that the first queue will execute the first set of operations
-//! (represented by `prev_future` in the example), then put a semaphore in the signalled state.
-//! Meanwhile the second queue blocks (if necessary) until that same semaphore gets signalled, and
-//! then only will execute the second set of operations.
-//!
-//! Since you want to avoid blocking the second queue as much as possible, you probably want to
-//! flush the operation to the first queue as soon as possible. This can easily be done by calling
-//! `then_signal_semaphore_and_flush()` instead of `then_signal_semaphore()`.
-//!
-//! ## Between several different GPU queues
-//!
-//! The `then_signal_semaphore()` method is appropriate when you perform an operation in one queue,
-//! and want to see the result in another queue. However in some situations you want to start
-//! multiple operations on several different queues.
-//!
-//! TODO: this is not yet implemented
-//!
-//! # Fences
-//!
-//! A `Fence` is an object that is used to signal the CPU when an operation on the GPU is finished.
-//!
-//! Signalling a fence is done by calling `then_signal_fence()` on a future. Just like semaphores,
-//! you are encouraged to use `then_signal_fence_and_flush()` instead.
-//!
-//! Signalling a fence is kind of a "terminator" to a chain of futures.
-//!
-//! TODO: lots of problems with how to use fences
-//! TODO: talk about fence + semaphore simultaneously
-//! TODO: talk about using fences to clean up
 
-#[cfg(unix)]
-pub use self::fence::ImportFenceFdInfo;
-#[cfg(windows)]
-pub use self::fence::ImportFenceWin32HandleInfo;
 pub use self::{
-    event::{Event, EventCreateInfo},
-    fence::{
-        ExternalFenceHandleType, ExternalFenceHandleTypes, ExternalFenceInfo,
-        ExternalFenceProperties, Fence, FenceCreateInfo, FenceError, FenceImportFlags,
-    },
-    future::{
-        now, AccessCheckError, AccessError, FenceSignalFuture, FlushError, GpuFuture, JoinFuture,
-        NowFuture, SemaphoreSignalFuture, SubmitAnyBuilder,
-    },
+    future::{now, FlushError, GpuFuture},
     pipeline::{
-        AccessFlags, BufferMemoryBarrier, DependencyInfo, ImageMemoryBarrier, MemoryBarrier,
-        PipelineMemoryAccess, PipelineStage, PipelineStages, QueueFamilyTransfer,
-    },
-    semaphore::{
-        ExternalSemaphoreHandleType, ExternalSemaphoreHandleTypes, ExternalSemaphoreInfo,
-        ExternalSemaphoreProperties, Semaphore, SemaphoreCreateInfo, SemaphoreError,
-        SemaphoreImportFlags,
+        AccessFlags, BufferMemoryBarrier, DependencyFlags, DependencyInfo, ImageMemoryBarrier,
+        MemoryBarrier, PipelineMemoryAccess, PipelineStage, PipelineStages,
+        QueueFamilyOwnershipTransfer,
     },
 };
-pub(crate) use self::{fence::FenceState, semaphore::SemaphoreState};
 use crate::device::Queue;
 use std::sync::Arc;
 
-mod event;
-mod fence;
-mod future;
+pub mod event;
+pub mod fence;
+pub mod future;
 mod pipeline;
-mod semaphore;
+pub mod semaphore;
 
 /// Declares in which queue(s) a resource can be used.
 ///

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -7,6 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+//! A semaphore provides synchronization between multiple queues, with non-command buffer
+//! commands on the same queue, or between the device and an external source.
+
 use crate::{
     device::{Device, DeviceOwned, Queue},
     macros::{vulkan_bitflags, vulkan_bitflags_enum},
@@ -1572,10 +1575,12 @@ mod tests {
     use crate::{
         device::{Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo},
         instance::{Instance, InstanceCreateInfo, InstanceExtensions},
-        sync::{ExternalSemaphoreHandleType, ExternalSemaphoreHandleTypes, SemaphoreCreateInfo},
+        sync::semaphore::{
+            ExternalSemaphoreHandleType, ExternalSemaphoreHandleTypes, SemaphoreCreateInfo,
+        },
         VulkanLibrary,
     };
-    use crate::{sync::Semaphore, VulkanObject};
+    use crate::{sync::semaphore::Semaphore, VulkanObject};
 
     #[test]
     fn semaphore_create() {


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to the `sync` module and types:
- Split the module into several submodules: `event`, `fence`, `future`, `semaphore`.
- Added the `DependencyFlags` type, which is now used by `DependencyInfo` and `SubpassDependency`.
- Renamed `QueueFamilyTransfer` to `QueueFamilyOwnershipTransfer` and made it into an enum to prevent invalid usage.
````

Reorganising things a bit to make the documentation a bit easier to read, and adding some missing features.