### PR TITLE
Added support for using vulkano-win with winit without compiling Waland support

### DIFF
--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -2,7 +2,10 @@
 name = "vulkano-win"
 version = "0.32.0"
 edition = "2021"
-authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
+authors = [
+    "Pierre Krieger <pierre.krieger1708@gmail.com>",
+    "The vulkano contributors",
+]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Link between vulkano and winit"
 license = "MIT/Apache-2.0"
@@ -12,14 +15,17 @@ keywords = ["vulkan", "bindings", "graphics", "gpu", "rendering"]
 categories = ["rendering::graphics-api"]
 
 [features]
-default = ["winit_", "raw-window-handle_"]
+default = ["winit_", "raw-window-handle_", "wayland"]
 winit_ = ["winit", "objc", "core-graphics-types"]
+wayland = ["winit/wayland"]
 raw-window-handle_ = ["raw-window-handle"]
 
 [dependencies]
 raw-window-handle = { version = "0.5", optional = true }
 vulkano = { version = "0.32.0", path = "../vulkano" }
-winit = { version = "0.27", optional = true }
+winit = { version = "0.27", optional = true, default-features = false, features = [
+    "x11",
+] }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 objc = { version = "0.2.5", optional = true }


### PR DESCRIPTION
1. [x] Update documentation to reflect any user-facing changes - in this repository.
I didn't see any documentation of features, so there is no documentation to update.

3. [x] Make sure that the changes are covered by unit-tests.
All existing tests still build. I can add a trivial duplication of some existing test (e.g. triangle-v1_3) that builds without Wayland if wanted.

4. [x] Run `cargo fmt` on the changes.
Done

5. [x] Please put changelog entries **in the description of this Pull Request**
Done

6. [x] Describe in common words what is the purpose of this change, related
Wayland support in winit is still immature and pulls in some non-Rust libraries that need to be installed in the system package manager (yuck! Rust is supposed to get away from that), and on Nvidia Wayland is still pretty unstable. Given this, I prefer to not build with Wayland enabled in my applications. When using vulkano-win, however, the winit features for Wayland are enabled even if I disable them in winit in my own Cargo.toml since vulkano-win relies on winit having all default features enabled. This PR adds a default feature to vulkano-win and a simple code change to support operation in Xorg-only mode when vulkano-win is also configured to not have the wayland feature enabled. The merits of disabling Wayland are a different discussion — I think that it is quite reasonable to let developer of each program make this decision for their own program, which is what this PR allows.

Changelog:
```markdown
### Breaking changes
None, since the feature is default

### Additions
- Added default (as to be non-breaking) wayland feature to vulkan-win that a user can disable in order to build vulkano-win without Wayland support

### Bugs fixed
None
````
