### PR TITLE
Add new `CommandBufferBuilder`, and `*CommandBuffer` types

### DIFF
--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -7,14 +7,11 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-//! In the Vulkan API, command buffers must be allocated from *command pools*.
+//! Traits and types for managing the allocation of command buffers and command pools.
 //!
-//! A command pool holds and manages the memory of one or more command buffers. If you destroy a
-//! command pool, all of its command buffers are automatically destroyed.
-//!
-//! In vulkano, creating a command buffer requires passing an implementation of the
-//! [`CommandBufferAllocator`] trait, which you can implement yourself or use the vulkano-provided
-//! [`StandardCommandBufferAllocator`].
+//! In Vulkano, creating a command buffer requires passing an implementation of the
+//! [`CommandBufferAllocator`] trait. You can implement this trait yourself, or use the
+//! Vulkano-provided [`StandardCommandBufferAllocator`].
 
 use super::{
     pool::{

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -7,6 +7,14 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+//! Memory and resource pool for recording command buffers.
+//!
+//! A command pool holds and manages the memory of one or more command buffers. If you destroy a
+//! command pool, all command buffers recorded from it become invalid. This could lead to invalid
+//! usage and unsoundness, so to ensure safety you must use a [command buffer allocator].
+//!
+//! [command buffer allocator]: crate::command_buffer::allocator
+
 use crate::{
     command_buffer::CommandBufferLevel,
     device::{Device, DeviceOwned},

--- a/vulkano/src/command_buffer/standard/builder/bind_push.rs
+++ b/vulkano/src/command_buffer/standard/builder/bind_push.rs
@@ -1,0 +1,868 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{CommandBufferBuilder, RenderPassStateType, SetOrPush};
+use crate::{
+    buffer::{BufferAccess, BufferContents, BufferUsage, TypedBufferAccess},
+    command_buffer::{allocator::CommandBufferAllocator, commands::bind_push::BindPushError},
+    descriptor_set::{
+        check_descriptor_write, DescriptorSetResources, DescriptorSetWithOffsets,
+        DescriptorSetsCollection, DescriptorWriteInfo, WriteDescriptorSet,
+    },
+    device::{DeviceOwned, QueueFlags},
+    pipeline::{
+        graphics::{
+            input_assembly::{Index, IndexType},
+            render_pass::PipelineRenderPassType,
+            vertex_input::VertexBuffersCollection,
+        },
+        ComputePipeline, GraphicsPipeline, PipelineBindPoint, PipelineLayout,
+    },
+    RequiresOneOf, VulkanObject,
+};
+use smallvec::SmallVec;
+use std::{cmp::min, sync::Arc};
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Binds descriptor sets for future dispatch or draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support `pipeline_bind_point`.
+    /// - Panics if the highest descriptor set slot being bound is not less than the number of sets
+    ///   in `pipeline_layout`.
+    /// - Panics if `self` and any element of `descriptor_sets` do not belong to the same device.
+    pub fn bind_descriptor_sets(
+        &mut self,
+        pipeline_bind_point: PipelineBindPoint,
+        pipeline_layout: Arc<PipelineLayout>,
+        first_set: u32,
+        descriptor_sets: impl DescriptorSetsCollection,
+    ) -> &mut Self {
+        let descriptor_sets = descriptor_sets.into_vec();
+        self.validate_bind_descriptor_sets(
+            pipeline_bind_point,
+            &pipeline_layout,
+            first_set,
+            &descriptor_sets,
+        )
+        .unwrap();
+
+        unsafe {
+            self.bind_descriptor_sets_unchecked(
+                pipeline_bind_point,
+                pipeline_layout,
+                first_set,
+                descriptor_sets,
+            )
+        }
+    }
+
+    fn validate_bind_descriptor_sets(
+        &self,
+        pipeline_bind_point: PipelineBindPoint,
+        pipeline_layout: &PipelineLayout,
+        first_set: u32,
+        descriptor_sets: &[DescriptorSetWithOffsets],
+    ) -> Result<(), BindPushError> {
+        // VUID-vkCmdBindDescriptorSets-pipelineBindPoint-parameter
+        pipeline_bind_point.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBindDescriptorSets-commandBuffer-cmdpool
+        // VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361
+        match pipeline_bind_point {
+            PipelineBindPoint::Compute => {
+                if !queue_family_properties
+                    .queue_flags
+                    .intersects(QueueFlags::COMPUTE)
+                {
+                    return Err(BindPushError::NotSupportedByQueueFamily);
+                }
+            }
+            PipelineBindPoint::Graphics => {
+                if !queue_family_properties
+                    .queue_flags
+                    .intersects(QueueFlags::GRAPHICS)
+                {
+                    return Err(BindPushError::NotSupportedByQueueFamily);
+                }
+            }
+        }
+
+        // VUID-vkCmdBindDescriptorSets-firstSet-00360
+        if first_set + descriptor_sets.len() as u32 > pipeline_layout.set_layouts().len() as u32 {
+            return Err(BindPushError::DescriptorSetOutOfRange {
+                set_num: first_set + descriptor_sets.len() as u32,
+                pipeline_layout_set_count: pipeline_layout.set_layouts().len() as u32,
+            });
+        }
+
+        for (i, set) in descriptor_sets.iter().enumerate() {
+            let set_num = first_set + i as u32;
+
+            // VUID-vkCmdBindDescriptorSets-commonparent
+            assert_eq!(self.device(), set.as_ref().0.device());
+
+            let pipeline_layout_set = &pipeline_layout.set_layouts()[set_num as usize];
+
+            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358
+            if !pipeline_layout_set.is_compatible_with(set.as_ref().0.layout()) {
+                return Err(BindPushError::DescriptorSetNotCompatible { set_num });
+            }
+
+            // TODO: see https://github.com/vulkano-rs/vulkano/issues/1643
+            // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971
+            // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972
+            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979
+            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-06715
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn bind_descriptor_sets_unchecked(
+        &mut self,
+        pipeline_bind_point: PipelineBindPoint,
+        pipeline_layout: Arc<PipelineLayout>,
+        first_set: u32,
+        descriptor_sets: impl DescriptorSetsCollection,
+    ) -> &mut Self {
+        let descriptor_sets_with_offsets = descriptor_sets.into_vec();
+
+        if descriptor_sets_with_offsets.is_empty() {
+            return self;
+        }
+
+        let descriptor_sets: SmallVec<[_; 12]> = descriptor_sets_with_offsets
+            .iter()
+            .map(|x| x.as_ref().0.inner().handle())
+            .collect();
+        let dynamic_offsets: SmallVec<[_; 32]> = descriptor_sets_with_offsets
+            .iter()
+            .flat_map(|x| x.as_ref().1.iter().copied())
+            .collect();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_bind_descriptor_sets)(
+            self.handle(),
+            pipeline_bind_point.into(),
+            pipeline_layout.handle(),
+            first_set,
+            descriptor_sets.len() as u32,
+            descriptor_sets.as_ptr(),
+            dynamic_offsets.len() as u32,
+            dynamic_offsets.as_ptr(),
+        );
+
+        let state = self.current_state.invalidate_descriptor_sets(
+            pipeline_bind_point,
+            pipeline_layout.clone(),
+            first_set,
+            descriptor_sets_with_offsets.len() as u32,
+        );
+
+        self.resources
+            .reserve(descriptor_sets_with_offsets.len() + 1);
+
+        for (set_num, descriptor_set_with_offsets) in
+            descriptor_sets_with_offsets.into_iter().enumerate()
+        {
+            let descriptor_set = descriptor_set_with_offsets.as_ref().0.clone();
+            state.descriptor_sets.insert(
+                first_set + set_num as u32,
+                SetOrPush::Set(descriptor_set_with_offsets),
+            );
+            self.resources.push(Box::new(descriptor_set));
+        }
+
+        self.resources.push(Box::new(pipeline_layout));
+
+        self
+    }
+
+    /// Binds an index buffer for future indexed draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if `self` and `index_buffer` do not belong to the same device.
+    /// - Panics if `index_buffer` does not have the [`BufferUsage::INDEX_BUFFER`] usage enabled.
+    /// - If the index buffer contains `u8` indices, panics if the [`index_type_uint8`] feature is
+    ///   not enabled on the device.
+    ///
+    /// [`BufferUsage::INDEX_BUFFER`]: crate::buffer::BufferUsage::INDEX_BUFFER
+    /// [`index_type_uint8`]: crate::device::Features::index_type_uint8
+    pub fn bind_index_buffer<Ib, I>(&mut self, index_buffer: Arc<Ib>) -> &mut Self
+    where
+        Ib: TypedBufferAccess<Content = [I]> + 'static,
+        I: Index + 'static,
+    {
+        self.validate_bind_index_buffer(&index_buffer, I::ty())
+            .unwrap();
+
+        unsafe { self.bind_index_buffer_unchecked(index_buffer, I::ty()) }
+    }
+
+    fn validate_bind_index_buffer(
+        &self,
+        index_buffer: &dyn BufferAccess,
+        index_type: IndexType,
+    ) -> Result<(), BindPushError> {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBindIndexBuffer-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(BindPushError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdBindIndexBuffer-commonparent
+        assert_eq!(self.device(), index_buffer.device());
+
+        // VUID-vkCmdBindIndexBuffer-buffer-00433
+        if !index_buffer.usage().intersects(BufferUsage::INDEX_BUFFER) {
+            return Err(BindPushError::IndexBufferMissingUsage);
+        }
+
+        // VUID-vkCmdBindIndexBuffer-indexType-02765
+        if index_type == IndexType::U8 && !self.device().enabled_features().index_type_uint8 {
+            return Err(BindPushError::RequirementNotMet {
+                required_for: "`index_type` is `IndexType::U8`",
+                requires_one_of: RequiresOneOf {
+                    features: &["index_type_uint8"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // TODO:
+        // VUID-vkCmdBindIndexBuffer-offset-00432
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn bind_index_buffer_unchecked(
+        &mut self,
+        buffer: Arc<dyn BufferAccess>,
+        index_type: IndexType,
+    ) -> &mut Self {
+        let buffer_inner = buffer.inner();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_bind_index_buffer)(
+            self.handle(),
+            buffer_inner.buffer.handle(),
+            buffer_inner.offset,
+            index_type.into(),
+        );
+
+        self.current_state.index_buffer = Some((buffer.clone(), index_type));
+        self.resources.push(Box::new(buffer));
+
+        self
+    }
+
+    /// Binds a compute pipeline for future dispatch calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support compute operations.
+    /// - Panics if `self` and `pipeline` do not belong to the same device.
+    pub fn bind_pipeline_compute(&mut self, pipeline: Arc<ComputePipeline>) -> &mut Self {
+        self.validate_bind_pipeline_compute(&pipeline).unwrap();
+
+        unsafe { self.bind_pipeline_compute_unchecked(pipeline) }
+    }
+
+    fn validate_bind_pipeline_compute(
+        &self,
+        pipeline: &ComputePipeline,
+    ) -> Result<(), BindPushError> {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBindPipeline-pipelineBindPoint-00777
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(BindPushError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdBindPipeline-commonparent
+        assert_eq!(self.device(), pipeline.device());
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn bind_pipeline_compute_unchecked(
+        &mut self,
+        pipeline: Arc<ComputePipeline>,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_bind_pipeline)(
+            self.handle(),
+            ash::vk::PipelineBindPoint::COMPUTE,
+            pipeline.handle(),
+        );
+
+        self.current_state.pipeline_compute = Some(pipeline.clone());
+        self.resources.push(Box::new(pipeline));
+
+        self
+    }
+
+    /// Binds a graphics pipeline for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if `self` and `pipeline` do not belong to the same device.
+    pub fn bind_pipeline_graphics(&mut self, pipeline: Arc<GraphicsPipeline>) -> &mut Self {
+        self.validate_bind_pipeline_graphics(&pipeline).unwrap();
+
+        unsafe { self.bind_pipeline_graphics_unchecked(pipeline) }
+    }
+
+    fn validate_bind_pipeline_graphics(
+        &self,
+        pipeline: &GraphicsPipeline,
+    ) -> Result<(), BindPushError> {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBindPipeline-pipelineBindPoint-00778
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(BindPushError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdBindPipeline-commonparent
+        assert_eq!(self.device(), pipeline.device());
+
+        if let Some(last_pipeline) =
+            self.current_state
+                .render_pass
+                .as_ref()
+                .and_then(|render_pass_state| match &render_pass_state.render_pass {
+                    RenderPassStateType::BeginRendering(state) if state.pipeline_used => {
+                        self.current_state.pipeline_graphics.as_ref()
+                    }
+                    _ => None,
+                })
+        {
+            if let (
+                PipelineRenderPassType::BeginRendering(pipeline_rendering_info),
+                PipelineRenderPassType::BeginRendering(last_pipeline_rendering_info),
+            ) = (pipeline.render_pass(), last_pipeline.render_pass())
+            {
+                // VUID-vkCmdBindPipeline-pipeline-06195
+                // VUID-vkCmdBindPipeline-pipeline-06196
+                if pipeline_rendering_info.color_attachment_formats
+                    != last_pipeline_rendering_info.color_attachment_formats
+                {
+                    return Err(BindPushError::PreviousPipelineColorAttachmentFormatMismatch);
+                }
+
+                // VUID-vkCmdBindPipeline-pipeline-06197
+                if pipeline_rendering_info.depth_attachment_format
+                    != last_pipeline_rendering_info.depth_attachment_format
+                {
+                    return Err(BindPushError::PreviousPipelineDepthAttachmentFormatMismatch);
+                }
+
+                // VUID-vkCmdBindPipeline-pipeline-06194
+                if pipeline_rendering_info.stencil_attachment_format
+                    != last_pipeline_rendering_info.stencil_attachment_format
+                {
+                    return Err(BindPushError::PreviousPipelineStencilAttachmentFormatMismatch);
+                }
+            }
+        }
+
+        // VUID-vkCmdBindPipeline-pipeline-00781
+        // TODO:
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn bind_pipeline_graphics_unchecked(
+        &mut self,
+        pipeline: Arc<GraphicsPipeline>,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_bind_pipeline)(
+            self.handle(),
+            ash::vk::PipelineBindPoint::GRAPHICS,
+            pipeline.handle(),
+        );
+
+        // Reset any states that are fixed in the new pipeline. The pipeline bind command will
+        // overwrite these states.
+        self.current_state.reset_dynamic_states(
+            pipeline
+                .dynamic_states()
+                .filter(|(_, d)| !d) // not dynamic
+                .map(|(s, _)| s),
+        );
+        self.current_state.pipeline_graphics = Some(pipeline.clone());
+        self.resources.push(Box::new(pipeline));
+
+        self
+    }
+
+    /// Binds vertex buffers for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the highest vertex buffer binding being bound is greater than the
+    ///   [`max_vertex_input_bindings`] device property.
+    /// - Panics if `self` and any element of `vertex_buffers` do not belong to the same device.
+    /// - Panics if any element of `vertex_buffers` does not have the
+    ///   [`BufferUsage::VERTEX_BUFFER`] usage enabled.
+    ///
+    /// [`max_vertex_input_bindings`]: crate::device::Properties::max_vertex_input_bindings
+    /// [`BufferUsage::VERTEX_BUFFER`]: crate::buffer::BufferUsage::VERTEX_BUFFER
+    pub fn bind_vertex_buffers(
+        &mut self,
+        first_binding: u32,
+        vertex_buffers: impl VertexBuffersCollection,
+    ) -> &mut Self {
+        let vertex_buffers = vertex_buffers.into_vec();
+        self.validate_bind_vertex_buffers(first_binding, &vertex_buffers)
+            .unwrap();
+
+        unsafe { self.bind_vertex_buffers_unchecked(first_binding, vertex_buffers) }
+    }
+
+    fn validate_bind_vertex_buffers(
+        &self,
+        first_binding: u32,
+        vertex_buffers: &[Arc<dyn BufferAccess>],
+    ) -> Result<(), BindPushError> {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBindVertexBuffers-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(BindPushError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdBindVertexBuffers-firstBinding-00624
+        // VUID-vkCmdBindVertexBuffers-firstBinding-00625
+        if first_binding + vertex_buffers.len() as u32
+            > self
+                .device()
+                .physical_device()
+                .properties()
+                .max_vertex_input_bindings
+        {
+            return Err(BindPushError::MaxVertexInputBindingsExceeded {
+                _binding_count: first_binding + vertex_buffers.len() as u32,
+                _max: self
+                    .device()
+                    .physical_device()
+                    .properties()
+                    .max_vertex_input_bindings,
+            });
+        }
+
+        for buffer in vertex_buffers {
+            // VUID-vkCmdBindVertexBuffers-commonparent
+            assert_eq!(self.device(), buffer.device());
+
+            // VUID-vkCmdBindVertexBuffers-pBuffers-00627
+            if !buffer.usage().intersects(BufferUsage::VERTEX_BUFFER) {
+                return Err(BindPushError::VertexBufferMissingUsage);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn bind_vertex_buffers_unchecked(
+        &mut self,
+        first_binding: u32,
+        buffers: impl VertexBuffersCollection,
+    ) -> &mut Self {
+        let buffers = buffers.into_vec();
+
+        if buffers.is_empty() {
+            return self;
+        }
+
+        let (buffers_vk, offsets_vk): (SmallVec<[_; 4]>, SmallVec<[_; 4]>) = buffers
+            .iter()
+            .map(|buffer| {
+                let buffer_inner = buffer.inner();
+                (buffer_inner.buffer.handle(), buffer_inner.offset)
+            })
+            .unzip();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_bind_vertex_buffers)(
+            self.handle(),
+            first_binding,
+            buffers_vk.len() as u32,
+            buffers_vk.as_ptr(),
+            offsets_vk.as_ptr(),
+        );
+
+        self.resources.reserve(buffers.len());
+
+        for (i, buffer) in buffers.into_iter().enumerate() {
+            self.current_state
+                .vertex_buffers
+                .insert(first_binding + i as u32, buffer.clone());
+            self.resources.push(Box::new(buffer));
+        }
+
+        self
+    }
+
+    /// Sets push constants for future dispatch or draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `offset` is not a multiple of 4.
+    /// - Panics if the size of `push_constants` is not a multiple of 4.
+    /// - Panics if any of the bytes in `push_constants` do not fall within any of the pipeline
+    ///   layout's push constant ranges.
+    pub fn push_constants(
+        &mut self,
+        pipeline_layout: Arc<PipelineLayout>,
+        offset: u32,
+        push_constants: &impl BufferContents,
+    ) -> &mut Self {
+        let push_constants = push_constants.as_bytes();
+
+        if push_constants.is_empty() {
+            return self;
+        }
+
+        self.validate_push_constants(&pipeline_layout, offset, push_constants)
+            .unwrap();
+
+        unsafe { self.push_constants_unchecked(pipeline_layout, offset, push_constants) }
+    }
+
+    fn validate_push_constants(
+        &self,
+        pipeline_layout: &PipelineLayout,
+        offset: u32,
+        push_constants: &[u8],
+    ) -> Result<(), BindPushError> {
+        if offset % 4 != 0 {
+            return Err(BindPushError::PushConstantsOffsetNotAligned);
+        }
+
+        if push_constants.len() % 4 != 0 {
+            return Err(BindPushError::PushConstantsSizeNotAligned);
+        }
+
+        let mut current_offset = offset;
+        let mut remaining_size = push_constants.len() as u32;
+
+        for range in pipeline_layout
+            .push_constant_ranges_disjoint()
+            .iter()
+            .skip_while(|range| range.offset + range.size <= offset)
+        {
+            // there is a gap between ranges, but the passed push_constants contains
+            // some bytes in this gap, exit the loop and report error
+            if range.offset > current_offset {
+                break;
+            }
+
+            // push the minimum of the whole remaining data, and the part until the end of this range
+            let push_size = remaining_size.min(range.offset + range.size - current_offset);
+            current_offset += push_size;
+            remaining_size -= push_size;
+
+            if remaining_size == 0 {
+                break;
+            }
+        }
+
+        if remaining_size != 0 {
+            return Err(BindPushError::PushConstantsDataOutOfRange {
+                offset: current_offset,
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn push_constants_unchecked(
+        &mut self,
+        pipeline_layout: Arc<PipelineLayout>,
+        offset: u32,
+        push_constants: &(impl BufferContents + ?Sized),
+    ) -> &mut Self {
+        let push_constants = push_constants.as_bytes();
+        let mut current_offset = offset;
+        let mut remaining_size = push_constants.len() as u32;
+
+        let fns = self.device().fns();
+
+        for range in pipeline_layout
+            .push_constant_ranges_disjoint()
+            .iter()
+            .skip_while(|range| range.offset + range.size <= offset)
+        {
+            // there is a gap between ranges, but the passed push_constants contains
+            // some bytes in this gap, exit the loop and report error
+            if range.offset > current_offset {
+                break;
+            }
+
+            // push the minimum of the whole remaining data, and the part until the end of this range
+            let push_size = min(remaining_size, range.offset + range.size - current_offset);
+            let data_offset = (current_offset - offset) as usize;
+            let values = &push_constants[data_offset..(data_offset + push_size as usize)];
+
+            (fns.v1_0.cmd_push_constants)(
+                self.handle(),
+                pipeline_layout.handle(),
+                range.stages.into(),
+                current_offset as u32,
+                values.len() as u32,
+                values.as_ptr() as *const _,
+            );
+
+            current_offset += push_size;
+            remaining_size -= push_size;
+
+            if remaining_size == 0 {
+                break;
+            }
+        }
+
+        debug_assert!(remaining_size == 0);
+
+        // TODO: Push constant invalidations.
+        // The Vulkan spec currently is unclear about this, so Vulkano currently just marks
+        // push constants as set, and never unsets them. See:
+        // https://github.com/KhronosGroup/Vulkan-Docs/issues/1485
+        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2711
+        self.current_state
+            .push_constants
+            .insert(offset..offset + push_constants.len() as u32);
+        self.current_state.push_constants_pipeline_layout = Some(pipeline_layout.clone());
+
+        self.resources.push(Box::new(pipeline_layout));
+
+        self
+    }
+
+    /// Pushes descriptor data directly into the command buffer for future dispatch or draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support `pipeline_bind_point`.
+    /// - Panics if the [`khr_push_descriptor`] extension is not enabled on the device.
+    /// - Panics if `set_num` is not less than the number of sets in `pipeline_layout`.
+    /// - Panics if an element of `descriptor_writes` is not compatible with `pipeline_layout`.
+    ///
+    /// [`khr_push_descriptor`]: crate::device::DeviceExtensions::khr_push_descriptor
+    pub fn push_descriptor_set(
+        &mut self,
+        pipeline_bind_point: PipelineBindPoint,
+        pipeline_layout: Arc<PipelineLayout>,
+        set_num: u32,
+        descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
+    ) -> &mut Self {
+        let descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
+        self.validate_push_descriptor_set(
+            pipeline_bind_point,
+            &pipeline_layout,
+            set_num,
+            &descriptor_writes,
+        )
+        .unwrap();
+
+        unsafe {
+            self.push_descriptor_set_unchecked(
+                pipeline_bind_point,
+                pipeline_layout,
+                set_num,
+                descriptor_writes,
+            )
+        }
+    }
+
+    fn validate_push_descriptor_set(
+        &self,
+        pipeline_bind_point: PipelineBindPoint,
+        pipeline_layout: &PipelineLayout,
+        set_num: u32,
+        descriptor_writes: &[WriteDescriptorSet],
+    ) -> Result<(), BindPushError> {
+        if !self.device().enabled_extensions().khr_push_descriptor {
+            return Err(BindPushError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::push_descriptor_set`",
+                requires_one_of: RequiresOneOf {
+                    device_extensions: &["khr_push_descriptor"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-parameter
+        pipeline_bind_point.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdPushDescriptorSetKHR-commandBuffer-cmdpool
+        // VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-00363
+        match pipeline_bind_point {
+            PipelineBindPoint::Compute => {
+                if !queue_family_properties
+                    .queue_flags
+                    .intersects(QueueFlags::COMPUTE)
+                {
+                    return Err(BindPushError::NotSupportedByQueueFamily);
+                }
+            }
+            PipelineBindPoint::Graphics => {
+                if !queue_family_properties
+                    .queue_flags
+                    .intersects(QueueFlags::GRAPHICS)
+                {
+                    return Err(BindPushError::NotSupportedByQueueFamily);
+                }
+            }
+        }
+
+        // VUID-vkCmdPushDescriptorSetKHR-commonparent
+        assert_eq!(self.device(), pipeline_layout.device());
+
+        // VUID-vkCmdPushDescriptorSetKHR-set-00364
+        if set_num as usize > pipeline_layout.set_layouts().len() {
+            return Err(BindPushError::DescriptorSetOutOfRange {
+                set_num,
+                pipeline_layout_set_count: pipeline_layout.set_layouts().len() as u32,
+            });
+        }
+
+        let descriptor_set_layout = &pipeline_layout.set_layouts()[set_num as usize];
+
+        // VUID-vkCmdPushDescriptorSetKHR-set-00365
+        if !descriptor_set_layout.push_descriptor() {
+            return Err(BindPushError::DescriptorSetNotPush { set_num });
+        }
+
+        for write in descriptor_writes {
+            check_descriptor_write(write, descriptor_set_layout, 0)?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn push_descriptor_set_unchecked(
+        &mut self,
+        pipeline_bind_point: PipelineBindPoint,
+        pipeline_layout: Arc<PipelineLayout>,
+        set_num: u32,
+        descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
+    ) -> &mut Self {
+        let descriptor_writes: SmallVec<[WriteDescriptorSet; 8]> =
+            descriptor_writes.into_iter().collect();
+
+        debug_assert!(self.device().enabled_extensions().khr_push_descriptor);
+
+        let (infos, mut writes): (SmallVec<[_; 8]>, SmallVec<[_; 8]>) = descriptor_writes
+            .iter()
+            .map(|write| {
+                let binding =
+                    &pipeline_layout.set_layouts()[set_num as usize].bindings()[&write.binding()];
+
+                (
+                    write.to_vulkan_info(binding.descriptor_type),
+                    write.to_vulkan(ash::vk::DescriptorSet::null(), binding.descriptor_type),
+                )
+            })
+            .unzip();
+
+        if writes.is_empty() {
+            return self;
+        }
+
+        // Set the info pointers separately.
+        for (info, write) in infos.iter().zip(writes.iter_mut()) {
+            match info {
+                DescriptorWriteInfo::Image(info) => {
+                    write.descriptor_count = info.len() as u32;
+                    write.p_image_info = info.as_ptr();
+                }
+                DescriptorWriteInfo::Buffer(info) => {
+                    write.descriptor_count = info.len() as u32;
+                    write.p_buffer_info = info.as_ptr();
+                }
+                DescriptorWriteInfo::BufferView(info) => {
+                    write.descriptor_count = info.len() as u32;
+                    write.p_texel_buffer_view = info.as_ptr();
+                }
+            }
+
+            debug_assert!(write.descriptor_count != 0);
+        }
+
+        let fns = self.device().fns();
+        (fns.khr_push_descriptor.cmd_push_descriptor_set_khr)(
+            self.handle(),
+            pipeline_bind_point.into(),
+            pipeline_layout.handle(),
+            set_num,
+            writes.len() as u32,
+            writes.as_ptr(),
+        );
+
+        let state = self.current_state.invalidate_descriptor_sets(
+            pipeline_bind_point,
+            pipeline_layout.clone(),
+            set_num,
+            1,
+        );
+        let descriptor_set_layout = state.pipeline_layout.set_layouts()[set_num as usize].as_ref();
+        debug_assert!(descriptor_set_layout.push_descriptor());
+
+        let set_resources = match state.descriptor_sets.entry(set_num).or_insert_with(|| {
+            SetOrPush::Push(DescriptorSetResources::new(descriptor_set_layout, 0))
+        }) {
+            SetOrPush::Push(set_resources) => set_resources,
+            _ => unreachable!(),
+        };
+
+        for write in &descriptor_writes {
+            set_resources.update(write);
+        }
+
+        self.resources.push(Box::new(pipeline_layout));
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/clear.rs
+++ b/vulkano/src/command_buffer/standard/builder/clear.rs
@@ -1,0 +1,693 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{
+    ClearColorImageInfo, ClearDepthStencilImageInfo, ClearError, CommandBufferBuilder,
+    FillBufferInfo,
+};
+use crate::{
+    buffer::{BufferAccess, BufferContents, BufferUsage, TypedBufferAccess},
+    command_buffer::allocator::CommandBufferAllocator,
+    device::{DeviceOwned, QueueFlags},
+    format::FormatFeatures,
+    image::{ImageAccess, ImageAspects, ImageLayout, ImageUsage},
+    DeviceSize, RequiresOneOf, Version, VulkanObject,
+};
+use smallvec::SmallVec;
+use std::{mem::size_of_val, sync::Arc};
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Clears a color image with a specific value.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn clear_color_image(
+        &mut self,
+        clear_info: ClearColorImageInfo,
+    ) -> Result<&mut Self, ClearError> {
+        self.validate_clear_color_image(&clear_info)?;
+
+        unsafe { Ok(self.clear_color_image_unchecked(clear_info)) }
+    }
+
+    fn validate_clear_color_image(
+        &self,
+        clear_info: &ClearColorImageInfo,
+    ) -> Result<(), ClearError> {
+        let device = self.device();
+
+        // VUID-vkCmdClearColorImage-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(ClearError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdClearColorImage-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(ClearError::NotSupportedByQueueFamily);
+        }
+
+        let &ClearColorImageInfo {
+            ref image,
+            image_layout,
+            clear_value: _,
+            ref regions,
+            _ne: _,
+        } = clear_info;
+
+        // VUID-vkCmdClearColorImage-imageLayout-parameter
+        image_layout.validate_device(device)?;
+
+        // VUID-vkCmdClearColorImage-commonparent
+        assert_eq!(device, image.device());
+
+        // VUID-vkCmdClearColorImage-image-00002
+        if !image.usage().intersects(ImageUsage::TRANSFER_DST) {
+            return Err(ClearError::MissingUsage {
+                usage: "transfer_dst",
+            });
+        }
+
+        if device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1 {
+            // VUID-vkCmdClearColorImage-image-01993
+            if !image
+                .format_features()
+                .intersects(FormatFeatures::TRANSFER_DST)
+            {
+                return Err(ClearError::MissingFormatFeature {
+                    format_feature: "transfer_dst",
+                });
+            }
+        }
+
+        let image_aspects = image.format().aspects();
+
+        // VUID-vkCmdClearColorImage-image-00007
+        if image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
+            return Err(ClearError::FormatNotSupported {
+                format: image.format(),
+            });
+        }
+
+        // VUID-vkCmdClearColorImage-image-00007
+        if image.format().compression().is_some() {
+            return Err(ClearError::FormatNotSupported {
+                format: image.format(),
+            });
+        }
+
+        // VUID-vkCmdClearColorImage-image-01545
+        if image.format().ycbcr_chroma_sampling().is_some() {
+            return Err(ClearError::FormatNotSupported {
+                format: image.format(),
+            });
+        }
+
+        // VUID-vkCmdClearColorImage-imageLayout-01394
+        if !matches!(
+            image_layout,
+            ImageLayout::TransferDstOptimal | ImageLayout::General
+        ) {
+            return Err(ClearError::ImageLayoutInvalid { image_layout });
+        }
+
+        for (region_index, subresource_range) in regions.iter().enumerate() {
+            // VUID-VkImageSubresourceRange-aspectMask-parameter
+            subresource_range.aspects.validate_device(device)?;
+
+            // VUID-VkImageSubresourceRange-aspectMask-requiredbitmask
+            assert!(!subresource_range.aspects.is_empty());
+
+            // VUID-vkCmdClearColorImage-aspectMask-02498
+            if !image_aspects.contains(subresource_range.aspects) {
+                return Err(ClearError::AspectsNotAllowed {
+                    region_index,
+                    aspects: subresource_range.aspects,
+                    allowed_aspects: image_aspects,
+                });
+            }
+
+            // VUID-VkImageSubresourceRange-levelCount-01720
+            assert!(!subresource_range.mip_levels.is_empty());
+
+            // VUID-vkCmdClearColorImage-baseMipLevel-01470
+            // VUID-vkCmdClearColorImage-pRanges-01692
+            if subresource_range.mip_levels.end > image.mip_levels() {
+                return Err(ClearError::MipLevelsOutOfRange {
+                    region_index,
+                    mip_levels_range_end: subresource_range.mip_levels.end,
+                    image_mip_levels: image.dimensions().array_layers(),
+                });
+            }
+
+            // VUID-VkImageSubresourceRange-layerCount-01721
+            assert!(!subresource_range.array_layers.is_empty());
+
+            // VUID-vkCmdClearDepthStencilImage-baseArrayLayer-01476
+            // VUID-vkCmdClearDepthStencilImage-pRanges-01695
+            if subresource_range.array_layers.end > image.dimensions().array_layers() {
+                return Err(ClearError::ArrayLayersOutOfRange {
+                    region_index,
+                    array_layers_range_end: subresource_range.array_layers.end,
+                    image_array_layers: image.dimensions().array_layers(),
+                });
+            }
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn clear_color_image_unchecked(
+        &mut self,
+        clear_info: ClearColorImageInfo,
+    ) -> &mut Self {
+        let ClearColorImageInfo {
+            image,
+            image_layout,
+            clear_value,
+            regions,
+            _ne: _,
+        } = clear_info;
+
+        if regions.is_empty() {
+            return self;
+        }
+
+        let clear_value = clear_value.into();
+        let ranges: SmallVec<[_; 8]> = regions
+            .iter()
+            .cloned()
+            .map(ash::vk::ImageSubresourceRange::from)
+            .collect();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_clear_color_image)(
+            self.handle(),
+            image.inner().image.handle(),
+            image_layout.into(),
+            &clear_value,
+            ranges.len() as u32,
+            ranges.as_ptr(),
+        );
+
+        self.resources.push(Box::new(image));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Clears a depth/stencil image with a specific value.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn clear_depth_stencil_image(
+        &mut self,
+        clear_info: ClearDepthStencilImageInfo,
+    ) -> Result<&mut Self, ClearError> {
+        self.validate_clear_depth_stencil_image(&clear_info)?;
+
+        unsafe { Ok(self.clear_depth_stencil_image_unchecked(clear_info)) }
+    }
+
+    fn validate_clear_depth_stencil_image(
+        &self,
+        clear_info: &ClearDepthStencilImageInfo,
+    ) -> Result<(), ClearError> {
+        let device = self.device();
+
+        // VUID-vkCmdClearDepthStencilImage-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(ClearError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdClearDepthStencilImage-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(ClearError::NotSupportedByQueueFamily);
+        }
+
+        let &ClearDepthStencilImageInfo {
+            ref image,
+            image_layout,
+            clear_value,
+            ref regions,
+            _ne: _,
+        } = clear_info;
+
+        // VUID-vkCmdClearDepthStencilImage-imageLayout-parameter
+        image_layout.validate_device(device)?;
+
+        // VUID-vkCmdClearDepthStencilImage-commonparent
+        assert_eq!(device, image.device());
+
+        if device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1 {
+            // VUID-vkCmdClearDepthStencilImage-image-01994
+            if !image
+                .format_features()
+                .intersects(FormatFeatures::TRANSFER_DST)
+            {
+                return Err(ClearError::MissingFormatFeature {
+                    format_feature: "transfer_dst",
+                });
+            }
+        }
+
+        let image_aspects = image.format().aspects();
+
+        // VUID-vkCmdClearDepthStencilImage-image-00014
+        if !image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
+            return Err(ClearError::FormatNotSupported {
+                format: image.format(),
+            });
+        }
+
+        // VUID-vkCmdClearDepthStencilImage-imageLayout-00012
+        if !matches!(
+            image_layout,
+            ImageLayout::TransferDstOptimal | ImageLayout::General
+        ) {
+            return Err(ClearError::ImageLayoutInvalid { image_layout });
+        }
+
+        // VUID-VkClearDepthStencilValue-depth-00022
+        if !device.enabled_extensions().ext_depth_range_unrestricted
+            && !(0.0..=1.0).contains(&clear_value.depth)
+        {
+            return Err(ClearError::RequirementNotMet {
+                required_for: "`clear_info.clear_value.depth` is not between `0.0` and `1.0` \
+                    inclusive",
+                requires_one_of: RequiresOneOf {
+                    device_extensions: &["ext_depth_range_unrestricted"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        let mut image_aspects_used = ImageAspects::empty();
+
+        for (region_index, subresource_range) in regions.iter().enumerate() {
+            // VUID-VkImageSubresourceRange-aspectMask-parameter
+            subresource_range.aspects.validate_device(device)?;
+
+            // VUID-VkImageSubresourceRange-aspectMask-requiredbitmask
+            assert!(!subresource_range.aspects.is_empty());
+
+            // VUID-vkCmdClearDepthStencilImage-aspectMask-02824
+            // VUID-vkCmdClearDepthStencilImage-image-02825
+            // VUID-vkCmdClearDepthStencilImage-image-02826
+            if !image_aspects.contains(subresource_range.aspects) {
+                return Err(ClearError::AspectsNotAllowed {
+                    region_index,
+                    aspects: subresource_range.aspects,
+                    allowed_aspects: image_aspects,
+                });
+            }
+
+            image_aspects_used |= subresource_range.aspects;
+
+            // VUID-VkImageSubresourceRange-levelCount-01720
+            assert!(!subresource_range.mip_levels.is_empty());
+
+            // VUID-vkCmdClearDepthStencilImage-baseMipLevel-01474
+            // VUID-vkCmdClearDepthStencilImage-pRanges-01694
+            if subresource_range.mip_levels.end > image.mip_levels() {
+                return Err(ClearError::MipLevelsOutOfRange {
+                    region_index,
+                    mip_levels_range_end: subresource_range.mip_levels.end,
+                    image_mip_levels: image.dimensions().array_layers(),
+                });
+            }
+
+            // VUID-VkImageSubresourceRange-layerCount-01721
+            assert!(!subresource_range.array_layers.is_empty());
+
+            // VUID-vkCmdClearDepthStencilImage-baseArrayLayer-01476
+            // VUID-vkCmdClearDepthStencilImage-pRanges-01695
+            if subresource_range.array_layers.end > image.dimensions().array_layers() {
+                return Err(ClearError::ArrayLayersOutOfRange {
+                    region_index,
+                    array_layers_range_end: subresource_range.array_layers.end,
+                    image_array_layers: image.dimensions().array_layers(),
+                });
+            }
+        }
+
+        // VUID-vkCmdClearDepthStencilImage-pRanges-02658
+        // VUID-vkCmdClearDepthStencilImage-pRanges-02659
+        if image_aspects_used.intersects(ImageAspects::STENCIL)
+            && !image.stencil_usage().intersects(ImageUsage::TRANSFER_DST)
+        {
+            return Err(ClearError::MissingUsage {
+                usage: "transfer_dst",
+            });
+        }
+
+        // VUID-vkCmdClearDepthStencilImage-pRanges-02660
+        if !(image_aspects_used - ImageAspects::STENCIL).is_empty()
+            && !image.usage().intersects(ImageUsage::TRANSFER_DST)
+        {
+            return Err(ClearError::MissingUsage {
+                usage: "transfer_dst",
+            });
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn clear_depth_stencil_image_unchecked(
+        &mut self,
+        clear_info: ClearDepthStencilImageInfo,
+    ) -> &mut Self {
+        let ClearDepthStencilImageInfo {
+            image,
+            image_layout,
+            clear_value,
+            regions,
+            _ne: _,
+        } = clear_info;
+
+        if regions.is_empty() {
+            return self;
+        }
+
+        let clear_value = clear_value.into();
+        let ranges: SmallVec<[_; 8]> = regions
+            .iter()
+            .cloned()
+            .map(ash::vk::ImageSubresourceRange::from)
+            .collect();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_clear_depth_stencil_image)(
+            self.handle(),
+            image.inner().image.handle(),
+            image_layout.into(),
+            &clear_value,
+            ranges.len() as u32,
+            ranges.as_ptr(),
+        );
+
+        self.resources.push(Box::new(image));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Fills a region of a buffer with repeated copies of a value.
+    ///
+    /// This function is similar to the `memset` function in C. The `data` parameter is a number
+    /// that will be repeatedly written through the entire buffer.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `dst_buffer` was not created from the same device as `self`.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers
+    ///   that are accessed by the command.
+    #[inline]
+    pub unsafe fn fill_buffer(
+        &mut self,
+        fill_buffer_info: FillBufferInfo,
+    ) -> Result<&mut Self, ClearError> {
+        self.validate_fill_buffer(&fill_buffer_info)?;
+
+        unsafe { Ok(self.fill_buffer_unchecked(fill_buffer_info)) }
+    }
+
+    fn validate_fill_buffer(&self, fill_buffer_info: &FillBufferInfo) -> Result<(), ClearError> {
+        let device = self.device();
+
+        // VUID-vkCmdFillBuffer-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(ClearError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        if device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1 {
+            // VUID-vkCmdFillBuffer-commandBuffer-cmdpool
+            if !queue_family_properties
+                .queue_flags
+                .intersects(QueueFlags::TRANSFER | QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+            {
+                return Err(ClearError::NotSupportedByQueueFamily);
+            }
+        } else {
+            // VUID-vkCmdFillBuffer-commandBuffer-00030
+            if !queue_family_properties
+                .queue_flags
+                .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+            {
+                return Err(ClearError::NotSupportedByQueueFamily);
+            }
+        }
+
+        let &FillBufferInfo {
+            data: _,
+            ref dst_buffer,
+            dst_offset,
+            size,
+            _ne: _,
+        } = fill_buffer_info;
+
+        let dst_buffer_inner = dst_buffer.inner();
+
+        // VUID-vkCmdFillBuffer-commonparent
+        assert_eq!(device, dst_buffer.device());
+
+        // VUID-vkCmdFillBuffer-size-00026
+        assert!(size != 0);
+
+        // VUID-vkCmdFillBuffer-dstBuffer-00029
+        if !dst_buffer.usage().intersects(BufferUsage::TRANSFER_DST) {
+            return Err(ClearError::MissingUsage {
+                usage: "transfer_dst",
+            });
+        }
+
+        // VUID-vkCmdFillBuffer-dstOffset-00024
+        // VUID-vkCmdFillBuffer-size-00027
+        if dst_offset + size > dst_buffer.size() {
+            return Err(ClearError::RegionOutOfBufferBounds {
+                region_index: 0,
+                offset_range_end: dst_offset + size,
+                buffer_size: dst_buffer.size(),
+            });
+        }
+
+        // VUID-vkCmdFillBuffer-dstOffset-00025
+        if (dst_buffer_inner.offset + dst_offset) % 4 != 0 {
+            return Err(ClearError::OffsetNotAlignedForBuffer {
+                region_index: 0,
+                offset: dst_buffer_inner.offset + dst_offset,
+                required_alignment: 4,
+            });
+        }
+
+        // VUID-vkCmdFillBuffer-size-00028
+        if size % 4 != 0 {
+            return Err(ClearError::SizeNotAlignedForBuffer {
+                region_index: 0,
+                size,
+                required_alignment: 4,
+            });
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn fill_buffer_unchecked(&mut self, fill_buffer_info: FillBufferInfo) -> &mut Self {
+        let FillBufferInfo {
+            data,
+            dst_buffer,
+            dst_offset,
+            size,
+            _ne: _,
+        } = fill_buffer_info;
+
+        let dst_buffer_inner = dst_buffer.inner();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_fill_buffer)(
+            self.handle(),
+            dst_buffer_inner.buffer.handle(),
+            dst_offset,
+            size,
+            data,
+        );
+
+        self.resources.push(Box::new(dst_buffer));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Writes data to a region of a buffer.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `dst_buffer` was not created from the same device as `self`.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers
+    ///   that are accessed by the command.
+    #[inline]
+    pub unsafe fn update_buffer<B, D>(
+        &mut self,
+        data: &D,
+        dst_buffer: Arc<B>,
+        dst_offset: DeviceSize,
+    ) -> Result<&mut Self, ClearError>
+    where
+        B: TypedBufferAccess<Content = D> + 'static,
+        D: BufferContents + ?Sized,
+    {
+        self.validate_update_buffer(data, &dst_buffer, dst_offset)?;
+
+        unsafe { Ok(self.update_buffer_unchecked(data, dst_buffer, dst_offset)) }
+    }
+
+    fn validate_update_buffer(
+        &self,
+        data: &impl ?Sized,
+        dst_buffer: &dyn BufferAccess,
+        dst_offset: DeviceSize,
+    ) -> Result<(), ClearError> {
+        let device = self.device();
+
+        // VUID-vkCmdUpdateBuffer-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(ClearError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdUpdateBuffer-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::TRANSFER | QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(ClearError::NotSupportedByQueueFamily);
+        }
+
+        let dst_buffer_inner = dst_buffer.inner();
+
+        // VUID-vkCmdUpdateBuffer-commonparent
+        assert_eq!(device, dst_buffer.device());
+
+        // VUID-vkCmdUpdateBuffer-dataSize-arraylength
+        assert!(size_of_val(data) != 0);
+
+        // VUID-vkCmdUpdateBuffer-dstBuffer-00034
+        if !dst_buffer.usage().intersects(BufferUsage::TRANSFER_DST) {
+            return Err(ClearError::MissingUsage {
+                usage: "transfer_dst",
+            });
+        }
+
+        // VUID-vkCmdUpdateBuffer-dstOffset-00032
+        // VUID-vkCmdUpdateBuffer-dataSize-00033
+        if dst_offset + size_of_val(data) as DeviceSize > dst_buffer.size() {
+            return Err(ClearError::RegionOutOfBufferBounds {
+                region_index: 0,
+                offset_range_end: dst_offset + size_of_val(data) as DeviceSize,
+                buffer_size: dst_buffer.size(),
+            });
+        }
+
+        // VUID-vkCmdUpdateBuffer-dstOffset-00036
+        if (dst_buffer_inner.offset + dst_offset) % 4 != 0 {
+            return Err(ClearError::OffsetNotAlignedForBuffer {
+                region_index: 0,
+                offset: dst_buffer_inner.offset + dst_offset,
+                required_alignment: 4,
+            });
+        }
+
+        // VUID-vkCmdUpdateBuffer-dataSize-00037
+        if size_of_val(data) > 65536 {
+            return Err(ClearError::DataTooLarge {
+                size: size_of_val(data) as DeviceSize,
+                max: 65536,
+            });
+        }
+
+        // VUID-vkCmdUpdateBuffer-dataSize-00038
+        if size_of_val(data) % 4 != 0 {
+            return Err(ClearError::SizeNotAlignedForBuffer {
+                region_index: 0,
+                size: size_of_val(data) as DeviceSize,
+                required_alignment: 4,
+            });
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn update_buffer_unchecked(
+        &mut self,
+        data: &(impl BufferContents + ?Sized),
+        dst_buffer: Arc<dyn BufferAccess>,
+        dst_offset: DeviceSize,
+    ) -> &mut Self {
+        let dst_buffer_inner = dst_buffer.inner();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_update_buffer)(
+            self.handle(),
+            dst_buffer_inner.buffer.handle(),
+            dst_buffer_inner.offset + dst_offset,
+            size_of_val(data) as DeviceSize,
+            data.as_bytes().as_ptr() as *const _,
+        );
+
+        self.resources.push(Box::new(dst_buffer));
+
+        // TODO: sync state update
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/copy.rs
+++ b/vulkano/src/command_buffer/standard/builder/copy.rs
@@ -1,0 +1,3422 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{
+    BlitImageInfo, BufferCopy, BufferImageCopy, CommandBufferBuilder, CopyBufferInfo,
+    CopyBufferToImageInfo, CopyError, CopyErrorResource, CopyImageInfo, CopyImageToBufferInfo,
+    ImageCopy, ResolveImageInfo,
+};
+use crate::{
+    buffer::{BufferAccess, BufferUsage},
+    command_buffer::{allocator::CommandBufferAllocator, ImageBlit, ImageResolve},
+    device::{DeviceOwned, QueueFlags},
+    format::{Format, FormatFeatures, NumericType},
+    image::{
+        ImageAccess, ImageAspects, ImageDimensions, ImageLayout, ImageSubresourceLayers, ImageType,
+        ImageUsage, SampleCount, SampleCounts,
+    },
+    sampler::Filter,
+    DeviceSize, Version, VulkanObject,
+};
+use smallvec::SmallVec;
+use std::cmp::{max, min};
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Copies data from a buffer to another buffer.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `src_buffer` or `dst_buffer` were not created from the same device
+    ///   as `self`.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers
+    ///   that are accessed by the command.
+    #[inline]
+    pub unsafe fn copy_buffer(
+        &mut self,
+        copy_buffer_info: impl Into<CopyBufferInfo>,
+    ) -> Result<&mut Self, CopyError> {
+        let copy_buffer_info = copy_buffer_info.into();
+        self.validate_copy_buffer(&copy_buffer_info)?;
+
+        unsafe { Ok(self.copy_buffer_unchecked(copy_buffer_info)) }
+    }
+
+    fn validate_copy_buffer(&self, copy_buffer_info: &CopyBufferInfo) -> Result<(), CopyError> {
+        let device = self.device();
+
+        // VUID-vkCmdCopyBuffer2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(CopyError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdCopyBuffer2-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::TRANSFER | QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(CopyError::NotSupportedByQueueFamily);
+        }
+
+        let &CopyBufferInfo {
+            ref src_buffer,
+            ref dst_buffer,
+            ref regions,
+            _ne: _,
+        } = copy_buffer_info;
+
+        let src_buffer_inner = src_buffer.inner();
+        let dst_buffer_inner = dst_buffer.inner();
+
+        // VUID-VkCopyBufferInfo2-commonparent
+        assert_eq!(device, src_buffer.device());
+        assert_eq!(device, dst_buffer.device());
+
+        // VUID-VkCopyBufferInfo2-srcBuffer-00118
+        if !src_buffer.usage().intersects(BufferUsage::TRANSFER_SRC) {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Source,
+                usage: "transfer_src",
+            });
+        }
+
+        // VUID-VkCopyBufferInfo2-dstBuffer-00120
+        if !dst_buffer.usage().intersects(BufferUsage::TRANSFER_DST) {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Destination,
+                usage: "transfer_dst",
+            });
+        }
+
+        let same_buffer = src_buffer_inner.buffer == dst_buffer_inner.buffer;
+        let mut overlap_indices = None;
+
+        for (region_index, region) in regions.iter().enumerate() {
+            let &BufferCopy {
+                src_offset,
+                dst_offset,
+                size,
+                _ne: _,
+            } = region;
+
+            // VUID-VkBufferCopy2-size-01988
+            assert!(size != 0);
+
+            // VUID-VkCopyBufferInfo2-srcOffset-00113
+            // VUID-VkCopyBufferInfo2-size-00115
+            if src_offset + size > src_buffer.size() {
+                return Err(CopyError::RegionOutOfBufferBounds {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    offset_range_end: src_offset + size,
+                    buffer_size: src_buffer.size(),
+                });
+            }
+
+            // VUID-VkCopyBufferInfo2-dstOffset-00114
+            // VUID-VkCopyBufferInfo2-size-00116
+            if dst_offset + size > dst_buffer.size() {
+                return Err(CopyError::RegionOutOfBufferBounds {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    offset_range_end: dst_offset + size,
+                    buffer_size: dst_buffer.size(),
+                });
+            }
+
+            // VUID-VkCopyBufferInfo2-pRegions-00117
+            if same_buffer {
+                let src_region_index = region_index;
+                let src_range = src_buffer_inner.offset + src_offset
+                    ..src_buffer_inner.offset + src_offset + size;
+
+                for (dst_region_index, dst_region) in regions.iter().enumerate() {
+                    let &BufferCopy { dst_offset, .. } = dst_region;
+
+                    let dst_range = dst_buffer_inner.offset + dst_offset
+                        ..dst_buffer_inner.offset + dst_offset + size;
+
+                    if src_range.start >= dst_range.end || dst_range.start >= src_range.end {
+                        // The regions do not overlap
+                        continue;
+                    }
+
+                    overlap_indices = Some((src_region_index, dst_region_index));
+                }
+            }
+        }
+
+        // VUID-VkCopyBufferInfo2-pRegions-00117
+        if let Some((src_region_index, dst_region_index)) = overlap_indices {
+            return Err(CopyError::OverlappingRegions {
+                src_region_index,
+                dst_region_index,
+            });
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn copy_buffer_unchecked(
+        &mut self,
+        copy_buffer_info: impl Into<CopyBufferInfo>,
+    ) -> &mut Self {
+        let copy_buffer_info = copy_buffer_info.into();
+        let CopyBufferInfo {
+            src_buffer,
+            dst_buffer,
+            regions,
+            _ne: _,
+        } = copy_buffer_info;
+
+        if regions.is_empty() {
+            return self;
+        }
+
+        let src_buffer_inner = src_buffer.inner();
+        let dst_buffer_inner = dst_buffer.inner();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3
+            || self.device().enabled_extensions().khr_copy_commands2
+        {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &BufferCopy {
+                        src_offset,
+                        dst_offset,
+                        size,
+                        _ne,
+                    } = region;
+
+                    ash::vk::BufferCopy2 {
+                        src_offset: src_offset + src_buffer_inner.offset,
+                        dst_offset: dst_offset + dst_buffer_inner.offset,
+                        size,
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let copy_buffer_info = ash::vk::CopyBufferInfo2 {
+                src_buffer: src_buffer_inner.buffer.handle(),
+                dst_buffer: dst_buffer_inner.buffer.handle(),
+                region_count: regions.len() as u32,
+                p_regions: regions.as_ptr(),
+                ..Default::default()
+            };
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_copy_buffer2)(self.handle(), &copy_buffer_info);
+            } else {
+                (fns.khr_copy_commands2.cmd_copy_buffer2_khr)(self.handle(), &copy_buffer_info);
+            }
+        } else {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &BufferCopy {
+                        src_offset,
+                        dst_offset,
+                        size,
+                        _ne,
+                    } = region;
+
+                    ash::vk::BufferCopy {
+                        src_offset: src_offset + src_buffer_inner.offset,
+                        dst_offset: dst_offset + dst_buffer_inner.offset,
+                        size,
+                    }
+                })
+                .collect();
+
+            (fns.v1_0.cmd_copy_buffer)(
+                self.handle(),
+                src_buffer_inner.buffer.handle(),
+                dst_buffer_inner.buffer.handle(),
+                regions.len() as u32,
+                regions.as_ptr(),
+            );
+        }
+
+        self.resources.push(Box::new(src_buffer));
+        self.resources.push(Box::new(dst_buffer));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Copies data from an image to another image.
+    ///
+    /// There are several restrictions:
+    ///
+    /// - The number of samples in the source and destination images must be equal.
+    /// - The size of the uncompressed element format of the source image must be equal to the
+    ///   compressed element format of the destination.
+    /// - If you copy between depth, stencil or depth-stencil images, the format of both images
+    ///   must match exactly.
+    /// - For two-dimensional images, the Z coordinate must be 0 for the image offsets and 1 for
+    ///   the extent. Same for the Y coordinate for one-dimensional images.
+    /// - For non-array images, the base array layer must be 0 and the number of layers must be 1.
+    ///
+    /// If `layer_count` is greater than 1, the copy will happen between each individual layer as
+    /// if they were separate images.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `src_image` or `dst_image` were not created from the same device
+    ///   as `self`.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn copy_image(
+        &mut self,
+        copy_image_info: CopyImageInfo,
+    ) -> Result<&mut Self, CopyError> {
+        self.validate_copy_image(&copy_image_info)?;
+
+        unsafe { Ok(self.copy_image_unchecked(copy_image_info)) }
+    }
+
+    fn validate_copy_image(&self, copy_image_info: &CopyImageInfo) -> Result<(), CopyError> {
+        let device = self.device();
+
+        // VUID-vkCmdCopyImage2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(CopyError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdCopyImage2-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::TRANSFER | QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(CopyError::NotSupportedByQueueFamily);
+        }
+
+        let &CopyImageInfo {
+            ref src_image,
+            src_image_layout,
+            ref dst_image,
+            dst_image_layout,
+            ref regions,
+            _ne: _,
+        } = copy_image_info;
+
+        // VUID-VkCopyImageInfo2-srcImageLayout-parameter
+        src_image_layout.validate_device(device)?;
+
+        // VUID-VkCopyImageInfo2-dstImageLayout-parameter
+        dst_image_layout.validate_device(device)?;
+
+        // VUID-VkCopyImageInfo2-commonparent
+        assert_eq!(device, src_image.device());
+        assert_eq!(device, dst_image.device());
+
+        let copy_2d_3d_supported =
+            device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1;
+        let src_image_inner = src_image.inner();
+        let dst_image_inner = dst_image.inner();
+        let mut src_image_aspects = src_image.format().aspects();
+        let mut dst_image_aspects = dst_image.format().aspects();
+
+        if device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1 {
+            // VUID-VkCopyImageInfo2-srcImage-01995
+            if !src_image
+                .format_features()
+                .intersects(FormatFeatures::TRANSFER_SRC)
+            {
+                return Err(CopyError::MissingFormatFeature {
+                    resource: CopyErrorResource::Source,
+                    format_feature: "transfer_src",
+                });
+            }
+
+            // VUID-VkCopyImageInfo2-dstImage-01996
+            if !dst_image
+                .format_features()
+                .intersects(FormatFeatures::TRANSFER_DST)
+            {
+                return Err(CopyError::MissingFormatFeature {
+                    resource: CopyErrorResource::Destination,
+                    format_feature: "transfer_dst",
+                });
+            }
+        }
+
+        // VUID-VkCopyImageInfo2-srcImage-00136
+        if src_image.samples() != dst_image.samples() {
+            return Err(CopyError::SampleCountMismatch {
+                src_sample_count: src_image.samples(),
+                dst_sample_count: dst_image.samples(),
+            });
+        }
+
+        if !(src_image_aspects.intersects(ImageAspects::COLOR)
+            || dst_image_aspects.intersects(ImageAspects::COLOR))
+        {
+            // VUID-VkCopyImageInfo2-srcImage-01548
+            if src_image.format() != dst_image.format() {
+                return Err(CopyError::FormatsMismatch {
+                    src_format: src_image.format(),
+                    dst_format: dst_image.format(),
+                });
+            }
+        }
+
+        // VUID-VkCopyImageInfo2-srcImageLayout-01917
+        if !matches!(
+            src_image_layout,
+            ImageLayout::TransferSrcOptimal | ImageLayout::General
+        ) {
+            return Err(CopyError::ImageLayoutInvalid {
+                resource: CopyErrorResource::Source,
+                image_layout: src_image_layout,
+            });
+        }
+
+        // VUID-VkCopyImageInfo2-dstImageLayout-01395
+        if !matches!(
+            dst_image_layout,
+            ImageLayout::TransferDstOptimal | ImageLayout::General
+        ) {
+            return Err(CopyError::ImageLayoutInvalid {
+                resource: CopyErrorResource::Destination,
+                image_layout: dst_image_layout,
+            });
+        }
+
+        let extent_alignment = match queue_family_properties.min_image_transfer_granularity {
+            [0, 0, 0] => None,
+            min_image_transfer_granularity => {
+                let granularity = move |block_extent: [u32; 3], is_multi_plane: bool| {
+                    if is_multi_plane {
+                        // Assume planes always have 1x1 blocks
+                        min_image_transfer_granularity
+                    } else {
+                        // "The value returned in minImageTransferGranularity has a unit of
+                        // compressed texel blocks for images having a block-compressed format, and
+                        // a unit of texels otherwise."
+                        [
+                            min_image_transfer_granularity[0] * block_extent[0],
+                            min_image_transfer_granularity[1] * block_extent[1],
+                            min_image_transfer_granularity[2] * block_extent[2],
+                        ]
+                    }
+                };
+
+                Some((
+                    granularity(
+                        src_image.format().block_extent(),
+                        src_image_aspects.intersects(ImageAspects::PLANE_0),
+                    ),
+                    granularity(
+                        dst_image.format().block_extent(),
+                        dst_image_aspects.intersects(ImageAspects::PLANE_0),
+                    ),
+                ))
+            }
+        };
+
+        if src_image_aspects.intersects(ImageAspects::PLANE_0) {
+            // VUID-VkCopyImageInfo2-srcImage-01552
+            // VUID-VkCopyImageInfo2-srcImage-01553
+            src_image_aspects -= ImageAspects::COLOR;
+        }
+
+        if dst_image_aspects.intersects(ImageAspects::PLANE_0) {
+            // VUID-VkCopyImageInfo2-dstImage-01554
+            // VUID-VkCopyImageInfo2-dstImage-01555
+            dst_image_aspects -= ImageAspects::COLOR;
+        }
+
+        let mut src_image_aspects_used = ImageAspects::empty();
+        let mut dst_image_aspects_used = ImageAspects::empty();
+        let same_image = src_image_inner.image == dst_image_inner.image;
+        let mut overlap_subresource_indices = None;
+        let mut overlap_extent_indices = None;
+
+        for (region_index, region) in regions.iter().enumerate() {
+            let &ImageCopy {
+                ref src_subresource,
+                src_offset,
+                ref dst_subresource,
+                dst_offset,
+                extent,
+                _ne,
+            } = region;
+
+            let check_subresource = |resource: CopyErrorResource,
+                                     image: &dyn ImageAccess,
+                                     image_aspects: ImageAspects,
+                                     subresource: &ImageSubresourceLayers|
+             -> Result<_, CopyError> {
+                // VUID-VkCopyImageInfo2-srcSubresource-01696
+                // VUID-VkCopyImageInfo2-dstSubresource-01697
+                if subresource.mip_level >= image.mip_levels() {
+                    return Err(CopyError::MipLevelsOutOfRange {
+                        resource,
+                        region_index,
+                        mip_levels_range_end: subresource.mip_level + 1,
+                        image_mip_levels: image.mip_levels(),
+                    });
+                }
+
+                // VUID-VkImageSubresourceLayers-layerCount-01700
+                assert!(!subresource.array_layers.is_empty());
+
+                // VUID-VkCopyImageInfo2-srcSubresource-01698
+                // VUID-VkCopyImageInfo2-dstSubresource-01699
+                // VUID-VkCopyImageInfo2-srcImage-04443
+                // VUID-VkCopyImageInfo2-dstImage-04444
+                if subresource.array_layers.end > image.dimensions().array_layers() {
+                    return Err(CopyError::ArrayLayersOutOfRange {
+                        resource,
+                        region_index,
+                        array_layers_range_end: subresource.array_layers.end,
+                        image_array_layers: image.dimensions().array_layers(),
+                    });
+                }
+
+                // VUID-VkImageSubresourceLayers-aspectMask-parameter
+                subresource.aspects.validate_device(device)?;
+
+                // VUID-VkImageSubresourceLayers-aspectMask-requiredbitmask
+                assert!(!subresource.aspects.is_empty());
+
+                // VUID-VkCopyImageInfo2-aspectMask-00142
+                // VUID-VkCopyImageInfo2-aspectMask-00143
+                if !image_aspects.contains(subresource.aspects) {
+                    return Err(CopyError::AspectsNotAllowed {
+                        resource,
+                        region_index,
+                        aspects: subresource.aspects,
+                        allowed_aspects: image_aspects,
+                    });
+                }
+
+                let (subresource_format, subresource_extent) =
+                    if image_aspects.intersects(ImageAspects::PLANE_0) {
+                        // VUID-VkCopyImageInfo2-srcImage-01552
+                        // VUID-VkCopyImageInfo2-srcImage-01553
+                        // VUID-VkCopyImageInfo2-dstImage-01554
+                        // VUID-VkCopyImageInfo2-dstImage-01555
+                        if subresource.aspects.count() != 1 {
+                            return Err(CopyError::MultipleAspectsNotAllowed {
+                                resource,
+                                region_index,
+                                aspects: subresource.aspects,
+                            });
+                        }
+
+                        if subresource.aspects.intersects(ImageAspects::PLANE_0) {
+                            (
+                                image.format().planes()[0],
+                                image.dimensions().width_height_depth(),
+                            )
+                        } else if subresource.aspects.intersects(ImageAspects::PLANE_1) {
+                            (
+                                image.format().planes()[1],
+                                image
+                                    .format()
+                                    .ycbcr_chroma_sampling()
+                                    .unwrap()
+                                    .subsampled_extent(image.dimensions().width_height_depth()),
+                            )
+                        } else {
+                            (
+                                image.format().planes()[2],
+                                image
+                                    .format()
+                                    .ycbcr_chroma_sampling()
+                                    .unwrap()
+                                    .subsampled_extent(image.dimensions().width_height_depth()),
+                            )
+                        }
+                    } else {
+                        (
+                            image.format(),
+                            image
+                                .dimensions()
+                                .mip_level_dimensions(subresource.mip_level)
+                                .unwrap()
+                                .width_height_depth(),
+                        )
+                    };
+
+                Ok((subresource_format, subresource_extent))
+            };
+
+            src_image_aspects_used |= src_subresource.aspects;
+            dst_image_aspects_used |= dst_subresource.aspects;
+
+            let (src_subresource_format, src_subresource_extent) = check_subresource(
+                CopyErrorResource::Source,
+                src_image,
+                src_image_aspects,
+                src_subresource,
+            )?;
+            let (dst_subresource_format, dst_subresource_extent) = check_subresource(
+                CopyErrorResource::Destination,
+                dst_image,
+                dst_image_aspects,
+                dst_subresource,
+            )?;
+
+            if !(src_image_aspects.intersects(ImageAspects::PLANE_0)
+                || dst_image_aspects.intersects(ImageAspects::PLANE_0))
+            {
+                // VUID-VkCopyImageInfo2-srcImage-01551
+                if src_subresource.aspects != dst_subresource.aspects {
+                    return Err(CopyError::AspectsMismatch {
+                        region_index,
+                        src_aspects: src_subresource.aspects,
+                        dst_aspects: dst_subresource.aspects,
+                    });
+                }
+            }
+
+            // VUID-VkCopyImageInfo2-srcImage-01548
+            // VUID-VkCopyImageInfo2-None-01549
+            // Color formats must be size-compatible.
+            if src_subresource_format.block_size() != dst_subresource_format.block_size() {
+                return Err(CopyError::FormatsNotCompatible {
+                    src_format: src_subresource_format,
+                    dst_format: dst_subresource_format,
+                });
+            }
+
+            // TODO:
+            // "When copying between compressed and uncompressed formats the extent members
+            // represent the texel dimensions of the source image and not the destination."
+            let mut src_extent = extent;
+            let mut dst_extent = extent;
+            let src_layer_count =
+                src_subresource.array_layers.end - src_subresource.array_layers.start;
+            let dst_layer_count =
+                dst_subresource.array_layers.end - dst_subresource.array_layers.start;
+
+            if copy_2d_3d_supported {
+                match (
+                    src_image.dimensions().image_type(),
+                    dst_image.dimensions().image_type(),
+                ) {
+                    (ImageType::Dim2d, ImageType::Dim3d) => {
+                        src_extent[2] = 1;
+
+                        // VUID-vkCmdCopyImage-srcImage-01791
+                        if dst_extent[2] != src_layer_count {
+                            return Err(CopyError::ArrayLayerCountMismatch {
+                                region_index,
+                                src_layer_count,
+                                dst_layer_count: dst_extent[2],
+                            });
+                        }
+                    }
+                    (ImageType::Dim3d, ImageType::Dim2d) => {
+                        dst_extent[2] = 1;
+
+                        // VUID-vkCmdCopyImage-dstImage-01792
+                        if src_extent[2] != dst_layer_count {
+                            return Err(CopyError::ArrayLayerCountMismatch {
+                                region_index,
+                                src_layer_count: src_extent[2],
+                                dst_layer_count,
+                            });
+                        }
+                    }
+                    _ => {
+                        // VUID-VkImageCopy2-extent-00140
+                        if src_layer_count != dst_layer_count {
+                            return Err(CopyError::ArrayLayerCountMismatch {
+                                region_index,
+                                src_layer_count,
+                                dst_layer_count,
+                            });
+                        }
+                    }
+                }
+            } else {
+                // VUID-VkImageCopy2-extent-00140
+                if src_layer_count != dst_layer_count {
+                    return Err(CopyError::ArrayLayerCountMismatch {
+                        region_index,
+                        src_layer_count,
+                        dst_layer_count,
+                    });
+                }
+            };
+
+            if let Some((src_extent_alignment, dst_extent_alignment)) = extent_alignment {
+                let check_offset_extent = |resource: CopyErrorResource,
+                                           extent_alignment: [u32; 3],
+                                           subresource_extent: [u32; 3],
+                                           offset: [u32; 3],
+                                           extent: [u32; 3]|
+                 -> Result<_, CopyError> {
+                    for i in 0..3 {
+                        // VUID-VkImageCopy2-extent-06668
+                        // VUID-VkImageCopy2-extent-06669
+                        // VUID-VkImageCopy2-extent-06670
+                        assert!(extent[i] != 0);
+
+                        // VUID-VkCopyImageInfo2-srcOffset-00144
+                        // VUID-VkCopyImageInfo2-srcOffset-00145
+                        // VUID-VkCopyImageInfo2-srcOffset-00147
+                        // VUID-VkCopyImageInfo2-dstOffset-00150
+                        // VUID-VkCopyImageInfo2-dstOffset-00151
+                        // VUID-VkCopyImageInfo2-dstOffset-00153
+                        if offset[i] + extent[i] > subresource_extent[i] {
+                            return Err(CopyError::RegionOutOfImageBounds {
+                                resource,
+                                region_index,
+                                offset_range_end: [
+                                    offset[0] + extent[0],
+                                    offset[1] + extent[1],
+                                    offset[2] + extent[2],
+                                ],
+                                subresource_extent,
+                            });
+                        }
+
+                        // VUID-VkCopyImageInfo2-srcImage-01727
+                        // VUID-VkCopyImageInfo2-dstImage-01731
+                        // VUID-VkCopyImageInfo2-srcOffset-01783
+                        // VUID-VkCopyImageInfo2-dstOffset-01784
+                        if offset[i] % extent_alignment[i] != 0 {
+                            return Err(CopyError::OffsetNotAlignedForImage {
+                                resource,
+                                region_index,
+                                offset,
+                                required_alignment: extent_alignment,
+                            });
+                        }
+
+                        // VUID-VkCopyImageInfo2-srcImage-01728
+                        // VUID-VkCopyImageInfo2-srcImage-01729
+                        // VUID-VkCopyImageInfo2-srcImage-01730
+                        // VUID-VkCopyImageInfo2-dstImage-01732
+                        // VUID-VkCopyImageInfo2-dstImage-01733
+                        // VUID-VkCopyImageInfo2-dstImage-01734
+                        if offset[i] + extent[i] != subresource_extent[i]
+                            && extent[i] % extent_alignment[i] != 0
+                        {
+                            return Err(CopyError::ExtentNotAlignedForImage {
+                                resource,
+                                region_index,
+                                extent,
+                                required_alignment: extent_alignment,
+                            });
+                        }
+                    }
+
+                    Ok(())
+                };
+
+                check_offset_extent(
+                    CopyErrorResource::Source,
+                    src_extent_alignment,
+                    src_subresource_extent,
+                    src_offset,
+                    src_extent,
+                )?;
+                check_offset_extent(
+                    CopyErrorResource::Destination,
+                    dst_extent_alignment,
+                    dst_subresource_extent,
+                    dst_offset,
+                    dst_extent,
+                )?;
+
+                // VUID-VkCopyImageInfo2-pRegions-00124
+                if same_image {
+                    let src_region_index = region_index;
+                    let src_subresource_axes = [
+                        src_image_inner.first_mipmap_level + src_subresource.mip_level
+                            ..src_image_inner.first_mipmap_level + src_subresource.mip_level + 1,
+                        src_image_inner.first_layer + src_subresource.array_layers.start
+                            ..src_image_inner.first_layer + src_subresource.array_layers.end,
+                    ];
+                    let src_extent_axes = [
+                        src_offset[0]..src_offset[0] + extent[0],
+                        src_offset[1]..src_offset[1] + extent[1],
+                        src_offset[2]..src_offset[2] + extent[2],
+                    ];
+
+                    for (dst_region_index, dst_region) in regions.iter().enumerate() {
+                        let &ImageCopy {
+                            ref dst_subresource,
+                            dst_offset,
+                            ..
+                        } = dst_region;
+
+                        // For a single-plane image, the aspects must always be identical anyway
+                        if src_image_aspects.intersects(ImageAspects::PLANE_0)
+                            && src_subresource.aspects != dst_subresource.aspects
+                        {
+                            continue;
+                        }
+
+                        let dst_subresource_axes = [
+                            dst_image_inner.first_mipmap_level + dst_subresource.mip_level
+                                ..dst_image_inner.first_mipmap_level
+                                    + dst_subresource.mip_level
+                                    + 1,
+                            dst_image_inner.first_layer + src_subresource.array_layers.start
+                                ..dst_image_inner.first_layer + src_subresource.array_layers.end,
+                        ];
+
+                        if src_subresource_axes.iter().zip(dst_subresource_axes).any(
+                            |(src_range, dst_range)| {
+                                src_range.start >= dst_range.end || dst_range.start >= src_range.end
+                            },
+                        ) {
+                            continue;
+                        }
+
+                        // If the subresource axes all overlap, then the source and destination must
+                        // have the same layout.
+                        overlap_subresource_indices = Some((src_region_index, dst_region_index));
+
+                        let dst_extent_axes = [
+                            dst_offset[0]..dst_offset[0] + extent[0],
+                            dst_offset[1]..dst_offset[1] + extent[1],
+                            dst_offset[2]..dst_offset[2] + extent[2],
+                        ];
+
+                        // There is only overlap if all of the axes overlap.
+                        if src_extent_axes.iter().zip(dst_extent_axes).any(
+                            |(src_range, dst_range)| {
+                                src_range.start >= dst_range.end || dst_range.start >= src_range.end
+                            },
+                        ) {
+                            continue;
+                        }
+
+                        overlap_extent_indices = Some((src_region_index, dst_region_index));
+                    }
+                }
+            } else {
+                // If granularity is `None`, then we can only copy whole subresources.
+                let check_offset_extent = |resource: CopyErrorResource,
+                                           subresource_extent: [u32; 3],
+                                           offset: [u32; 3],
+                                           extent: [u32; 3]|
+                 -> Result<_, CopyError> {
+                    // VUID-VkCopyImageInfo2-srcImage-01727
+                    // VUID-VkCopyImageInfo2-dstImage-01731
+                    // VUID-vkCmdCopyImage-srcOffset-01783
+                    // VUID-vkCmdCopyImage-dstOffset-01784
+                    if offset != [0, 0, 0] {
+                        return Err(CopyError::OffsetNotAlignedForImage {
+                            resource,
+                            region_index,
+                            offset,
+                            required_alignment: subresource_extent,
+                        });
+                    }
+
+                    // VUID-VkCopyImageInfo2-srcImage-01728
+                    // VUID-VkCopyImageInfo2-srcImage-01729
+                    // VUID-VkCopyImageInfo2-srcImage-01730
+                    // VUID-VkCopyImageInfo2-dstImage-01732
+                    // VUID-VkCopyImageInfo2-dstImage-01733
+                    // VUID-VkCopyImageInfo2-dstImage-01734
+                    if extent != subresource_extent {
+                        return Err(CopyError::ExtentNotAlignedForImage {
+                            resource,
+                            region_index,
+                            extent,
+                            required_alignment: subresource_extent,
+                        });
+                    }
+
+                    Ok(())
+                };
+
+                check_offset_extent(
+                    CopyErrorResource::Source,
+                    src_subresource_extent,
+                    src_offset,
+                    src_extent,
+                )?;
+                check_offset_extent(
+                    CopyErrorResource::Destination,
+                    dst_subresource_extent,
+                    dst_offset,
+                    dst_extent,
+                )?;
+
+                // VUID-VkCopyImageInfo2-pRegions-00124
+                // A simpler version that assumes the region covers the full extent.
+                if same_image {
+                    let src_region_index = region_index;
+                    let src_axes = [
+                        src_image_inner.first_mipmap_level + src_subresource.mip_level
+                            ..src_image_inner.first_mipmap_level + src_subresource.mip_level + 1,
+                        src_image_inner.first_layer + src_subresource.array_layers.start
+                            ..src_image_inner.first_layer + src_subresource.array_layers.end,
+                    ];
+
+                    for (dst_region_index, dst_region) in regions.iter().enumerate() {
+                        let &ImageCopy {
+                            ref dst_subresource,
+                            dst_offset: _,
+                            ..
+                        } = dst_region;
+
+                        if src_image_aspects.intersects(ImageAspects::PLANE_0)
+                            && src_subresource.aspects != dst_subresource.aspects
+                        {
+                            continue;
+                        }
+
+                        let dst_axes = [
+                            dst_image_inner.first_mipmap_level + dst_subresource.mip_level
+                                ..dst_image_inner.first_mipmap_level
+                                    + dst_subresource.mip_level
+                                    + 1,
+                            dst_image_inner.first_layer + src_subresource.array_layers.start
+                                ..dst_image_inner.first_layer + src_subresource.array_layers.end,
+                        ];
+
+                        // There is only overlap if all of the axes overlap.
+                        if src_axes.iter().zip(dst_axes).any(|(src_range, dst_range)| {
+                            src_range.start >= dst_range.end || dst_range.start >= src_range.end
+                        }) {
+                            continue;
+                        }
+
+                        overlap_extent_indices = Some((src_region_index, dst_region_index));
+                    }
+                }
+            }
+        }
+
+        // VUID-VkCopyImageInfo2-aspect-06662
+        if !(src_image_aspects_used - ImageAspects::STENCIL).is_empty()
+            && !src_image.usage().intersects(ImageUsage::TRANSFER_SRC)
+        {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Source,
+                usage: "transfer_src",
+            });
+        }
+
+        // VUID-VkCopyImageInfo2-aspect-06663
+        if !(dst_image_aspects_used - ImageAspects::STENCIL).is_empty()
+            && !dst_image.usage().intersects(ImageUsage::TRANSFER_DST)
+        {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Destination,
+                usage: "transfer_dst",
+            });
+        }
+
+        // VUID-VkCopyImageInfo2-aspect-06664
+        if src_image_aspects_used.intersects(ImageAspects::STENCIL)
+            && !src_image
+                .stencil_usage()
+                .intersects(ImageUsage::TRANSFER_SRC)
+        {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Source,
+                usage: "transfer_src",
+            });
+        }
+
+        // VUID-VkCopyImageInfo2-aspect-06665
+        if dst_image_aspects_used.intersects(ImageAspects::STENCIL)
+            && !dst_image
+                .stencil_usage()
+                .intersects(ImageUsage::TRANSFER_DST)
+        {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Destination,
+                usage: "transfer_dst",
+            });
+        }
+
+        // VUID-VkCopyImageInfo2-pRegions-00124
+        if let Some((src_region_index, dst_region_index)) = overlap_extent_indices {
+            return Err(CopyError::OverlappingRegions {
+                src_region_index,
+                dst_region_index,
+            });
+        }
+
+        // VUID-VkCopyImageInfo2-srcImageLayout-00128
+        // VUID-VkCopyImageInfo2-dstImageLayout-00133
+        if let Some((src_region_index, dst_region_index)) = overlap_subresource_indices {
+            if src_image_layout != dst_image_layout {
+                return Err(CopyError::OverlappingSubresourcesLayoutMismatch {
+                    src_region_index,
+                    dst_region_index,
+                    src_image_layout,
+                    dst_image_layout,
+                });
+            }
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn copy_image_unchecked(&mut self, copy_image_info: CopyImageInfo) -> &mut Self {
+        let CopyImageInfo {
+            src_image,
+            src_image_layout,
+            dst_image,
+            dst_image_layout,
+            regions,
+            _ne: _,
+        } = copy_image_info;
+
+        if regions.is_empty() {
+            return self;
+        }
+
+        let src_image_inner = src_image.inner();
+        let dst_image_inner = dst_image.inner();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3
+            || self.device().enabled_extensions().khr_copy_commands2
+        {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &ImageCopy {
+                        ref src_subresource,
+                        src_offset,
+                        ref dst_subresource,
+                        dst_offset,
+                        extent,
+                        _ne: _,
+                    } = region;
+
+                    let mut src_subresource = src_subresource.clone();
+                    src_subresource.array_layers.start += src_image_inner.first_layer;
+                    src_subresource.array_layers.end += src_image_inner.first_layer;
+                    src_subresource.mip_level += src_image_inner.first_mipmap_level;
+
+                    let mut dst_subresource = dst_subresource.clone();
+                    dst_subresource.array_layers.start += dst_image_inner.first_layer;
+                    dst_subresource.array_layers.end += dst_image_inner.first_layer;
+                    dst_subresource.mip_level += dst_image_inner.first_mipmap_level;
+
+                    ash::vk::ImageCopy2 {
+                        src_subresource: src_subresource.into(),
+                        src_offset: ash::vk::Offset3D {
+                            x: src_offset[0] as i32,
+                            y: src_offset[1] as i32,
+                            z: src_offset[2] as i32,
+                        },
+                        dst_subresource: dst_subresource.into(),
+                        dst_offset: ash::vk::Offset3D {
+                            x: dst_offset[0] as i32,
+                            y: dst_offset[1] as i32,
+                            z: dst_offset[2] as i32,
+                        },
+                        extent: ash::vk::Extent3D {
+                            width: extent[0],
+                            height: extent[1],
+                            depth: extent[2],
+                        },
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let copy_image_info = ash::vk::CopyImageInfo2 {
+                src_image: src_image_inner.image.handle(),
+                src_image_layout: src_image_layout.into(),
+                dst_image: dst_image_inner.image.handle(),
+                dst_image_layout: dst_image_layout.into(),
+                region_count: regions.len() as u32,
+                p_regions: regions.as_ptr(),
+                ..Default::default()
+            };
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_copy_image2)(self.handle(), &copy_image_info);
+            } else {
+                (fns.khr_copy_commands2.cmd_copy_image2_khr)(self.handle(), &copy_image_info);
+            }
+        } else {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &ImageCopy {
+                        ref src_subresource,
+                        src_offset,
+                        ref dst_subresource,
+                        dst_offset,
+                        extent,
+                        _ne: _,
+                    } = region;
+
+                    let mut src_subresource = src_subresource.clone();
+                    src_subresource.array_layers.start += src_image_inner.first_layer;
+                    src_subresource.array_layers.end += src_image_inner.first_layer;
+                    src_subresource.mip_level += src_image_inner.first_mipmap_level;
+
+                    let mut dst_subresource = dst_subresource.clone();
+                    dst_subresource.array_layers.start += dst_image_inner.first_layer;
+                    dst_subresource.array_layers.end += dst_image_inner.first_layer;
+                    dst_subresource.mip_level += dst_image_inner.first_mipmap_level;
+
+                    ash::vk::ImageCopy {
+                        src_subresource: src_subresource.into(),
+                        src_offset: ash::vk::Offset3D {
+                            x: src_offset[0] as i32,
+                            y: src_offset[1] as i32,
+                            z: src_offset[2] as i32,
+                        },
+                        dst_subresource: dst_subresource.into(),
+                        dst_offset: ash::vk::Offset3D {
+                            x: dst_offset[0] as i32,
+                            y: dst_offset[1] as i32,
+                            z: dst_offset[2] as i32,
+                        },
+                        extent: ash::vk::Extent3D {
+                            width: extent[0],
+                            height: extent[1],
+                            depth: extent[2],
+                        },
+                    }
+                })
+                .collect();
+
+            (fns.v1_0.cmd_copy_image)(
+                self.handle(),
+                src_image_inner.image.handle(),
+                src_image_layout.into(),
+                dst_image_inner.image.handle(),
+                dst_image_layout.into(),
+                regions.len() as u32,
+                regions.as_ptr(),
+            );
+        }
+
+        self.resources.push(Box::new(src_image));
+        self.resources.push(Box::new(dst_image));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Copies from a buffer to an image.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn copy_buffer_to_image(
+        &mut self,
+        copy_buffer_to_image_info: CopyBufferToImageInfo,
+    ) -> Result<&mut Self, CopyError> {
+        self.validate_copy_buffer_to_image(&copy_buffer_to_image_info)?;
+
+        unsafe { Ok(self.copy_buffer_to_image_unchecked(copy_buffer_to_image_info)) }
+    }
+
+    fn validate_copy_buffer_to_image(
+        &self,
+        copy_buffer_to_image_info: &CopyBufferToImageInfo,
+    ) -> Result<(), CopyError> {
+        let device = self.device();
+
+        // VUID-vkCmdCopyBufferToImage2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(CopyError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdCopyBufferToImage2-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::TRANSFER | QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(CopyError::NotSupportedByQueueFamily);
+        }
+
+        let &CopyBufferToImageInfo {
+            ref src_buffer,
+            ref dst_image,
+            dst_image_layout,
+            ref regions,
+            _ne: _,
+        } = copy_buffer_to_image_info;
+
+        // VUID-VkCopyBufferToImageInfo2-dstImageLayout-parameter
+        dst_image_layout.validate_device(device)?;
+
+        // VUID-VkCopyBufferToImageInfo2-commonparent
+        assert_eq!(device, src_buffer.device());
+        assert_eq!(device, dst_image.device());
+
+        let buffer_inner = src_buffer.inner();
+        let mut image_aspects = dst_image.format().aspects();
+
+        // VUID-VkCopyBufferToImageInfo2-commandBuffer-04477
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+            && !image_aspects.intersects(ImageAspects::COLOR)
+        {
+            return Err(CopyError::DepthStencilNotSupportedByQueueFamily);
+        }
+
+        // VUID-VkCopyBufferToImageInfo2-srcBuffer-00174
+        if !src_buffer.usage().intersects(BufferUsage::TRANSFER_SRC) {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Source,
+                usage: "transfer_src",
+            });
+        }
+
+        // VUID-VkCopyBufferToImageInfo2-dstImage-00177
+        if !dst_image.usage().intersects(ImageUsage::TRANSFER_DST) {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Destination,
+                usage: "transfer_dst",
+            });
+        }
+
+        if device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1 {
+            // VUID-VkCopyBufferToImageInfo2-dstImage-01997
+            if !dst_image
+                .format_features()
+                .intersects(FormatFeatures::TRANSFER_DST)
+            {
+                return Err(CopyError::MissingFormatFeature {
+                    resource: CopyErrorResource::Destination,
+                    format_feature: "transfer_dst",
+                });
+            }
+        }
+
+        // VUID-VkCopyBufferToImageInfo2-dstImage-00179
+        if dst_image.samples() != SampleCount::Sample1 {
+            return Err(CopyError::SampleCountInvalid {
+                resource: CopyErrorResource::Destination,
+                sample_count: dst_image.samples(),
+                allowed_sample_counts: SampleCounts::SAMPLE_1,
+            });
+        }
+
+        // VUID-VkCopyBufferToImageInfo2-dstImageLayout-01396
+        if !matches!(
+            dst_image_layout,
+            ImageLayout::TransferDstOptimal | ImageLayout::General
+        ) {
+            return Err(CopyError::ImageLayoutInvalid {
+                resource: CopyErrorResource::Destination,
+                image_layout: dst_image_layout,
+            });
+        }
+
+        let extent_alignment = match queue_family_properties.min_image_transfer_granularity {
+            [0, 0, 0] => None,
+            min_image_transfer_granularity => {
+                let granularity = move |block_extent: [u32; 3], is_multi_plane: bool| {
+                    if is_multi_plane {
+                        // Assume planes always have 1x1 blocks
+                        min_image_transfer_granularity
+                    } else {
+                        // "The value returned in minImageTransferGranularity has a unit of
+                        // compressed texel blocks for images having a block-compressed format, and
+                        // a unit of texels otherwise."
+                        [
+                            min_image_transfer_granularity[0] * block_extent[0],
+                            min_image_transfer_granularity[1] * block_extent[1],
+                            min_image_transfer_granularity[2] * block_extent[2],
+                        ]
+                    }
+                };
+
+                Some(granularity(
+                    dst_image.format().block_extent(),
+                    image_aspects.intersects(ImageAspects::PLANE_0),
+                ))
+            }
+        };
+
+        if image_aspects.intersects(ImageAspects::PLANE_0) {
+            // VUID-VkCopyBufferToImageInfo2-aspectMask-01560
+            image_aspects -= ImageAspects::COLOR;
+        }
+
+        for (region_index, region) in regions.iter().enumerate() {
+            let &BufferImageCopy {
+                buffer_offset,
+                buffer_row_length,
+                buffer_image_height,
+                ref image_subresource,
+                image_offset,
+                image_extent,
+                _ne: _,
+            } = region;
+
+            // VUID-VkCopyBufferToImageInfo2-imageSubresource-01701
+            if image_subresource.mip_level >= dst_image.mip_levels() {
+                return Err(CopyError::MipLevelsOutOfRange {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    mip_levels_range_end: image_subresource.mip_level + 1,
+                    image_mip_levels: dst_image.mip_levels(),
+                });
+            }
+
+            // VUID-VkImageSubresourceLayers-layerCount-01700
+            // VUID-VkCopyBufferToImageInfo2-baseArrayLayer-00213
+            assert!(!image_subresource.array_layers.is_empty());
+
+            // VUID-VkCopyBufferToImageInfo2-imageSubresource-01702
+            // VUID-VkCopyBufferToImageInfo2-baseArrayLayer-00213
+            if image_subresource.array_layers.end > dst_image.dimensions().array_layers() {
+                return Err(CopyError::ArrayLayersOutOfRange {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    array_layers_range_end: image_subresource.array_layers.end,
+                    image_array_layers: dst_image.dimensions().array_layers(),
+                });
+            }
+
+            // VUID-VkImageSubresourceLayers-aspectMask-requiredbitmask
+            assert!(!image_subresource.aspects.is_empty());
+
+            // VUID-VkCopyBufferToImageInfo2-aspectMask-00211
+            if !image_aspects.contains(image_subresource.aspects) {
+                return Err(CopyError::AspectsNotAllowed {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    aspects: image_subresource.aspects,
+                    allowed_aspects: image_aspects,
+                });
+            }
+
+            // VUID-VkBufferImageCopy2-aspectMask-00212
+            // VUID-VkCopyBufferToImageInfo2-aspectMask-01560
+            if image_subresource.aspects.count() != 1 {
+                return Err(CopyError::MultipleAspectsNotAllowed {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    aspects: image_subresource.aspects,
+                });
+            }
+
+            let (image_subresource_format, image_subresource_extent) =
+                if image_aspects.intersects(ImageAspects::PLANE_0) {
+                    if image_subresource.aspects.intersects(ImageAspects::PLANE_0) {
+                        (
+                            dst_image.format().planes()[0],
+                            dst_image.dimensions().width_height_depth(),
+                        )
+                    } else if image_subresource.aspects.intersects(ImageAspects::PLANE_1) {
+                        (
+                            dst_image.format().planes()[1],
+                            dst_image
+                                .format()
+                                .ycbcr_chroma_sampling()
+                                .unwrap()
+                                .subsampled_extent(dst_image.dimensions().width_height_depth()),
+                        )
+                    } else {
+                        (
+                            dst_image.format().planes()[2],
+                            dst_image
+                                .format()
+                                .ycbcr_chroma_sampling()
+                                .unwrap()
+                                .subsampled_extent(dst_image.dimensions().width_height_depth()),
+                        )
+                    }
+                } else {
+                    (
+                        dst_image.format(),
+                        dst_image
+                            .dimensions()
+                            .mip_level_dimensions(image_subresource.mip_level)
+                            .unwrap()
+                            .width_height_depth(),
+                    )
+                };
+
+            if let Some(extent_alignment) = extent_alignment {
+                for i in 0..3 {
+                    // VUID-VkBufferImageCopy2-imageExtent-06659
+                    // VUID-VkBufferImageCopy2-imageExtent-06660
+                    // VUID-VkBufferImageCopy2-imageExtent-06661
+                    assert!(image_extent[i] != 0);
+
+                    // VUID-VkCopyBufferToImageInfo2-pRegions-06223
+                    // VUID-VkCopyBufferToImageInfo2-pRegions-06224
+                    // VUID-VkCopyBufferToImageInfo2-imageOffset-00200
+                    if image_offset[i] + image_extent[i] > image_subresource_extent[i] {
+                        return Err(CopyError::RegionOutOfImageBounds {
+                            resource: CopyErrorResource::Destination,
+                            region_index,
+                            offset_range_end: [
+                                image_offset[0] + image_extent[0],
+                                image_offset[1] + image_extent[1],
+                                image_offset[2] + image_extent[2],
+                            ],
+                            subresource_extent: image_subresource_extent,
+                        });
+                    }
+
+                    // VUID-VkCopyBufferToImageInfo2-imageOffset-01793
+                    // VUID-VkCopyBufferToImageInfo2-imageOffset-00205
+                    if image_offset[i] % extent_alignment[i] != 0 {
+                        return Err(CopyError::OffsetNotAlignedForImage {
+                            resource: CopyErrorResource::Destination,
+                            region_index,
+                            offset: image_offset,
+                            required_alignment: extent_alignment,
+                        });
+                    }
+
+                    // VUID-VkCopyBufferToImageInfo2-imageOffset-01793
+                    // VUID-VkCopyBufferToImageInfo2-imageExtent-00207
+                    // VUID-VkCopyBufferToImageInfo2-imageExtent-00208
+                    // VUID-VkCopyBufferToImageInfo2-imageExtent-00209
+                    if image_offset[i] + image_extent[i] != image_subresource_extent[i]
+                        && image_extent[i] % extent_alignment[i] != 0
+                    {
+                        return Err(CopyError::ExtentNotAlignedForImage {
+                            resource: CopyErrorResource::Destination,
+                            region_index,
+                            extent: image_extent,
+                            required_alignment: extent_alignment,
+                        });
+                    }
+                }
+            } else {
+                // If granularity is `None`, then we can only copy whole subresources.
+
+                // VUID-VkCopyBufferToImageInfo2-imageOffset-01793
+                if image_offset != [0, 0, 0] {
+                    return Err(CopyError::OffsetNotAlignedForImage {
+                        resource: CopyErrorResource::Destination,
+                        region_index,
+                        offset: image_offset,
+                        required_alignment: image_subresource_extent,
+                    });
+                }
+
+                // VUID-VkCopyBufferToImageInfo2-imageOffset-01793
+                if image_extent != image_subresource_extent {
+                    return Err(CopyError::ExtentNotAlignedForImage {
+                        resource: CopyErrorResource::Destination,
+                        region_index,
+                        extent: image_extent,
+                        required_alignment: image_subresource_extent,
+                    });
+                }
+            }
+
+            // VUID-VkBufferImageCopy2-bufferRowLength-00195
+            if !(buffer_row_length == 0 || buffer_row_length >= image_extent[0]) {
+                return Err(CopyError::BufferRowLengthTooSmall {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    row_length: buffer_row_length,
+                    min: image_extent[0],
+                });
+            }
+
+            // VUID-VkBufferImageCopy2-bufferImageHeight-00196
+            if !(buffer_image_height == 0 || buffer_image_height >= image_extent[1]) {
+                return Err(CopyError::BufferImageHeightTooSmall {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    image_height: buffer_image_height,
+                    min: image_extent[1],
+                });
+            }
+
+            let image_subresource_block_extent = image_subresource_format.block_extent();
+
+            // VUID-VkCopyBufferToImageInfo2-bufferRowLength-00203
+            if buffer_row_length % image_subresource_block_extent[0] != 0 {
+                return Err(CopyError::BufferRowLengthNotAligned {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    row_length: buffer_row_length,
+                    required_alignment: image_subresource_block_extent[0],
+                });
+            }
+
+            // VUID-VkCopyBufferToImageInfo2-bufferImageHeight-00204
+            if buffer_image_height % image_subresource_block_extent[1] != 0 {
+                return Err(CopyError::BufferImageHeightNotAligned {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    image_height: buffer_image_height,
+                    required_alignment: image_subresource_block_extent[1],
+                });
+            }
+
+            // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBufferImageCopy.html#_description
+            let image_subresource_block_size =
+                if image_subresource.aspects.intersects(ImageAspects::STENCIL) {
+                    1
+                } else if image_subresource.aspects.intersects(ImageAspects::DEPTH) {
+                    match image_subresource_format {
+                        Format::D16_UNORM | Format::D16_UNORM_S8_UINT => 2,
+                        Format::D32_SFLOAT
+                        | Format::D32_SFLOAT_S8_UINT
+                        | Format::X8_D24_UNORM_PACK32
+                        | Format::D24_UNORM_S8_UINT => 4,
+                        _ => unreachable!(),
+                    }
+                } else {
+                    image_subresource_format.block_size().unwrap()
+                };
+
+            // VUID-VkCopyBufferToImageInfo2-pRegions-04725
+            // VUID-VkCopyBufferToImageInfo2-pRegions-04726
+            if (buffer_row_length / image_subresource_block_extent[0]) as DeviceSize
+                * image_subresource_block_size
+                > 0x7FFFFFFF
+            {
+                return Err(CopyError::BufferRowLengthTooLarge {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    buffer_row_length,
+                });
+            }
+
+            let buffer_offset_alignment =
+                if image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
+                    4
+                } else {
+                    let mut buffer_offset_alignment = image_subresource_block_size;
+
+                    // VUID-VkCopyBufferToImageInfo2-commandBuffer-04052
+                    // Make the alignment a multiple of 4.
+                    if !queue_family_properties
+                        .queue_flags
+                        .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+                    {
+                        if buffer_offset_alignment % 2 != 0 {
+                            buffer_offset_alignment *= 2;
+                        }
+
+                        if buffer_offset_alignment % 4 != 0 {
+                            buffer_offset_alignment *= 2;
+                        }
+                    }
+
+                    buffer_offset_alignment
+                };
+
+            // VUID-VkCopyBufferToImageInfo2-bufferOffset-00206
+            // VUID-VkCopyBufferToImageInfo2-bufferOffset-01558
+            // VUID-VkCopyBufferToImageInfo2-bufferOffset-01559
+            // VUID-VkCopyBufferToImageInfo2-srcImage-04053
+            if (buffer_inner.offset + buffer_offset) % buffer_offset_alignment != 0 {
+                return Err(CopyError::OffsetNotAlignedForBuffer {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    offset: buffer_inner.offset + buffer_offset,
+                    required_alignment: buffer_offset_alignment,
+                });
+            }
+
+            let buffer_copy_size = region.buffer_copy_size(image_subresource_format);
+
+            // VUID-VkCopyBufferToImageInfo2-pRegions-00171
+            if buffer_offset + buffer_copy_size > src_buffer.size() {
+                return Err(CopyError::RegionOutOfBufferBounds {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    offset_range_end: buffer_offset + buffer_copy_size,
+                    buffer_size: src_buffer.size(),
+                });
+            }
+        }
+
+        // VUID-VkCopyBufferToImageInfo2-pRegions-00173
+        // Can't occur as long as memory aliasing isn't allowed.
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn copy_buffer_to_image_unchecked(
+        &mut self,
+        copy_buffer_to_image_info: CopyBufferToImageInfo,
+    ) -> &mut Self {
+        let CopyBufferToImageInfo {
+            src_buffer,
+            dst_image,
+            dst_image_layout,
+            regions,
+            _ne: _,
+        } = copy_buffer_to_image_info;
+
+        if regions.is_empty() {
+            return self;
+        }
+
+        let src_buffer_inner = src_buffer.inner();
+        let dst_image_inner = dst_image.inner();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3
+            || self.device().enabled_extensions().khr_copy_commands2
+        {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &BufferImageCopy {
+                        buffer_offset,
+                        buffer_row_length,
+                        buffer_image_height,
+                        ref image_subresource,
+                        image_offset,
+                        image_extent,
+                        _ne: _,
+                    } = region;
+
+                    let mut image_subresource = image_subresource.clone();
+                    image_subresource.array_layers.start += dst_image_inner.first_layer;
+                    image_subresource.array_layers.end += dst_image_inner.first_layer;
+                    image_subresource.mip_level += dst_image_inner.first_mipmap_level;
+
+                    ash::vk::BufferImageCopy2 {
+                        buffer_offset: buffer_offset + src_buffer_inner.offset,
+                        buffer_row_length,
+                        buffer_image_height,
+                        image_subresource: image_subresource.into(),
+                        image_offset: ash::vk::Offset3D {
+                            x: image_offset[0] as i32,
+                            y: image_offset[1] as i32,
+                            z: image_offset[2] as i32,
+                        },
+                        image_extent: ash::vk::Extent3D {
+                            width: image_extent[0],
+                            height: image_extent[1],
+                            depth: image_extent[2],
+                        },
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let copy_buffer_to_image_info = ash::vk::CopyBufferToImageInfo2 {
+                src_buffer: src_buffer_inner.buffer.handle(),
+                dst_image: dst_image_inner.image.handle(),
+                dst_image_layout: dst_image_layout.into(),
+                region_count: regions.len() as u32,
+                p_regions: regions.as_ptr(),
+                ..Default::default()
+            };
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_copy_buffer_to_image2)(self.handle(), &copy_buffer_to_image_info);
+            } else {
+                (fns.khr_copy_commands2.cmd_copy_buffer_to_image2_khr)(
+                    self.handle(),
+                    &copy_buffer_to_image_info,
+                );
+            }
+        } else {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &BufferImageCopy {
+                        buffer_offset,
+                        buffer_row_length,
+                        buffer_image_height,
+                        ref image_subresource,
+                        image_offset,
+                        image_extent,
+                        _ne: _,
+                    } = region;
+
+                    let mut image_subresource = image_subresource.clone();
+                    image_subresource.array_layers.start += dst_image_inner.first_layer;
+                    image_subresource.array_layers.end += dst_image_inner.first_layer;
+                    image_subresource.mip_level += dst_image_inner.first_mipmap_level;
+
+                    ash::vk::BufferImageCopy {
+                        buffer_offset: buffer_offset + src_buffer_inner.offset,
+                        buffer_row_length,
+                        buffer_image_height,
+                        image_subresource: image_subresource.into(),
+                        image_offset: ash::vk::Offset3D {
+                            x: image_offset[0] as i32,
+                            y: image_offset[1] as i32,
+                            z: image_offset[2] as i32,
+                        },
+                        image_extent: ash::vk::Extent3D {
+                            width: image_extent[0],
+                            height: image_extent[1],
+                            depth: image_extent[2],
+                        },
+                    }
+                })
+                .collect();
+
+            (fns.v1_0.cmd_copy_buffer_to_image)(
+                self.handle(),
+                src_buffer_inner.buffer.handle(),
+                dst_image_inner.image.handle(),
+                dst_image_layout.into(),
+                regions.len() as u32,
+                regions.as_ptr(),
+            );
+        }
+
+        self.resources.push(Box::new(src_buffer));
+        self.resources.push(Box::new(dst_image));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Copies from an image to a buffer.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn copy_image_to_buffer(
+        &mut self,
+        copy_image_to_buffer_info: CopyImageToBufferInfo,
+    ) -> Result<&mut Self, CopyError> {
+        self.validate_copy_image_to_buffer(&copy_image_to_buffer_info)?;
+
+        unsafe { Ok(self.copy_image_to_buffer_unchecked(copy_image_to_buffer_info)) }
+    }
+
+    fn validate_copy_image_to_buffer(
+        &self,
+        copy_image_to_buffer_info: &CopyImageToBufferInfo,
+    ) -> Result<(), CopyError> {
+        let device = self.device();
+
+        // VUID-vkCmdCopyImageToBuffer2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(CopyError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdCopyImageToBuffer2-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::TRANSFER | QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(CopyError::NotSupportedByQueueFamily);
+        }
+
+        let &CopyImageToBufferInfo {
+            ref src_image,
+            src_image_layout,
+            ref dst_buffer,
+            ref regions,
+            _ne: _,
+        } = copy_image_to_buffer_info;
+
+        // VUID-VkCopyImageToBufferInfo2-srcImageLayout-parameter
+        src_image_layout.validate_device(device)?;
+
+        // VUID-VkCopyImageToBufferInfo2-commonparent
+        assert_eq!(device, dst_buffer.device());
+        assert_eq!(device, src_image.device());
+
+        let buffer_inner = dst_buffer.inner();
+        let mut image_aspects = src_image.format().aspects();
+
+        // VUID-VkCopyImageToBufferInfo2-srcImage-00186
+        if !src_image.usage().intersects(ImageUsage::TRANSFER_SRC) {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Source,
+                usage: "transfer_src",
+            });
+        }
+
+        // VUID-VkCopyImageToBufferInfo2-dstBuffer-00191
+        if !dst_buffer.usage().intersects(BufferUsage::TRANSFER_DST) {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Destination,
+                usage: "transfer_dst",
+            });
+        }
+
+        if device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1 {
+            // VUID-VkCopyImageToBufferInfo2-srcImage-01998
+            if !src_image
+                .format_features()
+                .intersects(FormatFeatures::TRANSFER_SRC)
+            {
+                return Err(CopyError::MissingFormatFeature {
+                    resource: CopyErrorResource::Source,
+                    format_feature: "transfer_src",
+                });
+            }
+        }
+
+        // VUID-VkCopyImageToBufferInfo2-srcImage-00188
+        if src_image.samples() != SampleCount::Sample1 {
+            return Err(CopyError::SampleCountInvalid {
+                resource: CopyErrorResource::Source,
+                sample_count: src_image.samples(),
+                allowed_sample_counts: SampleCounts::SAMPLE_1,
+            });
+        }
+
+        // VUID-VkCopyImageToBufferInfo2-srcImageLayout-01397
+        if !matches!(
+            src_image_layout,
+            ImageLayout::TransferSrcOptimal | ImageLayout::General
+        ) {
+            return Err(CopyError::ImageLayoutInvalid {
+                resource: CopyErrorResource::Source,
+                image_layout: src_image_layout,
+            });
+        }
+
+        let extent_alignment = match queue_family_properties.min_image_transfer_granularity {
+            [0, 0, 0] => None,
+            min_image_transfer_granularity => {
+                let granularity = move |block_extent: [u32; 3], is_multi_plane: bool| {
+                    if is_multi_plane {
+                        // Assume planes always have 1x1 blocks
+                        min_image_transfer_granularity
+                    } else {
+                        // "The value returned in minImageTransferGranularity has a unit of
+                        // compressed texel blocks for images having a block-compressed format, and
+                        // a unit of texels otherwise."
+                        [
+                            min_image_transfer_granularity[0] * block_extent[0],
+                            min_image_transfer_granularity[1] * block_extent[1],
+                            min_image_transfer_granularity[2] * block_extent[2],
+                        ]
+                    }
+                };
+
+                Some(granularity(
+                    src_image.format().block_extent(),
+                    image_aspects.intersects(ImageAspects::PLANE_0),
+                ))
+            }
+        };
+
+        if image_aspects.intersects(ImageAspects::PLANE_0) {
+            // VUID-VkCopyImageToBufferInfo2-aspectMask-01560
+            image_aspects -= ImageAspects::COLOR;
+        }
+
+        for (region_index, region) in regions.iter().enumerate() {
+            let &BufferImageCopy {
+                buffer_offset,
+                buffer_row_length,
+                buffer_image_height,
+                ref image_subresource,
+                image_offset,
+                image_extent,
+                _ne: _,
+            } = region;
+
+            // VUID-VkCopyImageToBufferInfo2-imageSubresource-01703
+            if image_subresource.mip_level >= src_image.mip_levels() {
+                return Err(CopyError::MipLevelsOutOfRange {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    mip_levels_range_end: image_subresource.mip_level + 1,
+                    image_mip_levels: src_image.mip_levels(),
+                });
+            }
+
+            // VUID-VkImageSubresourceLayers-layerCount-01700
+            assert!(!image_subresource.array_layers.is_empty());
+
+            // VUID-VkCopyImageToBufferInfo2-imageSubresource-01704
+            // VUID-VkCopyImageToBufferInfo2-baseArrayLayer-00213
+            if image_subresource.array_layers.end > src_image.dimensions().array_layers() {
+                return Err(CopyError::ArrayLayersOutOfRange {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    array_layers_range_end: image_subresource.array_layers.end,
+                    image_array_layers: src_image.dimensions().array_layers(),
+                });
+            }
+
+            // VUID-VkImageSubresourceLayers-aspectMask-requiredbitmask
+            assert!(!image_subresource.aspects.is_empty());
+
+            // VUID-VkCopyImageToBufferInfo2-aspectMask-00211
+            if !image_aspects.contains(image_subresource.aspects) {
+                return Err(CopyError::AspectsNotAllowed {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    aspects: image_subresource.aspects,
+                    allowed_aspects: image_aspects,
+                });
+            }
+
+            // VUID-VkBufferImageCopy2-aspectMask-00212
+            if image_subresource.aspects.count() != 1 {
+                return Err(CopyError::MultipleAspectsNotAllowed {
+                    resource: CopyErrorResource::Source,
+                    region_index,
+                    aspects: image_subresource.aspects,
+                });
+            }
+
+            let (image_subresource_format, image_subresource_extent) =
+                if image_aspects.intersects(ImageAspects::PLANE_0) {
+                    if image_subresource.aspects.intersects(ImageAspects::PLANE_0) {
+                        (
+                            src_image.format().planes()[0],
+                            src_image.dimensions().width_height_depth(),
+                        )
+                    } else if image_subresource.aspects.intersects(ImageAspects::PLANE_1) {
+                        (
+                            src_image.format().planes()[1],
+                            src_image
+                                .format()
+                                .ycbcr_chroma_sampling()
+                                .unwrap()
+                                .subsampled_extent(src_image.dimensions().width_height_depth()),
+                        )
+                    } else {
+                        (
+                            src_image.format().planes()[2],
+                            src_image
+                                .format()
+                                .ycbcr_chroma_sampling()
+                                .unwrap()
+                                .subsampled_extent(src_image.dimensions().width_height_depth()),
+                        )
+                    }
+                } else {
+                    (
+                        src_image.format(),
+                        src_image
+                            .dimensions()
+                            .mip_level_dimensions(image_subresource.mip_level)
+                            .unwrap()
+                            .width_height_depth(),
+                    )
+                };
+
+            if let Some(extent_alignment) = extent_alignment {
+                for i in 0..3 {
+                    // VUID-VkBufferImageCopy2-imageExtent-06659
+                    // VUID-VkBufferImageCopy2-imageExtent-06660
+                    // VUID-VkBufferImageCopy2-imageExtent-06661
+                    assert!(image_extent[i] != 0);
+
+                    // VUID-VkCopyImageToBufferInfo2-imageOffset-00197
+                    // VUID-VkCopyImageToBufferInfo2-imageOffset-00198
+                    // VUID-VkCopyImageToBufferInfo2-imageOffset-00200
+                    if image_offset[i] + image_extent[i] > image_subresource_extent[i] {
+                        return Err(CopyError::RegionOutOfImageBounds {
+                            resource: CopyErrorResource::Source,
+                            region_index,
+                            offset_range_end: [
+                                image_offset[0] + image_extent[0],
+                                image_offset[1] + image_extent[1],
+                                image_offset[2] + image_extent[2],
+                            ],
+                            subresource_extent: image_subresource_extent,
+                        });
+                    }
+
+                    // VUID-VkCopyImageToBufferInfo2-imageOffset-01794
+                    // VUID-VkCopyImageToBufferInfo2-imageOffset-00205
+                    if image_offset[i] % extent_alignment[i] != 0 {
+                        return Err(CopyError::OffsetNotAlignedForImage {
+                            resource: CopyErrorResource::Source,
+                            region_index,
+                            offset: image_offset,
+                            required_alignment: extent_alignment,
+                        });
+                    }
+
+                    // VUID-VkCopyImageToBufferInfo2-imageOffset-01794
+                    // VUID-VkCopyImageToBufferInfo2-imageExtent-00207
+                    // VUID-VkCopyImageToBufferInfo2-imageExtent-00208
+                    // VUID-VkCopyImageToBufferInfo2-imageExtent-00209
+                    if image_offset[i] + image_extent[i] != image_subresource_extent[i]
+                        && image_extent[i] % extent_alignment[i] != 0
+                    {
+                        return Err(CopyError::ExtentNotAlignedForImage {
+                            resource: CopyErrorResource::Source,
+                            region_index,
+                            extent: image_extent,
+                            required_alignment: extent_alignment,
+                        });
+                    }
+                }
+            } else {
+                // If granularity is `None`, then we can only copy whole subresources.
+
+                // VUID-VkCopyBufferToImageInfo2-imageOffset-01793
+                if image_offset != [0, 0, 0] {
+                    return Err(CopyError::OffsetNotAlignedForImage {
+                        resource: CopyErrorResource::Source,
+                        region_index,
+                        offset: image_offset,
+                        required_alignment: image_subresource_extent,
+                    });
+                }
+
+                // VUID-VkCopyBufferToImageInfo2-imageOffset-01793
+                if image_extent != image_subresource_extent {
+                    return Err(CopyError::ExtentNotAlignedForImage {
+                        resource: CopyErrorResource::Source,
+                        region_index,
+                        extent: image_extent,
+                        required_alignment: image_subresource_extent,
+                    });
+                }
+            }
+
+            // VUID-VkBufferImageCopy2-bufferRowLength-00195
+            if !(buffer_row_length == 0 || buffer_row_length >= image_extent[0]) {
+                return Err(CopyError::BufferRowLengthTooSmall {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    row_length: buffer_row_length,
+                    min: image_extent[0],
+                });
+            }
+
+            // VUID-VkBufferImageCopy2-bufferImageHeight-00196
+            if !(buffer_image_height == 0 || buffer_image_height >= image_extent[1]) {
+                return Err(CopyError::BufferImageHeightTooSmall {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    image_height: buffer_image_height,
+                    min: image_extent[1],
+                });
+            }
+
+            let image_subresource_block_extent = image_subresource_format.block_extent();
+
+            // VUID-VkCopyImageToBufferInfo2-bufferRowLength-00203
+            if buffer_row_length % image_subresource_block_extent[0] != 0 {
+                return Err(CopyError::BufferRowLengthNotAligned {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    row_length: buffer_row_length,
+                    required_alignment: image_subresource_block_extent[0],
+                });
+            }
+
+            // VUID-VkCopyImageToBufferInfo2-bufferImageHeight-00204
+            if buffer_image_height % image_subresource_block_extent[1] != 0 {
+                return Err(CopyError::BufferImageHeightNotAligned {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    image_height: buffer_image_height,
+                    required_alignment: image_subresource_block_extent[1],
+                });
+            }
+
+            // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkBufferImageCopy.html#_description
+            let image_subresource_block_size =
+                if image_subresource.aspects.intersects(ImageAspects::STENCIL) {
+                    1
+                } else if image_subresource.aspects.intersects(ImageAspects::DEPTH) {
+                    match image_subresource_format {
+                        Format::D16_UNORM | Format::D16_UNORM_S8_UINT => 2,
+                        Format::D32_SFLOAT
+                        | Format::D32_SFLOAT_S8_UINT
+                        | Format::X8_D24_UNORM_PACK32
+                        | Format::D24_UNORM_S8_UINT => 4,
+                        _ => unreachable!(),
+                    }
+                } else {
+                    image_subresource_format.block_size().unwrap()
+                };
+
+            // VUID-VkCopyImageToBufferInfo2-pRegions-04725
+            // VUID-VkCopyImageToBufferInfo2-pRegions-04726
+            if (buffer_row_length / image_subresource_block_extent[0]) as DeviceSize
+                * image_subresource_block_size
+                > 0x7FFFFFFF
+            {
+                return Err(CopyError::BufferRowLengthTooLarge {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    buffer_row_length,
+                });
+            }
+
+            let buffer_offset_alignment =
+                if image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
+                    4
+                } else {
+                    let mut buffer_offset_alignment = image_subresource_block_size;
+
+                    // VUID-VkCopyImageToBufferInfo2-commandBuffer-04052
+                    // Make the alignment a multiple of 4.
+                    if !queue_family_properties
+                        .queue_flags
+                        .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+                    {
+                        if buffer_offset_alignment % 2 != 0 {
+                            buffer_offset_alignment *= 2;
+                        }
+
+                        if buffer_offset_alignment % 4 != 0 {
+                            buffer_offset_alignment *= 2;
+                        }
+                    }
+
+                    buffer_offset_alignment
+                };
+
+            // VUID-VkCopyImageToBufferInfo2-bufferOffset-01558
+            // VUID-VkCopyImageToBufferInfo2-bufferOffset-01559
+            // VUID-VkCopyImageToBufferInfo2-bufferOffset-00206
+            // VUID-VkCopyImageToBufferInfo2-srcImage-04053
+            if (buffer_inner.offset + buffer_offset) % buffer_offset_alignment != 0 {
+                return Err(CopyError::OffsetNotAlignedForBuffer {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    offset: buffer_inner.offset + buffer_offset,
+                    required_alignment: buffer_offset_alignment,
+                });
+            }
+
+            let buffer_copy_size = region.buffer_copy_size(image_subresource_format);
+
+            // VUID-VkCopyImageToBufferInfo2-pRegions-00183
+            if buffer_offset + buffer_copy_size > dst_buffer.size() {
+                return Err(CopyError::RegionOutOfBufferBounds {
+                    resource: CopyErrorResource::Destination,
+                    region_index,
+                    offset_range_end: buffer_offset + buffer_copy_size,
+                    buffer_size: dst_buffer.size(),
+                });
+            }
+        }
+
+        // VUID-VkCopyImageToBufferInfo2-pRegions-00184
+        // Can't occur as long as memory aliasing isn't allowed.
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn copy_image_to_buffer_unchecked(
+        &mut self,
+        copy_image_to_buffer_info: CopyImageToBufferInfo,
+    ) -> &mut Self {
+        let CopyImageToBufferInfo {
+            src_image,
+            src_image_layout,
+            dst_buffer,
+            regions,
+            _ne: _,
+        } = copy_image_to_buffer_info;
+
+        if regions.is_empty() {
+            return self;
+        }
+
+        let src_image_inner = src_image.inner();
+        let dst_buffer_inner = dst_buffer.inner();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3
+            || self.device().enabled_extensions().khr_copy_commands2
+        {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &BufferImageCopy {
+                        buffer_offset,
+                        buffer_row_length,
+                        buffer_image_height,
+                        ref image_subresource,
+                        image_offset,
+                        image_extent,
+                        _ne: _,
+                    } = region;
+
+                    let mut image_subresource = image_subresource.clone();
+                    image_subresource.array_layers.start += src_image_inner.first_layer;
+                    image_subresource.array_layers.end += src_image_inner.first_layer;
+                    image_subresource.mip_level += src_image_inner.first_mipmap_level;
+
+                    ash::vk::BufferImageCopy2 {
+                        buffer_offset: buffer_offset + dst_buffer_inner.offset,
+                        buffer_row_length,
+                        buffer_image_height,
+                        image_subresource: image_subresource.into(),
+                        image_offset: ash::vk::Offset3D {
+                            x: image_offset[0] as i32,
+                            y: image_offset[1] as i32,
+                            z: image_offset[2] as i32,
+                        },
+                        image_extent: ash::vk::Extent3D {
+                            width: image_extent[0],
+                            height: image_extent[1],
+                            depth: image_extent[2],
+                        },
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let copy_image_to_buffer_info = ash::vk::CopyImageToBufferInfo2 {
+                src_image: src_image_inner.image.handle(),
+                src_image_layout: src_image_layout.into(),
+                dst_buffer: dst_buffer_inner.buffer.handle(),
+                region_count: regions.len() as u32,
+                p_regions: regions.as_ptr(),
+                ..Default::default()
+            };
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_copy_image_to_buffer2)(self.handle(), &copy_image_to_buffer_info);
+            } else {
+                (fns.khr_copy_commands2.cmd_copy_image_to_buffer2_khr)(
+                    self.handle(),
+                    &copy_image_to_buffer_info,
+                );
+            }
+        } else {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &BufferImageCopy {
+                        buffer_offset,
+                        buffer_row_length,
+                        buffer_image_height,
+                        ref image_subresource,
+                        image_offset,
+                        image_extent,
+                        _ne: _,
+                    } = region;
+                    let mut image_subresource = image_subresource.clone();
+                    image_subresource.array_layers.start += src_image_inner.first_layer;
+                    image_subresource.array_layers.end += src_image_inner.first_layer;
+                    image_subresource.mip_level += src_image_inner.first_mipmap_level;
+
+                    ash::vk::BufferImageCopy {
+                        buffer_offset: buffer_offset + dst_buffer_inner.offset,
+                        buffer_row_length,
+                        buffer_image_height,
+                        image_subresource: image_subresource.into(),
+                        image_offset: ash::vk::Offset3D {
+                            x: image_offset[0] as i32,
+                            y: image_offset[1] as i32,
+                            z: image_offset[2] as i32,
+                        },
+                        image_extent: ash::vk::Extent3D {
+                            width: image_extent[0],
+                            height: image_extent[1],
+                            depth: image_extent[2],
+                        },
+                    }
+                })
+                .collect();
+
+            (fns.v1_0.cmd_copy_image_to_buffer)(
+                self.handle(),
+                src_image_inner.image.handle(),
+                src_image_layout.into(),
+                dst_buffer_inner.buffer.handle(),
+                regions.len() as u32,
+                regions.as_ptr(),
+            );
+        }
+
+        self.resources.push(Box::new(src_image));
+        self.resources.push(Box::new(dst_buffer));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Blits an image to another.
+    ///
+    /// A *blit* is similar to an image copy operation, except that the portion of the image that
+    /// is transferred can be resized. You choose an area of the source and an area of the
+    /// destination, and the implementation will resize the area of the source so that it matches
+    /// the size of the area of the destination before writing it.
+    ///
+    /// Blit operations have several restrictions:
+    ///
+    /// - Blit operations are only allowed on queue families that support graphics operations.
+    /// - The format of the source and destination images must support blit operations, which
+    ///   depends on the Vulkan implementation. Vulkan guarantees that some specific formats must
+    ///   always be supported. See tables 52 to 61 of the specifications.
+    /// - Only single-sampled images are allowed.
+    /// - You can only blit between two images whose formats belong to the same type. The types
+    ///   are: floating-point, signed integers, unsigned integers, depth-stencil.
+    /// - If you blit between depth, stencil or depth-stencil images, the format of both images
+    ///   must match exactly.
+    /// - If you blit between depth, stencil or depth-stencil images, only the `Nearest` filter is
+    ///   allowed.
+    /// - For two-dimensional images, the Z coordinate must be 0 for the top-left offset and 1 for
+    ///   the bottom-right offset. Same for the Y coordinate for one-dimensional images.
+    /// - For non-array images, the base array layer must be 0 and the number of layers must be 1.
+    ///
+    /// If `layer_count` is greater than 1, the blit will happen between each individual layer as
+    /// if they were separate images.
+    ///
+    /// # Panic
+    ///
+    /// - Panics if the source or the destination was not created with `device`.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn blit_image(
+        &mut self,
+        blit_image_info: BlitImageInfo,
+    ) -> Result<&mut Self, CopyError> {
+        self.validate_blit_image(&blit_image_info)?;
+
+        unsafe { Ok(self.blit_image_unchecked(blit_image_info)) }
+    }
+
+    fn validate_blit_image(&self, blit_image_info: &BlitImageInfo) -> Result<(), CopyError> {
+        let device = self.device();
+
+        // VUID-vkCmdBlitImage2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(CopyError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBlitImage2-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(CopyError::NotSupportedByQueueFamily);
+        }
+
+        let &BlitImageInfo {
+            ref src_image,
+            src_image_layout,
+            ref dst_image,
+            dst_image_layout,
+            ref regions,
+            filter,
+            _ne: _,
+        } = blit_image_info;
+
+        // VUID-VkBlitImageInfo2-srcImageLayout-parameter
+        src_image_layout.validate_device(device)?;
+
+        // VUID-VkBlitImageInfo2-dstImageLayout-parameter
+        dst_image_layout.validate_device(device)?;
+
+        // VUID-VkBlitImageInfo2-filter-parameter
+        filter.validate_device(device)?;
+
+        let src_image_inner = src_image.inner();
+        let dst_image_inner = dst_image.inner();
+
+        // VUID-VkBlitImageInfo2-commonparent
+        assert_eq!(device, src_image.device());
+        assert_eq!(device, dst_image.device());
+
+        let src_image_aspects = src_image.format().aspects();
+        let dst_image_aspects = dst_image.format().aspects();
+        let src_image_type = src_image.dimensions().image_type();
+        let dst_image_type = dst_image.dimensions().image_type();
+
+        // VUID-VkBlitImageInfo2-srcImage-00219
+        if !src_image.usage().intersects(ImageUsage::TRANSFER_SRC) {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Source,
+                usage: "transfer_src",
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-dstImage-00224
+        if !dst_image.usage().intersects(ImageUsage::TRANSFER_DST) {
+            return Err(CopyError::MissingUsage {
+                resource: CopyErrorResource::Destination,
+                usage: "transfer_dst",
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-srcImage-01999
+        if !src_image
+            .format_features()
+            .intersects(FormatFeatures::BLIT_SRC)
+        {
+            return Err(CopyError::MissingFormatFeature {
+                resource: CopyErrorResource::Source,
+                format_feature: "blit_src",
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-dstImage-02000
+        if !dst_image
+            .format_features()
+            .intersects(FormatFeatures::BLIT_DST)
+        {
+            return Err(CopyError::MissingFormatFeature {
+                resource: CopyErrorResource::Destination,
+                format_feature: "blit_dst",
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-srcImage-06421
+        if src_image.format().ycbcr_chroma_sampling().is_some() {
+            return Err(CopyError::FormatNotSupported {
+                resource: CopyErrorResource::Source,
+                format: src_image.format(),
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-dstImage-06422
+        if dst_image.format().ycbcr_chroma_sampling().is_some() {
+            return Err(CopyError::FormatNotSupported {
+                resource: CopyErrorResource::Destination,
+                format: src_image.format(),
+            });
+        }
+
+        if !(src_image_aspects.intersects(ImageAspects::COLOR)
+            && dst_image_aspects.intersects(ImageAspects::COLOR))
+        {
+            // VUID-VkBlitImageInfo2-srcImage-00231
+            if src_image.format() != dst_image.format() {
+                return Err(CopyError::FormatsMismatch {
+                    src_format: src_image.format(),
+                    dst_format: dst_image.format(),
+                });
+            }
+        } else {
+            // VUID-VkBlitImageInfo2-srcImage-00229
+            // VUID-VkBlitImageInfo2-srcImage-00230
+            if !matches!(
+                (
+                    src_image.format().type_color().unwrap(),
+                    dst_image.format().type_color().unwrap()
+                ),
+                (
+                    NumericType::SFLOAT
+                        | NumericType::UFLOAT
+                        | NumericType::SNORM
+                        | NumericType::UNORM
+                        | NumericType::SSCALED
+                        | NumericType::USCALED
+                        | NumericType::SRGB,
+                    NumericType::SFLOAT
+                        | NumericType::UFLOAT
+                        | NumericType::SNORM
+                        | NumericType::UNORM
+                        | NumericType::SSCALED
+                        | NumericType::USCALED
+                        | NumericType::SRGB,
+                ) | (NumericType::SINT, NumericType::SINT)
+                    | (NumericType::UINT, NumericType::UINT)
+            ) {
+                return Err(CopyError::FormatsNotCompatible {
+                    src_format: src_image.format(),
+                    dst_format: dst_image.format(),
+                });
+            }
+        }
+
+        // VUID-VkBlitImageInfo2-srcImage-00233
+        if src_image.samples() != SampleCount::Sample1 {
+            return Err(CopyError::SampleCountInvalid {
+                resource: CopyErrorResource::Destination,
+                sample_count: dst_image.samples(),
+                allowed_sample_counts: SampleCounts::SAMPLE_1,
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-dstImage-00234
+        if dst_image.samples() != SampleCount::Sample1 {
+            return Err(CopyError::SampleCountInvalid {
+                resource: CopyErrorResource::Destination,
+                sample_count: dst_image.samples(),
+                allowed_sample_counts: SampleCounts::SAMPLE_1,
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-srcImageLayout-01398
+        if !matches!(
+            src_image_layout,
+            ImageLayout::TransferSrcOptimal | ImageLayout::General
+        ) {
+            return Err(CopyError::ImageLayoutInvalid {
+                resource: CopyErrorResource::Source,
+                image_layout: src_image_layout,
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-dstImageLayout-01399
+        if !matches!(
+            dst_image_layout,
+            ImageLayout::TransferDstOptimal | ImageLayout::General
+        ) {
+            return Err(CopyError::ImageLayoutInvalid {
+                resource: CopyErrorResource::Destination,
+                image_layout: dst_image_layout,
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-srcImage-00232
+        if !src_image_aspects.intersects(ImageAspects::COLOR) && filter != Filter::Nearest {
+            return Err(CopyError::FilterNotSupportedByFormat);
+        }
+
+        match filter {
+            Filter::Nearest => (),
+            Filter::Linear => {
+                // VUID-VkBlitImageInfo2-filter-02001
+                if !src_image
+                    .format_features()
+                    .intersects(FormatFeatures::SAMPLED_IMAGE_FILTER_LINEAR)
+                {
+                    return Err(CopyError::FilterNotSupportedByFormat);
+                }
+            }
+            Filter::Cubic => {
+                // VUID-VkBlitImageInfo2-filter-02002
+                if !src_image
+                    .format_features()
+                    .intersects(FormatFeatures::SAMPLED_IMAGE_FILTER_CUBIC)
+                {
+                    return Err(CopyError::FilterNotSupportedByFormat);
+                }
+
+                // VUID-VkBlitImageInfo2-filter-00237
+                if !matches!(src_image.dimensions(), ImageDimensions::Dim2d { .. }) {
+                    return Err(CopyError::FilterNotSupportedForImageType);
+                }
+            }
+        }
+
+        let same_image = src_image_inner.image == dst_image_inner.image;
+        let mut overlap_subresource_indices = None;
+        let mut overlap_extent_indices = None;
+
+        for (region_index, region) in regions.iter().enumerate() {
+            let &ImageBlit {
+                ref src_subresource,
+                src_offsets,
+                ref dst_subresource,
+                dst_offsets,
+                _ne: _,
+            } = region;
+
+            let check_subresource = |resource: CopyErrorResource,
+                                     image: &dyn ImageAccess,
+                                     image_aspects: ImageAspects,
+                                     subresource: &ImageSubresourceLayers|
+             -> Result<_, CopyError> {
+                // VUID-VkBlitImageInfo2-srcSubresource-01705
+                // VUID-VkBlitImageInfo2-dstSubresource-01706
+                if subresource.mip_level >= image.mip_levels() {
+                    return Err(CopyError::MipLevelsOutOfRange {
+                        resource,
+                        region_index,
+                        mip_levels_range_end: subresource.mip_level + 1,
+                        image_mip_levels: image.mip_levels(),
+                    });
+                }
+
+                // VUID-VkImageSubresourceLayers-layerCount-01700
+                assert!(!subresource.array_layers.is_empty());
+
+                // VUID-VkBlitImageInfo2-srcSubresource-01707
+                // VUID-VkBlitImageInfo2-dstSubresource-01708
+                // VUID-VkBlitImageInfo2-srcImage-00240
+                if subresource.array_layers.end > image.dimensions().array_layers() {
+                    return Err(CopyError::ArrayLayersOutOfRange {
+                        resource,
+                        region_index,
+                        array_layers_range_end: subresource.array_layers.end,
+                        image_array_layers: image.dimensions().array_layers(),
+                    });
+                }
+
+                // VUID-VkImageSubresourceLayers-aspectMask-parameter
+                subresource.aspects.validate_device(device)?;
+
+                // VUID-VkImageSubresourceLayers-aspectMask-requiredbitmask
+                assert!(!subresource.aspects.is_empty());
+
+                // VUID-VkBlitImageInfo2-aspectMask-00241
+                // VUID-VkBlitImageInfo2-aspectMask-00242
+                if !image_aspects.contains(subresource.aspects) {
+                    return Err(CopyError::AspectsNotAllowed {
+                        resource,
+                        region_index,
+                        aspects: subresource.aspects,
+                        allowed_aspects: image_aspects,
+                    });
+                }
+
+                Ok(image
+                    .dimensions()
+                    .mip_level_dimensions(subresource.mip_level)
+                    .unwrap()
+                    .width_height_depth())
+            };
+
+            let src_subresource_extent = check_subresource(
+                CopyErrorResource::Source,
+                src_image,
+                src_image_aspects,
+                src_subresource,
+            )?;
+            let dst_subresource_extent = check_subresource(
+                CopyErrorResource::Destination,
+                dst_image,
+                dst_image_aspects,
+                dst_subresource,
+            )?;
+
+            // VUID-VkImageBlit2-aspectMask-00238
+            if src_subresource.aspects != dst_subresource.aspects {
+                return Err(CopyError::AspectsMismatch {
+                    region_index,
+                    src_aspects: src_subresource.aspects,
+                    dst_aspects: dst_subresource.aspects,
+                });
+            }
+
+            let src_layer_count =
+                src_subresource.array_layers.end - src_subresource.array_layers.start;
+            let dst_layer_count =
+                dst_subresource.array_layers.end - dst_subresource.array_layers.start;
+
+            // VUID-VkImageBlit2-layerCount-00239
+            // VUID-VkBlitImageInfo2-srcImage-00240
+            if src_layer_count != dst_layer_count {
+                return Err(CopyError::ArrayLayerCountMismatch {
+                    region_index,
+                    src_layer_count,
+                    dst_layer_count,
+                });
+            }
+
+            let check_offset_extent = |resource: CopyErrorResource,
+                                       image_type: ImageType,
+                                       subresource_extent: [u32; 3],
+                                       offsets: [[u32; 3]; 2]|
+             -> Result<_, CopyError> {
+                match image_type {
+                    ImageType::Dim1d => {
+                        // VUID-VkBlitImageInfo2-srcImage-00245
+                        // VUID-VkBlitImageInfo2-dstImage-00250
+                        if !(offsets[0][1] == 0 && offsets[1][1] == 1) {
+                            return Err(CopyError::OffsetsInvalidForImageType {
+                                resource,
+                                region_index,
+                                offsets: [offsets[0][1], offsets[1][1]],
+                            });
+                        }
+
+                        // VUID-VkBlitImageInfo2-srcImage-00247
+                        // VUID-VkBlitImageInfo2-dstImage-00252
+                        if !(offsets[0][2] == 0 && offsets[1][2] == 1) {
+                            return Err(CopyError::OffsetsInvalidForImageType {
+                                resource,
+                                region_index,
+                                offsets: [offsets[0][2], offsets[1][2]],
+                            });
+                        }
+                    }
+                    ImageType::Dim2d => {
+                        // VUID-VkBlitImageInfo2-srcImage-00247
+                        // VUID-VkBlitImageInfo2-dstImage-00252
+                        if !(offsets[0][2] == 0 && offsets[1][2] == 1) {
+                            return Err(CopyError::OffsetsInvalidForImageType {
+                                resource,
+                                region_index,
+                                offsets: [offsets[0][2], offsets[1][2]],
+                            });
+                        }
+                    }
+                    ImageType::Dim3d => (),
+                }
+
+                let offset_range_end = [
+                    max(offsets[0][0], offsets[1][0]),
+                    max(offsets[0][1], offsets[1][1]),
+                    max(offsets[0][2], offsets[1][2]),
+                ];
+
+                for i in 0..3 {
+                    // VUID-VkBlitImageInfo2-srcOffset-00243
+                    // VUID-VkBlitImageInfo2-srcOffset-00244
+                    // VUID-VkBlitImageInfo2-srcOffset-00246
+                    // VUID-VkBlitImageInfo2-dstOffset-00248
+                    // VUID-VkBlitImageInfo2-dstOffset-00249
+                    // VUID-VkBlitImageInfo2-dstOffset-00251
+                    if offset_range_end[i] > subresource_extent[i] {
+                        return Err(CopyError::RegionOutOfImageBounds {
+                            resource,
+                            region_index,
+                            offset_range_end,
+                            subresource_extent,
+                        });
+                    }
+                }
+
+                Ok(())
+            };
+
+            check_offset_extent(
+                CopyErrorResource::Source,
+                src_image_type,
+                src_subresource_extent,
+                src_offsets,
+            )?;
+            check_offset_extent(
+                CopyErrorResource::Destination,
+                dst_image_type,
+                dst_subresource_extent,
+                dst_offsets,
+            )?;
+
+            // VUID-VkBlitImageInfo2-pRegions-00217
+            if same_image {
+                let src_region_index = region_index;
+                let src_subresource_axes = [
+                    src_image_inner.first_mipmap_level + src_subresource.mip_level
+                        ..src_image_inner.first_mipmap_level + src_subresource.mip_level + 1,
+                    src_image_inner.first_layer + src_subresource.array_layers.start
+                        ..src_image_inner.first_layer + src_subresource.array_layers.end,
+                ];
+                let src_extent_axes = [
+                    min(src_offsets[0][0], src_offsets[1][0])
+                        ..max(src_offsets[0][0], src_offsets[1][0]),
+                    min(src_offsets[0][1], src_offsets[1][1])
+                        ..max(src_offsets[0][1], src_offsets[1][1]),
+                    min(src_offsets[0][2], src_offsets[1][2])
+                        ..max(src_offsets[0][2], src_offsets[1][2]),
+                ];
+
+                for (dst_region_index, dst_region) in regions.iter().enumerate() {
+                    let &ImageBlit {
+                        ref dst_subresource,
+                        dst_offsets,
+                        ..
+                    } = dst_region;
+
+                    let dst_subresource_axes = [
+                        dst_image_inner.first_mipmap_level + dst_subresource.mip_level
+                            ..dst_image_inner.first_mipmap_level + dst_subresource.mip_level + 1,
+                        dst_image_inner.first_layer + src_subresource.array_layers.start
+                            ..dst_image_inner.first_layer + src_subresource.array_layers.end,
+                    ];
+
+                    if src_subresource_axes.iter().zip(dst_subresource_axes).any(
+                        |(src_range, dst_range)| {
+                            src_range.start >= dst_range.end || dst_range.start >= src_range.end
+                        },
+                    ) {
+                        continue;
+                    }
+
+                    // If the subresource axes all overlap, then the source and destination must
+                    // have the same layout.
+                    overlap_subresource_indices = Some((src_region_index, dst_region_index));
+
+                    let dst_extent_axes = [
+                        min(dst_offsets[0][0], dst_offsets[1][0])
+                            ..max(dst_offsets[0][0], dst_offsets[1][0]),
+                        min(dst_offsets[0][1], dst_offsets[1][1])
+                            ..max(dst_offsets[0][1], dst_offsets[1][1]),
+                        min(dst_offsets[0][2], dst_offsets[1][2])
+                            ..max(dst_offsets[0][2], dst_offsets[1][2]),
+                    ];
+
+                    if src_extent_axes
+                        .iter()
+                        .zip(dst_extent_axes)
+                        .any(|(src_range, dst_range)| {
+                            src_range.start >= dst_range.end || dst_range.start >= src_range.end
+                        })
+                    {
+                        continue;
+                    }
+
+                    // If the extent axes *also* overlap, then that's an error.
+                    overlap_extent_indices = Some((src_region_index, dst_region_index));
+                }
+            }
+        }
+
+        // VUID-VkBlitImageInfo2-pRegions-00217
+        if let Some((src_region_index, dst_region_index)) = overlap_extent_indices {
+            return Err(CopyError::OverlappingRegions {
+                src_region_index,
+                dst_region_index,
+            });
+        }
+
+        // VUID-VkBlitImageInfo2-srcImageLayout-00221
+        // VUID-VkBlitImageInfo2-dstImageLayout-00226
+        if let Some((src_region_index, dst_region_index)) = overlap_subresource_indices {
+            if src_image_layout != dst_image_layout {
+                return Err(CopyError::OverlappingSubresourcesLayoutMismatch {
+                    src_region_index,
+                    dst_region_index,
+                    src_image_layout,
+                    dst_image_layout,
+                });
+            }
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn blit_image_unchecked(&mut self, blit_image_info: BlitImageInfo) -> &mut Self {
+        let BlitImageInfo {
+            src_image,
+            src_image_layout,
+            dst_image,
+            dst_image_layout,
+            regions,
+            filter,
+            _ne: _,
+        } = blit_image_info;
+
+        if regions.is_empty() {
+            return self;
+        }
+
+        let src_image_inner = src_image.inner();
+        let dst_image_inner = dst_image.inner();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3
+            || self.device().enabled_extensions().khr_copy_commands2
+        {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &ImageBlit {
+                        ref src_subresource,
+                        src_offsets,
+                        ref dst_subresource,
+                        dst_offsets,
+                        _ne: _,
+                    } = region;
+
+                    let mut src_subresource = src_subresource.clone();
+                    src_subresource.array_layers.start += src_image_inner.first_layer;
+                    src_subresource.array_layers.end += src_image_inner.first_layer;
+                    src_subresource.mip_level += src_image_inner.first_mipmap_level;
+
+                    let mut dst_subresource = dst_subresource.clone();
+                    dst_subresource.array_layers.start += dst_image_inner.first_layer;
+                    dst_subresource.array_layers.end += dst_image_inner.first_layer;
+                    dst_subresource.mip_level += dst_image_inner.first_mipmap_level;
+
+                    ash::vk::ImageBlit2 {
+                        src_subresource: src_subresource.into(),
+                        src_offsets: [
+                            ash::vk::Offset3D {
+                                x: src_offsets[0][0] as i32,
+                                y: src_offsets[0][1] as i32,
+                                z: src_offsets[0][2] as i32,
+                            },
+                            ash::vk::Offset3D {
+                                x: src_offsets[1][0] as i32,
+                                y: src_offsets[1][1] as i32,
+                                z: src_offsets[1][2] as i32,
+                            },
+                        ],
+                        dst_subresource: dst_subresource.into(),
+                        dst_offsets: [
+                            ash::vk::Offset3D {
+                                x: dst_offsets[0][0] as i32,
+                                y: dst_offsets[0][1] as i32,
+                                z: dst_offsets[0][2] as i32,
+                            },
+                            ash::vk::Offset3D {
+                                x: dst_offsets[1][0] as i32,
+                                y: dst_offsets[1][1] as i32,
+                                z: dst_offsets[1][2] as i32,
+                            },
+                        ],
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let blit_image_info = ash::vk::BlitImageInfo2 {
+                src_image: src_image_inner.image.handle(),
+                src_image_layout: src_image_layout.into(),
+                dst_image: dst_image_inner.image.handle(),
+                dst_image_layout: dst_image_layout.into(),
+                region_count: regions.len() as u32,
+                p_regions: regions.as_ptr(),
+                filter: filter.into(),
+                ..Default::default()
+            };
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_blit_image2)(self.handle(), &blit_image_info);
+            } else {
+                (fns.khr_copy_commands2.cmd_blit_image2_khr)(self.handle(), &blit_image_info);
+            }
+        } else {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &ImageBlit {
+                        ref src_subresource,
+                        src_offsets,
+                        ref dst_subresource,
+                        dst_offsets,
+                        _ne: _,
+                    } = region;
+
+                    let mut src_subresource = src_subresource.clone();
+                    src_subresource.array_layers.start += src_image_inner.first_layer;
+                    src_subresource.array_layers.end += src_image_inner.first_layer;
+                    src_subresource.mip_level += src_image_inner.first_mipmap_level;
+
+                    let mut dst_subresource = dst_subresource.clone();
+                    dst_subresource.array_layers.start += dst_image_inner.first_layer;
+                    dst_subresource.array_layers.end += dst_image_inner.first_layer;
+                    dst_subresource.mip_level += dst_image_inner.first_mipmap_level;
+
+                    ash::vk::ImageBlit {
+                        src_subresource: src_subresource.into(),
+                        src_offsets: [
+                            ash::vk::Offset3D {
+                                x: src_offsets[0][0] as i32,
+                                y: src_offsets[0][1] as i32,
+                                z: src_offsets[0][2] as i32,
+                            },
+                            ash::vk::Offset3D {
+                                x: src_offsets[1][0] as i32,
+                                y: src_offsets[1][1] as i32,
+                                z: src_offsets[1][2] as i32,
+                            },
+                        ],
+                        dst_subresource: dst_subresource.into(),
+                        dst_offsets: [
+                            ash::vk::Offset3D {
+                                x: dst_offsets[0][0] as i32,
+                                y: dst_offsets[0][1] as i32,
+                                z: dst_offsets[0][2] as i32,
+                            },
+                            ash::vk::Offset3D {
+                                x: dst_offsets[1][0] as i32,
+                                y: dst_offsets[1][1] as i32,
+                                z: dst_offsets[1][2] as i32,
+                            },
+                        ],
+                    }
+                })
+                .collect();
+
+            (fns.v1_0.cmd_blit_image)(
+                self.handle(),
+                src_image_inner.image.handle(),
+                src_image_layout.into(),
+                dst_image_inner.image.handle(),
+                dst_image_layout.into(),
+                regions.len() as u32,
+                regions.as_ptr(),
+                filter.into(),
+            );
+        }
+
+        self.resources.push(Box::new(src_image));
+        self.resources.push(Box::new(dst_image));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Resolves a multisampled image into a single-sampled image.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `src_image` or `dst_image` were not created from the same device
+    ///   as `self`.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn resolve_image(
+        &mut self,
+        resolve_image_info: ResolveImageInfo,
+    ) -> Result<&mut Self, CopyError> {
+        self.validate_resolve_image(&resolve_image_info)?;
+
+        unsafe { Ok(self.resolve_image_unchecked(resolve_image_info)) }
+    }
+
+    fn validate_resolve_image(
+        &self,
+        resolve_image_info: &ResolveImageInfo,
+    ) -> Result<(), CopyError> {
+        let device = self.device();
+
+        // VUID-vkCmdResolveImage2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(CopyError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdResolveImage2-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(CopyError::NotSupportedByQueueFamily);
+        }
+
+        let &ResolveImageInfo {
+            ref src_image,
+            src_image_layout,
+            ref dst_image,
+            dst_image_layout,
+            ref regions,
+            _ne: _,
+        } = resolve_image_info;
+
+        // VUID-VkResolveImageInfo2-srcImageLayout-parameter
+        src_image_layout.validate_device(device)?;
+
+        // VUID-VkResolveImageInfo2-dstImageLayout-parameter
+        dst_image_layout.validate_device(device)?;
+
+        // VUID-VkResolveImageInfo2-commonparent
+        assert_eq!(device, src_image.device());
+        assert_eq!(device, dst_image.device());
+
+        let src_image_type = src_image.dimensions().image_type();
+        let dst_image_type = dst_image.dimensions().image_type();
+
+        // VUID-VkResolveImageInfo2-srcImage-00257
+        if src_image.samples() == SampleCount::Sample1 {
+            return Err(CopyError::SampleCountInvalid {
+                resource: CopyErrorResource::Source,
+                sample_count: dst_image.samples(),
+                allowed_sample_counts: SampleCounts::SAMPLE_2
+                    | SampleCounts::SAMPLE_4
+                    | SampleCounts::SAMPLE_8
+                    | SampleCounts::SAMPLE_16
+                    | SampleCounts::SAMPLE_32
+                    | SampleCounts::SAMPLE_64,
+            });
+        }
+
+        // VUID-VkResolveImageInfo2-dstImage-00259
+        if dst_image.samples() != SampleCount::Sample1 {
+            return Err(CopyError::SampleCountInvalid {
+                resource: CopyErrorResource::Destination,
+                sample_count: dst_image.samples(),
+                allowed_sample_counts: SampleCounts::SAMPLE_1,
+            });
+        }
+
+        // VUID-VkResolveImageInfo2-dstImage-02003
+        if !dst_image
+            .format_features()
+            .intersects(FormatFeatures::COLOR_ATTACHMENT)
+        {
+            return Err(CopyError::MissingFormatFeature {
+                resource: CopyErrorResource::Destination,
+                format_feature: "color_attachment",
+            });
+        }
+
+        // VUID-VkResolveImageInfo2-srcImage-01386
+        if src_image.format() != dst_image.format() {
+            return Err(CopyError::FormatsMismatch {
+                src_format: src_image.format(),
+                dst_format: dst_image.format(),
+            });
+        }
+
+        // VUID-VkResolveImageInfo2-srcImageLayout-01400
+        if !matches!(
+            src_image_layout,
+            ImageLayout::TransferSrcOptimal | ImageLayout::General
+        ) {
+            return Err(CopyError::ImageLayoutInvalid {
+                resource: CopyErrorResource::Source,
+                image_layout: src_image_layout,
+            });
+        }
+
+        // VUID-VkResolveImageInfo2-dstImageLayout-01401
+        if !matches!(
+            dst_image_layout,
+            ImageLayout::TransferDstOptimal | ImageLayout::General
+        ) {
+            return Err(CopyError::ImageLayoutInvalid {
+                resource: CopyErrorResource::Destination,
+                image_layout: dst_image_layout,
+            });
+        }
+
+        // Should be guaranteed by the requirement that formats match, and that the destination
+        // image format features support color attachments.
+        debug_assert!(
+            src_image.format().aspects().intersects(ImageAspects::COLOR)
+                && dst_image.format().aspects().intersects(ImageAspects::COLOR)
+        );
+
+        for (region_index, region) in regions.iter().enumerate() {
+            let &ImageResolve {
+                ref src_subresource,
+                src_offset,
+                ref dst_subresource,
+                dst_offset,
+                extent,
+                _ne: _,
+            } = region;
+
+            let check_subresource = |resource: CopyErrorResource,
+                                     image: &dyn ImageAccess,
+                                     subresource: &ImageSubresourceLayers|
+             -> Result<_, CopyError> {
+                // VUID-VkResolveImageInfo2-srcSubresource-01709
+                // VUID-VkResolveImageInfo2-dstSubresource-01710
+                if subresource.mip_level >= image.mip_levels() {
+                    return Err(CopyError::MipLevelsOutOfRange {
+                        resource,
+                        region_index,
+                        mip_levels_range_end: subresource.mip_level + 1,
+                        image_mip_levels: image.mip_levels(),
+                    });
+                }
+
+                // VUID-VkImageSubresourceLayers-layerCount-01700
+                // VUID-VkResolveImageInfo2-srcImage-04446
+                // VUID-VkResolveImageInfo2-srcImage-04447
+                assert!(!subresource.array_layers.is_empty());
+
+                // VUID-VkResolveImageInfo2-srcSubresource-01711
+                // VUID-VkResolveImageInfo2-dstSubresource-01712
+                // VUID-VkResolveImageInfo2-srcImage-04446
+                // VUID-VkResolveImageInfo2-srcImage-04447
+                if subresource.array_layers.end > image.dimensions().array_layers() {
+                    return Err(CopyError::ArrayLayersOutOfRange {
+                        resource: CopyErrorResource::Destination,
+                        region_index,
+                        array_layers_range_end: subresource.array_layers.end,
+                        image_array_layers: image.dimensions().array_layers(),
+                    });
+                }
+
+                // VUID-VkImageSubresourceLayers-aspectMask-parameter
+                subresource.aspects.validate_device(device)?;
+
+                // VUID-VkImageSubresourceLayers-aspectMask-requiredbitmask
+                // VUID-VkImageResolve2-aspectMask-00266
+                if subresource.aspects != (ImageAspects::COLOR) {
+                    return Err(CopyError::AspectsNotAllowed {
+                        resource,
+                        region_index,
+                        aspects: subresource.aspects,
+                        allowed_aspects: ImageAspects::COLOR,
+                    });
+                }
+
+                Ok(image
+                    .dimensions()
+                    .mip_level_dimensions(subresource.mip_level)
+                    .unwrap()
+                    .width_height_depth())
+            };
+
+            let src_subresource_extent =
+                check_subresource(CopyErrorResource::Source, src_image, src_subresource)?;
+            let dst_subresource_extent =
+                check_subresource(CopyErrorResource::Destination, dst_image, dst_subresource)?;
+
+            let src_layer_count =
+                src_subresource.array_layers.end - src_subresource.array_layers.start;
+            let dst_layer_count =
+                dst_subresource.array_layers.end - dst_subresource.array_layers.start;
+
+            // VUID-VkImageResolve2-layerCount-00267
+            // VUID-VkResolveImageInfo2-srcImage-04446
+            // VUID-VkResolveImageInfo2-srcImage-04447
+            if src_layer_count != dst_layer_count {
+                return Err(CopyError::ArrayLayerCountMismatch {
+                    region_index,
+                    src_layer_count,
+                    dst_layer_count,
+                });
+            }
+
+            // No VUID, but it makes sense?
+            assert!(extent[0] != 0 && extent[1] != 0 && extent[2] != 0);
+
+            let check_offset_extent = |resource: CopyErrorResource,
+                                       _image_type: ImageType,
+                                       subresource_extent: [u32; 3],
+                                       offset: [u32; 3]|
+             -> Result<_, CopyError> {
+                for i in 0..3 {
+                    // No VUID, but makes sense?
+                    assert!(extent[i] != 0);
+
+                    // VUID-VkResolveImageInfo2-srcOffset-00269
+                    // VUID-VkResolveImageInfo2-srcOffset-00270
+                    // VUID-VkResolveImageInfo2-srcOffset-00272
+                    // VUID-VkResolveImageInfo2-dstOffset-00274
+                    // VUID-VkResolveImageInfo2-dstOffset-00275
+                    // VUID-VkResolveImageInfo2-dstOffset-00277
+                    if offset[i] + extent[i] > subresource_extent[i] {
+                        return Err(CopyError::RegionOutOfImageBounds {
+                            resource,
+                            region_index,
+                            offset_range_end: [
+                                offset[0] + extent[0],
+                                offset[1] + extent[1],
+                                offset[2] + extent[2],
+                            ],
+                            subresource_extent,
+                        });
+                    }
+                }
+
+                Ok(())
+            };
+
+            check_offset_extent(
+                CopyErrorResource::Source,
+                src_image_type,
+                src_subresource_extent,
+                src_offset,
+            )?;
+            check_offset_extent(
+                CopyErrorResource::Destination,
+                dst_image_type,
+                dst_subresource_extent,
+                dst_offset,
+            )?;
+        }
+
+        // VUID-VkResolveImageInfo2-pRegions-00255
+        // Can't occur as long as memory aliasing isn't allowed, because `src_image` and
+        // `dst_image` must have different sample counts and therefore can never be the same image.
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn resolve_image_unchecked(
+        &mut self,
+        resolve_image_info: ResolveImageInfo,
+    ) -> &mut Self {
+        let ResolveImageInfo {
+            src_image,
+            src_image_layout,
+            dst_image,
+            dst_image_layout,
+            regions,
+            _ne: _,
+        } = resolve_image_info;
+
+        if regions.is_empty() {
+            return self;
+        }
+
+        let src_image_inner = src_image.inner();
+        let dst_image_inner = dst_image.inner();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3
+            || self.device().enabled_extensions().khr_copy_commands2
+        {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &ImageResolve {
+                        ref src_subresource,
+                        src_offset,
+                        ref dst_subresource,
+                        dst_offset,
+                        extent,
+                        _ne: _,
+                    } = region;
+
+                    let mut src_subresource = src_subresource.clone();
+                    src_subresource.array_layers.start += src_image_inner.first_layer;
+                    src_subresource.array_layers.end += src_image_inner.first_layer;
+                    src_subresource.mip_level += src_image_inner.first_mipmap_level;
+
+                    let mut dst_subresource = dst_subresource.clone();
+                    dst_subresource.array_layers.start += dst_image_inner.first_layer;
+                    dst_subresource.array_layers.end += dst_image_inner.first_layer;
+                    dst_subresource.mip_level += dst_image_inner.first_mipmap_level;
+
+                    ash::vk::ImageResolve2 {
+                        src_subresource: src_subresource.into(),
+                        src_offset: ash::vk::Offset3D {
+                            x: src_offset[0] as i32,
+                            y: src_offset[1] as i32,
+                            z: src_offset[2] as i32,
+                        },
+                        dst_subresource: dst_subresource.into(),
+                        dst_offset: ash::vk::Offset3D {
+                            x: dst_offset[0] as i32,
+                            y: dst_offset[1] as i32,
+                            z: dst_offset[2] as i32,
+                        },
+                        extent: ash::vk::Extent3D {
+                            width: extent[0],
+                            height: extent[1],
+                            depth: extent[2],
+                        },
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let resolve_image_info = ash::vk::ResolveImageInfo2 {
+                src_image: src_image_inner.image.handle(),
+                src_image_layout: src_image_layout.into(),
+                dst_image: dst_image_inner.image.handle(),
+                dst_image_layout: dst_image_layout.into(),
+                region_count: regions.len() as u32,
+                p_regions: regions.as_ptr(),
+                ..Default::default()
+            };
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_resolve_image2)(self.handle(), &resolve_image_info);
+            } else {
+                (fns.khr_copy_commands2.cmd_resolve_image2_khr)(self.handle(), &resolve_image_info);
+            }
+        } else {
+            let regions: SmallVec<[_; 8]> = regions
+                .iter()
+                .map(|region| {
+                    let &ImageResolve {
+                        ref src_subresource,
+                        src_offset,
+                        ref dst_subresource,
+                        dst_offset,
+                        extent,
+                        _ne: _,
+                    } = region;
+
+                    let mut src_subresource = src_subresource.clone();
+                    src_subresource.array_layers.start += src_image_inner.first_layer;
+                    src_subresource.array_layers.end += src_image_inner.first_layer;
+                    src_subresource.mip_level += src_image_inner.first_mipmap_level;
+
+                    let mut dst_subresource = dst_subresource.clone();
+                    dst_subresource.array_layers.start += dst_image_inner.first_layer;
+                    dst_subresource.array_layers.end += dst_image_inner.first_layer;
+                    dst_subresource.mip_level += dst_image_inner.first_mipmap_level;
+
+                    ash::vk::ImageResolve {
+                        src_subresource: src_subresource.into(),
+                        src_offset: ash::vk::Offset3D {
+                            x: src_offset[0] as i32,
+                            y: src_offset[1] as i32,
+                            z: src_offset[2] as i32,
+                        },
+                        dst_subresource: dst_subresource.into(),
+                        dst_offset: ash::vk::Offset3D {
+                            x: dst_offset[0] as i32,
+                            y: dst_offset[1] as i32,
+                            z: dst_offset[2] as i32,
+                        },
+                        extent: ash::vk::Extent3D {
+                            width: extent[0],
+                            height: extent[1],
+                            depth: extent[2],
+                        },
+                    }
+                })
+                .collect();
+
+            (fns.v1_0.cmd_resolve_image)(
+                self.handle(),
+                src_image_inner.image.handle(),
+                src_image_layout.into(),
+                dst_image_inner.image.handle(),
+                dst_image_layout.into(),
+                regions.len() as u32,
+                regions.as_ptr(),
+            );
+        }
+
+        self.resources.push(Box::new(src_image));
+        self.resources.push(Box::new(dst_image));
+
+        // TODO: sync state update
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/debug.rs
+++ b/vulkano/src/command_buffer/standard/builder/debug.rs
@@ -1,0 +1,213 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{CommandBufferBuilder, DebugUtilsError};
+use crate::{
+    command_buffer::allocator::CommandBufferAllocator,
+    device::{DeviceOwned, QueueFlags},
+    instance::debug::DebugUtilsLabel,
+    RequiresOneOf, VulkanObject,
+};
+use std::ffi::CString;
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Opens a command buffer debug label region.
+    #[inline]
+    pub fn begin_debug_utils_label(
+        &mut self,
+        label_info: DebugUtilsLabel,
+    ) -> Result<&mut Self, DebugUtilsError> {
+        self.validate_begin_debug_utils_label(&label_info)?;
+
+        unsafe { Ok(self.begin_debug_utils_label_unchecked(label_info)) }
+    }
+
+    fn validate_begin_debug_utils_label(
+        &self,
+        _label_info: &DebugUtilsLabel,
+    ) -> Result<(), DebugUtilsError> {
+        if !self
+            .device()
+            .instance()
+            .enabled_extensions()
+            .ext_debug_utils
+        {
+            return Err(DebugUtilsError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::begin_debug_utils_label`",
+                requires_one_of: RequiresOneOf {
+                    instance_extensions: &["ext_debug_utils"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBeginDebugUtilsLabelEXT-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(DebugUtilsError::NotSupportedByQueueFamily);
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn begin_debug_utils_label_unchecked(
+        &mut self,
+        label_info: DebugUtilsLabel,
+    ) -> &mut Self {
+        let DebugUtilsLabel {
+            label_name,
+            color,
+            _ne: _,
+        } = label_info;
+
+        let label_name_vk = CString::new(label_name.as_str()).unwrap();
+        let label_info = ash::vk::DebugUtilsLabelEXT {
+            p_label_name: label_name_vk.as_ptr(),
+            color,
+            ..Default::default()
+        };
+
+        let fns = self.device().instance().fns();
+        (fns.ext_debug_utils.cmd_begin_debug_utils_label_ext)(self.handle(), &label_info);
+
+        self
+    }
+
+    /// Closes a command buffer debug label region.
+    ///
+    /// # Safety
+    ///
+    /// - When submitting the command buffer, there must be an outstanding command buffer label
+    ///   region begun with `begin_debug_utils_label` in the queue, either within this command
+    ///   buffer or a previously submitted one.
+    #[inline]
+    pub unsafe fn end_debug_utils_label(&mut self) -> Result<&mut Self, DebugUtilsError> {
+        self.validate_end_debug_utils_label()?;
+
+        Ok(self.end_debug_utils_label_unchecked())
+    }
+
+    fn validate_end_debug_utils_label(&self) -> Result<(), DebugUtilsError> {
+        if !self
+            .device()
+            .instance()
+            .enabled_extensions()
+            .ext_debug_utils
+        {
+            return Err(DebugUtilsError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::end_debug_utils_label`",
+                requires_one_of: RequiresOneOf {
+                    instance_extensions: &["ext_debug_utils"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(DebugUtilsError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912
+        // TODO: not checked, so unsafe for now
+
+        // VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01913
+        // TODO: not checked, so unsafe for now
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn end_debug_utils_label_unchecked(&mut self) -> &mut Self {
+        let fns = self.device().instance().fns();
+        (fns.ext_debug_utils.cmd_end_debug_utils_label_ext)(self.handle());
+
+        self
+    }
+
+    /// Inserts a command buffer debug label.
+    #[inline]
+    pub fn insert_debug_utils_label(
+        &mut self,
+        label_info: DebugUtilsLabel,
+    ) -> Result<&mut Self, DebugUtilsError> {
+        self.validate_insert_debug_utils_label(&label_info)?;
+
+        unsafe { Ok(self.insert_debug_utils_label_unchecked(label_info)) }
+    }
+
+    fn validate_insert_debug_utils_label(
+        &self,
+        _label_info: &DebugUtilsLabel,
+    ) -> Result<(), DebugUtilsError> {
+        if !self
+            .device()
+            .instance()
+            .enabled_extensions()
+            .ext_debug_utils
+        {
+            return Err(DebugUtilsError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::insert_debug_utils_label`",
+                requires_one_of: RequiresOneOf {
+                    instance_extensions: &["ext_debug_utils"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdInsertDebugUtilsLabelEXT-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(DebugUtilsError::NotSupportedByQueueFamily);
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn insert_debug_utils_label_unchecked(
+        &mut self,
+        label_info: DebugUtilsLabel,
+    ) -> &mut Self {
+        let DebugUtilsLabel {
+            label_name,
+            color,
+            _ne: _,
+        } = label_info;
+
+        let label_name_vk = CString::new(label_name.as_str()).unwrap();
+        let label_info = ash::vk::DebugUtilsLabelEXT {
+            p_label_name: label_name_vk.as_ptr(),
+            color,
+            ..Default::default()
+        };
+
+        let fns = self.device().instance().fns();
+        (fns.ext_debug_utils.cmd_insert_debug_utils_label_ext)(self.handle(), &label_info);
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/dynamic_state.rs
+++ b/vulkano/src/command_buffer/standard/builder/dynamic_state.rs
@@ -1,0 +1,2326 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::CommandBufferBuilder;
+use crate::{
+    command_buffer::{
+        allocator::CommandBufferAllocator, commands::dynamic_state::SetDynamicStateError,
+    },
+    device::{DeviceOwned, QueueFlags},
+    pipeline::{
+        graphics::{
+            color_blend::LogicOp,
+            depth_stencil::{CompareOp, StencilFaces, StencilOp, StencilOps},
+            input_assembly::PrimitiveTopology,
+            rasterization::{CullMode, DepthBias, FrontFace, LineStipple},
+            viewport::{Scissor, Viewport},
+        },
+        DynamicState,
+    },
+    RequiresOneOf, Version, VulkanObject,
+};
+use smallvec::SmallVec;
+use std::ops::RangeInclusive;
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    // Helper function for dynamic state setting.
+    #[inline]
+    fn validate_pipeline_fixed_state(
+        &self,
+        state: DynamicState,
+    ) -> Result<(), SetDynamicStateError> {
+        // VUID-vkCmdDispatch-None-02859
+        if self
+            .current_state
+            .pipeline_graphics
+            .as_ref()
+            .map_or(false, |pipeline| {
+                matches!(pipeline.dynamic_state(state), Some(false))
+            })
+        {
+            return Err(SetDynamicStateError::PipelineHasFixedState);
+        }
+
+        Ok(())
+    }
+
+    /// Sets the dynamic blend constants for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_blend_constants(&mut self, constants: [f32; 4]) -> &mut Self {
+        self.validate_set_blend_constants(constants).unwrap();
+
+        unsafe { self.set_blend_constants_unchecked(constants) }
+    }
+
+    fn validate_set_blend_constants(
+        &self,
+        _constants: [f32; 4],
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::BlendConstants)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetBlendConstants-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_blend_constants_unchecked(&mut self, constants: [f32; 4]) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_blend_constants)(self.handle(), &constants);
+
+        self.current_state.blend_constants = Some(constants);
+
+        self
+    }
+
+    /// Sets whether dynamic color writes should be enabled for each attachment in the
+    /// framebuffer.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the [`color_write_enable`] feature is not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - If there is a graphics pipeline with color blend state bound, `enables.len()` must equal
+    ///   [`attachments.len()`].
+    ///
+    /// [`color_write_enable`]: crate::device::Features::color_write_enable
+    /// [`attachments.len()`]: crate::pipeline::graphics::color_blend::ColorBlendState::attachments
+    #[inline]
+    pub fn set_color_write_enable<I>(&mut self, enables: I) -> &mut Self
+    where
+        I: IntoIterator<Item = bool>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let enables = enables.into_iter();
+        self.validate_set_color_write_enable(&enables).unwrap();
+
+        unsafe { self.set_color_write_enable_unchecked(enables) }
+    }
+
+    fn validate_set_color_write_enable(
+        &self,
+        enables: &impl ExactSizeIterator,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::ColorWriteEnable)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetColorWriteEnableEXT-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetColorWriteEnableEXT-None-04803
+        if !self.device().enabled_features().color_write_enable {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_color_write_enable`",
+                requires_one_of: RequiresOneOf {
+                    device_extensions: &["ext_color_write_enable"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        if let Some(color_blend_state) = self
+            .current_state
+            .pipeline_graphics
+            .as_ref()
+            .and_then(|pipeline| pipeline.color_blend_state())
+        {
+            // VUID-vkCmdSetColorWriteEnableEXT-attachmentCount-06656
+            // Indirectly checked
+            if enables.len() != color_blend_state.attachments.len() {
+                return Err(
+                    SetDynamicStateError::PipelineColorBlendAttachmentCountMismatch {
+                        provided_count: enables.len() as u32,
+                        required_count: color_blend_state.attachments.len() as u32,
+                    },
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_color_write_enable_unchecked(
+        &mut self,
+        enables: impl IntoIterator<Item = bool>,
+    ) -> &mut Self {
+        let enables: SmallVec<[bool; 4]> = enables.into_iter().collect();
+
+        if enables.is_empty() {
+            return self;
+        }
+
+        debug_assert!(self.device().enabled_extensions().ext_color_write_enable);
+        let enables_vk = enables
+            .iter()
+            .copied()
+            .map(ash::vk::Bool32::from)
+            .collect::<SmallVec<[_; 4]>>();
+
+        let fns = self.device().fns();
+        (fns.ext_color_write_enable.cmd_set_color_write_enable_ext)(
+            self.handle(),
+            enables_vk.len() as u32,
+            enables_vk.as_ptr(),
+        );
+
+        self.current_state.color_write_enable = Some(enables);
+
+        self
+    }
+
+    /// Sets the dynamic cull mode for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the [`extended_dynamic_state`]
+    ///   feature is not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    ///
+    /// [`extended_dynamic_state`]: crate::device::Features::extended_dynamic_state
+    #[inline]
+    pub fn set_cull_mode(&mut self, cull_mode: CullMode) -> &mut Self {
+        self.validate_set_cull_mode(cull_mode).unwrap();
+
+        unsafe { self.set_cull_mode_unchecked(cull_mode) }
+    }
+
+    fn validate_set_cull_mode(&self, cull_mode: CullMode) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::CullMode)?;
+
+        // VUID-vkCmdSetCullMode-cullMode-parameter
+        cull_mode.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetCullMode-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetCullMode-None-03384
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_cull_mode`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_cull_mode_unchecked(&mut self, cull_mode: CullMode) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_cull_mode)(self.handle(), cull_mode.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state.cmd_set_cull_mode_ext)(self.handle(), cull_mode.into());
+        }
+
+        self.current_state.cull_mode = Some(cull_mode);
+
+        self
+    }
+
+    /// Sets the dynamic depth bias values for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - If the [`depth_bias_clamp`] feature is not enabled on the device, panics if `clamp` is
+    ///   not 0.0.
+    ///
+    /// [`depth_bias_clamp`]: crate::device::Features::depth_bias_clamp
+    #[inline]
+    pub fn set_depth_bias(
+        &mut self,
+        constant_factor: f32,
+        clamp: f32,
+        slope_factor: f32,
+    ) -> &mut Self {
+        self.validate_set_depth_bias(constant_factor, clamp, slope_factor)
+            .unwrap();
+
+        unsafe { self.set_depth_bias_unchecked(constant_factor, clamp, slope_factor) }
+    }
+
+    fn validate_set_depth_bias(
+        &self,
+        _constant_factor: f32,
+        clamp: f32,
+        _slope_factor: f32,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::DepthBias)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetDepthBias-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetDepthBias-depthBiasClamp-00790
+        if clamp != 0.0 && !self.device().enabled_features().depth_bias_clamp {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`clamp` is not `0.0`",
+                requires_one_of: RequiresOneOf {
+                    features: &["depth_bias_clamp"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_depth_bias_unchecked(
+        &mut self,
+        constant_factor: f32,
+        clamp: f32,
+        slope_factor: f32,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_depth_bias)(self.handle(), constant_factor, clamp, slope_factor);
+
+        self.current_state.depth_bias = Some(DepthBias {
+            constant_factor,
+            clamp,
+            slope_factor,
+        });
+
+        self
+    }
+
+    /// Sets whether dynamic depth bias is enabled for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the [`extended_dynamic_state2`]
+    ///   feature is not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    ///
+    /// [`extended_dynamic_state2`]: crate::device::Features::extended_dynamic_state2
+    #[inline]
+    pub fn set_depth_bias_enable(&mut self, enable: bool) -> &mut Self {
+        self.validate_set_depth_bias_enable(enable).unwrap();
+
+        unsafe { self.set_depth_bias_enable_unchecked(enable) }
+    }
+
+    fn validate_set_depth_bias_enable(&self, _enable: bool) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::DepthBiasEnable)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetDepthBiasEnable-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetDepthBiasEnable-None-04872
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state2)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_depth_bias_enable`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state2"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_depth_bias_enable_unchecked(&mut self, enable: bool) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_depth_bias_enable)(self.handle(), enable.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state2
+            );
+            (fns.ext_extended_dynamic_state2
+                .cmd_set_depth_bias_enable_ext)(self.handle(), enable.into());
+        }
+
+        self.current_state.depth_bias_enable = Some(enable);
+
+        self
+    }
+
+    /// Sets the dynamic depth bounds for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - If the [`ext_depth_range_unrestricted`] extension is not enabled on the device, panics if
+    ///   the start and end of `bounds` are not between 0.0 and 1.0 inclusive.
+    ///
+    /// [`ext_depth_range_unrestricted`]: crate::device::DeviceExtensions::ext_depth_range_unrestricted
+    pub fn set_depth_bounds(&mut self, bounds: RangeInclusive<f32>) -> &mut Self {
+        self.validate_set_depth_bounds(bounds.clone()).unwrap();
+
+        unsafe { self.set_depth_bounds_unchecked(bounds) }
+    }
+
+    fn validate_set_depth_bounds(
+        &self,
+        bounds: RangeInclusive<f32>,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::DepthBounds)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetDepthBounds-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetDepthBounds-minDepthBounds-00600
+        // VUID-vkCmdSetDepthBounds-maxDepthBounds-00601
+        if !self
+            .device()
+            .enabled_extensions()
+            .ext_depth_range_unrestricted
+            && !((0.0..=1.0).contains(bounds.start()) && (0.0..=1.0).contains(bounds.end()))
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`bounds` is not between `0.0` and `1.0` inclusive",
+                requires_one_of: RequiresOneOf {
+                    device_extensions: &["ext_depth_range_unrestricted"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_depth_bounds_unchecked(&mut self, bounds: RangeInclusive<f32>) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_depth_bounds)(self.handle(), *bounds.start(), *bounds.end());
+
+        self.current_state.depth_bounds = Some(bounds);
+
+        self
+    }
+
+    /// Sets whether dynamic depth bounds testing is enabled for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the [`extended_dynamic_state`]
+    ///   feature is not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    ///
+    /// [`extended_dynamic_state`]: crate::device::Features::extended_dynamic_state
+    #[inline]
+    pub fn set_depth_bounds_test_enable(&mut self, enable: bool) -> &mut Self {
+        self.validate_set_depth_bounds_test_enable(enable).unwrap();
+
+        unsafe { self.set_depth_bounds_test_enable_unchecked(enable) }
+    }
+
+    fn validate_set_depth_bounds_test_enable(
+        &self,
+        _enable: bool,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::DepthBoundsTestEnable)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetDepthBoundsTestEnable-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetDepthBoundsTestEnable-None-03349
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_depth_bounds_test_enable`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_depth_bounds_test_enable_unchecked(&mut self, enable: bool) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_depth_bounds_test_enable)(self.handle(), enable.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state
+                .cmd_set_depth_bounds_test_enable_ext)(self.handle(), enable.into());
+        }
+
+        self.current_state.depth_bounds_test_enable = Some(enable);
+
+        self
+    }
+
+    /// Sets the dynamic depth compare op for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_depth_compare_op(&mut self, compare_op: CompareOp) -> &mut Self {
+        self.validate_set_depth_compare_op(compare_op).unwrap();
+
+        unsafe { self.set_depth_compare_op_unchecked(compare_op) }
+    }
+
+    fn validate_set_depth_compare_op(
+        &self,
+        compare_op: CompareOp,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::DepthCompareOp)?;
+
+        // VUID-vkCmdSetDepthCompareOp-depthCompareOp-parameter
+        compare_op.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetDepthCompareOp-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetDepthCompareOp-None-03353
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_depth_compare_op`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_depth_compare_op_unchecked(&mut self, compare_op: CompareOp) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_depth_compare_op)(self.handle(), compare_op.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state.cmd_set_depth_compare_op_ext)(
+                self.handle(),
+                compare_op.into(),
+            );
+        }
+
+        self.current_state.depth_compare_op = Some(compare_op);
+
+        self
+    }
+
+    /// Sets whether dynamic depth testing is enabled for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_depth_test_enable(&mut self, enable: bool) -> &mut Self {
+        self.validate_set_depth_test_enable(enable).unwrap();
+
+        unsafe { self.set_depth_test_enable_unchecked(enable) }
+    }
+
+    fn validate_set_depth_test_enable(&self, _enable: bool) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::DepthTestEnable)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetDepthTestEnable-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetDepthTestEnable-None-03352
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_depth_test_enable`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_depth_test_enable_unchecked(&mut self, enable: bool) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_depth_test_enable)(self.handle(), enable.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state.cmd_set_depth_test_enable_ext)(
+                self.handle(),
+                enable.into(),
+            );
+        }
+
+        self.current_state.depth_test_enable = Some(enable);
+
+        self
+    }
+
+    /// Sets whether dynamic depth write is enabled for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_depth_write_enable(&mut self, enable: bool) -> &mut Self {
+        self.validate_set_depth_write_enable(enable).unwrap();
+
+        unsafe { self.set_depth_write_enable_unchecked(enable) }
+    }
+
+    fn validate_set_depth_write_enable(&self, _enable: bool) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::DepthWriteEnable)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetDepthWriteEnable-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetDepthWriteEnable-None-03354
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_depth_write_enable`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_depth_write_enable_unchecked(&mut self, enable: bool) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_depth_write_enable)(self.handle(), enable.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state
+                .cmd_set_depth_write_enable_ext)(self.handle(), enable.into());
+        }
+
+        self.current_state.depth_write_enable = Some(enable);
+
+        self
+    }
+
+    /// Sets the dynamic discard rectangles for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the
+    ///   [`ext_discard_rectangles`](crate::device::DeviceExtensions::ext_discard_rectangles)
+    ///   extension is not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - Panics if the highest discard rectangle slot being set is greater than the
+    ///   [`max_discard_rectangles`](crate::device::Properties::max_discard_rectangles) device
+    ///   property.
+    pub fn set_discard_rectangle(
+        &mut self,
+        first_rectangle: u32,
+        rectangles: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
+        let rectangles: SmallVec<[Scissor; 2]> = rectangles.into_iter().collect();
+        self.validate_set_discard_rectangle(first_rectangle, &rectangles)
+            .unwrap();
+
+        unsafe {
+            self.set_discard_rectangle_unchecked(first_rectangle, rectangles);
+        }
+
+        self
+    }
+
+    fn validate_set_discard_rectangle(
+        &self,
+        first_rectangle: u32,
+        rectangles: &[Scissor],
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::DiscardRectangle)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetDiscardRectangle-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        if self.device().enabled_extensions().ext_discard_rectangles {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_discard_rectangle`",
+                requires_one_of: RequiresOneOf {
+                    device_extensions: &["ext_discard_rectangles"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdSetDiscardRectangleEXT-firstDiscardRectangle-00585
+        if first_rectangle + rectangles.len() as u32
+            > self
+                .device()
+                .physical_device()
+                .properties()
+                .max_discard_rectangles
+                .unwrap()
+        {
+            return Err(SetDynamicStateError::MaxDiscardRectanglesExceeded {
+                provided: first_rectangle + rectangles.len() as u32,
+                max: self
+                    .device()
+                    .physical_device()
+                    .properties()
+                    .max_discard_rectangles
+                    .unwrap(),
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_discard_rectangle_unchecked(
+        &mut self,
+        first_rectangle: u32,
+        rectangles: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
+        let rectangles: SmallVec<[Scissor; 2]> = rectangles.into_iter().collect();
+
+        if rectangles.is_empty() {
+            return self;
+        }
+
+        debug_assert!(self.device().enabled_extensions().ext_discard_rectangles);
+
+        let rectangles_vk = rectangles
+            .iter()
+            .copied()
+            .map(ash::vk::Rect2D::from)
+            .collect::<SmallVec<[_; 2]>>();
+
+        debug_assert!(
+            first_rectangle + rectangles.len() as u32
+                <= self
+                    .device()
+                    .physical_device()
+                    .properties()
+                    .max_discard_rectangles
+                    .unwrap()
+        );
+
+        let fns = self.device().fns();
+        (fns.ext_discard_rectangles.cmd_set_discard_rectangle_ext)(
+            self.handle(),
+            first_rectangle,
+            rectangles_vk.len() as u32,
+            rectangles_vk.as_ptr(),
+        );
+
+        for (num, rectangle) in rectangles.iter().enumerate() {
+            let num = num as u32 + first_rectangle;
+            self.current_state.discard_rectangle.insert(num, *rectangle);
+        }
+
+        self
+    }
+
+    /// Sets the dynamic front face for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_front_face(&mut self, face: FrontFace) -> &mut Self {
+        self.validate_set_front_face(face).unwrap();
+
+        unsafe { self.set_front_face_unchecked(face) }
+    }
+
+    fn validate_set_front_face(&self, face: FrontFace) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::FrontFace)?;
+
+        // VUID-vkCmdSetFrontFace-frontFace-parameter
+        face.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetFrontFace-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetFrontFace-None-03383
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_front_face`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_front_face_unchecked(&mut self, face: FrontFace) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_front_face)(self.handle(), face.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state.cmd_set_front_face_ext)(self.handle(), face.into());
+        }
+
+        self.current_state.front_face = Some(face);
+
+        self
+    }
+
+    /// Sets the dynamic line stipple values for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the [`ext_line_rasterization`](crate::device::DeviceExtensions::ext_line_rasterization)
+    ///   extension is not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - Panics if `factor` is not between 1 and 256 inclusive.
+    #[inline]
+    pub fn set_line_stipple(&mut self, factor: u32, pattern: u16) -> &mut Self {
+        self.validate_set_line_stipple(factor, pattern).unwrap();
+
+        unsafe { self.set_line_stipple_unchecked(factor, pattern) }
+    }
+
+    fn validate_set_line_stipple(
+        &self,
+        factor: u32,
+        _pattern: u16,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::LineStipple)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetLineStippleEXT-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        if !self.device().enabled_extensions().ext_line_rasterization {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_line_stipple`",
+                requires_one_of: RequiresOneOf {
+                    device_extensions: &["ext_line_rasterization"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdSetLineStippleEXT-lineStippleFactor-02776
+        if !(1..=256).contains(&factor) {
+            return Err(SetDynamicStateError::FactorOutOfRange);
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_line_stipple_unchecked(&mut self, factor: u32, pattern: u16) -> &mut Self {
+        debug_assert!(self.device().enabled_extensions().ext_line_rasterization);
+        let fns = self.device().fns();
+        (fns.ext_line_rasterization.cmd_set_line_stipple_ext)(self.handle(), factor, pattern);
+
+        self.current_state.line_stipple = Some(LineStipple { factor, pattern });
+
+        self
+    }
+
+    /// Sets the dynamic line width for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - If the [`wide_lines`](crate::device::Features::wide_lines) feature is not enabled, panics
+    ///   if `line_width` is not 1.0.
+    pub fn set_line_width(&mut self, line_width: f32) -> &mut Self {
+        self.validate_set_line_width(line_width).unwrap();
+
+        unsafe { self.set_line_width_unchecked(line_width) }
+    }
+
+    fn validate_set_line_width(&self, line_width: f32) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::LineWidth)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetLineWidth-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetLineWidth-lineWidth-00788
+        if !self.device().enabled_features().wide_lines && line_width != 1.0 {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`line_width` is not `1.0`",
+                requires_one_of: RequiresOneOf {
+                    features: &["wide_lines"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_line_width_unchecked(&mut self, line_width: f32) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_line_width)(self.handle(), line_width);
+
+        self.current_state.line_width = Some(line_width);
+
+        self
+    }
+
+    /// Sets the dynamic logic op for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the
+    ///   [`extended_dynamic_state2_logic_op`](crate::device::Features::extended_dynamic_state2_logic_op)
+    ///   feature is not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_logic_op(&mut self, logic_op: LogicOp) -> &mut Self {
+        self.validate_set_logic_op(logic_op).unwrap();
+
+        unsafe { self.set_logic_op_unchecked(logic_op) }
+    }
+
+    fn validate_set_logic_op(&self, logic_op: LogicOp) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::LogicOp)?;
+
+        // VUID-vkCmdSetLogicOpEXT-logicOp-parameter
+        logic_op.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetLogicOpEXT-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetLogicOpEXT-None-04867
+        if !self
+            .device()
+            .enabled_features()
+            .extended_dynamic_state2_logic_op
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_logic_op`",
+                requires_one_of: RequiresOneOf {
+                    features: &["extended_dynamic_state2_logic_op"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_logic_op_unchecked(&mut self, logic_op: LogicOp) -> &mut Self {
+        debug_assert!(
+            self.device()
+                .enabled_extensions()
+                .ext_extended_dynamic_state2
+        );
+        debug_assert!(
+            self.device()
+                .enabled_features()
+                .extended_dynamic_state2_logic_op
+        );
+        let fns = self.device().fns();
+        (fns.ext_extended_dynamic_state2.cmd_set_logic_op_ext)(self.handle(), logic_op.into());
+
+        self.current_state.logic_op = Some(logic_op);
+
+        self
+    }
+
+    /// Sets the dynamic number of patch control points for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the
+    ///   [`extended_dynamic_state2_patch_control_points`](crate::device::Features::extended_dynamic_state2_patch_control_points)
+    ///   feature is not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - Panics if `num` is 0.
+    /// - Panics if `num` is greater than the
+    ///   [`max_tessellation_patch_size`](crate::device::Properties::max_tessellation_patch_size)
+    ///   property of the device.
+    #[inline]
+    pub fn set_patch_control_points(&mut self, num: u32) -> &mut Self {
+        self.validate_set_patch_control_points(num).unwrap();
+
+        unsafe { self.set_patch_control_points_unchecked(num) }
+    }
+
+    fn validate_set_patch_control_points(&self, num: u32) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::PatchControlPoints)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetPatchControlPointsEXT-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetPatchControlPointsEXT-None-04873
+        if !self
+            .device()
+            .enabled_features()
+            .extended_dynamic_state2_patch_control_points
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_patch_control_points`",
+                requires_one_of: RequiresOneOf {
+                    features: &["extended_dynamic_state2_patch_control_points"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdSetPatchControlPointsEXT-patchControlPoints-04874
+        assert!(num > 0, "num must be greater than 0");
+
+        // VUID-vkCmdSetPatchControlPointsEXT-patchControlPoints-04874
+        if num
+            > self
+                .device()
+                .physical_device()
+                .properties()
+                .max_tessellation_patch_size
+        {
+            return Err(SetDynamicStateError::MaxTessellationPatchSizeExceeded {
+                provided: num,
+                max: self
+                    .device()
+                    .physical_device()
+                    .properties()
+                    .max_tessellation_patch_size,
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_patch_control_points_unchecked(&mut self, num: u32) -> &mut Self {
+        debug_assert!(
+            self.device()
+                .enabled_extensions()
+                .ext_extended_dynamic_state2
+        );
+        let fns = self.device().fns();
+        (fns.ext_extended_dynamic_state2
+            .cmd_set_patch_control_points_ext)(self.handle(), num);
+
+        self.current_state.patch_control_points = Some(num);
+
+        self
+    }
+
+    /// Sets whether dynamic primitive restart is enabled for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state2`](crate::device::Features::extended_dynamic_state2) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_primitive_restart_enable(&mut self, enable: bool) -> &mut Self {
+        self.validate_set_primitive_restart_enable(enable).unwrap();
+
+        unsafe { self.set_primitive_restart_enable_unchecked(enable) }
+    }
+
+    fn validate_set_primitive_restart_enable(
+        &self,
+        _enable: bool,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::PrimitiveRestartEnable)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetPrimitiveRestartEnable-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetPrimitiveRestartEnable-None-04866
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state2)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_primitive_restart_enable`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state2"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_primitive_restart_enable_unchecked(&mut self, enable: bool) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_primitive_restart_enable)(self.handle(), enable.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state2
+            );
+            (fns.ext_extended_dynamic_state2
+                .cmd_set_primitive_restart_enable_ext)(self.handle(), enable.into());
+        }
+
+        self.current_state.primitive_restart_enable = Some(enable);
+
+        self
+    }
+
+    /// Sets the dynamic primitive topology for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - If the [`geometry_shader`](crate::device::Features::geometry_shader) feature is not
+    ///   enabled, panics if `topology` is a `WithAdjacency` topology.
+    /// - If the [`tessellation_shader`](crate::device::Features::tessellation_shader) feature is
+    ///   not enabled, panics if `topology` is `PatchList`.
+    #[inline]
+    pub fn set_primitive_topology(&mut self, topology: PrimitiveTopology) -> &mut Self {
+        self.validate_set_primitive_topology(topology).unwrap();
+
+        unsafe { self.set_primitive_topology_unchecked(topology) }
+    }
+
+    fn validate_set_primitive_topology(
+        &self,
+        topology: PrimitiveTopology,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::PrimitiveTopology)?;
+
+        // VUID-vkCmdSetPrimitiveTopology-primitiveTopology-parameter
+        topology.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetPrimitiveTopology-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetPrimitiveTopology-None-03347
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_primitive_topology`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID?
+        // Since these requirements exist for fixed state when creating the pipeline,
+        // I assume they exist for dynamic state as well.
+        match topology {
+            PrimitiveTopology::TriangleFan => {
+                if self.device().enabled_extensions().khr_portability_subset
+                    && !self.device().enabled_features().triangle_fans
+                {
+                    return Err(SetDynamicStateError::RequirementNotMet {
+                        required_for: "this device is a portability subset device, and `topology` \
+                            is `PrimitiveTopology::TriangleFan`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["triangle_fans"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PrimitiveTopology::LineListWithAdjacency
+            | PrimitiveTopology::LineStripWithAdjacency
+            | PrimitiveTopology::TriangleListWithAdjacency
+            | PrimitiveTopology::TriangleStripWithAdjacency => {
+                if !self.device().enabled_features().geometry_shader {
+                    return Err(SetDynamicStateError::RequirementNotMet {
+                        required_for: "`topology` is `PrimitiveTopology::*WithAdjacency`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["geometry_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PrimitiveTopology::PatchList => {
+                if !self.device().enabled_features().tessellation_shader {
+                    return Err(SetDynamicStateError::RequirementNotMet {
+                        required_for: "`topology` is `PrimitiveTopology::PatchList`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["tessellation_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_primitive_topology_unchecked(
+        &mut self,
+        topology: PrimitiveTopology,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_primitive_topology)(self.handle(), topology.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state
+                .cmd_set_primitive_topology_ext)(self.handle(), topology.into());
+        }
+
+        self.current_state.primitive_topology = Some(topology);
+
+        self
+    }
+
+    /// Sets whether dynamic rasterizer discard is enabled for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state2`](crate::device::Features::extended_dynamic_state2) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_rasterizer_discard_enable(&mut self, enable: bool) -> &mut Self {
+        self.validate_set_rasterizer_discard_enable(enable).unwrap();
+
+        unsafe { self.set_rasterizer_discard_enable_unchecked(enable) }
+    }
+
+    fn validate_set_rasterizer_discard_enable(
+        &self,
+        _enable: bool,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::RasterizerDiscardEnable)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetRasterizerDiscardEnable-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetRasterizerDiscardEnable-None-04871
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state2)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_rasterizer_discard_enable`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state2"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_rasterizer_discard_enable_unchecked(&mut self, enable: bool) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_rasterizer_discard_enable)(self.handle(), enable.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state2
+            );
+            (fns.ext_extended_dynamic_state2
+                .cmd_set_rasterizer_discard_enable_ext)(self.handle(), enable.into());
+        }
+
+        self.current_state.rasterizer_discard_enable = Some(enable);
+
+        self
+    }
+
+    /// Sets the dynamic scissors for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - Panics if the highest scissor slot being set is greater than the
+    ///   [`max_viewports`](crate::device::Properties::max_viewports) device property.
+    /// - If the [`multi_viewport`](crate::device::Features::multi_viewport) feature is not enabled,
+    ///   panics if `first_scissor` is not 0, or if more than 1 scissor is provided.
+    #[inline]
+    pub fn set_scissor(
+        &mut self,
+        first_scissor: u32,
+        scissors: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
+        let scissors: SmallVec<[Scissor; 2]> = scissors.into_iter().collect();
+        self.validate_set_scissor(first_scissor, &scissors).unwrap();
+
+        unsafe { self.set_scissor_unchecked(first_scissor, scissors) }
+    }
+
+    fn validate_set_scissor(
+        &self,
+        first_scissor: u32,
+        scissors: &[Scissor],
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::Scissor)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetScissor-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetScissor-firstScissor-00592
+        if first_scissor + scissors.len() as u32
+            > self.device().physical_device().properties().max_viewports
+        {
+            return Err(SetDynamicStateError::MaxViewportsExceeded {
+                provided: first_scissor + scissors.len() as u32,
+                max: self.device().physical_device().properties().max_viewports,
+            });
+        }
+
+        if !self.device().enabled_features().multi_viewport {
+            // VUID-vkCmdSetScissor-firstScissor-00593
+            if first_scissor != 0 {
+                return Err(SetDynamicStateError::RequirementNotMet {
+                    required_for: "`first_scissor` is not `0`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["multi_viewport"],
+                        ..Default::default()
+                    },
+                });
+            }
+
+            // VUID-vkCmdSetScissor-scissorCount-00594
+            if scissors.len() > 1 {
+                return Err(SetDynamicStateError::RequirementNotMet {
+                    required_for: "`scissors.len()` is greater than `1`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["multi_viewport"],
+                        ..Default::default()
+                    },
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_scissor_unchecked(
+        &mut self,
+        first_scissor: u32,
+        scissors: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
+        let scissors: SmallVec<[Scissor; 2]> = scissors.into_iter().collect();
+
+        if scissors.is_empty() {
+            return self;
+        }
+
+        let scissors_vk = scissors
+            .iter()
+            .copied()
+            .map(ash::vk::Rect2D::from)
+            .collect::<SmallVec<[_; 2]>>();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_scissor)(
+            self.handle(),
+            first_scissor,
+            scissors_vk.len() as u32,
+            scissors_vk.as_ptr(),
+        );
+
+        for (num, scissor) in scissors.iter().enumerate() {
+            let num = num as u32 + first_scissor;
+            self.current_state.scissor.insert(num, *scissor);
+        }
+
+        self
+    }
+
+    /// Sets the dynamic scissors with count for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - Panics if the highest scissor slot being set is greater than the
+    ///   [`max_viewports`](crate::device::Properties::max_viewports) device property.
+    /// - If the [`multi_viewport`](crate::device::Features::multi_viewport) feature is not enabled,
+    ///   panics if more than 1 scissor is provided.
+    #[inline]
+    pub fn set_scissor_with_count(
+        &mut self,
+        scissors: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
+        let scissors: SmallVec<[Scissor; 2]> = scissors.into_iter().collect();
+        self.validate_set_scissor_with_count(&scissors).unwrap();
+
+        unsafe { self.set_scissor_with_count_unchecked(scissors) }
+    }
+
+    fn validate_set_scissor_with_count(
+        &self,
+        scissors: &[Scissor],
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::ScissorWithCount)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetScissorWithCount-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetScissorWithCount-None-03396
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_scissor_with_count`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdSetScissorWithCount-scissorCount-03397
+        if scissors.len() as u32 > self.device().physical_device().properties().max_viewports {
+            return Err(SetDynamicStateError::MaxViewportsExceeded {
+                provided: scissors.len() as u32,
+                max: self.device().physical_device().properties().max_viewports,
+            });
+        }
+
+        // VUID-vkCmdSetScissorWithCount-scissorCount-03398
+        if !self.device().enabled_features().multi_viewport && scissors.len() > 1 {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`scissors.len()` is greater than `1`",
+                requires_one_of: RequiresOneOf {
+                    features: &["multi_viewport"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_scissor_with_count_unchecked(
+        &mut self,
+        scissors: impl IntoIterator<Item = Scissor>,
+    ) -> &mut Self {
+        let scissors: SmallVec<[Scissor; 2]> = scissors.into_iter().collect();
+
+        if scissors.is_empty() {
+            return self;
+        }
+
+        let scissors_vk = scissors
+            .iter()
+            .copied()
+            .map(ash::vk::Rect2D::from)
+            .collect::<SmallVec<[_; 2]>>();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_scissor_with_count)(
+                self.handle(),
+                scissors_vk.len() as u32,
+                scissors_vk.as_ptr(),
+            );
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state
+                .cmd_set_scissor_with_count_ext)(
+                self.handle(),
+                scissors_vk.len() as u32,
+                scissors_vk.as_ptr(),
+            );
+        }
+
+        self.current_state.scissor_with_count = Some(scissors);
+
+        self
+    }
+
+    /// Sets the dynamic stencil compare mask on one or both faces for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    pub fn set_stencil_compare_mask(
+        &mut self,
+        faces: StencilFaces,
+        compare_mask: u32,
+    ) -> &mut Self {
+        self.validate_set_stencil_compare_mask(faces, compare_mask)
+            .unwrap();
+
+        unsafe { self.set_stencil_compare_mask_unchecked(faces, compare_mask) }
+    }
+
+    fn validate_set_stencil_compare_mask(
+        &self,
+        faces: StencilFaces,
+        _compare_mask: u32,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::StencilCompareMask)?;
+
+        // VUID-vkCmdSetStencilCompareMask-faceMask-parameter
+        faces.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetStencilCompareMask-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_stencil_compare_mask_unchecked(
+        &mut self,
+        faces: StencilFaces,
+        compare_mask: u32,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_stencil_compare_mask)(self.handle(), faces.into(), compare_mask);
+
+        let faces = ash::vk::StencilFaceFlags::from(faces);
+
+        if faces.intersects(ash::vk::StencilFaceFlags::FRONT) {
+            self.current_state.stencil_compare_mask.front = Some(compare_mask);
+        }
+
+        if faces.intersects(ash::vk::StencilFaceFlags::BACK) {
+            self.current_state.stencil_compare_mask.back = Some(compare_mask);
+        }
+
+        self
+    }
+
+    /// Sets the dynamic stencil ops on one or both faces for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_stencil_op(
+        &mut self,
+        faces: StencilFaces,
+        fail_op: StencilOp,
+        pass_op: StencilOp,
+        depth_fail_op: StencilOp,
+        compare_op: CompareOp,
+    ) -> &mut Self {
+        self.validate_set_stencil_op(faces, fail_op, pass_op, depth_fail_op, compare_op)
+            .unwrap();
+
+        unsafe { self.set_stencil_op_unchecked(faces, fail_op, pass_op, depth_fail_op, compare_op) }
+    }
+
+    fn validate_set_stencil_op(
+        &self,
+        faces: StencilFaces,
+        fail_op: StencilOp,
+        pass_op: StencilOp,
+        depth_fail_op: StencilOp,
+        compare_op: CompareOp,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::StencilOp)?;
+
+        // VUID-vkCmdSetStencilOp-faceMask-parameter
+        faces.validate_device(self.device())?;
+
+        // VUID-vkCmdSetStencilOp-failOp-parameter
+        fail_op.validate_device(self.device())?;
+
+        // VUID-vkCmdSetStencilOp-passOp-parameter
+        pass_op.validate_device(self.device())?;
+
+        // VUID-vkCmdSetStencilOp-depthFailOp-parameter
+        depth_fail_op.validate_device(self.device())?;
+
+        // VUID-vkCmdSetStencilOp-compareOp-parameter
+        compare_op.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetStencilOp-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetStencilOp-None-03351
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_stencil_op`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_stencil_op_unchecked(
+        &mut self,
+        faces: StencilFaces,
+        fail_op: StencilOp,
+        pass_op: StencilOp,
+        depth_fail_op: StencilOp,
+        compare_op: CompareOp,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_stencil_op)(
+                self.handle(),
+                faces.into(),
+                fail_op.into(),
+                pass_op.into(),
+                depth_fail_op.into(),
+                compare_op.into(),
+            );
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state.cmd_set_stencil_op_ext)(
+                self.handle(),
+                faces.into(),
+                fail_op.into(),
+                pass_op.into(),
+                depth_fail_op.into(),
+                compare_op.into(),
+            );
+        }
+
+        let faces = ash::vk::StencilFaceFlags::from(faces);
+
+        if faces.intersects(ash::vk::StencilFaceFlags::FRONT) {
+            self.current_state.stencil_op.front = Some(StencilOps {
+                fail_op,
+                pass_op,
+                depth_fail_op,
+                compare_op,
+            });
+        }
+
+        if faces.intersects(ash::vk::StencilFaceFlags::BACK) {
+            self.current_state.stencil_op.back = Some(StencilOps {
+                fail_op,
+                pass_op,
+                depth_fail_op,
+                compare_op,
+            });
+        }
+
+        self
+    }
+
+    /// Sets the dynamic stencil reference on one or both faces for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    pub fn set_stencil_reference(&mut self, faces: StencilFaces, reference: u32) -> &mut Self {
+        self.validate_set_stencil_reference(faces, reference)
+            .unwrap();
+
+        unsafe { self.set_stencil_reference_unchecked(faces, reference) }
+    }
+
+    fn validate_set_stencil_reference(
+        &self,
+        faces: StencilFaces,
+        _reference: u32,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::StencilReference)?;
+
+        // VUID-vkCmdSetStencilReference-faceMask-parameter
+        faces.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetStencilReference-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_stencil_reference_unchecked(
+        &mut self,
+        faces: StencilFaces,
+        reference: u32,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_stencil_reference)(self.handle(), faces.into(), reference);
+
+        let faces = ash::vk::StencilFaceFlags::from(faces);
+
+        if faces.intersects(ash::vk::StencilFaceFlags::FRONT) {
+            self.current_state.stencil_reference.front = Some(reference);
+        }
+
+        if faces.intersects(ash::vk::StencilFaceFlags::BACK) {
+            self.current_state.stencil_reference.back = Some(reference);
+        }
+
+        self
+    }
+
+    /// Sets whether dynamic stencil testing is enabled for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    #[inline]
+    pub fn set_stencil_test_enable(&mut self, enable: bool) -> &mut Self {
+        self.validate_set_stencil_test_enable(enable).unwrap();
+
+        unsafe { self.set_stencil_test_enable_unchecked(enable) }
+    }
+
+    fn validate_set_stencil_test_enable(&self, _enable: bool) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::StencilTestEnable)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetStencilTestEnable-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetStencilTestEnable-None-03350
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_stencil_test_enable`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_stencil_test_enable_unchecked(&mut self, enable: bool) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_stencil_test_enable)(self.handle(), enable.into());
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state
+                .cmd_set_stencil_test_enable_ext)(self.handle(), enable.into());
+        }
+
+        self.current_state.stencil_test_enable = Some(enable);
+
+        self
+    }
+
+    /// Sets the dynamic stencil write mask on one or both faces for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    pub fn set_stencil_write_mask(&mut self, faces: StencilFaces, write_mask: u32) -> &mut Self {
+        self.validate_set_stencil_write_mask(faces, write_mask)
+            .unwrap();
+
+        unsafe { self.set_stencil_write_mask_unchecked(faces, write_mask) }
+    }
+
+    fn validate_set_stencil_write_mask(
+        &self,
+        faces: StencilFaces,
+        _write_mask: u32,
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::StencilWriteMask)?;
+
+        // VUID-vkCmdSetStencilWriteMask-faceMask-parameter
+        faces.validate_device(self.device())?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetStencilWriteMask-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_stencil_write_mask_unchecked(
+        &mut self,
+        faces: StencilFaces,
+        write_mask: u32,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_stencil_write_mask)(self.handle(), faces.into(), write_mask);
+
+        let faces = ash::vk::StencilFaceFlags::from(faces);
+
+        if faces.intersects(ash::vk::StencilFaceFlags::FRONT) {
+            self.current_state.stencil_write_mask.front = Some(write_mask);
+        }
+
+        if faces.intersects(ash::vk::StencilFaceFlags::BACK) {
+            self.current_state.stencil_write_mask.back = Some(write_mask);
+        }
+
+        self
+    }
+
+    /// Sets the dynamic viewports for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - Panics if the highest viewport slot being set is greater than the
+    ///   [`max_viewports`](crate::device::Properties::max_viewports) device property.
+    /// - If the [`multi_viewport`](crate::device::Features::multi_viewport) feature is not enabled,
+    ///   panics if `first_viewport` is not 0, or if more than 1 viewport is provided.
+    pub fn set_viewport(
+        &mut self,
+        first_viewport: u32,
+        viewports: impl IntoIterator<Item = Viewport>,
+    ) -> &mut Self {
+        let viewports: SmallVec<[Viewport; 2]> = viewports.into_iter().collect();
+        self.validate_set_viewport(first_viewport, &viewports)
+            .unwrap();
+
+        unsafe { self.set_viewport_unchecked(first_viewport, viewports) }
+    }
+
+    fn validate_set_viewport(
+        &self,
+        first_viewport: u32,
+        viewports: &[Viewport],
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::Viewport)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetViewport-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetViewport-firstViewport-01223
+        if first_viewport + viewports.len() as u32
+            > self.device().physical_device().properties().max_viewports
+        {
+            return Err(SetDynamicStateError::MaxViewportsExceeded {
+                provided: first_viewport + viewports.len() as u32,
+                max: self.device().physical_device().properties().max_viewports,
+            });
+        }
+
+        if !self.device().enabled_features().multi_viewport {
+            // VUID-vkCmdSetViewport-firstViewport-01224
+            if first_viewport != 0 {
+                return Err(SetDynamicStateError::RequirementNotMet {
+                    required_for: "`first_scissors` is not `0`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["multi_viewport"],
+                        ..Default::default()
+                    },
+                });
+            }
+
+            // VUID-vkCmdSetViewport-viewportCount-01225
+            if viewports.len() > 1 {
+                return Err(SetDynamicStateError::RequirementNotMet {
+                    required_for: "`viewports.len()` is greater than `1`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["multi_viewport"],
+                        ..Default::default()
+                    },
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_viewport_unchecked(
+        &mut self,
+        first_viewport: u32,
+        viewports: impl IntoIterator<Item = Viewport>,
+    ) -> &mut Self {
+        let viewports: SmallVec<[Viewport; 2]> = viewports.into_iter().collect();
+
+        if viewports.is_empty() {
+            return self;
+        }
+
+        let viewports_vk = viewports
+            .iter()
+            .cloned()
+            .map(ash::vk::Viewport::from)
+            .collect::<SmallVec<[_; 2]>>();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_set_viewport)(
+            self.handle(),
+            first_viewport,
+            viewports_vk.len() as u32,
+            viewports_vk.as_ptr(),
+        );
+
+        for (num, viewport) in viewports.iter().enumerate() {
+            let num = num as u32 + first_viewport;
+            self.current_state.viewport.insert(num, viewport.clone());
+        }
+
+        self
+    }
+
+    /// Sets the dynamic viewports with count for future draw calls.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the queue family of the command buffer does not support graphics operations.
+    /// - Panics if the device API version is less than 1.3 and the
+    ///   [`extended_dynamic_state`](crate::device::Features::extended_dynamic_state) feature is
+    ///   not enabled on the device.
+    /// - Panics if the currently bound graphics pipeline already contains this state internally.
+    /// - Panics if the highest viewport slot being set is greater than the
+    ///   [`max_viewports`](crate::device::Properties::max_viewports) device property.
+    /// - If the [`multi_viewport`](crate::device::Features::multi_viewport) feature is not enabled,
+    ///   panics if more than 1 viewport is provided.
+    #[inline]
+    pub fn set_viewport_with_count(
+        &mut self,
+        viewports: impl IntoIterator<Item = Viewport>,
+    ) -> &mut Self {
+        let viewports: SmallVec<[Viewport; 2]> = viewports.into_iter().collect();
+        self.validate_set_viewport_with_count(&viewports).unwrap();
+
+        unsafe { self.set_viewport_with_count_unchecked(viewports) }
+    }
+
+    fn validate_set_viewport_with_count(
+        &self,
+        viewports: &[Viewport],
+    ) -> Result<(), SetDynamicStateError> {
+        self.validate_pipeline_fixed_state(DynamicState::ViewportWithCount)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetViewportWithCount-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(SetDynamicStateError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetViewportWithCount-None-03393
+        if !(self.device().api_version() >= Version::V1_3
+            || self.device().enabled_features().extended_dynamic_state)
+        {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::set_viewport_with_count`",
+                requires_one_of: RequiresOneOf {
+                    api_version: Some(Version::V1_3),
+                    features: &["extended_dynamic_state"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdSetViewportWithCount-viewportCount-03394
+        if viewports.len() as u32 > self.device().physical_device().properties().max_viewports {
+            return Err(SetDynamicStateError::MaxViewportsExceeded {
+                provided: viewports.len() as u32,
+                max: self.device().physical_device().properties().max_viewports,
+            });
+        }
+
+        // VUID-vkCmdSetViewportWithCount-viewportCount-03395
+        if !self.device().enabled_features().multi_viewport && viewports.len() > 1 {
+            return Err(SetDynamicStateError::RequirementNotMet {
+                required_for: "`viewports.len()` is greater than `1`",
+                requires_one_of: RequiresOneOf {
+                    features: &["multi_viewport"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_viewport_with_count_unchecked(
+        &mut self,
+        viewports: impl IntoIterator<Item = Viewport>,
+    ) -> &mut Self {
+        let viewports: SmallVec<[Viewport; 2]> = viewports.into_iter().collect();
+
+        if viewports.is_empty() {
+            return self;
+        }
+
+        let viewports_vk = viewports
+            .iter()
+            .cloned()
+            .map(ash::vk::Viewport::from)
+            .collect::<SmallVec<[_; 2]>>();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_set_viewport_with_count)(
+                self.handle(),
+                viewports_vk.len() as u32,
+                viewports_vk.as_ptr(),
+            );
+        } else {
+            debug_assert!(
+                self.device()
+                    .enabled_extensions()
+                    .ext_extended_dynamic_state
+            );
+            (fns.ext_extended_dynamic_state
+                .cmd_set_viewport_with_count_ext)(
+                self.handle(),
+                viewports_vk.len() as u32,
+                viewports_vk.as_ptr(),
+            );
+        }
+
+        self.current_state.viewport_with_count = Some(viewports);
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/mod.rs
+++ b/vulkano/src/command_buffer/standard/builder/mod.rs
@@ -1,0 +1,933 @@
+// Copyright (c) 2022 The Vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+pub use self::{
+    bind_push::*, clear::*, copy::*, debug::*, dynamic_state::*, pipeline::*, query::*,
+    render_pass::*, secondary::*, sync::*,
+};
+use super::{PrimaryCommandBuffer, SecondaryCommandBuffer, SubmitState};
+pub use crate::command_buffer::{
+    BlitImageInfo, BufferCopy, BufferImageCopy, ClearAttachment, ClearColorImageInfo,
+    ClearDepthStencilImageInfo, ClearError, ClearRect, CopyBufferInfo, CopyBufferInfoTyped,
+    CopyBufferToImageInfo, CopyError, CopyErrorResource, CopyImageInfo, CopyImageToBufferInfo,
+    DebugUtilsError, ExecuteCommandsError, FillBufferInfo, ImageBlit, ImageCopy, ImageResolve,
+    PipelineExecutionError, QueryError, RenderPassBeginInfo, RenderPassError,
+    RenderingAttachmentInfo, RenderingAttachmentResolveInfo, RenderingInfo, ResolveImageInfo,
+};
+use crate::{
+    buffer::BufferAccess,
+    command_buffer::{
+        allocator::{
+            CommandBufferAllocator, CommandBufferBuilderAlloc, StandardCommandBufferAllocator,
+        },
+        sys::CommandBufferBeginInfo,
+        BuildError, CommandBufferBeginError, CommandBufferInheritanceInfo,
+        CommandBufferInheritanceRenderPassInfo, CommandBufferInheritanceRenderPassType,
+        CommandBufferInheritanceRenderingInfo, CommandBufferLevel, CommandBufferUsage,
+        SubpassContents,
+    },
+    descriptor_set::{DescriptorSetResources, DescriptorSetWithOffsets},
+    device::{Device, DeviceOwned, QueueFamilyProperties},
+    format::{Format, FormatFeatures},
+    image::ImageAspects,
+    pipeline::{
+        graphics::{
+            color_blend::LogicOp,
+            depth_stencil::{CompareOp, StencilOps},
+            input_assembly::{IndexType, PrimitiveTopology},
+            rasterization::{CullMode, DepthBias, FrontFace, LineStipple},
+            viewport::{Scissor, Viewport},
+        },
+        ComputePipeline, DynamicState, GraphicsPipeline, PipelineBindPoint, PipelineLayout,
+    },
+    query::{QueryControlFlags, QueryType},
+    range_set::RangeSet,
+    render_pass::{Framebuffer, Subpass},
+    OomError, RequiresOneOf, VulkanError, VulkanObject,
+};
+use parking_lot::Mutex;
+use smallvec::SmallVec;
+use std::{
+    any::Any,
+    collections::{hash_map::Entry, HashMap},
+    marker::PhantomData,
+    ops::RangeInclusive,
+    ptr,
+    sync::{atomic::AtomicBool, Arc},
+};
+
+mod bind_push;
+mod clear;
+mod copy;
+mod debug;
+mod dynamic_state;
+mod pipeline;
+mod query;
+mod render_pass;
+mod secondary;
+mod sync;
+
+/// Records commands to a command buffer.
+pub struct CommandBufferBuilder<L, A = StandardCommandBufferAllocator>
+where
+    A: CommandBufferAllocator,
+{
+    builder_alloc: A::Builder,
+    inheritance_info: Option<CommandBufferInheritanceInfo>, // Must be `None` in a primary command buffer and `Some` in a secondary command buffer.
+    queue_family_index: u32,
+    usage: CommandBufferUsage,
+
+    resources: Vec<Box<dyn Any + Send + Sync>>,
+    current_state: CurrentState,
+
+    _data: PhantomData<L>,
+}
+
+unsafe impl<L, A> DeviceOwned for CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        self.builder_alloc.device()
+    }
+}
+
+unsafe impl<L, A> VulkanObject for CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    type Handle = ash::vk::CommandBuffer;
+
+    #[inline]
+    fn handle(&self) -> Self::Handle {
+        self.builder_alloc.inner().handle()
+    }
+}
+
+impl<A> CommandBufferBuilder<PrimaryCommandBuffer, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Starts recording a primary command buffer.
+    #[inline]
+    pub fn primary(
+        allocator: &A,
+        queue_family_index: u32,
+        usage: CommandBufferUsage,
+    ) -> Result<Self, CommandBufferBeginError> {
+        unsafe {
+            CommandBufferBuilder::begin(
+                allocator,
+                queue_family_index,
+                CommandBufferLevel::Primary,
+                CommandBufferBeginInfo {
+                    usage,
+                    inheritance_info: None,
+                    _ne: crate::NonExhaustive(()),
+                },
+            )
+        }
+    }
+}
+
+impl<A> CommandBufferBuilder<SecondaryCommandBuffer, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Starts recording a secondary command buffer.
+    #[inline]
+    pub fn secondary(
+        allocator: &A,
+        queue_family_index: u32,
+        usage: CommandBufferUsage,
+        inheritance_info: CommandBufferInheritanceInfo,
+    ) -> Result<Self, CommandBufferBeginError> {
+        unsafe {
+            CommandBufferBuilder::begin(
+                allocator,
+                queue_family_index,
+                CommandBufferLevel::Secondary,
+                CommandBufferBeginInfo {
+                    usage,
+                    inheritance_info: Some(inheritance_info),
+                    _ne: crate::NonExhaustive(()),
+                },
+            )
+        }
+    }
+}
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    // Actual constructor. Private.
+    //
+    // `begin_info.inheritance_info` must match `level`.
+    unsafe fn begin(
+        allocator: &A,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+        begin_info: CommandBufferBeginInfo,
+    ) -> Result<Self, CommandBufferBeginError> {
+        Self::validate_begin(allocator.device(), queue_family_index, level, &begin_info)?;
+        Ok(Self::begin_unchecked(
+            allocator,
+            queue_family_index,
+            level,
+            begin_info,
+        )?)
+    }
+
+    fn validate_begin(
+        device: &Device,
+        _queue_family_index: u32,
+        level: CommandBufferLevel,
+        begin_info: &CommandBufferBeginInfo,
+    ) -> Result<(), CommandBufferBeginError> {
+        let physical_device = device.physical_device();
+        let properties = physical_device.properties();
+
+        let &CommandBufferBeginInfo {
+            usage: _,
+            ref inheritance_info,
+            _ne: _,
+        } = &begin_info;
+
+        if let Some(inheritance_info) = &inheritance_info {
+            debug_assert!(level == CommandBufferLevel::Secondary);
+
+            let &CommandBufferInheritanceInfo {
+                ref render_pass,
+                occlusion_query,
+                query_statistics_flags,
+                _ne: _,
+            } = inheritance_info;
+
+            if let Some(render_pass) = render_pass {
+                // VUID-VkCommandBufferBeginInfo-flags-06000
+                // VUID-VkCommandBufferBeginInfo-flags-06002
+                // Ensured by the definition of the `CommandBufferInheritanceRenderPassType` enum.
+
+                match render_pass {
+                    CommandBufferInheritanceRenderPassType::BeginRenderPass(render_pass_info) => {
+                        let &CommandBufferInheritanceRenderPassInfo {
+                            ref subpass,
+                            ref framebuffer,
+                        } = render_pass_info;
+
+                        // VUID-VkCommandBufferInheritanceInfo-commonparent
+                        assert_eq!(device, subpass.render_pass().device().as_ref());
+
+                        // VUID-VkCommandBufferBeginInfo-flags-06001
+                        // Ensured by how the `Subpass` type is constructed.
+
+                        if let Some(framebuffer) = framebuffer {
+                            // VUID-VkCommandBufferInheritanceInfo-commonparent
+                            assert_eq!(device, framebuffer.device().as_ref());
+
+                            // VUID-VkCommandBufferBeginInfo-flags-00055
+                            if !framebuffer
+                                .render_pass()
+                                .is_compatible_with(subpass.render_pass())
+                            {
+                                return Err(CommandBufferBeginError::FramebufferNotCompatible);
+                            }
+                        }
+                    }
+                    CommandBufferInheritanceRenderPassType::BeginRendering(rendering_info) => {
+                        let &CommandBufferInheritanceRenderingInfo {
+                            view_mask,
+                            ref color_attachment_formats,
+                            depth_attachment_format,
+                            stencil_attachment_format,
+                            rasterization_samples,
+                        } = rendering_info;
+
+                        // VUID-VkCommandBufferInheritanceRenderingInfo-multiview-06008
+                        if view_mask != 0 && !device.enabled_features().multiview {
+                            return Err(CommandBufferBeginError::RequirementNotMet {
+                                required_for: "`inheritance_info.render_pass` is \
+                                    `CommandBufferInheritanceRenderPassType::BeginRendering`, \
+                                    where `view_mask` is not `0`",
+                                requires_one_of: RequiresOneOf {
+                                    features: &["multiview"],
+                                    ..Default::default()
+                                },
+                            });
+                        }
+
+                        let view_count = u32::BITS - view_mask.leading_zeros();
+
+                        // VUID-VkCommandBufferInheritanceRenderingInfo-viewMask-06009
+                        if view_count > properties.max_multiview_view_count.unwrap_or(0) {
+                            return Err(CommandBufferBeginError::MaxMultiviewViewCountExceeded {
+                                view_count,
+                                max: properties.max_multiview_view_count.unwrap_or(0),
+                            });
+                        }
+
+                        for (attachment_index, format) in color_attachment_formats
+                            .iter()
+                            .enumerate()
+                            .flat_map(|(i, f)| f.map(|f| (i, f)))
+                        {
+                            let attachment_index = attachment_index as u32;
+
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-pColorAttachmentFormats-parameter
+                            format.validate_device(device)?;
+
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-pColorAttachmentFormats-06006
+                            // Use unchecked, because all validation has been done above.
+                            if !unsafe { physical_device.format_properties_unchecked(format) }
+                                .potential_format_features()
+                                .intersects(FormatFeatures::COLOR_ATTACHMENT)
+                            {
+                                return Err(
+                                    CommandBufferBeginError::ColorAttachmentFormatUsageNotSupported {
+                                        attachment_index,
+                                    },
+                                );
+                            }
+                        }
+
+                        if let Some(format) = depth_attachment_format {
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-parameter
+                            format.validate_device(device)?;
+
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-06540
+                            if !format.aspects().intersects(ImageAspects::DEPTH) {
+                                return Err(
+                                    CommandBufferBeginError::DepthAttachmentFormatUsageNotSupported,
+                                );
+                            }
+
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-06007
+                            // Use unchecked, because all validation has been done above.
+                            if !unsafe { physical_device.format_properties_unchecked(format) }
+                                .potential_format_features()
+                                .intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT)
+                            {
+                                return Err(
+                                    CommandBufferBeginError::DepthAttachmentFormatUsageNotSupported,
+                                );
+                            }
+                        }
+
+                        if let Some(format) = stencil_attachment_format {
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-parameter
+                            format.validate_device(device)?;
+
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-06541
+                            if !format.aspects().intersects(ImageAspects::STENCIL) {
+                                return Err(
+                                    CommandBufferBeginError::StencilAttachmentFormatUsageNotSupported,
+                                );
+                            }
+
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-06199
+                            // Use unchecked, because all validation has been done above.
+                            if !unsafe { physical_device.format_properties_unchecked(format) }
+                                .potential_format_features()
+                                .intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT)
+                            {
+                                return Err(
+                                    CommandBufferBeginError::StencilAttachmentFormatUsageNotSupported,
+                                );
+                            }
+                        }
+
+                        if let (Some(depth_format), Some(stencil_format)) =
+                            (depth_attachment_format, stencil_attachment_format)
+                        {
+                            // VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-06200
+                            if depth_format != stencil_format {
+                                return Err(
+                                    CommandBufferBeginError::DepthStencilAttachmentFormatMismatch,
+                                );
+                            }
+                        }
+
+                        // VUID-VkCommandBufferInheritanceRenderingInfo-rasterizationSamples-parameter
+                        rasterization_samples.validate_device(device)?;
+                    }
+                }
+            }
+
+            if let Some(control_flags) = occlusion_query {
+                // VUID-VkCommandBufferInheritanceInfo-queryFlags-00057
+                control_flags.validate_device(device)?;
+
+                // VUID-VkCommandBufferInheritanceInfo-occlusionQueryEnable-00056
+                // VUID-VkCommandBufferInheritanceInfo-queryFlags-02788
+                if !device.enabled_features().inherited_queries {
+                    return Err(CommandBufferBeginError::RequirementNotMet {
+                        required_for: "`inheritance_info.occlusion_query` is `Some`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["inherited_queries"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-vkBeginCommandBuffer-commandBuffer-00052
+                if control_flags.intersects(QueryControlFlags::PRECISE)
+                    && !device.enabled_features().occlusion_query_precise
+                {
+                    return Err(CommandBufferBeginError::RequirementNotMet {
+                        required_for: "`inheritance_info.occlusion_query` is \
+                            `Some(control_flags)`, where `control_flags` contains \
+                            `QueryControlFlags::PRECISE`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["occlusion_query_precise"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+
+            // VUID-VkCommandBufferInheritanceInfo-pipelineStatistics-02789
+            query_statistics_flags.validate_device(device)?;
+
+            // VUID-VkCommandBufferInheritanceInfo-pipelineStatistics-00058
+            if query_statistics_flags.count() > 0
+                && !device.enabled_features().pipeline_statistics_query
+            {
+                return Err(CommandBufferBeginError::RequirementNotMet {
+                    required_for: "`inheritance_info.query_statistics_flags` is not empty",
+                    requires_one_of: RequiresOneOf {
+                        features: &["pipeline_statistics_query"],
+                        ..Default::default()
+                    },
+                });
+            }
+        } else {
+            debug_assert!(level == CommandBufferLevel::Primary);
+
+            // VUID-vkBeginCommandBuffer-commandBuffer-02840
+            // Ensured by the definition of the `CommandBufferUsage` enum.
+        }
+
+        Ok(())
+    }
+
+    unsafe fn begin_unchecked(
+        allocator: &A,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+        begin_info: CommandBufferBeginInfo,
+    ) -> Result<Self, OomError> {
+        let CommandBufferBeginInfo {
+            usage,
+            inheritance_info,
+            _ne: _,
+        } = begin_info;
+
+        let builder_alloc = allocator
+            .allocate(queue_family_index, level, 1)?
+            .next()
+            .expect("requested one command buffer from the command pool, but got zero");
+
+        {
+            let device = builder_alloc.device();
+
+            let mut flags = ash::vk::CommandBufferUsageFlags::from(usage);
+            let mut inheritance_info_vk = None;
+            let mut inheritance_rendering_info_vk = None;
+            let mut color_attachment_formats_vk: SmallVec<[_; 4]> = SmallVec::new();
+
+            if let Some(inheritance_info) = &inheritance_info {
+                let &CommandBufferInheritanceInfo {
+                    ref render_pass,
+                    occlusion_query,
+                    query_statistics_flags,
+                    _ne: _,
+                } = inheritance_info;
+
+                let inheritance_info_vk =
+                    inheritance_info_vk.insert(ash::vk::CommandBufferInheritanceInfo {
+                        render_pass: ash::vk::RenderPass::null(),
+                        subpass: 0,
+                        framebuffer: ash::vk::Framebuffer::null(),
+                        occlusion_query_enable: ash::vk::FALSE,
+                        query_flags: ash::vk::QueryControlFlags::empty(),
+                        pipeline_statistics: query_statistics_flags.into(),
+                        ..Default::default()
+                    });
+
+                if let Some(flags) = occlusion_query {
+                    inheritance_info_vk.occlusion_query_enable = ash::vk::TRUE;
+
+                    if flags.intersects(QueryControlFlags::PRECISE) {
+                        inheritance_info_vk.query_flags = ash::vk::QueryControlFlags::PRECISE;
+                    }
+                }
+
+                if let Some(render_pass) = render_pass {
+                    flags |= ash::vk::CommandBufferUsageFlags::RENDER_PASS_CONTINUE;
+
+                    match render_pass {
+                        CommandBufferInheritanceRenderPassType::BeginRenderPass(
+                            render_pass_info,
+                        ) => {
+                            let &CommandBufferInheritanceRenderPassInfo {
+                                ref subpass,
+                                ref framebuffer,
+                            } = render_pass_info;
+
+                            inheritance_info_vk.render_pass = subpass.render_pass().handle();
+                            inheritance_info_vk.subpass = subpass.index();
+                            inheritance_info_vk.framebuffer = framebuffer
+                                .as_ref()
+                                .map(|fb| fb.handle())
+                                .unwrap_or_default();
+                        }
+                        CommandBufferInheritanceRenderPassType::BeginRendering(rendering_info) => {
+                            let &CommandBufferInheritanceRenderingInfo {
+                                view_mask,
+                                ref color_attachment_formats,
+                                depth_attachment_format,
+                                stencil_attachment_format,
+                                rasterization_samples,
+                            } = rendering_info;
+
+                            color_attachment_formats_vk.extend(
+                                color_attachment_formats.iter().map(|format| {
+                                    format.map_or(ash::vk::Format::UNDEFINED, Into::into)
+                                }),
+                            );
+
+                            let inheritance_rendering_info_vk = inheritance_rendering_info_vk
+                                .insert(ash::vk::CommandBufferInheritanceRenderingInfo {
+                                    flags: ash::vk::RenderingFlags::empty(),
+                                    view_mask,
+                                    color_attachment_count: color_attachment_formats_vk.len()
+                                        as u32,
+                                    p_color_attachment_formats: color_attachment_formats_vk
+                                        .as_ptr(),
+                                    depth_attachment_format: depth_attachment_format
+                                        .map_or(ash::vk::Format::UNDEFINED, Into::into),
+                                    stencil_attachment_format: stencil_attachment_format
+                                        .map_or(ash::vk::Format::UNDEFINED, Into::into),
+                                    rasterization_samples: rasterization_samples.into(),
+                                    ..Default::default()
+                                });
+
+                            inheritance_info_vk.p_next =
+                                inheritance_rendering_info_vk as *const _ as *const _;
+                        }
+                    }
+                }
+            }
+
+            let begin_info_vk = ash::vk::CommandBufferBeginInfo {
+                flags,
+                p_inheritance_info: inheritance_info_vk
+                    .as_ref()
+                    .map_or(ptr::null(), |info| info),
+                ..Default::default()
+            };
+
+            let fns = device.fns();
+
+            (fns.v1_0.begin_command_buffer)(builder_alloc.inner().handle(), &begin_info_vk)
+                .result()
+                .map_err(VulkanError::from)?;
+        }
+
+        let mut current_state: CurrentState = Default::default();
+
+        if let Some(inheritance_info) = &inheritance_info {
+            let &CommandBufferInheritanceInfo {
+                ref render_pass,
+                occlusion_query: _,
+                query_statistics_flags: _,
+                _ne: _,
+            } = inheritance_info;
+
+            if let Some(render_pass) = render_pass {
+                current_state.render_pass = Some(RenderPassState::from_inheritance(render_pass));
+            }
+        }
+
+        Ok(CommandBufferBuilder {
+            builder_alloc,
+            inheritance_info,
+            queue_family_index,
+            usage,
+
+            resources: Vec::new(),
+            current_state,
+
+            _data: PhantomData,
+        })
+    }
+
+    fn queue_family_properties(&self) -> &QueueFamilyProperties {
+        &self.device().physical_device().queue_family_properties()[self.queue_family_index as usize]
+    }
+}
+
+impl<A> CommandBufferBuilder<PrimaryCommandBuffer<A::Alloc>, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Builds the command buffer.
+    pub fn build(self) -> Result<PrimaryCommandBuffer<A::Alloc>, BuildError> {
+        if self.current_state.render_pass.is_some() {
+            return Err(BuildError::RenderPassActive);
+        }
+
+        if !self.current_state.queries.is_empty() {
+            return Err(BuildError::QueryActive);
+        }
+
+        Ok(unsafe { self.build_unchecked()? })
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn build_unchecked(self) -> Result<PrimaryCommandBuffer<A::Alloc>, OomError> {
+        let fns = self.device().fns();
+        (fns.v1_0.end_command_buffer)(self.builder_alloc.inner().handle())
+            .result()
+            .map_err(VulkanError::from)?;
+
+        Ok(PrimaryCommandBuffer {
+            alloc: self.builder_alloc.into_alloc(),
+            _usage: self.usage,
+            _resources: self.resources,
+
+            _state: Mutex::new(Default::default()),
+        })
+    }
+}
+
+impl<A> CommandBufferBuilder<SecondaryCommandBuffer<A::Alloc>, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Builds the command buffer.
+    pub fn build(self) -> Result<SecondaryCommandBuffer<A::Alloc>, BuildError> {
+        if !self.current_state.queries.is_empty() {
+            return Err(BuildError::QueryActive);
+        }
+
+        Ok(unsafe { self.build_unchecked()? })
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn build_unchecked(self) -> Result<SecondaryCommandBuffer<A::Alloc>, OomError> {
+        let fns = self.device().fns();
+        (fns.v1_0.end_command_buffer)(self.builder_alloc.inner().handle())
+            .result()
+            .map_err(VulkanError::from)?;
+
+        let submit_state = match self.usage {
+            CommandBufferUsage::MultipleSubmit => SubmitState::ExclusiveUse {
+                in_use: AtomicBool::new(false),
+            },
+            CommandBufferUsage::SimultaneousUse => SubmitState::Concurrent,
+            CommandBufferUsage::OneTimeSubmit => SubmitState::OneTime {
+                already_submitted: AtomicBool::new(false),
+            },
+        };
+
+        Ok(SecondaryCommandBuffer {
+            alloc: self.builder_alloc.into_alloc(),
+            inheritance_info: self.inheritance_info.unwrap(),
+            usage: self.usage,
+
+            _resources: self.resources,
+
+            submit_state,
+        })
+    }
+}
+
+/// Holds the current binding and setting state.
+#[derive(Default)]
+struct CurrentState {
+    // Render pass
+    render_pass: Option<RenderPassState>,
+
+    // Bind/push
+    descriptor_sets: HashMap<PipelineBindPoint, DescriptorSetState>,
+    index_buffer: Option<(Arc<dyn BufferAccess>, IndexType)>,
+    pipeline_compute: Option<Arc<ComputePipeline>>,
+    pipeline_graphics: Option<Arc<GraphicsPipeline>>,
+    vertex_buffers: HashMap<u32, Arc<dyn BufferAccess>>,
+    push_constants: RangeSet<u32>,
+    push_constants_pipeline_layout: Option<Arc<PipelineLayout>>,
+
+    // Dynamic state
+    blend_constants: Option<[f32; 4]>,
+    color_write_enable: Option<SmallVec<[bool; 4]>>,
+    cull_mode: Option<CullMode>,
+    depth_bias: Option<DepthBias>,
+    depth_bias_enable: Option<bool>,
+    depth_bounds: Option<RangeInclusive<f32>>,
+    depth_bounds_test_enable: Option<bool>,
+    depth_compare_op: Option<CompareOp>,
+    depth_test_enable: Option<bool>,
+    depth_write_enable: Option<bool>,
+    discard_rectangle: HashMap<u32, Scissor>,
+    front_face: Option<FrontFace>,
+    line_stipple: Option<LineStipple>,
+    line_width: Option<f32>,
+    logic_op: Option<LogicOp>,
+    patch_control_points: Option<u32>,
+    primitive_restart_enable: Option<bool>,
+    primitive_topology: Option<PrimitiveTopology>,
+    rasterizer_discard_enable: Option<bool>,
+    scissor: HashMap<u32, Scissor>,
+    scissor_with_count: Option<SmallVec<[Scissor; 2]>>,
+    stencil_compare_mask: StencilStateDynamic,
+    stencil_op: StencilOpStateDynamic,
+    stencil_reference: StencilStateDynamic,
+    stencil_test_enable: Option<bool>,
+    stencil_write_mask: StencilStateDynamic,
+    viewport: HashMap<u32, Viewport>,
+    viewport_with_count: Option<SmallVec<[Viewport; 2]>>,
+
+    // Active queries
+    queries: HashMap<ash::vk::QueryType, QueryState>,
+}
+
+impl CurrentState {
+    fn reset_dynamic_states(&mut self, states: impl IntoIterator<Item = DynamicState>) {
+        for state in states {
+            match state {
+                DynamicState::BlendConstants => self.blend_constants = None,
+                DynamicState::ColorWriteEnable => self.color_write_enable = None,
+                DynamicState::CullMode => self.cull_mode = None,
+                DynamicState::DepthBias => self.depth_bias = None,
+                DynamicState::DepthBiasEnable => self.depth_bias_enable = None,
+                DynamicState::DepthBounds => self.depth_bounds = None,
+                DynamicState::DepthBoundsTestEnable => self.depth_bounds_test_enable = None,
+                DynamicState::DepthCompareOp => self.depth_compare_op = None,
+                DynamicState::DepthTestEnable => self.depth_test_enable = None,
+                DynamicState::DepthWriteEnable => self.depth_write_enable = None,
+                DynamicState::DiscardRectangle => self.discard_rectangle.clear(),
+                DynamicState::ExclusiveScissor => (), // TODO;
+                DynamicState::FragmentShadingRate => (), // TODO:
+                DynamicState::FrontFace => self.front_face = None,
+                DynamicState::LineStipple => self.line_stipple = None,
+                DynamicState::LineWidth => self.line_width = None,
+                DynamicState::LogicOp => self.logic_op = None,
+                DynamicState::PatchControlPoints => self.patch_control_points = None,
+                DynamicState::PrimitiveRestartEnable => self.primitive_restart_enable = None,
+                DynamicState::PrimitiveTopology => self.primitive_topology = None,
+                DynamicState::RasterizerDiscardEnable => self.rasterizer_discard_enable = None,
+                DynamicState::RayTracingPipelineStackSize => (), // TODO:
+                DynamicState::SampleLocations => (),             // TODO:
+                DynamicState::Scissor => self.scissor.clear(),
+                DynamicState::ScissorWithCount => self.scissor_with_count = None,
+                DynamicState::StencilCompareMask => self.stencil_compare_mask = Default::default(),
+                DynamicState::StencilOp => self.stencil_op = Default::default(),
+                DynamicState::StencilReference => self.stencil_reference = Default::default(),
+                DynamicState::StencilTestEnable => self.stencil_test_enable = None,
+                DynamicState::StencilWriteMask => self.stencil_write_mask = Default::default(),
+                DynamicState::VertexInput => (), // TODO:
+                DynamicState::VertexInputBindingStride => (), // TODO:
+                DynamicState::Viewport => self.viewport.clear(),
+                DynamicState::ViewportCoarseSampleOrder => (), // TODO:
+                DynamicState::ViewportShadingRatePalette => (), // TODO:
+                DynamicState::ViewportWScaling => (),          // TODO:
+                DynamicState::ViewportWithCount => self.viewport_with_count = None,
+            }
+        }
+    }
+
+    fn invalidate_descriptor_sets(
+        &mut self,
+        pipeline_bind_point: PipelineBindPoint,
+        pipeline_layout: Arc<PipelineLayout>,
+        first_set: u32,
+        num_descriptor_sets: u32,
+    ) -> &mut DescriptorSetState {
+        match self.descriptor_sets.entry(pipeline_bind_point) {
+            Entry::Vacant(entry) => entry.insert(DescriptorSetState {
+                descriptor_sets: Default::default(),
+                pipeline_layout,
+            }),
+            Entry::Occupied(entry) => {
+                let state = entry.into_mut();
+
+                let invalidate_from = if state.pipeline_layout == pipeline_layout {
+                    // If we're still using the exact same layout, then of course it's compatible.
+                    None
+                } else if state.pipeline_layout.push_constant_ranges()
+                    != pipeline_layout.push_constant_ranges()
+                {
+                    // If the push constant ranges don't match,
+                    // all bound descriptor sets are disturbed.
+                    Some(0)
+                } else {
+                    // Find the first descriptor set layout in the current pipeline layout that
+                    // isn't compatible with the corresponding set in the new pipeline layout.
+                    // If an incompatible set was found, all bound sets from that slot onwards will
+                    // be disturbed.
+                    let current_layouts = state.pipeline_layout.set_layouts();
+                    let new_layouts = pipeline_layout.set_layouts();
+                    let max = (current_layouts.len() as u32).min(first_set + num_descriptor_sets);
+                    (0..max).find(|&num| {
+                        let num = num as usize;
+                        !current_layouts[num].is_compatible_with(&new_layouts[num])
+                    })
+                };
+
+                if let Some(invalidate_from) = invalidate_from {
+                    // Remove disturbed sets and set new pipeline layout.
+                    state
+                        .descriptor_sets
+                        .retain(|&num, _| num < invalidate_from);
+                    state.pipeline_layout = pipeline_layout;
+                } else if (first_set + num_descriptor_sets) as usize
+                    >= state.pipeline_layout.set_layouts().len()
+                {
+                    // New layout is a superset of the old one.
+                    state.pipeline_layout = pipeline_layout;
+                }
+
+                state
+            }
+        }
+    }
+}
+
+struct RenderPassState {
+    contents: SubpassContents,
+    render_area_offset: [u32; 2],
+    render_area_extent: [u32; 2],
+    render_pass: RenderPassStateType,
+    view_mask: u32,
+}
+
+impl RenderPassState {
+    fn from_inheritance(render_pass: &CommandBufferInheritanceRenderPassType) -> Self {
+        // In a secondary command buffer, we don't know the render area yet, so use a
+        // dummy value.
+        let render_area_offset = [0, 0];
+        let mut render_area_extent = [u32::MAX, u32::MAX];
+
+        match render_pass {
+            CommandBufferInheritanceRenderPassType::BeginRenderPass(info) => {
+                if let Some(framebuffer) = &info.framebuffer {
+                    // Still not exact, but it's a better upper bound.
+                    render_area_extent = framebuffer.extent();
+                }
+
+                RenderPassState {
+                    contents: SubpassContents::Inline,
+                    render_area_offset,
+                    render_area_extent,
+                    render_pass: BeginRenderPassState {
+                        subpass: info.subpass.clone(),
+                        framebuffer: info.framebuffer.clone(),
+                    }
+                    .into(),
+                    view_mask: info.subpass.subpass_desc().view_mask,
+                }
+            }
+            CommandBufferInheritanceRenderPassType::BeginRendering(info) => RenderPassState {
+                contents: SubpassContents::Inline,
+                render_area_offset,
+                render_area_extent,
+                render_pass: BeginRenderingState {
+                    attachments: None,
+                    color_attachment_formats: info.color_attachment_formats.clone(),
+                    depth_attachment_format: info.depth_attachment_format,
+                    stencil_attachment_format: info.stencil_attachment_format,
+                    pipeline_used: false,
+                }
+                .into(),
+                view_mask: info.view_mask,
+            },
+        }
+    }
+}
+
+enum RenderPassStateType {
+    BeginRenderPass(BeginRenderPassState),
+    BeginRendering(BeginRenderingState),
+}
+
+impl From<BeginRenderPassState> for RenderPassStateType {
+    #[inline]
+    fn from(val: BeginRenderPassState) -> Self {
+        Self::BeginRenderPass(val)
+    }
+}
+
+impl From<BeginRenderingState> for RenderPassStateType {
+    #[inline]
+    fn from(val: BeginRenderingState) -> Self {
+        Self::BeginRendering(val)
+    }
+}
+
+struct BeginRenderPassState {
+    subpass: Subpass,
+    framebuffer: Option<Arc<Framebuffer>>,
+}
+
+struct BeginRenderingState {
+    attachments: Option<BeginRenderingAttachments>,
+    color_attachment_formats: Vec<Option<Format>>,
+    depth_attachment_format: Option<Format>,
+    stencil_attachment_format: Option<Format>,
+    pipeline_used: bool,
+}
+
+struct BeginRenderingAttachments {
+    color_attachments: Vec<Option<RenderingAttachmentInfo>>,
+    depth_attachment: Option<RenderingAttachmentInfo>,
+    stencil_attachment: Option<RenderingAttachmentInfo>,
+}
+
+struct DescriptorSetState {
+    descriptor_sets: HashMap<u32, SetOrPush>,
+    pipeline_layout: Arc<PipelineLayout>,
+}
+
+#[derive(Clone)]
+enum SetOrPush {
+    Set(DescriptorSetWithOffsets),
+    Push(DescriptorSetResources),
+}
+
+impl SetOrPush {
+    pub fn resources(&self) -> &DescriptorSetResources {
+        match self {
+            Self::Set(set) => set.as_ref().0.resources(),
+            Self::Push(resources) => resources,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct StencilStateDynamic {
+    front: Option<u32>,
+    back: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct StencilOpStateDynamic {
+    front: Option<StencilOps>,
+    back: Option<StencilOps>,
+}
+
+struct QueryState {
+    query_pool: ash::vk::QueryPool,
+    query: u32,
+    ty: QueryType,
+    flags: QueryControlFlags,
+    in_subpass: bool,
+}

--- a/vulkano/src/command_buffer/standard/builder/pipeline.rs
+++ b/vulkano/src/command_buffer/standard/builder/pipeline.rs
@@ -1,0 +1,1798 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{CommandBufferBuilder, PipelineExecutionError, RenderPassState, RenderPassStateType};
+use crate::{
+    buffer::{view::BufferViewAbstract, BufferAccess, BufferUsage, TypedBufferAccess},
+    command_buffer::{
+        allocator::CommandBufferAllocator, commands::pipeline::DescriptorResourceInvalidError,
+        DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand, SubpassContents,
+    },
+    descriptor_set::{layout::DescriptorType, DescriptorBindingResources},
+    device::{DeviceOwned, QueueFlags},
+    format::FormatFeatures,
+    image::{ImageAspects, ImageViewAbstract, SampleCount},
+    pipeline::{
+        graphics::{
+            input_assembly::PrimitiveTopology, render_pass::PipelineRenderPassType,
+            vertex_input::VertexInputRate,
+        },
+        DynamicState, GraphicsPipeline, PartialStateMode, Pipeline, PipelineLayout,
+    },
+    sampler::Sampler,
+    shader::{DescriptorBindingRequirements, ShaderScalarType, ShaderStage},
+    RequiresOneOf, VulkanObject,
+};
+use std::{cmp::min, mem::size_of, sync::Arc};
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Perform a single compute operation using a compute pipeline.
+    ///
+    /// A compute pipeline must have been bound using [`bind_pipeline_compute`]. Any resources used
+    /// by the compute pipeline, such as descriptor sets, must have been set beforehand.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    ///
+    /// [`bind_pipeline_compute`]: Self::bind_pipeline_compute
+    #[inline]
+    pub unsafe fn dispatch(
+        &mut self,
+        group_counts: [u32; 3],
+    ) -> Result<&mut Self, PipelineExecutionError> {
+        self.validate_dispatch(group_counts)?;
+
+        unsafe { Ok(self.dispatch_unchecked(group_counts)) }
+    }
+
+    fn validate_dispatch(&self, group_counts: [u32; 3]) -> Result<(), PipelineExecutionError> {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdDispatch-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(PipelineExecutionError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdDispatch-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(PipelineExecutionError::ForbiddenInsideRenderPass);
+        }
+
+        // VUID-vkCmdDispatch-None-02700
+        let pipeline = self
+            .current_state
+            .pipeline_compute
+            .as_ref()
+            .ok_or(PipelineExecutionError::PipelineNotBound)?
+            .as_ref();
+
+        self.validate_pipeline_descriptor_sets(
+            pipeline,
+            pipeline.descriptor_binding_requirements(),
+        )?;
+        self.validate_pipeline_push_constants(pipeline.layout())?;
+
+        let max = self
+            .device()
+            .physical_device()
+            .properties()
+            .max_compute_work_group_count;
+
+        // VUID-vkCmdDispatch-groupCountX-00386
+        // VUID-vkCmdDispatch-groupCountY-00387
+        // VUID-vkCmdDispatch-groupCountZ-00388
+        if group_counts[0] > max[0] || group_counts[1] > max[1] || group_counts[2] > max[2] {
+            return Err(PipelineExecutionError::MaxComputeWorkGroupCountExceeded {
+                requested: group_counts,
+                max,
+            });
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn dispatch_unchecked(&mut self, group_counts: [u32; 3]) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_dispatch)(
+            self.handle(),
+            group_counts[0],
+            group_counts[1],
+            group_counts[2],
+        );
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Perform multiple compute operations using a compute pipeline. One dispatch is performed for
+    /// each [`DispatchIndirectCommand`] struct in `indirect_buffer`.
+    ///
+    /// A compute pipeline must have been bound using [`bind_pipeline_compute`]. Any resources used
+    /// by the compute pipeline, such as descriptor sets, must have been set beforehand.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    ///
+    /// [`bind_pipeline_compute`]: Self::bind_pipeline_compute
+    #[inline]
+    pub unsafe fn dispatch_indirect(
+        &mut self,
+        indirect_buffer: Arc<impl TypedBufferAccess<Content = [DispatchIndirectCommand]> + 'static>,
+    ) -> Result<&mut Self, PipelineExecutionError> {
+        self.validate_dispatch_indirect(&indirect_buffer)?;
+
+        unsafe { Ok(self.dispatch_indirect_unchecked(indirect_buffer)) }
+    }
+
+    fn validate_dispatch_indirect(
+        &self,
+        indirect_buffer: &dyn BufferAccess,
+    ) -> Result<(), PipelineExecutionError> {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdDispatchIndirect-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(PipelineExecutionError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdDispatchIndirect-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(PipelineExecutionError::ForbiddenInsideRenderPass);
+        }
+
+        // VUID-vkCmdDispatchIndirect-None-02700
+        let pipeline = self
+            .current_state
+            .pipeline_compute
+            .as_ref()
+            .ok_or(PipelineExecutionError::PipelineNotBound)?
+            .as_ref();
+
+        self.validate_pipeline_descriptor_sets(
+            pipeline,
+            pipeline.descriptor_binding_requirements(),
+        )?;
+        self.validate_pipeline_push_constants(pipeline.layout())?;
+        self.validate_indirect_buffer(indirect_buffer)?;
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn dispatch_indirect_unchecked(
+        &mut self,
+        indirect_buffer: Arc<dyn BufferAccess>,
+    ) -> &mut Self {
+        let indirect_buffer_inner = indirect_buffer.inner();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_dispatch_indirect)(
+            self.handle(),
+            indirect_buffer_inner.buffer.handle(),
+            indirect_buffer_inner.offset,
+        );
+
+        self.resources.push(Box::new(indirect_buffer));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Perform a single draw operation using a graphics pipeline.
+    ///
+    /// The parameters specify the first vertex and the number of vertices to draw, and the first
+    /// instance and number of instances. For non-instanced drawing, specify `instance_count` as 1
+    /// and `first_instance` as 0.
+    ///
+    /// A graphics pipeline must have been bound using [`bind_pipeline_graphics`]. Any resources
+    /// used by the graphics pipeline, such as descriptor sets, vertex buffers and dynamic state,
+    /// must have been set beforehand. If the bound graphics pipeline uses vertex buffers, then the
+    /// provided vertex and instance ranges must be in range of the bound vertex buffers.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    ///
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    #[inline]
+    pub unsafe fn draw(
+        &mut self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> Result<&mut Self, PipelineExecutionError> {
+        self.validate_draw(vertex_count, instance_count, first_vertex, first_instance)?;
+
+        unsafe {
+            Ok(self.draw_unchecked(vertex_count, instance_count, first_vertex, first_instance))
+        }
+    }
+
+    fn validate_draw(
+        &self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> Result<(), PipelineExecutionError> {
+        // VUID-vkCmdDraw-renderpass
+        let render_pass_state = self
+            .current_state
+            .render_pass
+            .as_ref()
+            .ok_or(PipelineExecutionError::ForbiddenOutsideRenderPass)?;
+
+        // VUID-vkCmdDraw-None-02700
+        let pipeline = self
+            .current_state
+            .pipeline_graphics
+            .as_ref()
+            .ok_or(PipelineExecutionError::PipelineNotBound)?
+            .as_ref();
+
+        self.validate_pipeline_descriptor_sets(
+            pipeline,
+            pipeline.descriptor_binding_requirements(),
+        )?;
+        self.validate_pipeline_push_constants(pipeline.layout())?;
+        self.validate_pipeline_graphics_dynamic_state(pipeline)?;
+        self.validate_pipeline_graphics_render_pass(pipeline, render_pass_state)?;
+        self.validate_pipeline_graphics_vertex_buffers(
+            pipeline,
+            Some((first_vertex, vertex_count)),
+            Some((first_instance, instance_count)),
+        )?;
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn draw_unchecked(
+        &mut self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_draw)(
+            self.handle(),
+            vertex_count,
+            instance_count,
+            first_vertex,
+            first_instance,
+        );
+
+        if let RenderPassStateType::BeginRendering(state) =
+            &mut self.current_state.render_pass.as_mut().unwrap().render_pass
+        {
+            state.pipeline_used = true;
+        }
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Perform multiple draw operations using a graphics pipeline.
+    ///
+    /// One draw is performed for each [`DrawIndirectCommand`] struct in `indirect_buffer`.
+    /// The maximum number of draw commands in the buffer is limited by the
+    /// [`max_draw_indirect_count`] limit.
+    /// This limit is 1 unless the [`multi_draw_indirect`] feature has been enabled on the device.
+    ///
+    /// A graphics pipeline must have been bound using [`bind_pipeline_graphics`]. Any resources
+    /// used by the graphics pipeline, such as descriptor sets, vertex buffers and dynamic state,
+    /// must have been set beforehand. If the bound graphics pipeline uses vertex buffers, then the
+    /// vertex and instance ranges of each `DrawIndirectCommand` in the indirect buffer must be in
+    /// range of the bound vertex buffers.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    ///
+    /// [`max_draw_indirect_count`]: crate::device::Properties::max_draw_indirect_count
+    /// [`multi_draw_indirect`]: crate::device::Features::multi_draw_indirect
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    #[inline]
+    pub unsafe fn draw_indirect(
+        &mut self,
+        indirect_buffer: Arc<impl TypedBufferAccess<Content = [DrawIndirectCommand]> + 'static>,
+    ) -> Result<&mut Self, PipelineExecutionError> {
+        let draw_count = indirect_buffer.len() as u32;
+        let stride = size_of::<DrawIndirectCommand>() as u32;
+        self.validate_draw_indirect(&indirect_buffer, draw_count, stride)?;
+
+        unsafe { Ok(self.draw_indirect_unchecked(indirect_buffer, draw_count, stride)) }
+    }
+
+    fn validate_draw_indirect(
+        &self,
+        indirect_buffer: &dyn BufferAccess,
+        draw_count: u32,
+        _stride: u32,
+    ) -> Result<(), PipelineExecutionError> {
+        // VUID-vkCmdDrawIndirect-renderpass
+        let render_pass_state = self
+            .current_state
+            .render_pass
+            .as_ref()
+            .ok_or(PipelineExecutionError::ForbiddenOutsideRenderPass)?;
+
+        // VUID-vkCmdDrawIndirect-None-02700
+        let pipeline = self
+            .current_state
+            .pipeline_graphics
+            .as_ref()
+            .ok_or(PipelineExecutionError::PipelineNotBound)?
+            .as_ref();
+
+        self.validate_pipeline_descriptor_sets(
+            pipeline,
+            pipeline.descriptor_binding_requirements(),
+        )?;
+        self.validate_pipeline_push_constants(pipeline.layout())?;
+        self.validate_pipeline_graphics_dynamic_state(pipeline)?;
+        self.validate_pipeline_graphics_render_pass(pipeline, render_pass_state)?;
+        self.validate_pipeline_graphics_vertex_buffers(pipeline, None, None)?;
+
+        self.validate_indirect_buffer(indirect_buffer)?;
+
+        // VUID-vkCmdDrawIndirect-drawCount-02718
+        if draw_count > 1 && !self.device().enabled_features().multi_draw_indirect {
+            return Err(PipelineExecutionError::RequirementNotMet {
+                required_for: "`draw_count` is greater than `1`",
+                requires_one_of: RequiresOneOf {
+                    features: &["multi_draw_indirect"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        let max = self
+            .device()
+            .physical_device()
+            .properties()
+            .max_draw_indirect_count;
+
+        // VUID-vkCmdDrawIndirect-drawCount-02719
+        if draw_count > max {
+            return Err(PipelineExecutionError::MaxDrawIndirectCountExceeded {
+                provided: draw_count,
+                max,
+            });
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn draw_indirect_unchecked(
+        &mut self,
+        indirect_buffer: Arc<dyn BufferAccess>,
+        draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        let indirect_buffer_inner = indirect_buffer.inner();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_draw_indirect)(
+            self.handle(),
+            indirect_buffer_inner.buffer.handle(),
+            indirect_buffer_inner.offset,
+            draw_count,
+            stride,
+        );
+
+        if let RenderPassStateType::BeginRendering(state) =
+            &mut self.current_state.render_pass.as_mut().unwrap().render_pass
+        {
+            state.pipeline_used = true;
+        }
+
+        self.resources.push(Box::new(indirect_buffer));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Perform a single draw operation using a graphics pipeline, using an index buffer.
+    ///
+    /// The parameters specify the first index and the number of indices in the index buffer that
+    /// should be used, and the first instance and number of instances. For non-instanced drawing,
+    /// specify `instance_count` as 1 and `first_instance` as 0. The `vertex_offset` is a constant
+    /// value that should be added to each index in the index buffer to produce the final vertex
+    /// number to be used.
+    ///
+    /// An index buffer must have been bound using [`bind_index_buffer`], and the provided index
+    /// range must be in range of the bound index buffer.
+    ///
+    /// A graphics pipeline must have been bound using [`bind_pipeline_graphics`]. Any resources
+    /// used by the graphics pipeline, such as descriptor sets, vertex buffers and dynamic state,
+    /// must have been set beforehand. If the bound graphics pipeline uses vertex buffers, then the
+    /// provided instance range must be in range of the bound vertex buffers. The vertex indices in
+    /// the index buffer must be in range of the bound vertex buffers.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    ///
+    /// [`bind_index_buffer`]: Self::bind_index_buffer
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    #[inline]
+    pub unsafe fn draw_indexed(
+        &mut self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        vertex_offset: i32,
+        first_instance: u32,
+    ) -> Result<&mut Self, PipelineExecutionError> {
+        self.validate_draw_indexed(
+            index_count,
+            instance_count,
+            first_index,
+            vertex_offset,
+            first_instance,
+        )?;
+
+        unsafe {
+            Ok(self.draw_indexed_unchecked(
+                index_count,
+                instance_count,
+                first_index,
+                vertex_offset,
+                first_instance,
+            ))
+        }
+    }
+
+    fn validate_draw_indexed(
+        &self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        _vertex_offset: i32,
+        first_instance: u32,
+    ) -> Result<(), PipelineExecutionError> {
+        // TODO: how to handle an index out of range of the vertex buffers?
+
+        // VUID-vkCmdDrawIndexed-renderpass
+        let render_pass_state = self
+            .current_state
+            .render_pass
+            .as_ref()
+            .ok_or(PipelineExecutionError::ForbiddenOutsideRenderPass)?;
+
+        // VUID-vkCmdDrawIndexed-None-02700
+        let pipeline = self
+            .current_state
+            .pipeline_graphics
+            .as_ref()
+            .ok_or(PipelineExecutionError::PipelineNotBound)?
+            .as_ref();
+
+        self.validate_pipeline_descriptor_sets(
+            pipeline,
+            pipeline.descriptor_binding_requirements(),
+        )?;
+        self.validate_pipeline_push_constants(pipeline.layout())?;
+        self.validate_pipeline_graphics_dynamic_state(pipeline)?;
+        self.validate_pipeline_graphics_render_pass(pipeline, render_pass_state)?;
+        self.validate_pipeline_graphics_vertex_buffers(
+            pipeline,
+            None,
+            Some((first_instance, instance_count)),
+        )?;
+
+        self.validate_index_buffer(Some((first_index, index_count)))?;
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn draw_indexed_unchecked(
+        &mut self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        vertex_offset: i32,
+        first_instance: u32,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_draw_indexed)(
+            self.handle(),
+            index_count,
+            instance_count,
+            first_index,
+            vertex_offset,
+            first_instance,
+        );
+
+        if let RenderPassStateType::BeginRendering(state) =
+            &mut self.current_state.render_pass.as_mut().unwrap().render_pass
+        {
+            state.pipeline_used = true;
+        }
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Perform multiple draw operations using a graphics pipeline, using an index buffer.
+    ///
+    /// One draw is performed for each [`DrawIndexedIndirectCommand`] struct in `indirect_buffer`.
+    /// The maximum number of draw commands in the buffer is limited by the
+    /// [`max_draw_indirect_count`] limit.
+    /// This limit is 1 unless the [`multi_draw_indirect`] feature has been enabled on the device.
+    ///
+    /// An index buffer must have been bound using [`bind_index_buffer`], and the index ranges of
+    /// each `DrawIndexedIndirectCommand` in the indirect buffer must be in range of the bound
+    /// index buffer.
+    ///
+    /// A graphics pipeline must have been bound using [`bind_pipeline_graphics`]. Any resources
+    /// used by the graphics pipeline, such as descriptor sets, vertex buffers and dynamic state,
+    /// must have been set beforehand. If the bound graphics pipeline uses vertex buffers, then the
+    /// instance ranges of each `DrawIndexedIndirectCommand` in the indirect buffer must be in
+    /// range of the bound vertex buffers.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    ///
+    /// [`max_draw_indirect_count`]: crate::device::Properties::max_draw_indirect_count
+    /// [`multi_draw_indirect`]: crate::device::Features::multi_draw_indirect
+    /// [`bind_index_buffer`]: Self::bind_index_buffer
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    #[inline]
+    pub unsafe fn draw_indexed_indirect(
+        &mut self,
+        indirect_buffer: Arc<
+            impl TypedBufferAccess<Content = [DrawIndexedIndirectCommand]> + 'static,
+        >,
+    ) -> Result<&mut Self, PipelineExecutionError> {
+        let draw_count = indirect_buffer.len() as u32;
+        let stride = size_of::<DrawIndexedIndirectCommand>() as u32;
+        self.validate_draw_indexed_indirect(&indirect_buffer, draw_count, stride)?;
+
+        unsafe { Ok(self.draw_indexed_indirect_unchecked(indirect_buffer, draw_count, stride)) }
+    }
+
+    fn validate_draw_indexed_indirect(
+        &self,
+        indirect_buffer: &dyn BufferAccess,
+        draw_count: u32,
+        _stride: u32,
+    ) -> Result<(), PipelineExecutionError> {
+        // VUID-vkCmdDrawIndexedIndirect-renderpass
+        let render_pass_state = self
+            .current_state
+            .render_pass
+            .as_ref()
+            .ok_or(PipelineExecutionError::ForbiddenOutsideRenderPass)?;
+
+        // VUID-vkCmdDrawIndexedIndirect-None-02700
+        let pipeline = self
+            .current_state
+            .pipeline_graphics
+            .as_ref()
+            .ok_or(PipelineExecutionError::PipelineNotBound)?
+            .as_ref();
+
+        self.validate_pipeline_descriptor_sets(
+            pipeline,
+            pipeline.descriptor_binding_requirements(),
+        )?;
+        self.validate_pipeline_push_constants(pipeline.layout())?;
+        self.validate_pipeline_graphics_dynamic_state(pipeline)?;
+        self.validate_pipeline_graphics_render_pass(pipeline, render_pass_state)?;
+        self.validate_pipeline_graphics_vertex_buffers(pipeline, None, None)?;
+
+        self.validate_index_buffer(None)?;
+        self.validate_indirect_buffer(indirect_buffer)?;
+
+        // VUID-vkCmdDrawIndexedIndirect-drawCount-02718
+        if draw_count > 1 && !self.device().enabled_features().multi_draw_indirect {
+            return Err(PipelineExecutionError::RequirementNotMet {
+                required_for: "`draw_count` is greater than `1`",
+                requires_one_of: RequiresOneOf {
+                    features: &["multi_draw_indirect"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        let max = self
+            .device()
+            .physical_device()
+            .properties()
+            .max_draw_indirect_count;
+
+        // VUID-vkCmdDrawIndexedIndirect-drawCount-02719
+        if draw_count > max {
+            return Err(PipelineExecutionError::MaxDrawIndirectCountExceeded {
+                provided: draw_count,
+                max,
+            });
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn draw_indexed_indirect_unchecked(
+        &mut self,
+        indirect_buffer: Arc<dyn BufferAccess>,
+        draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        let indirect_buffer_inner = indirect_buffer.inner();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_draw_indexed_indirect)(
+            self.handle(),
+            indirect_buffer_inner.buffer.handle(),
+            indirect_buffer_inner.offset,
+            draw_count,
+            stride,
+        );
+
+        if let RenderPassStateType::BeginRendering(state) =
+            &mut self.current_state.render_pass.as_mut().unwrap().render_pass
+        {
+            state.pipeline_used = true;
+        }
+
+        self.resources.push(Box::new(indirect_buffer));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    fn validate_index_buffer(
+        &self,
+        indices: Option<(u32, u32)>,
+    ) -> Result<(), PipelineExecutionError> {
+        // VUID?
+        let (index_buffer, index_type) = self
+            .current_state
+            .index_buffer
+            .as_ref()
+            .ok_or(PipelineExecutionError::IndexBufferNotBound)?;
+
+        if let Some((first_index, index_count)) = indices {
+            let max_index_count = (index_buffer.size() / index_type.size()) as u32;
+
+            // // VUID-vkCmdDrawIndexed-firstIndex-04932
+            if first_index + index_count > max_index_count {
+                return Err(PipelineExecutionError::IndexBufferRangeOutOfBounds {
+                    highest_index: first_index + index_count,
+                    max_index_count,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_indirect_buffer(
+        &self,
+        buffer: &dyn BufferAccess,
+    ) -> Result<(), PipelineExecutionError> {
+        // VUID-vkCmdDispatchIndirect-commonparent
+        assert_eq!(self.device(), buffer.device());
+
+        // VUID-vkCmdDispatchIndirect-buffer-02709
+        if !buffer.usage().intersects(BufferUsage::INDIRECT_BUFFER) {
+            return Err(PipelineExecutionError::IndirectBufferMissingUsage);
+        }
+
+        // VUID-vkCmdDispatchIndirect-offset-02710
+        // TODO:
+
+        Ok(())
+    }
+
+    fn validate_pipeline_descriptor_sets<'a>(
+        &self,
+        pipeline: &impl Pipeline,
+        descriptor_binding_requirements: impl IntoIterator<
+            Item = ((u32, u32), &'a DescriptorBindingRequirements),
+        >,
+    ) -> Result<(), PipelineExecutionError> {
+        fn validate_resources<T>(
+            set_num: u32,
+            binding_num: u32,
+            binding_reqs: &DescriptorBindingRequirements,
+            elements: &[Option<T>],
+            mut extra_check: impl FnMut(u32, &T) -> Result<(), DescriptorResourceInvalidError>,
+        ) -> Result<(), PipelineExecutionError> {
+            let elements_to_check = if let Some(descriptor_count) = binding_reqs.descriptor_count {
+                // The shader has a fixed-sized array, so it will never access more than
+                // the first `descriptor_count` elements.
+                elements.get(..descriptor_count as usize).ok_or({
+                    // There are less than `descriptor_count` elements in `elements`
+                    PipelineExecutionError::DescriptorResourceInvalid {
+                        set_num,
+                        binding_num,
+                        index: elements.len() as u32,
+                        error: DescriptorResourceInvalidError::Missing,
+                    }
+                })?
+            } else {
+                // The shader has a runtime-sized array, so any element could potentially
+                // be accessed. We must check them all.
+                elements
+            };
+
+            for (index, element) in elements_to_check.iter().enumerate() {
+                let index = index as u32;
+
+                // VUID-vkCmdDispatch-None-02699
+                let element = match element {
+                    Some(x) => x,
+                    None => {
+                        return Err(PipelineExecutionError::DescriptorResourceInvalid {
+                            set_num,
+                            binding_num,
+                            index,
+                            error: DescriptorResourceInvalidError::Missing,
+                        })
+                    }
+                };
+
+                if let Err(error) = extra_check(index, element) {
+                    return Err(PipelineExecutionError::DescriptorResourceInvalid {
+                        set_num,
+                        binding_num,
+                        index,
+                        error,
+                    });
+                }
+            }
+
+            Ok(())
+        }
+
+        if pipeline.num_used_descriptor_sets() == 0 {
+            return Ok(());
+        }
+
+        // VUID-vkCmdDispatch-None-02697
+        let descriptor_set_state = self
+            .current_state
+            .descriptor_sets
+            .get(&pipeline.bind_point())
+            .ok_or(PipelineExecutionError::PipelineLayoutNotCompatible)?;
+
+        // VUID-vkCmdDispatch-None-02697
+        if !pipeline.layout().is_compatible_with(
+            &descriptor_set_state.pipeline_layout,
+            pipeline.num_used_descriptor_sets(),
+        ) {
+            return Err(PipelineExecutionError::PipelineLayoutNotCompatible);
+        }
+
+        for ((set_num, binding_num), binding_reqs) in descriptor_binding_requirements {
+            let layout_binding =
+                &pipeline.layout().set_layouts()[set_num as usize].bindings()[&binding_num];
+
+            let check_buffer = |_index: u32, _buffer: &Arc<dyn BufferAccess>| Ok(());
+
+            let check_buffer_view = |index: u32, buffer_view: &Arc<dyn BufferViewAbstract>| {
+                for desc_reqs in (binding_reqs.descriptors.get(&Some(index)).into_iter())
+                    .chain(binding_reqs.descriptors.get(&None))
+                {
+                    if layout_binding.descriptor_type == DescriptorType::StorageTexelBuffer {
+                        // VUID-vkCmdDispatch-OpTypeImage-06423
+                        if binding_reqs.image_format.is_none()
+                            && !desc_reqs.memory_write.is_empty()
+                            && !buffer_view
+                                .format_features()
+                                .intersects(FormatFeatures::STORAGE_WRITE_WITHOUT_FORMAT)
+                        {
+                            return Err(DescriptorResourceInvalidError::StorageWriteWithoutFormatNotSupported);
+                        }
+
+                        // VUID-vkCmdDispatch-OpTypeImage-06424
+                        if binding_reqs.image_format.is_none()
+                            && !desc_reqs.memory_read.is_empty()
+                            && !buffer_view
+                                .format_features()
+                                .intersects(FormatFeatures::STORAGE_READ_WITHOUT_FORMAT)
+                        {
+                            return Err(DescriptorResourceInvalidError::StorageReadWithoutFormatNotSupported);
+                        }
+                    }
+                }
+
+                Ok(())
+            };
+
+            let check_image_view_common = |index: u32, image_view: &Arc<dyn ImageViewAbstract>| {
+                for desc_reqs in (binding_reqs.descriptors.get(&Some(index)).into_iter())
+                    .chain(binding_reqs.descriptors.get(&None))
+                {
+                    // VUID-vkCmdDispatch-None-02691
+                    if desc_reqs.storage_image_atomic
+                        && !image_view
+                            .format_features()
+                            .intersects(FormatFeatures::STORAGE_IMAGE_ATOMIC)
+                    {
+                        return Err(DescriptorResourceInvalidError::StorageImageAtomicNotSupported);
+                    }
+
+                    if layout_binding.descriptor_type == DescriptorType::StorageImage {
+                        // VUID-vkCmdDispatch-OpTypeImage-06423
+                        if binding_reqs.image_format.is_none()
+                            && !desc_reqs.memory_write.is_empty()
+                            && !image_view
+                                .format_features()
+                                .intersects(FormatFeatures::STORAGE_WRITE_WITHOUT_FORMAT)
+                        {
+                            return Err(
+                            DescriptorResourceInvalidError::StorageWriteWithoutFormatNotSupported,
+                        );
+                        }
+
+                        // VUID-vkCmdDispatch-OpTypeImage-06424
+                        if binding_reqs.image_format.is_none()
+                            && !desc_reqs.memory_read.is_empty()
+                            && !image_view
+                                .format_features()
+                                .intersects(FormatFeatures::STORAGE_READ_WITHOUT_FORMAT)
+                        {
+                            return Err(
+                            DescriptorResourceInvalidError::StorageReadWithoutFormatNotSupported,
+                        );
+                        }
+                    }
+                }
+
+                /*
+                   Instruction/Sampler/Image View Validation
+                   https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap16.html#textures-input-validation
+                */
+
+                // The SPIR-V Image Format is not compatible with the image view’s format.
+                if let Some(format) = binding_reqs.image_format {
+                    if image_view.format() != Some(format) {
+                        return Err(DescriptorResourceInvalidError::ImageViewFormatMismatch {
+                            required: format,
+                            provided: image_view.format(),
+                        });
+                    }
+                }
+
+                // Rules for viewType
+                if let Some(image_view_type) = binding_reqs.image_view_type {
+                    if image_view.view_type() != image_view_type {
+                        return Err(DescriptorResourceInvalidError::ImageViewTypeMismatch {
+                            required: image_view_type,
+                            provided: image_view.view_type(),
+                        });
+                    }
+                }
+
+                // - If the image was created with VkImageCreateInfo::samples equal to
+                //   VK_SAMPLE_COUNT_1_BIT, the instruction must have MS = 0.
+                // - If the image was created with VkImageCreateInfo::samples not equal to
+                //   VK_SAMPLE_COUNT_1_BIT, the instruction must have MS = 1.
+                if binding_reqs.image_multisampled
+                    != (image_view.image().samples() != SampleCount::Sample1)
+                {
+                    return Err(
+                        DescriptorResourceInvalidError::ImageViewMultisampledMismatch {
+                            required: binding_reqs.image_multisampled,
+                            provided: image_view.image().samples() != SampleCount::Sample1,
+                        },
+                    );
+                }
+
+                // - If the Sampled Type of the OpTypeImage does not match the numeric format of the
+                //   image, as shown in the SPIR-V Sampled Type column of the
+                //   Interpretation of Numeric Format table.
+                // - If the signedness of any read or sample operation does not match the signedness of
+                //   the image’s format.
+                if let Some(scalar_type) = binding_reqs.image_scalar_type {
+                    let aspects = image_view.subresource_range().aspects;
+                    let view_scalar_type = ShaderScalarType::from(
+                        if aspects.intersects(
+                            ImageAspects::COLOR
+                                | ImageAspects::PLANE_0
+                                | ImageAspects::PLANE_1
+                                | ImageAspects::PLANE_2,
+                        ) {
+                            image_view.format().unwrap().type_color().unwrap()
+                        } else if aspects.intersects(ImageAspects::DEPTH) {
+                            image_view.format().unwrap().type_depth().unwrap()
+                        } else if aspects.intersects(ImageAspects::STENCIL) {
+                            image_view.format().unwrap().type_stencil().unwrap()
+                        } else {
+                            // Per `ImageViewBuilder::aspects` and
+                            // VUID-VkDescriptorImageInfo-imageView-01976
+                            unreachable!()
+                        },
+                    );
+
+                    if scalar_type != view_scalar_type {
+                        return Err(
+                            DescriptorResourceInvalidError::ImageViewScalarTypeMismatch {
+                                required: scalar_type,
+                                provided: view_scalar_type,
+                            },
+                        );
+                    }
+                }
+
+                Ok(())
+            };
+
+            let check_sampler_common = |index: u32, sampler: &Arc<Sampler>| {
+                for desc_reqs in (binding_reqs.descriptors.get(&Some(index)).into_iter())
+                    .chain(binding_reqs.descriptors.get(&None))
+                {
+                    // VUID-vkCmdDispatch-None-02703
+                    // VUID-vkCmdDispatch-None-02704
+                    if desc_reqs.sampler_no_unnormalized_coordinates
+                        && sampler.unnormalized_coordinates()
+                    {
+                        return Err(
+                        DescriptorResourceInvalidError::SamplerUnnormalizedCoordinatesNotAllowed,
+                    );
+                    }
+
+                    // - OpImageFetch, OpImageSparseFetch, OpImage*Gather, and OpImageSparse*Gather must not
+                    //   be used with a sampler that enables sampler Y′CBCR conversion.
+                    // - The ConstOffset and Offset operands must not be used with a sampler that enables
+                    //   sampler Y′CBCR conversion.
+                    if desc_reqs.sampler_no_ycbcr_conversion
+                        && sampler.sampler_ycbcr_conversion().is_some()
+                    {
+                        return Err(
+                            DescriptorResourceInvalidError::SamplerYcbcrConversionNotAllowed,
+                        );
+                    }
+
+                    /*
+                        Instruction/Sampler/Image View Validation
+                        https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap16.html#textures-input-validation
+                    */
+
+                    // - The SPIR-V instruction is one of the OpImage*Dref* instructions and the sampler
+                    //   compareEnable is VK_FALSE
+                    // - The SPIR-V instruction is not one of the OpImage*Dref* instructions and the sampler
+                    //   compareEnable is VK_TRUE
+                    if desc_reqs.sampler_compare != sampler.compare().is_some() {
+                        return Err(DescriptorResourceInvalidError::SamplerCompareMismatch {
+                            required: desc_reqs.sampler_compare,
+                            provided: sampler.compare().is_some(),
+                        });
+                    }
+                }
+
+                Ok(())
+            };
+
+            let check_image_view = |index: u32, image_view: &Arc<dyn ImageViewAbstract>| {
+                check_image_view_common(index, image_view)?;
+
+                if let Some(sampler) = layout_binding.immutable_samplers.get(index as usize) {
+                    check_sampler_common(index, sampler)?;
+                }
+
+                Ok(())
+            };
+
+            let check_image_view_sampler =
+                |index: u32, (image_view, sampler): &(Arc<dyn ImageViewAbstract>, Arc<Sampler>)| {
+                    check_image_view_common(index, image_view)?;
+                    check_sampler_common(index, sampler)?;
+
+                    Ok(())
+                };
+
+            let check_sampler = |index: u32, sampler: &Arc<Sampler>| {
+                check_sampler_common(index, sampler)?;
+
+                for desc_reqs in (binding_reqs.descriptors.get(&Some(index)).into_iter())
+                    .chain(binding_reqs.descriptors.get(&None))
+                {
+                    // Check sampler-image compatibility. Only done for separate samplers;
+                    // combined image samplers are checked when updating the descriptor set.
+
+                    // If the image view isn't actually present in the resources, then just skip it.
+                    // It will be caught later by check_resources.
+                    let iter = desc_reqs.sampler_with_images.iter().filter_map(|id| {
+                        descriptor_set_state
+                            .descriptor_sets
+                            .get(&id.set)
+                            .and_then(|set| set.resources().binding(id.binding))
+                            .and_then(|res| match res {
+                                DescriptorBindingResources::ImageView(elements) => elements
+                                    .get(id.index as usize)
+                                    .and_then(|opt| opt.as_ref().map(|opt| (id, opt))),
+                                _ => None,
+                            })
+                    });
+
+                    for (id, image_view) in iter {
+                        if let Err(error) = sampler.check_can_sample(image_view.as_ref()) {
+                            return Err(
+                                DescriptorResourceInvalidError::SamplerImageViewIncompatible {
+                                    image_view_set_num: id.set,
+                                    image_view_binding_num: id.binding,
+                                    image_view_index: id.index,
+                                    error,
+                                },
+                            );
+                        }
+                    }
+                }
+
+                Ok(())
+            };
+
+            let check_none = |index: u32, _: &()| {
+                if let Some(sampler) = layout_binding.immutable_samplers.get(index as usize) {
+                    check_sampler(index, sampler)?;
+                }
+
+                Ok(())
+            };
+
+            let set_resources = descriptor_set_state
+                .descriptor_sets
+                .get(&set_num)
+                .ok_or(PipelineExecutionError::DescriptorSetNotBound { set_num })?
+                .resources();
+
+            let binding_resources = set_resources.binding(binding_num).unwrap();
+
+            match binding_resources {
+                DescriptorBindingResources::None(elements) => {
+                    validate_resources(set_num, binding_num, binding_reqs, elements, check_none)?;
+                }
+                DescriptorBindingResources::Buffer(elements) => {
+                    validate_resources(set_num, binding_num, binding_reqs, elements, check_buffer)?;
+                }
+                DescriptorBindingResources::BufferView(elements) => {
+                    validate_resources(
+                        set_num,
+                        binding_num,
+                        binding_reqs,
+                        elements,
+                        check_buffer_view,
+                    )?;
+                }
+                DescriptorBindingResources::ImageView(elements) => {
+                    validate_resources(
+                        set_num,
+                        binding_num,
+                        binding_reqs,
+                        elements,
+                        check_image_view,
+                    )?;
+                }
+                DescriptorBindingResources::ImageViewSampler(elements) => {
+                    validate_resources(
+                        set_num,
+                        binding_num,
+                        binding_reqs,
+                        elements,
+                        check_image_view_sampler,
+                    )?;
+                }
+                DescriptorBindingResources::Sampler(elements) => {
+                    validate_resources(
+                        set_num,
+                        binding_num,
+                        binding_reqs,
+                        elements,
+                        check_sampler,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_pipeline_push_constants(
+        &self,
+        pipeline_layout: &PipelineLayout,
+    ) -> Result<(), PipelineExecutionError> {
+        if pipeline_layout.push_constant_ranges().is_empty()
+            || self.device().enabled_features().maintenance4
+        {
+            return Ok(());
+        }
+
+        // VUID-vkCmdDispatch-maintenance4-06425
+        let constants_pipeline_layout = self
+            .current_state
+            .push_constants_pipeline_layout
+            .as_ref()
+            .ok_or(PipelineExecutionError::PushConstantsMissing)?;
+
+        // VUID-vkCmdDispatch-maintenance4-06425
+        if pipeline_layout.handle() != constants_pipeline_layout.handle()
+            && pipeline_layout.push_constant_ranges()
+                != constants_pipeline_layout.push_constant_ranges()
+        {
+            return Err(PipelineExecutionError::PushConstantsNotCompatible);
+        }
+
+        let set_bytes = &self.current_state.push_constants;
+
+        // VUID-vkCmdDispatch-maintenance4-06425
+        if !pipeline_layout
+            .push_constant_ranges()
+            .iter()
+            .all(|pc_range| set_bytes.contains(pc_range.offset..pc_range.offset + pc_range.size))
+        {
+            return Err(PipelineExecutionError::PushConstantsMissing);
+        }
+
+        Ok(())
+    }
+
+    fn validate_pipeline_graphics_dynamic_state(
+        &self,
+        pipeline: &GraphicsPipeline,
+    ) -> Result<(), PipelineExecutionError> {
+        let device = pipeline.device();
+
+        // VUID-vkCmdDraw-commandBuffer-02701
+        for dynamic_state in pipeline
+            .dynamic_states()
+            .filter(|(_, d)| *d)
+            .map(|(s, _)| s)
+        {
+            match dynamic_state {
+                DynamicState::BlendConstants => {
+                    // VUID?
+                    if self.current_state.blend_constants.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::ColorWriteEnable => {
+                    // VUID-vkCmdDraw-attachmentCount-06667
+                    let enables = self.current_state.color_write_enable.as_ref().ok_or(PipelineExecutionError::DynamicStateNotSet { dynamic_state })?;
+
+                    // VUID-vkCmdDraw-attachmentCount-06667
+                    if enables.len() < pipeline.color_blend_state().unwrap().attachments.len() {
+                        return Err(
+                            PipelineExecutionError::DynamicColorWriteEnableNotEnoughValues {
+                                color_write_enable_count: enables.len() as u32,
+                                attachment_count: pipeline
+                                    .color_blend_state()
+                                    .unwrap()
+                                    .attachments
+                                    .len() as u32,
+                            },
+                        );
+                    }
+                }
+                DynamicState::CullMode => {
+                    // VUID?
+                    if self.current_state.cull_mode.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::DepthBias => {
+                    // VUID?
+                    if self.current_state.depth_bias.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::DepthBiasEnable => {
+                    // VUID-vkCmdDraw-None-04877
+                    if self.current_state.depth_bias_enable.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::DepthBounds => {
+                    // VUID?
+                    if self.current_state.depth_bounds.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::DepthBoundsTestEnable => {
+                    // VUID?
+                    if self.current_state.depth_bounds_test_enable.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::DepthCompareOp => {
+                    // VUID?
+                    if self.current_state.depth_compare_op.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::DepthTestEnable => {
+                    // VUID?
+                    if self.current_state.depth_test_enable.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::DepthWriteEnable => {
+                    // VUID?
+                    if self.current_state.depth_write_enable.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+
+                    // TODO: Check if the depth buffer is writable
+                }
+                DynamicState::DiscardRectangle => {
+                    let discard_rectangle_count =
+                        match pipeline.discard_rectangle_state().unwrap().rectangles {
+                            PartialStateMode::Dynamic(count) => count,
+                            _ => unreachable!(),
+                        };
+
+                    for num in 0..discard_rectangle_count {
+                        // VUID?
+                        if !self.current_state.discard_rectangle.contains_key(&num) {
+                            return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                        }
+                    }
+                }
+                DynamicState::ExclusiveScissor => todo!(),
+                DynamicState::FragmentShadingRate => todo!(),
+                DynamicState::FrontFace => {
+                    // VUID?
+                    if self.current_state.front_face.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::LineStipple => {
+                    // VUID?
+                    if self.current_state.line_stipple.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::LineWidth => {
+                    // VUID?
+                    if self.current_state.line_width.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::LogicOp => {
+                    // VUID-vkCmdDraw-logicOp-04878
+                    if self.current_state.logic_op.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::PatchControlPoints => {
+                    // VUID-vkCmdDraw-None-04875
+                    if self.current_state.patch_control_points.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::PrimitiveRestartEnable => {
+                    // VUID-vkCmdDraw-None-04879
+                    let primitive_restart_enable =
+                        if let Some(enable) = self.current_state.primitive_restart_enable {
+                            enable
+                        } else {
+                            return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                        };
+
+                    if primitive_restart_enable {
+                        let topology = match pipeline.input_assembly_state().topology {
+                            PartialStateMode::Fixed(topology) => topology,
+                            PartialStateMode::Dynamic(_) => {
+                                if let Some(topology) = self.current_state.primitive_topology {
+                                    topology
+                                } else {
+                                    return Err(PipelineExecutionError::DynamicStateNotSet {
+                                        dynamic_state: DynamicState::PrimitiveTopology,
+                                    });
+                                }
+                            }
+                        };
+
+                        match topology {
+                            PrimitiveTopology::PointList
+                            | PrimitiveTopology::LineList
+                            | PrimitiveTopology::TriangleList
+                            | PrimitiveTopology::LineListWithAdjacency
+                            | PrimitiveTopology::TriangleListWithAdjacency => {
+                                // VUID?
+                                if !device.enabled_features().primitive_topology_list_restart {
+                                    return Err(PipelineExecutionError::RequirementNotMet {
+                                        required_for: "The bound pipeline sets \
+                                            `DynamicState::PrimitiveRestartEnable` and the \
+                                            current primitive topology is \
+                                            `PrimitiveTopology::*List`",
+                                        requires_one_of: RequiresOneOf {
+                                            features: &["primitive_topology_list_restart"],
+                                            ..Default::default()
+                                        },
+                                    });
+                                }
+                            }
+                            PrimitiveTopology::PatchList => {
+                                // VUID?
+                                if !device
+                                    .enabled_features()
+                                    .primitive_topology_patch_list_restart
+                                {
+                                    return Err(PipelineExecutionError::RequirementNotMet {
+                                        required_for: "The bound pipeline sets \
+                                            `DynamicState::PrimitiveRestartEnable` and the \
+                                            current primitive topology is \
+                                            `PrimitiveTopology::PatchList`",
+                                        requires_one_of: RequiresOneOf {
+                                            features: &["primitive_topology_patch_list_restart"],
+                                            ..Default::default()
+                                        },
+                                    });
+                                }
+                            }
+                            _ => (),
+                        }
+                    }
+                }
+                DynamicState::PrimitiveTopology => {
+                    // VUID-vkCmdDraw-primitiveTopology-03420
+                    let topology = if let Some(topology) = self.current_state.primitive_topology {
+                        topology
+                    } else {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    };
+
+                    if pipeline.shader(ShaderStage::TessellationControl).is_some() {
+                        // VUID?
+                        if !matches!(topology, PrimitiveTopology::PatchList) {
+                            return Err(PipelineExecutionError::DynamicPrimitiveTopologyInvalid {
+                                topology,
+                            });
+                        }
+                    } else {
+                        // VUID?
+                        if matches!(topology, PrimitiveTopology::PatchList) {
+                            return Err(PipelineExecutionError::DynamicPrimitiveTopologyInvalid {
+                                topology,
+                            });
+                        }
+                    }
+
+                    let required_topology_class = match pipeline.input_assembly_state().topology {
+                        PartialStateMode::Dynamic(topology_class) => topology_class,
+                        _ => unreachable!(),
+                    };
+
+                    // VUID-vkCmdDraw-primitiveTopology-03420
+                    if topology.class() != required_topology_class {
+                        return Err(
+                            PipelineExecutionError::DynamicPrimitiveTopologyClassMismatch {
+                                provided_class: topology.class(),
+                                required_class: required_topology_class,
+                            },
+                        );
+                    }
+
+                    // TODO: check that the topology matches the geometry shader
+                }
+                DynamicState::RasterizerDiscardEnable => {
+                    // VUID-vkCmdDraw-None-04876
+                    if self.current_state.rasterizer_discard_enable.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::RayTracingPipelineStackSize => unreachable!(
+                    "RayTracingPipelineStackSize dynamic state should not occur on a graphics pipeline"
+                ),
+                DynamicState::SampleLocations => todo!(),
+                DynamicState::Scissor => {
+                    for num in 0..pipeline.viewport_state().unwrap().count().unwrap() {
+                        // VUID?
+                        if !self.current_state.scissor.contains_key(&num) {
+                            return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                        }
+                    }
+                }
+                DynamicState::ScissorWithCount => {
+                    // VUID-vkCmdDraw-scissorCount-03418
+                    // VUID-vkCmdDraw-viewportCount-03419
+                    let scissor_count = self.current_state.scissor_with_count.as_ref().ok_or(PipelineExecutionError::DynamicStateNotSet { dynamic_state })?.len() as u32;
+
+                    // Check if the counts match, but only if the viewport count is fixed.
+                    // If the viewport count is also dynamic, then the
+                    // DynamicState::ViewportWithCount match arm will handle it.
+                    if let Some(viewport_count) = pipeline.viewport_state().unwrap().count() {
+                        // VUID-vkCmdDraw-scissorCount-03418
+                        if viewport_count != scissor_count {
+                            return Err(
+                                PipelineExecutionError::DynamicViewportScissorCountMismatch {
+                                    viewport_count,
+                                    scissor_count,
+                                },
+                            );
+                        }
+                    }
+                }
+                DynamicState::StencilCompareMask => {
+                    let state = self.current_state.stencil_compare_mask;
+
+                    // VUID?
+                    if state.front.is_none() || state.back.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::StencilOp => {
+                    let state = self.current_state.stencil_op;
+
+                    // VUID?
+                    if state.front.is_none() || state.back.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::StencilReference => {
+                    let state = self.current_state.stencil_reference;
+
+                    // VUID?
+                    if state.front.is_none() || state.back.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::StencilTestEnable => {
+                    // VUID?
+                    if self.current_state.stencil_test_enable.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+
+                    // TODO: Check if the stencil buffer is writable
+                }
+                DynamicState::StencilWriteMask => {
+                    let state = self.current_state.stencil_write_mask;
+
+                    // VUID?
+                    if state.front.is_none() || state.back.is_none() {
+                        return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                    }
+                }
+                DynamicState::VertexInput => todo!(),
+                DynamicState::VertexInputBindingStride => todo!(),
+                DynamicState::Viewport => {
+                    for num in 0..pipeline.viewport_state().unwrap().count().unwrap() {
+                        // VUID?
+                        if !self.current_state.viewport.contains_key(&num) {
+                            return Err(PipelineExecutionError::DynamicStateNotSet { dynamic_state });
+                        }
+                    }
+                }
+                DynamicState::ViewportCoarseSampleOrder => todo!(),
+                DynamicState::ViewportShadingRatePalette => todo!(),
+                DynamicState::ViewportWithCount => {
+                    // VUID-vkCmdDraw-viewportCount-03417
+                    let viewport_count = self.current_state.viewport_with_count.as_ref().ok_or(PipelineExecutionError::DynamicStateNotSet { dynamic_state })?.len() as u32;
+
+                    let scissor_count = if let Some(scissor_count) =
+                        pipeline.viewport_state().unwrap().count()
+                    {
+                        // The scissor count is fixed.
+                        scissor_count
+                    } else {
+                        // VUID-vkCmdDraw-viewportCount-03419
+                        // The scissor count is also dynamic.
+                        self.current_state.scissor_with_count.as_ref().ok_or(PipelineExecutionError::DynamicStateNotSet { dynamic_state })?.len() as u32
+                    };
+
+                    // VUID-vkCmdDraw-viewportCount-03417
+                    // VUID-vkCmdDraw-viewportCount-03419
+                    if viewport_count != scissor_count {
+                        return Err(
+                            PipelineExecutionError::DynamicViewportScissorCountMismatch {
+                                viewport_count,
+                                scissor_count,
+                            },
+                        );
+                    }
+
+                    // TODO: VUID-vkCmdDrawIndexed-primitiveFragmentShadingRateWithMultipleViewports-04552
+                    // If the primitiveFragmentShadingRateWithMultipleViewports limit is not supported,
+                    // the bound graphics pipeline was created with the
+                    // VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT dynamic state enabled, and any of the
+                    // shader stages of the bound graphics pipeline write to the PrimitiveShadingRateKHR
+                    // built-in, then vkCmdSetViewportWithCountEXT must have been called in the current
+                    // command buffer prior to this drawing command, and the viewportCount parameter of
+                    // vkCmdSetViewportWithCountEXT must be 1
+                }
+                DynamicState::ViewportWScaling => todo!(),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_pipeline_graphics_render_pass(
+        &self,
+        pipeline: &GraphicsPipeline,
+        render_pass_state: &RenderPassState,
+    ) -> Result<(), PipelineExecutionError> {
+        // VUID?
+        if render_pass_state.contents != SubpassContents::Inline {
+            return Err(PipelineExecutionError::ForbiddenWithSubpassContents {
+                subpass_contents: render_pass_state.contents,
+            });
+        }
+
+        match (&render_pass_state.render_pass, pipeline.render_pass()) {
+            (
+                RenderPassStateType::BeginRenderPass(state),
+                PipelineRenderPassType::BeginRenderPass(pipeline_subpass),
+            ) => {
+                // VUID-vkCmdDraw-renderPass-02684
+                if !pipeline_subpass
+                    .render_pass()
+                    .is_compatible_with(state.subpass.render_pass())
+                {
+                    return Err(PipelineExecutionError::PipelineRenderPassNotCompatible);
+                }
+
+                // VUID-vkCmdDraw-subpass-02685
+                if pipeline_subpass.index() != state.subpass.index() {
+                    return Err(PipelineExecutionError::PipelineSubpassMismatch {
+                        pipeline: pipeline_subpass.index(),
+                        current: state.subpass.index(),
+                    });
+                }
+            }
+            (
+                RenderPassStateType::BeginRendering(current_rendering_info),
+                PipelineRenderPassType::BeginRendering(pipeline_rendering_info),
+            ) => {
+                // VUID-vkCmdDraw-viewMask-06178
+                if pipeline_rendering_info.view_mask != render_pass_state.view_mask {
+                    return Err(PipelineExecutionError::PipelineViewMaskMismatch {
+                        pipeline_view_mask: pipeline_rendering_info.view_mask,
+                        required_view_mask: render_pass_state.view_mask,
+                    });
+                }
+
+                // VUID-vkCmdDraw-colorAttachmentCount-06179
+                if pipeline_rendering_info.color_attachment_formats.len()
+                    != current_rendering_info.color_attachment_formats.len()
+                {
+                    return Err(
+                        PipelineExecutionError::PipelineColorAttachmentCountMismatch {
+                            pipeline_count: pipeline_rendering_info.color_attachment_formats.len()
+                                as u32,
+                            required_count: current_rendering_info.color_attachment_formats.len()
+                                as u32,
+                        },
+                    );
+                }
+
+                for (color_attachment_index, required_format, pipeline_format) in
+                    current_rendering_info
+                        .color_attachment_formats
+                        .iter()
+                        .zip(
+                            pipeline_rendering_info
+                                .color_attachment_formats
+                                .iter()
+                                .copied(),
+                        )
+                        .enumerate()
+                        .filter_map(|(i, (r, p))| r.map(|r| (i as u32, r, p)))
+                {
+                    // VUID-vkCmdDraw-colorAttachmentCount-06180
+                    if Some(required_format) != pipeline_format {
+                        return Err(
+                            PipelineExecutionError::PipelineColorAttachmentFormatMismatch {
+                                color_attachment_index,
+                                pipeline_format,
+                                required_format,
+                            },
+                        );
+                    }
+                }
+
+                if let Some((required_format, pipeline_format)) = current_rendering_info
+                    .depth_attachment_format
+                    .map(|r| (r, pipeline_rendering_info.depth_attachment_format))
+                {
+                    // VUID-vkCmdDraw-pDepthAttachment-06181
+                    if Some(required_format) != pipeline_format {
+                        return Err(
+                            PipelineExecutionError::PipelineDepthAttachmentFormatMismatch {
+                                pipeline_format,
+                                required_format,
+                            },
+                        );
+                    }
+                }
+
+                if let Some((required_format, pipeline_format)) = current_rendering_info
+                    .stencil_attachment_format
+                    .map(|r| (r, pipeline_rendering_info.stencil_attachment_format))
+                {
+                    // VUID-vkCmdDraw-pStencilAttachment-06182
+                    if Some(required_format) != pipeline_format {
+                        return Err(
+                            PipelineExecutionError::PipelineStencilAttachmentFormatMismatch {
+                                pipeline_format,
+                                required_format,
+                            },
+                        );
+                    }
+                }
+
+                // VUID-vkCmdDraw-imageView-06172
+                // VUID-vkCmdDraw-imageView-06173
+                // VUID-vkCmdDraw-imageView-06174
+                // VUID-vkCmdDraw-imageView-06175
+                // VUID-vkCmdDraw-imageView-06176
+                // VUID-vkCmdDraw-imageView-06177
+                // TODO:
+            }
+            _ => return Err(PipelineExecutionError::PipelineRenderPassTypeMismatch),
+        }
+
+        // VUID-vkCmdDraw-None-02686
+        // TODO:
+
+        Ok(())
+    }
+
+    fn validate_pipeline_graphics_vertex_buffers(
+        &self,
+        pipeline: &GraphicsPipeline,
+        vertices: Option<(u32, u32)>,
+        instances: Option<(u32, u32)>,
+    ) -> Result<(), PipelineExecutionError> {
+        let vertex_input = pipeline.vertex_input_state();
+        let mut vertices_in_buffers: Option<u64> = None;
+        let mut instances_in_buffers: Option<u64> = None;
+
+        for (&binding_num, binding_desc) in &vertex_input.bindings {
+            // VUID-vkCmdDraw-None-04007
+            let vertex_buffer = match self.current_state.vertex_buffers.get(&binding_num) {
+                Some(x) => x,
+                None => return Err(PipelineExecutionError::VertexBufferNotBound { binding_num }),
+            };
+
+            let mut num_elements = vertex_buffer.size() as u64 / binding_desc.stride as u64;
+
+            match binding_desc.input_rate {
+                VertexInputRate::Vertex => {
+                    vertices_in_buffers = Some(if let Some(x) = vertices_in_buffers {
+                        min(x, num_elements)
+                    } else {
+                        num_elements
+                    });
+                }
+                VertexInputRate::Instance { divisor } => {
+                    if divisor == 0 {
+                        // A divisor of 0 means the same instance data is used for all instances,
+                        // so we can draw any number of instances from a single element.
+                        // The buffer must contain at least one element though.
+                        if num_elements != 0 {
+                            num_elements = u64::MAX;
+                        }
+                    } else {
+                        // If divisor is e.g. 2, we use only half the amount of data from the source
+                        // buffer, so the number of instances that can be drawn is twice as large.
+                        num_elements = num_elements.saturating_mul(divisor as u64);
+                    }
+
+                    instances_in_buffers = Some(if let Some(x) = instances_in_buffers {
+                        min(x, num_elements)
+                    } else {
+                        num_elements
+                    });
+                }
+            };
+        }
+
+        if let Some((first_vertex, vertex_count)) = vertices {
+            let vertices_needed = first_vertex as u64 + vertex_count as u64;
+
+            if let Some(vertices_in_buffers) = vertices_in_buffers {
+                // VUID-vkCmdDraw-None-02721
+                if vertices_needed > vertices_in_buffers {
+                    return Err(PipelineExecutionError::VertexBufferVertexRangeOutOfBounds {
+                        vertices_needed,
+                        vertices_in_buffers,
+                    });
+                }
+            }
+        }
+
+        if let Some((first_instance, instance_count)) = instances {
+            let instances_needed = first_instance as u64 + instance_count as u64;
+
+            if let Some(instances_in_buffers) = instances_in_buffers {
+                // VUID-vkCmdDraw-None-02721
+                if instances_needed > instances_in_buffers {
+                    return Err(
+                        PipelineExecutionError::VertexBufferInstanceRangeOutOfBounds {
+                            instances_needed,
+                            instances_in_buffers,
+                        },
+                    );
+                }
+            }
+
+            let view_mask = match pipeline.render_pass() {
+                PipelineRenderPassType::BeginRenderPass(subpass) => {
+                    subpass.render_pass().views_used()
+                }
+                PipelineRenderPassType::BeginRendering(rendering_info) => rendering_info.view_mask,
+            };
+
+            if view_mask != 0 {
+                let max = pipeline
+                    .device()
+                    .physical_device()
+                    .properties()
+                    .max_multiview_instance_index
+                    .unwrap_or(0);
+
+                let highest_instance = instances_needed.saturating_sub(1);
+
+                // VUID-vkCmdDraw-maxMultiviewInstanceIndex-02688
+                if highest_instance > max as u64 {
+                    return Err(PipelineExecutionError::MaxMultiviewInstanceIndexExceeded {
+                        highest_instance,
+                        max,
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/query.rs
+++ b/vulkano/src/command_buffer/standard/builder/query.rs
@@ -1,0 +1,739 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{CommandBufferBuilder, QueryError, QueryState};
+use crate::{
+    buffer::{BufferUsage, TypedBufferAccess},
+    command_buffer::allocator::CommandBufferAllocator,
+    device::{DeviceOwned, QueueFlags},
+    query::{QueryControlFlags, QueryPool, QueryResultElement, QueryResultFlags, QueryType},
+    sync::{PipelineStage, PipelineStages},
+    DeviceSize, RequiresOneOf, Version, VulkanObject,
+};
+use std::{ops::Range, sync::Arc};
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Begins a query.
+    ///
+    /// The query will be active until [`end_query`] is called for the same query.
+    ///
+    /// # Safety
+    ///
+    /// - The query must be unavailable, ensured by calling [`reset_query_pool`].
+    ///
+    /// [`end_query`]: Self::end_query
+    /// [`reset_query_pool`]: Self::reset_query_pool
+    #[inline]
+    pub unsafe fn begin_query(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        query: u32,
+        flags: QueryControlFlags,
+    ) -> Result<&mut Self, QueryError> {
+        self.validate_begin_query(&query_pool, query, flags)?;
+
+        Ok(self.begin_query_unchecked(query_pool, query, flags))
+    }
+
+    fn validate_begin_query(
+        &self,
+        query_pool: &QueryPool,
+        query: u32,
+        flags: QueryControlFlags,
+    ) -> Result<(), QueryError> {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBeginQuery-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(QueryError::NotSupportedByQueueFamily);
+        }
+
+        let device = self.device();
+
+        // VUID-vkCmdBeginQuery-flags-parameter
+        flags.validate_device(device)?;
+
+        // VUID-vkCmdBeginQuery-commonparent
+        assert_eq!(device, query_pool.device());
+
+        // VUID-vkCmdBeginQuery-query-00802
+        query_pool.query(query).ok_or(QueryError::OutOfRange)?;
+
+        match query_pool.query_type() {
+            QueryType::Occlusion => {
+                // VUID-vkCmdBeginQuery-commandBuffer-cmdpool
+                // // VUID-vkCmdBeginQuery-queryType-00803
+                if !queue_family_properties
+                    .queue_flags
+                    .intersects(QueueFlags::GRAPHICS)
+                {
+                    return Err(QueryError::NotSupportedByQueueFamily);
+                }
+
+                // VUID-vkCmdBeginQuery-queryType-00800
+                if flags.intersects(QueryControlFlags::PRECISE)
+                    && !device.enabled_features().occlusion_query_precise
+                {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`flags` contains `QueryControlFlags::PRECISE`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["occlusion_query_precise"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            QueryType::PipelineStatistics(statistic_flags) => {
+                // VUID-vkCmdBeginQuery-commandBuffer-cmdpool
+                // VUID-vkCmdBeginQuery-queryType-00804
+                // VUID-vkCmdBeginQuery-queryType-00805
+                if statistic_flags.is_compute()
+                    && !queue_family_properties
+                        .queue_flags
+                        .intersects(QueueFlags::COMPUTE)
+                    || statistic_flags.is_graphics()
+                        && !queue_family_properties
+                            .queue_flags
+                            .intersects(QueueFlags::GRAPHICS)
+                {
+                    return Err(QueryError::NotSupportedByQueueFamily);
+                }
+
+                // VUID-vkCmdBeginQuery-queryType-00800
+                if flags.intersects(QueryControlFlags::PRECISE) {
+                    return Err(QueryError::InvalidFlags);
+                }
+            }
+            // VUID-vkCmdBeginQuery-queryType-02804
+            QueryType::Timestamp => return Err(QueryError::NotPermitted),
+        }
+
+        // VUID-vkCmdBeginQuery-queryPool-01922
+        if self
+            .current_state
+            .queries
+            .contains_key(&query_pool.query_type().into())
+        {
+            return Err(QueryError::QueryIsActive);
+        }
+
+        if let Some(render_pass_state) = &self.current_state.render_pass {
+            // VUID-vkCmdBeginQuery-query-00808
+            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
+                return Err(QueryError::OutOfRangeMultiview);
+            }
+        }
+
+        // VUID-vkCmdBeginQuery-None-00807
+        // Not checked, therefore unsafe.
+        // TODO: add check.
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn begin_query_unchecked(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        query: u32,
+        flags: QueryControlFlags,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_begin_query)(self.handle(), query_pool.handle(), query, flags.into());
+
+        let ty = query_pool.query_type();
+        self.current_state.queries.insert(
+            ty.into(),
+            QueryState {
+                query_pool: query_pool.handle(),
+                query,
+                ty,
+                flags,
+                in_subpass: self.current_state.render_pass.is_some(),
+            },
+        );
+
+        self.resources.push(Box::new(query_pool));
+
+        self
+    }
+
+    /// Ends an active query.
+    #[inline]
+    pub fn end_query(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        query: u32,
+    ) -> Result<&mut Self, QueryError> {
+        self.validate_end_query(&query_pool, query)?;
+
+        unsafe { Ok(self.end_query_unchecked(query_pool, query)) }
+    }
+
+    fn validate_end_query(&self, query_pool: &QueryPool, query: u32) -> Result<(), QueryError> {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdEndQuery-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(QueryError::NotSupportedByQueueFamily);
+        }
+
+        let device = self.device();
+
+        // VUID-vkCmdEndQuery-commonparent
+        assert_eq!(device, query_pool.device());
+
+        // VUID-vkCmdEndQuery-None-01923
+        if !self
+            .current_state
+            .queries
+            .get(&query_pool.query_type().into())
+            .map_or(false, |state| {
+                state.query_pool == query_pool.handle() && state.query == query
+            })
+        {
+            return Err(QueryError::QueryNotActive);
+        }
+
+        // VUID-vkCmdEndQuery-query-00810
+        query_pool.query(query).ok_or(QueryError::OutOfRange)?;
+
+        if let Some(render_pass_state) = &self.current_state.render_pass {
+            // VUID-vkCmdEndQuery-query-00812
+            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
+                return Err(QueryError::OutOfRangeMultiview);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn end_query_unchecked(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        query: u32,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_end_query)(self.handle(), query_pool.handle(), query);
+
+        self.current_state
+            .queries
+            .remove(&query_pool.query_type().into());
+
+        self.resources.push(Box::new(query_pool));
+
+        self
+    }
+
+    /// Writes a timestamp to a timestamp query.
+    ///
+    /// # Safety
+    ///
+    /// - The query must be unavailable, ensured by calling [`reset_query_pool`].
+    ///
+    /// [`reset_query_pool`]: Self::reset_query_pool
+    pub unsafe fn write_timestamp(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        query: u32,
+        stage: PipelineStage,
+    ) -> Result<&mut Self, QueryError> {
+        self.validate_write_timestamp(&query_pool, query, stage)?;
+
+        Ok(self.write_timestamp_unchecked(query_pool, query, stage))
+    }
+
+    fn validate_write_timestamp(
+        &self,
+        query_pool: &QueryPool,
+        query: u32,
+        stage: PipelineStage,
+    ) -> Result<(), QueryError> {
+        let device = self.device();
+
+        if !device.enabled_features().synchronization2 && PipelineStages::from(stage).is_2() {
+            return Err(QueryError::RequirementNotMet {
+                required_for: "`stage` has flags set from `VkPipelineStageFlagBits2`",
+                requires_one_of: RequiresOneOf {
+                    features: &["synchronization2"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdWriteTimestamp2-stage-parameter
+        stage.validate_device(device)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdWriteTimestamp2-commandBuffer-cmdpool
+        if !queue_family_properties.queue_flags.intersects(
+            QueueFlags::TRANSFER
+                | QueueFlags::GRAPHICS
+                | QueueFlags::COMPUTE
+                | QueueFlags::VIDEO_DECODE
+                | QueueFlags::VIDEO_ENCODE,
+        ) {
+            return Err(QueryError::NotSupportedByQueueFamily);
+        }
+
+        let device = self.device();
+
+        // VUID-vkCmdWriteTimestamp2-commonparent
+        assert_eq!(device, query_pool.device());
+
+        // VUID-vkCmdWriteTimestamp2-stage-03860
+        if !PipelineStages::from(queue_family_properties.queue_flags).contains_enum(stage) {
+            return Err(QueryError::StageNotSupported);
+        }
+
+        match stage {
+            PipelineStage::GeometryShader => {
+                // VUID-vkCmdWriteTimestamp2-stage-03929
+                if !device.enabled_features().geometry_shader {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::GeometryShader`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["geometry_shadere"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::TessellationControlShader
+            | PipelineStage::TessellationEvaluationShader => {
+                // VUID-vkCmdWriteTimestamp2-stage-03930
+                if !device.enabled_features().tessellation_shader {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::TessellationControlShader` or \
+                            `PipelineStage::TessellationEvaluationShader`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["tessellation_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::ConditionalRendering => {
+                // VUID-vkCmdWriteTimestamp2-stage-03931
+                if !device.enabled_features().conditional_rendering {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::ConditionalRendering`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["conditional_rendering"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::FragmentDensityProcess => {
+                // VUID-vkCmdWriteTimestamp2-stage-03932
+                if !device.enabled_features().fragment_density_map {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::FragmentDensityProcess`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["fragment_density_map"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::TransformFeedback => {
+                // VUID-vkCmdWriteTimestamp2-stage-03933
+                if !device.enabled_features().transform_feedback {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::TransformFeedback`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["transform_feedback"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::MeshShader => {
+                // VUID-vkCmdWriteTimestamp2-stage-03934
+                if !device.enabled_features().mesh_shader {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::MeshShader`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["mesh_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::TaskShader => {
+                // VUID-vkCmdWriteTimestamp2-stage-03935
+                if !device.enabled_features().task_shader {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::TaskShader`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["task_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::FragmentShadingRateAttachment => {
+                // VUID-vkCmdWriteTimestamp2-shadingRateImage-07316
+                if !(device.enabled_features().attachment_fragment_shading_rate
+                    || device.enabled_features().shading_rate_image)
+                {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::FragmentShadingRateAttachment`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["attachment_fragment_shading_rate", "shading_rate_image"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::SubpassShading => {
+                // VUID-vkCmdWriteTimestamp2-stage-04957
+                if !device.enabled_features().subpass_shading {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::SubpassShading`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["subpass_shading"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            PipelineStage::InvocationMask => {
+                // VUID-vkCmdWriteTimestamp2-stage-04995
+                if !device.enabled_features().invocation_mask {
+                    return Err(QueryError::RequirementNotMet {
+                        required_for: "`stage` is `PipelineStage::InvocationMask`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["invocation_mask"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            }
+            _ => (),
+        }
+
+        // VUID-vkCmdWriteTimestamp2-queryPool-03861
+        if !matches!(query_pool.query_type(), QueryType::Timestamp) {
+            return Err(QueryError::NotPermitted);
+        }
+
+        // VUID-vkCmdWriteTimestamp2-timestampValidBits-03863
+        if queue_family_properties.timestamp_valid_bits.is_none() {
+            return Err(QueryError::NoTimestampValidBits);
+        }
+
+        // VUID-vkCmdWriteTimestamp2-query-04903
+        query_pool.query(query).ok_or(QueryError::OutOfRange)?;
+
+        if let Some(render_pass_state) = &self.current_state.render_pass {
+            // VUID-vkCmdWriteTimestamp2-query-03865
+            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
+                return Err(QueryError::OutOfRangeMultiview);
+            }
+        }
+
+        // VUID-vkCmdWriteTimestamp2-queryPool-03862
+        // VUID-vkCmdWriteTimestamp2-None-03864
+        // Not checked, therefore unsafe.
+        // TODO: add check.
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn write_timestamp_unchecked(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        query: u32,
+        stage: PipelineStage,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().enabled_features().synchronization2 {
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_write_timestamp2)(
+                    self.handle(),
+                    stage.into(),
+                    query_pool.handle(),
+                    query,
+                );
+            } else {
+                debug_assert!(self.device().enabled_extensions().khr_synchronization2);
+                (fns.khr_synchronization2.cmd_write_timestamp2_khr)(
+                    self.handle(),
+                    stage.into(),
+                    query_pool.handle(),
+                    query,
+                );
+            }
+        } else {
+            (fns.v1_0.cmd_write_timestamp)(self.handle(), stage.into(), query_pool.handle(), query);
+        }
+
+        self.resources.push(Box::new(query_pool));
+
+        self
+    }
+
+    /// Copies the results of a range of queries to a buffer on the GPU.
+    ///
+    /// [`query_pool.ty().result_len()`] elements will be written for each query in the range, plus
+    /// 1 extra element per query if [`QueryResultFlags::WITH_AVAILABILITY`] is enabled.
+    /// The provided buffer must be large enough to hold the data.
+    ///
+    /// See also [`get_results`].
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers
+    ///   that are accessed by the command.
+    ///
+    /// [`query_pool.ty().result_len()`]: crate::query::QueryType::result_len
+    /// [`QueryResultFlags::WITH_AVAILABILITY`]: crate::query::QueryResultFlags::WITH_AVAILABILITY
+    /// [`get_results`]: crate::query::QueriesRange::get_results
+    pub unsafe fn copy_query_pool_results<D, T>(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        queries: Range<u32>,
+        destination: Arc<D>,
+        flags: QueryResultFlags,
+    ) -> Result<&mut Self, QueryError>
+    where
+        D: TypedBufferAccess<Content = [T]> + 'static,
+        T: QueryResultElement,
+    {
+        self.validate_copy_query_pool_results(
+            &query_pool,
+            queries.clone(),
+            destination.as_ref(),
+            flags,
+        )?;
+
+        unsafe {
+            let per_query_len = query_pool.query_type().result_len()
+                + flags.intersects(QueryResultFlags::WITH_AVAILABILITY) as DeviceSize;
+            let stride = per_query_len * std::mem::size_of::<T>() as DeviceSize;
+            Ok(self.copy_query_pool_results_unchecked(
+                query_pool,
+                queries,
+                destination,
+                stride,
+                flags,
+            ))
+        }
+    }
+
+    fn validate_copy_query_pool_results<D, T>(
+        &self,
+        query_pool: &QueryPool,
+        queries: Range<u32>,
+        destination: &D,
+        flags: QueryResultFlags,
+    ) -> Result<(), QueryError>
+    where
+        D: ?Sized + TypedBufferAccess<Content = [T]>,
+        T: QueryResultElement,
+    {
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdCopyQueryPoolResults-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(QueryError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdCopyQueryPoolResults-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(QueryError::ForbiddenInsideRenderPass);
+        }
+
+        let device = self.device();
+        let buffer_inner = destination.inner();
+
+        // VUID-vkCmdCopyQueryPoolResults-commonparent
+        assert_eq!(device, buffer_inner.buffer.device());
+        assert_eq!(device, query_pool.device());
+
+        assert!(destination.len() > 0);
+
+        // VUID-vkCmdCopyQueryPoolResults-flags-00822
+        // VUID-vkCmdCopyQueryPoolResults-flags-00823
+        debug_assert!(buffer_inner.offset % std::mem::size_of::<T>() as DeviceSize == 0);
+
+        // VUID-vkCmdCopyQueryPoolResults-firstQuery-00820
+        // VUID-vkCmdCopyQueryPoolResults-firstQuery-00821
+        query_pool
+            .queries_range(queries.clone())
+            .ok_or(QueryError::OutOfRange)?;
+
+        let count = queries.end - queries.start;
+        let per_query_len = query_pool.query_type().result_len()
+            + flags.intersects(QueryResultFlags::WITH_AVAILABILITY) as DeviceSize;
+        let required_len = per_query_len * count as DeviceSize;
+
+        // VUID-vkCmdCopyQueryPoolResults-dstBuffer-00824
+        if destination.len() < required_len {
+            return Err(QueryError::BufferTooSmall {
+                required_len,
+                actual_len: destination.len(),
+            });
+        }
+
+        // VUID-vkCmdCopyQueryPoolResults-dstBuffer-00825
+        if !buffer_inner
+            .buffer
+            .usage()
+            .intersects(BufferUsage::TRANSFER_DST)
+        {
+            return Err(QueryError::DestinationMissingUsage);
+        }
+
+        // VUID-vkCmdCopyQueryPoolResults-queryType-00827
+        if matches!(query_pool.query_type(), QueryType::Timestamp)
+            && flags.intersects(QueryResultFlags::PARTIAL)
+        {
+            return Err(QueryError::InvalidFlags);
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn copy_query_pool_results_unchecked<D, T>(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        queries: Range<u32>,
+        destination: Arc<D>,
+        stride: DeviceSize,
+        flags: QueryResultFlags,
+    ) -> &mut Self
+    where
+        D: TypedBufferAccess<Content = [T]> + 'static,
+        T: QueryResultElement,
+    {
+        let destination_inner = destination.inner();
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_copy_query_pool_results)(
+            self.handle(),
+            query_pool.handle(),
+            queries.start,
+            queries.end - queries.start,
+            destination_inner.buffer.handle(),
+            destination_inner.offset,
+            stride,
+            ash::vk::QueryResultFlags::from(flags) | T::FLAG,
+        );
+
+        self.resources.push(Box::new(query_pool));
+        self.resources.push(Box::new(destination));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Resets a range of queries on a query pool.
+    ///
+    /// The affected queries will be marked as "unavailable" after this command runs, and will no
+    /// longer return any results. They will be ready to have new results recorded for them.
+    ///
+    /// # Safety
+    /// The queries in the specified range must not be active in another command buffer.
+    // TODO: Do other command buffers actually matter here? Not sure on the Vulkan spec.
+    pub unsafe fn reset_query_pool(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        queries: Range<u32>,
+    ) -> Result<&mut Self, QueryError> {
+        self.validate_reset_query_pool(&query_pool, queries.clone())?;
+
+        Ok(self.reset_query_pool_unchecked(query_pool, queries))
+    }
+
+    fn validate_reset_query_pool(
+        &self,
+        query_pool: &QueryPool,
+        queries: Range<u32>,
+    ) -> Result<(), QueryError> {
+        // VUID-vkCmdResetQueryPool-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(QueryError::ForbiddenInsideRenderPass);
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdResetQueryPool-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(QueryError::NotSupportedByQueueFamily);
+        }
+
+        let device = self.device();
+
+        // VUID-vkCmdResetQueryPool-commonparent
+        assert_eq!(device, query_pool.device());
+
+        // VUID-vkCmdResetQueryPool-firstQuery-00796
+        // VUID-vkCmdResetQueryPool-firstQuery-00797
+        query_pool
+            .queries_range(queries.clone())
+            .ok_or(QueryError::OutOfRange)?;
+
+        // VUID-vkCmdResetQueryPool-None-02841
+        if self
+            .current_state
+            .queries
+            .values()
+            .any(|state| state.query_pool == query_pool.handle() && queries.contains(&state.query))
+        {
+            return Err(QueryError::QueryIsActive);
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn reset_query_pool_unchecked(
+        &mut self,
+        query_pool: Arc<QueryPool>,
+        queries: Range<u32>,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_reset_query_pool)(
+            self.handle(),
+            query_pool.handle(),
+            queries.start,
+            queries.end - queries.start,
+        );
+
+        self.resources.push(Box::new(query_pool));
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/render_pass.rs
+++ b/vulkano/src/command_buffer/standard/builder/render_pass.rs
@@ -1,0 +1,1834 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{
+    BeginRenderPassState, BeginRenderingAttachments, BeginRenderingState, ClearAttachment,
+    ClearRect, CommandBufferBuilder, RenderPassBeginInfo, RenderPassError, RenderPassState,
+    RenderPassStateType, RenderingAttachmentInfo, RenderingAttachmentResolveInfo, RenderingInfo,
+};
+use crate::{
+    command_buffer::{allocator::CommandBufferAllocator, PrimaryCommandBuffer, SubpassContents},
+    device::{DeviceOwned, QueueFlags},
+    format::{ClearColorValue, ClearValue, NumericType},
+    image::{ImageAspects, ImageLayout, ImageUsage, SampleCount},
+    render_pass::{AttachmentDescription, LoadOp, ResolveMode, SubpassDescription},
+    RequiresOneOf, Version, VulkanObject,
+};
+use smallvec::SmallVec;
+use std::cmp::min;
+
+impl<A> CommandBufferBuilder<PrimaryCommandBuffer<A::Alloc>, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Begins a render pass using a render pass object and framebuffer.
+    ///
+    /// You must call this or `begin_rendering` before you can record draw commands.
+    ///
+    /// `contents` specifies what kinds of commands will be recorded in the render pass, either
+    /// draw commands or executions of secondary command buffers.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn begin_render_pass(
+        &mut self,
+        render_pass_begin_info: RenderPassBeginInfo,
+        contents: SubpassContents,
+    ) -> Result<&mut Self, RenderPassError> {
+        self.validate_begin_render_pass(&render_pass_begin_info, contents)?;
+
+        unsafe { Ok(self.begin_render_pass_unchecked(render_pass_begin_info, contents)) }
+    }
+
+    fn validate_begin_render_pass(
+        &self,
+        render_pass_begin_info: &RenderPassBeginInfo,
+        contents: SubpassContents,
+    ) -> Result<(), RenderPassError> {
+        let device = self.device();
+
+        // VUID-VkSubpassBeginInfo-contents-parameter
+        contents.validate_device(device)?;
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBeginRenderPass2-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(RenderPassError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdBeginRenderPass2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(RenderPassError::ForbiddenInsideRenderPass);
+        }
+
+        let RenderPassBeginInfo {
+            render_pass,
+            framebuffer,
+            render_area_offset,
+            render_area_extent,
+            clear_values,
+            _ne: _,
+        } = render_pass_begin_info;
+
+        // VUID-VkRenderPassBeginInfo-commonparent
+        // VUID-vkCmdBeginRenderPass2-framebuffer-02779
+        assert_eq!(device, framebuffer.device());
+
+        // VUID-VkRenderPassBeginInfo-renderPass-00904
+        if !render_pass.is_compatible_with(framebuffer.render_pass()) {
+            return Err(RenderPassError::FramebufferNotCompatible);
+        }
+
+        for i in 0..2 {
+            // VUID-VkRenderPassBeginInfo-pNext-02852
+            // VUID-VkRenderPassBeginInfo-pNext-02853
+            if render_area_offset[i] + render_area_extent[i] > framebuffer.extent()[i] {
+                return Err(RenderPassError::RenderAreaOutOfBounds);
+            }
+        }
+
+        for (attachment_index, (attachment_desc, image_view)) in render_pass
+            .attachments()
+            .iter()
+            .zip(framebuffer.attachments())
+            .enumerate()
+        {
+            let attachment_index = attachment_index as u32;
+            let &AttachmentDescription {
+                initial_layout,
+                final_layout,
+                ..
+            } = attachment_desc;
+
+            for layout in [initial_layout, final_layout] {
+                match layout {
+                    ImageLayout::ColorAttachmentOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03094
+                        if !image_view.usage().intersects(ImageUsage::COLOR_ATTACHMENT) {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index,
+                                usage: "color_attachment",
+                            });
+                        }
+                    }
+                    ImageLayout::DepthReadOnlyStencilAttachmentOptimal
+                    | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+                    | ImageLayout::DepthStencilAttachmentOptimal
+                    | ImageLayout::DepthStencilReadOnlyOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03096
+                        if !image_view
+                            .usage()
+                            .intersects(ImageUsage::DEPTH_STENCIL_ATTACHMENT)
+                        {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index,
+                                usage: "depth_stencil_attachment",
+                            });
+                        }
+                    }
+                    ImageLayout::ShaderReadOnlyOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03097
+                        if !image_view
+                            .usage()
+                            .intersects(ImageUsage::SAMPLED | ImageUsage::INPUT_ATTACHMENT)
+                        {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index,
+                                usage: "sampled or input_attachment",
+                            });
+                        }
+                    }
+                    ImageLayout::TransferSrcOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03098
+                        if !image_view.usage().intersects(ImageUsage::TRANSFER_SRC) {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index,
+                                usage: "transfer_src",
+                            });
+                        }
+                    }
+                    ImageLayout::TransferDstOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03099
+                        if !image_view.usage().intersects(ImageUsage::TRANSFER_DST) {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index,
+                                usage: "transfer_dst",
+                            });
+                        }
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        for subpass_desc in render_pass.subpasses() {
+            let SubpassDescription {
+                view_mask: _,
+                input_attachments,
+                color_attachments,
+                resolve_attachments,
+                depth_stencil_attachment,
+                preserve_attachments: _,
+                _ne: _,
+            } = subpass_desc;
+
+            for atch_ref in (input_attachments.iter())
+                .chain(color_attachments)
+                .chain(resolve_attachments)
+                .chain([depth_stencil_attachment])
+                .flatten()
+            {
+                let image_view = &framebuffer.attachments()[atch_ref.attachment as usize];
+
+                match atch_ref.layout {
+                    ImageLayout::ColorAttachmentOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03094
+                        if !image_view.usage().intersects(ImageUsage::COLOR_ATTACHMENT) {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index: atch_ref.attachment,
+                                usage: "color_attachment",
+                            });
+                        }
+                    }
+                    ImageLayout::DepthReadOnlyStencilAttachmentOptimal
+                    | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+                    | ImageLayout::DepthStencilAttachmentOptimal
+                    | ImageLayout::DepthStencilReadOnlyOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03096
+                        if !image_view
+                            .usage()
+                            .intersects(ImageUsage::DEPTH_STENCIL_ATTACHMENT)
+                        {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index: atch_ref.attachment,
+                                usage: "depth_stencil_attachment",
+                            });
+                        }
+                    }
+                    ImageLayout::ShaderReadOnlyOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03097
+                        if !image_view
+                            .usage()
+                            .intersects(ImageUsage::SAMPLED | ImageUsage::INPUT_ATTACHMENT)
+                        {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index: atch_ref.attachment,
+                                usage: "sampled or input_attachment",
+                            });
+                        }
+                    }
+                    ImageLayout::TransferSrcOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03098
+                        if !image_view.usage().intersects(ImageUsage::TRANSFER_SRC) {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index: atch_ref.attachment,
+                                usage: "transfer_src",
+                            });
+                        }
+                    }
+                    ImageLayout::TransferDstOptimal => {
+                        // VUID-vkCmdBeginRenderPass2-initialLayout-03099
+                        if !image_view.usage().intersects(ImageUsage::TRANSFER_DST) {
+                            return Err(RenderPassError::AttachmentImageMissingUsage {
+                                attachment_index: atch_ref.attachment,
+                                usage: "transfer_dst",
+                            });
+                        }
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        // VUID-VkRenderPassBeginInfo-clearValueCount-00902
+        if clear_values.len() < render_pass.attachments().len() {
+            return Err(RenderPassError::ClearValueMissing {
+                attachment_index: clear_values.len() as u32,
+            });
+        }
+
+        // VUID-VkRenderPassBeginInfo-clearValueCount-04962
+        for (attachment_index, (attachment_desc, &clear_value)) in render_pass
+            .attachments()
+            .iter()
+            .zip(clear_values)
+            .enumerate()
+        {
+            let attachment_index = attachment_index as u32;
+            let attachment_format = attachment_desc.format.unwrap();
+
+            if attachment_desc.load_op == LoadOp::Clear
+                || attachment_desc.stencil_load_op == LoadOp::Clear
+            {
+                let clear_value = match clear_value {
+                    Some(x) => x,
+                    None => return Err(RenderPassError::ClearValueMissing { attachment_index }),
+                };
+
+                if let (Some(numeric_type), LoadOp::Clear) =
+                    (attachment_format.type_color(), attachment_desc.load_op)
+                {
+                    match numeric_type {
+                        NumericType::SFLOAT
+                        | NumericType::UFLOAT
+                        | NumericType::SNORM
+                        | NumericType::UNORM
+                        | NumericType::SSCALED
+                        | NumericType::USCALED
+                        | NumericType::SRGB => {
+                            if !matches!(clear_value, ClearValue::Float(_)) {
+                                return Err(RenderPassError::ClearValueNotCompatible {
+                                    clear_value,
+                                    attachment_index,
+                                    attachment_format,
+                                });
+                            }
+                        }
+                        NumericType::SINT => {
+                            if !matches!(clear_value, ClearValue::Int(_)) {
+                                return Err(RenderPassError::ClearValueNotCompatible {
+                                    clear_value,
+                                    attachment_index,
+                                    attachment_format,
+                                });
+                            }
+                        }
+                        NumericType::UINT => {
+                            if !matches!(clear_value, ClearValue::Uint(_)) {
+                                return Err(RenderPassError::ClearValueNotCompatible {
+                                    clear_value,
+                                    attachment_index,
+                                    attachment_format,
+                                });
+                            }
+                        }
+                    }
+                } else {
+                    let attachment_aspects = attachment_format.aspects();
+                    let need_depth = attachment_aspects.intersects(ImageAspects::DEPTH)
+                        && attachment_desc.load_op == LoadOp::Clear;
+                    let need_stencil = attachment_aspects.intersects(ImageAspects::STENCIL)
+                        && attachment_desc.stencil_load_op == LoadOp::Clear;
+
+                    if need_depth && need_stencil {
+                        if !matches!(clear_value, ClearValue::DepthStencil(_)) {
+                            return Err(RenderPassError::ClearValueNotCompatible {
+                                clear_value,
+                                attachment_index,
+                                attachment_format,
+                            });
+                        }
+                    } else if need_depth {
+                        if !matches!(clear_value, ClearValue::Depth(_)) {
+                            return Err(RenderPassError::ClearValueNotCompatible {
+                                clear_value,
+                                attachment_index,
+                                attachment_format,
+                            });
+                        }
+                    } else if need_stencil {
+                        if !matches!(clear_value, ClearValue::Stencil(_)) {
+                            return Err(RenderPassError::ClearValueNotCompatible {
+                                clear_value,
+                                attachment_index,
+                                attachment_format,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // VUID-vkCmdBeginRenderPass2-initialLayout-03100
+        // TODO:
+
+        // VUID-vkCmdBeginRenderPass2-srcStageMask-06453
+        // TODO:
+
+        // VUID-vkCmdBeginRenderPass2-dstStageMask-06454
+        // TODO:
+
+        // VUID-vkCmdBeginRenderPass2-framebuffer-02533
+        // For any attachment in framebuffer that is used by renderPass and is bound to memory locations that are also bound to another attachment used by renderPass, and if at least one of those uses causes either
+        // attachment to be written to, both attachments must have had the VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT set
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn begin_render_pass_unchecked(
+        &mut self,
+        render_pass_begin_info: RenderPassBeginInfo,
+        contents: SubpassContents,
+    ) -> &mut Self {
+        let RenderPassBeginInfo {
+            render_pass,
+            framebuffer,
+            render_area_offset,
+            render_area_extent,
+            clear_values,
+            _ne: _,
+        } = render_pass_begin_info;
+
+        let clear_values_vk: SmallVec<[_; 4]> = clear_values
+            .iter()
+            .copied()
+            .map(|clear_value| clear_value.map(Into::into).unwrap_or_default())
+            .collect();
+
+        let render_pass_begin_info = ash::vk::RenderPassBeginInfo {
+            render_pass: render_pass.handle(),
+            framebuffer: framebuffer.handle(),
+            render_area: ash::vk::Rect2D {
+                offset: ash::vk::Offset2D {
+                    x: render_area_offset[0] as i32,
+                    y: render_area_offset[1] as i32,
+                },
+                extent: ash::vk::Extent2D {
+                    width: render_area_extent[0],
+                    height: render_area_extent[1],
+                },
+            },
+            clear_value_count: clear_values_vk.len() as u32,
+            p_clear_values: clear_values_vk.as_ptr(),
+            ..Default::default()
+        };
+
+        let subpass_begin_info = ash::vk::SubpassBeginInfo {
+            contents: contents.into(),
+            ..Default::default()
+        };
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_2
+            || self.device().enabled_extensions().khr_create_renderpass2
+        {
+            if self.device().api_version() >= Version::V1_2 {
+                (fns.v1_2.cmd_begin_render_pass2)(
+                    self.handle(),
+                    &render_pass_begin_info,
+                    &subpass_begin_info,
+                );
+            } else {
+                (fns.khr_create_renderpass2.cmd_begin_render_pass2_khr)(
+                    self.handle(),
+                    &render_pass_begin_info,
+                    &subpass_begin_info,
+                );
+            }
+        } else {
+            debug_assert!(subpass_begin_info.p_next.is_null());
+
+            (fns.v1_0.cmd_begin_render_pass)(
+                self.handle(),
+                &render_pass_begin_info,
+                subpass_begin_info.contents,
+            );
+        }
+
+        let subpass = render_pass.clone().first_subpass();
+        let view_mask = subpass.subpass_desc().view_mask;
+
+        self.current_state.render_pass = Some(RenderPassState {
+            contents,
+            render_area_offset,
+            render_area_extent,
+            render_pass: BeginRenderPassState {
+                subpass,
+                framebuffer: Some(framebuffer.clone()),
+            }
+            .into(),
+            view_mask,
+        });
+
+        self.resources.push(Box::new(render_pass));
+        self.resources.push(Box::new(framebuffer));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Advances to the next subpass of the render pass previously begun with `begin_render_pass`.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn next_subpass(
+        &mut self,
+        contents: SubpassContents,
+    ) -> Result<&mut Self, RenderPassError> {
+        self.validate_next_subpass(contents)?;
+
+        unsafe { Ok(self.next_subpass_unchecked(contents)) }
+    }
+
+    fn validate_next_subpass(&self, contents: SubpassContents) -> Result<(), RenderPassError> {
+        let device = self.device();
+
+        // VUID-VkSubpassBeginInfo-contents-parameter
+        contents.validate_device(device)?;
+
+        // VUID-vkCmdNextSubpass2-renderpass
+        let render_pass_state = self
+            .current_state
+            .render_pass
+            .as_ref()
+            .ok_or(RenderPassError::ForbiddenOutsideRenderPass)?;
+
+        let begin_render_pass_state = match &render_pass_state.render_pass {
+            RenderPassStateType::BeginRenderPass(state) => state,
+            RenderPassStateType::BeginRendering(_) => {
+                return Err(RenderPassError::ForbiddenWithBeginRendering)
+            }
+        };
+
+        // VUID-vkCmdNextSubpass2-None-03102
+        if begin_render_pass_state.subpass.is_last_subpass() {
+            return Err(RenderPassError::NoSubpassesRemaining {
+                current_subpass: begin_render_pass_state.subpass.index(),
+            });
+        }
+
+        // VUID?
+        if self
+            .current_state
+            .queries
+            .values()
+            .any(|state| state.in_subpass)
+        {
+            return Err(RenderPassError::QueryIsActive);
+        }
+
+        // VUID-vkCmdNextSubpass2-commandBuffer-cmdpool
+        debug_assert!(self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS));
+
+        // VUID-vkCmdNextSubpass2-bufferlevel
+        // Ensured by the type of the impl block
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn next_subpass_unchecked(&mut self, contents: SubpassContents) -> &mut Self {
+        let subpass_begin_info = ash::vk::SubpassBeginInfo {
+            contents: contents.into(),
+            ..Default::default()
+        };
+
+        let subpass_end_info = ash::vk::SubpassEndInfo::default();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_2
+            || self.device().enabled_extensions().khr_create_renderpass2
+        {
+            if self.device().api_version() >= Version::V1_2 {
+                (fns.v1_2.cmd_next_subpass2)(self.handle(), &subpass_begin_info, &subpass_end_info);
+            } else {
+                (fns.khr_create_renderpass2.cmd_next_subpass2_khr)(
+                    self.handle(),
+                    &subpass_begin_info,
+                    &subpass_end_info,
+                );
+            }
+        } else {
+            (fns.v1_0.cmd_next_subpass)(self.handle(), subpass_begin_info.contents);
+        }
+
+        let render_pass_state = self.current_state.render_pass.as_mut().unwrap();
+        let begin_render_pass_state = match &mut render_pass_state.render_pass {
+            RenderPassStateType::BeginRenderPass(x) => x,
+            _ => unreachable!(),
+        };
+
+        begin_render_pass_state.subpass.next_subpass();
+        render_pass_state.contents = contents;
+        render_pass_state.view_mask = begin_render_pass_state.subpass.subpass_desc().view_mask;
+
+        if render_pass_state.view_mask != 0 {
+            // When multiview is enabled, at the beginning of each subpass, all
+            // non-render pass state is undefined.
+            self.current_state = Default::default();
+        }
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Ends the render pass previously begun with `begin_render_pass`.
+    ///
+    /// This must be called after you went through all the subpasses.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn end_render_pass(&mut self) -> Result<&mut Self, RenderPassError> {
+        self.validate_end_render_pass()?;
+
+        unsafe { Ok(self.end_render_pass_unchecked()) }
+    }
+
+    fn validate_end_render_pass(&self) -> Result<(), RenderPassError> {
+        // VUID-vkCmdEndRenderPass2-renderpass
+        let render_pass_state = self
+            .current_state
+            .render_pass
+            .as_ref()
+            .ok_or(RenderPassError::ForbiddenOutsideRenderPass)?;
+
+        let begin_render_pass_state = match &render_pass_state.render_pass {
+            RenderPassStateType::BeginRenderPass(state) => state,
+            RenderPassStateType::BeginRendering(_) => {
+                return Err(RenderPassError::ForbiddenWithBeginRendering)
+            }
+        };
+
+        // VUID-vkCmdEndRenderPass2-None-03103
+        if !begin_render_pass_state.subpass.is_last_subpass() {
+            return Err(RenderPassError::SubpassesRemaining {
+                current_subpass: begin_render_pass_state.subpass.index(),
+                remaining_subpasses: begin_render_pass_state
+                    .subpass
+                    .render_pass()
+                    .subpasses()
+                    .len() as u32
+                    - begin_render_pass_state.subpass.index(),
+            });
+        }
+
+        // VUID?
+        if self
+            .current_state
+            .queries
+            .values()
+            .any(|state| state.in_subpass)
+        {
+            return Err(RenderPassError::QueryIsActive);
+        }
+
+        // VUID-vkCmdEndRenderPass2-commandBuffer-cmdpool
+        debug_assert!(self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS));
+
+        // VUID-vkCmdEndRenderPass2-bufferlevel
+        // Ensured by the type of the impl block
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn end_render_pass_unchecked(&mut self) -> &mut Self {
+        let subpass_end_info = ash::vk::SubpassEndInfo::default();
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_2
+            || self.device().enabled_extensions().khr_create_renderpass2
+        {
+            if self.device().api_version() >= Version::V1_2 {
+                (fns.v1_2.cmd_end_render_pass2)(self.handle(), &subpass_end_info);
+            } else {
+                (fns.khr_create_renderpass2.cmd_end_render_pass2_khr)(
+                    self.handle(),
+                    &subpass_end_info,
+                );
+            }
+        } else {
+            (fns.v1_0.cmd_end_render_pass)(self.handle());
+        }
+
+        self.current_state.render_pass = None;
+
+        // TODO: sync state update
+
+        self
+    }
+}
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Begins a render pass without a render pass object or framebuffer.
+    ///
+    /// You must call this or `begin_render_pass` before you can record draw commands.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn begin_rendering(
+        &mut self,
+        mut rendering_info: RenderingInfo,
+    ) -> Result<&mut Self, RenderPassError> {
+        rendering_info.set_extent_layers()?;
+        self.validate_begin_rendering(&rendering_info)?;
+
+        unsafe { Ok(self.begin_rendering_unchecked(rendering_info)) }
+    }
+
+    fn validate_begin_rendering(
+        &self,
+        rendering_info: &RenderingInfo,
+    ) -> Result<(), RenderPassError> {
+        let device = self.device();
+        let properties = device.physical_device().properties();
+
+        // VUID-vkCmdBeginRendering-dynamicRendering-06446
+        if !device.enabled_features().dynamic_rendering {
+            return Err(RenderPassError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::begin_rendering`",
+                requires_one_of: RequiresOneOf {
+                    features: &["dynamic_rendering"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdBeginRendering-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS)
+        {
+            return Err(RenderPassError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdBeginRendering-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(RenderPassError::ForbiddenInsideRenderPass);
+        }
+
+        let &RenderingInfo {
+            render_area_offset,
+            render_area_extent,
+            layer_count,
+            view_mask,
+            ref color_attachments,
+            ref depth_attachment,
+            ref stencil_attachment,
+            contents,
+            _ne: _,
+        } = rendering_info;
+
+        // VUID-VkRenderingInfo-flags-parameter
+        contents.validate_device(device)?;
+
+        // VUID-vkCmdBeginRendering-commandBuffer-06068
+        if self.inheritance_info.is_some() && contents == SubpassContents::SecondaryCommandBuffers {
+            return Err(RenderPassError::ContentsForbiddenInSecondaryCommandBuffer);
+        }
+
+        // No VUID, but for sanity it makes sense to treat this the same as in framebuffers.
+        if view_mask != 0 && layer_count != 1 {
+            return Err(RenderPassError::MultiviewLayersInvalid);
+        }
+
+        // VUID-VkRenderingInfo-multiview-06127
+        if view_mask != 0 && !device.enabled_features().multiview {
+            return Err(RenderPassError::RequirementNotMet {
+                required_for: "`rendering_info.viewmask` is not `0`",
+                requires_one_of: RequiresOneOf {
+                    features: &["multiview"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        let view_count = u32::BITS - view_mask.leading_zeros();
+
+        // VUID-VkRenderingInfo-viewMask-06128
+        if view_count > properties.max_multiview_view_count.unwrap_or(0) {
+            return Err(RenderPassError::MaxMultiviewViewCountExceeded {
+                view_count,
+                max: properties.max_multiview_view_count.unwrap_or(0),
+            });
+        }
+
+        let mut samples = None;
+
+        // VUID-VkRenderingInfo-colorAttachmentCount-06106
+        if color_attachments.len() > properties.max_color_attachments as usize {
+            return Err(RenderPassError::MaxColorAttachmentsExceeded {
+                color_attachment_count: color_attachments.len() as u32,
+                max: properties.max_color_attachments,
+            });
+        }
+
+        for (attachment_index, attachment_info) in
+            color_attachments
+                .iter()
+                .enumerate()
+                .filter_map(|(index, attachment_info)| {
+                    attachment_info
+                        .as_ref()
+                        .map(|attachment_info| (index, attachment_info))
+                })
+        {
+            let attachment_index = attachment_index as u32;
+            let RenderingAttachmentInfo {
+                image_view,
+                image_layout,
+                resolve_info,
+                load_op,
+                store_op,
+                clear_value: _,
+                _ne: _,
+            } = attachment_info;
+
+            // VUID-VkRenderingAttachmentInfo-imageLayout-parameter
+            image_layout.validate_device(device)?;
+
+            // VUID-VkRenderingAttachmentInfo-loadOp-parameter
+            load_op.validate_device(device)?;
+
+            // VUID-VkRenderingAttachmentInfo-storeOp-parameter
+            store_op.validate_device(device)?;
+
+            // VUID-VkRenderingInfo-colorAttachmentCount-06087
+            if !image_view.usage().intersects(ImageUsage::COLOR_ATTACHMENT) {
+                return Err(RenderPassError::ColorAttachmentMissingUsage { attachment_index });
+            }
+
+            let image = image_view.image();
+            let image_extent = image.dimensions().width_height_depth();
+
+            for i in 0..2 {
+                // VUID-VkRenderingInfo-pNext-06079
+                // VUID-VkRenderingInfo-pNext-06080
+                if render_area_offset[i] + render_area_extent[i] > image_extent[i] {
+                    return Err(RenderPassError::RenderAreaOutOfBounds);
+                }
+            }
+
+            // VUID-VkRenderingInfo-imageView-06070
+            match samples {
+                Some(samples) if samples == image.samples() => (),
+                Some(_) => {
+                    return Err(RenderPassError::ColorAttachmentSamplesMismatch {
+                        attachment_index,
+                    });
+                }
+                None => samples = Some(image.samples()),
+            }
+
+            // VUID-VkRenderingAttachmentInfo-imageView-06135
+            // VUID-VkRenderingAttachmentInfo-imageView-06145
+            // VUID-VkRenderingInfo-colorAttachmentCount-06090
+            // VUID-VkRenderingInfo-colorAttachmentCount-06096
+            if matches!(
+                image_layout,
+                ImageLayout::Undefined
+                    | ImageLayout::ShaderReadOnlyOptimal
+                    | ImageLayout::TransferSrcOptimal
+                    | ImageLayout::TransferDstOptimal
+                    | ImageLayout::Preinitialized
+                    | ImageLayout::PresentSrc
+                    | ImageLayout::DepthStencilAttachmentOptimal
+                    | ImageLayout::DepthStencilReadOnlyOptimal
+                    | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
+                    | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+            ) {
+                return Err(RenderPassError::ColorAttachmentLayoutInvalid { attachment_index });
+            }
+
+            if let Some(resolve_info) = resolve_info {
+                let &RenderingAttachmentResolveInfo {
+                    mode,
+                    image_view: ref resolve_image_view,
+                    image_layout: resolve_image_layout,
+                } = resolve_info;
+
+                // VUID-VkRenderingAttachmentInfo-resolveImageLayout-parameter
+                resolve_image_layout.validate_device(device)?;
+
+                // VUID-VkRenderingAttachmentInfo-resolveMode-parameter
+                mode.validate_device(device)?;
+
+                let resolve_image = resolve_image_view.image();
+
+                match image_view.format().unwrap().type_color() {
+                    Some(
+                        NumericType::SFLOAT
+                        | NumericType::UFLOAT
+                        | NumericType::SNORM
+                        | NumericType::UNORM
+                        | NumericType::SSCALED
+                        | NumericType::USCALED
+                        | NumericType::SRGB,
+                    ) => {
+                        // VUID-VkRenderingAttachmentInfo-imageView-06129
+                        if mode != ResolveMode::Average {
+                            return Err(RenderPassError::ColorAttachmentResolveModeNotSupported {
+                                attachment_index,
+                            });
+                        }
+                    }
+                    Some(NumericType::SINT | NumericType::UINT) => {
+                        // VUID-VkRenderingAttachmentInfo-imageView-06130
+                        if mode != ResolveMode::SampleZero {
+                            return Err(RenderPassError::ColorAttachmentResolveModeNotSupported {
+                                attachment_index,
+                            });
+                        }
+                    }
+                    None => (),
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06132
+                if image.samples() == SampleCount::Sample1 {
+                    return Err(RenderPassError::ColorAttachmentWithResolveNotMultisampled {
+                        attachment_index,
+                    });
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06133
+                if resolve_image.samples() != SampleCount::Sample1 {
+                    return Err(RenderPassError::ColorAttachmentResolveMultisampled {
+                        attachment_index,
+                    });
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06134
+                if image_view.format() != resolve_image_view.format() {
+                    return Err(RenderPassError::ColorAttachmentResolveFormatMismatch {
+                        attachment_index,
+                    });
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06136
+                // VUID-VkRenderingAttachmentInfo-imageView-06146
+                // VUID-VkRenderingInfo-colorAttachmentCount-06091
+                // VUID-VkRenderingInfo-colorAttachmentCount-06097
+                if matches!(
+                    resolve_image_layout,
+                    ImageLayout::Undefined
+                        | ImageLayout::ShaderReadOnlyOptimal
+                        | ImageLayout::TransferSrcOptimal
+                        | ImageLayout::TransferDstOptimal
+                        | ImageLayout::Preinitialized
+                        | ImageLayout::PresentSrc
+                        | ImageLayout::DepthStencilAttachmentOptimal
+                        | ImageLayout::DepthStencilReadOnlyOptimal
+                        | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
+                        | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+                ) {
+                    return Err(RenderPassError::ColorAttachmentResolveLayoutInvalid {
+                        attachment_index,
+                    });
+                }
+            }
+        }
+
+        if let Some(attachment_info) = depth_attachment {
+            let RenderingAttachmentInfo {
+                image_view,
+                image_layout,
+                resolve_info,
+                load_op,
+                store_op,
+                clear_value: _,
+                _ne: _,
+            } = attachment_info;
+
+            // VUID-VkRenderingAttachmentInfo-imageLayout-parameter
+            image_layout.validate_device(device)?;
+
+            // VUID-VkRenderingAttachmentInfo-loadOp-parameter
+            load_op.validate_device(device)?;
+
+            // VUID-VkRenderingAttachmentInfo-storeOp-parameter
+            store_op.validate_device(device)?;
+
+            let image_aspects = image_view.format().unwrap().aspects();
+
+            // VUID-VkRenderingInfo-pDepthAttachment-06547
+            if !image_aspects.intersects(ImageAspects::DEPTH) {
+                return Err(RenderPassError::DepthAttachmentFormatUsageNotSupported);
+            }
+
+            // VUID-VkRenderingInfo-pDepthAttachment-06088
+            if !image_view
+                .usage()
+                .intersects(ImageUsage::DEPTH_STENCIL_ATTACHMENT)
+            {
+                return Err(RenderPassError::DepthAttachmentMissingUsage);
+            }
+
+            let image = image_view.image();
+            let image_extent = image.dimensions().width_height_depth();
+
+            for i in 0..2 {
+                // VUID-VkRenderingInfo-pNext-06079
+                // VUID-VkRenderingInfo-pNext-06080
+                if render_area_offset[i] + render_area_extent[i] > image_extent[i] {
+                    return Err(RenderPassError::RenderAreaOutOfBounds);
+                }
+            }
+
+            // VUID-VkRenderingInfo-imageView-06070
+            match samples {
+                Some(samples) if samples == image.samples() => (),
+                Some(_) => {
+                    return Err(RenderPassError::DepthAttachmentSamplesMismatch);
+                }
+                None => samples = Some(image.samples()),
+            }
+
+            // VUID-VkRenderingAttachmentInfo-imageView-06135
+            // VUID-VkRenderingAttachmentInfo-imageView-06145
+            // VUID-VkRenderingInfo-pDepthAttachment-06092
+            if matches!(
+                image_layout,
+                ImageLayout::Undefined
+                    | ImageLayout::ShaderReadOnlyOptimal
+                    | ImageLayout::TransferSrcOptimal
+                    | ImageLayout::TransferDstOptimal
+                    | ImageLayout::Preinitialized
+                    | ImageLayout::PresentSrc
+                    | ImageLayout::ColorAttachmentOptimal
+            ) {
+                return Err(RenderPassError::DepthAttachmentLayoutInvalid);
+            }
+
+            if let Some(resolve_info) = resolve_info {
+                let &RenderingAttachmentResolveInfo {
+                    mode,
+                    image_view: ref resolve_image_view,
+                    image_layout: resolve_image_layout,
+                } = resolve_info;
+
+                // VUID-VkRenderingAttachmentInfo-resolveImageLayout-parameter
+                resolve_image_layout.validate_device(device)?;
+
+                // VUID-VkRenderingAttachmentInfo-resolveMode-parameter
+                mode.validate_device(device)?;
+
+                // VUID-VkRenderingInfo-pDepthAttachment-06102
+                if !properties
+                    .supported_depth_resolve_modes
+                    .map_or(false, |modes| modes.contains_enum(mode))
+                {
+                    return Err(RenderPassError::DepthAttachmentResolveModeNotSupported);
+                }
+
+                let resolve_image = resolve_image_view.image();
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06132
+                if image.samples() == SampleCount::Sample1 {
+                    return Err(RenderPassError::DepthAttachmentWithResolveNotMultisampled);
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06133
+                if resolve_image.samples() != SampleCount::Sample1 {
+                    return Err(RenderPassError::DepthAttachmentResolveMultisampled);
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06134
+                if image_view.format() != resolve_image_view.format() {
+                    return Err(RenderPassError::DepthAttachmentResolveFormatMismatch);
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06136
+                // VUID-VkRenderingAttachmentInfo-imageView-06146
+                // VUID-VkRenderingInfo-pDepthAttachment-06093
+                // VUID-VkRenderingInfo-pDepthAttachment-06098
+                if matches!(
+                    resolve_image_layout,
+                    ImageLayout::Undefined
+                        | ImageLayout::DepthStencilReadOnlyOptimal
+                        | ImageLayout::ShaderReadOnlyOptimal
+                        | ImageLayout::TransferSrcOptimal
+                        | ImageLayout::TransferDstOptimal
+                        | ImageLayout::Preinitialized
+                        | ImageLayout::PresentSrc
+                        | ImageLayout::ColorAttachmentOptimal
+                        | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
+                ) {
+                    return Err(RenderPassError::DepthAttachmentResolveLayoutInvalid);
+                }
+            }
+        }
+
+        if let Some(attachment_info) = stencil_attachment {
+            let RenderingAttachmentInfo {
+                image_view,
+                image_layout,
+                resolve_info,
+                load_op,
+                store_op,
+                clear_value: _,
+                _ne: _,
+            } = attachment_info;
+
+            // VUID-VkRenderingAttachmentInfo-imageLayout-parameter
+            image_layout.validate_device(device)?;
+
+            // VUID-VkRenderingAttachmentInfo-loadOp-parameter
+            load_op.validate_device(device)?;
+
+            // VUID-VkRenderingAttachmentInfo-storeOp-parameter
+            store_op.validate_device(device)?;
+
+            let image_aspects = image_view.format().unwrap().aspects();
+
+            // VUID-VkRenderingInfo-pStencilAttachment-06548
+            if !image_aspects.intersects(ImageAspects::STENCIL) {
+                return Err(RenderPassError::StencilAttachmentFormatUsageNotSupported);
+            }
+
+            // VUID-VkRenderingInfo-pStencilAttachment-06089
+            if !image_view
+                .usage()
+                .intersects(ImageUsage::DEPTH_STENCIL_ATTACHMENT)
+            {
+                return Err(RenderPassError::StencilAttachmentMissingUsage);
+            }
+
+            let image = image_view.image();
+            let image_extent = image.dimensions().width_height_depth();
+
+            for i in 0..2 {
+                // VUID-VkRenderingInfo-pNext-06079
+                // VUID-VkRenderingInfo-pNext-06080
+                if render_area_offset[i] + render_area_extent[i] > image_extent[i] {
+                    return Err(RenderPassError::RenderAreaOutOfBounds);
+                }
+            }
+
+            // VUID-VkRenderingInfo-imageView-06070
+            match samples {
+                Some(samples) if samples == image.samples() => (),
+                Some(_) => {
+                    return Err(RenderPassError::StencilAttachmentSamplesMismatch);
+                }
+                None => (),
+            }
+
+            // VUID-VkRenderingAttachmentInfo-imageView-06135
+            // VUID-VkRenderingAttachmentInfo-imageView-06145
+            // VUID-VkRenderingInfo-pStencilAttachment-06094
+            if matches!(
+                image_layout,
+                ImageLayout::Undefined
+                    | ImageLayout::ShaderReadOnlyOptimal
+                    | ImageLayout::TransferSrcOptimal
+                    | ImageLayout::TransferDstOptimal
+                    | ImageLayout::Preinitialized
+                    | ImageLayout::PresentSrc
+                    | ImageLayout::ColorAttachmentOptimal
+            ) {
+                return Err(RenderPassError::StencilAttachmentLayoutInvalid);
+            }
+
+            if let Some(resolve_info) = resolve_info {
+                let &RenderingAttachmentResolveInfo {
+                    mode,
+                    image_view: ref resolve_image_view,
+                    image_layout: resolve_image_layout,
+                } = resolve_info;
+
+                // VUID-VkRenderingAttachmentInfo-resolveImageLayout-parameter
+                resolve_image_layout.validate_device(device)?;
+
+                // VUID-VkRenderingAttachmentInfo-resolveMode-parameter
+                mode.validate_device(device)?;
+
+                // VUID-VkRenderingInfo-pStencilAttachment-06103
+                if !properties
+                    .supported_stencil_resolve_modes
+                    .map_or(false, |modes| modes.contains_enum(mode))
+                {
+                    return Err(RenderPassError::StencilAttachmentResolveModeNotSupported);
+                }
+
+                let resolve_image = resolve_image_view.image();
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06132
+                if image.samples() == SampleCount::Sample1 {
+                    return Err(RenderPassError::StencilAttachmentWithResolveNotMultisampled);
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06133
+                if resolve_image.samples() != SampleCount::Sample1 {
+                    return Err(RenderPassError::StencilAttachmentResolveMultisampled);
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06134
+                if image_view.format() != resolve_image_view.format() {
+                    return Err(RenderPassError::StencilAttachmentResolveFormatMismatch);
+                }
+
+                // VUID-VkRenderingAttachmentInfo-imageView-06136
+                // VUID-VkRenderingAttachmentInfo-imageView-06146
+                // VUID-VkRenderingInfo-pStencilAttachment-06095
+                // VUID-VkRenderingInfo-pStencilAttachment-06099
+                if matches!(
+                    resolve_image_layout,
+                    ImageLayout::Undefined
+                        | ImageLayout::DepthStencilReadOnlyOptimal
+                        | ImageLayout::ShaderReadOnlyOptimal
+                        | ImageLayout::TransferSrcOptimal
+                        | ImageLayout::TransferDstOptimal
+                        | ImageLayout::Preinitialized
+                        | ImageLayout::PresentSrc
+                        | ImageLayout::ColorAttachmentOptimal
+                        | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+                ) {
+                    return Err(RenderPassError::StencilAttachmentResolveLayoutInvalid);
+                }
+            }
+        }
+
+        if let (Some(depth_attachment_info), Some(stencil_attachment_info)) =
+            (depth_attachment, stencil_attachment)
+        {
+            // VUID-VkRenderingInfo-pDepthAttachment-06085
+            if &depth_attachment_info.image_view != &stencil_attachment_info.image_view {
+                return Err(RenderPassError::DepthStencilAttachmentImageViewMismatch);
+            }
+
+            match (
+                &depth_attachment_info.resolve_info,
+                &stencil_attachment_info.resolve_info,
+            ) {
+                (None, None) => (),
+                (None, Some(_)) | (Some(_), None) => {
+                    // VUID-VkRenderingInfo-pDepthAttachment-06104
+                    if !properties.independent_resolve_none.unwrap_or(false) {
+                        return Err(
+                            RenderPassError::DepthStencilAttachmentResolveModesNotSupported,
+                        );
+                    }
+                }
+                (Some(depth_resolve_info), Some(stencil_resolve_info)) => {
+                    // VUID-VkRenderingInfo-pDepthAttachment-06105
+                    if !properties.independent_resolve.unwrap_or(false)
+                        && depth_resolve_info.mode != stencil_resolve_info.mode
+                    {
+                        return Err(
+                            RenderPassError::DepthStencilAttachmentResolveModesNotSupported,
+                        );
+                    }
+
+                    // VUID-VkRenderingInfo-pDepthAttachment-06086
+                    if &depth_resolve_info.image_view != &stencil_resolve_info.image_view {
+                        return Err(
+                            RenderPassError::DepthStencilAttachmentResolveImageViewMismatch,
+                        );
+                    }
+                }
+            }
+        }
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn begin_rendering_unchecked(&mut self, rendering_info: RenderingInfo) -> &mut Self {
+        let RenderingInfo {
+            render_area_offset,
+            render_area_extent,
+            layer_count,
+            view_mask,
+            color_attachments,
+            depth_attachment,
+            stencil_attachment,
+            contents,
+            _ne,
+        } = rendering_info;
+
+        let map_attachment_info = |attachment_info: &Option<_>| {
+            if let Some(attachment_info) = attachment_info {
+                let &RenderingAttachmentInfo {
+                    ref image_view,
+                    image_layout,
+                    resolve_info: ref resolve,
+                    load_op,
+                    store_op,
+                    clear_value,
+                    _ne: _,
+                } = attachment_info;
+
+                let (resolve_mode, resolve_image_view, resolve_image_layout) =
+                    if let Some(resolve) = resolve {
+                        let &RenderingAttachmentResolveInfo {
+                            mode,
+                            ref image_view,
+                            image_layout,
+                        } = resolve;
+
+                        (mode.into(), image_view.handle(), image_layout.into())
+                    } else {
+                        (
+                            ash::vk::ResolveModeFlags::NONE,
+                            Default::default(),
+                            Default::default(),
+                        )
+                    };
+
+                ash::vk::RenderingAttachmentInfo {
+                    image_view: image_view.handle(),
+                    image_layout: image_layout.into(),
+                    resolve_mode,
+                    resolve_image_view,
+                    resolve_image_layout,
+                    load_op: load_op.into(),
+                    store_op: store_op.into(),
+                    clear_value: clear_value.map_or_else(Default::default, Into::into),
+                    ..Default::default()
+                }
+            } else {
+                ash::vk::RenderingAttachmentInfo {
+                    image_view: ash::vk::ImageView::null(),
+                    ..Default::default()
+                }
+            }
+        };
+
+        let color_attachments_vk: SmallVec<[_; 2]> =
+            color_attachments.iter().map(map_attachment_info).collect();
+        let depth_attachment_vk = map_attachment_info(&depth_attachment);
+        let stencil_attachment_vk = map_attachment_info(&stencil_attachment);
+
+        let rendering_info = ash::vk::RenderingInfo {
+            flags: contents.into(),
+            render_area: ash::vk::Rect2D {
+                offset: ash::vk::Offset2D {
+                    x: render_area_offset[0] as i32,
+                    y: render_area_offset[1] as i32,
+                },
+                extent: ash::vk::Extent2D {
+                    width: render_area_extent[0],
+                    height: render_area_extent[1],
+                },
+            },
+            layer_count,
+            view_mask,
+            color_attachment_count: color_attachments_vk.len() as u32,
+            p_color_attachments: color_attachments_vk.as_ptr(),
+            p_depth_attachment: &depth_attachment_vk,
+            p_stencil_attachment: &stencil_attachment_vk,
+            ..Default::default()
+        };
+
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_begin_rendering)(self.handle(), &rendering_info);
+        } else {
+            debug_assert!(self.device().enabled_extensions().khr_dynamic_rendering);
+            (fns.khr_dynamic_rendering.cmd_begin_rendering_khr)(self.handle(), &rendering_info);
+        }
+
+        self.current_state.render_pass = Some(RenderPassState {
+            contents,
+            render_area_offset,
+            render_area_extent,
+            render_pass: BeginRenderingState {
+                attachments: Some(BeginRenderingAttachments {
+                    color_attachments: color_attachments.clone(),
+                    depth_attachment: depth_attachment.clone(),
+                    stencil_attachment: stencil_attachment.clone(),
+                }),
+                color_attachment_formats: color_attachments
+                    .iter()
+                    .map(|a| a.as_ref().map(|a| a.image_view.format().unwrap()))
+                    .collect(),
+                depth_attachment_format: depth_attachment
+                    .as_ref()
+                    .map(|a| a.image_view.format().unwrap()),
+                stencil_attachment_format: stencil_attachment
+                    .as_ref()
+                    .map(|a| a.image_view.format().unwrap()),
+                pipeline_used: false,
+            }
+            .into(),
+            view_mask,
+        });
+
+        for attachment_info in color_attachments.into_iter().flatten() {
+            let RenderingAttachmentInfo {
+                image_view,
+                image_layout: _,
+                resolve_info,
+                load_op: _,
+                store_op: _,
+                clear_value: _,
+                _ne: _,
+            } = attachment_info;
+
+            self.resources.push(Box::new(image_view));
+
+            if let Some(resolve_info) = resolve_info {
+                let RenderingAttachmentResolveInfo {
+                    mode: _,
+                    image_view,
+                    image_layout: _,
+                } = resolve_info;
+
+                self.resources.push(Box::new(image_view));
+            }
+        }
+
+        if let Some(attachment_info) = depth_attachment {
+            let RenderingAttachmentInfo {
+                image_view,
+                image_layout: _,
+                resolve_info,
+                load_op: _,
+                store_op: _,
+                clear_value: _,
+                _ne: _,
+            } = attachment_info;
+
+            self.resources.push(Box::new(image_view));
+
+            if let Some(resolve_info) = resolve_info {
+                let RenderingAttachmentResolveInfo {
+                    mode: _,
+                    image_view,
+                    image_layout: _,
+                } = resolve_info;
+
+                self.resources.push(Box::new(image_view));
+            }
+        }
+
+        if let Some(attachment_info) = stencil_attachment {
+            let RenderingAttachmentInfo {
+                image_view,
+                image_layout: _,
+                resolve_info,
+                load_op: _,
+                store_op: _,
+                clear_value: _,
+                _ne: _,
+            } = attachment_info;
+
+            self.resources.push(Box::new(image_view));
+
+            if let Some(resolve_info) = resolve_info {
+                let RenderingAttachmentResolveInfo {
+                    mode: _,
+                    image_view,
+                    image_layout: _,
+                } = resolve_info;
+
+                self.resources.push(Box::new(image_view));
+            }
+        }
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Ends the render pass previously begun with `begin_rendering`.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    #[inline]
+    pub unsafe fn end_rendering(&mut self) -> Result<&mut Self, RenderPassError> {
+        self.validate_end_rendering()?;
+
+        unsafe { Ok(self.end_rendering_unchecked()) }
+    }
+
+    fn validate_end_rendering(&self) -> Result<(), RenderPassError> {
+        // VUID-vkCmdEndRendering-renderpass
+        let render_pass_state = self
+            .current_state
+            .render_pass
+            .as_ref()
+            .ok_or(RenderPassError::ForbiddenOutsideRenderPass)?;
+
+        // VUID?
+        if self.inheritance_info.is_some() {
+            return Err(RenderPassError::ForbiddenWithInheritedRenderPass);
+        }
+
+        // VUID-vkCmdEndRendering-None-06161
+        // VUID-vkCmdEndRendering-commandBuffer-06162
+        match &render_pass_state.render_pass {
+            RenderPassStateType::BeginRenderPass(_) => {
+                return Err(RenderPassError::ForbiddenWithBeginRenderPass)
+            }
+            RenderPassStateType::BeginRendering(_) => (),
+        }
+
+        // VUID-vkCmdEndRendering-commandBuffer-cmdpool
+        debug_assert!(self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS));
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn end_rendering_unchecked(&mut self) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().api_version() >= Version::V1_3 {
+            (fns.v1_3.cmd_end_rendering)(self.handle());
+        } else {
+            debug_assert!(self.device().enabled_extensions().khr_dynamic_rendering);
+            (fns.khr_dynamic_rendering.cmd_end_rendering_khr)(self.handle());
+        }
+
+        self.current_state.render_pass = None;
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Clears specific regions of specific attachments of the framebuffer.
+    ///
+    /// `attachments` specify the types of attachments and their clear values.
+    /// `rects` specify the regions to clear.
+    ///
+    /// A graphics pipeline must have been bound using [`bind_pipeline_graphics`].
+    /// And the command must be inside render pass.
+    ///
+    /// If the render pass instance this is recorded in uses multiview,
+    /// then `ClearRect.base_array_layer` must be zero and `ClearRect.layer_count` must be one.
+    ///
+    /// The rectangle area must be inside the render area ranges.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    ///
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    #[inline]
+    pub unsafe fn clear_attachments(
+        &mut self,
+        attachments: impl IntoIterator<Item = ClearAttachment>,
+        rects: impl IntoIterator<Item = ClearRect>,
+    ) -> Result<&mut Self, RenderPassError> {
+        let attachments: SmallVec<[ClearAttachment; 3]> = attachments.into_iter().collect();
+        let rects: SmallVec<[ClearRect; 4]> = rects.into_iter().collect();
+
+        self.validate_clear_attachments(&attachments, &rects)?;
+
+        unsafe { Ok(self.clear_attachments_unchecked(attachments, rects)) }
+    }
+
+    fn validate_clear_attachments(
+        &self,
+        attachments: &[ClearAttachment],
+        rects: &[ClearRect],
+    ) -> Result<(), RenderPassError> {
+        // VUID-vkCmdClearAttachments-renderpass
+        let render_pass_state = self
+            .current_state
+            .render_pass
+            .as_ref()
+            .ok_or(RenderPassError::ForbiddenOutsideRenderPass)?;
+
+        if render_pass_state.contents != SubpassContents::Inline {
+            return Err(RenderPassError::ForbiddenWithSubpassContents {
+                contents: render_pass_state.contents,
+            });
+        }
+
+        //let subpass_desc = begin_render_pass_state.subpass.subpass_desc();
+        //let render_pass = begin_render_pass_state.subpass.render_pass();
+        let is_multiview = render_pass_state.view_mask != 0;
+        let mut layer_count = u32::MAX;
+
+        for &clear_attachment in attachments {
+            match clear_attachment {
+                ClearAttachment::Color {
+                    color_attachment,
+                    clear_value,
+                } => {
+                    let attachment_format = match &render_pass_state.render_pass {
+                        RenderPassStateType::BeginRenderPass(state) => {
+                            let color_attachments = &state.subpass.subpass_desc().color_attachments;
+                            let atch_ref = color_attachments.get(color_attachment as usize).ok_or(
+                                RenderPassError::ColorAttachmentIndexOutOfRange {
+                                    color_attachment_index: color_attachment,
+                                    num_color_attachments: color_attachments.len() as u32,
+                                },
+                            )?;
+
+                            atch_ref.as_ref().map(|atch_ref| {
+                                state.subpass.render_pass().attachments()
+                                    [atch_ref.attachment as usize]
+                                    .format
+                                    .unwrap()
+                            })
+                        }
+                        RenderPassStateType::BeginRendering(state) => *state
+                            .color_attachment_formats
+                            .get(color_attachment as usize)
+                            .ok_or(RenderPassError::ColorAttachmentIndexOutOfRange {
+                                color_attachment_index: color_attachment,
+                                num_color_attachments: state.color_attachment_formats.len() as u32,
+                            })?,
+                    };
+
+                    // VUID-vkCmdClearAttachments-aspectMask-02501
+                    if !attachment_format.map_or(false, |format| {
+                        matches!(
+                            (clear_value, format.type_color().unwrap()),
+                            (
+                                ClearColorValue::Float(_),
+                                NumericType::SFLOAT
+                                    | NumericType::UFLOAT
+                                    | NumericType::SNORM
+                                    | NumericType::UNORM
+                                    | NumericType::SSCALED
+                                    | NumericType::USCALED
+                                    | NumericType::SRGB
+                            ) | (ClearColorValue::Int(_), NumericType::SINT)
+                                | (ClearColorValue::Uint(_), NumericType::UINT)
+                        )
+                    }) {
+                        return Err(RenderPassError::ClearAttachmentNotCompatible {
+                            clear_attachment,
+                            attachment_format,
+                        });
+                    }
+
+                    let image_view = match &render_pass_state.render_pass {
+                        RenderPassStateType::BeginRenderPass(state) => (state.framebuffer.as_ref())
+                            .zip(
+                                state.subpass.subpass_desc().color_attachments
+                                    [color_attachment as usize]
+                                    .as_ref(),
+                            )
+                            .map(|(framebuffer, atch_ref)| {
+                                &framebuffer.attachments()[atch_ref.attachment as usize]
+                            }),
+                        RenderPassStateType::BeginRendering(state) => state
+                            .attachments
+                            .as_ref()
+                            .and_then(|attachments| {
+                                attachments.color_attachments[color_attachment as usize].as_ref()
+                            })
+                            .map(|attachment_info| &attachment_info.image_view),
+                    };
+
+                    // We only know the layer count if we have a known attachment image.
+                    if let Some(image_view) = image_view {
+                        let array_layers = &image_view.subresource_range().array_layers;
+                        layer_count = min(layer_count, array_layers.end - array_layers.start);
+                    }
+                }
+                ClearAttachment::Depth(_)
+                | ClearAttachment::Stencil(_)
+                | ClearAttachment::DepthStencil(_) => {
+                    let (depth_format, stencil_format) = match &render_pass_state.render_pass {
+                        RenderPassStateType::BeginRenderPass(state) => state
+                            .subpass
+                            .subpass_desc()
+                            .depth_stencil_attachment
+                            .as_ref()
+                            .map_or((None, None), |atch_ref| {
+                                let format = state.subpass.render_pass().attachments()
+                                    [atch_ref.attachment as usize]
+                                    .format
+                                    .unwrap();
+                                (Some(format), Some(format))
+                            }),
+                        RenderPassStateType::BeginRendering(state) => (
+                            state.depth_attachment_format,
+                            state.stencil_attachment_format,
+                        ),
+                    };
+
+                    // VUID-vkCmdClearAttachments-aspectMask-02502
+                    if matches!(
+                        clear_attachment,
+                        ClearAttachment::Depth(_) | ClearAttachment::DepthStencil(_)
+                    ) && !depth_format.map_or(false, |format| {
+                        format.aspects().intersects(ImageAspects::DEPTH)
+                    }) {
+                        return Err(RenderPassError::ClearAttachmentNotCompatible {
+                            clear_attachment,
+                            attachment_format: None,
+                        });
+                    }
+
+                    // VUID-vkCmdClearAttachments-aspectMask-02503
+                    if matches!(
+                        clear_attachment,
+                        ClearAttachment::Stencil(_) | ClearAttachment::DepthStencil(_)
+                    ) && !stencil_format.map_or(false, |format| {
+                        format.aspects().intersects(ImageAspects::STENCIL)
+                    }) {
+                        return Err(RenderPassError::ClearAttachmentNotCompatible {
+                            clear_attachment,
+                            attachment_format: None,
+                        });
+                    }
+
+                    let image_view = match &render_pass_state.render_pass {
+                        RenderPassStateType::BeginRenderPass(state) => (state.framebuffer.as_ref())
+                            .zip(
+                                state
+                                    .subpass
+                                    .subpass_desc()
+                                    .depth_stencil_attachment
+                                    .as_ref(),
+                            )
+                            .map(|(framebuffer, atch_ref)| {
+                                &framebuffer.attachments()[atch_ref.attachment as usize]
+                            }),
+                        RenderPassStateType::BeginRendering(state) => state
+                            .attachments
+                            .as_ref()
+                            .and_then(|attachments| attachments.depth_attachment.as_ref())
+                            .map(|attachment_info| &attachment_info.image_view),
+                    };
+
+                    // We only know the layer count if we have a known attachment image.
+                    if let Some(image_view) = image_view {
+                        let array_layers = &image_view.subresource_range().array_layers;
+                        layer_count = min(layer_count, array_layers.end - array_layers.start);
+                    }
+                }
+            }
+        }
+
+        for (rect_index, rect) in rects.iter().enumerate() {
+            for i in 0..2 {
+                // VUID-vkCmdClearAttachments-rect-02682
+                // VUID-vkCmdClearAttachments-rect-02683
+                if rect.extent[i] == 0 {
+                    return Err(RenderPassError::RectExtentZero { rect_index });
+                }
+
+                // VUID-vkCmdClearAttachments-pRects-00016
+                // TODO: This check will always pass in secondary command buffers because of how
+                // it's set in `with_level`.
+                // It needs to be checked during `execute_commands` instead.
+                if rect.offset[i] < render_pass_state.render_area_offset[i]
+                    || rect.offset[i] + rect.extent[i]
+                        > render_pass_state.render_area_offset[i]
+                            + render_pass_state.render_area_extent[i]
+                {
+                    return Err(RenderPassError::RectOutOfBounds { rect_index });
+                }
+            }
+
+            // VUID-vkCmdClearAttachments-layerCount-01934
+            if rect.array_layers.is_empty() {
+                return Err(RenderPassError::RectArrayLayersEmpty { rect_index });
+            }
+
+            // VUID-vkCmdClearAttachments-pRects-00017
+            if rect.array_layers.end > layer_count {
+                return Err(RenderPassError::RectArrayLayersOutOfBounds { rect_index });
+            }
+
+            // VUID-vkCmdClearAttachments-baseArrayLayer-00018
+            if is_multiview && rect.array_layers != (0..1) {
+                return Err(RenderPassError::MultiviewRectArrayLayersInvalid { rect_index });
+            }
+        }
+
+        // VUID-vkCmdClearAttachments-commandBuffer-cmdpool
+        debug_assert!(self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::GRAPHICS));
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn clear_attachments_unchecked(
+        &mut self,
+        attachments: impl IntoIterator<Item = ClearAttachment>,
+        rects: impl IntoIterator<Item = ClearRect>,
+    ) -> &mut Self {
+        let attachments_vk: SmallVec<[_; 3]> = attachments.into_iter().map(|v| v.into()).collect();
+        let rects_vk: SmallVec<[_; 4]> = rects
+            .into_iter()
+            .map(|rect| ash::vk::ClearRect {
+                rect: ash::vk::Rect2D {
+                    offset: ash::vk::Offset2D {
+                        x: rect.offset[0] as i32,
+                        y: rect.offset[1] as i32,
+                    },
+                    extent: ash::vk::Extent2D {
+                        width: rect.extent[0],
+                        height: rect.extent[1],
+                    },
+                },
+                base_array_layer: rect.array_layers.start,
+                layer_count: rect.array_layers.end - rect.array_layers.start,
+            })
+            .collect();
+
+        if attachments_vk.is_empty() || rects_vk.is_empty() {
+            return self;
+        }
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_clear_attachments)(
+            self.handle(),
+            attachments_vk.len() as u32,
+            attachments_vk.as_ptr(),
+            rects_vk.len() as u32,
+            rects_vk.as_ptr(),
+        );
+
+        // TODO: sync state update
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/secondary.rs
+++ b/vulkano/src/command_buffer/standard/builder/secondary.rs
@@ -1,0 +1,389 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{CommandBufferBuilder, ExecuteCommandsError, RenderPassStateType};
+use crate::{
+    command_buffer::{
+        allocator::{CommandBufferAlloc, CommandBufferAllocator},
+        CommandBufferInheritanceRenderPassType, PrimaryCommandBuffer, SecondaryCommandBuffer,
+        SubpassContents,
+    },
+    device::{DeviceOwned, QueueFlags},
+    query::QueryType,
+    RequiresOneOf, SafeDeref, VulkanObject,
+};
+
+impl<A> CommandBufferBuilder<PrimaryCommandBuffer<A::Alloc>, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Executes a secondary command buffer.
+    ///
+    /// If the `usage` that `command_buffer` was created with are more restrictive than those of
+    /// `self`, then `self` will be restricted to match. E.g. executing a secondary command buffer
+    /// with [`OneTimeSubmit`] will set `self`'s usage to
+    /// `OneTimeSubmit` also.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for all buffers and images
+    ///   that are accessed by the command.
+    /// - All images that are accessed by the command must be in the expected image layout.
+    ///
+    /// [`OneTimeSubmit`]: crate::command_buffer::CommandBufferUsage::OneTimeSubmit
+    pub unsafe fn execute_commands(
+        &mut self,
+        command_buffer: SecondaryCommandBuffer<impl CommandBufferAlloc + 'static>,
+    ) -> Result<&mut Self, ExecuteCommandsError> {
+        self.validate_execute_commands(&command_buffer, 0)?;
+
+        unsafe { Ok(self.execute_commands_unchecked(command_buffer)) }
+    }
+
+    fn validate_execute_commands(
+        &self,
+        command_buffer: &SecondaryCommandBuffer<impl CommandBufferAlloc + 'static>,
+        command_buffer_index: u32,
+    ) -> Result<(), ExecuteCommandsError> {
+        // VUID-vkCmdExecuteCommands-commonparent
+        assert_eq!(self.device(), command_buffer.device());
+
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdExecuteCommands-commandBuffer-cmdpool
+        if !queue_family_properties
+            .queue_flags
+            .intersects(QueueFlags::TRANSFER | QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
+        {
+            return Err(ExecuteCommandsError::NotSupportedByQueueFamily);
+        }
+
+        // TODO:
+        // VUID-vkCmdExecuteCommands-pCommandBuffers-00094
+
+        if let Some(render_pass_state) = &self.current_state.render_pass {
+            // VUID-vkCmdExecuteCommands-contents-06018
+            // VUID-vkCmdExecuteCommands-flags-06024
+            if render_pass_state.contents != SubpassContents::SecondaryCommandBuffers {
+                return Err(ExecuteCommandsError::ForbiddenWithSubpassContents {
+                    contents: render_pass_state.contents,
+                });
+            }
+
+            // VUID-vkCmdExecuteCommands-pCommandBuffers-00096
+            let inheritance_render_pass = command_buffer
+                .inheritance_info()
+                .render_pass
+                .as_ref()
+                .ok_or(ExecuteCommandsError::RenderPassInheritanceRequired {
+                    command_buffer_index,
+                })?;
+
+            match (&render_pass_state.render_pass, inheritance_render_pass) {
+                (
+                    RenderPassStateType::BeginRenderPass(state),
+                    CommandBufferInheritanceRenderPassType::BeginRenderPass(inheritance_info),
+                ) => {
+                    // VUID-vkCmdExecuteCommands-pBeginInfo-06020
+                    if !inheritance_info
+                        .subpass
+                        .render_pass()
+                        .is_compatible_with(state.subpass.render_pass())
+                    {
+                        return Err(ExecuteCommandsError::RenderPassNotCompatible {
+                            command_buffer_index,
+                        });
+                    }
+
+                    // VUID-vkCmdExecuteCommands-pCommandBuffers-06019
+                    if inheritance_info.subpass.index() != state.subpass.index() {
+                        return Err(ExecuteCommandsError::RenderPassSubpassMismatch {
+                            command_buffer_index,
+                            required_subpass: state.subpass.index(),
+                            inherited_subpass: inheritance_info.subpass.index(),
+                        });
+                    }
+
+                    // VUID-vkCmdExecuteCommands-pCommandBuffers-00099
+                    if let Some(framebuffer) = &inheritance_info.framebuffer {
+                        if framebuffer != state.framebuffer.as_ref().unwrap() {
+                            return Err(ExecuteCommandsError::RenderPassFramebufferMismatch {
+                                command_buffer_index,
+                            });
+                        }
+                    }
+                }
+                (
+                    RenderPassStateType::BeginRendering(state),
+                    CommandBufferInheritanceRenderPassType::BeginRendering(inheritance_info),
+                ) => {
+                    let attachments = state.attachments.as_ref().unwrap();
+
+                    // VUID-vkCmdExecuteCommands-colorAttachmentCount-06027
+                    if inheritance_info.color_attachment_formats.len()
+                        != attachments.color_attachments.len()
+                    {
+                        return Err(
+                            ExecuteCommandsError::RenderPassColorAttachmentCountMismatch {
+                                command_buffer_index,
+                                required_count: attachments.color_attachments.len() as u32,
+                                inherited_count: inheritance_info.color_attachment_formats.len()
+                                    as u32,
+                            },
+                        );
+                    }
+
+                    for (color_attachment_index, image_view, inherited_format) in attachments
+                        .color_attachments
+                        .iter()
+                        .zip(inheritance_info.color_attachment_formats.iter().copied())
+                        .enumerate()
+                        .filter_map(|(i, (a, f))| a.as_ref().map(|a| (i as u32, &a.image_view, f)))
+                    {
+                        let required_format = image_view.format().unwrap();
+
+                        // VUID-vkCmdExecuteCommands-imageView-06028
+                        if Some(required_format) != inherited_format {
+                            return Err(
+                                ExecuteCommandsError::RenderPassColorAttachmentFormatMismatch {
+                                    command_buffer_index,
+                                    color_attachment_index,
+                                    required_format,
+                                    inherited_format,
+                                },
+                            );
+                        }
+
+                        // VUID-vkCmdExecuteCommands-pNext-06035
+                        if image_view.image().samples() != inheritance_info.rasterization_samples {
+                            return Err(
+                                ExecuteCommandsError::RenderPassColorAttachmentSamplesMismatch {
+                                    command_buffer_index,
+                                    color_attachment_index,
+                                    required_samples: image_view.image().samples(),
+                                    inherited_samples: inheritance_info.rasterization_samples,
+                                },
+                            );
+                        }
+                    }
+
+                    if let Some((image_view, format)) = attachments
+                        .depth_attachment
+                        .as_ref()
+                        .map(|a| (&a.image_view, inheritance_info.depth_attachment_format))
+                    {
+                        // VUID-vkCmdExecuteCommands-pDepthAttachment-06029
+                        if Some(image_view.format().unwrap()) != format {
+                            return Err(
+                                ExecuteCommandsError::RenderPassDepthAttachmentFormatMismatch {
+                                    command_buffer_index,
+                                    required_format: image_view.format().unwrap(),
+                                    inherited_format: format,
+                                },
+                            );
+                        }
+
+                        // VUID-vkCmdExecuteCommands-pNext-06036
+                        if image_view.image().samples() != inheritance_info.rasterization_samples {
+                            return Err(
+                                ExecuteCommandsError::RenderPassDepthAttachmentSamplesMismatch {
+                                    command_buffer_index,
+                                    required_samples: image_view.image().samples(),
+                                    inherited_samples: inheritance_info.rasterization_samples,
+                                },
+                            );
+                        }
+                    }
+
+                    if let Some((image_view, format)) = attachments
+                        .stencil_attachment
+                        .as_ref()
+                        .map(|a| (&a.image_view, inheritance_info.stencil_attachment_format))
+                    {
+                        // VUID-vkCmdExecuteCommands-pStencilAttachment-06030
+                        if Some(image_view.format().unwrap()) != format {
+                            return Err(
+                                ExecuteCommandsError::RenderPassStencilAttachmentFormatMismatch {
+                                    command_buffer_index,
+                                    required_format: image_view.format().unwrap(),
+                                    inherited_format: format,
+                                },
+                            );
+                        }
+
+                        // VUID-vkCmdExecuteCommands-pNext-06037
+                        if image_view.image().samples() != inheritance_info.rasterization_samples {
+                            return Err(
+                                ExecuteCommandsError::RenderPassStencilAttachmentSamplesMismatch {
+                                    command_buffer_index,
+                                    required_samples: image_view.image().samples(),
+                                    inherited_samples: inheritance_info.rasterization_samples,
+                                },
+                            );
+                        }
+                    }
+
+                    // VUID-vkCmdExecuteCommands-viewMask-06031
+                    if inheritance_info.view_mask != render_pass_state.view_mask {
+                        return Err(ExecuteCommandsError::RenderPassViewMaskMismatch {
+                            command_buffer_index,
+                            required_view_mask: render_pass_state.view_mask,
+                            inherited_view_mask: inheritance_info.view_mask,
+                        });
+                    }
+                }
+                _ => {
+                    // VUID-vkCmdExecuteCommands-pBeginInfo-06025
+                    return Err(ExecuteCommandsError::RenderPassTypeMismatch {
+                        command_buffer_index,
+                    });
+                }
+            }
+
+            // TODO:
+            // VUID-vkCmdExecuteCommands-commandBuffer-06533
+            // VUID-vkCmdExecuteCommands-commandBuffer-06534
+            // VUID-vkCmdExecuteCommands-pCommandBuffers-06535
+            // VUID-vkCmdExecuteCommands-pCommandBuffers-06536
+        } else {
+            // VUID-vkCmdExecuteCommands-pCommandBuffers-00100
+            if command_buffer.inheritance_info().render_pass.is_some() {
+                return Err(ExecuteCommandsError::RenderPassInheritanceForbidden {
+                    command_buffer_index,
+                });
+            }
+        }
+
+        // VUID-vkCmdExecuteCommands-commandBuffer-00101
+        if !self.current_state.queries.is_empty()
+            && !self.device().enabled_features().inherited_queries
+        {
+            return Err(ExecuteCommandsError::RequirementNotMet {
+                required_for: "`CommandBufferBuilder::execute_commands` when a query is active",
+                requires_one_of: RequiresOneOf {
+                    features: &["inherited_queries"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        for state in self.current_state.queries.values() {
+            match state.ty {
+                QueryType::Occlusion => {
+                    // VUID-vkCmdExecuteCommands-commandBuffer-00102
+                    let inherited_flags = command_buffer.inheritance_info().occlusion_query.ok_or(
+                        ExecuteCommandsError::OcclusionQueryInheritanceRequired {
+                            command_buffer_index,
+                        },
+                    )?;
+
+                    let inherited_flags_vk = ash::vk::QueryControlFlags::from(inherited_flags);
+                    let state_flags_vk = ash::vk::QueryControlFlags::from(state.flags);
+
+                    // VUID-vkCmdExecuteCommands-commandBuffer-00103
+                    if inherited_flags_vk & state_flags_vk != state_flags_vk {
+                        return Err(ExecuteCommandsError::OcclusionQueryFlagsNotSuperset {
+                            command_buffer_index,
+                            required_flags: state.flags,
+                            inherited_flags,
+                        });
+                    }
+                }
+                QueryType::PipelineStatistics(state_flags) => {
+                    let inherited_flags = command_buffer.inheritance_info().query_statistics_flags;
+                    let inherited_flags_vk =
+                        ash::vk::QueryPipelineStatisticFlags::from(inherited_flags);
+                    let state_flags_vk = ash::vk::QueryPipelineStatisticFlags::from(state_flags);
+
+                    // VUID-vkCmdExecuteCommands-commandBuffer-00104
+                    if inherited_flags_vk & state_flags_vk != state_flags_vk {
+                        return Err(
+                            ExecuteCommandsError::PipelineStatisticsQueryFlagsNotSuperset {
+                                command_buffer_index,
+                                required_flags: state_flags,
+                                inherited_flags,
+                            },
+                        );
+                    }
+                }
+                QueryType::Timestamp => (),
+            }
+        }
+
+        // TODO:
+        // VUID-vkCmdExecuteCommands-pCommandBuffers-00091
+        // VUID-vkCmdExecuteCommands-pCommandBuffers-00092
+        // VUID-vkCmdExecuteCommands-pCommandBuffers-00093
+        // VUID-vkCmdExecuteCommands-pCommandBuffers-00105
+
+        // VUID-vkCmdExecuteCommands-bufferlevel
+        // Ensured by the type of the impl block.
+
+        // VUID-vkCmdExecuteCommands-pCommandBuffers-00088
+        // VUID-vkCmdExecuteCommands-pCommandBuffers-00089
+        // Ensured by the SecondaryCommandBuffer trait.
+
+        // TODO: sync check
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn execute_commands_unchecked(
+        &mut self,
+        command_buffer: SecondaryCommandBuffer<impl CommandBufferAlloc + 'static>,
+    ) -> &mut Self {
+        struct DropUnlock<As>(SecondaryCommandBuffer<As>)
+        where
+            As: CommandBufferAlloc;
+
+        impl<As> std::ops::Deref for DropUnlock<As>
+        where
+            As: CommandBufferAlloc,
+        {
+            type Target = SecondaryCommandBuffer<As>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+        unsafe impl<As> SafeDeref for DropUnlock<As> where As: CommandBufferAlloc {}
+
+        impl<As> Drop for DropUnlock<As>
+        where
+            As: CommandBufferAlloc,
+        {
+            fn drop(&mut self) {
+                unsafe {
+                    self.unlock();
+                }
+            }
+        }
+
+        let command_buffer = {
+            command_buffer.lock_record().unwrap();
+            DropUnlock(command_buffer)
+        };
+
+        let fns = self.device().fns();
+        (fns.v1_0.cmd_execute_commands)(self.handle(), 1, &command_buffer.handle());
+
+        // The secondary command buffer could leave the primary in any state.
+        self.current_state = Default::default();
+
+        // If the secondary is non-concurrent or one-time use, that restricts the primary as well.
+        self.usage = std::cmp::min(self.usage, command_buffer.usage);
+
+        self.resources.push(Box::new(command_buffer));
+
+        // TODO: sync state update
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/standard/builder/sync.rs
+++ b/vulkano/src/command_buffer/standard/builder/sync.rs
@@ -1,0 +1,4472 @@
+// Copyright (c) 2022 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use super::{CommandBufferBuilder, RenderPassStateType};
+use crate::{
+    command_buffer::allocator::CommandBufferAllocator,
+    device::{DeviceOwned, QueueFlags},
+    image::{ImageAspects, ImageCreateFlags, ImageLayout, ImageUsage},
+    sync::{
+        event::Event, AccessFlags, BufferMemoryBarrier, DependencyFlags, DependencyInfo,
+        ImageMemoryBarrier, MemoryBarrier, PipelineStages, QueueFamilyOwnershipTransfer, Sharing,
+    },
+    DeviceSize, RequirementNotMet, RequiresOneOf, Version, VulkanObject,
+};
+use smallvec::SmallVec;
+use std::{
+    cmp::max,
+    error::Error,
+    fmt::{Display, Error as FmtError, Formatter},
+    ptr,
+    sync::Arc,
+};
+
+impl<L, A> CommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Inserts a memory dependency into the queue.
+    ///
+    /// A pipeline barrier is the primary means of synchronizing work within a single queue.
+    /// Without a pipeline barrier, all commands in a queue could complete out of order, and there
+    /// would be no guarantee about the ordering of memory accesses. When a dependency is inserted,
+    /// a chosen subset of operations after the barrier (the destination synchronization scope)
+    /// depend on, and therefore must wait for the completion of, a chosen subset operations before
+    /// barrier (the source synchronization scope).
+    ///
+    /// When the queue has to wait, it may not be doing useful work, so barriers should be kept to
+    /// the minimum needed to ensure proper functioning. Overly broad barriers, specifying
+    /// a larger class of operations than needed (especially [`ALL_COMMANDS`]), can slow down the
+    /// queue and make it work less efficiently.
+    ///
+    /// In addition to ensuring correct operation, pipeline barriers are also used to transition
+    /// images (or parts of images) from one [image layout] to another.
+    ///
+    /// # Safety
+    ///
+    /// - All images that are accessed by the command must be in the expected image layout.
+    /// - For each element of `dependency_info.image_memory_barriers` that contains an image layout
+    ///   transition, which is a write operation, the barrier must be defined appropriately to
+    ///   ensure no memory access hazard occurs.
+    ///
+    /// [`ALL_COMMANDS`]: PipelineStages::ALL_COMMANDS
+    /// [image layout]: ImageLayout
+    #[inline]
+    pub unsafe fn pipeline_barrier(
+        &mut self,
+        dependency_info: DependencyInfo,
+    ) -> Result<&mut Self, SynchronizationError> {
+        self.validate_pipeline_barrier(&dependency_info)?;
+
+        unsafe { Ok(self.pipeline_barrier_unchecked(dependency_info)) }
+    }
+
+    fn validate_pipeline_barrier(
+        &self,
+        dependency_info: &DependencyInfo,
+    ) -> Result<(), SynchronizationError> {
+        let device = self.device();
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdPipelineBarrier2-commandBuffer-cmdpool
+        if !queue_family_properties.queue_flags.intersects(
+            QueueFlags::TRANSFER
+                | QueueFlags::GRAPHICS
+                | QueueFlags::COMPUTE
+                | QueueFlags::VIDEO_DECODE
+                | QueueFlags::VIDEO_ENCODE,
+        ) {
+            return Err(SynchronizationError::NotSupportedByQueueFamily);
+        }
+
+        let &DependencyInfo {
+            dependency_flags,
+            ref memory_barriers,
+            ref buffer_memory_barriers,
+            ref image_memory_barriers,
+            _ne: _,
+        } = dependency_info;
+
+        // VUID-VkDependencyInfo-dependencyFlags-parameter
+        dependency_flags.validate_device(device)?;
+
+        let check_stages_access = |ty: char,
+                                   barrier_index: usize,
+                                   src_stages: PipelineStages,
+                                   src_access: AccessFlags,
+                                   dst_stages: PipelineStages,
+                                   dst_access: AccessFlags|
+         -> Result<(), SynchronizationError> {
+            for (stages, access) in [(src_stages, src_access), (dst_stages, dst_access)] {
+                // VUID-vkCmdPipelineBarrier2-synchronization2-03848
+                if !device.enabled_features().synchronization2 {
+                    if stages.is_2() {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                                `dependency_info.buffer_memory_barriers` or \
+                                `dependency_info.image_memory_barriers` has an element where \
+                                `src_stages` or `dst_stages` contains flags from \
+                                `VkPipelineStageFlagBits2`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["synchronization2"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    if access.is_2() {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                                `dependency_info.buffer_memory_barriers` or \
+                                `dependency_info.image_memory_barriers` has an element where \
+                                `src_access` or `dst_access` contains flags from \
+                                `VkAccessFlagBits2`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["synchronization2"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-parameter
+                // VUID-VkMemoryBarrier2-dstStageMask-parameter
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-parameter
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-parameter
+                // VUID-VkImageMemoryBarrier2-srcStageMask-parameter
+                // VUID-VkImageMemoryBarrier2-dstStageMask-parameter
+                stages.validate_device(device)?;
+
+                // VUID-VkMemoryBarrier2-srcAccessMask-parameter
+                // VUID-VkMemoryBarrier2-dstAccessMask-parameter
+                // VUID-VkBufferMemoryBarrier2-srcAccessMask-parameter
+                // VUID-VkBufferMemoryBarrier2-dstAccessMask-parameter
+                // VUID-VkImageMemoryBarrier2-srcAccessMask-parameter
+                // VUID-VkImageMemoryBarrier2-dstAccessMask-parameter
+                access.validate_device(device)?;
+
+                // VUID-vkCmdPipelineBarrier2-srcStageMask-03849
+                // VUID-vkCmdPipelineBarrier2-dstStageMask-03850
+                if !PipelineStages::from(queue_family_properties.queue_flags).contains(stages) {
+                    match ty {
+                        'm' => {
+                            return Err(SynchronizationError::MemoryBarrierStageNotSupported {
+                                barrier_index,
+                            })
+                        }
+                        'b' => {
+                            return Err(
+                                SynchronizationError::BufferMemoryBarrierStageNotSupported {
+                                    barrier_index,
+                                },
+                            )
+                        }
+                        'i' => {
+                            return Err(SynchronizationError::ImageMemoryBarrierStageNotSupported {
+                                barrier_index,
+                            })
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03929
+                // VUID-VkMemoryBarrier2-dstStageMask-03929
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03929
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03929
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03930
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03930
+                if stages.intersects(PipelineStages::GEOMETRY_SHADER)
+                    && !device.enabled_features().geometry_shader
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::GEOMETRY_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["geometry_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03930
+                // VUID-VkMemoryBarrier2-dstStageMask-03930
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03930
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03930
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03930
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03930
+                if stages.intersects(
+                    PipelineStages::TESSELLATION_CONTROL_SHADER
+                        | PipelineStages::TESSELLATION_EVALUATION_SHADER,
+                ) && !device.enabled_features().tessellation_shader
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TESSELLATION_CONTROL_SHADER` or \
+                            `PipelineStages::TESSELLATION_EVALUATION_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["tessellation_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03931
+                // VUID-VkMemoryBarrier2-dstStageMask-03931
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03931
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03931
+                // VUID-VImagekMemoryBarrier2-srcStageMask-03931
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03931
+                if stages.intersects(PipelineStages::CONDITIONAL_RENDERING)
+                    && !device.enabled_features().conditional_rendering
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::CONDITIONAL_RENDERING`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["conditional_rendering"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03932
+                // VUID-VkMemoryBarrier2-dstStageMask-03932
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03932
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03932
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03932
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03932
+                if stages.intersects(PipelineStages::FRAGMENT_DENSITY_PROCESS)
+                    && !device.enabled_features().fragment_density_map
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::FRAGMENT_DENSITY_PROCESS`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["fragment_density_map"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03933
+                // VUID-VkMemoryBarrier2-dstStageMask-03933
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03933
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03933
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03933
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03933
+                if stages.intersects(PipelineStages::TRANSFORM_FEEDBACK)
+                    && !device.enabled_features().transform_feedback
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TRANSFORM_FEEDBACK`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["transform_feedback"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03934
+                // VUID-VkMemoryBarrier2-dstStageMask-03934
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03934
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03934
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03934
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03934
+                if stages.intersects(PipelineStages::MESH_SHADER)
+                    && !device.enabled_features().mesh_shader
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::MESH_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["mesh_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03935
+                // VUID-VkMemoryBarrier2-dstStageMask-03935
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03935
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03935
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03935
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03935
+                if stages.intersects(PipelineStages::TASK_SHADER)
+                    && !device.enabled_features().task_shader
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TASK_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["task_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkBufferMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkBufferMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkImageMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkImageMemoryBarrier2-shadingRateImage-07316
+                if stages.intersects(PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT)
+                    && !(device.enabled_features().attachment_fragment_shading_rate
+                        || device.enabled_features().shading_rate_image)
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["attachment_fragment_shading_rate", "shading_rate_image"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-04957
+                // VUID-VkMemoryBarrier2-dstStageMask-04957
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-04957
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-04957
+                // VUID-VkImageMemoryBarrier2-srcStageMask-04957
+                // VUID-VkImageMemoryBarrier2-dstStageMask-04957
+                if stages.intersects(PipelineStages::SUBPASS_SHADING)
+                    && !device.enabled_features().subpass_shading
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::SUBPASS_SHADING`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["subpass_shading"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-04995
+                // VUID-VkMemoryBarrier2-dstStageMask-04995
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-04995
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-04995
+                // VUID-VkImageMemoryBarrier2-srcStageMask-04995
+                // VUID-VkImageMemoryBarrier2-dstStageMask-04995
+                if stages.intersects(PipelineStages::INVOCATION_MASK)
+                    && !device.enabled_features().invocation_mask
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::INVOCATION_MASK`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["invocation_mask"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-vkCmdPipelineBarrier-srcStageMask-03937
+                // VUID-vkCmdPipelineBarrier-dstStageMask-03937
+                if stages.is_empty() && !device.enabled_features().synchronization2 {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            is empty",
+                        requires_one_of: RequiresOneOf {
+                            features: &["synchronization2"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // A bit of a ridiculous number of VUIDs...
+
+                // VUID-VkMemoryBarrier2-srcAccessMask-03900
+                // ..
+                // VUID-VkMemoryBarrier2-srcAccessMask-07458
+
+                // VUID-VkMemoryBarrier2-dstAccessMask-03900
+                // ..
+                // VUID-VkMemoryBarrier2-dstAccessMask-07458
+
+                // VUID-VkBufferMemoryBarrier2-srcAccessMask-03900
+                // ..
+                // VUID-VkBufferMemoryBarrier2-srcAccessMask-07458
+
+                // VUID-VkBufferMemoryBarrier2-dstAccessMask-03900
+                // ..
+                // VUID-VkBufferMemoryBarrier2-dstAccessMask-07458
+
+                // VUID-VkImageMemoryBarrier2-srcAccessMask-03900
+                // ..
+                // VUID-VkImageMemoryBarrier2-srcAccessMask-07458
+
+                // VUID-VkImageMemoryBarrier2-dstAccessMask-03900
+                // ..
+                // VUID-VkImageMemoryBarrier2-dstAccessMask-07458
+
+                if !AccessFlags::from(stages).contains(access) {
+                    match ty {
+                        'm' => {
+                            return Err(
+                                SynchronizationError::MemoryBarrierAccessNotSupportedByStages {
+                                    barrier_index,
+                                },
+                            )
+                        }
+                        'b' => return Err(
+                            SynchronizationError::BufferMemoryBarrierAccessNotSupportedByStages {
+                                barrier_index,
+                            },
+                        ),
+                        'i' => return Err(
+                            SynchronizationError::ImageMemoryBarrierAccessNotSupportedByStages {
+                                barrier_index,
+                            },
+                        ),
+                        _ => unreachable!(),
+                    }
+                }
+            }
+
+            // VUID-VkMemoryBarrier2-srcAccessMask-06256
+            // VUID-VkBufferMemoryBarrier2-srcAccessMask-06256
+            // VUID-VkImageMemoryBarrier2-srcAccessMask-06256
+            if !device.enabled_features().ray_query
+                && src_access.intersects(AccessFlags::ACCELERATION_STRUCTURE_READ)
+                && src_stages.intersects(
+                    PipelineStages::VERTEX_SHADER
+                        | PipelineStages::TESSELLATION_CONTROL_SHADER
+                        | PipelineStages::TESSELLATION_EVALUATION_SHADER
+                        | PipelineStages::GEOMETRY_SHADER
+                        | PipelineStages::FRAGMENT_SHADER
+                        | PipelineStages::COMPUTE_SHADER
+                        | PipelineStages::PRE_RASTERIZATION_SHADERS
+                        | PipelineStages::TASK_SHADER
+                        | PipelineStages::MESH_SHADER,
+                )
+            {
+                return Err(SynchronizationError::RequirementNotMet {
+                    required_for: "One of `dependency_info.memory_barriers`, \
+                        `dependency_info.buffer_memory_barriers` or \
+                        `dependency_info.image_memory_barriers` has an element where \
+                        `src_access` contains `ACCELERATION_STRUCTURE_READ`, and \
+                        `src_stages` contains a shader stage other than `RAY_TRACING_SHADER`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["ray_query"],
+                        ..Default::default()
+                    },
+                });
+            }
+
+            Ok(())
+        };
+
+        let check_queue_family_ownership_transfer = |ty: char,
+                                                     barrier_index: usize,
+                                                     src_stages: PipelineStages,
+                                                     dst_stages: PipelineStages,
+                                                     queue_family_ownership_transfer: Option<
+            QueueFamilyOwnershipTransfer,
+        >,
+                                                     sharing: &Sharing<_>|
+         -> Result<(), SynchronizationError> {
+            if let Some(transfer) = queue_family_ownership_transfer {
+                // VUID?
+                transfer.validate_device(device)?;
+
+                // VUID-VkBufferMemoryBarrier2-srcQueueFamilyIndex-04087
+                // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04070
+                // Ensured by the definition of `QueueFamilyOwnershipTransfer`.
+
+                // VUID-VkBufferMemoryBarrier2-buffer-04088
+                // VUID-VkImageMemoryBarrier2-image-04071
+                // Ensured by the definition of `QueueFamilyOwnershipTransfer`.
+
+                let queue_family_count =
+                    device.physical_device().queue_family_properties().len() as u32;
+
+                let provided_queue_family_index = match (sharing, transfer) {
+                    (
+                        Sharing::Exclusive,
+                        QueueFamilyOwnershipTransfer::ExclusiveBetweenLocal {
+                            src_index,
+                            dst_index,
+                        },
+                    ) => Some(max(src_index, dst_index)),
+                    (
+                        Sharing::Exclusive,
+                        QueueFamilyOwnershipTransfer::ExclusiveToExternal { src_index }
+                        | QueueFamilyOwnershipTransfer::ExclusiveToForeign { src_index },
+                    ) => Some(src_index),
+                    (
+                        Sharing::Exclusive,
+                        QueueFamilyOwnershipTransfer::ExclusiveFromExternal { dst_index }
+                        | QueueFamilyOwnershipTransfer::ExclusiveFromForeign { dst_index },
+                    ) => Some(dst_index),
+                    (
+                        Sharing::Concurrent(_),
+                        QueueFamilyOwnershipTransfer::ConcurrentToExternal
+                        | QueueFamilyOwnershipTransfer::ConcurrentFromExternal
+                        | QueueFamilyOwnershipTransfer::ConcurrentToForeign
+                        | QueueFamilyOwnershipTransfer::ConcurrentFromForeign,
+                    ) => None,
+                    _ => match ty {
+                        'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferSharingMismatch {
+                            barrier_index,
+                        }),
+                        'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferSharingMismatch {
+                            barrier_index,
+                        }),
+                        _ => unreachable!(),
+                    },
+                }.filter(|&index| index >= queue_family_count);
+
+                // VUID-VkBufferMemoryBarrier2-buffer-04089
+                // VUID-VkImageMemoryBarrier2-image-04072
+
+                if let Some(provided_queue_family_index) = provided_queue_family_index {
+                    match ty {
+                        'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferIndexOutOfRange {
+                            barrier_index,
+                            provided_queue_family_index,
+                            queue_family_count,
+                        }),
+                        'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferIndexOutOfRange {
+                            barrier_index,
+                            provided_queue_family_index,
+                            queue_family_count,
+                        }),
+                        _ => unreachable!(),
+                    }
+                }
+
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03851
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03854
+                if src_stages.intersects(PipelineStages::HOST)
+                    || dst_stages.intersects(PipelineStages::HOST)
+                {
+                    match ty {
+                        'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferHostNotAllowed {
+                            barrier_index,
+                        }),
+                        'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferHostForbidden {
+                            barrier_index,
+                        }),
+                        _ => unreachable!(),
+                    }
+                }
+            }
+
+            Ok(())
+        };
+
+        for (barrier_index, barrier) in memory_barriers.iter().enumerate() {
+            let &MemoryBarrier {
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+                _ne: _,
+            } = barrier;
+
+            /*
+                Check stages and access
+            */
+
+            check_stages_access(
+                'm',
+                barrier_index,
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+            )?;
+        }
+
+        for (barrier_index, barrier) in buffer_memory_barriers.iter().enumerate() {
+            let &BufferMemoryBarrier {
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+                queue_family_ownership_transfer,
+                ref buffer,
+                ref range,
+                _ne: _,
+            } = barrier;
+
+            // VUID-VkBufferMemoryBarrier2-buffer-01931
+            // Ensured by Buffer type construction.
+
+            /*
+                Check stages and access
+            */
+
+            check_stages_access(
+                'b',
+                barrier_index,
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+            )?;
+
+            /*
+                Check queue family transfer
+            */
+
+            check_queue_family_ownership_transfer(
+                'b',
+                barrier_index,
+                src_stages,
+                dst_stages,
+                queue_family_ownership_transfer,
+                buffer.sharing(),
+            )?;
+
+            /*
+                Check range
+            */
+
+            // VUID-VkBufferMemoryBarrier2-size-01188
+            assert!(!range.is_empty());
+
+            // VUID-VkBufferMemoryBarrier2-offset-01187
+            // VUID-VkBufferMemoryBarrier2-size-01189
+            if range.end > buffer.size() {
+                return Err(SynchronizationError::BufferMemoryBarrierOutOfRange {
+                    barrier_index,
+                    range_end: range.end,
+                    buffer_size: buffer.size(),
+                });
+            }
+        }
+
+        for (barrier_index, barrier) in image_memory_barriers.iter().enumerate() {
+            let &ImageMemoryBarrier {
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+                old_layout,
+                new_layout,
+                queue_family_ownership_transfer,
+                ref image,
+                ref subresource_range,
+                _ne: _,
+            } = barrier;
+
+            // VUID-VkImageMemoryBarrier2-image-01932
+            // Ensured by Image type construction.
+
+            /*
+                Check stages and access
+            */
+
+            check_stages_access(
+                'i',
+                barrier_index,
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+            )?;
+
+            /*
+                Check layouts
+            */
+
+            // VUID-VkImageMemoryBarrier2-oldLayout-parameter
+            old_layout.validate_device(device)?;
+
+            // VUID-VkImageMemoryBarrier2-newLayout-parameter
+            new_layout.validate_device(device)?;
+
+            // VUID-VkImageMemoryBarrier2-srcStageMask-03855
+            if src_stages.intersects(PipelineStages::HOST)
+                && !matches!(
+                    old_layout,
+                    ImageLayout::Preinitialized | ImageLayout::Undefined | ImageLayout::General
+                )
+            {
+                return Err(
+                    SynchronizationError::ImageMemoryBarrierOldLayoutFromHostInvalid {
+                        barrier_index,
+                        old_layout,
+                    },
+                );
+            }
+
+            // VUID-VkImageMemoryBarrier2-oldLayout-01197
+            // Not checked yet, therefore unsafe.
+
+            // VUID-VkImageMemoryBarrier2-newLayout-01198
+            if matches!(
+                new_layout,
+                ImageLayout::Undefined | ImageLayout::Preinitialized
+            ) {
+                return Err(SynchronizationError::ImageMemoryBarrierNewLayoutInvalid {
+                    barrier_index,
+                });
+            }
+
+            // VUID-VkImageMemoryBarrier2-attachmentFeedbackLoopLayout-07313
+            /*if !device.enabled_features().attachment_feedback_loop_layout
+                && matches!(new_layout, ImageLayout::AttachmentFeedbackLoopOptimal)
+            {
+                return Err(SynchronizationError::RequirementNotMet {
+                    required_for: "`dependency_info.image_memory_barriers` has an element where \
+                        `new_layout` is `AttachmentFeedbackLoopOptimal`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["attachment_feedback_loop_layout"],
+                        ..Default::default()
+                    },
+                });
+            }*/
+
+            for layout in [old_layout, new_layout] {
+                // VUID-VkImageMemoryBarrier2-synchronization2-06911
+                /*if !device.enabled_features().synchronization2
+                    && matches!(
+                        layout,
+                        ImageLayout::AttachmentOptimal | ImageLayout::ReadOnlyOptimal
+                    )
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "`dependency_info.image_memory_barriers` has an element \
+                            where `old_layout` or `new_layout` is `AttachmentOptimal` or \
+                            `ReadOnlyOptimal`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["synchronization2"],
+                            ..Default::default()
+                        },
+                    });
+                }*/
+
+                // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-07006
+                /*if layout == ImageLayout::AttachmentFeedbackLoopOptimal {
+                    if !image.usage().intersects(
+                        ImageUsage::COLOR_ATTACHMENT | ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+                    ) {
+                        return Err(
+                            SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                barrier_index,
+                                layout,
+                                requires_one_of_usage: ImageUsage::COLOR_ATTACHMENT
+                                    | ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+                            },
+                        );
+                    }
+
+                    if !image
+                        .usage()
+                        .intersects(ImageUsage::INPUT_ATTACHMENT | ImageUsage::SAMPLED)
+                    {
+                        return Err(
+                            SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                barrier_index,
+                                layout,
+                                requires_one_of_usage: ImageUsage::INPUT_ATTACHMENT
+                                    | ImageUsage::SAMPLED,
+                            },
+                        );
+                    }
+
+                    if !image
+                        .usage()
+                        .intersects(ImageUsage::ATTACHMENT_FEEDBACK_LOOP)
+                    {
+                        return Err(
+                            SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                barrier_index,
+                                layout,
+                                requires_one_of_usage: ImageUsage::ATTACHMENT_FEEDBACK_LOOP,
+                            },
+                        );
+                    }
+                }*/
+
+                let requires_one_of_usage = match layout {
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01208
+                    ImageLayout::ColorAttachmentOptimal => ImageUsage::COLOR_ATTACHMENT,
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01209
+                    ImageLayout::DepthStencilAttachmentOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01210
+                    ImageLayout::DepthStencilReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01211
+                    ImageLayout::ShaderReadOnlyOptimal => {
+                        ImageUsage::SAMPLED | ImageUsage::INPUT_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01212
+                    ImageLayout::TransferSrcOptimal => ImageUsage::TRANSFER_SRC,
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01213
+                    ImageLayout::TransferDstOptimal => ImageUsage::TRANSFER_DST,
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01658
+                    ImageLayout::DepthReadOnlyStencilAttachmentOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01659
+                    ImageLayout::DepthAttachmentStencilReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    /*
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04065
+                    ImageLayout::DepthReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                            | ImageUsage::SAMPLED
+                            | ImageUsage::INPUT_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04066
+                    ImageLayout::DepthAttachmentOptimal => ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04067
+                    ImageLayout::StencilReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                            | ImageUsage::SAMPLED
+                            | ImageUsage::INPUT_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04068
+                    ImageLayout::StencilAttachmentOptimal => ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-03938
+                    ImageLayout::AttachmentOptimal => {
+                        ImageUsage::COLOR_ATTACHMENT | ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-03939
+                    ImageLayout::ReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                            | ImageUsage::SAMPLED
+                            | ImageUsage::INPUT_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-02088
+                    ImageLayout::FragmentShadingRateAttachmentOptimal => {
+                        ImageUsage::FRAGMENT_SHADING_RATE_ATTACHMENT
+                    }
+                     */
+                    _ => continue,
+                };
+
+                if !image.usage().intersects(requires_one_of_usage) {
+                    return Err(
+                        SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                            barrier_index,
+                            layout,
+                            requires_one_of_usage,
+                        },
+                    );
+                }
+            }
+
+            /*
+                Check queue family tansfer
+            */
+
+            check_queue_family_ownership_transfer(
+                'i',
+                barrier_index,
+                src_stages,
+                dst_stages,
+                queue_family_ownership_transfer,
+                image.sharing(),
+            )?;
+
+            /*
+                Check subresource range
+            */
+
+            // VUID-VkImageSubresourceRange-aspectMask-requiredbitmask
+            assert!(!subresource_range.aspects.is_empty());
+
+            // VUID-VkImageSubresourceRange-aspectMask-parameter
+            subresource_range.aspects.validate_device(device)?;
+
+            let image_aspects = image.format().unwrap().aspects();
+
+            // VUID-VkImageMemoryBarrier2-image-01673
+            // VUID-VkImageMemoryBarrier2-image-03319
+            if image_aspects.contains(subresource_range.aspects) {
+                return Err(SynchronizationError::ImageMemoryBarrierAspectsNotAllowed {
+                    barrier_index,
+                    aspects: subresource_range.aspects - image_aspects,
+                });
+            }
+
+            if image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
+                // VUID-VkImageMemoryBarrier2-image-03320
+                if !device.enabled_features().separate_depth_stencil_layouts
+                    && image_aspects.contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
+                    && !subresource_range
+                        .aspects
+                        .contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "`dependency_info.image_memory_barriers` has an element \
+                            where `image` has both a depth and a stencil aspect, and \
+                            `subresource_range.aspects` does not contain both aspects",
+                        requires_one_of: RequiresOneOf {
+                            features: &["separate_depth_stencil_layouts"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            } else {
+                // VUID-VkImageMemoryBarrier2-image-01671
+                if !image.flags().intersects(ImageCreateFlags::DISJOINT)
+                    && subresource_range.aspects != ImageAspects::COLOR
+                {
+                    return Err(SynchronizationError::ImageMemoryBarrierAspectsNotAllowed {
+                        barrier_index,
+                        aspects: subresource_range.aspects - ImageAspects::COLOR,
+                    });
+                }
+            }
+
+            // VUID-VkImageSubresourceRange-levelCount-01720
+            assert!(!subresource_range.mip_levels.is_empty());
+
+            // VUID-VkImageMemoryBarrier2-subresourceRange-01486
+            // VUID-VkImageMemoryBarrier2-subresourceRange-01724
+            if subresource_range.mip_levels.end > image.mip_levels() {
+                return Err(
+                    SynchronizationError::ImageMemoryBarrierMipLevelsOutOfRange {
+                        barrier_index,
+                        mip_levels_range_end: subresource_range.mip_levels.end,
+                        image_mip_levels: image.mip_levels(),
+                    },
+                );
+            }
+
+            // VUID-VkImageSubresourceRange-layerCount-01721
+            assert!(!subresource_range.array_layers.is_empty());
+
+            // VUID-VkImageMemoryBarrier2-subresourceRange-01488
+            // VUID-VkImageMemoryBarrier2-subresourceRange-01725
+            if subresource_range.array_layers.end > image.dimensions().array_layers() {
+                return Err(
+                    SynchronizationError::ImageMemoryBarrierArrayLayersOutOfRange {
+                        barrier_index,
+                        array_layers_range_end: subresource_range.array_layers.end,
+                        image_array_layers: image.dimensions().array_layers(),
+                    },
+                );
+            }
+        }
+
+        /*
+            Checks for current render pass
+        */
+
+        if let Some(render_pass_state) = self.current_state.render_pass.as_ref() {
+            // VUID-vkCmdPipelineBarrier2-None-06191
+            let begin_render_pass_state = match &render_pass_state.render_pass {
+                RenderPassStateType::BeginRenderPass(x) => x,
+                RenderPassStateType::BeginRendering(_) => {
+                    return Err(SynchronizationError::ForbiddenWithBeginRendering)
+                }
+            };
+            let subpass_index = begin_render_pass_state.subpass.index();
+            let subpass_desc = begin_render_pass_state.subpass.subpass_desc();
+            let dependencies = begin_render_pass_state.subpass.render_pass().dependencies();
+
+            // VUID-vkCmdPipelineBarrier2-pDependencies-02285
+            // TODO: see https://github.com/KhronosGroup/Vulkan-Docs/issues/1982
+            if !dependencies.iter().any(|dependency| {
+                dependency.src_subpass == Some(subpass_index)
+                    && dependency.dst_subpass == Some(subpass_index)
+            }) {
+                return Err(SynchronizationError::MemoryBarrierNoMatchingSubpassSelfDependency);
+            }
+
+            // VUID-vkCmdPipelineBarrier2-bufferMemoryBarrierCount-01178
+            if !buffer_memory_barriers.is_empty() {
+                return Err(SynchronizationError::BufferMemoryBarrierForbiddenInsideRenderPass);
+            }
+
+            for (barrier_index, barrier) in image_memory_barriers.iter().enumerate() {
+                // VUID-vkCmdPipelineBarrier2-image-04073
+                // TODO: How are you supposed to verify this in secondary command buffers,
+                // when there is no inherited framebuffer?
+                // The image is not known until you execute it in a primary command buffer.
+                if let Some(framebuffer) = &begin_render_pass_state.framebuffer {
+                    let attachment_index = (framebuffer.attachments().iter())
+                        .position(|attachment| attachment.image().inner().image == &barrier.image)
+                        .ok_or(SynchronizationError::ImageMemoryBarrierNotInputAttachment {
+                            barrier_index,
+                        })? as u32;
+
+                    if !(subpass_desc.input_attachments.iter().flatten())
+                        .any(|atch_ref| atch_ref.attachment == attachment_index)
+                    {
+                        return Err(SynchronizationError::ImageMemoryBarrierNotInputAttachment {
+                            barrier_index,
+                        });
+                    }
+
+                    if !(subpass_desc.color_attachments.iter().flatten())
+                        .chain(subpass_desc.depth_stencil_attachment.as_ref())
+                        .any(|atch_ref| atch_ref.attachment == attachment_index)
+                    {
+                        return Err(SynchronizationError::ImageMemoryBarrierNotColorDepthStencilAttachment {
+                            barrier_index,
+                        });
+                    }
+                }
+
+                // VUID-vkCmdPipelineBarrier2-oldLayout-01181
+                if barrier.old_layout != barrier.new_layout {
+                    return Err(SynchronizationError::ImageMemoryBarrierLayoutTransitionForbiddenInsideRenderPass {
+                        barrier_index,
+                    });
+                }
+
+                // VUID-vkCmdPipelineBarrier2-srcQueueFamilyIndex-01182
+                if barrier.queue_family_ownership_transfer.is_some() {
+                    return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferForbiddenInsideRenderPass {
+                        barrier_index,
+                    });
+                }
+            }
+        } else {
+            // VUID-vkCmdPipelineBarrier2-dependencyFlags-01186
+            if dependency_flags.intersects(DependencyFlags::VIEW_LOCAL) {
+                return Err(SynchronizationError::DependencyFlagsViewLocalNotAllowed);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn pipeline_barrier_unchecked(
+        &mut self,
+        dependency_info: DependencyInfo,
+    ) -> &mut Self {
+        if dependency_info.is_empty() {
+            return self;
+        }
+
+        let DependencyInfo {
+            dependency_flags,
+            memory_barriers,
+            buffer_memory_barriers,
+            image_memory_barriers,
+            _ne: _,
+        } = dependency_info;
+
+        if self.device().enabled_features().synchronization2 {
+            let memory_barriers_vk: SmallVec<[_; 2]> = memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &MemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        _ne: _,
+                    } = barrier;
+
+                    ash::vk::MemoryBarrier2 {
+                        src_stage_mask: src_stages.into(),
+                        src_access_mask: src_access.into(),
+                        dst_stage_mask: dst_stages.into(),
+                        dst_access_mask: dst_access.into(),
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let buffer_memory_barriers_vk: SmallVec<[_; 8]> = buffer_memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &BufferMemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        queue_family_ownership_transfer,
+                        ref buffer,
+                        ref range,
+                        _ne: _,
+                    } = barrier;
+
+                    let (src_queue_family_index, dst_queue_family_index) =
+                        queue_family_ownership_transfer.map_or(
+                            (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                            Into::into,
+                        );
+
+                    ash::vk::BufferMemoryBarrier2 {
+                        src_stage_mask: src_stages.into(),
+                        src_access_mask: src_access.into(),
+                        dst_stage_mask: dst_stages.into(),
+                        dst_access_mask: dst_access.into(),
+                        src_queue_family_index,
+                        dst_queue_family_index,
+                        buffer: buffer.handle(),
+                        offset: range.start,
+                        size: range.end - range.start,
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let image_memory_barriers_vk: SmallVec<[_; 8]> = image_memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &ImageMemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        old_layout,
+                        new_layout,
+                        queue_family_ownership_transfer,
+                        ref image,
+                        ref subresource_range,
+                        _ne: _,
+                    } = barrier;
+
+                    let (src_queue_family_index, dst_queue_family_index) =
+                        queue_family_ownership_transfer.map_or(
+                            (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                            Into::into,
+                        );
+
+                    ash::vk::ImageMemoryBarrier2 {
+                        src_stage_mask: src_stages.into(),
+                        src_access_mask: src_access.into(),
+                        dst_stage_mask: dst_stages.into(),
+                        dst_access_mask: dst_access.into(),
+                        old_layout: old_layout.into(),
+                        new_layout: new_layout.into(),
+                        src_queue_family_index,
+                        dst_queue_family_index,
+                        image: image.handle(),
+                        subresource_range: subresource_range.clone().into(),
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let dependency_info_vk = ash::vk::DependencyInfo {
+                dependency_flags: dependency_flags.into(),
+                memory_barrier_count: memory_barriers_vk.len() as u32,
+                p_memory_barriers: memory_barriers_vk.as_ptr(),
+                buffer_memory_barrier_count: buffer_memory_barriers_vk.len() as u32,
+                p_buffer_memory_barriers: buffer_memory_barriers_vk.as_ptr(),
+                image_memory_barrier_count: image_memory_barriers_vk.len() as u32,
+                p_image_memory_barriers: image_memory_barriers_vk.as_ptr(),
+                ..Default::default()
+            };
+
+            let fns = self.device().fns();
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_pipeline_barrier2)(self.handle(), &dependency_info_vk);
+            } else {
+                debug_assert!(self.device().enabled_extensions().khr_synchronization2);
+                (fns.khr_synchronization2.cmd_pipeline_barrier2_khr)(
+                    self.handle(),
+                    &dependency_info_vk,
+                );
+            }
+        } else {
+            let mut src_stage_mask = ash::vk::PipelineStageFlags::empty();
+            let mut dst_stage_mask = ash::vk::PipelineStageFlags::empty();
+
+            let memory_barriers_vk: SmallVec<[_; 2]> = memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &MemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        _ne: _,
+                    } = barrier;
+
+                    src_stage_mask |= src_stages.into();
+                    dst_stage_mask |= dst_stages.into();
+
+                    ash::vk::MemoryBarrier {
+                        src_access_mask: src_access.into(),
+                        dst_access_mask: dst_access.into(),
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let buffer_memory_barriers_vk: SmallVec<[_; 8]> = buffer_memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &BufferMemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        queue_family_ownership_transfer,
+                        ref buffer,
+                        ref range,
+                        _ne: _,
+                    } = barrier;
+
+                    src_stage_mask |= src_stages.into();
+                    dst_stage_mask |= dst_stages.into();
+
+                    let (src_queue_family_index, dst_queue_family_index) =
+                        queue_family_ownership_transfer.map_or(
+                            (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                            Into::into,
+                        );
+
+                    ash::vk::BufferMemoryBarrier {
+                        src_access_mask: src_access.into(),
+                        dst_access_mask: dst_access.into(),
+                        src_queue_family_index,
+                        dst_queue_family_index,
+                        buffer: buffer.handle(),
+                        offset: range.start,
+                        size: range.end - range.start,
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let image_memory_barriers_vk: SmallVec<[_; 8]> = image_memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &ImageMemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        old_layout,
+                        new_layout,
+                        queue_family_ownership_transfer,
+                        ref image,
+                        ref subresource_range,
+                        _ne: _,
+                    } = barrier;
+
+                    src_stage_mask |= src_stages.into();
+                    dst_stage_mask |= dst_stages.into();
+
+                    let (src_queue_family_index, dst_queue_family_index) =
+                        queue_family_ownership_transfer.map_or(
+                            (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                            Into::into,
+                        );
+
+                    ash::vk::ImageMemoryBarrier {
+                        src_access_mask: src_access.into(),
+                        dst_access_mask: dst_access.into(),
+                        old_layout: old_layout.into(),
+                        new_layout: new_layout.into(),
+                        src_queue_family_index,
+                        dst_queue_family_index,
+                        image: image.handle(),
+                        subresource_range: subresource_range.clone().into(),
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            if src_stage_mask.is_empty() {
+                // "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT is [...] equivalent to
+                // VK_PIPELINE_STAGE_2_NONE in the first scope."
+                src_stage_mask |= ash::vk::PipelineStageFlags::TOP_OF_PIPE;
+            }
+
+            if dst_stage_mask.is_empty() {
+                // "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT is [...] equivalent to
+                // VK_PIPELINE_STAGE_2_NONE in the second scope."
+                dst_stage_mask |= ash::vk::PipelineStageFlags::BOTTOM_OF_PIPE;
+            }
+
+            let fns = self.device().fns();
+            (fns.v1_0.cmd_pipeline_barrier)(
+                self.handle(),
+                src_stage_mask,
+                dst_stage_mask,
+                dependency_flags.into(),
+                memory_barriers_vk.len() as u32,
+                memory_barriers_vk.as_ptr(),
+                buffer_memory_barriers_vk.len() as u32,
+                buffer_memory_barriers_vk.as_ptr(),
+                image_memory_barriers_vk.len() as u32,
+                image_memory_barriers_vk.as_ptr(),
+            );
+        }
+
+        self.resources
+            .reserve(buffer_memory_barriers.len() + image_memory_barriers.len());
+
+        for barrier in buffer_memory_barriers {
+            let BufferMemoryBarrier {
+                src_stages: _,
+                src_access: _,
+                dst_stages: _,
+                dst_access: _,
+                queue_family_ownership_transfer: _, // TODO:
+                buffer,
+                range: _,
+                _ne: _,
+            } = barrier;
+
+            self.resources.push(Box::new(buffer));
+        }
+
+        for barrier in image_memory_barriers {
+            let ImageMemoryBarrier {
+                src_stages: _,
+                src_access: _,
+                dst_stages: _,
+                dst_access: _,
+                old_layout: _,                      // TODO:
+                new_layout: _,                      // TODO:
+                queue_family_ownership_transfer: _, // TODO:
+                image,
+                subresource_range: _,
+                _ne: _,
+            } = barrier;
+
+            self.resources.push(Box::new(image));
+        }
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Signals an [`Event`] from the device.
+    ///
+    /// # Safety
+    ///
+    /// - All images that are accessed by the command must be in the expected image layout.
+    /// - For each element of `dependency_info.image_memory_barriers` that contains an image layout
+    ///   transition, which is a write operation, the barrier must be defined appropriately to
+    ///   ensure no memory access hazard occurs.
+    #[inline]
+    pub unsafe fn set_event(
+        &mut self,
+        event: Arc<Event>,
+        dependency_info: DependencyInfo,
+    ) -> Result<&mut Self, SynchronizationError> {
+        self.validate_set_event(&event, &dependency_info)?;
+
+        unsafe { Ok(self.set_event_unchecked(event, dependency_info)) }
+    }
+
+    fn validate_set_event(
+        &self,
+        event: &Event,
+        dependency_info: &DependencyInfo,
+    ) -> Result<(), SynchronizationError> {
+        // VUID-vkCmdSetEvent2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(SynchronizationError::ForbiddenInsideRenderPass);
+        }
+
+        // VUID-vkCmdSetEvent2-commandBuffer-03826
+        // TODO:
+
+        let device = self.device();
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdSetEvent2-commandBuffer-cmdpool
+        if !queue_family_properties.queue_flags.intersects(
+            QueueFlags::GRAPHICS
+                | QueueFlags::COMPUTE
+                | QueueFlags::VIDEO_DECODE
+                | QueueFlags::VIDEO_ENCODE,
+        ) {
+            return Err(SynchronizationError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdSetEvent2-commonparent
+        assert_eq!(device, event.device());
+
+        let &DependencyInfo {
+            dependency_flags,
+            ref memory_barriers,
+            ref buffer_memory_barriers,
+            ref image_memory_barriers,
+            _ne: _,
+        } = dependency_info;
+
+        // VUID-VkDependencyInfo-dependencyFlags-parameter
+        dependency_flags.validate_device(device)?;
+
+        // VUID-vkCmdSetEvent2-dependencyFlags-03825
+        assert!(dependency_flags.is_empty());
+
+        let check_stages_access = |ty: char,
+                                   barrier_index: usize,
+                                   src_stages: PipelineStages,
+                                   src_access: AccessFlags,
+                                   dst_stages: PipelineStages,
+                                   dst_access: AccessFlags|
+         -> Result<(), SynchronizationError> {
+            for (stages, access) in [(src_stages, src_access), (dst_stages, dst_access)] {
+                // VUID-vkCmdSetEvent2-synchronization2-03824
+                if !device.enabled_features().synchronization2 {
+                    if stages.is_2() {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                                `dependency_info.buffer_memory_barriers` or \
+                                `dependency_info.image_memory_barriers` has an element where \
+                                `src_stages` or `dst_stages` contains flags from \
+                                `VkPipelineStageFlagBits2`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["synchronization2"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    if access.is_2() {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                                `dependency_info.buffer_memory_barriers` or \
+                                `dependency_info.image_memory_barriers` has an element where \
+                                `src_access` or `dst_access` contains flags from \
+                                `VkAccessFlagBits2`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["synchronization2"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-parameter
+                // VUID-VkMemoryBarrier2-dstStageMask-parameter
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-parameter
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-parameter
+                // VUID-VkImageMemoryBarrier2-srcStageMask-parameter
+                // VUID-VkImageMemoryBarrier2-dstStageMask-parameter
+                stages.validate_device(device)?;
+
+                // VUID-VkMemoryBarrier2-srcAccessMask-parameter
+                // VUID-VkMemoryBarrier2-dstAccessMask-parameter
+                // VUID-VkBufferMemoryBarrier2-srcAccessMask-parameter
+                // VUID-VkBufferMemoryBarrier2-dstAccessMask-parameter
+                // VUID-VkImageMemoryBarrier2-srcAccessMask-parameter
+                // VUID-VkImageMemoryBarrier2-dstAccessMask-parameter
+                access.validate_device(device)?;
+
+                // VUID-vkCmdSetEvent2-srcStageMask-03827
+                // VUID-vkCmdSetEvent2-dstStageMask-03828
+                if !PipelineStages::from(queue_family_properties.queue_flags).contains(stages) {
+                    match ty {
+                        'm' => {
+                            return Err(SynchronizationError::MemoryBarrierStageNotSupported {
+                                barrier_index,
+                            })
+                        }
+                        'b' => {
+                            return Err(
+                                SynchronizationError::BufferMemoryBarrierStageNotSupported {
+                                    barrier_index,
+                                },
+                            )
+                        }
+                        'i' => {
+                            return Err(SynchronizationError::ImageMemoryBarrierStageNotSupported {
+                                barrier_index,
+                            })
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03929
+                // VUID-VkMemoryBarrier2-dstStageMask-03929
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03929
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03929
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03930
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03930
+                if stages.intersects(PipelineStages::GEOMETRY_SHADER)
+                    && !device.enabled_features().geometry_shader
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::GEOMETRY_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["geometry_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03930
+                // VUID-VkMemoryBarrier2-dstStageMask-03930
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03930
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03930
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03930
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03930
+                if stages.intersects(
+                    PipelineStages::TESSELLATION_CONTROL_SHADER
+                        | PipelineStages::TESSELLATION_EVALUATION_SHADER,
+                ) && !device.enabled_features().tessellation_shader
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TESSELLATION_CONTROL_SHADER` or \
+                            `PipelineStages::TESSELLATION_EVALUATION_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["tessellation_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03931
+                // VUID-VkMemoryBarrier2-dstStageMask-03931
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03931
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03931
+                // VUID-VImagekMemoryBarrier2-srcStageMask-03931
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03931
+                if stages.intersects(PipelineStages::CONDITIONAL_RENDERING)
+                    && !device.enabled_features().conditional_rendering
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::CONDITIONAL_RENDERING`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["conditional_rendering"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03932
+                // VUID-VkMemoryBarrier2-dstStageMask-03932
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03932
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03932
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03932
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03932
+                if stages.intersects(PipelineStages::FRAGMENT_DENSITY_PROCESS)
+                    && !device.enabled_features().fragment_density_map
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::FRAGMENT_DENSITY_PROCESS`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["fragment_density_map"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03933
+                // VUID-VkMemoryBarrier2-dstStageMask-03933
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03933
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03933
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03933
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03933
+                if stages.intersects(PipelineStages::TRANSFORM_FEEDBACK)
+                    && !device.enabled_features().transform_feedback
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TRANSFORM_FEEDBACK`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["transform_feedback"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03934
+                // VUID-VkMemoryBarrier2-dstStageMask-03934
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03934
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03934
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03934
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03934
+                if stages.intersects(PipelineStages::MESH_SHADER)
+                    && !device.enabled_features().mesh_shader
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::MESH_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["mesh_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-03935
+                // VUID-VkMemoryBarrier2-dstStageMask-03935
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03935
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-03935
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03935
+                // VUID-VkImageMemoryBarrier2-dstStageMask-03935
+                if stages.intersects(PipelineStages::TASK_SHADER)
+                    && !device.enabled_features().task_shader
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TASK_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["task_shader"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkBufferMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkBufferMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkImageMemoryBarrier2-shadingRateImage-07316
+                // VUID-VkImageMemoryBarrier2-shadingRateImage-07316
+                if stages.intersects(PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT)
+                    && !(device.enabled_features().attachment_fragment_shading_rate
+                        || device.enabled_features().shading_rate_image)
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["attachment_fragment_shading_rate", "shading_rate_image"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-04957
+                // VUID-VkMemoryBarrier2-dstStageMask-04957
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-04957
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-04957
+                // VUID-VkImageMemoryBarrier2-srcStageMask-04957
+                // VUID-VkImageMemoryBarrier2-dstStageMask-04957
+                if stages.intersects(PipelineStages::SUBPASS_SHADING)
+                    && !device.enabled_features().subpass_shading
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::SUBPASS_SHADING`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["subpass_shading"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-VkMemoryBarrier2-srcStageMask-04995
+                // VUID-VkMemoryBarrier2-dstStageMask-04995
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-04995
+                // VUID-VkBufferMemoryBarrier2-dstStageMask-04995
+                // VUID-VkImageMemoryBarrier2-srcStageMask-04995
+                // VUID-VkImageMemoryBarrier2-dstStageMask-04995
+                if stages.intersects(PipelineStages::INVOCATION_MASK)
+                    && !device.enabled_features().invocation_mask
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::INVOCATION_MASK`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["invocation_mask"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-vkCmdSetEvent-stageMask-03937
+                if stages.is_empty() && !device.enabled_features().synchronization2 {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            is empty",
+                        requires_one_of: RequiresOneOf {
+                            features: &["synchronization2"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // A bit of a ridiculous number of VUIDs...
+
+                // VUID-VkMemoryBarrier2-srcAccessMask-03900
+                // ..
+                // VUID-VkMemoryBarrier2-srcAccessMask-07458
+
+                // VUID-VkMemoryBarrier2-dstAccessMask-03900
+                // ..
+                // VUID-VkMemoryBarrier2-dstAccessMask-07458
+
+                // VUID-VkBufferMemoryBarrier2-srcAccessMask-03900
+                // ..
+                // VUID-VkBufferMemoryBarrier2-srcAccessMask-07458
+
+                // VUID-VkBufferMemoryBarrier2-dstAccessMask-03900
+                // ..
+                // VUID-VkBufferMemoryBarrier2-dstAccessMask-07458
+
+                // VUID-VkImageMemoryBarrier2-srcAccessMask-03900
+                // ..
+                // VUID-VkImageMemoryBarrier2-srcAccessMask-07458
+
+                // VUID-VkImageMemoryBarrier2-dstAccessMask-03900
+                // ..
+                // VUID-VkImageMemoryBarrier2-dstAccessMask-07458
+
+                if !AccessFlags::from(stages).contains(access) {
+                    match ty {
+                        'm' => {
+                            return Err(
+                                SynchronizationError::MemoryBarrierAccessNotSupportedByStages {
+                                    barrier_index,
+                                },
+                            )
+                        }
+                        'b' => return Err(
+                            SynchronizationError::BufferMemoryBarrierAccessNotSupportedByStages {
+                                barrier_index,
+                            },
+                        ),
+                        'i' => return Err(
+                            SynchronizationError::ImageMemoryBarrierAccessNotSupportedByStages {
+                                barrier_index,
+                            },
+                        ),
+                        _ => unreachable!(),
+                    }
+                }
+            }
+
+            // VUID-VkMemoryBarrier2-srcAccessMask-06256
+            // VUID-VkBufferMemoryBarrier2-srcAccessMask-06256
+            // VUID-VkImageMemoryBarrier2-srcAccessMask-06256
+            if !device.enabled_features().ray_query
+                && src_access.intersects(AccessFlags::ACCELERATION_STRUCTURE_READ)
+                && src_stages.intersects(
+                    PipelineStages::VERTEX_SHADER
+                        | PipelineStages::TESSELLATION_CONTROL_SHADER
+                        | PipelineStages::TESSELLATION_EVALUATION_SHADER
+                        | PipelineStages::GEOMETRY_SHADER
+                        | PipelineStages::FRAGMENT_SHADER
+                        | PipelineStages::COMPUTE_SHADER
+                        | PipelineStages::PRE_RASTERIZATION_SHADERS
+                        | PipelineStages::TASK_SHADER
+                        | PipelineStages::MESH_SHADER,
+                )
+            {
+                return Err(SynchronizationError::RequirementNotMet {
+                    required_for: "One of `dependency_info.memory_barriers`, \
+                        `dependency_info.buffer_memory_barriers` or \
+                        `dependency_info.image_memory_barriers` has an element where \
+                        `src_access` contains `ACCELERATION_STRUCTURE_READ`, and \
+                        `src_stages` contains a shader stage other than `RAY_TRACING_SHADER`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["ray_query"],
+                        ..Default::default()
+                    },
+                });
+            }
+
+            Ok(())
+        };
+
+        let check_queue_family_ownership_transfer = |ty: char,
+                                                     barrier_index: usize,
+                                                     src_stages: PipelineStages,
+                                                     dst_stages: PipelineStages,
+                                                     queue_family_ownership_transfer: Option<
+            QueueFamilyOwnershipTransfer,
+        >,
+                                                     sharing: &Sharing<_>|
+         -> Result<(), SynchronizationError> {
+            if let Some(transfer) = queue_family_ownership_transfer {
+                // VUID?
+                transfer.validate_device(device)?;
+
+                // VUID-VkBufferMemoryBarrier2-srcQueueFamilyIndex-04087
+                // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04070
+                // Ensured by the definition of `QueueFamilyOwnershipTransfer`.
+
+                // VUID-VkBufferMemoryBarrier2-buffer-04088
+                // VUID-VkImageMemoryBarrier2-image-04071
+                // Ensured by the definition of `QueueFamilyOwnershipTransfer`.
+
+                let queue_family_count =
+                    device.physical_device().queue_family_properties().len() as u32;
+
+                let provided_queue_family_index = match (sharing, transfer) {
+                    (
+                        Sharing::Exclusive,
+                        QueueFamilyOwnershipTransfer::ExclusiveBetweenLocal {
+                            src_index,
+                            dst_index,
+                        },
+                    ) => Some(max(src_index, dst_index)),
+                    (
+                        Sharing::Exclusive,
+                        QueueFamilyOwnershipTransfer::ExclusiveToExternal { src_index }
+                        | QueueFamilyOwnershipTransfer::ExclusiveToForeign { src_index },
+                    ) => Some(src_index),
+                    (
+                        Sharing::Exclusive,
+                        QueueFamilyOwnershipTransfer::ExclusiveFromExternal { dst_index }
+                        | QueueFamilyOwnershipTransfer::ExclusiveFromForeign { dst_index },
+                    ) => Some(dst_index),
+                    (
+                        Sharing::Concurrent(_),
+                        QueueFamilyOwnershipTransfer::ConcurrentToExternal
+                        | QueueFamilyOwnershipTransfer::ConcurrentFromExternal
+                        | QueueFamilyOwnershipTransfer::ConcurrentToForeign
+                        | QueueFamilyOwnershipTransfer::ConcurrentFromForeign,
+                    ) => None,
+                    _ => match ty {
+                        'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferSharingMismatch {
+                            barrier_index,
+                        }),
+                        'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferSharingMismatch {
+                            barrier_index,
+                        }),
+                        _ => unreachable!(),
+                    },
+                }.filter(|&index| index >= queue_family_count);
+
+                // VUID-VkBufferMemoryBarrier2-buffer-04089
+                // VUID-VkImageMemoryBarrier2-image-04072
+
+                if let Some(provided_queue_family_index) = provided_queue_family_index {
+                    match ty {
+                        'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferIndexOutOfRange {
+                            barrier_index,
+                            provided_queue_family_index,
+                            queue_family_count,
+                        }),
+                        'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferIndexOutOfRange {
+                            barrier_index,
+                            provided_queue_family_index,
+                            queue_family_count,
+                        }),
+                        _ => unreachable!(),
+                    }
+                }
+
+                // VUID-VkBufferMemoryBarrier2-srcStageMask-03851
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03854
+                if src_stages.intersects(PipelineStages::HOST)
+                    || dst_stages.intersects(PipelineStages::HOST)
+                {
+                    match ty {
+                        'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferHostNotAllowed {
+                            barrier_index,
+                        }),
+                        'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferHostForbidden {
+                            barrier_index,
+                        }),
+                        _ => unreachable!(),
+                    }
+                }
+            }
+
+            Ok(())
+        };
+
+        for (barrier_index, barrier) in memory_barriers.iter().enumerate() {
+            let &MemoryBarrier {
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+                _ne: _,
+            } = barrier;
+
+            /*
+                Check stages and access
+            */
+
+            check_stages_access(
+                'm',
+                barrier_index,
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+            )?;
+        }
+
+        for (barrier_index, barrier) in buffer_memory_barriers.iter().enumerate() {
+            let &BufferMemoryBarrier {
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+                queue_family_ownership_transfer,
+                ref buffer,
+                ref range,
+                _ne: _,
+            } = barrier;
+
+            // VUID-VkBufferMemoryBarrier2-buffer-01931
+            // Ensured by Buffer type construction.
+
+            /*
+                Check stages and access
+            */
+
+            check_stages_access(
+                'b',
+                barrier_index,
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+            )?;
+
+            /*
+                Check queue family transfer
+            */
+
+            check_queue_family_ownership_transfer(
+                'b',
+                barrier_index,
+                src_stages,
+                dst_stages,
+                queue_family_ownership_transfer,
+                buffer.sharing(),
+            )?;
+
+            /*
+                Check range
+            */
+
+            // VUID-VkBufferMemoryBarrier2-size-01188
+            assert!(!range.is_empty());
+
+            // VUID-VkBufferMemoryBarrier2-offset-01187
+            // VUID-VkBufferMemoryBarrier2-size-01189
+            if range.end > buffer.size() {
+                return Err(SynchronizationError::BufferMemoryBarrierOutOfRange {
+                    barrier_index,
+                    range_end: range.end,
+                    buffer_size: buffer.size(),
+                });
+            }
+        }
+
+        for (barrier_index, barrier) in image_memory_barriers.iter().enumerate() {
+            let &ImageMemoryBarrier {
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+                old_layout,
+                new_layout,
+                queue_family_ownership_transfer,
+                ref image,
+                ref subresource_range,
+                _ne: _,
+            } = barrier;
+
+            // VUID-VkImageMemoryBarrier2-image-01932
+            // Ensured by Image type construction.
+
+            /*
+                Check stages and access
+            */
+
+            check_stages_access(
+                'i',
+                barrier_index,
+                src_stages,
+                src_access,
+                dst_stages,
+                dst_access,
+            )?;
+
+            /*
+                Check layouts
+            */
+
+            // VUID-VkImageMemoryBarrier2-oldLayout-parameter
+            old_layout.validate_device(device)?;
+
+            // VUID-VkImageMemoryBarrier2-newLayout-parameter
+            new_layout.validate_device(device)?;
+
+            // VUID-VkImageMemoryBarrier2-srcStageMask-03855
+            if src_stages.intersects(PipelineStages::HOST)
+                && !matches!(
+                    old_layout,
+                    ImageLayout::Preinitialized | ImageLayout::Undefined | ImageLayout::General
+                )
+            {
+                return Err(
+                    SynchronizationError::ImageMemoryBarrierOldLayoutFromHostInvalid {
+                        barrier_index,
+                        old_layout,
+                    },
+                );
+            }
+
+            // VUID-VkImageMemoryBarrier2-oldLayout-01197
+            // Not checked yet, therefore unsafe.
+
+            // VUID-VkImageMemoryBarrier2-newLayout-01198
+            if matches!(
+                new_layout,
+                ImageLayout::Undefined | ImageLayout::Preinitialized
+            ) {
+                return Err(SynchronizationError::ImageMemoryBarrierNewLayoutInvalid {
+                    barrier_index,
+                });
+            }
+
+            // VUID-VkImageMemoryBarrier2-attachmentFeedbackLoopLayout-07313
+            /*if !device.enabled_features().attachment_feedback_loop_layout
+                && matches!(new_layout, ImageLayout::AttachmentFeedbackLoopOptimal)
+            {
+                return Err(SynchronizationError::RequirementNotMet {
+                    required_for: "`dependency_info.image_memory_barriers` has an element where \
+                        `new_layout` is `AttachmentFeedbackLoopOptimal`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["attachment_feedback_loop_layout"],
+                        ..Default::default()
+                    },
+                });
+            }*/
+
+            for layout in [old_layout, new_layout] {
+                // VUID-VkImageMemoryBarrier2-synchronization2-06911
+                /*if !device.enabled_features().synchronization2
+                    && matches!(
+                        layout,
+                        ImageLayout::AttachmentOptimal | ImageLayout::ReadOnlyOptimal
+                    )
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "`dependency_info.image_memory_barriers` has an element \
+                            where `old_layout` or `new_layout` is `AttachmentOptimal` or \
+                            `ReadOnlyOptimal`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["synchronization2"],
+                            ..Default::default()
+                        },
+                    });
+                }*/
+
+                // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-07006
+                /*if layout == ImageLayout::AttachmentFeedbackLoopOptimal {
+                    if !image.usage().intersects(
+                        ImageUsage::COLOR_ATTACHMENT | ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+                    ) {
+                        return Err(
+                            SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                barrier_index,
+                                layout,
+                                requires_one_of_usage: ImageUsage::COLOR_ATTACHMENT
+                                    | ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+                            },
+                        );
+                    }
+
+                    if !image
+                        .usage()
+                        .intersects(ImageUsage::INPUT_ATTACHMENT | ImageUsage::SAMPLED)
+                    {
+                        return Err(
+                            SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                barrier_index,
+                                layout,
+                                requires_one_of_usage: ImageUsage::INPUT_ATTACHMENT
+                                    | ImageUsage::SAMPLED,
+                            },
+                        );
+                    }
+
+                    if !image
+                        .usage()
+                        .intersects(ImageUsage::ATTACHMENT_FEEDBACK_LOOP)
+                    {
+                        return Err(
+                            SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                barrier_index,
+                                layout,
+                                requires_one_of_usage: ImageUsage::ATTACHMENT_FEEDBACK_LOOP,
+                            },
+                        );
+                    }
+                }*/
+
+                let requires_one_of_usage = match layout {
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01208
+                    ImageLayout::ColorAttachmentOptimal => ImageUsage::COLOR_ATTACHMENT,
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01209
+                    ImageLayout::DepthStencilAttachmentOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01210
+                    ImageLayout::DepthStencilReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01211
+                    ImageLayout::ShaderReadOnlyOptimal => {
+                        ImageUsage::SAMPLED | ImageUsage::INPUT_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01212
+                    ImageLayout::TransferSrcOptimal => ImageUsage::TRANSFER_SRC,
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01213
+                    ImageLayout::TransferDstOptimal => ImageUsage::TRANSFER_DST,
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01658
+                    ImageLayout::DepthReadOnlyStencilAttachmentOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-01659
+                    ImageLayout::DepthAttachmentStencilReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    /*
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04065
+                    ImageLayout::DepthReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                            | ImageUsage::SAMPLED
+                            | ImageUsage::INPUT_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04066
+                    ImageLayout::DepthAttachmentOptimal => ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04067
+                    ImageLayout::StencilReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                            | ImageUsage::SAMPLED
+                            | ImageUsage::INPUT_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04068
+                    ImageLayout::StencilAttachmentOptimal => ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-03938
+                    ImageLayout::AttachmentOptimal => {
+                        ImageUsage::COLOR_ATTACHMENT | ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-03939
+                    ImageLayout::ReadOnlyOptimal => {
+                        ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                            | ImageUsage::SAMPLED
+                            | ImageUsage::INPUT_ATTACHMENT
+                    }
+
+                    // VUID-VkImageMemoryBarrier2-oldLayout-02088
+                    ImageLayout::FragmentShadingRateAttachmentOptimal => {
+                        ImageUsage::FRAGMENT_SHADING_RATE_ATTACHMENT
+                    }
+                     */
+                    _ => continue,
+                };
+
+                if !image.usage().intersects(requires_one_of_usage) {
+                    return Err(
+                        SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                            barrier_index,
+                            layout,
+                            requires_one_of_usage,
+                        },
+                    );
+                }
+            }
+
+            /*
+                Check queue family tansfer
+            */
+
+            check_queue_family_ownership_transfer(
+                'i',
+                barrier_index,
+                src_stages,
+                dst_stages,
+                queue_family_ownership_transfer,
+                image.sharing(),
+            )?;
+
+            /*
+                Check subresource range
+            */
+
+            // VUID-VkImageSubresourceRange-aspectMask-requiredbitmask
+            assert!(!subresource_range.aspects.is_empty());
+
+            // VUID-VkImageSubresourceRange-aspectMask-parameter
+            subresource_range.aspects.validate_device(device)?;
+
+            let image_aspects = image.format().unwrap().aspects();
+
+            // VUID-VkImageMemoryBarrier2-image-01673
+            // VUID-VkImageMemoryBarrier2-image-03319
+            if image_aspects.contains(subresource_range.aspects) {
+                return Err(SynchronizationError::ImageMemoryBarrierAspectsNotAllowed {
+                    barrier_index,
+                    aspects: subresource_range.aspects - image_aspects,
+                });
+            }
+
+            if image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
+                // VUID-VkImageMemoryBarrier2-image-03320
+                if !device.enabled_features().separate_depth_stencil_layouts
+                    && image_aspects.contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
+                    && !subresource_range
+                        .aspects
+                        .contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "`dependency_info.image_memory_barriers` has an element \
+                            where `image` has both a depth and a stencil aspect, and \
+                            `subresource_range.aspects` does not contain both aspects",
+                        requires_one_of: RequiresOneOf {
+                            features: &["separate_depth_stencil_layouts"],
+                            ..Default::default()
+                        },
+                    });
+                }
+            } else {
+                // VUID-VkImageMemoryBarrier2-image-01671
+                if !image.flags().intersects(ImageCreateFlags::DISJOINT)
+                    && subresource_range.aspects != ImageAspects::COLOR
+                {
+                    return Err(SynchronizationError::ImageMemoryBarrierAspectsNotAllowed {
+                        barrier_index,
+                        aspects: subresource_range.aspects - ImageAspects::COLOR,
+                    });
+                }
+            }
+
+            // VUID-VkImageSubresourceRange-levelCount-01720
+            assert!(!subresource_range.mip_levels.is_empty());
+
+            // VUID-VkImageMemoryBarrier2-subresourceRange-01486
+            // VUID-VkImageMemoryBarrier2-subresourceRange-01724
+            if subresource_range.mip_levels.end > image.mip_levels() {
+                return Err(
+                    SynchronizationError::ImageMemoryBarrierMipLevelsOutOfRange {
+                        barrier_index,
+                        mip_levels_range_end: subresource_range.mip_levels.end,
+                        image_mip_levels: image.mip_levels(),
+                    },
+                );
+            }
+
+            // VUID-VkImageSubresourceRange-layerCount-01721
+            assert!(!subresource_range.array_layers.is_empty());
+
+            // VUID-VkImageMemoryBarrier2-subresourceRange-01488
+            // VUID-VkImageMemoryBarrier2-subresourceRange-01725
+            if subresource_range.array_layers.end > image.dimensions().array_layers() {
+                return Err(
+                    SynchronizationError::ImageMemoryBarrierArrayLayersOutOfRange {
+                        barrier_index,
+                        array_layers_range_end: subresource_range.array_layers.end,
+                        image_array_layers: image.dimensions().array_layers(),
+                    },
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_event_unchecked(
+        &mut self,
+        event: Arc<Event>,
+        dependency_info: DependencyInfo,
+    ) -> &mut Self {
+        let DependencyInfo {
+            dependency_flags,
+            memory_barriers,
+            buffer_memory_barriers,
+            image_memory_barriers,
+            _ne: _,
+        } = dependency_info;
+
+        let fns = self.device().fns();
+
+        if self.device().enabled_features().synchronization2 {
+            let memory_barriers_vk: SmallVec<[_; 2]> = memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &MemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        _ne: _,
+                    } = barrier;
+
+                    ash::vk::MemoryBarrier2 {
+                        src_stage_mask: src_stages.into(),
+                        src_access_mask: src_access.into(),
+                        dst_stage_mask: dst_stages.into(),
+                        dst_access_mask: dst_access.into(),
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let buffer_memory_barriers_vk: SmallVec<[_; 8]> = buffer_memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &BufferMemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        queue_family_ownership_transfer,
+                        ref buffer,
+                        ref range,
+                        _ne: _,
+                    } = barrier;
+
+                    let (src_queue_family_index, dst_queue_family_index) =
+                        queue_family_ownership_transfer.map_or(
+                            (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                            Into::into,
+                        );
+
+                    ash::vk::BufferMemoryBarrier2 {
+                        src_stage_mask: src_stages.into(),
+                        src_access_mask: src_access.into(),
+                        dst_stage_mask: dst_stages.into(),
+                        dst_access_mask: dst_access.into(),
+                        src_queue_family_index,
+                        dst_queue_family_index,
+                        buffer: buffer.handle(),
+                        offset: range.start,
+                        size: range.end - range.start,
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let image_memory_barriers_vk: SmallVec<[_; 8]> = image_memory_barriers
+                .iter()
+                .map(|barrier| {
+                    let &ImageMemoryBarrier {
+                        src_stages,
+                        src_access,
+                        dst_stages,
+                        dst_access,
+                        old_layout,
+                        new_layout,
+                        queue_family_ownership_transfer,
+                        ref image,
+                        ref subresource_range,
+                        _ne: _,
+                    } = barrier;
+
+                    let (src_queue_family_index, dst_queue_family_index) =
+                        queue_family_ownership_transfer.map_or(
+                            (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                            Into::into,
+                        );
+
+                    ash::vk::ImageMemoryBarrier2 {
+                        src_stage_mask: src_stages.into(),
+                        src_access_mask: src_access.into(),
+                        dst_stage_mask: dst_stages.into(),
+                        dst_access_mask: dst_access.into(),
+                        old_layout: old_layout.into(),
+                        new_layout: new_layout.into(),
+                        src_queue_family_index,
+                        dst_queue_family_index,
+                        image: image.handle(),
+                        subresource_range: subresource_range.clone().into(),
+                        ..Default::default()
+                    }
+                })
+                .collect();
+
+            let dependency_info_vk = ash::vk::DependencyInfo {
+                dependency_flags: dependency_flags.into(),
+                memory_barrier_count: memory_barriers_vk.len() as u32,
+                p_memory_barriers: memory_barriers_vk.as_ptr(),
+                buffer_memory_barrier_count: buffer_memory_barriers_vk.len() as u32,
+                p_buffer_memory_barriers: buffer_memory_barriers_vk.as_ptr(),
+                image_memory_barrier_count: image_memory_barriers_vk.len() as u32,
+                p_image_memory_barriers: image_memory_barriers_vk.as_ptr(),
+                ..Default::default()
+            };
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_set_event2)(self.handle(), event.handle(), &dependency_info_vk);
+            } else {
+                debug_assert!(self.device().enabled_extensions().khr_synchronization2);
+                (fns.khr_synchronization2.cmd_set_event2_khr)(
+                    self.handle(),
+                    event.handle(),
+                    &dependency_info_vk,
+                );
+            }
+        } else {
+            // The original function only takes a source stage mask; the rest of the info is
+            // provided with `wait_events` instead. Therefore, we condense the source stages
+            // here and ignore the rest.
+
+            let mut stage_mask = ash::vk::PipelineStageFlags::empty();
+
+            for barrier in memory_barriers {
+                stage_mask |= barrier.src_stages.into();
+            }
+
+            for barrier in buffer_memory_barriers {
+                stage_mask |= barrier.src_stages.into();
+            }
+
+            for barrier in image_memory_barriers {
+                stage_mask |= barrier.src_stages.into();
+            }
+
+            if stage_mask.is_empty() {
+                // "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT is [...] equivalent to
+                // VK_PIPELINE_STAGE_2_NONE in the first scope."
+                stage_mask |= ash::vk::PipelineStageFlags::TOP_OF_PIPE;
+            }
+
+            (fns.v1_0.cmd_set_event)(self.handle(), event.handle(), stage_mask);
+        }
+
+        self.resources.push(Box::new(event));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Waits for one or more [`Event`]s to be signaled.
+    ///
+    /// # Safety
+    ///
+    /// - For each element in `events`, if the event is signaled by [`set_event`], that command
+    ///   must have already been recorded or previously submitted to the queue, and the
+    ///   `DependencyInfo` provided here must be equal to the `DependencyInfo` used in that
+    ///   command.
+    /// - For each element in `events`, if the event is signaled by [`Event::set`], that function
+    ///   must have already been called before submitting this command to a queue.
+    ///
+    /// [`set_event`]: Self::set_event
+    /// [`Event::set`]: Event::set
+    #[inline]
+    pub unsafe fn wait_events(
+        &mut self,
+        events: impl IntoIterator<Item = (Arc<Event>, DependencyInfo)>,
+    ) -> Result<&mut Self, SynchronizationError> {
+        let events: SmallVec<[(Arc<Event>, DependencyInfo); 4]> = events.into_iter().collect();
+        self.validate_wait_events(&events)?;
+
+        unsafe { Ok(self.wait_events_unchecked(events)) }
+    }
+
+    fn validate_wait_events(
+        &self,
+        events: &[(Arc<Event>, DependencyInfo)],
+    ) -> Result<(), SynchronizationError> {
+        // VUID-vkCmdWaitEvents2-commandBuffer-03846
+        // TODO:
+
+        let device = self.device();
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdWaitEvents2-commandBuffer-cmdpool
+        if !queue_family_properties.queue_flags.intersects(
+            QueueFlags::GRAPHICS
+                | QueueFlags::COMPUTE
+                | QueueFlags::VIDEO_DECODE
+                | QueueFlags::VIDEO_ENCODE,
+        ) {
+            return Err(SynchronizationError::NotSupportedByQueueFamily);
+        }
+
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        for (event, dependency_info) in events {
+            // VUID-vkCmdWaitEvents2-commonparent
+            assert_eq!(device, event.device());
+
+            // VUID-vkCmdWaitEvents2-pEvents-03838
+            // TODO:
+
+            // VUID-vkCmdWaitEvents2-pEvents-03839
+            // TODO:
+
+            // VUID-vkCmdWaitEvents2-pEvents-03840
+            // TODO:
+
+            // VUID-vkCmdWaitEvents2-pEvents-03841
+            // TODO:
+
+            let &DependencyInfo {
+                dependency_flags,
+                ref memory_barriers,
+                ref buffer_memory_barriers,
+                ref image_memory_barriers,
+                _ne: _,
+            } = dependency_info;
+
+            // VUID-VkDependencyInfo-dependencyFlags-parameter
+            dependency_flags.validate_device(device)?;
+
+            let check_stages_access = |ty: char,
+                                       barrier_index: usize,
+                                       src_stages: PipelineStages,
+                                       src_access: AccessFlags,
+                                       dst_stages: PipelineStages,
+                                       dst_access: AccessFlags|
+             -> Result<(), SynchronizationError> {
+                for (stages, access) in [(src_stages, src_access), (dst_stages, dst_access)] {
+                    // VUID-vkCmdWaitEvents2-synchronization2-03836
+                    if !device.enabled_features().synchronization2 {
+                        if stages.is_2() {
+                            return Err(SynchronizationError::RequirementNotMet {
+                                required_for: "One of `dependency_info.memory_barriers`, \
+                                `dependency_info.buffer_memory_barriers` or \
+                                `dependency_info.image_memory_barriers` has an element where \
+                                `src_stages` or `dst_stages` contains flags from \
+                                `VkPipelineStageFlagBits2`",
+                                requires_one_of: RequiresOneOf {
+                                    features: &["synchronization2"],
+                                    ..Default::default()
+                                },
+                            });
+                        }
+
+                        if access.is_2() {
+                            return Err(SynchronizationError::RequirementNotMet {
+                                required_for: "One of `dependency_info.memory_barriers`, \
+                                `dependency_info.buffer_memory_barriers` or \
+                                `dependency_info.image_memory_barriers` has an element where \
+                                `src_access` or `dst_access` contains flags from \
+                                `VkAccessFlagBits2`",
+                                requires_one_of: RequiresOneOf {
+                                    features: &["synchronization2"],
+                                    ..Default::default()
+                                },
+                            });
+                        }
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-parameter
+                    // VUID-VkMemoryBarrier2-dstStageMask-parameter
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-parameter
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-parameter
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-parameter
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-parameter
+                    stages.validate_device(device)?;
+
+                    // VUID-VkMemoryBarrier2-srcAccessMask-parameter
+                    // VUID-VkMemoryBarrier2-dstAccessMask-parameter
+                    // VUID-VkBufferMemoryBarrier2-srcAccessMask-parameter
+                    // VUID-VkBufferMemoryBarrier2-dstAccessMask-parameter
+                    // VUID-VkImageMemoryBarrier2-srcAccessMask-parameter
+                    // VUID-VkImageMemoryBarrier2-dstAccessMask-parameter
+                    access.validate_device(device)?;
+
+                    // VUID-vkCmdWaitEvents2-srcStageMask-03842
+                    // VUID-vkCmdWaitEvents2-dstStageMask-03843
+                    if !PipelineStages::from(queue_family_properties.queue_flags).contains(stages) {
+                        match ty {
+                            'm' => {
+                                return Err(SynchronizationError::MemoryBarrierStageNotSupported {
+                                    barrier_index,
+                                })
+                            }
+                            'b' => {
+                                return Err(
+                                    SynchronizationError::BufferMemoryBarrierStageNotSupported {
+                                        barrier_index,
+                                    },
+                                )
+                            }
+                            'i' => {
+                                return Err(
+                                    SynchronizationError::ImageMemoryBarrierStageNotSupported {
+                                        barrier_index,
+                                    },
+                                )
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-03929
+                    // VUID-VkMemoryBarrier2-dstStageMask-03929
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-03929
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-03929
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-03930
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-03930
+                    if stages.intersects(PipelineStages::GEOMETRY_SHADER)
+                        && !device.enabled_features().geometry_shader
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::GEOMETRY_SHADER`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["geometry_shader"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-03930
+                    // VUID-VkMemoryBarrier2-dstStageMask-03930
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-03930
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-03930
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-03930
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-03930
+                    if stages.intersects(
+                        PipelineStages::TESSELLATION_CONTROL_SHADER
+                            | PipelineStages::TESSELLATION_EVALUATION_SHADER,
+                    ) && !device.enabled_features().tessellation_shader
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TESSELLATION_CONTROL_SHADER` or \
+                            `PipelineStages::TESSELLATION_EVALUATION_SHADER`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["tessellation_shader"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-03931
+                    // VUID-VkMemoryBarrier2-dstStageMask-03931
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-03931
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-03931
+                    // VUID-VImagekMemoryBarrier2-srcStageMask-03931
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-03931
+                    if stages.intersects(PipelineStages::CONDITIONAL_RENDERING)
+                        && !device.enabled_features().conditional_rendering
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::CONDITIONAL_RENDERING`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["conditional_rendering"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-03932
+                    // VUID-VkMemoryBarrier2-dstStageMask-03932
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-03932
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-03932
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-03932
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-03932
+                    if stages.intersects(PipelineStages::FRAGMENT_DENSITY_PROCESS)
+                        && !device.enabled_features().fragment_density_map
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::FRAGMENT_DENSITY_PROCESS`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["fragment_density_map"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-03933
+                    // VUID-VkMemoryBarrier2-dstStageMask-03933
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-03933
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-03933
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-03933
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-03933
+                    if stages.intersects(PipelineStages::TRANSFORM_FEEDBACK)
+                        && !device.enabled_features().transform_feedback
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TRANSFORM_FEEDBACK`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["transform_feedback"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-03934
+                    // VUID-VkMemoryBarrier2-dstStageMask-03934
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-03934
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-03934
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-03934
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-03934
+                    if stages.intersects(PipelineStages::MESH_SHADER)
+                        && !device.enabled_features().mesh_shader
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::MESH_SHADER`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["mesh_shader"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-03935
+                    // VUID-VkMemoryBarrier2-dstStageMask-03935
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-03935
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-03935
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-03935
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-03935
+                    if stages.intersects(PipelineStages::TASK_SHADER)
+                        && !device.enabled_features().task_shader
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::TASK_SHADER`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["task_shader"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-shadingRateImage-07316
+                    // VUID-VkMemoryBarrier2-shadingRateImage-07316
+                    // VUID-VkBufferMemoryBarrier2-shadingRateImage-07316
+                    // VUID-VkBufferMemoryBarrier2-shadingRateImage-07316
+                    // VUID-VkImageMemoryBarrier2-shadingRateImage-07316
+                    // VUID-VkImageMemoryBarrier2-shadingRateImage-07316
+                    if stages.intersects(PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT)
+                        && !(device.enabled_features().attachment_fragment_shading_rate
+                            || device.enabled_features().shading_rate_image)
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT`",
+                            requires_one_of: RequiresOneOf {
+                                features: &[
+                                    "attachment_fragment_shading_rate",
+                                    "shading_rate_image",
+                                ],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-04957
+                    // VUID-VkMemoryBarrier2-dstStageMask-04957
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-04957
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-04957
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-04957
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-04957
+                    if stages.intersects(PipelineStages::SUBPASS_SHADING)
+                        && !device.enabled_features().subpass_shading
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::SUBPASS_SHADING`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["subpass_shading"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-VkMemoryBarrier2-srcStageMask-04995
+                    // VUID-VkMemoryBarrier2-dstStageMask-04995
+                    // VUID-VkBufferMemoryBarrier2-srcStageMask-04995
+                    // VUID-VkBufferMemoryBarrier2-dstStageMask-04995
+                    // VUID-VkImageMemoryBarrier2-srcStageMask-04995
+                    // VUID-VkImageMemoryBarrier2-dstStageMask-04995
+                    if stages.intersects(PipelineStages::INVOCATION_MASK)
+                        && !device.enabled_features().invocation_mask
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            contains `PipelineStages::INVOCATION_MASK`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["invocation_mask"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // VUID-vkCmdWaitEvents-srcStageMask-03937
+                    // VUID-vkCmdWaitEvents-dstStageMask-03937
+                    if stages.is_empty() && !device.enabled_features().synchronization2 {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "One of `dependency_info.memory_barriers`, \
+                            `dependency_info.buffer_memory_barriers` or \
+                            `dependency_info.image_memory_barriers` has an element where `stages` \
+                            is empty",
+                            requires_one_of: RequiresOneOf {
+                                features: &["synchronization2"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+
+                    // A bit of a ridiculous number of VUIDs...
+
+                    // VUID-VkMemoryBarrier2-srcAccessMask-03900
+                    // ..
+                    // VUID-VkMemoryBarrier2-srcAccessMask-07458
+
+                    // VUID-VkMemoryBarrier2-dstAccessMask-03900
+                    // ..
+                    // VUID-VkMemoryBarrier2-dstAccessMask-07458
+
+                    // VUID-VkBufferMemoryBarrier2-srcAccessMask-03900
+                    // ..
+                    // VUID-VkBufferMemoryBarrier2-srcAccessMask-07458
+
+                    // VUID-VkBufferMemoryBarrier2-dstAccessMask-03900
+                    // ..
+                    // VUID-VkBufferMemoryBarrier2-dstAccessMask-07458
+
+                    // VUID-VkImageMemoryBarrier2-srcAccessMask-03900
+                    // ..
+                    // VUID-VkImageMemoryBarrier2-srcAccessMask-07458
+
+                    // VUID-VkImageMemoryBarrier2-dstAccessMask-03900
+                    // ..
+                    // VUID-VkImageMemoryBarrier2-dstAccessMask-07458
+
+                    if !AccessFlags::from(stages).contains(access) {
+                        match ty {
+                            'm' => {
+                                return Err(
+                                    SynchronizationError::MemoryBarrierAccessNotSupportedByStages {
+                                        barrier_index,
+                                    },
+                                )
+                            }
+                            'b' => return Err(
+                                SynchronizationError::BufferMemoryBarrierAccessNotSupportedByStages {
+                                    barrier_index,
+                                },
+                            ),
+                            'i' => return Err(
+                                SynchronizationError::ImageMemoryBarrierAccessNotSupportedByStages {
+                                    barrier_index,
+                                },
+                            ),
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+
+                // VUID-VkMemoryBarrier2-srcAccessMask-06256
+                // VUID-VkBufferMemoryBarrier2-srcAccessMask-06256
+                // VUID-VkImageMemoryBarrier2-srcAccessMask-06256
+                if !device.enabled_features().ray_query
+                    && src_access.intersects(AccessFlags::ACCELERATION_STRUCTURE_READ)
+                    && src_stages.intersects(
+                        PipelineStages::VERTEX_SHADER
+                            | PipelineStages::TESSELLATION_CONTROL_SHADER
+                            | PipelineStages::TESSELLATION_EVALUATION_SHADER
+                            | PipelineStages::GEOMETRY_SHADER
+                            | PipelineStages::FRAGMENT_SHADER
+                            | PipelineStages::COMPUTE_SHADER
+                            | PipelineStages::PRE_RASTERIZATION_SHADERS
+                            | PipelineStages::TASK_SHADER
+                            | PipelineStages::MESH_SHADER,
+                    )
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "One of `dependency_info.memory_barriers`, \
+                        `dependency_info.buffer_memory_barriers` or \
+                        `dependency_info.image_memory_barriers` has an element where \
+                        `src_access` contains `ACCELERATION_STRUCTURE_READ`, and \
+                        `src_stages` contains a shader stage other than `RAY_TRACING_SHADER`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["ray_query"],
+                            ..Default::default()
+                        },
+                    });
+                }
+
+                // VUID-vkCmdWaitEvents2-dependencyFlags-03844
+                if self.current_state.render_pass.is_some()
+                    && src_stages.intersects(PipelineStages::HOST)
+                {
+                    todo!()
+                }
+
+                Ok(())
+            };
+
+            let check_queue_family_ownership_transfer =
+                |ty: char,
+                 barrier_index: usize,
+                 src_stages: PipelineStages,
+                 dst_stages: PipelineStages,
+                 queue_family_ownership_transfer: Option<QueueFamilyOwnershipTransfer>,
+                 sharing: &Sharing<_>|
+                 -> Result<(), SynchronizationError> {
+                    if let Some(transfer) = queue_family_ownership_transfer {
+                        // VUID?
+                        transfer.validate_device(device)?;
+
+                        // VUID-VkBufferMemoryBarrier2-srcQueueFamilyIndex-04087
+                        // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04070
+                        // Ensured by the definition of `QueueFamilyOwnershipTransfer`.
+
+                        // VUID-VkBufferMemoryBarrier2-buffer-04088
+                        // VUID-VkImageMemoryBarrier2-image-04071
+                        // Ensured by the definition of `QueueFamilyOwnershipTransfer`.
+
+                        let queue_family_count =
+                            device.physical_device().queue_family_properties().len() as u32;
+
+                        let provided_queue_family_index = match (sharing, transfer) {
+                            (
+                                Sharing::Exclusive,
+                                QueueFamilyOwnershipTransfer::ExclusiveBetweenLocal {
+                                    src_index,
+                                    dst_index,
+                                },
+                            ) => Some(max(src_index, dst_index)),
+                            (
+                                Sharing::Exclusive,
+                                QueueFamilyOwnershipTransfer::ExclusiveToExternal { src_index }
+                                | QueueFamilyOwnershipTransfer::ExclusiveToForeign { src_index },
+                            ) => Some(src_index),
+                            (
+                                Sharing::Exclusive,
+                                QueueFamilyOwnershipTransfer::ExclusiveFromExternal { dst_index }
+                                | QueueFamilyOwnershipTransfer::ExclusiveFromForeign { dst_index },
+                            ) => Some(dst_index),
+                            (
+                                Sharing::Concurrent(_),
+                                QueueFamilyOwnershipTransfer::ConcurrentToExternal
+                                | QueueFamilyOwnershipTransfer::ConcurrentFromExternal
+                                | QueueFamilyOwnershipTransfer::ConcurrentToForeign
+                                | QueueFamilyOwnershipTransfer::ConcurrentFromForeign,
+                            ) => None,
+                            _ => match ty {
+                                'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferSharingMismatch {
+                                    barrier_index,
+                                }),
+                                'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferSharingMismatch {
+                                    barrier_index,
+                                }),
+                                _ => unreachable!(),
+                            },
+                        }.filter(|&index| index >= queue_family_count);
+
+                        // VUID-VkBufferMemoryBarrier2-buffer-04089
+                        // VUID-VkImageMemoryBarrier2-image-04072
+
+                        if let Some(provided_queue_family_index) = provided_queue_family_index {
+                            match ty {
+                                'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferIndexOutOfRange {
+                                    barrier_index,
+                                    provided_queue_family_index,
+                                    queue_family_count,
+                                }),
+                                'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferIndexOutOfRange {
+                                    barrier_index,
+                                    provided_queue_family_index,
+                                    queue_family_count,
+                                }),
+                                _ => unreachable!(),
+                            }
+                        }
+
+                        // VUID-VkBufferMemoryBarrier2-srcStageMask-03851
+                        // VUID-VkImageMemoryBarrier2-srcStageMask-03854
+                        if src_stages.intersects(PipelineStages::HOST)
+                            || dst_stages.intersects(PipelineStages::HOST)
+                        {
+                            match ty {
+                                'b' => return Err(SynchronizationError::BufferMemoryBarrierOwnershipTransferHostNotAllowed {
+                                    barrier_index,
+                                }),
+                                'i' => return Err(SynchronizationError::ImageMemoryBarrierOwnershipTransferHostForbidden {
+                                    barrier_index,
+                                }),
+                                _ => unreachable!(),
+                            }
+                        }
+                    }
+
+                    Ok(())
+                };
+
+            for (barrier_index, barrier) in memory_barriers.iter().enumerate() {
+                let &MemoryBarrier {
+                    src_stages,
+                    src_access,
+                    dst_stages,
+                    dst_access,
+                    _ne: _,
+                } = barrier;
+
+                /*
+                    Check stages and access
+                */
+
+                check_stages_access(
+                    'm',
+                    barrier_index,
+                    src_stages,
+                    src_access,
+                    dst_stages,
+                    dst_access,
+                )?;
+            }
+
+            for (barrier_index, barrier) in buffer_memory_barriers.iter().enumerate() {
+                let &BufferMemoryBarrier {
+                    src_stages,
+                    src_access,
+                    dst_stages,
+                    dst_access,
+                    queue_family_ownership_transfer,
+                    ref buffer,
+                    ref range,
+                    _ne: _,
+                } = barrier;
+
+                // VUID-VkBufferMemoryBarrier2-buffer-01931
+                // Ensured by Buffer type construction.
+
+                /*
+                    Check stages and access
+                */
+
+                check_stages_access(
+                    'b',
+                    barrier_index,
+                    src_stages,
+                    src_access,
+                    dst_stages,
+                    dst_access,
+                )?;
+
+                /*
+                    Check queue family transfer
+                */
+
+                check_queue_family_ownership_transfer(
+                    'b',
+                    barrier_index,
+                    src_stages,
+                    dst_stages,
+                    queue_family_ownership_transfer,
+                    buffer.sharing(),
+                )?;
+
+                /*
+                    Check range
+                */
+
+                // VUID-VkBufferMemoryBarrier2-size-01188
+                assert!(!range.is_empty());
+
+                // VUID-VkBufferMemoryBarrier2-offset-01187
+                // VUID-VkBufferMemoryBarrier2-size-01189
+                if range.end > buffer.size() {
+                    return Err(SynchronizationError::BufferMemoryBarrierOutOfRange {
+                        barrier_index,
+                        range_end: range.end,
+                        buffer_size: buffer.size(),
+                    });
+                }
+            }
+
+            for (barrier_index, barrier) in image_memory_barriers.iter().enumerate() {
+                let &ImageMemoryBarrier {
+                    src_stages,
+                    src_access,
+                    dst_stages,
+                    dst_access,
+                    old_layout,
+                    new_layout,
+                    queue_family_ownership_transfer,
+                    ref image,
+                    ref subresource_range,
+                    _ne: _,
+                } = barrier;
+
+                // VUID-VkImageMemoryBarrier2-image-01932
+                // Ensured by Image type construction.
+
+                /*
+                    Check stages and access
+                */
+
+                check_stages_access(
+                    'i',
+                    barrier_index,
+                    src_stages,
+                    src_access,
+                    dst_stages,
+                    dst_access,
+                )?;
+
+                /*
+                    Check layouts
+                */
+
+                // VUID-VkImageMemoryBarrier2-oldLayout-parameter
+                old_layout.validate_device(device)?;
+
+                // VUID-VkImageMemoryBarrier2-newLayout-parameter
+                new_layout.validate_device(device)?;
+
+                // VUID-VkImageMemoryBarrier2-srcStageMask-03855
+                if src_stages.intersects(PipelineStages::HOST)
+                    && !matches!(
+                        old_layout,
+                        ImageLayout::Preinitialized | ImageLayout::Undefined | ImageLayout::General
+                    )
+                {
+                    return Err(
+                        SynchronizationError::ImageMemoryBarrierOldLayoutFromHostInvalid {
+                            barrier_index,
+                            old_layout,
+                        },
+                    );
+                }
+
+                // VUID-VkImageMemoryBarrier2-oldLayout-01197
+                // Not checked yet, therefore unsafe.
+
+                // VUID-VkImageMemoryBarrier2-newLayout-01198
+                if matches!(
+                    new_layout,
+                    ImageLayout::Undefined | ImageLayout::Preinitialized
+                ) {
+                    return Err(SynchronizationError::ImageMemoryBarrierNewLayoutInvalid {
+                        barrier_index,
+                    });
+                }
+
+                // VUID-VkImageMemoryBarrier2-attachmentFeedbackLoopLayout-07313
+                /*if !device.enabled_features().attachment_feedback_loop_layout
+                    && matches!(new_layout, ImageLayout::AttachmentFeedbackLoopOptimal)
+                {
+                    return Err(SynchronizationError::RequirementNotMet {
+                        required_for: "`dependency_info.image_memory_barriers` has an element where \
+                            `new_layout` is `AttachmentFeedbackLoopOptimal`",
+                        requires_one_of: RequiresOneOf {
+                            features: &["attachment_feedback_loop_layout"],
+                            ..Default::default()
+                        },
+                    });
+                }*/
+
+                for layout in [old_layout, new_layout] {
+                    // VUID-VkImageMemoryBarrier2-synchronization2-06911
+                    /*if !device.enabled_features().synchronization2
+                        && matches!(
+                            layout,
+                            ImageLayout::AttachmentOptimal | ImageLayout::ReadOnlyOptimal
+                        )
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "`dependency_info.image_memory_barriers` has an element \
+                                where `old_layout` or `new_layout` is `AttachmentOptimal` or \
+                                `ReadOnlyOptimal`",
+                            requires_one_of: RequiresOneOf {
+                                features: &["synchronization2"],
+                                ..Default::default()
+                            },
+                        });
+                    }*/
+
+                    // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-07006
+                    /*if layout == ImageLayout::AttachmentFeedbackLoopOptimal {
+                        if !image.usage().intersects(
+                            ImageUsage::COLOR_ATTACHMENT | ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+                        ) {
+                            return Err(
+                                SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                    barrier_index,
+                                    layout,
+                                    requires_one_of_usage: ImageUsage::COLOR_ATTACHMENT
+                                        | ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+                                },
+                            );
+                        }
+
+                        if !image
+                            .usage()
+                            .intersects(ImageUsage::INPUT_ATTACHMENT | ImageUsage::SAMPLED)
+                        {
+                            return Err(
+                                SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                    barrier_index,
+                                    layout,
+                                    requires_one_of_usage: ImageUsage::INPUT_ATTACHMENT
+                                        | ImageUsage::SAMPLED,
+                                },
+                            );
+                        }
+
+                        if !image
+                            .usage()
+                            .intersects(ImageUsage::ATTACHMENT_FEEDBACK_LOOP)
+                        {
+                            return Err(
+                                SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                    barrier_index,
+                                    layout,
+                                    requires_one_of_usage: ImageUsage::ATTACHMENT_FEEDBACK_LOOP,
+                                },
+                            );
+                        }
+                    }*/
+
+                    let requires_one_of_usage = match layout {
+                        // VUID-VkImageMemoryBarrier2-oldLayout-01208
+                        ImageLayout::ColorAttachmentOptimal => ImageUsage::COLOR_ATTACHMENT,
+
+                        // VUID-VkImageMemoryBarrier2-oldLayout-01209
+                        ImageLayout::DepthStencilAttachmentOptimal => {
+                            ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                        }
+
+                        // VUID-VkImageMemoryBarrier2-oldLayout-01210
+                        ImageLayout::DepthStencilReadOnlyOptimal => {
+                            ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                        }
+
+                        // VUID-VkImageMemoryBarrier2-oldLayout-01211
+                        ImageLayout::ShaderReadOnlyOptimal => {
+                            ImageUsage::SAMPLED | ImageUsage::INPUT_ATTACHMENT
+                        }
+
+                        // VUID-VkImageMemoryBarrier2-oldLayout-01212
+                        ImageLayout::TransferSrcOptimal => ImageUsage::TRANSFER_SRC,
+
+                        // VUID-VkImageMemoryBarrier2-oldLayout-01213
+                        ImageLayout::TransferDstOptimal => ImageUsage::TRANSFER_DST,
+
+                        // VUID-VkImageMemoryBarrier2-oldLayout-01658
+                        ImageLayout::DepthReadOnlyStencilAttachmentOptimal => {
+                            ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                        }
+
+                        // VUID-VkImageMemoryBarrier2-oldLayout-01659
+                        ImageLayout::DepthAttachmentStencilReadOnlyOptimal => {
+                            ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                        }
+
+                        /*
+                        // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04065
+                        ImageLayout::DepthReadOnlyOptimal => {
+                            ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                                | ImageUsage::SAMPLED
+                                | ImageUsage::INPUT_ATTACHMENT
+                        }
+
+                        // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04066
+                        ImageLayout::DepthAttachmentOptimal => ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+
+                        // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04067
+                        ImageLayout::StencilReadOnlyOptimal => {
+                            ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                                | ImageUsage::SAMPLED
+                                | ImageUsage::INPUT_ATTACHMENT
+                        }
+
+                        // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-04068
+                        ImageLayout::StencilAttachmentOptimal => ImageUsage::DEPTH_STENCIL_ATTACHMENT,
+
+                        // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-03938
+                        ImageLayout::AttachmentOptimal => {
+                            ImageUsage::COLOR_ATTACHMENT | ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                        }
+
+                        // VUID-VkImageMemoryBarrier2-srcQueueFamilyIndex-03939
+                        ImageLayout::ReadOnlyOptimal => {
+                            ImageUsage::DEPTH_STENCIL_ATTACHMENT
+                                | ImageUsage::SAMPLED
+                                | ImageUsage::INPUT_ATTACHMENT
+                        }
+
+                        // VUID-VkImageMemoryBarrier2-oldLayout-02088
+                        ImageLayout::FragmentShadingRateAttachmentOptimal => {
+                            ImageUsage::FRAGMENT_SHADING_RATE_ATTACHMENT
+                        }
+                         */
+                        _ => continue,
+                    };
+
+                    if !image.usage().intersects(requires_one_of_usage) {
+                        return Err(
+                            SynchronizationError::ImageMemoryBarrierImageMissingUsageForLayout {
+                                barrier_index,
+                                layout,
+                                requires_one_of_usage,
+                            },
+                        );
+                    }
+                }
+
+                /*
+                    Check queue family tansfer
+                */
+
+                check_queue_family_ownership_transfer(
+                    'i',
+                    barrier_index,
+                    src_stages,
+                    dst_stages,
+                    queue_family_ownership_transfer,
+                    image.sharing(),
+                )?;
+
+                /*
+                    Check subresource range
+                */
+
+                // VUID-VkImageSubresourceRange-aspectMask-requiredbitmask
+                assert!(!subresource_range.aspects.is_empty());
+
+                // VUID-VkImageSubresourceRange-aspectMask-parameter
+                subresource_range.aspects.validate_device(device)?;
+
+                let image_aspects = image.format().unwrap().aspects();
+
+                // VUID-VkImageMemoryBarrier2-image-01673
+                // VUID-VkImageMemoryBarrier2-image-03319
+                if image_aspects.contains(subresource_range.aspects) {
+                    return Err(SynchronizationError::ImageMemoryBarrierAspectsNotAllowed {
+                        barrier_index,
+                        aspects: subresource_range.aspects - image_aspects,
+                    });
+                }
+
+                if image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
+                    // VUID-VkImageMemoryBarrier2-image-03320
+                    if !device.enabled_features().separate_depth_stencil_layouts
+                        && image_aspects.contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
+                        && !subresource_range
+                            .aspects
+                            .contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
+                    {
+                        return Err(SynchronizationError::RequirementNotMet {
+                            required_for: "`dependency_info.image_memory_barriers` has an element \
+                            where `image` has both a depth and a stencil aspect, and \
+                            `subresource_range.aspects` does not contain both aspects",
+                            requires_one_of: RequiresOneOf {
+                                features: &["separate_depth_stencil_layouts"],
+                                ..Default::default()
+                            },
+                        });
+                    }
+                } else {
+                    // VUID-VkImageMemoryBarrier2-image-01671
+                    if !image.flags().intersects(ImageCreateFlags::DISJOINT)
+                        && subresource_range.aspects != ImageAspects::COLOR
+                    {
+                        return Err(SynchronizationError::ImageMemoryBarrierAspectsNotAllowed {
+                            barrier_index,
+                            aspects: subresource_range.aspects - ImageAspects::COLOR,
+                        });
+                    }
+                }
+
+                // VUID-VkImageSubresourceRange-levelCount-01720
+                assert!(!subresource_range.mip_levels.is_empty());
+
+                // VUID-VkImageMemoryBarrier2-subresourceRange-01486
+                // VUID-VkImageMemoryBarrier2-subresourceRange-01724
+                if subresource_range.mip_levels.end > image.mip_levels() {
+                    return Err(
+                        SynchronizationError::ImageMemoryBarrierMipLevelsOutOfRange {
+                            barrier_index,
+                            mip_levels_range_end: subresource_range.mip_levels.end,
+                            image_mip_levels: image.mip_levels(),
+                        },
+                    );
+                }
+
+                // VUID-VkImageSubresourceRange-layerCount-01721
+                assert!(!subresource_range.array_layers.is_empty());
+
+                // VUID-VkImageMemoryBarrier2-subresourceRange-01488
+                // VUID-VkImageMemoryBarrier2-subresourceRange-01725
+                if subresource_range.array_layers.end > image.dimensions().array_layers() {
+                    return Err(
+                        SynchronizationError::ImageMemoryBarrierArrayLayersOutOfRange {
+                            barrier_index,
+                            array_layers_range_end: subresource_range.array_layers.end,
+                            image_array_layers: image.dimensions().array_layers(),
+                        },
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn wait_events_unchecked(
+        &mut self,
+        events: impl IntoIterator<Item = (Arc<Event>, DependencyInfo)>,
+    ) -> &mut Self {
+        let events: SmallVec<[(Arc<Event>, DependencyInfo); 4]> = events.into_iter().collect();
+        let fns = self.device().fns();
+
+        // VUID-vkCmdWaitEvents2-pEvents-03837
+        // Ensured by using `vkCmdSetEvent2` and `vkCmdWaitEvents2` under the exact same
+        // conditions, i.e. when `synchronization2` is enabled.
+
+        if self.device().enabled_features().synchronization2 {
+            struct PerDependencyInfo {
+                memory_barriers_vk: SmallVec<[ash::vk::MemoryBarrier2; 2]>,
+                buffer_memory_barriers_vk: SmallVec<[ash::vk::BufferMemoryBarrier2; 8]>,
+                image_memory_barriers_vk: SmallVec<[ash::vk::ImageMemoryBarrier2; 8]>,
+            }
+
+            let mut events_vk: SmallVec<[_; 4]> = SmallVec::new();
+            let mut dependency_infos_vk: SmallVec<[_; 4]> = SmallVec::new();
+            let mut per_dependency_info_vk: SmallVec<[_; 4]> = SmallVec::new();
+
+            for (event, dependency_info) in &events {
+                let &DependencyInfo {
+                    dependency_flags,
+                    ref memory_barriers,
+                    ref buffer_memory_barriers,
+                    ref image_memory_barriers,
+                    _ne: _,
+                } = dependency_info;
+
+                let memory_barriers_vk: SmallVec<[_; 2]> = memory_barriers
+                    .iter()
+                    .map(|barrier| {
+                        let &MemoryBarrier {
+                            src_stages,
+                            src_access,
+                            dst_stages,
+                            dst_access,
+                            _ne: _,
+                        } = barrier;
+
+                        ash::vk::MemoryBarrier2 {
+                            src_stage_mask: src_stages.into(),
+                            src_access_mask: src_access.into(),
+                            dst_stage_mask: dst_stages.into(),
+                            dst_access_mask: dst_access.into(),
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+
+                let buffer_memory_barriers_vk: SmallVec<[_; 8]> = buffer_memory_barriers
+                    .iter()
+                    .map(|barrier| {
+                        let &BufferMemoryBarrier {
+                            src_stages,
+                            src_access,
+                            dst_stages,
+                            dst_access,
+                            queue_family_ownership_transfer,
+                            ref buffer,
+                            ref range,
+                            _ne: _,
+                        } = barrier;
+
+                        let (src_queue_family_index, dst_queue_family_index) =
+                            queue_family_ownership_transfer.map_or(
+                                (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                                Into::into,
+                            );
+
+                        ash::vk::BufferMemoryBarrier2 {
+                            src_stage_mask: src_stages.into(),
+                            src_access_mask: src_access.into(),
+                            dst_stage_mask: dst_stages.into(),
+                            dst_access_mask: dst_access.into(),
+                            src_queue_family_index,
+                            dst_queue_family_index,
+                            buffer: buffer.handle(),
+                            offset: range.start,
+                            size: range.end - range.start,
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+
+                let image_memory_barriers_vk: SmallVec<[_; 8]> = image_memory_barriers
+                    .iter()
+                    .map(|barrier| {
+                        let &ImageMemoryBarrier {
+                            src_stages,
+                            src_access,
+                            dst_stages,
+                            dst_access,
+                            old_layout,
+                            new_layout,
+                            queue_family_ownership_transfer,
+                            ref image,
+                            ref subresource_range,
+                            _ne: _,
+                        } = barrier;
+
+                        let (src_queue_family_index, dst_queue_family_index) =
+                            queue_family_ownership_transfer.map_or(
+                                (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                                Into::into,
+                            );
+
+                        ash::vk::ImageMemoryBarrier2 {
+                            src_stage_mask: src_stages.into(),
+                            src_access_mask: src_access.into(),
+                            dst_stage_mask: dst_stages.into(),
+                            dst_access_mask: dst_access.into(),
+                            old_layout: old_layout.into(),
+                            new_layout: new_layout.into(),
+                            src_queue_family_index,
+                            dst_queue_family_index,
+                            image: image.handle(),
+                            subresource_range: subresource_range.clone().into(),
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+
+                events_vk.push(event.handle());
+                dependency_infos_vk.push(ash::vk::DependencyInfo {
+                    dependency_flags: dependency_flags.into(),
+                    memory_barrier_count: 0,
+                    p_memory_barriers: ptr::null(),
+                    buffer_memory_barrier_count: 0,
+                    p_buffer_memory_barriers: ptr::null(),
+                    image_memory_barrier_count: 0,
+                    p_image_memory_barriers: ptr::null(),
+                    ..Default::default()
+                });
+                per_dependency_info_vk.push(PerDependencyInfo {
+                    memory_barriers_vk,
+                    buffer_memory_barriers_vk,
+                    image_memory_barriers_vk,
+                });
+            }
+
+            for (
+                dependency_info_vk,
+                PerDependencyInfo {
+                    memory_barriers_vk,
+                    buffer_memory_barriers_vk,
+                    image_memory_barriers_vk,
+                },
+            ) in (dependency_infos_vk.iter_mut()).zip(per_dependency_info_vk.iter_mut())
+            {
+                *dependency_info_vk = ash::vk::DependencyInfo {
+                    memory_barrier_count: memory_barriers_vk.len() as u32,
+                    p_memory_barriers: memory_barriers_vk.as_ptr(),
+                    buffer_memory_barrier_count: buffer_memory_barriers_vk.len() as u32,
+                    p_buffer_memory_barriers: buffer_memory_barriers_vk.as_ptr(),
+                    image_memory_barrier_count: image_memory_barriers_vk.len() as u32,
+                    p_image_memory_barriers: image_memory_barriers_vk.as_ptr(),
+                    ..*dependency_info_vk
+                }
+            }
+
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_wait_events2)(
+                    self.handle(),
+                    events_vk.len() as u32,
+                    events_vk.as_ptr(),
+                    dependency_infos_vk.as_ptr(),
+                );
+            } else {
+                debug_assert!(self.device().enabled_extensions().khr_synchronization2);
+                (fns.khr_synchronization2.cmd_wait_events2_khr)(
+                    self.handle(),
+                    events_vk.len() as u32,
+                    events_vk.as_ptr(),
+                    dependency_infos_vk.as_ptr(),
+                );
+            }
+        } else {
+            // With the original function, you can only specify a single dependency info for all
+            // events at once, rather than separately for each event. Therefore, to achieve the
+            // same behaviour as the "2" function, we split it up into multiple Vulkan API calls,
+            // one per event.
+
+            for (event, dependency_info) in &events {
+                let events_vk = [event.handle()];
+
+                let DependencyInfo {
+                    dependency_flags: _,
+                    memory_barriers,
+                    buffer_memory_barriers,
+                    image_memory_barriers,
+                    _ne: _,
+                } = dependency_info;
+
+                let mut src_stage_mask = ash::vk::PipelineStageFlags::empty();
+                let mut dst_stage_mask = ash::vk::PipelineStageFlags::empty();
+
+                let memory_barriers_vk: SmallVec<[_; 2]> = memory_barriers
+                    .iter()
+                    .map(|barrier| {
+                        let &MemoryBarrier {
+                            src_stages,
+                            src_access,
+                            dst_stages,
+                            dst_access,
+                            _ne: _,
+                        } = barrier;
+
+                        src_stage_mask |= src_stages.into();
+                        dst_stage_mask |= dst_stages.into();
+
+                        ash::vk::MemoryBarrier {
+                            src_access_mask: src_access.into(),
+                            dst_access_mask: dst_access.into(),
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+
+                let buffer_memory_barriers_vk: SmallVec<[_; 8]> = buffer_memory_barriers
+                    .iter()
+                    .map(|barrier| {
+                        let &BufferMemoryBarrier {
+                            src_stages,
+                            src_access,
+                            dst_stages,
+                            dst_access,
+                            queue_family_ownership_transfer,
+                            ref buffer,
+                            ref range,
+                            _ne: _,
+                        } = barrier;
+
+                        src_stage_mask |= src_stages.into();
+                        dst_stage_mask |= dst_stages.into();
+
+                        let (src_queue_family_index, dst_queue_family_index) =
+                            queue_family_ownership_transfer.map_or(
+                                (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                                Into::into,
+                            );
+
+                        ash::vk::BufferMemoryBarrier {
+                            src_access_mask: src_access.into(),
+                            dst_access_mask: dst_access.into(),
+                            src_queue_family_index,
+                            dst_queue_family_index,
+                            buffer: buffer.handle(),
+                            offset: range.start,
+                            size: range.end - range.start,
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+
+                let image_memory_barriers_vk: SmallVec<[_; 8]> = image_memory_barriers
+                    .iter()
+                    .map(|barrier| {
+                        let &ImageMemoryBarrier {
+                            src_stages,
+                            src_access,
+                            dst_stages,
+                            dst_access,
+                            old_layout,
+                            new_layout,
+                            queue_family_ownership_transfer,
+                            ref image,
+                            ref subresource_range,
+                            _ne: _,
+                        } = barrier;
+
+                        src_stage_mask |= src_stages.into();
+                        dst_stage_mask |= dst_stages.into();
+
+                        let (src_queue_family_index, dst_queue_family_index) =
+                            queue_family_ownership_transfer.map_or(
+                                (ash::vk::QUEUE_FAMILY_IGNORED, ash::vk::QUEUE_FAMILY_IGNORED),
+                                Into::into,
+                            );
+
+                        ash::vk::ImageMemoryBarrier {
+                            src_access_mask: src_access.into(),
+                            dst_access_mask: dst_access.into(),
+                            old_layout: old_layout.into(),
+                            new_layout: new_layout.into(),
+                            src_queue_family_index,
+                            dst_queue_family_index,
+                            image: image.handle(),
+                            subresource_range: subresource_range.clone().into(),
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+
+                if src_stage_mask.is_empty() {
+                    // "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT is [...] equivalent to
+                    // VK_PIPELINE_STAGE_2_NONE in the first scope."
+                    src_stage_mask |= ash::vk::PipelineStageFlags::TOP_OF_PIPE;
+                }
+
+                if dst_stage_mask.is_empty() {
+                    // "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT is [...] equivalent to
+                    // VK_PIPELINE_STAGE_2_NONE in the second scope."
+                    dst_stage_mask |= ash::vk::PipelineStageFlags::BOTTOM_OF_PIPE;
+                }
+
+                (fns.v1_0.cmd_wait_events)(
+                    self.handle(),
+                    1,
+                    events_vk.as_ptr(),
+                    src_stage_mask,
+                    dst_stage_mask,
+                    memory_barriers_vk.len() as u32,
+                    memory_barriers_vk.as_ptr(),
+                    buffer_memory_barriers_vk.len() as u32,
+                    buffer_memory_barriers_vk.as_ptr(),
+                    image_memory_barriers_vk.len() as u32,
+                    image_memory_barriers_vk.as_ptr(),
+                );
+            }
+        }
+
+        self.resources
+            .extend(events.into_iter().map(|(event, _)| Box::new(event) as _));
+
+        // TODO: sync state update
+
+        self
+    }
+
+    /// Resets an [`Event`] back to the unsignaled state.
+    ///
+    /// # Safety
+    ///
+    /// - Appropriate synchronization must be provided for `event` against any previous
+    ///   [`set_event`] or [`wait_events`] command.
+    ///
+    /// [`set_event`]: Self::set_event
+    /// [`wait_events`]: Self::wait_events
+    #[inline]
+    pub unsafe fn reset_event(
+        &mut self,
+        event: Arc<Event>,
+        stages: PipelineStages,
+    ) -> Result<&mut Self, SynchronizationError> {
+        self.validate_reset_event(&event, stages)?;
+
+        unsafe { Ok(self.reset_event_unchecked(event, stages)) }
+    }
+
+    fn validate_reset_event(
+        &self,
+        event: &Event,
+        stages: PipelineStages,
+    ) -> Result<(), SynchronizationError> {
+        // VUID-vkCmdResetEvent2-renderpass
+        if self.current_state.render_pass.is_some() {
+            return Err(SynchronizationError::ForbiddenInsideRenderPass);
+        }
+
+        // VUID-vkCmdResetEvent2-commandBuffer-03833
+        // TODO:
+
+        let device = self.device();
+        let queue_family_properties = self.queue_family_properties();
+
+        // VUID-vkCmdResetEvent2-commandBuffer-cmdpool
+        if !queue_family_properties.queue_flags.intersects(
+            QueueFlags::GRAPHICS
+                | QueueFlags::COMPUTE
+                | QueueFlags::VIDEO_DECODE
+                | QueueFlags::VIDEO_ENCODE,
+        ) {
+            return Err(SynchronizationError::NotSupportedByQueueFamily);
+        }
+
+        // VUID-vkCmdResetEvent2-commonparent
+        assert_eq!(device, event.device());
+
+        // VUID-vkCmdResetEvent2-stageMask-parameter
+        stages.validate_device(device)?;
+
+        // VUID-vkCmdResetEvent2-synchronization2-03829
+        if !device.enabled_features().synchronization2 {
+            if stages.is_2() {
+                return Err(SynchronizationError::RequirementNotMet {
+                    required_for: "`stages` contains flags from `VkPipelineStageFlagBits2`",
+                    requires_one_of: RequiresOneOf {
+                        features: &["synchronization2"],
+                        ..Default::default()
+                    },
+                });
+            }
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-03929
+        if stages.intersects(PipelineStages::GEOMETRY_SHADER)
+            && !device.enabled_features().geometry_shader
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::GEOMETRY_SHADER`",
+                requires_one_of: RequiresOneOf {
+                    features: &["geometry_shader"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-03930
+        if stages.intersects(
+            PipelineStages::TESSELLATION_CONTROL_SHADER
+                | PipelineStages::TESSELLATION_EVALUATION_SHADER,
+        ) && !device.enabled_features().tessellation_shader
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::TESSELLATION_CONTROL_SHADER` or \
+                    `PipelineStages::TESSELLATION_EVALUATION_SHADER`",
+                requires_one_of: RequiresOneOf {
+                    features: &["tessellation_shader"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-03931
+        if stages.intersects(PipelineStages::CONDITIONAL_RENDERING)
+            && !device.enabled_features().conditional_rendering
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::CONDITIONAL_RENDERING`",
+                requires_one_of: RequiresOneOf {
+                    features: &["conditional_rendering"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-03932
+        if stages.intersects(PipelineStages::FRAGMENT_DENSITY_PROCESS)
+            && !device.enabled_features().fragment_density_map
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::FRAGMENT_DENSITY_PROCESS`",
+                requires_one_of: RequiresOneOf {
+                    features: &["fragment_density_map"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-03933
+        if stages.intersects(PipelineStages::TRANSFORM_FEEDBACK)
+            && !device.enabled_features().transform_feedback
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::TRANSFORM_FEEDBACK`",
+                requires_one_of: RequiresOneOf {
+                    features: &["transform_feedback"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-03934
+        if stages.intersects(PipelineStages::MESH_SHADER) && !device.enabled_features().mesh_shader
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::MESH_SHADER`",
+                requires_one_of: RequiresOneOf {
+                    features: &["mesh_shader"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-03935
+        if stages.intersects(PipelineStages::TASK_SHADER) && !device.enabled_features().task_shader
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::TASK_SHADER`",
+                requires_one_of: RequiresOneOf {
+                    features: &["task_shader"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-shadingRateImage-07316
+        if stages.intersects(PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT)
+            && !(device.enabled_features().attachment_fragment_shading_rate
+                || device.enabled_features().shading_rate_image)
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains \
+                    `PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT`",
+                requires_one_of: RequiresOneOf {
+                    features: &["attachment_fragment_shading_rate", "shading_rate_image"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-04957
+        if stages.intersects(PipelineStages::SUBPASS_SHADING)
+            && !device.enabled_features().subpass_shading
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::SUBPASS_SHADING`",
+                requires_one_of: RequiresOneOf {
+                    features: &["subpass_shading"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-04995
+        if stages.intersects(PipelineStages::INVOCATION_MASK)
+            && !device.enabled_features().invocation_mask
+        {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` contains `PipelineStages::INVOCATION_MASK`",
+                requires_one_of: RequiresOneOf {
+                    features: &["invocation_mask"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent-stageMask-03937
+        if stages.is_empty() && !device.enabled_features().synchronization2 {
+            return Err(SynchronizationError::RequirementNotMet {
+                required_for: "`stages` is empty",
+                requires_one_of: RequiresOneOf {
+                    features: &["synchronization2"],
+                    ..Default::default()
+                },
+            });
+        }
+
+        // VUID-vkCmdResetEvent2-stageMask-03830
+        if stages.intersects(PipelineStages::HOST) {
+            todo!()
+        }
+
+        // VUID-vkCmdResetEvent2-event-03831
+        // VUID-vkCmdResetEvent2-event-03832
+        // TODO:
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn reset_event_unchecked(
+        &mut self,
+        event: Arc<Event>,
+        stages: PipelineStages,
+    ) -> &mut Self {
+        let fns = self.device().fns();
+
+        if self.device().enabled_features().synchronization2 {
+            if self.device().api_version() >= Version::V1_3 {
+                (fns.v1_3.cmd_reset_event2)(self.handle(), event.handle(), stages.into());
+            } else {
+                debug_assert!(self.device().enabled_extensions().khr_synchronization2);
+                (fns.khr_synchronization2.cmd_reset_event2_khr)(
+                    self.handle(),
+                    event.handle(),
+                    stages.into(),
+                );
+            }
+        } else {
+            (fns.v1_0.cmd_reset_event)(self.handle(), event.handle(), stages.into());
+        }
+
+        self.resources.push(Box::new(event));
+
+        // TODO: sync state update
+
+        self
+    }
+}
+
+/// Error that can happen when recording a synchronization command.
+#[derive(Clone, Debug)]
+pub enum SynchronizationError {
+    RequirementNotMet {
+        required_for: &'static str,
+        requires_one_of: RequiresOneOf,
+    },
+
+    /// One or more accesses of a buffer memory barrier are not supported by the corresponding
+    /// pipeline stages.
+    BufferMemoryBarrierAccessNotSupportedByStages { barrier_index: usize },
+
+    /// Buffer memory barriers are forbidden inside a render pass instance.
+    BufferMemoryBarrierForbiddenInsideRenderPass,
+
+    /// The end of `range` of a buffer memory barrier is greater than the size of `buffer`.
+    BufferMemoryBarrierOutOfRange {
+        barrier_index: usize,
+        range_end: DeviceSize,
+        buffer_size: DeviceSize,
+    },
+
+    /// A buffer memory barrier contains a queue family ownership transfer, but either the
+    /// `src_stages` or `dst_stages` contain [`HOST`].
+    ///
+    /// [`HOST`]: crate::sync::PipelineStages::HOST
+    BufferMemoryBarrierOwnershipTransferHostNotAllowed { barrier_index: usize },
+
+    /// The provided `src_index` or `dst_index` in the queue family ownership transfer of a
+    /// buffer memory barrier is not less than the number of queue families in the physical device.
+    BufferMemoryBarrierOwnershipTransferIndexOutOfRange {
+        barrier_index: usize,
+        provided_queue_family_index: u32,
+        queue_family_count: u32,
+    },
+
+    /// The provided `queue_family_ownership_transfer` value of a buffer memory barrier does not
+    /// match the sharing mode of `buffer`.
+    BufferMemoryBarrierOwnershipTransferSharingMismatch { barrier_index: usize },
+
+    /// One or more pipeline stages of a buffer memory barrier are not supported by the queue
+    /// family of the command buffer.
+    BufferMemoryBarrierStageNotSupported { barrier_index: usize },
+
+    /// A render pass instance is not active, and the `VIEW_LOCAL` dependency flag was provided.
+    DependencyFlagsViewLocalNotAllowed,
+
+    /// Operation forbidden inside a render pass.
+    ForbiddenInsideRenderPass,
+
+    /// Operation forbidden inside a render pass instance that was begun with `begin_rendering`.
+    ForbiddenWithBeginRendering,
+
+    /// One or more accesses of an image memory barrier are not supported by the corresponding
+    /// pipeline stages.
+    ImageMemoryBarrierAccessNotSupportedByStages { barrier_index: usize },
+
+    /// The end of the range of array layers of the subresource range of an image memory barrier
+    /// is greater than the number of array layers in the image.
+    ImageMemoryBarrierArrayLayersOutOfRange {
+        barrier_index: usize,
+        array_layers_range_end: u32,
+        image_array_layers: u32,
+    },
+
+    /// The aspects of the subresource range of an image memory barrier contain aspects that are
+    /// not present in the image, or that are not allowed.
+    ImageMemoryBarrierAspectsNotAllowed {
+        barrier_index: usize,
+        aspects: ImageAspects,
+    },
+
+    /// For the `old_layout` or `new_layout` of an image memory barrier, `image` does not have a
+    /// usage that is required.
+    ImageMemoryBarrierImageMissingUsageForLayout {
+        barrier_index: usize,
+        layout: ImageLayout,
+        requires_one_of_usage: ImageUsage,
+    },
+
+    /// An image memory barrier contains an image layout transition, but a render pass
+    /// instance is active.
+    ImageMemoryBarrierLayoutTransitionForbiddenInsideRenderPass { barrier_index: usize },
+
+    /// The end of the range of mip levels of the subresource range of an image memory barrier
+    /// is greater than the number of mip levels in the image.
+    ImageMemoryBarrierMipLevelsOutOfRange {
+        barrier_index: usize,
+        mip_levels_range_end: u32,
+        image_mip_levels: u32,
+    },
+
+    /// The `new_layout` of an image memory barrier is `Undefined` or `Preinitialized`.
+    ImageMemoryBarrierNewLayoutInvalid { barrier_index: usize },
+
+    /// A render pass instance is active, and the image of an image memory barrier is not a color
+    /// or depth/stencil attachment of the current subpass.
+    ImageMemoryBarrierNotColorDepthStencilAttachment { barrier_index: usize },
+
+    /// A render pass instance is active, and the image of an image memory barrier is not an input
+    /// attachment of the current subpass.
+    ImageMemoryBarrierNotInputAttachment { barrier_index: usize },
+
+    /// The `src_stages` of an image memory barrier contains [`HOST`], but `old_layout` is not
+    /// `Preinitialized`, `Undefined` or `General`.
+    ///
+    /// [`HOST`]: crate::sync::PipelineStages::HOST
+    ImageMemoryBarrierOldLayoutFromHostInvalid {
+        barrier_index: usize,
+        old_layout: ImageLayout,
+    },
+
+    /// An image memory barrier contains a queue family ownership transfer, but a render pass
+    /// instance is active.
+    ImageMemoryBarrierOwnershipTransferForbiddenInsideRenderPass { barrier_index: usize },
+
+    /// An image memory barrier contains a queue family ownership transfer, but either the
+    /// `src_stages` or `dst_stages` contain [`HOST`].
+    ///
+    /// [`HOST`]: crate::sync::PipelineStages::HOST
+    ImageMemoryBarrierOwnershipTransferHostForbidden { barrier_index: usize },
+
+    /// The provided `src_index` or `dst_index` in the queue family ownership transfer of an
+    /// image memory barrier is not less than the number of queue families in the physical device.
+    ImageMemoryBarrierOwnershipTransferIndexOutOfRange {
+        barrier_index: usize,
+        provided_queue_family_index: u32,
+        queue_family_count: u32,
+    },
+
+    /// The provided `queue_family_ownership_transfer` value of an image memory barrier does not
+    /// match the sharing mode of `image`.
+    ImageMemoryBarrierOwnershipTransferSharingMismatch { barrier_index: usize },
+
+    /// One or more pipeline stages of an image memory barrier are not supported by the queue
+    /// family of the command buffer.
+    ImageMemoryBarrierStageNotSupported { barrier_index: usize },
+
+    /// One or more accesses of a memory barrier are not supported by the corresponding
+    /// pipeline stages.
+    MemoryBarrierAccessNotSupportedByStages { barrier_index: usize },
+
+    /// A render pass instance is active, but the render pass does not have a subpass
+    /// self-dependency for the current subpass that is a superset of the barriers.
+    MemoryBarrierNoMatchingSubpassSelfDependency,
+
+    /// One or more pipeline stages of a memory barrier are not supported by the queue
+    /// family of the command buffer.
+    MemoryBarrierStageNotSupported { barrier_index: usize },
+
+    /// The queue family doesn't allow this operation.
+    NotSupportedByQueueFamily,
+}
+
+impl Error for SynchronizationError {}
+
+impl Display for SynchronizationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
+        match self {
+            Self::RequirementNotMet {
+                required_for,
+                requires_one_of,
+            } => write!(
+                f,
+                "a requirement was not met for: {}; requires one of: {}",
+                required_for, requires_one_of,
+            ),
+
+            Self::BufferMemoryBarrierAccessNotSupportedByStages { barrier_index } => write!(
+                f,
+                "one or more accesses of buffer memory barrier {} are not supported by the \
+                corresponding pipeline stages",
+                barrier_index,
+            ),
+            Self::BufferMemoryBarrierForbiddenInsideRenderPass => write!(
+                f,
+                "buffer memory barriers are forbidden inside a render pass instance",
+            ),
+            Self::BufferMemoryBarrierOutOfRange {
+                barrier_index,
+                range_end,
+                buffer_size,
+            } => write!(
+                f,
+                "the end of `range` ({}) of buffer memory barrier {} is greater than the size of \
+                `buffer` ({})",
+                range_end, barrier_index, buffer_size,
+            ),
+            Self::BufferMemoryBarrierOwnershipTransferHostNotAllowed { barrier_index } => write!(
+                f,
+                "buffer memory barrier {} contains a queue family ownership transfer, but either \
+                the `src_stages` or `dst_stages` contain `HOST`",
+                barrier_index,
+            ),
+            Self::BufferMemoryBarrierOwnershipTransferIndexOutOfRange {
+                barrier_index,
+                provided_queue_family_index,
+                queue_family_count,
+            } => write!(
+                f,
+                "the provided `src_index` or `dst_index` ({}) in the queue family ownership \
+                transfer of buffer memory barrier {} is not less than the number of queue \
+                families in the physical device ({})",
+                provided_queue_family_index, barrier_index, queue_family_count,
+            ),
+            Self::BufferMemoryBarrierOwnershipTransferSharingMismatch { barrier_index } => write!(
+                f,
+                "the provided `queue_family_ownership_transfer` value of buffer memory barrier {} \
+                does not match the sharing mode of `buffer`",
+                barrier_index,
+            ),
+            Self::BufferMemoryBarrierStageNotSupported { barrier_index } => write!(
+                f,
+                "one or more pipeline stages of buffer memory barrier {} are not supported by the \
+                queue family of the command buffer",
+                barrier_index,
+            ),
+            Self::DependencyFlagsViewLocalNotAllowed => write!(
+                f,
+                "a render pass instance is not active, and the `VIEW_LOCAL` dependency flag was \
+                provided",
+            ),
+            Self::ForbiddenInsideRenderPass => {
+                write!(f, "operation forbidden inside a render pass")
+            }
+            Self::ForbiddenWithBeginRendering => write!(
+                f,
+                "operation forbidden inside a render pass instance that was begun with \
+                `begin_rendering`",
+            ),
+            Self::ImageMemoryBarrierAccessNotSupportedByStages { barrier_index } => write!(
+                f,
+                "one or more accesses of image memory barrier {} are not supported by the \
+                corresponding pipeline stages",
+                barrier_index,
+            ),
+            Self::ImageMemoryBarrierArrayLayersOutOfRange {
+                barrier_index,
+                array_layers_range_end,
+                image_array_layers,
+            } => write!(
+                f,
+                "the end of the range of array layers ({}) of the subresource range of image \
+                memory barrier {} is greater than the number of array layers in the image ({})",
+                array_layers_range_end, barrier_index, image_array_layers,
+            ),
+            Self::ImageMemoryBarrierAspectsNotAllowed {
+                barrier_index,
+                aspects,
+            } => write!(
+                f,
+                "the aspects of the subresource range of image memory barrier {} contain aspects \
+                that are not present in the image, or that are not allowed ({:?})",
+                barrier_index, aspects,
+            ),
+            Self::ImageMemoryBarrierImageMissingUsageForLayout {
+                barrier_index,
+                layout,
+                requires_one_of_usage,
+            } => write!(
+                f,
+                "for the `old_layout` or `new_layout` ({:?}) of image memory barrier {}, `image` \
+                does not have a usage that is required ({}{:?})",
+                layout,
+                barrier_index,
+                if requires_one_of_usage.count() > 1 {
+                    "one of "
+                } else {
+                    ""
+                },
+                requires_one_of_usage,
+            ),
+            Self::ImageMemoryBarrierLayoutTransitionForbiddenInsideRenderPass { barrier_index } => {
+                write!(
+                    f,
+                    "image memory barrier {} contains an image layout transition, but a render \
+                    pass instance is active",
+                    barrier_index,
+                )
+            }
+            Self::ImageMemoryBarrierMipLevelsOutOfRange {
+                barrier_index,
+                mip_levels_range_end,
+                image_mip_levels,
+            } => write!(
+                f,
+                "the end of the range of mip levels ({}) of the subresource range of image \
+                memory barrier {} is greater than the number of mip levels in the image ({})",
+                mip_levels_range_end, barrier_index, image_mip_levels,
+            ),
+            Self::ImageMemoryBarrierNewLayoutInvalid { barrier_index } => write!(
+                f,
+                "the `new_layout` of image memory barrier {} is `Undefined` or `Preinitialized`",
+                barrier_index,
+            ),
+            Self::ImageMemoryBarrierNotColorDepthStencilAttachment { barrier_index } => write!(
+                f,
+                "a render pass instance is active, and the image of image memory barrier {} is \
+                not a color or depth/stencil attachment of the current subpass",
+                barrier_index,
+            ),
+            Self::ImageMemoryBarrierNotInputAttachment { barrier_index } => write!(
+                f,
+                "a render pass instance is active, and the image of image memory barrier {} is \
+                not an input attachment of the current subpass",
+                barrier_index,
+            ),
+            Self::ImageMemoryBarrierOldLayoutFromHostInvalid {
+                barrier_index,
+                old_layout,
+            } => write!(
+                f,
+                "the `src_stages` of image memory barrier {} contains `HOST`, but `old_layout`
+                ({:?}) is not `Preinitialized`, `Undefined` or `General`",
+                barrier_index, old_layout,
+            ),
+            Self::ImageMemoryBarrierOwnershipTransferForbiddenInsideRenderPass {
+                barrier_index,
+            } => write!(
+                f,
+                "image memory barrier {} contains a queue family ownership transfer, but a render \
+                pass instance is active",
+                barrier_index,
+            ),
+            Self::ImageMemoryBarrierOwnershipTransferHostForbidden { barrier_index } => write!(
+                f,
+                "image memory barrier {} contains a queue family ownership transfer, but either \
+                the `src_stages` or `dst_stages` contain `HOST`",
+                barrier_index,
+            ),
+            Self::ImageMemoryBarrierOwnershipTransferIndexOutOfRange {
+                barrier_index,
+                provided_queue_family_index,
+                queue_family_count,
+            } => write!(
+                f,
+                "the provided `src_index` or `dst_index` ({}) in the queue family ownership \
+                transfer of image memory barrier {} is not less than the number of queue
+                families in the physical device ({})",
+                provided_queue_family_index, barrier_index, queue_family_count,
+            ),
+            Self::ImageMemoryBarrierOwnershipTransferSharingMismatch { barrier_index } => write!(
+                f,
+                "the provided `queue_family_ownership_transfer` value of image memory barrier {} \
+                does not match the sharing mode of `image`",
+                barrier_index,
+            ),
+            Self::ImageMemoryBarrierStageNotSupported { barrier_index } => write!(
+                f,
+                "one or more pipeline stages of image memory barrier {} are not supported by the \
+                queue family of the command buffer",
+                barrier_index,
+            ),
+            Self::MemoryBarrierAccessNotSupportedByStages { barrier_index } => write!(
+                f,
+                "one or more accesses of memory barrier {} are not supported by the \
+                corresponding pipeline stages",
+                barrier_index,
+            ),
+            Self::MemoryBarrierNoMatchingSubpassSelfDependency => write!(
+                f,
+                "a render pass instance is active, but the render pass does not have a subpass \
+                self-dependency for the current subpass that is a superset of the barriers",
+            ),
+            Self::MemoryBarrierStageNotSupported { barrier_index } => write!(
+                f,
+                "one or more pipeline stages of memory barrier {} are not supported by the \
+                queue family of the command buffer",
+                barrier_index,
+            ),
+            Self::NotSupportedByQueueFamily => {
+                write!(f, "the queue family doesn't allow this operation")
+            }
+        }
+    }
+}
+
+impl From<RequirementNotMet> for SynchronizationError {
+    fn from(err: RequirementNotMet) -> Self {
+        Self::RequirementNotMet {
+            required_for: err.required_for,
+            requires_one_of: err.requires_one_of,
+        }
+    }
+}

--- a/vulkano/src/command_buffer/standard/mod.rs
+++ b/vulkano/src/command_buffer/standard/mod.rs
@@ -1,0 +1,173 @@
+// Copyright (c) 2022 The Vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+//! The standard command buffer and builder.
+//!
+//! Using `CommandBufferBuilder`, you must manually record synchronization commands to ensure
+//! correct operation.
+
+pub use self::builder::*;
+use super::{
+    allocator::{CommandBufferAlloc, StandardCommandBufferAlloc},
+    CommandBufferExecError, CommandBufferInheritanceInfo, CommandBufferState, CommandBufferUsage,
+};
+use crate::{
+    device::{Device, DeviceOwned},
+    VulkanObject,
+};
+use parking_lot::Mutex;
+use std::{
+    any::Any,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+mod builder;
+
+/// A command buffer that is finished recording, and can be submitted to a queue.
+pub struct PrimaryCommandBuffer<A = StandardCommandBufferAlloc>
+where
+    A: CommandBufferAlloc,
+{
+    alloc: A,
+    _usage: CommandBufferUsage,
+    _resources: Vec<Box<dyn Any + Send + Sync>>,
+
+    _state: Mutex<CommandBufferState>,
+}
+
+unsafe impl<A> VulkanObject for PrimaryCommandBuffer<A>
+where
+    A: CommandBufferAlloc,
+{
+    type Handle = ash::vk::CommandBuffer;
+
+    #[inline]
+    fn handle(&self) -> Self::Handle {
+        self.alloc.inner().handle()
+    }
+}
+
+unsafe impl<A> DeviceOwned for PrimaryCommandBuffer<A>
+where
+    A: CommandBufferAlloc,
+{
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        self.alloc.device()
+    }
+}
+
+/// A command buffer that is finished recording, and can be executed within a primary command
+/// buffer by calling [`execute_commands`].
+///
+/// [`execute_commands`]: CommandBufferBuilder::execute_commands
+pub struct SecondaryCommandBuffer<A = StandardCommandBufferAlloc>
+where
+    A: CommandBufferAlloc,
+{
+    alloc: A,
+    inheritance_info: CommandBufferInheritanceInfo,
+    usage: CommandBufferUsage,
+    _resources: Vec<Box<dyn Any + Send + Sync>>,
+
+    submit_state: SubmitState,
+}
+
+unsafe impl<A> VulkanObject for SecondaryCommandBuffer<A>
+where
+    A: CommandBufferAlloc,
+{
+    type Handle = ash::vk::CommandBuffer;
+
+    #[inline]
+    fn handle(&self) -> Self::Handle {
+        self.alloc.inner().handle()
+    }
+}
+
+unsafe impl<A> DeviceOwned for SecondaryCommandBuffer<A>
+where
+    A: CommandBufferAlloc,
+{
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        self.alloc.device()
+    }
+}
+
+impl<A> SecondaryCommandBuffer<A>
+where
+    A: CommandBufferAlloc,
+{
+    #[inline]
+    pub fn inheritance_info(&self) -> &CommandBufferInheritanceInfo {
+        &self.inheritance_info
+    }
+
+    pub fn lock_record(&self) -> Result<(), CommandBufferExecError> {
+        match self.submit_state {
+            SubmitState::OneTime {
+                ref already_submitted,
+            } => {
+                let was_already_submitted = already_submitted.swap(true, Ordering::Acquire);
+                if was_already_submitted {
+                    return Err(CommandBufferExecError::OneTimeSubmitAlreadySubmitted);
+                }
+            }
+            SubmitState::ExclusiveUse { ref in_use } => {
+                let already_in_use = in_use.swap(true, Ordering::Acquire);
+                if already_in_use {
+                    return Err(CommandBufferExecError::ExclusiveAlreadyInUse);
+                }
+            }
+            SubmitState::Concurrent => (),
+        };
+
+        Ok(())
+    }
+
+    pub unsafe fn unlock(&self) {
+        match self.submit_state {
+            SubmitState::OneTime {
+                ref already_submitted,
+            } => {
+                debug_assert!(already_submitted.load(Ordering::Relaxed));
+            }
+            SubmitState::ExclusiveUse { ref in_use } => {
+                let old_val = in_use.swap(false, Ordering::Release);
+                debug_assert!(old_val);
+            }
+            SubmitState::Concurrent => (),
+        };
+    }
+}
+
+/// Whether the command buffer can be submitted.
+#[derive(Debug)]
+enum SubmitState {
+    /// The command buffer was created with the "SimultaneousUse" flag. Can always be submitted at
+    /// any time.
+    Concurrent,
+
+    /// The command buffer can only be submitted once simultaneously.
+    ExclusiveUse {
+        /// True if the command buffer is current in use by the GPU.
+        in_use: AtomicBool,
+    },
+
+    /// The command buffer can only ever be submitted once.
+    OneTime {
+        /// True if the command buffer has already been submitted once and can be no longer be
+        /// submitted.
+        already_submitted: AtomicBool,
+    },
+}

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -9,6 +9,20 @@
 
 //! An event provides fine-grained synchronization within a single queue, or from the host to a
 //! queue.
+//!
+//! When an event is signaled from a queue using the [`set_event`] command buffer command,
+//! an event acts similar to a [pipeline barrier], but the synchronization scopes are split:
+//! the source synchronization scope includes only commands before the `set_event` command,
+//! while the destination synchronization scope includes only commands after the
+//! [`wait_events`] command. Commands in between the two are not included.
+//!
+//! An event can also be signaled from the host, by calling the [`set`] method directly on the
+//! [`Event`].
+//!
+//! [`set_event`]: crate::command_buffer::CommandBufferBuilder::set_event
+//! [pipeline barrier]: crate::command_buffer::CommandBufferBuilder::pipeline_barrier
+//! [`wait_events`]: crate::command_buffer::CommandBufferBuilder::wait_events
+//! [`set`]: Event::set
 
 use crate::{
     device::{Device, DeviceOwned},


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- A new `CommandBufferBuilder` type, that provides validation and keeps resources alive, but requires manual synchronization commands.
- The `PrimaryCommandBuffer` and `SecondaryCommandBuffer` types.
````

Closes #1917, closes #1360.

This adds the new "manual" command buffer builder that was announced some time ago. At the moment it does not do any synchronization tracking or validation, so any commands that rely on it are still unsafe. `PrimaryCommandBuffer` and `SecondaryCommandBuffer` don't implement the `PrimaryCommandBufferAbstract` and `SecondaryCommandBufferAbstract` traits yet either, so at the moment they're a bit useless. I'll work on this in future PRs.