### PR TITLE
Implement IntoIterator for `Features`, `DeviceExtensions` and `InstanceExtensions`

### DIFF
--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -450,7 +450,7 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
 
             /// Returns the list of extensions as an array.
             #[inline]
-            pub const fn as_arr(&self) -> [(&str, bool); #arr_len] {
+            pub const fn as_arr(&self) -> [(&'static str, bool); #arr_len] {
                [#(#arr_items)*]
             }
         }

--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -338,6 +338,13 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
         }
     });
 
+    let arr_items = members.iter().map(|ExtensionsMember { name, raw, .. }| {
+        quote! {
+            (#raw, self.#name),
+        }
+    });
+    let arr_len = members.len();
+
     let from_str_for_extensions_items =
         members.iter().map(|ExtensionsMember { name, raw, .. }| {
             let raw = Literal::string(raw);
@@ -439,6 +446,12 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
                     #(#symmetric_difference_items)*
                     _ne: crate::NonExhaustive(()),
                 }
+            }
+
+            /// Returns the list of extensions as an array.
+            #[inline]
+            pub fn as_arr(&self) -> [(&str, bool); #arr_len] {
+               [#(#arr_items)*]
             }
         }
 

--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -447,12 +447,6 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
                     _ne: crate::NonExhaustive(()),
                 }
             }
-
-            /// Returns the list of extensions as an array.
-            #[inline]
-            pub const fn as_arr(&self) -> [(&'static str, bool); #arr_len] {
-               [#(#arr_items)*]
-            }
         }
 
         impl std::ops::BitAnd for #struct_name {
@@ -551,6 +545,16 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
                 let mut data = Self::new();
                 #(#from_extensions_for_vec_cstring_items)*
                 data
+            }
+        }
+
+        impl IntoIterator for #struct_name {
+            type Item = (&'static str, bool);
+            type IntoIter = std::array::IntoIter<Self::Item, #arr_len>;
+
+            #[inline]
+            fn into_iter(self) -> Self::IntoIter {
+                [#(#arr_items)*].into_iter()
             }
         }
     }

--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -450,7 +450,7 @@ fn extensions_common_output(struct_name: Ident, members: &[ExtensionsMember]) ->
 
             /// Returns the list of extensions as an array.
             #[inline]
-            pub fn as_arr(&self) -> [(&str, bool); #arr_len] {
+            pub const fn as_arr(&self) -> [(&str, bool); #arr_len] {
                [#(#arr_items)*]
             }
         }

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -216,6 +216,13 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
         }
     });
 
+    let arr_items = members.iter().map(|FeaturesMember { name, raw, .. }| {
+        quote! {
+            (#raw, self.#name),
+        }
+    });
+    let arr_len = members.len();
+
     let write_items = members.iter().map(
         |FeaturesMember {
              name,
@@ -414,6 +421,12 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
                     #(#symmetric_difference_items)*
                     _ne: crate::NonExhaustive(()),
                 }
+            }
+
+            /// Returns the list of extensions as an array.
+            #[inline]
+            pub fn as_arr(&self) -> [(&str, bool); #arr_len] {
+               [#(#arr_items)*]
             }
         }
 

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -425,7 +425,7 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
 
             /// Returns the list of extensions as an array.
             #[inline]
-            pub fn as_arr(&self) -> [(&str, bool); #arr_len] {
+            pub const fn as_arr(&self) -> [(&str, bool); #arr_len] {
                [#(#arr_items)*]
             }
         }

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -422,12 +422,6 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
                     _ne: crate::NonExhaustive(()),
                 }
             }
-
-            /// Returns the list of extensions as an array.
-            #[inline]
-            pub const fn as_arr(&self) -> [(&'static str, bool); #arr_len] {
-               [#(#arr_items)*]
-            }
         }
 
         impl std::ops::BitAnd for Features {
@@ -521,6 +515,15 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
             }
         }
 
+        impl IntoIterator for Features {
+            type Item = (&'static str, bool);
+            type IntoIter = std::array::IntoIter<Self::Item, #arr_len>;
+
+            #[inline]
+            fn into_iter(self) -> Self::IntoIter {
+                [#(#arr_items)*].into_iter()
+            }
+        }
     }
 }
 

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -425,7 +425,7 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
 
             /// Returns the list of extensions as an array.
             #[inline]
-            pub const fn as_arr(&self) -> [(&str, bool); #arr_len] {
+            pub const fn as_arr(&self) -> [(&'static str, bool); #arr_len] {
                [#(#arr_items)*]
             }
         }

--- a/vulkano/src/device/extensions.rs
+++ b/vulkano/src/device/extensions.rs
@@ -22,4 +22,19 @@ mod tests {
         let d: Vec<CString> = (&DeviceExtensions::empty()).into();
         assert!(d.get(0).is_none());
     }
+
+    #[test]
+    fn as_arr() {
+        let extensions = DeviceExtensions {
+            khr_swapchain: true,
+            ..DeviceExtensions::empty()
+        };
+        for (name, enabled) in extensions.as_arr() {
+            if name == "VK_KHR_swapchain" {
+                assert!(enabled);
+            } else {
+                assert!(!enabled);
+            }
+        }
+    }
 }

--- a/vulkano/src/device/extensions.rs
+++ b/vulkano/src/device/extensions.rs
@@ -24,12 +24,12 @@ mod tests {
     }
 
     #[test]
-    fn as_arr() {
+    fn into_iter() {
         let extensions = DeviceExtensions {
             khr_swapchain: true,
             ..DeviceExtensions::empty()
         };
-        for (name, enabled) in extensions.as_arr() {
+        for (name, enabled) in extensions {
             if name == "VK_KHR_swapchain" {
                 assert!(enabled);
             } else {

--- a/vulkano/src/device/features.rs
+++ b/vulkano/src/device/features.rs
@@ -66,3 +66,23 @@ impl Display for FeatureRestriction {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Features;
+
+    #[test]
+    fn as_arr() {
+        let features = Features {
+            tessellation_shader: true,
+            ..Features::empty()
+        };
+        for (name, enabled) in features.as_arr() {
+            if name == "tessellationShader" {
+                assert!(enabled);
+            } else {
+                assert!(!enabled);
+            }
+        }
+    }
+}

--- a/vulkano/src/device/features.rs
+++ b/vulkano/src/device/features.rs
@@ -72,12 +72,12 @@ mod tests {
     use super::Features;
 
     #[test]
-    fn as_arr() {
+    fn into_iter() {
         let features = Features {
             tessellation_shader: true,
             ..Features::empty()
         };
-        for (name, enabled) in features.as_arr() {
+        for (name, enabled) in features {
             if name == "tessellationShader" {
                 assert!(enabled);
             } else {

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -22,4 +22,19 @@ mod tests {
         let i: Vec<CString> = (&InstanceExtensions::empty()).into();
         assert!(i.get(0).is_none());
     }
+
+    #[test]
+    fn as_arr() {
+        let extensions = InstanceExtensions {
+            khr_display: true,
+            ..InstanceExtensions::empty()
+        };
+        for (name, enabled) in extensions.as_arr() {
+            if name == "VK_KHR_display" {
+                assert!(enabled);
+            } else {
+                assert!(!enabled);
+            }
+        }
+    }
 }

--- a/vulkano/src/instance/extensions.rs
+++ b/vulkano/src/instance/extensions.rs
@@ -24,12 +24,12 @@ mod tests {
     }
 
     #[test]
-    fn as_arr() {
+    fn into_iter() {
         let extensions = InstanceExtensions {
             khr_display: true,
             ..InstanceExtensions::empty()
         };
-        for (name, enabled) in extensions.as_arr() {
+        for (name, enabled) in extensions {
             if name == "VK_KHR_display" {
                 assert!(enabled);
             } else {


### PR DESCRIPTION
1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [x] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo fmt` on the changes.

4. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.
   
   Please remove any items from the template below that are not applicable.

5. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Additions
- Implement `IntoIterator` for `Features`, `DeviceExtensions` and `InstanceExtensions`
````

This PR adds implements `IntoIterator` to auto-generated structs, allowing to get the list of features/extensions as an iterator. This is useful when the values need to be used in a non-programmatic scenario, such as showing the list of features to the user.