### PR TITLE
Refactor reporting of resources used in command buffers

### DIFF
--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -17,18 +17,16 @@ use super::{
     CommandBufferExecError, CommandBufferInheritanceInfo, CommandBufferInheritanceRenderPassInfo,
     CommandBufferInheritanceRenderPassType, CommandBufferLevel, CommandBufferResourcesUsage,
     CommandBufferState, CommandBufferUsage, PrimaryCommandBufferAbstract, RenderingAttachmentInfo,
-    SecondaryCommandBufferAbstract, SubpassContents,
+    SecondaryCommandBufferAbstract, SecondaryCommandBufferResourcesUsage, SubpassContents,
 };
 use crate::{
-    buffer::{sys::Buffer, BufferAccess},
     command_buffer::CommandBufferInheritanceRenderingInfo,
-    device::{Device, DeviceOwned, Queue, QueueFamilyProperties},
+    device::{Device, DeviceOwned, QueueFamilyProperties},
     format::{Format, FormatFeatures},
-    image::{sys::Image, ImageAccess, ImageAspects, ImageLayout, ImageSubresourceRange},
+    image::ImageAspects,
     query::{QueryControlFlags, QueryType},
     render_pass::{Framebuffer, Subpass},
-    sync::{future::AccessCheckError, AccessFlags, PipelineMemoryAccess, PipelineStages},
-    DeviceSize, OomError, RequirementNotMet, RequiresOneOf, VulkanObject,
+    OomError, RequirementNotMet, RequiresOneOf, VulkanObject,
 };
 use ahash::HashMap;
 use parking_lot::{Mutex, MutexGuard};
@@ -36,7 +34,6 @@ use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
     marker::PhantomData,
-    ops::Range,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -754,29 +751,6 @@ where
         self.usage
     }
 
-    fn check_buffer_access(
-        &self,
-        buffer: &Buffer,
-        range: Range<DeviceSize>,
-        exclusive: bool,
-        queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        self.inner
-            .check_buffer_access(buffer, range, exclusive, queue)
-    }
-
-    fn check_image_access(
-        &self,
-        image: &Image,
-        range: Range<DeviceSize>,
-        exclusive: bool,
-        expected_layout: ImageLayout,
-        queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        self.inner
-            .check_image_access(image, range, exclusive, expected_layout, queue)
-    }
-
     fn state(&self) -> MutexGuard<'_, CommandBufferState> {
         self.state.lock()
     }
@@ -859,36 +833,8 @@ where
         };
     }
 
-    fn num_buffers(&self) -> usize {
-        self.inner.num_buffers()
-    }
-
-    fn buffer(
-        &self,
-        index: usize,
-    ) -> Option<(
-        &Arc<dyn BufferAccess>,
-        Range<DeviceSize>,
-        PipelineMemoryAccess,
-    )> {
-        self.inner.buffer(index)
-    }
-
-    fn num_images(&self) -> usize {
-        self.inner.num_images()
-    }
-
-    fn image(
-        &self,
-        index: usize,
-    ) -> Option<(
-        &Arc<dyn ImageAccess>,
-        &ImageSubresourceRange,
-        PipelineMemoryAccess,
-        ImageLayout,
-        ImageLayout,
-    )> {
-        self.inner.image(index)
+    fn resources_usage(&self) -> &SecondaryCommandBufferResourcesUsage {
+        self.inner.secondary_resources_usage()
     }
 }
 

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -13,7 +13,7 @@ use crate::{
         allocator::CommandBufferAllocator,
         synced::{Command, Resource, SyncCommandBufferBuilder, SyncCommandBufferBuilderError},
         sys::UnsafeCommandBufferBuilder,
-        AutoCommandBufferBuilder,
+        AutoCommandBufferBuilder, ResourceInCommand, ResourceUseRef,
     },
     device::{DeviceOwned, QueueFlags},
     format::{ClearColorValue, ClearDepthStencilValue, Format, FormatFeatures},
@@ -583,12 +583,19 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &clear_info;
 
+        let command_index = self.commands.len();
+        let command_name = "clear_color_image";
         let resources: SmallVec<[_; 8]> = regions
             .iter()
             .cloned()
             .flat_map(|subresource_range| {
                 [(
-                    "image".into(),
+                    ResourceUseRef {
+                        command_index,
+                        command_name,
+                        resource_in_command: ResourceInCommand::Destination,
+                        secondary_use_ref: None,
+                    },
                     Resource::Image {
                         image: image.clone(),
                         subresource_range,
@@ -648,12 +655,19 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &clear_info;
 
+        let command_index = self.commands.len();
+        let command_name = "clear_depth_stencil_image";
         let resources: SmallVec<[_; 8]> = regions
             .iter()
             .cloned()
             .flat_map(|subresource_range| {
                 [(
-                    "image".into(),
+                    ResourceUseRef {
+                        command_index,
+                        command_name,
+                        resource_in_command: ResourceInCommand::Destination,
+                        secondary_use_ref: None,
+                    },
                     Resource::Image {
                         image: image.clone(),
                         subresource_range,
@@ -710,8 +724,15 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &fill_buffer_info;
 
+        let command_index = self.commands.len();
+        let command_name = "fill_buffer";
         let resources = [(
-            "dst_buffer".into(),
+            ResourceUseRef {
+                command_index,
+                command_name,
+                resource_in_command: ResourceInCommand::Destination,
+                secondary_use_ref: None,
+            },
             Resource::Buffer {
                 buffer: dst_buffer.clone(),
                 range: dst_offset..dst_offset + size,
@@ -767,8 +788,15 @@ impl SyncCommandBufferBuilder {
             }
         }
 
+        let command_index = self.commands.len();
+        let command_name = "update_buffer";
         let resources = [(
-            "dst_buffer".into(),
+            ResourceUseRef {
+                command_index,
+                command_name,
+                resource_in_command: ResourceInCommand::Destination,
+                secondary_use_ref: None,
+            },
             Resource::Buffer {
                 buffer: dst_buffer.clone(),
                 range: dst_offset..dst_offset + size_of_val(data.deref()) as DeviceSize,

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -13,7 +13,7 @@ use crate::{
         allocator::CommandBufferAllocator,
         synced::{Command, Resource, SyncCommandBufferBuilder, SyncCommandBufferBuilderError},
         sys::UnsafeCommandBufferBuilder,
-        AutoCommandBufferBuilder,
+        AutoCommandBufferBuilder, ResourceInCommand, ResourceUseRef,
     },
     device::{DeviceOwned, QueueFlags},
     format::{Format, FormatFeatures, NumericType},
@@ -2600,6 +2600,8 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &copy_buffer_info;
 
+        let command_index = self.commands.len();
+        let command_name = "copy_buffer";
         let resources: SmallVec<[_; 8]> = regions
             .iter()
             .flat_map(|region| {
@@ -2612,7 +2614,12 @@ impl SyncCommandBufferBuilder {
 
                 [
                     (
-                        "src_buffer".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Source,
+                            secondary_use_ref: None,
+                        },
                         Resource::Buffer {
                             buffer: src_buffer.clone(),
                             range: src_offset..src_offset + size,
@@ -2624,7 +2631,12 @@ impl SyncCommandBufferBuilder {
                         },
                     ),
                     (
-                        "dst_buffer".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Destination,
+                            secondary_use_ref: None,
+                        },
                         Resource::Buffer {
                             buffer: dst_buffer.clone(),
                             range: dst_offset..dst_offset + size,
@@ -2684,6 +2696,8 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &copy_image_info;
 
+        let command_index = self.commands.len();
+        let command_name = "copy_image";
         let resources: SmallVec<[_; 8]> = regions
             .iter()
             .flat_map(|region| {
@@ -2698,7 +2712,12 @@ impl SyncCommandBufferBuilder {
 
                 [
                     (
-                        "src_image".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Source,
+                            secondary_use_ref: None,
+                        },
                         Resource::Image {
                             image: src_image.clone(),
                             subresource_range: src_subresource.clone().into(),
@@ -2712,7 +2731,12 @@ impl SyncCommandBufferBuilder {
                         },
                     ),
                     (
-                        "dst_image".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Destination,
+                            secondary_use_ref: None,
+                        },
                         Resource::Image {
                             image: dst_image.clone(),
                             subresource_range: dst_subresource.clone().into(),
@@ -2773,6 +2797,8 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &copy_buffer_to_image_info;
 
+        let command_index = self.commands.len();
+        let command_name = "copy_buffer_to_image";
         let resources: SmallVec<[_; 8]> = regions
             .iter()
             .flat_map(|region| {
@@ -2788,7 +2814,12 @@ impl SyncCommandBufferBuilder {
 
                 [
                     (
-                        "src_buffer".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Source,
+                            secondary_use_ref: None,
+                        },
                         Resource::Buffer {
                             buffer: src_buffer.clone(),
                             range: buffer_offset
@@ -2801,7 +2832,12 @@ impl SyncCommandBufferBuilder {
                         },
                     ),
                     (
-                        "dst_image".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Destination,
+                            secondary_use_ref: None,
+                        },
                         Resource::Image {
                             image: dst_image.clone(),
                             subresource_range: image_subresource.clone().into(),
@@ -2864,6 +2900,8 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &copy_image_to_buffer_info;
 
+        let command_index = self.commands.len();
+        let command_name = "copy_image_to_buffer";
         let resources: SmallVec<[_; 8]> = regions
             .iter()
             .flat_map(|region| {
@@ -2879,7 +2917,12 @@ impl SyncCommandBufferBuilder {
 
                 [
                     (
-                        "src_image".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Source,
+                            secondary_use_ref: None,
+                        },
                         Resource::Image {
                             image: src_image.clone(),
                             subresource_range: image_subresource.clone().into(),
@@ -2893,7 +2936,12 @@ impl SyncCommandBufferBuilder {
                         },
                     ),
                     (
-                        "dst_buffer".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Destination,
+                            secondary_use_ref: None,
+                        },
                         Resource::Buffer {
                             buffer: dst_buffer.clone(),
                             range: buffer_offset
@@ -2957,6 +3005,8 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &blit_image_info;
 
+        let command_index = self.commands.len();
+        let command_name = "blit_image";
         let resources: SmallVec<[_; 8]> = regions
             .iter()
             .flat_map(|region| {
@@ -2970,7 +3020,12 @@ impl SyncCommandBufferBuilder {
 
                 [
                     (
-                        "src_image".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Source,
+                            secondary_use_ref: None,
+                        },
                         Resource::Image {
                             image: src_image.clone(),
                             subresource_range: src_subresource.clone().into(),
@@ -2984,7 +3039,12 @@ impl SyncCommandBufferBuilder {
                         },
                     ),
                     (
-                        "dst_image".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Destination,
+                            secondary_use_ref: None,
+                        },
                         Resource::Image {
                             image: dst_image.clone(),
                             subresource_range: dst_subresource.clone().into(),
@@ -3046,6 +3106,8 @@ impl SyncCommandBufferBuilder {
             _ne: _,
         } = &resolve_image_info;
 
+        let command_index = self.commands.len();
+        let command_name = "resolve_image";
         let resources: SmallVec<[_; 8]> = regions
             .iter()
             .flat_map(|region| {
@@ -3060,7 +3122,12 @@ impl SyncCommandBufferBuilder {
 
                 [
                     (
-                        "src_image".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Source,
+                            secondary_use_ref: None,
+                        },
                         Resource::Image {
                             image: src_image.clone(),
                             subresource_range: src_subresource.clone().into(),
@@ -3074,7 +3141,12 @@ impl SyncCommandBufferBuilder {
                         },
                     ),
                     (
-                        "dst_image".into(),
+                        ResourceUseRef {
+                            command_index,
+                            command_name,
+                            resource_in_command: ResourceInCommand::Destination,
+                            secondary_use_ref: None,
+                        },
                         Resource::Image {
                             image: dst_image.clone(),
                             subresource_range: dst_subresource.clone().into(),

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -14,7 +14,7 @@ use crate::{
         auto::QueryState,
         synced::{Command, Resource, SyncCommandBufferBuilder, SyncCommandBufferBuilderError},
         sys::UnsafeCommandBufferBuilder,
-        AutoCommandBufferBuilder,
+        AutoCommandBufferBuilder, ResourceInCommand, ResourceUseRef,
     },
     device::{DeviceOwned, QueueFlags},
     query::{
@@ -753,8 +753,15 @@ impl SyncCommandBufferBuilder {
             }
         }
 
+        let command_index = self.commands.len();
+        let command_name = "copy_query_pool_results";
         let resources = [(
-            "destination".into(),
+            ResourceUseRef {
+                command_index,
+                command_name,
+                resource_in_command: ResourceInCommand::Destination,
+                secondary_use_ref: None,
+            },
             Resource::Buffer {
                 buffer: destination.clone(),
                 range: 0..destination.size(), // TODO:

--- a/vulkano/src/command_buffer/standard/builder/pipeline.rs
+++ b/vulkano/src/command_buffer/standard/builder/pipeline.rs
@@ -81,10 +81,7 @@ where
             .ok_or(PipelineExecutionError::PipelineNotBound)?
             .as_ref();
 
-        self.validate_pipeline_descriptor_sets(
-            pipeline,
-            pipeline.descriptor_binding_requirements(),
-        )?;
+        self.validate_pipeline_descriptor_sets(pipeline)?;
         self.validate_pipeline_push_constants(pipeline.layout())?;
 
         let max = self
@@ -173,10 +170,7 @@ where
             .ok_or(PipelineExecutionError::PipelineNotBound)?
             .as_ref();
 
-        self.validate_pipeline_descriptor_sets(
-            pipeline,
-            pipeline.descriptor_binding_requirements(),
-        )?;
+        self.validate_pipeline_descriptor_sets(pipeline)?;
         self.validate_pipeline_push_constants(pipeline.layout())?;
         self.validate_indirect_buffer(indirect_buffer)?;
 
@@ -261,10 +255,7 @@ where
             .ok_or(PipelineExecutionError::PipelineNotBound)?
             .as_ref();
 
-        self.validate_pipeline_descriptor_sets(
-            pipeline,
-            pipeline.descriptor_binding_requirements(),
-        )?;
+        self.validate_pipeline_descriptor_sets(pipeline)?;
         self.validate_pipeline_push_constants(pipeline.layout())?;
         self.validate_pipeline_graphics_dynamic_state(pipeline)?;
         self.validate_pipeline_graphics_render_pass(pipeline, render_pass_state)?;
@@ -362,10 +353,7 @@ where
             .ok_or(PipelineExecutionError::PipelineNotBound)?
             .as_ref();
 
-        self.validate_pipeline_descriptor_sets(
-            pipeline,
-            pipeline.descriptor_binding_requirements(),
-        )?;
+        self.validate_pipeline_descriptor_sets(pipeline)?;
         self.validate_pipeline_push_constants(pipeline.layout())?;
         self.validate_pipeline_graphics_dynamic_state(pipeline)?;
         self.validate_pipeline_graphics_render_pass(pipeline, render_pass_state)?;
@@ -512,10 +500,7 @@ where
             .ok_or(PipelineExecutionError::PipelineNotBound)?
             .as_ref();
 
-        self.validate_pipeline_descriptor_sets(
-            pipeline,
-            pipeline.descriptor_binding_requirements(),
-        )?;
+        self.validate_pipeline_descriptor_sets(pipeline)?;
         self.validate_pipeline_push_constants(pipeline.layout())?;
         self.validate_pipeline_graphics_dynamic_state(pipeline)?;
         self.validate_pipeline_graphics_render_pass(pipeline, render_pass_state)?;
@@ -624,10 +609,7 @@ where
             .ok_or(PipelineExecutionError::PipelineNotBound)?
             .as_ref();
 
-        self.validate_pipeline_descriptor_sets(
-            pipeline,
-            pipeline.descriptor_binding_requirements(),
-        )?;
+        self.validate_pipeline_descriptor_sets(pipeline)?;
         self.validate_pipeline_push_constants(pipeline.layout())?;
         self.validate_pipeline_graphics_dynamic_state(pipeline)?;
         self.validate_pipeline_graphics_render_pass(pipeline, render_pass_state)?;
@@ -741,12 +723,9 @@ where
         Ok(())
     }
 
-    fn validate_pipeline_descriptor_sets<'a>(
+    fn validate_pipeline_descriptor_sets(
         &self,
         pipeline: &impl Pipeline,
-        descriptor_binding_requirements: impl IntoIterator<
-            Item = ((u32, u32), &'a DescriptorBindingRequirements),
-        >,
     ) -> Result<(), PipelineExecutionError> {
         fn validate_resources<T>(
             set_num: u32,
@@ -821,7 +800,7 @@ where
             return Err(PipelineExecutionError::PipelineLayoutNotCompatible);
         }
 
-        for ((set_num, binding_num), binding_reqs) in descriptor_binding_requirements {
+        for (&(set_num, binding_num), binding_reqs) in pipeline.descriptor_binding_requirements() {
             let layout_binding =
                 &pipeline.layout().set_layouts()[set_num as usize].bindings()[&binding_num];
 

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -18,11 +18,11 @@ use crate::{
     buffer::{sys::Buffer, BufferAccess},
     command_buffer::{
         pool::CommandPoolAlloc,
-        synced::{BufferUse, ImageUse},
         sys::{CommandBufferBeginInfo, UnsafeCommandBufferBuilder},
         CommandBufferBufferRangeUsage, CommandBufferBufferUsage, CommandBufferExecError,
         CommandBufferImageRangeUsage, CommandBufferImageUsage, CommandBufferLevel,
-        CommandBufferResourcesUsage, FirstResourceUse,
+        CommandBufferResourcesUsage, ResourceUseRef, SecondaryCommandBufferBufferUsage,
+        SecondaryCommandBufferImageUsage, SecondaryCommandBufferResourcesUsage,
     },
     descriptor_set::{DescriptorSetResources, DescriptorSetWithOffsets},
     device::{Device, DeviceOwned},
@@ -48,7 +48,6 @@ use crate::{
 use ahash::HashMap;
 use smallvec::SmallVec;
 use std::{
-    borrow::Cow,
     collections::hash_map::Entry,
     error::Error,
     fmt::{Debug, Display, Error as FmtError, Formatter},
@@ -97,18 +96,7 @@ pub struct SyncCommandBufferBuilder {
     images2: HashMap<Arc<Image>, RangeMap<DeviceSize, ImageState>>,
 
     // Resources and their accesses. Used for executing secondary command buffers in a primary.
-    buffers: Vec<(
-        Arc<dyn BufferAccess>,
-        Range<DeviceSize>,
-        PipelineMemoryAccess,
-    )>,
-    images: Vec<(
-        Arc<dyn ImageAccess>,
-        ImageSubresourceRange,
-        PipelineMemoryAccess,
-        ImageLayout,
-        ImageLayout,
-    )>,
+    secondary_resources_usage: SecondaryCommandBufferResourcesUsage,
 
     // Current binding/setting state.
     pub(in crate::command_buffer) current_state: CurrentState,
@@ -170,8 +158,7 @@ impl SyncCommandBufferBuilder {
             latest_render_pass_enter,
             buffers2: HashMap::default(),
             images2: HashMap::default(),
-            buffers: Vec::new(),
-            images: Vec::new(),
+            secondary_resources_usage: Default::default(),
             current_state: Default::default(),
         }
     }
@@ -195,9 +182,9 @@ impl SyncCommandBufferBuilder {
 
     pub(in crate::command_buffer) fn check_resource_conflicts(
         &self,
-        resource: &(Cow<'static, str>, Resource),
+        resource: &(ResourceUseRef, Resource),
     ) -> Result<(), SyncCommandBufferBuilderError> {
-        let (resource_name, resource) = resource;
+        let &(current_use_ref, ref resource) = resource;
 
         match *resource {
             Resource::Buffer {
@@ -207,14 +194,12 @@ impl SyncCommandBufferBuilder {
             } => {
                 debug_assert!(AccessFlags::from(memory.stages).contains(memory.access));
 
-                if let Some(conflicting_use) =
+                if let Some(previous_use_ref) =
                     self.find_buffer_conflict(buffer, range.clone(), memory)
                 {
                     return Err(SyncCommandBufferBuilderError::Conflict {
-                        command_param: resource_name.clone(),
-                        previous_command_name: self.commands[conflicting_use.command_index].name(),
-                        previous_command_offset: conflicting_use.command_index,
-                        previous_command_param: conflicting_use.name.clone(),
+                        current_use_ref,
+                        previous_use_ref,
                     });
                 }
             }
@@ -230,7 +215,7 @@ impl SyncCommandBufferBuilder {
                 debug_assert!(end_layout != ImageLayout::Undefined);
                 debug_assert!(end_layout != ImageLayout::Preinitialized);
 
-                if let Some(conflicting_use) = self.find_image_conflict(
+                if let Some(previous_use) = self.find_image_conflict(
                     image,
                     subresource_range.clone(),
                     memory,
@@ -238,10 +223,8 @@ impl SyncCommandBufferBuilder {
                     end_layout,
                 ) {
                     return Err(SyncCommandBufferBuilderError::Conflict {
-                        command_param: resource_name.clone(),
-                        previous_command_name: self.commands[conflicting_use.command_index].name(),
-                        previous_command_offset: conflicting_use.command_index,
-                        previous_command_param: conflicting_use.name.clone(),
+                        current_use_ref,
+                        previous_use_ref: previous_use,
                     });
                 }
             }
@@ -255,7 +238,7 @@ impl SyncCommandBufferBuilder {
         buffer: &dyn BufferAccess,
         mut range: Range<DeviceSize>,
         memory: &PipelineMemoryAccess,
-    ) -> Option<&BufferUse> {
+    ) -> Option<ResourceUseRef> {
         // Barriers work differently in render passes, so if we're in one, we can only insert a
         // barrier before the start of the render pass.
         let last_allowed_barrier_index =
@@ -279,12 +262,12 @@ impl SyncCommandBufferBuilder {
             if memory.exclusive || state.memory.exclusive {
                 // If there is a resource use at a position beyond where we can insert a
                 // barrier, then there is an unsolvable conflict.
-                if let Some(conflicting_use) = state
+                if let Some(&use_ref) = state
                     .resource_uses
                     .iter()
                     .find(|resource_use| resource_use.command_index >= last_allowed_barrier_index)
                 {
-                    return Some(conflicting_use);
+                    return Some(use_ref);
                 }
             }
         }
@@ -299,7 +282,7 @@ impl SyncCommandBufferBuilder {
         memory: &PipelineMemoryAccess,
         start_layout: ImageLayout,
         _end_layout: ImageLayout,
-    ) -> Option<&ImageUse> {
+    ) -> Option<ResourceUseRef> {
         // Barriers work differently in render passes, so if we're in one, we can only insert a
         // barrier before the start of the render pass.
         let last_allowed_barrier_index =
@@ -337,10 +320,10 @@ impl SyncCommandBufferBuilder {
                 {
                     // If there is a resource use at a position beyond where we can insert a
                     // barrier, then there is an unsolvable conflict.
-                    if let Some(conflicting_use) = state.resource_uses.iter().find(|resource_use| {
+                    if let Some(&use_ref) = state.resource_uses.iter().find(|resource_use| {
                         resource_use.command_index >= last_allowed_barrier_index
                     }) {
-                        return Some(conflicting_use);
+                        return Some(use_ref);
                     }
                 }
             }
@@ -360,11 +343,8 @@ impl SyncCommandBufferBuilder {
     /// - `start_layout` and `end_layout` designate the image layout that the image is expected to
     ///   be in when the command starts, and the image layout that the image will be transitioned to
     ///   during the command. When it comes to buffers, you should pass `Undefined` for both.
-    pub(in crate::command_buffer) fn add_resource(
-        &mut self,
-        resource: (Cow<'static, str>, Resource),
-    ) {
-        let (resource_name, resource) = resource;
+    pub(in crate::command_buffer) fn add_resource(&mut self, resource: (ResourceUseRef, Resource)) {
+        let (use_ref, resource) = resource;
 
         match resource {
             Resource::Buffer {
@@ -372,7 +352,7 @@ impl SyncCommandBufferBuilder {
                 range,
                 memory,
             } => {
-                self.add_buffer(resource_name, buffer, range, memory);
+                self.add_buffer(use_ref, buffer, range, memory);
             }
             Resource::Image {
                 image,
@@ -382,7 +362,7 @@ impl SyncCommandBufferBuilder {
                 end_layout,
             } => {
                 self.add_image(
-                    resource_name,
+                    use_ref,
                     image,
                     subresource_range,
                     memory,
@@ -395,12 +375,19 @@ impl SyncCommandBufferBuilder {
 
     fn add_buffer(
         &mut self,
-        resource_name: Cow<'static, str>,
+        use_ref: ResourceUseRef,
         buffer: Arc<dyn BufferAccess>,
         mut range: Range<DeviceSize>,
         memory: PipelineMemoryAccess,
     ) {
-        self.buffers.push((buffer.clone(), range.clone(), memory));
+        self.secondary_resources_usage
+            .buffers
+            .push(SecondaryCommandBufferBufferUsage {
+                use_ref,
+                buffer: buffer.clone(),
+                range: range.clone(),
+                memory,
+            });
 
         // Barriers work differently in render passes, so if we're in one, we can only insert a
         // barrier before the start of the render pass.
@@ -433,10 +420,7 @@ impl SyncCommandBufferBuilder {
         for (range, state) in range_map.range_mut(&range) {
             if state.resource_uses.is_empty() {
                 // This is the first time we use this resource range in this command buffer.
-                state.resource_uses.push(BufferUse {
-                    command_index: self.commands.len() - 1,
-                    name: resource_name.clone(),
-                });
+                state.resource_uses.push(use_ref);
                 state.memory = PipelineMemoryAccess {
                     stages: memory.stages,
                     access: memory.access,
@@ -518,30 +502,30 @@ impl SyncCommandBufferBuilder {
                     state.memory.access |= memory.access;
                 }
 
-                state.resource_uses.push(BufferUse {
-                    command_index: self.commands.len() - 1,
-                    name: resource_name.clone(),
-                });
+                state.resource_uses.push(use_ref);
             }
         }
     }
 
     fn add_image(
         &mut self,
-        resource_name: Cow<'static, str>,
+        use_ref: ResourceUseRef,
         image: Arc<dyn ImageAccess>,
         mut subresource_range: ImageSubresourceRange,
         memory: PipelineMemoryAccess,
         start_layout: ImageLayout,
         end_layout: ImageLayout,
     ) {
-        self.images.push((
-            image.clone(),
-            subresource_range.clone(),
-            memory,
-            start_layout,
-            end_layout,
-        ));
+        self.secondary_resources_usage
+            .images
+            .push(SecondaryCommandBufferImageUsage {
+                use_ref,
+                image: image.clone(),
+                subresource_range: subresource_range.clone(),
+                memory,
+                start_layout,
+                end_layout,
+            });
 
         // Barriers work differently in render passes, so if we're in one, we can only insert a
         // barrier before the start of the render pass.
@@ -609,10 +593,7 @@ impl SyncCommandBufferBuilder {
 
                     debug_assert_eq!(state.initial_layout, state.current_layout);
 
-                    state.resource_uses.push(ImageUse {
-                        command_index: self.commands.len() - 1,
-                        name: resource_name.clone(),
-                    });
+                    state.resource_uses.push(use_ref);
                     state.memory = PipelineMemoryAccess {
                         stages: memory.stages,
                         access: memory.access,
@@ -745,10 +726,7 @@ impl SyncCommandBufferBuilder {
                         state.memory.access |= memory.access;
                     }
 
-                    state.resource_uses.push(ImageUse {
-                        command_index: self.commands.len() - 1,
-                        name: resource_name.clone(),
-                    });
+                    state.resource_uses.push(use_ref);
                 }
             }
         }
@@ -800,7 +778,7 @@ impl SyncCommandBufferBuilder {
             }
         }
 
-        let resource_usage = CommandBufferResourcesUsage {
+        let mut resource_usage = CommandBufferResourcesUsage {
             buffers: self
                 .buffers2
                 .into_iter()
@@ -814,14 +792,8 @@ impl SyncCommandBufferBuilder {
                             (
                                 range,
                                 CommandBufferBufferRangeUsage {
-                                    first_use: FirstResourceUse {
-                                        command_index: first_use.command_index,
-                                        command_name: self.commands[first_use.command_index].name(),
-                                        description: first_use.name,
-                                    },
+                                    first_use,
                                     mutable: state.exclusive_any,
-                                    final_stages: state.memory.stages,
-                                    final_access: state.memory.access,
                                 },
                             )
                         })
@@ -849,14 +821,8 @@ impl SyncCommandBufferBuilder {
                             (
                                 range,
                                 CommandBufferImageRangeUsage {
-                                    first_use: FirstResourceUse {
-                                        command_index: first_use.command_index,
-                                        command_name: self.commands[first_use.command_index].name(),
-                                        description: first_use.name,
-                                    },
+                                    first_use,
                                     mutable: state.exclusive_any,
-                                    final_stages: state.memory.stages,
-                                    final_access: state.memory.access,
                                     expected_layout: state.initial_layout,
                                     final_layout: state.current_layout,
                                 },
@@ -865,15 +831,17 @@ impl SyncCommandBufferBuilder {
                         .collect(),
                 })
                 .collect(),
+            buffer_indices: Default::default(),
+            image_indices: Default::default(),
         };
 
-        let buffer_indices: HashMap<_, _> = resource_usage
+        resource_usage.buffer_indices = resource_usage
             .buffers
             .iter()
             .enumerate()
             .map(|(index, usage)| (usage.buffer.clone(), index))
             .collect();
-        let image_indices: HashMap<_, _> = resource_usage
+        resource_usage.image_indices = resource_usage
             .images
             .iter()
             .enumerate()
@@ -882,11 +850,8 @@ impl SyncCommandBufferBuilder {
 
         Ok(SyncCommandBuffer {
             inner: self.inner.build()?,
-            buffers: self.buffers,
-            images: self.images,
             resources_usage: resource_usage,
-            buffer_indices,
-            image_indices,
+            secondary_resources_usage: self.secondary_resources_usage,
             _commands: self.commands,
             _barriers: self.barriers,
         })
@@ -911,10 +876,8 @@ impl Debug for SyncCommandBufferBuilder {
 pub enum SyncCommandBufferBuilderError {
     /// Unsolvable conflict.
     Conflict {
-        command_param: Cow<'static, str>,
-        previous_command_name: &'static str,
-        previous_command_offset: usize,
-        previous_command_param: Cow<'static, str>,
+        current_use_ref: ResourceUseRef,
+        previous_use_ref: ResourceUseRef,
     },
 
     ExecError(CommandBufferExecError),
@@ -941,7 +904,7 @@ impl From<CommandBufferExecError> for SyncCommandBufferBuilderError {
 #[derive(Clone, PartialEq, Eq)]
 struct BufferState {
     // Lists every use of the resource.
-    resource_uses: Vec<BufferUse>,
+    resource_uses: Vec<ResourceUseRef>,
 
     // Memory access of the command that last used this resource.
     memory: PipelineMemoryAccess,
@@ -955,7 +918,7 @@ struct BufferState {
 #[derive(Clone, PartialEq, Eq)]
 struct ImageState {
     // Lists every use of the resource.
-    resource_uses: Vec<ImageUse>,
+    resource_uses: Vec<ResourceUseRef>,
 
     // Memory access of the command that last used this resource.
     memory: PipelineMemoryAccess,

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -9,18 +9,18 @@
 
 use super::{
     CommandBufferInheritanceInfo, CommandBufferResourcesUsage, CommandBufferState,
-    CommandBufferUsage, SemaphoreSubmitInfo, SubmitInfo,
+    CommandBufferUsage, SecondaryCommandBufferResourcesUsage, SemaphoreSubmitInfo, SubmitInfo,
 };
 use crate::{
-    buffer::{sys::Buffer, BufferAccess},
+    buffer::sys::Buffer,
     device::{Device, DeviceOwned, Queue},
-    image::{sys::Image, ImageAccess, ImageLayout, ImageSubresourceRange},
+    image::{sys::Image, ImageLayout},
     swapchain::Swapchain,
     sync::{
         future::{
             now, AccessCheckError, AccessError, FlushError, GpuFuture, NowFuture, SubmitAnyBuilder,
         },
-        AccessFlags, PipelineMemoryAccess, PipelineStages,
+        PipelineStages,
     },
     DeviceSize, SafeDeref, VulkanObject,
 };
@@ -118,23 +118,6 @@ pub unsafe trait PrimaryCommandBufferAbstract:
         })
     }
 
-    fn check_buffer_access(
-        &self,
-        buffer: &Buffer,
-        range: Range<DeviceSize>,
-        exclusive: bool,
-        queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError>;
-
-    fn check_image_access(
-        &self,
-        image: &Image,
-        range: Range<DeviceSize>,
-        exclusive: bool,
-        expected_layout: ImageLayout,
-        queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError>;
-
     #[doc(hidden)]
     fn state(&self) -> MutexGuard<'_, CommandBufferState>;
 
@@ -155,27 +138,6 @@ where
 {
     fn usage(&self) -> CommandBufferUsage {
         (**self).usage()
-    }
-
-    fn check_buffer_access(
-        &self,
-        buffer: &Buffer,
-        range: Range<DeviceSize>,
-        exclusive: bool,
-        queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        (**self).check_buffer_access(buffer, range, exclusive, queue)
-    }
-
-    fn check_image_access(
-        &self,
-        image: &Image,
-        range: Range<DeviceSize>,
-        exclusive: bool,
-        expected_layout: ImageLayout,
-        queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        (**self).check_image_access(image, range, exclusive, expected_layout, queue)
     }
 
     fn state(&self) -> MutexGuard<'_, CommandBufferState> {
@@ -210,37 +172,8 @@ pub unsafe trait SecondaryCommandBufferAbstract:
     /// Must not be called if you haven't called `lock_record` before.
     unsafe fn unlock(&self);
 
-    /// Returns the number of buffers accessed by this command buffer.
-    fn num_buffers(&self) -> usize;
-
-    /// Returns the `index`th buffer of this command buffer, or `None` if out of range.
-    ///
-    /// The valid range is between 0 and `num_buffers()`.
-    fn buffer(
-        &self,
-        index: usize,
-    ) -> Option<(
-        &Arc<dyn BufferAccess>,
-        Range<DeviceSize>,
-        PipelineMemoryAccess,
-    )>;
-
-    /// Returns the number of images accessed by this command buffer.
-    fn num_images(&self) -> usize;
-
-    /// Returns the `index`th image of this command buffer, or `None` if out of range.
-    ///
-    /// The valid range is between 0 and `num_images()`.
-    fn image(
-        &self,
-        index: usize,
-    ) -> Option<(
-        &Arc<dyn ImageAccess>,
-        &ImageSubresourceRange,
-        PipelineMemoryAccess,
-        ImageLayout,
-        ImageLayout,
-    )>;
+    #[doc(hidden)]
+    fn resources_usage(&self) -> &SecondaryCommandBufferResourcesUsage;
 }
 
 unsafe impl<T> SecondaryCommandBufferAbstract for T
@@ -264,36 +197,8 @@ where
         (**self).unlock();
     }
 
-    fn num_buffers(&self) -> usize {
-        (**self).num_buffers()
-    }
-
-    fn buffer(
-        &self,
-        index: usize,
-    ) -> Option<(
-        &Arc<dyn BufferAccess>,
-        Range<DeviceSize>,
-        PipelineMemoryAccess,
-    )> {
-        (**self).buffer(index)
-    }
-
-    fn num_images(&self) -> usize {
-        (**self).num_images()
-    }
-
-    fn image(
-        &self,
-        index: usize,
-    ) -> Option<(
-        &Arc<dyn ImageAccess>,
-        &ImageSubresourceRange,
-        PipelineMemoryAccess,
-        ImageLayout,
-        ImageLayout,
-    )> {
-        (**self).image(index)
+    fn resources_usage(&self) -> &SecondaryCommandBufferResourcesUsage {
+        (**self).resources_usage()
     }
 }
 
@@ -425,12 +330,28 @@ where
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        match self
-            .command_buffer
-            .check_buffer_access(buffer, range.clone(), exclusive, queue)
-        {
-            Ok(v) => Ok(v),
+    ) -> Result<(), AccessCheckError> {
+        let resources_usage = self.command_buffer.resources_usage();
+        let usage = match resources_usage.buffer_indices.get(buffer) {
+            Some(&index) => &resources_usage.buffers[index],
+            None => return Err(AccessCheckError::Unknown),
+        };
+
+        // TODO: check the queue family
+
+        let result = usage
+            .ranges
+            .range(&range)
+            .try_fold((), |_, (_range, range_usage)| {
+                if !range_usage.mutable && exclusive {
+                    Err(AccessCheckError::Unknown)
+                } else {
+                    Ok(())
+                }
+            });
+
+        match result {
+            Ok(()) => Ok(()),
             Err(AccessCheckError::Denied(err)) => Err(AccessCheckError::Denied(err)),
             Err(AccessCheckError::Unknown) => self
                 .previous
@@ -445,15 +366,39 @@ where
         exclusive: bool,
         expected_layout: ImageLayout,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
-        match self.command_buffer.check_image_access(
-            image,
-            range.clone(),
-            exclusive,
-            expected_layout,
-            queue,
-        ) {
-            Ok(v) => Ok(v),
+    ) -> Result<(), AccessCheckError> {
+        let resources_usage = self.command_buffer.resources_usage();
+        let usage = match resources_usage.image_indices.get(image) {
+            Some(&index) => &resources_usage.images[index],
+            None => return Err(AccessCheckError::Unknown),
+        };
+
+        // TODO: check the queue family
+
+        let result = usage
+            .ranges
+            .range(&range)
+            .try_fold((), |_, (_range, range_usage)| {
+                if expected_layout != ImageLayout::Undefined
+                    && range_usage.final_layout != expected_layout
+                {
+                    return Err(AccessCheckError::Denied(
+                        AccessError::UnexpectedImageLayout {
+                            allowed: range_usage.final_layout,
+                            requested: expected_layout,
+                        },
+                    ));
+                }
+
+                if !range_usage.mutable && exclusive {
+                    Err(AccessCheckError::Unknown)
+                } else {
+                    Ok(())
+                }
+            });
+
+        match result {
+            Ok(()) => Ok(()),
             Err(AccessCheckError::Denied(err)) => Err(AccessCheckError::Denied(err)),
             Err(AccessCheckError::Unknown) => {
                 self.previous

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -671,8 +671,12 @@ impl<'a> QueueGuard<'a> {
                     CommandBufferUsage::SimultaneousUse => (),
                 }
 
-                let CommandBufferResourcesUsage { buffers, images } =
-                    command_buffer.resources_usage();
+                let CommandBufferResourcesUsage {
+                    buffers,
+                    images,
+                    buffer_indices: _,
+                    image_indices: _,
+                } = command_buffer.resources_usage();
 
                 for usage in buffers {
                     let state = states.buffers.get_mut(&usage.buffer.handle()).unwrap();
@@ -684,12 +688,10 @@ impl<'a> QueueGuard<'a> {
                             range_usage.mutable,
                             queue,
                         ) {
-                            Err(AccessCheckError::Denied(err)) => {
+                            Err(AccessCheckError::Denied(error)) => {
                                 return Err(FlushError::ResourceAccessError {
-                                    error: err,
-                                    command_name: range_usage.first_use.command_name.into(),
-                                    command_param: range_usage.first_use.description.clone(),
-                                    command_offset: range_usage.first_use.command_index,
+                                    error,
+                                    use_ref: range_usage.first_use,
                                 });
                             }
                             Err(AccessCheckError::Unknown) => {
@@ -699,12 +701,10 @@ impl<'a> QueueGuard<'a> {
                                     state.check_gpu_read(range.clone())
                                 };
 
-                                if let Err(err) = result {
+                                if let Err(error) = result {
                                     return Err(FlushError::ResourceAccessError {
-                                        error: err,
-                                        command_name: range_usage.first_use.command_name.into(),
-                                        command_param: range_usage.first_use.description.clone(),
-                                        command_offset: range_usage.first_use.command_index,
+                                        error,
+                                        use_ref: range_usage.first_use,
                                     });
                                 }
                             }
@@ -724,13 +724,10 @@ impl<'a> QueueGuard<'a> {
                             range_usage.expected_layout,
                             queue,
                         ) {
-                            Err(AccessCheckError::Denied(err)) => {
-                                println!("Foo");
+                            Err(AccessCheckError::Denied(error)) => {
                                 return Err(FlushError::ResourceAccessError {
-                                    error: err,
-                                    command_name: range_usage.first_use.command_name.into(),
-                                    command_param: range_usage.first_use.description.clone(),
-                                    command_offset: range_usage.first_use.command_index,
+                                    error,
+                                    use_ref: range_usage.first_use,
                                 });
                             }
                             Err(AccessCheckError::Unknown) => {
@@ -741,13 +738,10 @@ impl<'a> QueueGuard<'a> {
                                     state.check_gpu_read(range.clone(), range_usage.expected_layout)
                                 };
 
-                                if let Err(err) = result {
-                                    println!("Bar");
+                                if let Err(error) = result {
                                     return Err(FlushError::ResourceAccessError {
-                                        error: err,
-                                        command_name: range_usage.first_use.command_name.into(),
-                                        command_param: range_usage.first_use.description.clone(),
-                                        command_offset: range_usage.first_use.command_index,
+                                        error,
+                                        use_ref: range_usage.first_use,
                                     });
                                 }
                             }
@@ -1049,8 +1043,12 @@ impl<'a> QueueGuard<'a> {
                     .unwrap();
                 state.add_queue_submit();
 
-                let CommandBufferResourcesUsage { buffers, images } =
-                    command_buffer.resources_usage();
+                let CommandBufferResourcesUsage {
+                    buffers,
+                    images,
+                    buffer_indices: _,
+                    image_indices: _,
+                } = command_buffer.resources_usage();
 
                 for usage in buffers {
                     let state = states.buffers.get_mut(&usage.buffer.handle()).unwrap();
@@ -1534,6 +1532,8 @@ impl<'a> States<'a> {
                 let CommandBufferResourcesUsage {
                     buffers: buffers_usage,
                     images: images_usage,
+                    buffer_indices: _,
+                    image_indices: _,
                 } = command_buffer.resources_usage();
 
                 for usage in buffers_usage {

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -1333,7 +1333,6 @@ impl RawImage {
     /// - If `self.flags().disjoint` is set, then `allocations` must contain exactly
     ///   `self.format().unwrap().planes().len()` elements. These elements must not be dedicated
     ///   allocations.
-    #[allow(clippy::result_large_err)]
     pub fn bind_memory(
         self,
         allocations: impl IntoIterator<Item = MemoryAlloc>,
@@ -1498,7 +1497,6 @@ impl RawImage {
     /// - If `self.flags().disjoint` is set, then `allocations` must contain exactly
     ///   `self.format().unwrap().planes().len()` elements.
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    #[allow(clippy::result_large_err)]
     pub unsafe fn bind_memory_unchecked(
         self,
         allocations: impl IntoIterator<Item = MemoryAlloc>,

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -79,6 +79,7 @@
     clippy::new_without_default,
     clippy::nonminimal_bool,
     clippy::op_ref, // Seems to be bugged, the fixed code triggers a compile error
+    clippy::result_large_err,
     clippy::too_many_arguments,
     clippy::type_complexity,
     clippy::vec_box,

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -247,16 +247,6 @@ impl ComputePipeline {
     pub fn device(&self) -> &Arc<Device> {
         &self.device
     }
-
-    /// Returns an iterator over the descriptor requirements for this pipeline.
-    #[inline]
-    pub fn descriptor_binding_requirements(
-        &self,
-    ) -> impl ExactSizeIterator<Item = ((u32, u32), &DescriptorBindingRequirements)> {
-        self.descriptor_binding_requirements
-            .iter()
-            .map(|(loc, reqs)| (*loc, reqs))
-    }
 }
 
 impl Pipeline for ComputePipeline {
@@ -273,6 +263,13 @@ impl Pipeline for ComputePipeline {
     #[inline]
     fn num_used_descriptor_sets(&self) -> u32 {
         self.num_used_descriptor_sets
+    }
+
+    #[inline]
+    fn descriptor_binding_requirements(
+        &self,
+    ) -> &HashMap<(u32, u32), DescriptorBindingRequirements> {
+        &self.descriptor_binding_requirements
     }
 }
 

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -165,16 +165,6 @@ impl GraphicsPipeline {
         self.shaders.get(&stage).copied()
     }
 
-    /// Returns an iterator over the descriptor binding requirements for this pipeline.
-    #[inline]
-    pub fn descriptor_binding_requirements(
-        &self,
-    ) -> impl ExactSizeIterator<Item = ((u32, u32), &DescriptorBindingRequirements)> {
-        self.descriptor_binding_requirements
-            .iter()
-            .map(|(loc, reqs)| (*loc, reqs))
-    }
-
     /// Returns the vertex input state used to create this pipeline.
     #[inline]
     pub fn vertex_input_state(&self) -> &VertexInputState {
@@ -259,6 +249,13 @@ impl Pipeline for GraphicsPipeline {
     #[inline]
     fn num_used_descriptor_sets(&self) -> u32 {
         self.num_used_descriptor_sets
+    }
+
+    #[inline]
+    fn descriptor_binding_requirements(
+        &self,
+    ) -> &HashMap<(u32, u32), DescriptorBindingRequirements> {
+        &self.descriptor_binding_requirements
     }
 }
 

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -18,7 +18,8 @@
 //! initialization or during a loading screen.
 
 pub use self::{compute::ComputePipeline, graphics::GraphicsPipeline, layout::PipelineLayout};
-use crate::{device::DeviceOwned, macros::vulkan_enum};
+use crate::{device::DeviceOwned, macros::vulkan_enum, shader::DescriptorBindingRequirements};
+use ahash::HashMap;
 use std::sync::Arc;
 
 pub mod cache;
@@ -37,6 +38,11 @@ pub trait Pipeline: DeviceOwned {
     /// Returns the number of descriptor sets actually accessed by this pipeline. This may be less
     /// than the number of sets in the pipeline layout.
     fn num_used_descriptor_sets(&self) -> u32;
+
+    /// Returns a reference to the descriptor binding requirements for this pipeline.
+    fn descriptor_binding_requirements(
+        &self,
+    ) -> &HashMap<(u32, u32), DescriptorBindingRequirements>;
 }
 
 vulkan_enum! {

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -25,7 +25,7 @@ use crate::{
         fence::{Fence, FenceError},
         future::{AccessCheckError, AccessError, FlushError, GpuFuture, SubmitAnyBuilder},
         semaphore::{Semaphore, SemaphoreError},
-        AccessFlags, PipelineStages, Sharing,
+        Sharing,
     },
     DeviceSize, OomError, RequirementNotMet, RequiresOneOf, VulkanError, VulkanObject,
 };
@@ -1684,7 +1684,7 @@ unsafe impl GpuFuture for SwapchainAcquireFuture {
         _range: Range<DeviceSize>,
         _exclusive: bool,
         _queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         Err(AccessCheckError::Unknown)
     }
 
@@ -1695,7 +1695,7 @@ unsafe impl GpuFuture for SwapchainAcquireFuture {
         _exclusive: bool,
         expected_layout: ImageLayout,
         _queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         if self.swapchain.index_of_image(image) != Some(self.image_index) {
             return Err(AccessCheckError::Unknown);
         }
@@ -1719,7 +1719,7 @@ unsafe impl GpuFuture for SwapchainAcquireFuture {
             ));
         }
 
-        Ok(None)
+        Ok(())
     }
 
     #[inline]
@@ -2122,7 +2122,7 @@ where
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         self.previous
             .check_buffer_access(buffer, range, exclusive, queue)
     }
@@ -2134,7 +2134,7 @@ where
         exclusive: bool,
         expected_layout: ImageLayout,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         if self.swapchain_info.swapchain.index_of_image(image)
             == Some(self.swapchain_info.image_index)
         {

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -17,7 +17,7 @@ use crate::{
     sync::{
         fence::Fence,
         future::{AccessError, SubmitAnyBuilder},
-        AccessFlags, PipelineStages,
+        PipelineStages,
     },
     DeviceSize, OomError,
 };
@@ -469,7 +469,7 @@ where
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         let state = self.state.lock();
         if let Some(previous) = state.get_prev() {
             previous.check_buffer_access(buffer, range, exclusive, queue)
@@ -485,7 +485,7 @@ where
         exclusive: bool,
         expected_layout: ImageLayout,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         let state = self.state.lock();
         if let Some(previous) = state.get_prev() {
             previous.check_image_access(image, range, exclusive, expected_layout, queue)
@@ -588,7 +588,7 @@ where
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         (**self).check_buffer_access(buffer, range, exclusive, queue)
     }
 
@@ -599,7 +599,7 @@ where
         exclusive: bool,
         expected_layout: ImageLayout,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         (**self).check_image_access(image, range, exclusive, expected_layout, queue)
     }
 

--- a/vulkano/src/sync/future/now.rs
+++ b/vulkano/src/sync/future/now.rs
@@ -13,7 +13,6 @@ use crate::{
     device::{Device, DeviceOwned, Queue},
     image::{sys::Image, ImageLayout},
     swapchain::Swapchain,
-    sync::{AccessFlags, PipelineStages},
     DeviceSize,
 };
 use std::{ops::Range, sync::Arc};
@@ -63,7 +62,7 @@ unsafe impl GpuFuture for NowFuture {
         _range: Range<DeviceSize>,
         _exclusive: bool,
         _queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         Err(AccessCheckError::Unknown)
     }
 
@@ -75,7 +74,7 @@ unsafe impl GpuFuture for NowFuture {
         _exclusive: bool,
         _expected_layout: ImageLayout,
         _queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         Err(AccessCheckError::Unknown)
     }
 

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -14,7 +14,7 @@ use crate::{
     device::{Device, DeviceOwned, Queue},
     image::{sys::Image, ImageLayout},
     swapchain::Swapchain,
-    sync::{future::AccessError, semaphore::Semaphore, AccessFlags, PipelineStages},
+    sync::{future::AccessError, semaphore::Semaphore, PipelineStages},
     DeviceSize,
 };
 use parking_lot::Mutex;
@@ -207,10 +207,9 @@ where
         range: Range<DeviceSize>,
         exclusive: bool,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         self.previous
             .check_buffer_access(buffer, range, exclusive, queue)
-            .map(|_| None)
     }
 
     fn check_image_access(
@@ -220,10 +219,9 @@ where
         exclusive: bool,
         expected_layout: ImageLayout,
         queue: &Queue,
-    ) -> Result<Option<(PipelineStages, AccessFlags)>, AccessCheckError> {
+    ) -> Result<(), AccessCheckError> {
         self.previous
             .check_image_access(image, range, exclusive, expected_layout, queue)
-            .map(|_| None)
     }
 
     #[inline]


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to `GpuFuture`:
- The `check_buffer_access` and `check_image_access` methods now return nothing on success.

Changes to pipelines:
- The `descriptor_binding_requirements` method is moved to the `Pipeline` trait, and returns a reference to the hashmap directly.
````

This is mostly an internal refactoring, with a few user-visible changes on the side. Where previously, strings were used to indicate which resource within a command was being indicated in an error message, there is now the `ResourceUseRef` type which indicates it structurally.