### PR TITLE
Add synchronization tracking for render pass operations in `CommandBufferBuilder`

### DIFF
--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -74,7 +74,18 @@ fn write_shader_execution(execution: &ShaderExecution) -> TokenStream {
                 )
             }
         }
-        ShaderExecution::Fragment => quote! { ::vulkano::shader::ShaderExecution::Fragment },
+        ShaderExecution::Fragment(::vulkano::shader::FragmentShaderExecution {
+            fragment_tests_stages,
+        }) => {
+            let fragment_tests_stages = format_ident!("{}", format!("{:?}", fragment_tests_stages));
+            quote! {
+                ::vulkano::shader::ShaderExecution::Fragment(
+                    ::vulkano::shader::FragmentShaderExecution {
+                        fragment_tests_stages: ::vulkano::shader::FragmentTestsStages::#fragment_tests_stages,
+                    }
+                )
+            }
+        }
         ShaderExecution::Compute => quote! { ::vulkano::shader::ShaderExecution::Compute },
         ShaderExecution::RayGeneration => {
             quote! { ::vulkano::shader::ShaderExecution::RayGeneration }

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1419,7 +1419,6 @@ where
                 DynamicState::ShadingRateImageEnable => todo!(),
                 DynamicState::RepresentativeFragmentTestEnable => todo!(),
                 DynamicState::CoverageReductionMode => todo!(),
-                
             }
         }
 

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -1709,7 +1709,7 @@ impl SyncCommandBufferBuilder {
                     ResourceUseRef {
                         command_index,
                         command_name,
-                        resource_in_command: ResourceInCommand::DepthAttachment,
+                        resource_in_command: ResourceInCommand::DepthStencilAttachment,
                         secondary_use_ref: None,
                     },
                     Resource::Image {
@@ -1736,7 +1736,7 @@ impl SyncCommandBufferBuilder {
                         ResourceUseRef {
                             command_index,
                             command_name,
-                            resource_in_command: ResourceInCommand::DepthResolveAttachment,
+                            resource_in_command: ResourceInCommand::DepthStencilResolveAttachment,
                             secondary_use_ref: None,
                         },
                         Resource::Image {
@@ -1773,7 +1773,7 @@ impl SyncCommandBufferBuilder {
                     ResourceUseRef {
                         command_index,
                         command_name,
-                        resource_in_command: ResourceInCommand::StencilAttachment,
+                        resource_in_command: ResourceInCommand::DepthStencilAttachment,
                         secondary_use_ref: None,
                     },
                     Resource::Image {
@@ -1800,7 +1800,7 @@ impl SyncCommandBufferBuilder {
                         ResourceUseRef {
                             command_index,
                             command_name,
-                            resource_in_command: ResourceInCommand::StencilResolveAttachment,
+                            resource_in_command: ResourceInCommand::DepthStencilResolveAttachment,
                             secondary_use_ref: None,
                         },
                         Resource::Image {

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -592,8 +592,8 @@ impl From<ResourceUseRef> for SecondaryResourceUseRef {
 pub enum ResourceInCommand {
     ColorAttachment { index: u32 },
     ColorResolveAttachment { index: u32 },
-    DepthAttachment,
-    DepthResolveAttachment,
+    DepthStencilAttachment,
+    DepthStencilResolveAttachment,
     DescriptorSet { set: u32, binding: u32, index: u32 },
     Destination,
     FramebufferAttachment { index: u32 },
@@ -602,8 +602,6 @@ pub enum ResourceInCommand {
     IndirectBuffer,
     SecondaryCommandBuffer { index: u32 },
     Source,
-    StencilAttachment,
-    StencilResolveAttachment,
     VertexBuffer { binding: u32 },
 }
 

--- a/vulkano/src/command_buffer/standard/builder/query.rs
+++ b/vulkano/src/command_buffer/standard/builder/query.rs
@@ -131,7 +131,9 @@ where
 
         if let Some(render_pass_state) = &self.builder_state.render_pass {
             // VUID-vkCmdBeginQuery-query-00808
-            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
+            if query + render_pass_state.rendering_info.view_mask.count_ones()
+                > query_pool.query_count()
+            {
                 return Err(QueryError::OutOfRangeMultiview);
             }
         }
@@ -216,7 +218,9 @@ where
 
         if let Some(render_pass_state) = &self.builder_state.render_pass {
             // VUID-vkCmdEndQuery-query-00812
-            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
+            if query + render_pass_state.rendering_info.view_mask.count_ones()
+                > query_pool.query_count()
+            {
                 return Err(QueryError::OutOfRangeMultiview);
             }
         }
@@ -448,7 +452,9 @@ where
 
         if let Some(render_pass_state) = &self.builder_state.render_pass {
             // VUID-vkCmdWriteTimestamp2-query-03865
-            if query + render_pass_state.view_mask.count_ones() > query_pool.query_count() {
+            if query + render_pass_state.rendering_info.view_mask.count_ones()
+                > query_pool.query_count()
+            {
                 return Err(QueryError::OutOfRangeMultiview);
             }
         }

--- a/vulkano/src/command_buffer/standard/builder/secondary.rs
+++ b/vulkano/src/command_buffer/standard/builder/secondary.rs
@@ -120,10 +120,10 @@ where
                     }
                 }
                 (
-                    RenderPassStateType::BeginRendering(state),
+                    RenderPassStateType::BeginRendering(_),
                     CommandBufferInheritanceRenderPassType::BeginRendering(inheritance_info),
                 ) => {
-                    let attachments = state.attachments.as_ref().unwrap();
+                    let attachments = render_pass_state.attachments.as_ref().unwrap();
 
                     // VUID-vkCmdExecuteCommands-colorAttachmentCount-06027
                     if inheritance_info.color_attachment_formats.len()
@@ -230,10 +230,10 @@ where
                     }
 
                     // VUID-vkCmdExecuteCommands-viewMask-06031
-                    if inheritance_info.view_mask != render_pass_state.view_mask {
+                    if inheritance_info.view_mask != render_pass_state.rendering_info.view_mask {
                         return Err(ExecuteCommandsError::RenderPassViewMaskMismatch {
                             command_buffer_index,
-                            required_view_mask: render_pass_state.view_mask,
+                            required_view_mask: render_pass_state.rendering_info.view_mask,
                             inherited_view_mask: inheritance_info.view_mask,
                         });
                     }

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -67,7 +67,7 @@ use self::{
 use super::{DynamicState, Pipeline, PipelineBindPoint, PipelineLayout};
 use crate::{
     device::{Device, DeviceOwned},
-    shader::{DescriptorBindingRequirements, ShaderStage},
+    shader::{DescriptorBindingRequirements, FragmentTestsStages, ShaderStage},
     VulkanObject,
 };
 use ahash::HashMap;
@@ -108,6 +108,7 @@ pub struct GraphicsPipeline {
     shaders: HashMap<ShaderStage, ()>,
     descriptor_binding_requirements: HashMap<(u32, u32), DescriptorBindingRequirements>,
     num_used_descriptor_sets: u32,
+    fragment_tests_stages: Option<FragmentTestsStages>,
 
     vertex_input_state: VertexInputState,
     input_assembly_state: InputAssemblyState,
@@ -232,6 +233,12 @@ impl GraphicsPipeline {
     #[inline]
     pub fn dynamic_states(&self) -> impl ExactSizeIterator<Item = (DynamicState, bool)> + '_ {
         self.dynamic_state.iter().map(|(k, v)| (*k, *v))
+    }
+
+    /// If the pipeline has a fragment shader, returns the fragment tests stages used.
+    #[inline]
+    pub fn fragment_tests_stages(&self) -> Option<FragmentTestsStages> {
+        self.fragment_tests_stages
     }
 }
 

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -426,6 +426,7 @@ pub enum StateMode<F> {
     /// The pipeline has a fixed value for this state. Previously set dynamic state will be lost
     /// when binding it, and will have to be re-set after binding a pipeline that uses it.
     Fixed(F),
+
     /// The pipeline expects a dynamic value to be set by a command buffer. Previously set dynamic
     /// state is not disturbed when binding it.
     Dynamic,

--- a/vulkano/src/render_pass/create.rs
+++ b/vulkano/src/render_pass/create.rs
@@ -30,7 +30,7 @@ impl RenderPass {
     pub(super) fn validate(
         device: &Device,
         create_info: &mut RenderPassCreateInfo,
-    ) -> Result<u32, RenderPassCreationError> {
+    ) -> Result<(), RenderPassCreationError> {
         let properties = device.physical_device().properties();
 
         let RenderPassCreateInfo {
@@ -40,8 +40,6 @@ impl RenderPass {
             correlated_view_masks,
             _ne: _,
         } = create_info;
-
-        let mut views_used = 0;
 
         /*
             Attachments
@@ -190,8 +188,6 @@ impl RenderPass {
                     },
                 );
             }
-
-            views_used = views_used.max(view_count);
 
             // VUID-VkSubpassDescription2-colorAttachmentCount-03063
             if color_attachments.len() as u32 > properties.max_color_attachments {
@@ -1041,7 +1037,7 @@ impl RenderPass {
             })?;
         }
 
-        Ok(views_used)
+        Ok(())
     }
 
     pub(super) unsafe fn create_v2(

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -467,7 +467,7 @@ pub enum ShaderExecution {
     TessellationControl,
     TessellationEvaluation,
     Geometry(GeometryShaderExecution),
-    Fragment,
+    Fragment(FragmentShaderExecution),
     Compute,
     RayGeneration,
     AnyHit,
@@ -549,6 +549,20 @@ pub enum GeometryShaderOutput {
     LineStrip,
     TriangleStrip,
 }*/
+
+/// The mode in which a fragment shader executes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FragmentShaderExecution {
+    pub fragment_tests_stages: FragmentTestsStages,
+}
+
+/// The fragment tests stages that will be executed in a fragment shader.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum FragmentTestsStages {
+    Early,
+    Late,
+    EarlyAndLate,
+}
 
 /// The requirements imposed by a shader on a binding within a descriptor set layout, and on any
 /// resource that is bound to that binding.
@@ -1189,7 +1203,7 @@ impl From<ShaderExecution> for ShaderStage {
             ShaderExecution::TessellationControl => Self::TessellationControl,
             ShaderExecution::TessellationEvaluation => Self::TessellationEvaluation,
             ShaderExecution::Geometry(_) => Self::Geometry,
-            ShaderExecution::Fragment => Self::Fragment,
+            ShaderExecution::Fragment(_) => Self::Fragment,
             ShaderExecution::Compute => Self::Compute,
             ShaderExecution::RayGeneration => Self::Raygen,
             ShaderExecution::AnyHit => Self::AnyHit,


### PR DESCRIPTION
Continuing on implementing the new command buffer, this adds most of the render pass operations, including:
- Load operations at the start of a subpass
- Use of attachments during a draw operation
- Resolve operations at the end of a subpass
- Store operations at the end of a subpass