### PR TITLE
Fix #1643

### DIFF
--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -32,7 +32,7 @@ use vulkano::{
     memory::allocator::StandardMemoryAllocator,
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
-    VulkanLibrary,
+    DeviceSize, VulkanLibrary,
 };
 
 fn main() {
@@ -188,7 +188,15 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [
-            WriteDescriptorSet::buffer(0, input_buffer),
+            // When writing to the dynamic buffer binding, the range of the buffer that the shader
+            // will access must also be provided. We specify the size of the `InData` struct here.
+            // When dynamic offsets are provided later, they get added to the start and end of
+            // this range.
+            WriteDescriptorSet::buffer_with_range(
+                0,
+                input_buffer,
+                0..size_of::<shader::ty::InData>() as DeviceSize,
+            ),
             WriteDescriptorSet::buffer(1, output_buffer.clone()),
         ],
     )

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -17,9 +17,10 @@ use crate::{
         AutoCommandBufferBuilder,
     },
     descriptor_set::{
-        check_descriptor_write, sys::UnsafeDescriptorSet, DescriptorSetResources,
-        DescriptorSetUpdateError, DescriptorSetWithOffsets, DescriptorSetsCollection,
-        DescriptorWriteInfo, WriteDescriptorSet,
+        check_descriptor_write, layout::DescriptorType, sys::UnsafeDescriptorSet,
+        DescriptorBindingResources, DescriptorSetResources, DescriptorSetUpdateError,
+        DescriptorSetWithOffsets, DescriptorSetsCollection, DescriptorWriteInfo,
+        WriteDescriptorSet,
     },
     device::{DeviceOwned, QueueFlags},
     pipeline::{
@@ -36,6 +37,7 @@ use crate::{
 use parking_lot::Mutex;
 use smallvec::SmallVec;
 use std::{
+    cmp::min,
     error,
     fmt::{Display, Error as FmtError, Formatter},
     mem::{size_of, size_of_val},
@@ -129,24 +131,93 @@ where
             });
         }
 
+        let properties = self.device().physical_device().properties();
+        let uniform_alignment = properties.min_uniform_buffer_offset_alignment as u32;
+        let storage_alignment = properties.min_storage_buffer_offset_alignment as u32;
+
         for (i, set) in descriptor_sets.iter().enumerate() {
             let set_num = first_set + i as u32;
+            let (set, dynamic_offsets) = set.as_ref();
 
             // VUID-vkCmdBindDescriptorSets-commonparent
-            assert_eq!(self.device(), set.as_ref().0.device());
+            assert_eq!(self.device(), set.device());
 
-            let pipeline_layout_set = &pipeline_layout.set_layouts()[set_num as usize];
+            let set_layout = set.layout();
+            let pipeline_set_layout = &pipeline_layout.set_layouts()[set_num as usize];
 
             // VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358
-            if !pipeline_layout_set.is_compatible_with(set.as_ref().0.layout()) {
+            if !pipeline_set_layout.is_compatible_with(set_layout) {
                 return Err(BindPushError::DescriptorSetNotCompatible { set_num });
             }
 
-            // TODO: see https://github.com/vulkano-rs/vulkano/issues/1643
-            // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971
-            // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972
-            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979
-            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-06715
+            let mut dynamic_offsets_remaining = dynamic_offsets;
+            let mut required_dynamic_offset_count = 0;
+
+            for (&binding_num, binding) in set_layout.bindings() {
+                let required_alignment = match binding.descriptor_type {
+                    DescriptorType::UniformBufferDynamic => uniform_alignment,
+                    DescriptorType::StorageBufferDynamic => storage_alignment,
+                    _ => continue,
+                };
+
+                let count = if binding.variable_descriptor_count {
+                    set.variable_descriptor_count()
+                } else {
+                    binding.descriptor_count
+                } as usize;
+
+                required_dynamic_offset_count += count;
+
+                if !dynamic_offsets_remaining.is_empty() {
+                    let split_index = min(count, dynamic_offsets_remaining.len());
+                    let dynamic_offsets = &dynamic_offsets_remaining[..split_index];
+                    dynamic_offsets_remaining = &dynamic_offsets_remaining[split_index..];
+
+                    let elements = match set.resources().binding(binding_num) {
+                        Some(DescriptorBindingResources::Buffer(elements)) => elements.as_slice(),
+                        _ => unreachable!(),
+                    };
+
+                    for (index, (&offset, element)) in
+                        dynamic_offsets.iter().zip(elements).enumerate()
+                    {
+                        // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971
+                        // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972
+                        if offset % required_alignment != 0 {
+                            return Err(BindPushError::DynamicOffsetNotAligned {
+                                set_num,
+                                binding_num,
+                                index: index as u32,
+                                offset,
+                                required_alignment,
+                            });
+                        }
+
+                        if let Some((buffer, range)) = element {
+                            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979
+                            if offset as DeviceSize + range.end > buffer.size() {
+                                return Err(BindPushError::DynamicOffsetOutOfBufferBounds {
+                                    set_num,
+                                    binding_num,
+                                    index: index as u32,
+                                    offset,
+                                    range_end: range.end,
+                                    buffer_size: buffer.size(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
+            // VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359
+            if dynamic_offsets.len() != required_dynamic_offset_count {
+                return Err(BindPushError::DynamicOffsetCountMismatch {
+                    set_num,
+                    provided_count: dynamic_offsets.len(),
+                    required_count: required_dynamic_offset_count,
+                });
+            }
         }
 
         Ok(())
@@ -1246,6 +1317,39 @@ pub(in super::super) enum BindPushError {
         pipeline_layout_set_count: u32,
     },
 
+    /// In an element of `descriptor_sets`, the number of provided dynamic offsets does not match
+    /// the number required by the descriptor set.
+    DynamicOffsetCountMismatch {
+        set_num: u32,
+        provided_count: usize,
+        required_count: usize,
+    },
+
+    /// In an element of `descriptor_sets`, a provided dynamic offset
+    /// is not a multiple of the value of the [`min_uniform_buffer_offset_alignment`] or
+    /// [`min_storage_buffer_offset_alignment`]  property.
+    ///
+    /// min_uniform_buffer_offset_alignment: crate::device::Properties::min_uniform_buffer_offset_alignment
+    /// min_storage_buffer_offset_alignment: crate::device::Properties::min_storage_buffer_offset_alignment
+    DynamicOffsetNotAligned {
+        set_num: u32,
+        binding_num: u32,
+        index: u32,
+        offset: u32,
+        required_alignment: u32,
+    },
+
+    /// In an element of `descriptor_sets`, a provided dynamic offset, when added to the end of the
+    /// buffer range bound to the descriptor set, is greater than the size of the buffer.
+    DynamicOffsetOutOfBufferBounds {
+        set_num: u32,
+        binding_num: u32,
+        index: u32,
+        offset: u32,
+        range_end: DeviceSize,
+        buffer_size: DeviceSize,
+    },
+
     /// An index buffer is missing the `index_buffer` usage.
     IndexBufferMissingUsage,
 
@@ -1327,6 +1431,45 @@ impl Display for BindPushError {
                 "the highest descriptor set slot being bound ({}) is greater than the number of \
                 sets in `pipeline_layout` ({})",
                 set_num, pipeline_layout_set_count,
+            ),
+            Self::DynamicOffsetCountMismatch {
+                set_num,
+                provided_count,
+                required_count,
+            } => write!(
+                f,
+                "in the element of `descriptor_sets` being bound to slot {}, the number of \
+                provided dynamic offsets ({}) does not match the number required by the \
+                descriptor set ({})",
+                set_num, provided_count, required_count,
+            ),
+            Self::DynamicOffsetNotAligned {
+                set_num,
+                binding_num,
+                index,
+                offset,
+                required_alignment,
+            } => write!(
+                f,
+                "in the element of `descriptor_sets` being bound to slot {}, the dynamic offset \
+                provided for binding {} index {} ({}) is not a multiple of the value of the \
+                `min_uniform_buffer_offset_alignment` or `min_storage_buffer_offset_alignment` \
+                property ({})",
+                set_num, binding_num, index, offset, required_alignment,
+            ),
+            Self::DynamicOffsetOutOfBufferBounds {
+                set_num,
+                binding_num,
+                index,
+                offset,
+                range_end,
+                buffer_size,
+            } => write!(
+                f,
+                "in the element of `descriptor_sets` being bound to slot {}, the dynamic offset \
+                provided for binding {} index {} ({}), when added to the end of the buffer range \
+                bound to the descriptor set ({}), is greater than the size of the buffer ({})",
+                set_num, binding_num, index, offset, range_end, buffer_size,
             ),
             Self::IndexBufferMissingUsage => {
                 write!(f, "an index buffer is missing the `index_buffer` usage")

--- a/vulkano/src/command_buffer/standard/builder/bind_push.rs
+++ b/vulkano/src/command_buffer/standard/builder/bind_push.rs
@@ -12,8 +12,9 @@ use crate::{
     buffer::{BufferAccess, BufferContents, BufferUsage, TypedBufferAccess},
     command_buffer::{allocator::CommandBufferAllocator, commands::bind_push::BindPushError},
     descriptor_set::{
-        check_descriptor_write, DescriptorSetResources, DescriptorSetWithOffsets,
-        DescriptorSetsCollection, DescriptorWriteInfo, WriteDescriptorSet,
+        check_descriptor_write, layout::DescriptorType, DescriptorBindingResources,
+        DescriptorSetResources, DescriptorSetWithOffsets, DescriptorSetsCollection,
+        DescriptorWriteInfo, WriteDescriptorSet,
     },
     device::{DeviceOwned, QueueFlags},
     pipeline::{
@@ -24,7 +25,7 @@ use crate::{
         },
         ComputePipeline, GraphicsPipeline, PipelineBindPoint, PipelineLayout,
     },
-    RequiresOneOf, VulkanObject,
+    DeviceSize, RequiresOneOf, VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{cmp::min, sync::Arc};
@@ -108,24 +109,93 @@ where
             });
         }
 
+        let properties = self.device().physical_device().properties();
+        let uniform_alignment = properties.min_uniform_buffer_offset_alignment as u32;
+        let storage_alignment = properties.min_storage_buffer_offset_alignment as u32;
+
         for (i, set) in descriptor_sets.iter().enumerate() {
             let set_num = first_set + i as u32;
+            let (set, dynamic_offsets) = set.as_ref();
 
             // VUID-vkCmdBindDescriptorSets-commonparent
-            assert_eq!(self.device(), set.as_ref().0.device());
+            assert_eq!(self.device(), set.device());
 
-            let pipeline_layout_set = &pipeline_layout.set_layouts()[set_num as usize];
+            let set_layout = set.layout();
+            let pipeline_set_layout = &pipeline_layout.set_layouts()[set_num as usize];
 
             // VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358
-            if !pipeline_layout_set.is_compatible_with(set.as_ref().0.layout()) {
+            if !pipeline_set_layout.is_compatible_with(set_layout) {
                 return Err(BindPushError::DescriptorSetNotCompatible { set_num });
             }
 
-            // TODO: see https://github.com/vulkano-rs/vulkano/issues/1643
-            // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971
-            // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972
-            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979
-            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-06715
+            let mut dynamic_offsets_remaining = dynamic_offsets;
+            let mut required_dynamic_offset_count = 0;
+
+            for (&binding_num, binding) in set_layout.bindings() {
+                let required_alignment = match binding.descriptor_type {
+                    DescriptorType::UniformBufferDynamic => uniform_alignment,
+                    DescriptorType::StorageBufferDynamic => storage_alignment,
+                    _ => continue,
+                };
+
+                let count = if binding.variable_descriptor_count {
+                    set.variable_descriptor_count()
+                } else {
+                    binding.descriptor_count
+                } as usize;
+
+                required_dynamic_offset_count += count;
+
+                if !dynamic_offsets_remaining.is_empty() {
+                    let split_index = min(count, dynamic_offsets_remaining.len());
+                    let dynamic_offsets = &dynamic_offsets_remaining[..split_index];
+                    dynamic_offsets_remaining = &dynamic_offsets_remaining[split_index..];
+
+                    let elements = match set.resources().binding(binding_num) {
+                        Some(DescriptorBindingResources::Buffer(elements)) => elements.as_slice(),
+                        _ => unreachable!(),
+                    };
+
+                    for (index, (&offset, element)) in
+                        dynamic_offsets.iter().zip(elements).enumerate()
+                    {
+                        // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971
+                        // VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972
+                        if offset % required_alignment != 0 {
+                            return Err(BindPushError::DynamicOffsetNotAligned {
+                                set_num,
+                                binding_num,
+                                index: index as u32,
+                                offset,
+                                required_alignment,
+                            });
+                        }
+
+                        if let Some((buffer, range)) = element {
+                            // VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979
+                            if offset as DeviceSize + range.end > buffer.size() {
+                                return Err(BindPushError::DynamicOffsetOutOfBufferBounds {
+                                    set_num,
+                                    binding_num,
+                                    index: index as u32,
+                                    offset,
+                                    range_end: range.end,
+                                    buffer_size: buffer.size(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
+            // VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359
+            if dynamic_offsets.len() != required_dynamic_offset_count {
+                return Err(BindPushError::DynamicOffsetCountMismatch {
+                    set_num,
+                    provided_count: dynamic_offsets.len(),
+                    required_count: required_dynamic_offset_count,
+                });
+            }
         }
 
         Ok(())

--- a/vulkano/src/command_buffer/standard/builder/mod.rs
+++ b/vulkano/src/command_buffer/standard/builder/mod.rs
@@ -1124,6 +1124,14 @@ impl SetOrPush {
             Self::Push(resources) => resources,
         }
     }
+
+    #[inline]
+    pub fn dynamic_offsets(&self) -> &[u32] {
+        match self {
+            Self::Set(set) => set.as_ref().1,
+            Self::Push(_) => &[],
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -1137,6 +1137,14 @@ impl SetOrPush {
             Self::Push(resources) => resources,
         }
     }
+
+    #[inline]
+    pub fn dynamic_offsets(&self) -> &[u32] {
+        match self {
+            Self::Set(set) => set.as_ref().1,
+            Self::Push(_) => &[],
+        }
+    }
 }
 
 /// Allows you to retrieve the current state of a command buffer builder.

--- a/vulkano/src/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor_set/persistent.rs
@@ -114,6 +114,10 @@ where
         self.inner.layout()
     }
 
+    fn variable_descriptor_count(&self) -> u32 {
+        self.inner.variable_descriptor_count
+    }
+
     fn resources(&self) -> &DescriptorSetResources {
         self.inner.resources()
     }


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- A `buffer_with_range` constructor for `WriteDescriptorSet`, which can be used to select the range within the buffer that should be bound. This must be used when using dynamic buffers.
````

Fixes #1643, a longstanding bug. It's not technically "fixed", but rather an API has been added that you're supposed to use instead. The old usage, which triggered a validation error, should now trigger an error from Vulkano as well.

Thank you @itmuckel for motivating me to finally get it done!