### PR TITLE
Fix #2094

### DIFF
--- a/vulkano/src/command_buffer/commands/sync.rs
+++ b/vulkano/src/command_buffer/commands/sync.rs
@@ -199,10 +199,14 @@ impl UnsafeCommandBufferBuilder {
 
                     debug_assert!(AccessFlags::from(src_stages).contains(src_access));
                     debug_assert!(AccessFlags::from(dst_stages).contains(dst_access));
-                    debug_assert!(!matches!(
-                        new_layout,
-                        ImageLayout::Undefined | ImageLayout::Preinitialized
-                    ));
+
+                    debug_assert!(
+                        !matches!(
+                            new_layout,
+                            ImageLayout::Undefined | ImageLayout::Preinitialized
+                        ) || self.device.enabled_features().synchronization2
+                            && old_layout == new_layout
+                    );
                     debug_assert!(image
                         .format()
                         .unwrap()

--- a/vulkano/src/command_buffer/commands/sync.rs
+++ b/vulkano/src/command_buffer/commands/sync.rs
@@ -201,11 +201,11 @@ impl UnsafeCommandBufferBuilder {
                     debug_assert!(AccessFlags::from(dst_stages).contains(dst_access));
 
                     debug_assert!(
-                        !matches!(
-                            new_layout,
-                            ImageLayout::Undefined | ImageLayout::Preinitialized
-                        ) || self.device.enabled_features().synchronization2
-                            && old_layout == new_layout
+                        old_layout == new_layout
+                            || !matches!(
+                                new_layout,
+                                ImageLayout::Undefined | ImageLayout::Preinitialized
+                            )
                     );
                     debug_assert!(image
                         .format()


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- [#2094](https://github.com/vulkano-rs/vulkano/issues/2094): Fixed debug assertion when the first command in a command buffer that uses an image expects it to be in the `Undefined` layout.
````

Fixes #2094.