### PR TITLE
Fix clippy warnings from Rust 1.66

### DIFF
--- a/examples/src/bin/interactive_fractal/app.rs
+++ b/examples/src/bin/interactive_fractal/app.rs
@@ -285,8 +285,8 @@ impl InputState {
 
     fn normalized_mouse_pos(&self) -> Vector2<f32> {
         Vector2::new(
-            (self.mouse_pos.x / self.window_size[0] as f32).clamp(0.0, 1.0),
-            (self.mouse_pos.y / self.window_size[1] as f32).clamp(0.0, 1.0),
+            (self.mouse_pos.x / self.window_size[0]).clamp(0.0, 1.0),
+            (self.mouse_pos.y / self.window_size[1]).clamp(0.0, 1.0),
         )
     }
 

--- a/examples/src/bin/multi_window_game_of_life/main.rs
+++ b/examples/src/bin/multi_window_game_of_life/main.rs
@@ -149,8 +149,8 @@ fn draw_life(
         let window_size = window.window_size();
         let compute_pipeline = &mut app.pipelines.get_mut(id).unwrap().compute;
         let mut normalized_pos = Vector2::new(
-            (cursor_pos.x / window_size[0] as f32).clamp(0.0, 1.0),
-            (cursor_pos.y / window_size[1] as f32).clamp(0.0, 1.0),
+            (cursor_pos.x / window_size[0]).clamp(0.0, 1.0),
+            (cursor_pos.y / window_size[1]).clamp(0.0, 1.0),
         );
         // flip y
         normalized_pos.y = 1.0 - normalized_pos.y;

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -148,7 +148,7 @@ fn main() {
             SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count,
                 image_format,
-                image_extent: [WINDOW_WIDTH as u32, WINDOW_HEIGHT as u32],
+                image_extent: [WINDOW_WIDTH, WINDOW_HEIGHT],
                 image_usage: ImageUsage::COLOR_ATTACHMENT,
                 composite_alpha: surface_capabilities
                     .supported_composite_alpha

--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -616,7 +616,7 @@ pub(super) fn type_from_id(
             (
                 quote! { [#element_type; #array_length] },
                 Cow::from(format!("[{}; {}]", element_type_string, array_length)),
-                Some(element_size * array_length as usize),
+                Some(element_size * array_length),
                 element_align,
             )
         }

--- a/vulkano-util/src/context.rs
+++ b/vulkano-util/src/context.rs
@@ -271,7 +271,7 @@ impl VulkanoContext {
         self.device
             .physical_device()
             .properties()
-            .max_memory_allocation_count as u32
+            .max_memory_allocation_count
     }
 
     /// Returns the instance.

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -1192,8 +1192,8 @@ impl UnsafeCommandBufferBuilder {
             self.handle,
             pipeline_layout.handle(),
             stages.into(),
-            offset as u32,
-            size as u32,
+            offset,
+            size,
             data.as_bytes().as_ptr() as *const _,
         );
     }

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -647,7 +647,8 @@ where
             let layout_binding =
                 &pipeline.layout().set_layouts()[set_num as usize].bindings()[&binding_num];
 
-            let check_buffer = |_index: u32, (_buffer, _range): &(Arc<dyn BufferAccess>, Range<DeviceSize>)| Ok(());
+            let check_buffer =
+                |_index: u32, (_buffer, _range): &(Arc<dyn BufferAccess>, Range<DeviceSize>)| Ok(());
 
             let check_buffer_view = |index: u32, buffer_view: &Arc<dyn BufferViewAbstract>| {
                 for desc_reqs in (binding_reqs.descriptors.get(&Some(index)).into_iter())
@@ -1574,7 +1575,7 @@ where
                 None => return Err(PipelineExecutionError::VertexBufferNotBound { binding_num }),
             };
 
-            let mut num_elements = vertex_buffer.size() as u64 / binding_desc.stride as u64;
+            let mut num_elements = vertex_buffer.size() / binding_desc.stride as u64;
 
             match binding_desc.input_rate {
                 VertexInputRate::Vertex => {
@@ -2146,13 +2147,13 @@ impl SyncCommandBufferBuilder {
 
             let descriptor_set_state = &descriptor_sets_state.descriptor_sets[&set];
 
-            match descriptor_set_state.resources()
-                .binding(binding)
-                .unwrap()
-            {
+            match descriptor_set_state.resources().binding(binding).unwrap() {
                 DescriptorBindingResources::None(_) => continue,
                 DescriptorBindingResources::Buffer(elements) => {
-                    if matches!(descriptor_type, DescriptorType::UniformBufferDynamic | DescriptorType::StorageBufferDynamic) {
+                    if matches!(
+                        descriptor_type,
+                        DescriptorType::UniformBufferDynamic | DescriptorType::StorageBufferDynamic
+                    ) {
                         let dynamic_offsets = descriptor_set_state.dynamic_offsets();
                         resources.extend(
                             (elements.iter().enumerate())
@@ -2163,7 +2164,8 @@ impl SyncCommandBufferBuilder {
                                         (
                                             index as u32,
                                             buffer.clone(),
-                                            dynamic_offset + range.start..dynamic_offset + range.end,
+                                            dynamic_offset + range.start
+                                                ..dynamic_offset + range.end,
                                         )
                                     })
                                 })
@@ -2174,11 +2176,7 @@ impl SyncCommandBufferBuilder {
                             (elements.iter().enumerate())
                                 .filter_map(|(index, element)| {
                                     element.as_ref().map(|(buffer, range)| {
-                                        (
-                                            index as u32,
-                                            buffer.clone(),
-                                            range.clone(),
-                                        )
+                                        (index as u32, buffer.clone(), range.clone())
                                     })
                                 })
                                 .flat_map(buffer_resource),

--- a/vulkano/src/command_buffer/standard/builder/bind_push.rs
+++ b/vulkano/src/command_buffer/standard/builder/bind_push.rs
@@ -722,7 +722,7 @@ where
                 self.handle(),
                 pipeline_layout.handle(),
                 range.stages.into(),
-                current_offset as u32,
+                current_offset,
                 values.len() as u32,
                 values.as_ptr() as *const _,
             );

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -217,7 +217,7 @@ impl PipelineCache {
                 .result()
                 .map_err(VulkanError::from)?;
 
-                let mut data: Vec<u8> = Vec::with_capacity(count as usize);
+                let mut data: Vec<u8> = Vec::with_capacity(count);
                 let result = (fns.v1_0.get_pipeline_cache_data)(
                     self.device.handle(),
                     self.cache,
@@ -227,7 +227,7 @@ impl PipelineCache {
 
                 match result {
                     ash::vk::Result::SUCCESS => {
-                        data.set_len(count as usize);
+                        data.set_len(count);
                         break data;
                     }
                     ash::vk::Result::INCOMPLETE => (),

--- a/vulkano/src/shader/reflect.rs
+++ b/vulkano/src/shader/reflect.rs
@@ -756,8 +756,8 @@ fn inspect_entry_point(
 
     context
         .result
-        .into_iter()
-        .map(|(_, variable)| ((variable.set, variable.binding), variable.reqs))
+        .into_values()
+        .map(|variable| ((variable.set, variable.binding), variable.reqs))
         .collect()
 }
 

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -1993,7 +1993,7 @@ where
         }
 
         let mut swapchain_info = self.swapchain_info.clone();
-        debug_assert!((swapchain_info.image_index as u32) < swapchain_info.swapchain.image_count());
+        debug_assert!(swapchain_info.image_index < swapchain_info.swapchain.image_count());
         let device = swapchain_info.swapchain.device();
 
         if !device.enabled_features().present_id {


### PR DESCRIPTION
This fixes some clippy warnings that are showing up with the new Rust 1.66 compiler.