### PR TITLE
Add more support for cgmath and nalgebra types

### DIFF
--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -24,5 +24,7 @@ syn = { version = "1.0", features = ["full", "extra-traits"] }
 vulkano = { version = "0.32.0", path = "../vulkano" }
 
 [features]
+cgmath = []
+nalgebra = []
 shaderc-build-from-source = ["shaderc/build-from-source"]
 shaderc-debug = []

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::{entry_point, read_file_to_string, structs, RegisteredType, TypesMeta};
+use crate::{entry_point, read_file_to_string, structs, LinAlgType, RegisteredType, TypesMeta};
 use ahash::HashMap;
 use proc_macro2::TokenStream;
 pub use shaderc::{CompilationArtifact, IncludeType, ResolvedInclude, ShaderKind};
@@ -205,7 +205,7 @@ pub fn compile(
     Ok((content, includes))
 }
 
-pub(super) fn reflect<'a>(
+pub(super) fn reflect<'a, L: LinAlgType>(
     prefix: &'a str,
     words: &[u32],
     types_meta: &TypesMeta,
@@ -243,8 +243,12 @@ pub(super) fn reflect<'a>(
     let entry_points = reflect::entry_points(&spirv)
         .map(|(name, model, info)| entry_point::write_entry_point(&name, model, &info));
 
-    let specialization_constants =
-        structs::write_specialization_constants(prefix, &spirv, shared_constants, types_registry);
+    let specialization_constants = structs::write_specialization_constants::<L>(
+        prefix,
+        &spirv,
+        shared_constants,
+        types_registry,
+    );
 
     let load_name = if prefix.is_empty() {
         format_ident!("load")
@@ -278,7 +282,7 @@ pub(super) fn reflect<'a>(
         #specialization_constants
     };
 
-    let structs = structs::write_structs(prefix, &spirv, types_meta, types_registry);
+    let structs = structs::write_structs::<L>(prefix, &spirv, types_meta, types_registry);
 
     Ok((shader_code, structs))
 }
@@ -304,7 +308,7 @@ impl From<SpirvError> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codegen::compile;
+    use crate::{codegen::compile, StdArray};
     use shaderc::ShaderKind;
     use std::path::{Path, PathBuf};
     use vulkano::shader::{reflect, spirv::Spirv};
@@ -371,7 +375,12 @@ mod tests {
         .unwrap();
         let spirv = Spirv::new(comp.as_binary()).unwrap();
         let res = std::panic::catch_unwind(|| {
-            structs::write_structs("", &spirv, &TypesMeta::default(), &mut HashMap::default())
+            structs::write_structs::<StdArray>(
+                "",
+                &spirv,
+                &TypesMeta::default(),
+                &mut HashMap::default(),
+            )
         });
         assert!(res.is_err());
     }
@@ -400,7 +409,12 @@ mod tests {
         )
         .unwrap();
         let spirv = Spirv::new(comp.as_binary()).unwrap();
-        structs::write_structs("", &spirv, &TypesMeta::default(), &mut HashMap::default());
+        structs::write_structs::<StdArray>(
+            "",
+            &spirv,
+            &TypesMeta::default(),
+            &mut HashMap::default(),
+        );
     }
     #[test]
     fn test_wrap_alignment() {
@@ -432,7 +446,12 @@ mod tests {
         )
         .unwrap();
         let spirv = Spirv::new(comp.as_binary()).unwrap();
-        structs::write_structs("", &spirv, &TypesMeta::default(), &mut HashMap::default());
+        structs::write_structs::<StdArray>(
+            "",
+            &spirv,
+            &TypesMeta::default(),
+            &mut HashMap::default(),
+        );
     }
 
     #[test]

--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use crate::{RegisteredType, TypesMeta};
+use crate::{LinAlgType, RegisteredType, TypesMeta};
 use ahash::HashMap;
 use heck::ToUpperCamelCase;
 use proc_macro2::{Span, TokenStream};
@@ -16,7 +16,7 @@ use syn::{Ident, LitStr};
 use vulkano::shader::spirv::{Decoration, Id, Instruction, Spirv};
 
 /// Translates all the structs that are contained in the SPIR-V document as Rust structs.
-pub(super) fn write_structs<'a>(
+pub(super) fn write_structs<'a, L: LinAlgType>(
     shader: &'a str,
     spirv: &'a Spirv,
     types_meta: &'a TypesMeta,
@@ -33,7 +33,8 @@ pub(super) fn write_structs<'a>(
         })
         .filter(|&(struct_id, _member_types)| has_defined_layout(spirv, struct_id))
         .filter_map(|(struct_id, member_types)| {
-            let (rust_members, is_sized) = write_struct_members(spirv, struct_id, member_types);
+            let (rust_members, is_sized) =
+                write_struct_members::<L>(spirv, struct_id, member_types);
 
             let struct_name = spirv
                 .id(struct_id)
@@ -85,7 +86,11 @@ struct Member {
     signature: Cow<'static, str>,
 }
 
-fn write_struct_members(spirv: &Spirv, struct_id: Id, members: &[Id]) -> (Vec<Member>, bool) {
+fn write_struct_members<L: LinAlgType>(
+    spirv: &Spirv,
+    struct_id: Id,
+    members: &[Id],
+) -> (Vec<Member>, bool) {
     let mut rust_members = Vec::with_capacity(members.len());
 
     // Dummy members will be named `_dummyN` where `N` is determined by this variable.
@@ -101,7 +106,7 @@ fn write_struct_members(spirv: &Spirv, struct_id: Id, members: &[Id]) -> (Vec<Me
         .enumerate()
     {
         // Compute infos about the member.
-        let (ty, signature, rust_size, rust_align) = type_from_id(spirv, member);
+        let (ty, signature, rust_size, rust_align) = type_from_id::<L>(spirv, member);
         let member_name = member_info
             .iter_name()
             .find_map(|instruction| match instruction {
@@ -397,7 +402,7 @@ fn struct_size_from_array_stride(spirv: &Spirv, type_id: Id) -> Option<u32> {
 /// Returns the type name to put in the Rust struct, and its size and alignment.
 ///
 /// The size can be `None` if it's only known at runtime.
-pub(super) fn type_from_id(
+pub(super) fn type_from_id<L: LinAlgType>(
     spirv: &Spirv,
     type_id: Id,
 ) -> (TokenStream, Cow<'static, str>, Option<usize>, usize) {
@@ -551,32 +556,53 @@ pub(super) fn type_from_id(
             ..
         } => {
             debug_assert_eq!(mem::align_of::<[u32; 3]>(), mem::align_of::<u32>());
-            let (ty, item, t_size, t_align) = type_from_id(spirv, component_type);
-            let array_length = component_count as usize;
-            let size = t_size.map(|s| s * component_count as usize);
-            (
-                quote! { [#ty; #array_length] },
-                Cow::from(format!("[{}; {}]", item, array_length)),
-                size,
-                t_align,
-            )
+            let component_count = component_count as usize;
+            let (element_ty, element_item, element_size, align) =
+                type_from_id::<L>(spirv, component_type);
+
+            let ty = L::vector(&element_ty, component_count);
+            let item = Cow::from(format!("[{}; {}]", element_item, component_count));
+            let size = element_size.map(|s| s * component_count);
+
+            (ty, item, size, align)
         }
         &Instruction::TypeMatrix {
             column_type,
             column_count,
             ..
         } => {
-            // FIXME: row-major or column-major
             debug_assert_eq!(mem::align_of::<[u32; 3]>(), mem::align_of::<u32>());
-            let (ty, item, t_size, t_align) = type_from_id(spirv, column_type);
-            let array_length = column_count as usize;
-            let size = t_size.map(|s| s * column_count as usize);
-            (
-                quote! { [#ty; #array_length] },
-                Cow::from(format!("[{}; {}]", item, array_length)),
-                size,
-                t_align,
-            )
+            let column_count = column_count as usize;
+
+            // FIXME: row-major or column-major
+            let (row_count, element, element_item, element_size, align) =
+                match spirv.id(column_type).instruction() {
+                    &Instruction::TypeVector {
+                        component_type,
+                        component_count,
+                        ..
+                    } => {
+                        let (element, element_item, element_size, align) =
+                            type_from_id::<L>(spirv, component_type);
+                        (
+                            component_count as usize,
+                            element,
+                            element_item,
+                            element_size,
+                            align,
+                        )
+                    }
+                    _ => unreachable!(),
+                };
+
+            let ty = L::matrix(&element, row_count, column_count);
+            let size = element_size.map(|s| s * row_count * column_count);
+            let item = Cow::from(format!(
+                "[[{}; {}]; {}]",
+                element_item, row_count, column_count
+            ));
+
+            (ty, item, size, align)
         }
         &Instruction::TypeArray {
             element_type,
@@ -586,7 +612,7 @@ pub(super) fn type_from_id(
             debug_assert_eq!(mem::align_of::<[u32; 3]>(), mem::align_of::<u32>());
 
             let (element_type, element_type_string, element_size, element_align) =
-                type_from_id(spirv, element_type);
+                type_from_id::<L>(spirv, element_type);
 
             let element_size = element_size.expect("array components must be sized");
             let array_length = match spirv.id(length).instruction() {
@@ -624,7 +650,7 @@ pub(super) fn type_from_id(
             debug_assert_eq!(mem::align_of::<[u32; 3]>(), mem::align_of::<u32>());
 
             let (element_type, element_type_string, _, element_align) =
-                type_from_id(spirv, element_type);
+                type_from_id::<L>(spirv, element_type);
 
             (
                 quote! { [#element_type] },
@@ -660,7 +686,7 @@ pub(super) fn type_from_id(
                                         _ => None,
                                     })
                                     .unwrap();
-                                let (_, _, rust_size, _) = type_from_id(spirv, member);
+                                let (_, _, rust_size, _) = type_from_id::<L>(spirv, member);
                                 rust_size.map(|rust_size| spirv_offset + rust_size)
                             })
                     })
@@ -668,7 +694,7 @@ pub(super) fn type_from_id(
 
             let align = member_types
                 .iter()
-                .map(|&t| type_from_id(spirv, t).3)
+                .map(|&t| type_from_id::<L>(spirv, t).3)
                 .max()
                 .unwrap_or(1);
 
@@ -692,7 +718,7 @@ pub(super) fn type_from_id(
 
 /// Writes the `SpecializationConstants` struct that contains the specialization constants and
 /// implements the `Default` and the `vulkano::shader::SpecializationConstants` traits.
-pub(super) fn write_specialization_constants<'a>(
+pub(super) fn write_specialization_constants<'a, L: LinAlgType>(
     shader: &'a str,
     spirv: &Spirv,
     shared_constants: bool,
@@ -757,7 +783,7 @@ pub(super) fn write_specialization_constants<'a>(
                     Some(mem::size_of::<u32>()),
                     mem::align_of::<u32>(),
                 ),
-                _ => type_from_id(spirv, result_type_id),
+                _ => type_from_id::<L>(spirv, result_type_id),
             };
         let rust_size = rust_size.expect("Found runtime-sized specialization constant");
 

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -19,6 +19,7 @@ ahash = "0.8"
 # All versions of vk.xml can be found at https://github.com/KhronosGroup/Vulkan-Headers/commits/main/registry/vk.xml.
 ash = "^0.37.1"
 bytemuck = { version = "1.7", features = ["derive", "extern_crate_std", "min_const_generics"] }
+cgmath = { version = "0.18.0", optional = true }
 crossbeam-queue = "0.3"
 half = "2"
 libloading = "0.7"

--- a/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
@@ -162,6 +162,81 @@ where
     }
 }
 
+#[cfg(feature = "cgmath")]
+unsafe impl<T> VertexMember for cgmath::Vector1<T>
+where
+    T: VertexMember,
+{
+    fn format() -> (VertexMemberTy, usize) {
+        <T as VertexMember>::format()
+    }
+}
+
+#[cfg(feature = "cgmath")]
+unsafe impl<T> VertexMember for cgmath::Vector2<T>
+where
+    T: VertexMember,
+{
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 2)
+    }
+}
+
+#[cfg(feature = "cgmath")]
+unsafe impl<T> VertexMember for cgmath::Vector3<T>
+where
+    T: VertexMember,
+{
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 3)
+    }
+}
+
+#[cfg(feature = "cgmath")]
+unsafe impl<T> VertexMember for cgmath::Vector4<T>
+where
+    T: VertexMember,
+{
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 4)
+    }
+}
+
+#[cfg(feature = "cgmath")]
+unsafe impl<T> VertexMember for cgmath::Point1<T>
+where
+    T: VertexMember,
+{
+    fn format() -> (VertexMemberTy, usize) {
+        <T as VertexMember>::format()
+    }
+}
+
+#[cfg(feature = "cgmath")]
+unsafe impl<T> VertexMember for cgmath::Point2<T>
+where
+    T: VertexMember,
+{
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 2)
+    }
+}
+
+#[cfg(feature = "cgmath")]
+unsafe impl<T> VertexMember for cgmath::Point3<T>
+where
+    T: VertexMember,
+{
+    fn format() -> (VertexMemberTy, usize) {
+        let (ty, sz) = <T as VertexMember>::format();
+        (ty, sz * 3)
+    }
+}
+
 #[cfg(feature = "nalgebra")]
 unsafe impl<T> VertexMember for nalgebra::Vector1<T>
 where


### PR DESCRIPTION
Changelog:
```markdown
### Additions
Better cgmath and nalgebra support, enabled by the `cgmath` or `nalgebra` features:
- `VertexMember` is now implemented for cgmath `Vector`s and `Point`s.
- `type_for_format_cgmath` and `type_for_format_nalgebra` macros, next to the existing `type_for_format` macro.
- Vulkano-shaders: `shader_cgmath` and `shader_nalgebra` macros, next to the existing `shader` macro.
```
