### PR TITLE
Fix incorrect aspects in barriers for depth+stencil images

### DIFF
--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -534,7 +534,7 @@ pub(crate) struct CommandBufferBufferUsage {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct CommandBufferBufferRangeUsage {
-    pub(crate) first_use: ResourceUseRef,
+    pub(crate) first_use: Option<ResourceUseRef>,
     pub(crate) mutable: bool,
 }
 
@@ -546,7 +546,7 @@ pub(crate) struct CommandBufferImageUsage {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct CommandBufferImageRangeUsage {
-    pub(crate) first_use: ResourceUseRef,
+    pub(crate) first_use: Option<ResourceUseRef>,
     pub(crate) mutable: bool,
     pub(crate) expected_layout: ImageLayout,
     pub(crate) final_layout: ImageLayout,

--- a/vulkano/src/command_buffer/synced/builder.rs
+++ b/vulkano/src/command_buffer/synced/builder.rs
@@ -829,7 +829,7 @@ impl SyncCommandBufferBuilder {
                         .into_iter()
                         .filter(|(_range, state)| !state.resource_uses.is_empty())
                         .map(|(range, state)| {
-                            let first_use = state.resource_uses.into_iter().next().unwrap();
+                            let first_use = state.resource_uses.into_iter().next();
                             (
                                 range,
                                 CommandBufferBufferRangeUsage {
@@ -858,7 +858,7 @@ impl SyncCommandBufferBuilder {
                                 state.current_layout = state.final_layout;
                             }
 
-                            let first_use = state.resource_uses.into_iter().next().unwrap();
+                            let first_use = state.resource_uses.into_iter().next();
                             (
                                 range,
                                 CommandBufferImageRangeUsage {

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -602,7 +602,7 @@ pub enum FlushError {
     /// Access to a resource has been denied.
     ResourceAccessError {
         error: AccessError,
-        use_ref: ResourceUseRef,
+        use_ref: Option<ResourceUseRef>,
     },
 
     /// The command buffer or one of the secondary command buffers it executes was created with the


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- Fixed wrong aspects being used in pipeline barriers when an image view selects one aspect of a combined depth+stencil image.
- Fixed panic when building a finished command buffer, if the command buffer contains commands that use only some subresources of an image.
````

This was reported by @itmuckel on Discord. Thanks!