### PR TITLE
Remove installation of python with Windows actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
     paths-ignore:
       - '**.md'
   pull_request:
-    branches: [ master ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,13 +18,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Ninja Install
-      uses: crazy-max/ghaction-chocolatey@v2
-      with:
-        args: install ninja
-    - name: Python3 Install
-      uses: crazy-max/ghaction-chocolatey@v2
-      with:
-        args: install python3 --params "/InstallAllUsers"
+      run: pip install ninja
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,22 +19,22 @@ jobs:
       run: pip install ninja
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build -j 2 --verbose
+      run: cargo build --verbose
     - name: Run tests
-      run: cargo test -j 2 --verbose
+      run: cargo test --verbose
   linux_stable:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build -j 2 --verbose
+      run: cargo build --verbose
     - name: Run tests
-      run: cargo test -j 2 --verbose
+      run: cargo test --verbose
   macos_stable:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build -j 3 --verbose
+      run: cargo build --verbose
     - name: Run tests
-      run: cargo test -j 3 --verbose
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,22 +19,22 @@ jobs:
       run: pip install ninja
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build --verbose
+      run: cargo build -j 2 --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -j 2 --verbose
   linux_stable:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build --verbose
+      run: cargo build -j 2 --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -j 2 --verbose
   macos_stable:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build --verbose
+      run: cargo build -j 3 --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -j 3 --verbose


### PR DESCRIPTION
This removes the use of `ghaction-chocolatey` and the installation of `python3`. Python is now included in the actions environment and so is `pip`. `pip` is now used to install `ninja`.

I also went ahead and remove the branch filter to allow actions to run on other branches say the `0.32.X` branch.