### PR TITLE
Automatically derive `Pod` and `Zeroable` for structs generated by vulkano-shaders

### DIFF
--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -217,10 +217,5 @@ void main() {
     f_color.rgb = push_constants.color.rgb * in_diffuse;
     f_color.a = 1.0;
 }",
-        types_meta: {
-            use bytemuck::{Pod, Zeroable};
-
-            #[derive(Clone, Copy, Zeroable, Pod)]
-        },
     }
 }

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -242,10 +242,5 @@ void main() {
     f_color.rgb = light_percent * push_constants.color.rgb * in_diffuse;
     f_color.a = 1.0;
 }",
-        types_meta: {
-            use bytemuck::{Pod, Zeroable};
-
-            #[derive(Clone, Copy, Zeroable, Pod)]
-        },
     }
 }

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -274,10 +274,5 @@ void main() {
     f_color.rgb = push_constants.color.rgb * light_percent * in_diffuse;
     f_color.a = 1.0;
 }",
-        types_meta: {
-            use bytemuck::{Pod, Zeroable};
-
-            #[derive(Clone, Copy, Zeroable, Pod)]
-        },
     }
 }

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -257,10 +257,5 @@ void main() {
     );
     imageStore(img, ivec2(gl_GlobalInvocationID.xy), write_color);
 }",
-        types_meta: {
-            use bytemuck::{Pod, Zeroable};
-
-            #[derive(Clone, Copy, Zeroable, Pod)]
-        },
     }
 }

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -265,10 +265,5 @@ void main() {
         compute_color();
     }
 }",
-        types_meta: {
-            use bytemuck::{Pod, Zeroable};
-
-            #[derive(Clone, Copy, Zeroable, Pod)]
-        },
     }
 }

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -113,11 +113,6 @@ fn main() {
                     }
                 }
             ",
-            types_meta: {
-                use bytemuck::{Pod, Zeroable};
-
-                #[derive(Clone, Copy, Zeroable, Pod)]
-            },
         }
     }
 

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -177,11 +177,6 @@ fn main() {
                     "
                 }
             },
-            types_meta: {
-                use bytemuck::{Pod, Zeroable};
-
-                #[derive(Clone, Copy, Zeroable, Pod)]
-            },
         }
 
         // The macro will create the following things in this module:

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -263,11 +263,6 @@ fn main() {
 	                verticies[index].vel = vel * exp(friction * push.delta_time);
                 }
             ",
-            types_meta: {
-                use bytemuck::{Pod, Zeroable};
-
-                #[derive(Clone, Copy, Zeroable, Pod)]
-            },
         }
     }
     // Vertex shader determines color and is run once per particle.

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -456,11 +456,6 @@ mod vs {
     vulkano_shaders::shader! {
         ty: "vertex",
         path: "src/bin/teapot/vert.glsl",
-        types_meta: {
-            use bytemuck::{Pod, Zeroable};
-
-            #[derive(Clone, Copy, Zeroable, Pod)]
-        },
     }
 }
 

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -408,8 +408,6 @@ enum SourceKind {
 
 struct TypesMeta {
     custom_derives: Vec<SynPath>,
-    clone: bool,
-    copy: bool,
     display: bool,
     debug: bool,
     default: bool,
@@ -422,9 +420,12 @@ impl Default for TypesMeta {
     #[inline]
     fn default() -> Self {
         Self {
-            custom_derives: vec![],
-            clone: true,
-            copy: true,
+            custom_derives: vec![
+                parse_quote! { Clone },
+                parse_quote! { Copy },
+                parse_quote! { bytemuck::Pod },
+                parse_quote! { bytemuck::Zeroable },
+            ],
             partial_eq: false,
             debug: false,
             display: false,
@@ -440,8 +441,6 @@ impl TypesMeta {
     fn empty() -> Self {
         Self {
             custom_derives: Vec::new(),
-            clone: false,
-            copy: false,
             partial_eq: false,
             debug: false,
             display: false,
@@ -780,26 +779,6 @@ impl Parse for MacroInput {
                                             path.get_ident()
                                         {
                                             match derive_ident.to_string().as_str() {
-                                                "Clone" => {
-                                                    if meta.default {
-                                                        return Err(in_brackets
-                                                            .error("Duplicate Clone derive"));
-                                                    }
-
-                                                    meta.clone = true;
-
-                                                    false
-                                                }
-                                                "Copy" => {
-                                                    if meta.copy {
-                                                        return Err(in_brackets
-                                                            .error("Duplicate Copy derive"));
-                                                    }
-
-                                                    meta.copy = true;
-
-                                                    false
-                                                }
                                                 "PartialEq" => {
                                                     if meta.partial_eq {
                                                         return Err(in_brackets
@@ -850,7 +829,7 @@ impl Parse for MacroInput {
                                             if meta
                                                 .custom_derives
                                                 .iter()
-                                                .any(|candidate| candidate.eq(&path))
+                                                .any(|candidate| *candidate == path)
                                             {
                                                 return Err(
                                                     in_braces.error("Duplicate derive declaration")

--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -220,14 +220,6 @@ fn register_struct(
 fn write_derives(types_meta: &TypesMeta) -> TokenStream {
     let mut derives = vec![];
 
-    if types_meta.clone {
-        derives.push(quote! { Clone });
-    }
-
-    if types_meta.copy {
-        derives.push(quote! { Copy });
-    }
-
     derives.extend(
         types_meta
             .custom_derives


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Vulkano-shaders: The bytemuck traits `Pod` and `Zeroable` are now automatically derived for generated structs, so there is no need to specify them with `types_meta` anymore.
````

Fixes #1925.