### PR TITLE
`impl From<SampleCount> for u32`

### DIFF
--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -287,6 +287,13 @@ vulkan_bitflags_enum! {
     SAMPLE_64, Sample64 = TYPE_64,
 }
 
+impl From<SampleCount> for u32 {
+    #[inline]
+    fn from(value: SampleCount) -> Self {
+        value as u32
+    }
+}
+
 impl TryFrom<u32> for SampleCount {
     type Error = ();
 


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Implemented `From<SampleCount>` for `u32`.
````

In response to #2124 and Discord discussion. It was already possible to do a direct cast `as u32`, so this is just for convenience.