### PR TITLE
Document data layout in shaders

### DIFF
--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -90,9 +90,13 @@
 //! Using uniform/storage texel buffers requires creating a *buffer view*. See [the `view` module]
 //! for how to create a buffer view.
 //!
+//! See also [the `shader` module documentation] for information about how buffer contents need to
+//! be laid out in accordance with the shader interface.
+//!
 //! [`RawBuffer`]: self::sys::RawBuffer
 //! [`SubbufferAllocator`]: self::allocator::SubbufferAllocator
 //! [the `view` module]: self::view
+//! [the `shader` module documentation]: crate::shader
 
 pub use self::{subbuffer::Subbuffer, usage::BufferUsage};
 use self::{

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -90,15 +90,6 @@
 //! Using uniform/storage texel buffers requires creating a *buffer view*. See [the `view` module]
 //! for how to create a buffer view.
 //!
-//! # A note on endianness
-//!
-//! The Vulkan specification requires that a Vulkan implementation has runtime support for the
-//! types [`u8`], [`u16`], [`u32`], [`u64`] as well as their signed versions, as well as [`f32`]
-//! and [`f64`] on the host, and that the representation and endianness of these types matches
-//! those on the device. This means that if you have for example a `Subbuffer<[u32]>`, you can be
-//! sure that it is represented the same way on the host as it is on the device, and you don't need
-//! to worry about converting the endianness.
-//!
 //! [`RawBuffer`]: self::sys::RawBuffer
 //! [`SubbufferAllocator`]: self::allocator::SubbufferAllocator
 //! [the `view` module]: self::view

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -228,7 +228,7 @@ mod tests {
 
             let cb_allocator =
                 StandardCommandBufferAllocator::new(device.clone(), Default::default());
-            let mut cbb = AutoCommandBufferBuilder::primary(
+            let cbb = AutoCommandBufferBuilder::primary(
                 &cb_allocator,
                 queue.queue_family_index(),
                 CommandBufferUsage::OneTimeSubmit,

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -90,14 +90,14 @@
 //! alignment is N, the scalar alignment considers the alignment of the compound type to be also N.
 //! However, the base and extended alignments are stricter:
 //!
-//! | GLSL type | Scalar         | Base           | Extended                                     |
-//! |-----------|----------------|----------------|----------------------------------------------|
-//! | primitive | N              | N              | N                                            |
-//! | `vec2`    | N              | N * 2          | N * 2                                        |
-//! | `vec3`    | N              | N * 4          | N * 4                                        |
-//! | `vec4`    | N              | N * 4          | N * 4                                        |
-//! | array     | N              | N              | N, rounded up to multiple of 16              |
-//! | `struct`  | max of members | max of members | max of members, rounded up to multiple of 16 |
+//! | GLSL type | Scalar | Base   | Extended                             |
+//! |-----------|--------|--------|--------------------------------------|
+//! | primitive | N      | N      | N                                    |
+//! | `vec2`    | N      | N * 2  | N * 2                                |
+//! | `vec3`    | N      | N * 4  | N * 4                                |
+//! | `vec4`    | N      | N * 4  | N * 4                                |
+//! | array     | N      | N      | N, rounded up to multiple of 16      |
+//! | `struct`  | max(N) | max(N) | max(N), rounded up to multiple of 16 |
 //!
 //! In the base and extended alignment, the alignment of a vector is the size of the whole vector,
 //! rather than the size of its individual elements as is the case in the scalar alignment.

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -27,7 +27,7 @@
 //! The Vulkan specification requires that a Vulkan implementation has runtime support for the
 //! types [`u8`], [`u16`], [`u32`], [`u64`] as well as their signed versions, as well as [`f32`]
 //! and [`f64`] on the host, and that the representation and endianness of these types matches
-//! those on the device. This means that if you have for example a `Subbuffer<[u32]>`, you can be
+//! those on the device. This means that if you have for example a `Subbuffer<u32>`, you can be
 //! sure that it is represented the same way on the host as it is on the device, and you don't need
 //! to worry about converting the endianness.
 //!

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -103,16 +103,17 @@
 //!
 //! In the base and extended alignment, the alignment of a vector is the size of the whole vector,
 //! rather than the size of its individual elements as is the case in the scalar alignment.
-//! But note that, because alignment must be a power of two, `vec3` has the same alignment as
-//! `vec4`, so it is not possible to tightly pack multiple `vec3` values (e.g. in an array);
-//! there will always be empty padding between them.
+//! But note that, because alignment must be a power of two, the alignment of `vec3` cannot be
+//! N * 3; it must be N * 4, the same alignment as `vec4`. This means that it is not possible to
+//! tightly pack multiple `vec3` values (e.g. in an array); there will always be empty padding
+//! between them.
 //!
-//! For arrays, in both the scalar and base alignment, the alignment is equal to the alignment of
-//! the array elements. In the extended alignment, however, the alignment is always at least 16
-//! (the size of a `vec4`). Therefore, the minimum stride of the array can be much greater than the
-//! element size. For example, in an array of `float`, the stride must be at least 16, even
-//! though a `float` itself is only 4 bytes in size. Every `float` element will be followed by at
-//! least 12 bytes of unused space.
+//! In both the scalar and base alignment, the alignment of arrays and their elements is equal to
+//! the alignment of the contained type. In the extended alignment, however, the alignment is
+//! always at least 16 (the size of a `vec4`). Therefore, the minimum stride of the array can be
+//! much greater than the element size. For example, in an array of `float`, the stride must be at
+//! least 16, even though a `float` itself is only 4 bytes in size. Every `float` element will be
+//! followed by at least 12 bytes of unused space.
 //!
 //! A matrix `matCxR` is considered equivalent to an array of column vectors `vecR[C]`.
 //! In the base and extended alignments, that means that if the matrix has 3 rows, there will be

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -36,12 +36,13 @@
 //! When buffers, push constants or other user-provided data are accessed in shaders,
 //! the shader expects the values inside to be laid out in a specific way. For every uniform buffer,
 //! storage buffer or push constant block, the SPIR-V specification requires the SPIR-V code to
-//! provide an explicit *offset* for every member of a struct, indicating where it is placed
+//! provide the `Offset` decoration for every member of a struct, indicating where it is placed
 //! relative to the start of the struct. If there are arrays or matrices among the variables, the
-//! SPIR-V code must also provide an explicit *stride* (the number of bytes between the start of
-//! each value) for them. When providing data to shaders, you must make sure that your data is
-//! placed at the locations indicated within the SPIR-V code, or the shader will read the wrong
-//! data and produce nonsense.
+//! SPIR-V code must also provide an `ArrayStride` or `MatrixStride` decoration for them,
+//! indicating the number of bytes between the start of each element in the array or column in the
+//! matrix. When providing data to shaders, you must make sure that your data is placed at the
+//! locations indicated within the SPIR-V code, or the shader will read the wrong data and produce
+//! nonsense.
 //!
 //! GLSL does not require you to give explicit offsets and/or strides to your variables (although
 //! it has the option to provide them if you wish). Instead, the shader compiler automatically


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Added documentation to the `shader` module to explain the layout of buffers, push constants and other data accessed by shaders.
````

Fixes #1111. This should hopefully reduce the confusion with users when shaders don't read the data they provided.