### PR TITLE
Switch Windows actions to self-hosted runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   windows_stable:
 #   runs-on: windows-latest
-    runs-on: runs-on: [self-hosted, Windows]
+    runs-on: [self-hosted, Windows]
     steps:
 #   - name: Ninja Install
 #     run: pip install ninja

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,10 +13,11 @@ env:
 
 jobs:
   windows_stable:
-    runs-on: windows-latest
+#   runs-on: windows-latest
+    runs-on: runs-on: [self-hosted, Windows]
     steps:
-    - name: Ninja Install
-      run: pip install ninja
+#   - name: Ninja Install
+#     run: pip install ninja
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
This switches the windows actions to use a self hosted runner that I have hosted. I decided to use windows first as it seems the most problematic currently with GitHub provided action runners. The self-hosted runner also has GPU access, which will actually perform tests. The GPU is a Intel HD Graphics 530 using GVT-g.

If all goes well and is stable, I can switch the linux actions over also. Some have setup up MacOS, but running MacOS in a kvm is a tricky business and then combine that with GVT-g.