### PR TITLE
Fix "expected expression, found `,`" compile error for precompiled shaders with more than one entrypoint

### DIFF
--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -51,7 +51,7 @@ pub(super) fn write_entry_point(
                 input_interface: #input_interface,
                 output_interface: #output_interface,
             },
-        ),
+        )
     }
 }
 


### PR DESCRIPTION
Commit c6959aa961c9c4bac59f53c99e73620b458d8d82 seems to have introduced a regression that causes the vulkano-shaders macro to emit two consecutive commas for any single shader module with more than one entry point. (Since vulkano-shaders doesn't generate shader modules with multiple entrypoints itself as far as I know, this regression only manifests on precompiled shaders in practice.)

Here's a minimal reproducible example with two entrypoints `vert` and `frag`: [shaders.spv.zip](https://github.com/vulkano-rs/vulkano/files/10682895/shaders.spv.zip)

```rust
mod shaders {
    vulkano_shaders::shader!{
        ty: "vertex",
        bytes: "shaders.spv",
    }
}
```

![oh noes](https://user-images.githubusercontent.com/45273859/217461399-080e608c-7553-45d4-b1e7-798e50503371.png)

Dumping the generated macro output reveals the double comma of doom:

```rs
unsafe {
    ::vulkano::shader::ShaderModule::from_words_with_data(
        // -- snip --
        [
            (
                "vert".to_owned(),
                ::vulkano::shader::spirv::ExecutionModel::Vertex,
                ::vulkano::shader::EntryPointInfo {
                    // -- snip --
                },
            ),, // <-- ERROR
            (
                "frag".to_owned(),
                ::vulkano::shader::spirv::ExecutionModel::Fragment,
                ::vulkano::shader::EntryPointInfo {
                    // -- snip --
                },
            ),
        ],
    )
}
```

Luckily, the fix for this is to simply remove the offending comma from the `write_entry_point` method - a one character change that makes this PR quite possibly the shortest PR I've ever authored :D

Changelog:
```markdown
### Bugs fixed
- Vulkano-shaders: Fixed an "expected expression, found `,`" compile error for precompiled shaders with more than one entrypoint.
```
