### PR TITLE
Fix inconcistently named macros crate

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -2,7 +2,10 @@
 name = "vulkano"
 version = "0.32.0"
 edition = "2021"
-authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
+authors = [
+    "Pierre Krieger <pierre.krieger1708@gmail.com>",
+    "The vulkano contributors",
+]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Safe wrapper for the Vulkan graphics API"
 license = "MIT/Apache-2.0"
@@ -18,7 +21,11 @@ ahash = "0.8"
 # When updating Ash, also update vk.xml to the same Vulkan patch version that Ash uses.
 # All versions of vk.xml can be found at https://github.com/KhronosGroup/Vulkan-Headers/commits/main/registry/vk.xml.
 ash = "^0.37.1"
-bytemuck = { version = "1.7", features = ["derive", "extern_crate_std", "min_const_generics"] }
+bytemuck = { version = "1.7", features = [
+    "derive",
+    "extern_crate_std",
+    "min_const_generics",
+] }
 cgmath = { version = "0.18.0", optional = true }
 crossbeam-queue = "0.3"
 half = "2"
@@ -28,7 +35,7 @@ once_cell = "1.16"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 smallvec = "1.8"
 thread_local = "1.1"
-vulkano_macros = { path = "macros", version = "0.32.0" }
+vulkano-macros = { path = "macros", version = "0.32.0" }
 
 [target.'cfg(target_os = "ios")'.dependencies]
 objc = "0.2.5"

--- a/vulkano/macros/Cargo.toml
+++ b/vulkano/macros/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
-name = "vulkano_macros"
+name = "vulkano-macros"
 version = "0.32.0"
 edition = "2021"
-authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
+authors = [
+    "Pierre Krieger <pierre.krieger1708@gmail.com>",
+    "The vulkano contributors",
+]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Macros used by Vulkano"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
All the other crates use hyphens in their name, so just fixing the inconsistency. The formatting was done by taplo.