### PR TITLE
Remove long-gone `www` crate from the exclude-list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
-members = ["examples", "vulkano", "vulkano-shaders", "vulkano-win", "vulkano-util"]
-exclude = ["www"]
+members = [
+    "examples",
+    "vulkano",
+    "vulkano-shaders",
+    "vulkano-win",
+    "vulkano-util",
+]


### PR DESCRIPTION
This crate has been extinct for a hot minute, so just removing it form the exclude-list. The formatting was done by taplo.