### PR TITLE
Fix subbuffer alignment to the non-coherent atom size limitation

### DIFF
--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -874,15 +874,6 @@ pub enum BufferError {
         queue_family_index: u32,
         queue_family_count: u32,
     },
-
-    /// The memory is not host-coherent, and the [`Subbuffer`] bounds are not a multiple of the
-    /// [`non_coherent_atom_size`] device property.
-    ///
-    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
-    SubbufferNotAlignedToAtomSize {
-        range: Range<DeviceSize>,
-        atom_size: DeviceAlignment,
-    },
 }
 
 impl Error for BufferError {
@@ -1005,12 +996,6 @@ impl Display for BufferError {
                 f,
                 "the sharing mode was set to `Concurrent`, but one of the specified queue family \
                 indices was out of range",
-            ),
-            Self::SubbufferNotAlignedToAtomSize { range, atom_size } => write!(
-                f,
-                "the memory is not host-coherent, and the `Subbuffer` bounds ({:?}) are not \
-                a multiple of the `non_coherent_atom_size` device property ({:?})",
-                range, atom_size,
             ),
         }
     }

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -212,15 +212,15 @@ where
         let range = self.range();
 
         let aligned_range = if let Some(atom_size) = allocation.atom_size() {
-            let memory_offset = allocation.offset() + self.offset();
+            // This works because the suballocators align allocations to the non-coherent atom size
+            // when the memory is host-visible but not host-coherent.
+            let start = align_down(self.offset, atom_size);
+            let end = cmp::min(
+                align_up(self.offset + self.size, atom_size),
+                allocation.size(),
+            );
 
-            Range {
-                start: align_down(memory_offset, atom_size) - allocation.offset(),
-                end: cmp::min(
-                    align_up(memory_offset + self.size, atom_size),
-                    allocation.offset() + allocation.size(),
-                ) - allocation.offset(),
-            }
+            Range { start, end }
         } else {
             range.clone()
         };
@@ -282,15 +282,15 @@ where
         let range = self.range();
 
         let aligned_range = if let Some(atom_size) = allocation.atom_size() {
-            let memory_offset = allocation.offset() + self.offset();
+            // This works because the suballocators align allocations to the non-coherent atom size
+            // when the memory is host-visible but not host-coherent.
+            let start = align_down(self.offset, atom_size);
+            let end = cmp::min(
+                align_up(self.offset + self.size, atom_size),
+                allocation.size(),
+            );
 
-            Range {
-                start: align_down(memory_offset, atom_size) - allocation.offset(),
-                end: cmp::min(
-                    align_up(memory_offset + self.size, atom_size),
-                    allocation.offset() + allocation.size(),
-                ) - allocation.offset(),
-            }
+            Range { start, end }
         } else {
             range.clone()
         };


### PR DESCRIPTION
This fixes the limitation that a subbuffer must be aligned to the non-coherent atom size when reading or writing its contents from the host and its backing memory is non-host-coherent, by allowing any offset/size in the subbuffer, but still locking a range that is aligned to the non-coherent atom size, such that cache flushes and invalidations will not alias other subbuffers within the same buffer. The downside is that it is pretty opaque to the user that this is happening, and the error messages will be mysterious. Alas, I can't think of a solution that's both intuitive and transparent, and doesn't suffer from this big limitation, that the user can't read/write any size of subbuffer when they underlying memory is not host-coherent.