### PR TITLE
Fix discarding image data when transitioning StorageImage

### DIFF
--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -316,12 +316,12 @@ unsafe impl ImageAccess for StorageImage {
 
     #[inline]
     unsafe fn layout_initialized(&self) {
-        self.layout_initialized.store(true, Ordering::SeqCst);
+        self.layout_initialized.store(true, Ordering::Relaxed);
     }
 
     #[inline]
     fn is_layout_initialized(&self) -> bool {
-        self.layout_initialized.load(Ordering::SeqCst)
+        self.layout_initialized.load(Ordering::Relaxed)
     }
 
     #[inline]


### PR DESCRIPTION
Fixes #2149
Now, when calling `SyncCommandBufferBuild::add_image` the `current_layout` would be `General` if its not the first time.
This fixes data being lost when using `Undefined` as stated in the issue.

I have ran all the examples, and unit tests with validation layer and all is good.

Changelog:
```markdown
### Bugs fixed
- added flag in `StorageImage` that would track if the layout has been initialized (first use) which fixes #2149
````
