### PR TITLE
render pass macros now allow trailing commas + options now use ? instead of *

### DIFF
--- a/vulkano/src/render_pass/macros.rs
+++ b/vulkano/src/render_pass/macros.rs
@@ -14,10 +14,11 @@ macro_rules! single_pass_renderpass {
         $device:expr,
         attachments: { $($a:tt)* },
         pass: {
-            color: [$($color_atch:ident),*],
-            depth_stencil: {$($depth_atch:ident)*}$(,)*
-            $(resolve: [$($resolve_atch:ident),*])*$(,)*
-        }
+            color: [$($color_atch:ident),* $(,)?],
+            depth_stencil: {$($depth_atch:ident)?}
+            $(,resolve: [$($resolve_atch:ident),* $(,)?])*
+            $(,)*
+        } $(,)?
     ) => (
         $crate::ordered_passes_renderpass!(
             $device,
@@ -45,22 +46,24 @@ macro_rules! ordered_passes_renderpass {
                     load: $load:ident,
                     store: $store:ident,
                     format: $format:expr,
-                    samples: $samples:expr,
-                    $(initial_layout: $init_layout:expr,)*
-                    $(final_layout: $final_layout:expr,)*
+                    samples: $samples:expr
+                    $(,initial_layout: $init_layout:expr)?
+                    $(,final_layout: $final_layout:expr)?
+                    $(,)?
                 }
-            ),*
+            ),* $(,)?
         },
         passes: [
             $(
                 {
-                    color: [$($color_atch:ident),*],
-                    depth_stencil: {$($depth_atch:ident)*},
-                    input: [$($input_atch:ident),*]$(,)*
-                    $(resolve: [$($resolve_atch:ident),*])*$(,)*
+                    color: [$($color_atch:ident),* $(,)?],
+                    depth_stencil: {$($depth_atch:ident)* $(,)?},
+                    input: [$($input_atch:ident),* $(,)?]
+                    $(,resolve: [$($resolve_atch:ident),* $(,)?])?
+                    $(,)*
                 }
-            ),*
-        ]
+            ),* $(,)?
+        ] $(,)?
     ) => ({
         use $crate::render_pass::RenderPass;
 


### PR DESCRIPTION
fixes #804

In addition to allowing trailing commas for comma-separated lists, I've also changed optional fields to use `?` instead of `*` since it makes it more clear that they are optional. I don't think that that's a breaking change since multiple elements in these places would probably cause a syntax error in the macro expansion.

Changelog:
```markdown
### Additions
- The macros `single_pass_renderpass!` and `ordered_passes_renderpass!` now allow trailing commas in various places.
````
