### PR TITLE
This lossen the `regex` dependency

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -42,7 +42,7 @@ indexmap = "1.8"
 once_cell = "1.16"
 proc-macro2 = "1.0"
 quote = "1.0"
-regex = "1.7"
+regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 vk-parse = "0.8"


### PR DESCRIPTION
Forcing usage of 1.7 is not a requierement as far as I can tell (sadly, `regex` release are not documented, at least I did not find the changelog).

By downgrading, we reduce potential conflicts when importing other libraries (`prost` and `slog` where conflicting in my case).

#### Changelog:
```markdown
### Additions
- Loosen `regex` dependency to use any version of the `1.x` series.
````
