### PR TITLE
Fix gl-interop not compiling

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,3 +24,6 @@ png = "0.17"
 rand = "0.8.4"
 ron = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+
+# Glium has still not been updated to the latest winit version
+winit_glium = { package = "winit", version = "0.27.1"}

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -67,18 +67,18 @@ mod linux {
     };
 
     pub fn main() {
-        let event_loop = EventLoop::new();
-        // For some reason, this must be created before the Vulkan window.
+        let event_loop_gl = winit_glium::event_loop::EventLoop::new();
+        // For some reason, this must be created before the vulkan window
         let hrb = glutin::ContextBuilder::new()
             .with_gl_debug_flag(true)
             .with_gl(glutin::GlRequest::Latest)
-            .build_surfaceless(&event_loop)
+            .build_surfaceless(&event_loop_gl)
             .unwrap();
 
         let hrb_vk = glutin::ContextBuilder::new()
             .with_gl_debug_flag(true)
             .with_gl(glutin::GlRequest::Latest)
-            .build_surfaceless(&event_loop)
+            .build_surfaceless(&event_loop_gl)
             .unwrap();
 
         // Used for checking device and driver UUIDs.
@@ -88,6 +88,7 @@ mod linux {
         )
         .unwrap();
 
+        let event_loop = EventLoop::new();
         let (
             device,
             _instance,


### PR DESCRIPTION
This fixes build errors caused by #2142 .

On my machine the examples crash with Wayland but work under X11. This might be due to how winit handles Wayland contexts. However, I am quite confident it would also work in Wayland if each event loop were moved to a different process.

Changelog:
```markdown

### Bugs fixed
- `gl-interop` example does not compile.
````
