### PR TITLE
Add `create_surface_from_handle_ref`

### DIFF
--- a/vulkano-win/src/raw_window_handle.rs
+++ b/vulkano-win/src/raw_window_handle.rs
@@ -82,7 +82,7 @@ pub fn create_surface_from_handle(
 /// # Safety
 ///
 /// - The passed-in `window` must outlive the created [`Surface`].
-pub unsafe fn create_surface_from_handle_unowned(
+pub unsafe fn create_surface_from_handle_ref(
     window: &(impl HasRawWindowHandle + HasRawDisplayHandle),
     instance: Arc<Instance>,
 ) -> Result<Arc<Surface>, SurfaceCreationError> {


### PR DESCRIPTION
Adds a function that can create a `Surface` from a reference to an `impl HasRawWindowHandle + HasRawDisplayHandle`, which makes it easier to work with windows that are not `Send + Sync` (like SDL2) while staying relatively safe.

```markdown
### Additions
- Vulkano-win: Added `create_surface_from_handle_ref`.
```