### PR TITLE
Deprecate `winit_` and `raw-window-handle_` features

### DIFF
--- a/vulkano-win/Cargo.toml
+++ b/vulkano-win/Cargo.toml
@@ -2,7 +2,10 @@
 name = "vulkano-win"
 version = "0.32.0"
 edition = "2021"
-authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
+authors = [
+    "Pierre Krieger <pierre.krieger1708@gmail.com>",
+    "The vulkano contributors",
+]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Link between vulkano and winit"
 license = "MIT/Apache-2.0"
@@ -12,9 +15,11 @@ keywords = ["vulkan", "bindings", "graphics", "gpu", "rendering"]
 categories = ["rendering::graphics-api"]
 
 [features]
-default = ["winit_", "raw-window-handle_"]
-winit_ = ["winit", "objc", "core-graphics-types"]
-raw-window-handle_ = ["raw-window-handle"]
+default = ["winit", "raw-window-handle"]
+raw-window-handle = ["dep:raw-window-handle"]
+raw-window-handle_ = ["dep:raw-window-handle"]
+winit = ["dep:winit", "dep:objc", "dep:core-graphics-types"]
+winit_ = ["dep:winit", "dep:objc", "dep:core-graphics-types"]
 
 [dependencies]
 raw-window-handle = { version = "0.5", optional = true }

--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -12,12 +12,30 @@
 #![allow(clippy::missing_safety_doc)]
 #![warn(rust_2018_idioms, rust_2021_compatibility)]
 
+#[cfg(feature = "raw-window-handle")]
+mod raw_window_handle;
+#[cfg(feature = "raw-window-handle")]
+pub use crate::raw_window_handle::*;
+
+#[cfg(feature = "winit")]
+mod winit;
+#[cfg(feature = "winit")]
+pub use crate::winit::*;
+
 #[cfg(feature = "raw-window-handle_")]
+#[deprecated(
+    since = "0.33.0",
+    note = "the `raw-window-handle_` feature is deprecated, use `raw-window-handle` instead"
+)]
 mod raw_window_handle;
 #[cfg(feature = "raw-window-handle_")]
 pub use crate::raw_window_handle::*;
 
 #[cfg(feature = "winit_")]
+#[deprecated(
+    since = "0.33.0",
+    note = "the `winit_` feature is deprecated, use `winit` instead"
+)]
 mod winit;
 #[cfg(feature = "winit_")]
 pub use crate::winit::*;


### PR DESCRIPTION
Since Rust 1.60, we can use the `dep:` syntax to specify dependencies that are enabled by features. Our current MSRV is 1.62, therefore I think it's best to deprecate vulkano-win's `winit_` and `raw-window-handle_` features because they're awkward.

Changelog:
```markdown
### Additions
- Vulkano-win: The features `winit` and `raw-window-handle` can now be used directly, `winit_` and `raw-window-handle_` have been deprecated.
```