### PR TITLE
Fix inconsistent trailing command in renderpass macro calls

### DIFF
--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -213,12 +213,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -143,12 +143,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -101,7 +101,8 @@ impl FrameSystem {
         // currently being processed by the fragment shader. If you want to read from attachments
         // but can't deal with these restrictions, then you should create multiple render passes
         // instead.
-        let render_pass = vulkano::ordered_passes_renderpass!(gfx_queue.device().clone(),
+        let render_pass = vulkano::ordered_passes_renderpass!(
+            gfx_queue.device().clone(),
             attachments: {
                 // The image that will contain the final rendering (in this example the swapchain
                 // image, but it could be another image).
@@ -131,22 +132,22 @@ impl FrameSystem {
                     store: DontCare,
                     format: Format::D16_UNORM,
                     samples: 1,
-                }
+                },
             },
             passes: [
                 // Write to the diffuse, normals and depth attachments.
                 {
                     color: [diffuse, normals],
                     depth_stencil: {depth},
-                    input: []
+                    input: [],
                 },
                 // Apply lighting by reading these three attachments and writing to `final_color`.
                 {
                     color: [final_color],
                     depth_stencil: {},
-                    input: [diffuse, normals, depth]
-                }
-            ]
+                    input: [diffuse, normals, depth],
+                },
+            ],
         )
         .unwrap();
 

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -588,12 +588,12 @@ mod linux {
                     store: Store,
                     format: swapchain.image_format(),
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [color],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
 

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -200,12 +200,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -191,19 +191,20 @@ fn main() {
     let vs = vs::load(device.clone()).unwrap();
     let fs = fs::load(device.clone()).unwrap();
 
-    let render_pass = vulkano::single_pass_renderpass!(device.clone(),
+    let render_pass = vulkano::single_pass_renderpass!(
+        device.clone(),
         attachments: {
             color: {
                 load: Clear,
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -197,19 +197,20 @@ fn main() {
     let vs = vs::load(device.clone()).unwrap();
     let fs = fs::load(device.clone()).unwrap();
 
-    let render_pass = vulkano::single_pass_renderpass!(device.clone(),
+    let render_pass = vulkano::single_pass_renderpass!(
+        device.clone(),
         attachments: {
             color: {
                 load: Clear,
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -282,12 +282,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -275,12 +275,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/interactive_fractal/place_over_frame.rs
+++ b/examples/src/bin/interactive_fractal/place_over_frame.rs
@@ -40,19 +40,20 @@ impl RenderPassPlaceOverFrame {
         descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
         output_format: Format,
     ) -> RenderPassPlaceOverFrame {
-        let render_pass = vulkano::single_pass_renderpass!(gfx_queue.device().clone(),
+        let render_pass = vulkano::single_pass_renderpass!(
+            gfx_queue.device().clone(),
             attachments: {
                 color: {
                     load: Clear,
                     store: Store,
                     format: output_format,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [color],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
         let subpass = Subpass::from(render_pass.clone(), 0).unwrap();

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -201,7 +201,7 @@ fn main() {
                 format: Format::R8G8B8A8_UNORM,
                 // Same here, this has to match.
                 samples: 1,
-            }
+            },
         },
         pass: {
             // When drawing, we have only one output which is the intermediary image.
@@ -213,7 +213,7 @@ fn main() {
             // the end of the pass, the `intermediary` attachment will be copied to the attachment
             // named `color`.
             resolve: [color],
-        }
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -248,12 +248,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/multi_window_game_of_life/render_pass.rs
+++ b/examples/src/bin/multi_window_game_of_life/render_pass.rs
@@ -36,19 +36,20 @@ impl RenderPassPlaceOverFrame {
         gfx_queue: Arc<Queue>,
         output_format: Format,
     ) -> RenderPassPlaceOverFrame {
-        let render_pass = vulkano::single_pass_renderpass!(gfx_queue.device().clone(),
+        let render_pass = vulkano::single_pass_renderpass!(
+            gfx_queue.device().clone(),
             attachments: {
                 color: {
                     load: Clear,
                     store: Store,
                     format: output_format,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [color],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
         let subpass = Subpass::from(render_pass.clone(), 0).unwrap();

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -289,12 +289,12 @@ fn main() {
                 store: DontCare,
                 format: Format::D16_UNORM,
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {depth}
-        }
+            depth_stencil: {depth},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -187,19 +187,20 @@ fn main() {
     let vs = vs::load(device.clone()).unwrap();
     let fs = fs::load(device.clone()).unwrap();
 
-    let render_pass = vulkano::single_pass_renderpass!(device.clone(),
+    let render_pass = vulkano::single_pass_renderpass!(
+        device.clone(),
         attachments: {
             color: {
                 load: Clear,
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -167,12 +167,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -254,19 +254,20 @@ fn main() {
     let vs = vs::load(device.clone()).unwrap();
     let fs = fs::load(device.clone()).unwrap();
 
-    let render_pass = vulkano::single_pass_renderpass!(device.clone(),
+    let render_pass = vulkano::single_pass_renderpass!(
+        device.clone(),
         attachments: {
             color: {
                 load: Clear,
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -170,12 +170,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -199,7 +199,8 @@ fn main() {
     let vs = vs::load(device.clone()).unwrap();
     let fs = fs::load(device.clone()).unwrap();
 
-    let render_pass = vulkano::single_pass_renderpass!(device.clone(),
+    let render_pass = vulkano::single_pass_renderpass!(
+        device.clone(),
         attachments: {
             color: {
                 load: Clear,
@@ -212,12 +213,12 @@ fn main() {
                 store: DontCare,
                 format: Format::D16_UNORM,
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {depth}
-        }
+            depth_stencil: {depth},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -324,12 +324,12 @@ fn main() {
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -193,19 +193,20 @@ fn main() {
     let vs = vs::load(device.clone()).unwrap();
     let fs = fs::load(device.clone()).unwrap();
 
-    let render_pass = vulkano::single_pass_renderpass!(device.clone(),
+    let render_pass = vulkano::single_pass_renderpass!(
+        device.clone(),
         attachments: {
             color: {
                 load: Clear,
                 store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -365,14 +365,14 @@ fn main() {
                 // (multisampling) for antialiasing. An example of this can be found in
                 // msaa-renderpass.rs.
                 samples: 1,
-            }
+            },
         },
         pass: {
             // We use the attachment named `color` as the one and only color attachment.
             color: [color],
             // No depth-stencil attachment is indicated with empty brackets.
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     )
     .unwrap();
 

--- a/vulkano/src/pipeline/graphics/tests.rs
+++ b/vulkano/src/pipeline/graphics/tests.rs
@@ -306,12 +306,12 @@ mod simple_rp {
                 load: Clear,
                 store: Store,
                 format: Format,
-            }
+            },
         },
         pass: {
             color: [color],
-            depth_stencil: {}
-        }
+            depth_stencil: {},
+        },
     }
 }
 

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -719,19 +719,20 @@ mod tests {
     fn simple_create() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let render_pass = single_pass_renderpass!(device.clone(),
+        let render_pass = single_pass_renderpass!(
+            device.clone(),
             attachments: {
                 color: {
                     load: Clear,
                     store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [color],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
 
@@ -787,19 +788,20 @@ mod tests {
     fn attachment_format_mismatch() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let render_pass = single_pass_renderpass!(device.clone(),
+        let render_pass = single_pass_renderpass!(
+            device.clone(),
             attachments: {
                 color: {
                     load: Clear,
                     store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [color],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
 
@@ -827,19 +829,20 @@ mod tests {
     fn attachment_dims_larger_than_specified_valid() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let render_pass = single_pass_renderpass!(device.clone(),
+        let render_pass = single_pass_renderpass!(
+            device.clone(),
             attachments: {
                 color: {
                     load: Clear,
                     store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [color],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
 
@@ -865,19 +868,20 @@ mod tests {
     fn attachment_dims_smaller_than_specified() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let render_pass = single_pass_renderpass!(device.clone(),
+        let render_pass = single_pass_renderpass!(
+            device.clone(),
             attachments: {
                 color: {
                     load: Clear,
                     store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [color],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
 
@@ -905,7 +909,8 @@ mod tests {
     fn multi_attachments_auto_smaller() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let render_pass = single_pass_renderpass!(device.clone(),
+        let render_pass = single_pass_renderpass!(
+            device.clone(),
             attachments: {
                 a: {
                     load: Clear,
@@ -918,12 +923,12 @@ mod tests {
                     store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [a, b],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
 
@@ -956,7 +961,8 @@ mod tests {
     fn not_enough_attachments() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let render_pass = single_pass_renderpass!(device.clone(),
+        let render_pass = single_pass_renderpass!(
+            device.clone(),
             attachments: {
                 a: {
                     load: Clear,
@@ -969,12 +975,12 @@ mod tests {
                     store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [a, b],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
 
@@ -1005,19 +1011,20 @@ mod tests {
     fn too_many_attachments() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let render_pass = single_pass_renderpass!(device.clone(),
+        let render_pass = single_pass_renderpass!(
+            device.clone(),
             attachments: {
                 a: {
                     load: Clear,
                     store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [a],
-                depth_stencil: {}
-            }
+                depth_stencil: {},
+            },
         )
         .unwrap();
 

--- a/vulkano/src/render_pass/macros.rs
+++ b/vulkano/src/render_pass/macros.rs
@@ -233,7 +233,8 @@ mod tests {
     #[test]
     fn single_pass_resolve() {
         let (device, _) = gfx_dev_and_queue!();
-        let _ = single_pass_renderpass!(device,
+        let _ = single_pass_renderpass!(
+            device,
             attachments: {
                 a: {
                     load: Clear,
@@ -246,13 +247,13 @@ mod tests {
                     store: Store,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
-                }
+                },
             },
             pass: {
                 color: [a],
                 depth_stencil: {},
                 resolve: [b],
-            }
+            },
         )
         .unwrap();
     }

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -79,7 +79,8 @@ mod framebuffer;
 /// # let device: std::sync::Arc<vulkano::device::Device> = return;
 /// use vulkano::format::Format;
 ///
-/// let render_pass = single_pass_renderpass!(device.clone(),
+/// let render_pass = single_pass_renderpass!(
+///     device.clone(),
 ///     attachments: {
 ///         // `foo` is a custom name we give to the first and only attachment.
 ///         foo: {
@@ -87,13 +88,14 @@ mod framebuffer;
 ///             store: Store,
 ///             format: Format::R8G8B8A8_UNORM,
 ///             samples: 1,
-///         }
+///         },
 ///     },
 ///     pass: {
 ///         color: [foo],       // Repeat the attachment name here.
-///         depth_stencil: {}
-///     }
-/// ).unwrap();
+///         depth_stencil: {},
+///     },
+/// )
+/// .unwrap();
 /// # }
 /// ```
 ///
@@ -1261,7 +1263,7 @@ mod tests {
             return; // test ignored
         }
 
-        let rp = single_pass_renderpass! {
+        let rp = single_pass_renderpass!(
             device,
             attachments: {
                 a1: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
@@ -1273,13 +1275,13 @@ mod tests {
                 a7: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
                 a8: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
                 a9: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a10: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, }
+                a10: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
             },
             pass: {
                 color: [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10],
-                depth_stencil: {}
-            }
-        };
+                depth_stencil: {},
+            },
+        );
 
         match rp {
             Err(RenderPassCreationError::SubpassMaxColorAttachmentsExceeded { .. }) => (),
@@ -1291,16 +1293,16 @@ mod tests {
     fn non_zero_granularity() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let rp = single_pass_renderpass! {
+        let rp = single_pass_renderpass!(
             device,
             attachments: {
-                a: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, }
+                a: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
             },
             pass: {
                 color: [a],
-                depth_stencil: {}
-            }
-        }
+                depth_stencil: {},
+            },
+        )
         .unwrap();
 
         let granularity = rp.granularity();


### PR DESCRIPTION
Following #2151, this makes the trailing commas consistent everywhere where the `single_pass_renderpass` and `ordered_passes_renderpass` macros are used.