### PR TITLE
Preemptively rename stuff, mark enums as non-exhaustive

### DIFF
--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -370,7 +370,7 @@ fn main() {
                     | BufferUsage::TRANSFER_DST
                     | BufferUsage::VERTEX_BUFFER,
                 // Specify this buffer will only be used by the device.
-                memory_usage: MemoryUsage::GpuOnly,
+                memory_usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             },
             PARTICLE_COUNT as vulkano::DeviceSize,

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -51,7 +51,7 @@
 //! When allocating memory for a buffer, you have to specify a *memory usage*. This tells the
 //! memory allocator what memory type it should pick for the allocation.
 //!
-//! - [`MemoryUsage::GpuOnly`] will allocate a buffer that's usually located in device-local
+//! - [`MemoryUsage::DeviceOnly`] will allocate a buffer that's usually located in device-local
 //!   memory and whose content can't be directly accessed by your application. Accessing this
 //!   buffer from the device is generally faster compared to accessing a buffer that's located in
 //!   host-visible memory.
@@ -195,7 +195,7 @@ pub mod view;
 ///         // Specify use as a storage buffer and transfer destination.
 ///         buffer_usage: BufferUsage::STORAGE_BUFFER | BufferUsage::TRANSFER_DST,
 ///         // Specify use by the device only.
-///         memory_usage: MemoryUsage::GpuOnly,
+///         memory_usage: MemoryUsage::DeviceOnly,
 ///         ..Default::default()
 ///     },
 ///     10_000 as DeviceSize,
@@ -565,7 +565,7 @@ pub struct BufferAllocateInfo {
 
     /// The memory usage to use for the allocation.
     ///
-    /// If this is set to [`MemoryUsage::GpuOnly`], then the buffer may need to be initialized
+    /// If this is set to [`MemoryUsage::DeviceOnly`], then the buffer may need to be initialized
     /// using a staging buffer. The exception is some integrated GPUs and laptop GPUs, which do not
     /// have memory types that are not host-visible. With [`MemoryUsage::Upload`] and
     /// [`MemoryUsage::Download`], a staging buffer is never needed.

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -1277,7 +1277,7 @@ mod tests {
                     ..requirements
                 },
                 allocation_type: AllocationType::Linear,
-                usage: MemoryUsage::GpuOnly,
+                usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             })
             .unwrap();
@@ -1286,7 +1286,7 @@ mod tests {
             .allocate(AllocationCreateInfo {
                 requirements,
                 allocation_type: AllocationType::Linear,
-                usage: MemoryUsage::GpuOnly,
+                usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             })
             .unwrap();

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -443,7 +443,7 @@ mod tests {
             &memory_allocator,
             BufferAllocateInfo {
                 buffer_usage: BufferUsage::UNIFORM_TEXEL_BUFFER,
-                memory_usage: MemoryUsage::GpuOnly,
+                memory_usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             },
             128,
@@ -469,7 +469,7 @@ mod tests {
             &memory_allocator,
             BufferAllocateInfo {
                 buffer_usage: BufferUsage::STORAGE_TEXEL_BUFFER,
-                memory_usage: MemoryUsage::GpuOnly,
+                memory_usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             },
             128,
@@ -495,7 +495,7 @@ mod tests {
             &memory_allocator,
             BufferAllocateInfo {
                 buffer_usage: BufferUsage::STORAGE_TEXEL_BUFFER,
-                memory_usage: MemoryUsage::GpuOnly,
+                memory_usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             },
             128,
@@ -521,7 +521,7 @@ mod tests {
             &memory_allocator,
             BufferAllocateInfo {
                 buffer_usage: BufferUsage::TRANSFER_DST, // Dummy value
-                memory_usage: MemoryUsage::GpuOnly,
+                memory_usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             },
             128,
@@ -549,7 +549,7 @@ mod tests {
             &memory_allocator,
             BufferAllocateInfo {
                 buffer_usage: BufferUsage::UNIFORM_TEXEL_BUFFER | BufferUsage::STORAGE_TEXEL_BUFFER,
-                memory_usage: MemoryUsage::GpuOnly,
+                memory_usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             },
             128,

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -419,7 +419,7 @@ impl AttachmentImage {
         let create_info = AllocationCreateInfo {
             requirements,
             allocation_type: AllocationType::NonLinear,
-            usage: MemoryUsage::GpuOnly,
+            usage: MemoryUsage::DeviceOnly,
             allocate_preference: MemoryAllocatePreference::Unknown,
             dedicated_allocation: Some(DedicatedAllocation::Image(&raw_image)),
             ..Default::default()
@@ -520,7 +520,10 @@ impl AttachmentImage {
         )?;
         let requirements = raw_image.memory_requirements()[0];
         let memory_type_index = allocator
-            .find_memory_type_index(requirements.memory_type_bits, MemoryUsage::GpuOnly.into())
+            .find_memory_type_index(
+                requirements.memory_type_bits,
+                MemoryUsage::DeviceOnly.into(),
+            )
             .expect("failed to find a suitable memory type");
 
         match unsafe {

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -141,7 +141,7 @@ impl ImmutableImage {
         let create_info = AllocationCreateInfo {
             requirements,
             allocation_type: AllocationType::NonLinear,
-            usage: MemoryUsage::GpuOnly,
+            usage: MemoryUsage::DeviceOnly,
             allocate_preference: MemoryAllocatePreference::Unknown,
             dedicated_allocation: Some(DedicatedAllocation::Image(&raw_image)),
             ..Default::default()

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -128,7 +128,7 @@ impl StorageImage {
         let create_info = AllocationCreateInfo {
             requirements,
             allocation_type: AllocationType::NonLinear,
-            usage: MemoryUsage::GpuOnly,
+            usage: MemoryUsage::DeviceOnly,
             allocate_preference: MemoryAllocatePreference::Unknown,
             dedicated_allocation: Some(DedicatedAllocation::Image(&raw_image)),
             ..Default::default()
@@ -204,7 +204,10 @@ impl StorageImage {
         )?;
         let requirements = raw_image.memory_requirements()[0];
         let memory_type_index = allocator
-            .find_memory_type_index(requirements.memory_type_bits, MemoryUsage::GpuOnly.into())
+            .find_memory_type_index(
+                requirements.memory_type_bits,
+                MemoryUsage::DeviceOnly.into(),
+            )
             .expect("failed to find a suitable memory type");
 
         match unsafe {
@@ -322,7 +325,10 @@ impl StorageImage {
 
         let requirements = image.memory_requirements()[0];
         let memory_type_index = allocator
-            .find_memory_type_index(requirements.memory_type_bits, MemoryUsage::GpuOnly.into())
+            .find_memory_type_index(
+                requirements.memory_type_bits,
+                MemoryUsage::DeviceOnly.into(),
+            )
             .expect("failed to find a suitable memory type");
 
         assert!(device.enabled_extensions().khr_external_memory_fd);

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -763,6 +763,7 @@ impl From<AllocationCreateInfo<'_>> for SuballocationCreateInfo {
 /// [suballocator]: Suballocator
 /// [buffer-image granularity]: super#buffer-image-granularity
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum AllocationType {
     /// The type of resource is unknown, it might be either linear or non-linear. What this means is
     /// that allocations created with this type must always be aligned to the buffer-image


### PR DESCRIPTION
Renamed `MemoryUsage::GpuOnly` to `MemoryUsage::DeviceOnly`, so that it uses the correct terminology before people start using it in 0.33. Also marked `MemoryUsage`, `MemoryAllocatePreference` and `AllocationType` as non-exhaustive, which I had forgotten. These are all technically breaking changes, but the user was not exposed to any of these APIs until now.

Changelog:
```markdown
### Breaking changes
- Renamed `MemoryUsage::GpuOnly` to `MemoryUsage::DeviceOnly`.
- Marked `MemoryUsage`, `MemoryAllocatePreference` and `AllocationType` as non-exhaustive.
```