### PR TITLE
Fix bytemuck dependency

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -21,7 +21,7 @@ ahash = "0.8"
 # When updating Ash, also update vk.xml to the same Vulkan patch version that Ash uses.
 # All versions of vk.xml can be found at https://github.com/KhronosGroup/Vulkan-Headers/commits/main/registry/vk.xml.
 ash = "^0.37.2"
-bytemuck = "1.7"
+bytemuck = "1.9"
 crossbeam-queue = "0.3"
 half = { version = "2", features = ["bytemuck"] }
 libloading = "0.7"


### PR DESCRIPTION
#2132 replaced uses of `bytemuck::Pod` with `bytemuck::AnyBitPattern`, but I had forgotten to update the bytemuck dependency. That trait was added in v1.9.

Changelog:
```markdown
### Public dependency updates
- bytemuck 1.9
```