### PR TITLE
Refactor `AllocationCreateInfo`

### DIFF
--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -14,7 +14,7 @@
 // GPU", or *GPGPU*. This is what this example demonstrates.
 
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
@@ -26,7 +26,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
     VulkanLibrary,
@@ -154,8 +154,12 @@ fn main() {
     // We start by creating the buffer that will store the data.
     let data_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::STORAGE_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::STORAGE_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         // Iterator that produces the data.

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder,
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
@@ -19,7 +19,7 @@ use vulkano::{
     },
     device::Queue,
     image::ImageViewAbstract,
-    memory::allocator::MemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -68,8 +68,12 @@ impl AmbientLightingSystem {
         ];
         let vertex_buffer = Buffer::from_iter(
             memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::VERTEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -10,7 +10,7 @@
 use cgmath::Vector3;
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder,
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
@@ -20,7 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::ImageViewAbstract,
-    memory::allocator::MemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -70,8 +70,12 @@ impl DirectionalLightingSystem {
         let vertex_buffer = {
             Buffer::from_iter(
                 memory_allocator,
-                BufferAllocateInfo {
-                    buffer_usage: BufferUsage::VERTEX_BUFFER,
+                BufferCreateInfo {
+                    usage: BufferUsage::VERTEX_BUFFER,
+                    ..Default::default()
+                },
+                AllocationCreateInfo {
+                    usage: MemoryUsage::Upload,
                     ..Default::default()
                 },
                 vertices,

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -10,7 +10,7 @@
 use cgmath::{Matrix4, Vector3};
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder,
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
@@ -20,7 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::ImageViewAbstract,
-    memory::allocator::MemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -68,8 +68,12 @@ impl PointLightingSystem {
         ];
         let vertex_buffer = Buffer::from_iter(
             memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::VERTEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -9,13 +9,13 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder,
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
     },
     device::Queue,
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             depth_stencil::DepthStencilState,
@@ -57,8 +57,12 @@ impl TriangleDrawSystem {
         ];
         let vertex_buffer = Buffer::from_iter(
             memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::VERTEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -15,7 +15,7 @@
 
 use std::{iter::repeat, mem::size_of};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
@@ -28,7 +28,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
     DeviceSize, VulkanLibrary,
@@ -167,8 +167,12 @@ fn main() {
 
     let input_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::UNIFORM_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::UNIFORM_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         aligned_data,
@@ -177,8 +181,12 @@ fn main() {
 
     let output_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::STORAGE_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::STORAGE_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         (0..12).map(|_| 0u32),

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -15,7 +15,7 @@
 
 use std::{fs::File, io::BufWriter, path::Path};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         CopyImageToBufferInfo,
@@ -30,7 +30,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, ImageDimensions, StorageImage},
     instance::{Instance, InstanceCreateInfo, InstanceExtensions},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
     VulkanLibrary,
@@ -220,8 +220,12 @@ fn main() {
 
     let buf = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::TRANSFER_DST,
+        BufferCreateInfo {
+            usage: BufferUsage::TRANSFER_DST,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         (0..1024 * 1024 * 4).map(|_| 0u8),

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -14,7 +14,7 @@ mod linux {
         time::Instant,
     };
     use vulkano::{
-        buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage, Subbuffer},
+        buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
         command_buffer::{
             allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder,
             CommandBufferUsage, RenderPassBeginInfo, SemaphoreSubmitInfo, SubmitInfo,
@@ -33,7 +33,7 @@ mod linux {
             debug::{DebugUtilsMessenger, DebugUtilsMessengerCreateInfo},
             Instance, InstanceCreateInfo, InstanceExtensions,
         },
-        memory::allocator::StandardMemoryAllocator,
+        memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
         pipeline::{
             graphics::{
                 color_blend::ColorBlendState,
@@ -570,8 +570,12 @@ mod linux {
         ];
         let vertex_buffer = Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::VERTEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -9,7 +9,7 @@
 
 use std::{io::Cursor, sync::Arc};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, BlitImageInfo,
         BufferImageCopy, ClearColorImageInfo, CommandBufferUsage, CopyBufferToImageInfo,
@@ -29,7 +29,7 @@ use vulkano::{
         SwapchainImage,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -182,8 +182,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,
@@ -245,8 +249,12 @@ fn main() {
 
         let buffer = Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::TRANSFER_SRC,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_SRC,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             image_data,

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -9,7 +9,7 @@
 
 use std::{io::Cursor, sync::Arc};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
@@ -27,7 +27,7 @@ use vulkano::{
         SwapchainImage,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -180,8 +180,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -18,7 +18,7 @@
 
 use std::{io::Cursor, sync::Arc};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
@@ -36,7 +36,7 @@ use vulkano::{
         SwapchainImage,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -186,8 +186,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         RenderPassBeginInfo, SubpassContents,
@@ -25,7 +25,7 @@ use vulkano::{
     },
     image::{view::ImageView, ImageAccess, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -186,8 +186,12 @@ fn main() {
     let vertex_buffer = {
         Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::VERTEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             vertices,
@@ -220,8 +224,12 @@ fn main() {
     };
     let instance_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         instances,

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -11,7 +11,7 @@ use cgmath::Vector2;
 use rand::Rng;
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         PrimaryCommandBufferAbstract,
@@ -21,7 +21,7 @@ use vulkano::{
     },
     device::Queue,
     image::ImageAccess,
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::GpuFuture,
 };
@@ -57,8 +57,12 @@ impl FractalComputePipeline {
         let palette_size = colors.len() as i32;
         let palette = Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::STORAGE_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::STORAGE_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             colors,
@@ -102,8 +106,12 @@ impl FractalComputePipeline {
         }
         self.palette = Buffer::from_iter(
             &self.memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::STORAGE_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::STORAGE_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             colors,

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder,
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
@@ -19,7 +19,7 @@ use vulkano::{
     },
     device::Queue,
     image::ImageViewAbstract,
-    memory::allocator::MemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -88,8 +88,12 @@ impl PixelsDrawPipeline {
         let (vertices, indices) = textured_quad(2.0, 2.0);
         let vertex_buffer = Buffer::from_iter(
             memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::VERTEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             vertices,
@@ -97,8 +101,12 @@ impl PixelsDrawPipeline {
         .unwrap();
         let index_buffer = Buffer::from_iter(
             memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::INDEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::INDEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             indices,

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -64,7 +64,7 @@
 
 use std::{fs::File, io::BufWriter, path::Path};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         CopyImageToBufferInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
@@ -76,7 +76,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, AttachmentImage, ImageDimensions, SampleCount, StorageImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             multisample::MultisampleState,
@@ -286,8 +286,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,
@@ -318,8 +322,12 @@ fn main() {
 
     let buf = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::TRANSFER_DST,
+        BufferCreateInfo {
+            usage: BufferUsage::TRANSFER_DST,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         (0..1024 * 1024 * 4).map(|_| 0u8),

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -18,7 +18,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         RenderPassBeginInfo, SubpassContents,
@@ -29,7 +29,7 @@ use vulkano::{
     },
     image::{view::ImageView, ImageAccess, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -199,8 +199,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -12,7 +12,7 @@ use cgmath::Vector2;
 use rand::Rng;
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         PrimaryAutoCommandBuffer,
@@ -23,7 +23,7 @@ use vulkano::{
     device::Queue,
     format::Format,
     image::{ImageAccess, ImageUsage, StorageImage},
-    memory::allocator::MemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::GpuFuture,
 };
@@ -46,8 +46,12 @@ pub struct GameOfLifeComputePipeline {
 fn rand_grid(memory_allocator: &impl MemoryAllocator, size: [u32; 2]) -> Subbuffer<[u32]> {
     Buffer::from_iter(
         memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::STORAGE_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::STORAGE_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         (0..(size[0] * size[1]))

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -10,7 +10,7 @@
 use crate::app::App;
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder,
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
@@ -20,6 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::ImageViewAbstract,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -83,8 +84,12 @@ impl PixelsDrawPipeline {
         let memory_allocator = app.context.memory_allocator();
         let vertex_buffer = Buffer::from_iter(
             memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::VERTEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             vertices,
@@ -92,8 +97,12 @@ impl PixelsDrawPipeline {
         .unwrap();
         let index_buffer = Buffer::from_iter(
             memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::INDEX_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::INDEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             indices,

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -14,7 +14,7 @@
 
 use std::{fs::File, io::BufWriter, path::Path};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, BufferImageCopy,
         CommandBufferUsage, CopyImageToBufferInfo, RenderPassBeginInfo, SubpassContents,
@@ -29,7 +29,7 @@ use vulkano::{
         ImageSubresourceLayers, ImageUsage, SampleCount, StorageImage,
     },
     instance::{Instance, InstanceCreateInfo, InstanceExtensions},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -166,8 +166,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,
@@ -278,8 +282,12 @@ fn main() {
     let create_buffer = || {
         Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::TRANSFER_DST,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_DST,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             (0..image.dimensions().width() * image.dimensions().height() * 4).map(|_| 0u8),

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -13,7 +13,7 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         RenderPassBeginInfo, SubpassContents,
@@ -25,7 +25,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, AttachmentImage, ImageAccess, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             depth_stencil::DepthStencilState,
@@ -207,8 +207,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -13,7 +13,7 @@
 // outperform such memory-backed resource updates.
 
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
@@ -25,7 +25,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
     VulkanLibrary,
@@ -134,8 +134,12 @@ fn main() {
         let data_iter = 0..65536u32;
         Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::STORAGE_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::STORAGE_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             data_iter,

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -9,7 +9,7 @@
 
 use std::{io::Cursor, sync::Arc};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
@@ -25,7 +25,7 @@ use vulkano::{
         SwapchainImage,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -176,8 +176,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -23,7 +23,7 @@
 
 use std::{fs::File, io::Read, sync::Arc};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         RenderPassBeginInfo, SubpassContents,
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, ImageAccess, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -242,8 +242,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -9,7 +9,7 @@
 
 use std::{io::Cursor, sync::Arc};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
@@ -31,7 +31,7 @@ use vulkano::{
         SwapchainImage,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -243,8 +243,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -12,7 +12,7 @@
 // second half.
 
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, BufferCopy,
         CommandBufferUsage, CopyBufferInfoTyped,
@@ -25,7 +25,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
     VulkanLibrary,
@@ -126,10 +126,14 @@ fn main() {
 
     let data_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::STORAGE_BUFFER
+        BufferCreateInfo {
+            usage: BufferUsage::STORAGE_BUFFER
                 | BufferUsage::TRANSFER_SRC
                 | BufferUsage::TRANSFER_DST,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         // We intitialize half of the array and leave the other half at 0, we will use the copy

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -12,7 +12,7 @@
 // the boilerplate is explained.
 
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
@@ -24,7 +24,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
     VulkanLibrary,
@@ -135,8 +135,12 @@ fn main() {
         let data_iter = 0..65536u32;
         Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::STORAGE_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::STORAGE_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             data_iter,

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -27,7 +27,7 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
@@ -39,7 +39,7 @@ use vulkano::{
         QueueCreateInfo, QueueFlags,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
     VulkanLibrary,
@@ -238,8 +238,12 @@ fn main() {
     // Prepare test array `[0, 1, 2, 3....]`.
     let data_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::STORAGE_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::STORAGE_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         0..65536u32,

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -14,7 +14,7 @@
 
 use std::{sync::Arc, time::SystemTime};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         CopyBufferInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
@@ -28,7 +28,7 @@ use vulkano::{
     },
     image::{view::ImageView, ImageUsage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::{MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::{InputAssemblyState, PrimitiveTopology},
@@ -349,11 +349,14 @@ fn main() {
         // Create a CPU-accessible buffer initialized with the vertex data.
         let temporary_accessible_buffer = Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
+            BufferCreateInfo {
                 // Specify this buffer will be used as a transfer source.
-                buffer_usage: BufferUsage::TRANSFER_SRC,
+                usage: BufferUsage::TRANSFER_SRC,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
                 // Specify this buffer will be used for uploading to the GPU.
-                memory_usage: MemoryUsage::Upload,
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             vertices,
@@ -364,13 +367,16 @@ fn main() {
         // `Vertex`.
         let device_local_buffer = Buffer::new_slice::<Vertex>(
             &memory_allocator,
-            BufferAllocateInfo {
+            BufferCreateInfo {
                 // Specify use as a storage buffer, vertex buffer, and transfer destination.
-                buffer_usage: BufferUsage::STORAGE_BUFFER
+                usage: BufferUsage::STORAGE_BUFFER
                     | BufferUsage::TRANSFER_DST
                     | BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
                 // Specify this buffer will only be used by the device.
-                memory_usage: MemoryUsage::DeviceOnly,
+                usage: MemoryUsage::DeviceOnly,
                 ..Default::default()
             },
             PARTICLE_COUNT as vulkano::DeviceSize,

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -10,7 +10,7 @@
 // TODO: Give a paragraph about what specialization are and what problems they solve.
 
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+    buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
@@ -22,7 +22,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
     sync::{self, GpuFuture},
     VulkanLibrary,
@@ -135,8 +135,12 @@ fn main() {
         let data_iter = 0..65536u32;
         Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::STORAGE_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::STORAGE_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             data_iter,

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -13,7 +13,7 @@ use std::{sync::Arc, time::Instant};
 use vulkano::{
     buffer::{
         allocator::{SubbufferAllocator, SubbufferAllocatorCreateInfo},
-        Buffer, BufferAllocateInfo, BufferUsage,
+        Buffer, BufferCreateInfo, BufferUsage,
     },
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
@@ -29,7 +29,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, AttachmentImage, ImageAccess, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             depth_stencil::DepthStencilState,
@@ -162,8 +162,12 @@ fn main() {
 
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         POSITIONS,
@@ -171,8 +175,12 @@ fn main() {
     .unwrap();
     let normals_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         NORMALS,
@@ -180,8 +188,12 @@ fn main() {
     .unwrap();
     let index_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::INDEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::INDEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         INDICES,

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -23,7 +23,7 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         RenderPassBeginInfo, SubpassContents,
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, ImageAccess, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::{InputAssemblyState, PrimitiveTopology},
@@ -303,8 +303,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -9,7 +9,7 @@
 
 use std::{io::Cursor, sync::Arc};
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
@@ -27,7 +27,7 @@ use vulkano::{
         SwapchainImage,
     },
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -182,8 +182,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -23,7 +23,7 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         RenderingAttachmentInfo, RenderingInfo,
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, ImageAccess, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -313,8 +313,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -18,7 +18,7 @@
 
 use std::sync::Arc;
 use vulkano::{
-    buffer::{Buffer, BufferAllocateInfo, BufferContents, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         RenderPassBeginInfo, SubpassContents,
@@ -29,7 +29,7 @@ use vulkano::{
     },
     image::{view::ImageView, ImageAccess, ImageUsage, SwapchainImage},
     instance::{Instance, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             input_assembly::InputAssemblyState,
@@ -282,8 +282,12 @@ fn main() {
     ];
     let vertex_buffer = Buffer::from_iter(
         &memory_allocator,
-        BufferAllocateInfo {
-            buffer_usage: BufferUsage::VERTEX_BUFFER,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            usage: MemoryUsage::Upload,
             ..Default::default()
         },
         vertices,

--- a/vulkano/src/buffer/allocator.rs
+++ b/vulkano/src/buffer/allocator.rs
@@ -9,14 +9,16 @@
 
 //! Efficiently suballocates buffers into smaller subbuffers.
 
-use super::{Buffer, BufferContents, BufferError, BufferMemory, BufferUsage, Subbuffer};
+use super::{
+    sys::BufferCreateInfo, Buffer, BufferContents, BufferError, BufferMemory, BufferUsage,
+    Subbuffer,
+};
 use crate::{
-    buffer::BufferAllocateInfo,
     device::{Device, DeviceOwned},
     memory::{
         allocator::{
-            align_up, AllocationCreationError, DeviceLayout, MemoryAllocator, MemoryUsage,
-            StandardMemoryAllocator,
+            align_up, AllocationCreateInfo, AllocationCreationError, DeviceLayout, MemoryAllocator,
+            MemoryUsage, StandardMemoryAllocator,
         },
         DeviceAlignment,
     },
@@ -353,9 +355,12 @@ where
     fn create_arena(&self) -> Result<Arc<Buffer>, AllocationCreationError> {
         Buffer::new(
             &self.memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: self.buffer_usage,
-                memory_usage: self.memory_usage,
+            BufferCreateInfo {
+                usage: self.buffer_usage,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: self.memory_usage,
                 ..Default::default()
             },
             DeviceLayout::from_size_alignment(self.arena_size, 1).unwrap(),

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -420,7 +420,7 @@ impl Buffer {
         // TODO: Enable once sparse binding materializes
         // assert!(!allocate_info.flags.contains(BufferCreateFlags::SPARSE_BINDING));
 
-        debug_assert!(
+        assert!(
             buffer_info.size == 0,
             "`Buffer::new*` functions set the `buffer_info.size` field themselves, you should not \
             set it yourself",

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -95,16 +95,20 @@
 //!
 //! [`RawBuffer`]: self::sys::RawBuffer
 //! [`SubbufferAllocator`]: self::allocator::SubbufferAllocator
+//! [`MemoryUsage::DeviceOnly`]: crate::memory::allocator::MemoryUsage::DeviceOnly
+//! [`MemoryUsage::Upload`]: crate::memory::allocator::MemoryUsage::Upload
+//! [`MemoryUsage::Download`]: crate::memory::allocator::MemoryUsage::Download
 //! [the `view` module]: self::view
 //! [the `shader` module documentation]: crate::shader
 
 pub use self::{
     subbuffer::{BufferContents, BufferContentsLayout, Subbuffer},
+    sys::BufferCreateInfo,
     usage::BufferUsage,
 };
 use self::{
     subbuffer::{ReadLockError, WriteLockError},
-    sys::{BufferCreateInfo, RawBuffer},
+    sys::RawBuffer,
 };
 use crate::{
     device::{Device, DeviceOwned},
@@ -112,7 +116,7 @@ use crate::{
     memory::{
         allocator::{
             AllocationCreateInfo, AllocationCreationError, AllocationType, DeviceLayout,
-            MemoryAlloc, MemoryAllocatePreference, MemoryAllocator, MemoryUsage,
+            MemoryAlloc, MemoryAllocator,
         },
         is_aligned, DedicatedAllocation, DeviceAlignment, ExternalMemoryHandleType,
         ExternalMemoryHandleTypes, ExternalMemoryProperties, MemoryRequirements,
@@ -157,12 +161,12 @@ pub mod view;
 ///
 /// ```
 /// use vulkano::{
-///     buffer::{BufferUsage, Buffer, BufferAllocateInfo},
+///     buffer::{BufferUsage, Buffer, BufferCreateInfo},
 ///     command_buffer::{
 ///         AutoCommandBufferBuilder, CommandBufferUsage, CopyBufferInfo,
 ///         PrimaryCommandBufferAbstract,
 ///     },
-///     memory::allocator::MemoryUsage,
+///     memory::allocator::{AllocationCreateInfo, MemoryUsage},
 ///     sync::GpuFuture,
 ///     DeviceSize,
 /// };
@@ -177,11 +181,14 @@ pub mod view;
 /// // Create a host-accessible buffer initialized with the data.
 /// let temporary_accessible_buffer = Buffer::from_iter(
 ///     &memory_allocator,
-///     BufferAllocateInfo {
+///     BufferCreateInfo {
 ///         // Specify that this buffer will be used as a transfer source.
-///         buffer_usage: BufferUsage::TRANSFER_SRC,
+///         usage: BufferUsage::TRANSFER_SRC,
+///         ..Default::default()
+///     },
+///     AllocationCreateInfo {
 ///         // Specify use for upload to the device.
-///         memory_usage: MemoryUsage::Upload,
+///         usage: MemoryUsage::Upload,
 ///         ..Default::default()
 ///     },
 ///     data,
@@ -191,11 +198,14 @@ pub mod view;
 /// // Create a buffer in device-local with enough space for a slice of `10_000` floats.
 /// let device_local_buffer = Buffer::new_slice::<f32>(
 ///     &memory_allocator,
-///     BufferAllocateInfo {
+///     BufferCreateInfo {
 ///         // Specify use as a storage buffer and transfer destination.
-///         buffer_usage: BufferUsage::STORAGE_BUFFER | BufferUsage::TRANSFER_DST,
+///         usage: BufferUsage::STORAGE_BUFFER | BufferUsage::TRANSFER_DST,
+///         ..Default::default()
+///     },
+///     AllocationCreateInfo {
 ///         // Specify use by the device only.
-///         memory_usage: MemoryUsage::DeviceOnly,
+///         usage: MemoryUsage::DeviceOnly,
 ///         ..Default::default()
 ///     },
 ///     10_000 as DeviceSize,
@@ -255,19 +265,23 @@ impl Buffer {
     /// buffer allocated in device-local memory, you will need to create a staging buffer and copy
     /// the contents over.
     ///
+    /// > **Note**: You should **not** set the `buffer_info.size` field. The function does that
+    /// > itself.
+    ///
     /// # Panics
     ///
     /// - Panics if `T` has zero size.
     /// - Panics if `T` has an alignment greater than `64`.
     pub fn from_data<T>(
         allocator: &(impl MemoryAllocator + ?Sized),
-        allocate_info: BufferAllocateInfo,
+        buffer_info: BufferCreateInfo,
+        allocation_info: AllocationCreateInfo,
         data: T,
     ) -> Result<Subbuffer<T>, BufferError>
     where
         T: BufferContents,
     {
-        let buffer = Buffer::new_sized(allocator, allocate_info)?;
+        let buffer = Buffer::new_sized(allocator, buffer_info, allocation_info)?;
 
         unsafe { ptr::write(&mut *buffer.write()?, data) };
 
@@ -281,12 +295,16 @@ impl Buffer {
     /// buffer allocated in device-local memory, you will need to create a staging buffer and copy
     /// the contents over.
     ///
+    /// > **Note**: You should **not** set the `buffer_info.size` field. The function does that
+    /// > itself.
+    ///
     /// # Panics
     ///
     /// - Panics if `iter` is empty.
     pub fn from_iter<T, I>(
         allocator: &(impl MemoryAllocator + ?Sized),
-        allocate_info: BufferAllocateInfo,
+        buffer_info: BufferCreateInfo,
+        allocation_info: AllocationCreateInfo,
         iter: I,
     ) -> Result<Subbuffer<[T]>, BufferError>
     where
@@ -295,7 +313,12 @@ impl Buffer {
         I::IntoIter: ExactSizeIterator,
     {
         let iter = iter.into_iter();
-        let buffer = Buffer::new_slice(allocator, allocate_info, iter.len().try_into().unwrap())?;
+        let buffer = Buffer::new_slice(
+            allocator,
+            buffer_info,
+            allocation_info,
+            iter.len().try_into().unwrap(),
+        )?;
 
         for (o, i) in buffer.write()?.iter_mut().zip(iter) {
             unsafe { ptr::write(o, i) };
@@ -306,15 +329,24 @@ impl Buffer {
 
     /// Creates a new uninitialized `Buffer` for sized data. Returns a [`Subbuffer`] spanning the
     /// whole buffer.
+    ///
+    /// > **Note**: You should **not** set the `buffer_info.size` field. The function does that
+    /// > itself.
     pub fn new_sized<T>(
         allocator: &(impl MemoryAllocator + ?Sized),
-        allocate_info: BufferAllocateInfo,
+        buffer_info: BufferCreateInfo,
+        allocation_info: AllocationCreateInfo,
     ) -> Result<Subbuffer<T>, BufferError>
     where
         T: BufferContents,
     {
         let layout = T::LAYOUT.unwrap_sized();
-        let buffer = Subbuffer::new(Buffer::new(allocator, allocate_info, layout)?);
+        let buffer = Subbuffer::new(Buffer::new(
+            allocator,
+            buffer_info,
+            allocation_info,
+            layout,
+        )?);
 
         Ok(unsafe { buffer.reinterpret_unchecked() })
     }
@@ -322,29 +354,37 @@ impl Buffer {
     /// Creates a new uninitialized `Buffer` for a slice. Returns a [`Subbuffer`] spanning the
     /// whole buffer.
     ///
+    /// > **Note**: You should **not** set the `buffer_info.size` field. The function does that
+    /// > itself.
+    ///
     /// # Panics
     ///
     /// - Panics if `len` is zero.
     pub fn new_slice<T>(
         allocator: &(impl MemoryAllocator + ?Sized),
-        allocate_info: BufferAllocateInfo,
+        buffer_info: BufferCreateInfo,
+        allocation_info: AllocationCreateInfo,
         len: DeviceSize,
     ) -> Result<Subbuffer<[T]>, BufferError>
     where
         T: BufferContents,
     {
-        Buffer::new_unsized(allocator, allocate_info, len)
+        Buffer::new_unsized(allocator, buffer_info, allocation_info, len)
     }
 
     /// Creates a new uninitialized `Buffer` for unsized data. Returns a [`Subbuffer`] spanning the
     /// whole buffer.
+    ///
+    /// > **Note**: You should **not** set the `buffer_info.size` field. The function does that
+    /// > itself.
     ///
     /// # Panics
     ///
     /// - Panics if `len` is zero.
     pub fn new_unsized<T>(
         allocator: &(impl MemoryAllocator + ?Sized),
-        allocate_info: BufferAllocateInfo,
+        buffer_info: BufferCreateInfo,
+        allocation_info: AllocationCreateInfo,
         len: DeviceSize,
     ) -> Result<Subbuffer<T>, BufferError>
     where
@@ -352,48 +392,54 @@ impl Buffer {
     {
         let len = NonZeroDeviceSize::new(len).expect("empty slices are not valid buffer contents");
         let layout = T::LAYOUT.layout_for_len(len).unwrap();
-        let buffer = Subbuffer::new(Buffer::new(allocator, allocate_info, layout)?);
+        let buffer = Subbuffer::new(Buffer::new(
+            allocator,
+            buffer_info,
+            allocation_info,
+            layout,
+        )?);
 
         Ok(unsafe { buffer.reinterpret_unchecked() })
     }
 
     /// Creates a new uninitialized `Buffer` with the given `layout`.
     ///
+    /// > **Note**: You should **not** set the `buffer_info.size` field. The function does that
+    /// > itself.
+    ///
     /// # Panics
     ///
     /// - Panics if `layout.alignment()` is greater than 64.
     pub fn new(
         allocator: &(impl MemoryAllocator + ?Sized),
-        allocate_info: BufferAllocateInfo,
+        mut buffer_info: BufferCreateInfo,
+        allocation_info: AllocationCreateInfo,
         layout: DeviceLayout,
     ) -> Result<Arc<Self>, BufferError> {
         assert!(layout.alignment().as_devicesize() <= 64);
         // TODO: Enable once sparse binding materializes
         // assert!(!allocate_info.flags.contains(BufferCreateFlags::SPARSE_BINDING));
 
-        let raw_buffer = RawBuffer::new(
-            allocator.device().clone(),
-            BufferCreateInfo {
-                flags: allocate_info.flags,
-                sharing: allocate_info.sharing,
-                size: layout.size(),
-                usage: allocate_info.buffer_usage,
-                external_memory_handle_types: allocate_info.external_memory_handle_types,
-                _ne: crate::NonExhaustive(()),
-            },
-        )?;
+        debug_assert!(
+            buffer_info.size == 0,
+            "`Buffer::new*` functions set the `buffer_info.size` field themselves, you should not \
+            set it yourself",
+        );
+
+        buffer_info.size = layout.size();
+
+        let raw_buffer = RawBuffer::new(allocator.device().clone(), buffer_info)?;
         let mut requirements = *raw_buffer.memory_requirements();
         requirements.layout = requirements.layout.align_to(layout.alignment()).unwrap();
-        let create_info = AllocationCreateInfo {
-            requirements,
-            allocation_type: AllocationType::Linear,
-            usage: allocate_info.memory_usage,
-            dedicated_allocation: Some(DedicatedAllocation::Buffer(&raw_buffer)),
-            allocate_preference: allocate_info.allocate_preference,
-            _ne: crate::NonExhaustive(()),
-        };
 
-        let mut allocation = unsafe { allocator.allocate_unchecked(create_info) }?;
+        let mut allocation = unsafe {
+            allocator.allocate_unchecked(
+                requirements,
+                AllocationType::Linear,
+                allocation_info,
+                Some(DedicatedAllocation::Buffer(&raw_buffer)),
+            )
+        }?;
         debug_assert!(is_aligned(
             allocation.offset(),
             requirements.layout.alignment(),
@@ -532,67 +578,6 @@ impl Eq for Buffer {}
 impl Hash for Buffer {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner.hash(state);
-    }
-}
-
-/// Parameters to create a new [`RawBuffer`] and allocate and bind memory to it.
-#[derive(Clone, Debug)]
-pub struct BufferAllocateInfo {
-    /// Flags to enable.
-    ///
-    /// The default value is [`BufferCreateFlags::empty()`].
-    pub flags: BufferCreateFlags,
-
-    /// Whether the buffer can be shared across multiple queues, or is limited to a single queue.
-    ///
-    /// The default value is [`Sharing::Exclusive`].
-    pub sharing: Sharing<SmallVec<[u32; 4]>>,
-
-    /// How the buffer is going to be used.
-    ///
-    /// The default value is [`BufferUsage::empty()`], which must be overridden.
-    pub buffer_usage: BufferUsage,
-
-    /// The external memory handle types that are going to be used with the buffer.
-    ///
-    /// If this value is not empty, then the device API version must be at least 1.1, or the
-    /// [`khr_external_memory`] extension must be enabled on the device.
-    ///
-    /// The default value is [`ExternalMemoryHandleTypes::empty()`].
-    ///
-    /// [`khr_external_memory`]: crate::device::DeviceExtensions::khr_external_memory
-    pub external_memory_handle_types: ExternalMemoryHandleTypes,
-
-    /// The memory usage to use for the allocation.
-    ///
-    /// If this is set to [`MemoryUsage::DeviceOnly`], then the buffer may need to be initialized
-    /// using a staging buffer. The exception is some integrated GPUs and laptop GPUs, which do not
-    /// have memory types that are not host-visible. With [`MemoryUsage::Upload`] and
-    /// [`MemoryUsage::Download`], a staging buffer is never needed.
-    ///
-    /// The default value is [`MemoryUsage::Upload`].
-    pub memory_usage: MemoryUsage,
-
-    /// The memory allocate preference to use for the allocation.
-    ///
-    /// The default value is [`MemoryAllocatePreference::Unknown`].
-    pub allocate_preference: MemoryAllocatePreference,
-
-    pub _ne: crate::NonExhaustive,
-}
-
-impl Default for BufferAllocateInfo {
-    #[inline]
-    fn default() -> Self {
-        BufferAllocateInfo {
-            flags: BufferCreateFlags::empty(),
-            sharing: Sharing::Exclusive,
-            buffer_usage: BufferUsage::empty(),
-            external_memory_handle_types: ExternalMemoryHandleTypes::empty(),
-            memory_usage: MemoryUsage::Upload,
-            allocate_preference: MemoryAllocatePreference::Unknown,
-            _ne: crate::NonExhaustive(()),
-        }
     }
 }
 

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -1138,7 +1138,7 @@ mod tests {
     use crate::{
         buffer::{
             sys::{BufferCreateInfo, RawBuffer},
-            BufferAllocateInfo, BufferUsage,
+            BufferUsage,
         },
         memory::{
             allocator::{
@@ -1218,8 +1218,12 @@ mod tests {
 
         let buffer = Buffer::new_slice::<u32>(
             &allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::TRANSFER_SRC,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_SRC,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             6,
@@ -1271,24 +1275,24 @@ mod tests {
 
         // Allocate some junk in the same block as the buffer.
         let _junk = allocator
-            .allocate(AllocationCreateInfo {
-                requirements: MemoryRequirements {
+            .allocate(
+                MemoryRequirements {
                     layout: DeviceLayout::from_size_alignment(17, 1).unwrap(),
                     ..requirements
                 },
-                allocation_type: AllocationType::Linear,
-                usage: MemoryUsage::DeviceOnly,
-                ..Default::default()
-            })
+                AllocationType::Linear,
+                AllocationCreateInfo::default(),
+                None,
+            )
             .unwrap();
 
         let allocation = allocator
-            .allocate(AllocationCreateInfo {
+            .allocate(
                 requirements,
-                allocation_type: AllocationType::Linear,
-                usage: MemoryUsage::DeviceOnly,
-                ..Default::default()
-            })
+                AllocationType::Linear,
+                AllocationCreateInfo::default(),
+                None,
+            )
             .unwrap();
 
         let buffer = Buffer::from_raw(raw_buffer, BufferMemory::Normal(allocation));

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -19,18 +19,20 @@
 //!
 //! ```
 //! # use std::sync::Arc;
-//! use vulkano::buffer::{Buffer, BufferAllocateInfo, BufferUsage};
+//! use vulkano::buffer::{Buffer, BufferCreateInfo, BufferUsage};
 //! use vulkano::buffer::view::{BufferView, BufferViewCreateInfo};
 //! use vulkano::format::Format;
+//! use vulkano::memory::allocator::AllocationCreateInfo;
 //!
 //! # let queue: Arc<vulkano::device::Queue> = return;
 //! # let memory_allocator: vulkano::memory::allocator::StandardMemoryAllocator = return;
 //! let buffer = Buffer::new_slice::<u32>(
 //!     &memory_allocator,
-//!     BufferAllocateInfo {
-//!         buffer_usage: BufferUsage::STORAGE_TEXEL_BUFFER,
+//!     BufferCreateInfo {
+//!         usage: BufferUsage::STORAGE_TEXEL_BUFFER,
 //!         ..Default::default()
 //!     },
+//!     AllocationCreateInfo::default(),
 //!     128,
 //! )
 //! .unwrap();
@@ -428,9 +430,9 @@ impl From<RequirementNotMet> for BufferViewCreationError {
 mod tests {
     use super::{BufferView, BufferViewCreateInfo, BufferViewCreationError};
     use crate::{
-        buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+        buffer::{Buffer, BufferCreateInfo, BufferUsage},
         format::Format,
-        memory::allocator::{MemoryUsage, StandardMemoryAllocator},
+        memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
     };
 
     #[test]
@@ -441,9 +443,12 @@ mod tests {
 
         let buffer = Buffer::new_slice::<[u8; 4]>(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::UNIFORM_TEXEL_BUFFER,
-                memory_usage: MemoryUsage::DeviceOnly,
+            BufferCreateInfo {
+                usage: BufferUsage::UNIFORM_TEXEL_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             128,
@@ -467,11 +472,11 @@ mod tests {
 
         let buffer = Buffer::new_slice::<[u8; 4]>(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::STORAGE_TEXEL_BUFFER,
-                memory_usage: MemoryUsage::DeviceOnly,
+            BufferCreateInfo {
+                usage: BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()
             },
+            AllocationCreateInfo::default(),
             128,
         )
         .unwrap();
@@ -493,11 +498,11 @@ mod tests {
 
         let buffer = Buffer::new_slice::<u32>(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::STORAGE_TEXEL_BUFFER,
-                memory_usage: MemoryUsage::DeviceOnly,
+            BufferCreateInfo {
+                usage: BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()
             },
+            AllocationCreateInfo::default(),
             128,
         )
         .unwrap();
@@ -519,11 +524,11 @@ mod tests {
 
         let buffer = Buffer::new_slice::<[u8; 4]>(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::TRANSFER_DST, // Dummy value
-                memory_usage: MemoryUsage::DeviceOnly,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_DST, // Dummy value
                 ..Default::default()
             },
+            AllocationCreateInfo::default(),
             128,
         )
         .unwrap();
@@ -547,11 +552,11 @@ mod tests {
 
         let buffer = Buffer::new_slice::<[f64; 4]>(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::UNIFORM_TEXEL_BUFFER | BufferUsage::STORAGE_TEXEL_BUFFER,
-                memory_usage: MemoryUsage::DeviceOnly,
+            BufferCreateInfo {
+                usage: BufferUsage::UNIFORM_TEXEL_BUFFER | BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()
             },
+            AllocationCreateInfo::default(),
             128,
         )
         .unwrap();

--- a/vulkano/src/command_buffer/auto.rs
+++ b/vulkano/src/command_buffer/auto.rs
@@ -863,13 +863,13 @@ enum SubmitState {
 mod tests {
     use super::*;
     use crate::{
-        buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+        buffer::{Buffer, BufferCreateInfo, BufferUsage},
         command_buffer::{
             synced::SyncCommandBufferBuilderError, BufferCopy, CopyBufferInfoTyped, CopyError,
             ExecuteCommandsError,
         },
         device::{DeviceCreateInfo, QueueCreateInfo},
-        memory::allocator::StandardMemoryAllocator,
+        memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
         sync::GpuFuture,
     };
 
@@ -899,8 +899,12 @@ mod tests {
 
         let source = Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::TRANSFER_SRC,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_SRC,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             [1_u32, 2].iter().copied(),
@@ -909,8 +913,12 @@ mod tests {
 
         let destination = Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::TRANSFER_DST,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_DST,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             [0_u32, 10, 20, 3, 4].iter().copied(),
@@ -1032,8 +1040,12 @@ mod tests {
         let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
         let source = Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::TRANSFER_SRC | BufferUsage::TRANSFER_DST,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_SRC | BufferUsage::TRANSFER_DST,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             [0_u32, 1, 2, 3].iter().copied(),
@@ -1082,8 +1094,12 @@ mod tests {
         let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
         let source = Buffer::from_iter(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::TRANSFER_SRC | BufferUsage::TRANSFER_DST,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_SRC | BufferUsage::TRANSFER_DST,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             [0_u32, 1, 2, 3].iter().copied(),

--- a/vulkano/src/command_buffer/synced/mod.rs
+++ b/vulkano/src/command_buffer/synced/mod.rs
@@ -173,7 +173,7 @@ impl Debug for dyn Command {
 mod tests {
     use super::*;
     use crate::{
-        buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+        buffer::{Buffer, BufferCreateInfo, BufferUsage},
         command_buffer::{
             allocator::{
                 CommandBufferAllocator, CommandBufferBuilderAlloc, StandardCommandBufferAllocator,
@@ -190,7 +190,7 @@ mod tests {
             },
             PersistentDescriptorSet, WriteDescriptorSet,
         },
-        memory::allocator::StandardMemoryAllocator,
+        memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
         pipeline::{layout::PipelineLayoutCreateInfo, PipelineBindPoint, PipelineLayout},
         sampler::{Sampler, SamplerCreateInfo},
         shader::ShaderStages,
@@ -239,8 +239,12 @@ mod tests {
             // Create a tiny test buffer
             let buffer = Buffer::from_data(
                 &memory_allocator,
-                BufferAllocateInfo {
-                    buffer_usage: BufferUsage::TRANSFER_DST,
+                BufferCreateInfo {
+                    usage: BufferUsage::TRANSFER_DST,
+                    ..Default::default()
+                },
+                AllocationCreateInfo {
+                    usage: MemoryUsage::Upload,
                     ..Default::default()
                 },
                 0u32,
@@ -351,8 +355,12 @@ mod tests {
             let memory_allocator = StandardMemoryAllocator::new_default(device);
             let buf = Buffer::from_data(
                 &memory_allocator,
-                BufferAllocateInfo {
-                    buffer_usage: BufferUsage::VERTEX_BUFFER,
+                BufferCreateInfo {
+                    usage: BufferUsage::VERTEX_BUFFER,
+                    ..Default::default()
+                },
+                AllocationCreateInfo {
+                    usage: MemoryUsage::Upload,
                     ..Default::default()
                 },
                 0u32,

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -416,25 +416,28 @@ impl AttachmentImage {
             },
         )?;
         let requirements = raw_image.memory_requirements()[0];
-        let create_info = AllocationCreateInfo {
-            requirements,
-            allocation_type: AllocationType::NonLinear,
-            usage: MemoryUsage::DeviceOnly,
-            allocate_preference: MemoryAllocatePreference::Unknown,
-            dedicated_allocation: Some(DedicatedAllocation::Image(&raw_image)),
-            ..Default::default()
+        let res = unsafe {
+            allocator.allocate_unchecked(
+                requirements,
+                AllocationType::NonLinear,
+                AllocationCreateInfo {
+                    usage: MemoryUsage::DeviceOnly,
+                    allocate_preference: MemoryAllocatePreference::Unknown,
+                    _ne: crate::NonExhaustive(()),
+                },
+                Some(DedicatedAllocation::Image(&raw_image)),
+            )
         };
 
-        match unsafe { allocator.allocate_unchecked(create_info) } {
+        match res {
             Ok(alloc) => {
                 debug_assert!(is_aligned(alloc.offset(), requirements.layout.alignment()));
                 debug_assert!(alloc.size() == requirements.layout.size());
 
-                let inner = Arc::new(unsafe {
-                    raw_image
-                        .bind_memory_unchecked([alloc])
-                        .map_err(|(err, _, _)| err)?
-                });
+                let inner = Arc::new(
+                    unsafe { raw_image.bind_memory_unchecked([alloc]) }
+                        .map_err(|(err, _, _)| err)?,
+                );
 
                 Ok(Arc::new(AttachmentImage {
                     inner,

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -15,8 +15,8 @@
 
 use self::host::SlotId;
 use super::{
-    align_down, align_up, array_vec::ArrayVec, AllocationCreateInfo, AllocationCreationError,
-    DeviceAlignment, DeviceLayout,
+    align_down, align_up, array_vec::ArrayVec, AllocationCreationError, DeviceAlignment,
+    DeviceLayout,
 };
 use crate::{
     device::{Device, DeviceOwned},
@@ -741,17 +741,6 @@ impl Default for SuballocationCreateInfo {
             )
             .unwrap(),
             allocation_type: AllocationType::Unknown,
-            _ne: crate::NonExhaustive(()),
-        }
-    }
-}
-
-impl From<AllocationCreateInfo<'_>> for SuballocationCreateInfo {
-    #[inline]
-    fn from(create_info: AllocationCreateInfo<'_>) -> Self {
-        SuballocationCreateInfo {
-            layout: create_info.requirements.layout,
-            allocation_type: create_info.allocation_type,
             _ne: crate::NonExhaustive(()),
         }
     }

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -397,14 +397,14 @@ impl From<VulkanError> for ComputePipelineCreationError {
 #[cfg(test)]
 mod tests {
     use crate::{
-        buffer::{Buffer, BufferAllocateInfo, BufferUsage},
+        buffer::{Buffer, BufferCreateInfo, BufferUsage},
         command_buffer::{
             allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         },
         descriptor_set::{
             allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,
         },
-        memory::allocator::StandardMemoryAllocator,
+        memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
         pipeline::{ComputePipeline, Pipeline, PipelineBindPoint},
         shader::{ShaderModule, SpecializationConstants, SpecializationMapEntry},
         sync::{now, GpuFuture},
@@ -490,8 +490,12 @@ mod tests {
         let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
         let data_buffer = Buffer::from_data(
             &memory_allocator,
-            BufferAllocateInfo {
-                buffer_usage: BufferUsage::STORAGE_BUFFER,
+            BufferCreateInfo {
+                usage: BufferUsage::STORAGE_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                usage: MemoryUsage::Upload,
                 ..Default::default()
             },
             0,


### PR DESCRIPTION
This refactors `AllocationCreateInfo` such that it can be used together with `BufferCreateInfo` and, in the future, `ImageCreateInfo`, to construct buffers and images, removing `BufferAllocateInfo`. Doing this before users start using this API in 0.33.

What is still unresolved is whether ignoring `BufferCreateInfo::size` when in these constructor functions is the right way.

Changelog:
Add:
```markdown
### Breaking changes
- `AllocationCreateInfo::{requirements, allocation_type, dedicated_allocation}` fields were removed.
- Added the parameters `requirements`, `allocation_type`, `dedicated_allocation` to `MemoryAllocator::allocate[_unchecked]`.
```