### PR TITLE
Require explicit `VertexInputState` creation

### DIFF
--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -35,7 +35,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -231,13 +231,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -26,7 +26,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -92,13 +92,16 @@ impl AmbientLightingSystem {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
+            let vertex_input_state = LightingVertex::per_vertex()
+                .definition(&vs.info().input_interface)
+                .unwrap();
 
             GraphicsPipeline::start()
                 .stages([
                     PipelineShaderStageCreateInfo::entry_point(vs),
                     PipelineShaderStageCreateInfo::entry_point(fs),
                 ])
-                .vertex_input_state(LightingVertex::per_vertex())
+                .vertex_input_state(vertex_input_state)
                 .input_assembly_state(InputAssemblyState::default())
                 .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
                 .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -27,7 +27,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -95,13 +95,16 @@ impl DirectionalLightingSystem {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
+            let vertex_input_state = LightingVertex::per_vertex()
+                .definition(&vs.info().input_interface)
+                .unwrap();
 
             GraphicsPipeline::start()
                 .stages([
                     PipelineShaderStageCreateInfo::entry_point(vs),
                     PipelineShaderStageCreateInfo::entry_point(fs),
                 ])
-                .vertex_input_state(LightingVertex::per_vertex())
+                .vertex_input_state(vertex_input_state)
                 .input_assembly_state(InputAssemblyState::default())
                 .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
                 .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -27,7 +27,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -92,13 +92,16 @@ impl PointLightingSystem {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
+            let vertex_input_state = LightingVertex::per_vertex()
+                .definition(&vs.info().input_interface)
+                .unwrap();
 
             GraphicsPipeline::start()
                 .stages([
                     PipelineShaderStageCreateInfo::entry_point(vs),
                     PipelineShaderStageCreateInfo::entry_point(fs),
                 ])
-                .vertex_input_state(LightingVertex::per_vertex())
+                .vertex_input_state(vertex_input_state)
                 .input_assembly_state(InputAssemblyState::default())
                 .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
                 .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -23,7 +23,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -82,13 +82,16 @@ impl TriangleDrawSystem {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
+            let vertex_input_state = TriangleVertex::per_vertex()
+                .definition(&vs.info().input_interface)
+                .unwrap();
 
             GraphicsPipeline::start()
                 .stages([
                     PipelineShaderStageCreateInfo::entry_point(vs),
                     PipelineShaderStageCreateInfo::entry_point(fs),
                 ])
-                .vertex_input_state(TriangleVertex::per_vertex())
+                .vertex_input_state(vertex_input_state)
                 .input_assembly_state(InputAssemblyState::default())
                 .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
                 .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -40,7 +40,7 @@ mod linux {
                 input_assembly::{InputAssemblyState, PrimitiveTopology},
                 multisample::MultisampleState,
                 rasterization::RasterizationState,
-                vertex_input::Vertex,
+                vertex_input::{Vertex, VertexDefinition},
                 viewport::{Scissor, Viewport, ViewportState},
             },
             GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -620,13 +620,16 @@ mod linux {
             .unwrap()
             .entry_point("main")
             .unwrap();
+        let vertex_input_state = MyVertex::per_vertex()
+            .definition(&vs.info().input_interface)
+            .unwrap();
         let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
         let pipeline = GraphicsPipeline::start()
             .stages([
                 PipelineShaderStageCreateInfo::entry_point(vs),
                 PipelineShaderStageCreateInfo::entry_point(fs),
             ])
-            .vertex_input_state(MyVertex::per_vertex())
+            .vertex_input_state(vertex_input_state)
             .input_assembly_state(
                 InputAssemblyState::new().topology(PrimitiveTopology::TriangleStrip),
             )

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -36,7 +36,7 @@ use vulkano::{
             input_assembly::{InputAssemblyState, PrimitiveTopology},
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -342,14 +342,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
-
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::new().topology(PrimitiveTopology::TriangleStrip))
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -34,7 +34,7 @@ use vulkano::{
             input_assembly::{InputAssemblyState, PrimitiveTopology},
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -268,13 +268,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::new().topology(PrimitiveTopology::TriangleStrip))
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -43,7 +43,7 @@ use vulkano::{
             input_assembly::{InputAssemblyState, PrimitiveTopology},
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -274,13 +274,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::new().topology(PrimitiveTopology::TriangleStrip))
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -49,7 +49,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         ComputePipeline, GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -311,13 +311,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let render_pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -32,7 +32,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -301,6 +301,9 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = [TriangleVertex::per_vertex(), InstanceData::per_instance()]
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
@@ -309,7 +312,7 @@ fn main() {
         ])
         // Use the implementations of the `Vertex` trait to describe to vulkano how the two vertex
         // types are expected to be used.
-        .vertex_input_state([TriangleVertex::per_vertex(), InstanceData::per_instance()])
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -26,7 +26,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -126,13 +126,16 @@ impl PixelsDrawPipeline {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
+            let vertex_input_state = TexturedVertex::per_vertex()
+                .definition(&vs.info().input_interface)
+                .unwrap();
 
             GraphicsPipeline::start()
                 .stages([
                     PipelineShaderStageCreateInfo::entry_point(vs),
                     PipelineShaderStageCreateInfo::entry_point(fs),
                 ])
-                .vertex_input_state(TexturedVertex::per_vertex())
+                .vertex_input_state(vertex_input_state)
                 .input_assembly_state(InputAssemblyState::default())
                 .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
                 .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -83,7 +83,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -307,13 +307,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass, 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -36,7 +36,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -270,13 +270,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -27,7 +27,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -122,13 +122,16 @@ impl PixelsDrawPipeline {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
+            let vertex_input_state = TexturedVertex::per_vertex()
+                .definition(&vs.info().input_interface)
+                .unwrap();
 
             GraphicsPipeline::start()
                 .stages([
                     PipelineShaderStageCreateInfo::entry_point(vs),
                     PipelineShaderStageCreateInfo::entry_point(fs),
                 ])
-                .vertex_input_state(TexturedVertex::per_vertex())
+                .vertex_input_state(vertex_input_state)
                 .input_assembly_state(InputAssemblyState::default())
                 .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
                 .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -36,7 +36,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -266,13 +266,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass, 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_fixed_scissor_irrelevant([
             Viewport {

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -33,7 +33,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -311,13 +311,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -32,7 +32,7 @@ use vulkano::{
             input_assembly::{InputAssemblyState, PrimitiveTopology},
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -263,13 +263,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::new().topology(PrimitiveTopology::TriangleStrip))
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -41,7 +41,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::{CullMode, FrontFace, RasterizationState},
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -201,13 +201,17 @@ fn main() {
         let module = unsafe { ShaderModule::from_bytes(device.clone(), &v).unwrap() };
         module.entry_point("main").unwrap()
     };
+
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let graphics_pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -38,7 +38,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         layout::PipelineLayoutCreateInfo,
@@ -396,13 +396,16 @@ fn main() {
         .unwrap()
     };
 
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -35,7 +35,7 @@ use vulkano::{
             input_assembly::{InputAssemblyState, PrimitiveTopology},
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, PipelineBindPoint,
@@ -455,13 +455,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass, 0).unwrap();
     let graphics_pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         // Vertices will be rendered as a list of points.
         .input_assembly_state(InputAssemblyState::new().topology(PrimitiveTopology::PointList))
         .viewport_state(ViewportState::viewport_fixed_scissor_irrelevant([viewport]))

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -37,7 +37,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -463,13 +463,16 @@ fn window_size_dependent_setup(
     // teapot example, we recreate the pipelines with a hardcoded viewport instead. This allows the
     // driver to optimize things, at the cost of slower window resizes.
     // https://computergraphics.stackexchange.com/questions/5742/vulkan-best-way-of-updating-pipeline-viewport
+    let vertex_input_state = [Position::per_vertex(), Normal::per_vertex()]
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass, 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state([Position::per_vertex(), Normal::per_vertex()])
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::default())
         .viewport_state(ViewportState::viewport_fixed_scissor_irrelevant([
             Viewport {

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -42,7 +42,7 @@ use vulkano::{
             multisample::MultisampleState,
             rasterization::{PolygonMode, RasterizationState},
             tessellation::TessellationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -351,6 +351,9 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
@@ -359,7 +362,7 @@ fn main() {
             PipelineShaderStageCreateInfo::entry_point(tes),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::new().topology(PrimitiveTopology::PatchList))
         .tessellation_state(
             TessellationState::new()

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -34,7 +34,7 @@ use vulkano::{
             input_assembly::{InputAssemblyState, PrimitiveTopology},
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline, Pipeline, PipelineBindPoint,
@@ -273,13 +273,16 @@ fn main() {
         .unwrap()
         .entry_point("main")
         .unwrap();
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
     let pipeline = GraphicsPipeline::start()
         .stages([
             PipelineShaderStageCreateInfo::entry_point(vs),
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         .input_assembly_state(InputAssemblyState::new().topology(PrimitiveTopology::TriangleStrip))
         .viewport_state(ViewportState::viewport_dynamic_scissor_irrelevant())
         .rasterization_state(RasterizationState::default())

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -42,7 +42,7 @@ use vulkano::{
             multisample::MultisampleState,
             rasterization::RasterizationState,
             render_pass::PipelineRenderingCreateInfo,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -388,6 +388,12 @@ fn main() {
         .entry_point("main")
         .unwrap();
 
+    // Automatically generate a vertex input state from the vertex shader's input interface,
+    // that takes a single vertex buffer containing `Vertex` structs.
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
+
     // We describe the formats of attachment images where the colors, depth and/or stencil
     // information will be written. The pipeline will only be usable with this particular
     // configuration of the attachment images.
@@ -408,7 +414,7 @@ fn main() {
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
         // How vertex data is read from the vertex buffers into the vertex shader.
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         // How vertices are arranged into primitive shapes.
         // The default primitive shape is a triangle.
         .input_assembly_state(InputAssemblyState::default())

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -36,7 +36,7 @@ use vulkano::{
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
             rasterization::RasterizationState,
-            vertex_input::Vertex,
+            vertex_input::{Vertex, VertexDefinition},
             viewport::{Viewport, ViewportState},
         },
         GraphicsPipeline,
@@ -392,6 +392,12 @@ fn main() {
         .entry_point("main")
         .unwrap();
 
+    // Automatically generate a vertex input state from the vertex shader's input interface,
+    // that takes a single vertex buffer containing `Vertex` structs.
+    let vertex_input_state = Vertex::per_vertex()
+        .definition(&vs.info().input_interface)
+        .unwrap();
+
     // We have to indicate which subpass of which render pass this pipeline is going to be used
     // in. The pipeline will only be usable from this particular subpass.
     let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
@@ -405,7 +411,7 @@ fn main() {
             PipelineShaderStageCreateInfo::entry_point(fs),
         ])
         // How vertex data is read from the vertex buffers into the vertex shader.
-        .vertex_input_state(Vertex::per_vertex())
+        .vertex_input_state(vertex_input_state)
         // How vertices are arranged into primitive shapes.
         // The default primitive shape is a triangle.
         .input_assembly_state(InputAssemblyState::default())

--- a/vulkano/src/pipeline/graphics/creation_error.rs
+++ b/vulkano/src/pipeline/graphics/creation_error.rs
@@ -7,7 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::vertex_input::IncompatibleVertexDefinitionError;
 use crate::{
     descriptor_set::layout::DescriptorSetLayoutCreationError,
     format::{Format, NumericType},
@@ -46,9 +45,6 @@ pub enum GraphicsPipelineCreationError {
 
     /// The pipeline layout is not compatible with what the shaders expect.
     IncompatiblePipelineLayout(PipelineLayoutSupersetError),
-
-    /// The vertex definition is not compatible with the input of the vertex shader.
-    IncompatibleVertexDefinition(IncompatibleVertexDefinitionError),
 
     /// Tried to use a patch list without a tessellation shader, or a non-patch-list with a
     /// tessellation shader.
@@ -250,7 +246,6 @@ impl Error for GraphicsPipelineCreationError {
             Self::PipelineLayoutCreationError(err) => Some(err),
             Self::IncompatiblePipelineLayout(err) => Some(err),
             Self::ShaderStagesMismatch(err) => Some(err),
-            Self::IncompatibleVertexDefinition(err) => Some(err),
             _ => None,
         }
     }
@@ -293,10 +288,6 @@ impl Display for GraphicsPipelineCreationError {
             Self::IncompatiblePipelineLayout(_) => write!(
                 f,
                 "the pipeline layout is not compatible with what the shaders expect",
-            ),
-            Self::IncompatibleVertexDefinition(_) => write!(
-                f,
-                "the vertex definition is not compatible with the input of the vertex shader",
             ),
             Self::InvalidPrimitiveTopology => write!(
                 f,
@@ -502,12 +493,6 @@ impl From<PipelineLayoutCreationError> for GraphicsPipelineCreationError {
 impl From<PipelineLayoutSupersetError> for GraphicsPipelineCreationError {
     fn from(err: PipelineLayoutSupersetError) -> Self {
         Self::IncompatiblePipelineLayout(err)
-    }
-}
-
-impl From<IncompatibleVertexDefinitionError> for GraphicsPipelineCreationError {
-    fn from(err: IncompatibleVertexDefinitionError) -> Self {
-        Self::IncompatibleVertexDefinition(err)
     }
 }
 

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -127,7 +127,7 @@ impl GraphicsPipeline {
     /// Starts the building process of a graphics pipeline. Returns a builder object that you can
     /// fill with the various parameters.
     #[inline]
-    pub fn start() -> GraphicsPipelineBuilder<VertexInputState> {
+    pub fn start() -> GraphicsPipelineBuilder {
         GraphicsPipelineBuilder::new()
     }
 

--- a/vulkano/src/pipeline/graphics/vertex_input/definition.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/definition.rs
@@ -7,49 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-//! Definition for creating a [`VertexInputState`] based on a [`ShaderInterface`].
-//!
-//! # Implementing `Vertex`
-//!
-//! The implementations of the `VertexDefinition` trait that are provided by vulkano require you to
-//! use a buffer whose content is `[V]` where `V` implements the `Vertex` trait.
-//!
-//! The `Vertex` trait is unsafe, but can be implemented on a struct with the `impl_vertex!`
-//! macro.
-//!
-//! # Examples
-//!
-//! ```ignore       // TODO:
-//! # #[macro_use] extern crate vulkano
-//! # fn main() {
-//! # use std::sync::Arc;
-//! # use vulkano::device::Device;
-//! # use vulkano::device::Queue;
-//! use vulkano::buffer::BufferAccess;
-//! use vulkano::buffer::BufferUsage;
-//! use vulkano::memory::HostVisible;
-//! use vulkano::pipeline::vertex::;
-//! # let device: Arc<Device> = return;
-//! # let queue: Arc<Queue> = return;
-//!
-//! struct Vertex {
-//!     position: [f32; 2]
-//! }
-//!
-//! impl_vertex!(Vertex, position);
-//!
-//! let usage = BufferUsage {
-//!     vertex_buffer: true,
-//!     ..BufferUsage::empty()
-//! };
-//!
-//! let vertex_buffer = BufferAccess::<[Vertex], _>::array(&device, 128, &usage, HostVisible, &queue)
-//!     .expect("failed to create buffer");
-//!
-//! // TODO: finish example
-//! # }
-//! ```
-
 use super::{
     VertexBufferDescription, VertexInputAttributeDescription, VertexInputBindingDescription,
 };
@@ -65,22 +22,12 @@ use std::{
 
 /// Trait for types that can create a [`VertexInputState`] from a [`ShaderInterface`].
 pub unsafe trait VertexDefinition {
-    /// Builds the vertex definition to use to link this definition to a vertex shader's input
-    /// interface.
+    /// Builds the `VertexInputState` for the provided `interface`.
     // TODO: remove error return, move checks to GraphicsPipelineBuilder
     fn definition(
         &self,
         interface: &ShaderInterface,
     ) -> Result<VertexInputState, IncompatibleVertexDefinitionError>;
-}
-
-unsafe impl VertexDefinition for VertexInputState {
-    fn definition(
-        &self,
-        _interface: &ShaderInterface,
-    ) -> Result<VertexInputState, IncompatibleVertexDefinitionError> {
-        Ok(self.clone())
-    }
 }
 
 /// Error that can happen when the vertex definition doesn't match the input of the vertex shader.


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to shaders and pipelines:
- `GraphicsPipelineBuilder::vertex_input_state` now requires a `VertexInputState` object directly, instead of a `VertexDefinition`. The `VertexDefinition` trait can be used to create the object.
````

This makes things a bit more explicit, and also eliminates the last type parameter from the builder.

After this, I intend to give the pipeline layout the same treatment, but while still allowing the user to auto-create it if they really want to.