### PR TITLE
Fix #2184

### DIFF
--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -362,9 +362,10 @@ impl Device {
             Create the device
         */
 
-        let has_khr_get_physical_device_properties2 = instance
-            .enabled_extensions()
-            .khr_get_physical_device_properties2;
+        let has_khr_get_physical_device_properties2 = instance.api_version() >= Version::V1_1
+            || instance
+                .enabled_extensions()
+                .khr_get_physical_device_properties2;
 
         let mut create_info = ash::vk::DeviceCreateInfo {
             flags: ash::vk::DeviceCreateFlags::empty(),


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- [#2184](https://github.com/vulkano-rs/vulkano/issues/2184): `VK_KHR_get_physical_device_properties2` not used in Device creation for Vulkan 1.1 and later.
````

Fixes #2184.