### PR TITLE
Single type for all validation errors

### DIFF
--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -238,9 +238,14 @@ where
     }
 }
 
+/// An error that can happen when calling a safe (validated) function that makes a call to the
+/// Vulkan API.
 #[derive(Clone, Debug)]
 pub enum ValidatedVulkanError {
+    /// The function call was invalid in some way.
     ValidationError(ValidationError),
+
+    /// The Vulkan driver returned an error and was unable to complete the operation.
     VulkanError(VulkanError),
 }
 
@@ -277,11 +282,19 @@ impl From<VulkanError> for ValidatedVulkanError {
     }
 }
 
+/// The arguments or other context of a call to a Vulkan function were not valid.
 #[derive(Clone, Debug, Default)]
 pub struct ValidationError {
+    /// The context in which the problem exists (e.g. a specific parameter).
     pub context: Cow<'static, str>,
+
+    /// A description of the problem.
     pub problem: Cow<'static, str>,
+
+    /// *Valid Usage IDs* (VUIDs) in the Vulkan specification that relate to the problem.
     pub vuids: &'static [&'static str],
+
+    /// If applicable, settings that the user could enable to avoid the problem in the future.
     pub requires_one_of: Option<RequiresOneOf>,
 }
 

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -134,7 +134,6 @@ impl ComputePipeline {
                 if let Some(default_value) =
                     entry_point_info.specialization_constants.get(&constant_id)
                 {
-                    // VUID-VkSpecializationMapEntry-constantID-00776
                     // Check for equal types rather than only equal size.
                     if !provided_value.eq_type(default_value) {
                         return Err(ValidationError {
@@ -150,11 +149,7 @@ impl ComputePipeline {
                 }
             }
 
-            // VUID-VkComputePipelineCreateInfo-layout-07987
-            // VUID-VkComputePipelineCreateInfo-layout-07988
-            // VUID-VkComputePipelineCreateInfo-layout-07990
-            // VUID-VkComputePipelineCreateInfo-layout-07991
-            // TODO: Make sure that all of these are indeed checked.
+            // TODO: Make sure that all VUIDs are indeed checked.
             layout
                 .ensure_compatible_with_shader(
                     entry_point_info


### PR DESCRIPTION
After some Discord discussion earlier today, this PR proposes a new way to report validation errors to the user. I've replaced the old error type in compute shader creation, as an example to show how it looks in practice. If accepted, this change would be made across the board, but we can do it peacemeal, it doesn't have to be all at once.

The enums that Vulkano currently uses to report errors have many problems:
- Users are very unlikely to want to match on any of the enum variants. These are validation errors, if they happen then they are bugs in the user's code.
- When you `unwrap` an error, which most people will do, then you only get the debug print, which is far less helpful than the display print.
- They are tedious to create: You have to define a new enum, think of a name, then implement various traits.
- They are tedious to extend: You have to add new variants each time a new error type is added, and then also update the `Display` implementation to add a friendly message for the user. And again, you have to think of names for all of these variants.
- Their definitions are elsewhere in the code from where the error is triggered, meaning that you have to scroll back and forth whenever you need to change something.
- There are *many* of them, in the many tens of different types.
- Frankly, I'm fed up with writing enums!

Several years ago, I made a proposal to replace all validation errors in Vulkano with panics: #1546. This was rejected, but it seemed that people were on board with simplifying the error types if Vulkan kept the standard `Result` + `Error` error reporting. This implements that now.