### PR TITLE
Remove needless `unsafe` from `Buffer::from_{data,iter}`

### DIFF
--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -134,7 +134,6 @@ use std::{
     hash::{Hash, Hasher},
     mem::size_of_val,
     ops::Range,
-    ptr,
     sync::Arc,
 };
 
@@ -280,7 +279,7 @@ impl Buffer {
     {
         let buffer = Buffer::new_sized(allocator, buffer_info, allocation_info)?;
 
-        unsafe { ptr::write(&mut *buffer.write()?, data) };
+        *buffer.write()? = data;
 
         Ok(buffer)
     }
@@ -317,7 +316,7 @@ impl Buffer {
         )?;
 
         for (o, i) in buffer.write()?.iter_mut().zip(iter) {
-            unsafe { ptr::write(o, i) };
+            *o = i;
         }
 
         Ok(buffer)


### PR DESCRIPTION
This must have been some relic that was never touched while things around it were refactored. I'm positive this unsafe is not needed and it might confuse users that are looking at how the library does things. I also [checked the assembly](https://godbolt.org/z/TPj9bKch7) and there's no change it seems.

It might be worth investigating why the assembly is so bloated but that's a different issue. Switching from an owned array to a borrowed one as the source makes it generate a memcpy. Note that in the throughput measurements I did in #2076, a memcpy was actually slightly *slower* than no memcpy, so that's something to consider as we're working with mapped memory and things don't always work as expected.