### PR TITLE
Replace `ImageAccess::descriptor_layouts()`

### DIFF
--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -17,10 +17,10 @@ use crate::{
         AutoCommandBufferBuilder,
     },
     descriptor_set::{
-        check_descriptor_write, layout::DescriptorType, sys::UnsafeDescriptorSet,
-        DescriptorBindingResources, DescriptorSetResources, DescriptorSetUpdateError,
-        DescriptorSetWithOffsets, DescriptorSetsCollection, DescriptorWriteInfo,
-        WriteDescriptorSet,
+        layout::DescriptorType, set_descriptor_write_image_layouts, sys::UnsafeDescriptorSet,
+        validate_descriptor_write, DescriptorBindingResources, DescriptorBufferInfo,
+        DescriptorSetResources, DescriptorSetUpdateError, DescriptorSetWithOffsets,
+        DescriptorSetsCollection, DescriptorWriteInfo, WriteDescriptorSet,
     },
     device::{DeviceOwned, QueueFlags},
     memory::{is_aligned, DeviceAlignment},
@@ -194,7 +194,9 @@ where
                             });
                         }
 
-                        if let Some((buffer, range)) = element {
+                        if let Some(info) = element {
+                            let DescriptorBufferInfo { buffer, range } = info;
+
                             // VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979
                             if offset as DeviceSize + range.end > buffer.size() {
                                 return Err(BindPushError::DynamicOffsetOutOfBufferBounds {
@@ -623,7 +625,15 @@ where
         set_num: u32,
         descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
     ) -> &mut Self {
-        let descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
+        let mut descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
+
+        // Set the image layouts
+        if let Some(set_layout) = pipeline_layout.set_layouts().get(set_num as usize) {
+            for write in &mut descriptor_writes {
+                set_descriptor_write_image_layouts(write, set_layout);
+            }
+        }
+
         self.validate_push_descriptor_set(
             pipeline_bind_point,
             &pipeline_layout,
@@ -706,7 +716,7 @@ where
         }
 
         for write in descriptor_writes {
-            check_descriptor_write(write, descriptor_set_layout, 0)?;
+            validate_descriptor_write(write, descriptor_set_layout, 0)?;
         }
 
         Ok(())
@@ -901,8 +911,15 @@ impl SyncCommandBufferBuilder {
             }
         }
 
-        let descriptor_writes: SmallVec<[WriteDescriptorSet; 8]> =
+        let mut descriptor_writes: SmallVec<[WriteDescriptorSet; 8]> =
             descriptor_writes.into_iter().collect();
+
+        // Set the image layouts
+        if let Some(set_layout) = pipeline_layout.set_layouts().get(set_num as usize) {
+            for write in &mut descriptor_writes {
+                set_descriptor_write_image_layouts(write, set_layout);
+            }
+        }
 
         let state = self.current_state.invalidate_descriptor_sets(
             pipeline_bind_point,
@@ -1213,12 +1230,15 @@ impl UnsafeCommandBufferBuilder {
         descriptor_writes: impl IntoIterator<Item = &'a WriteDescriptorSet>,
     ) {
         debug_assert!(self.device.enabled_extensions().khr_push_descriptor);
+        let set_layout = &pipeline_layout.set_layouts()[set_num as usize];
 
-        let (infos, mut writes): (SmallVec<[_; 8]>, SmallVec<[_; 8]>) = descriptor_writes
+        let (infos_vk, mut writes_vk): (SmallVec<[_; 8]>, SmallVec<[_; 8]>) = descriptor_writes
             .into_iter()
             .map(|write| {
-                let binding =
-                    &pipeline_layout.set_layouts()[set_num as usize].bindings()[&write.binding()];
+                let mut write = write.clone(); // Ew!
+                set_descriptor_write_image_layouts(&mut write, set_layout);
+
+                let binding = &set_layout.bindings()[&write.binding()];
 
                 (
                     write.to_vulkan_info(binding.descriptor_type),
@@ -1227,28 +1247,28 @@ impl UnsafeCommandBufferBuilder {
             })
             .unzip();
 
-        if writes.is_empty() {
+        if writes_vk.is_empty() {
             return;
         }
 
         // Set the info pointers separately.
-        for (info, write) in infos.iter().zip(writes.iter_mut()) {
-            match info {
+        for (info_vk, write_vk) in infos_vk.iter().zip(writes_vk.iter_mut()) {
+            match info_vk {
                 DescriptorWriteInfo::Image(info) => {
-                    write.descriptor_count = info.len() as u32;
-                    write.p_image_info = info.as_ptr();
+                    write_vk.descriptor_count = info.len() as u32;
+                    write_vk.p_image_info = info.as_ptr();
                 }
                 DescriptorWriteInfo::Buffer(info) => {
-                    write.descriptor_count = info.len() as u32;
-                    write.p_buffer_info = info.as_ptr();
+                    write_vk.descriptor_count = info.len() as u32;
+                    write_vk.p_buffer_info = info.as_ptr();
                 }
                 DescriptorWriteInfo::BufferView(info) => {
-                    write.descriptor_count = info.len() as u32;
-                    write.p_texel_buffer_view = info.as_ptr();
+                    write_vk.descriptor_count = info.len() as u32;
+                    write_vk.p_texel_buffer_view = info.as_ptr();
                 }
             }
 
-            debug_assert!(write.descriptor_count != 0);
+            debug_assert!(write_vk.descriptor_count != 0);
         }
 
         let fns = self.device.fns();
@@ -1258,8 +1278,8 @@ impl UnsafeCommandBufferBuilder {
             pipeline_bind_point.into(),
             pipeline_layout.handle(),
             set_num,
-            writes.len() as u32,
-            writes.as_ptr(),
+            writes_vk.len() as u32,
+            writes_vk.as_ptr(),
         );
     }
 }

--- a/vulkano/src/command_buffer/standard/builder/bind_push.rs
+++ b/vulkano/src/command_buffer/standard/builder/bind_push.rs
@@ -12,9 +12,10 @@ use crate::{
     buffer::{BufferContents, BufferUsage, Subbuffer},
     command_buffer::{allocator::CommandBufferAllocator, commands::bind_push::BindPushError},
     descriptor_set::{
-        check_descriptor_write, layout::DescriptorType, DescriptorBindingResources,
-        DescriptorSetResources, DescriptorSetWithOffsets, DescriptorSetsCollection,
-        DescriptorWriteInfo, WriteDescriptorSet,
+        layout::DescriptorType, set_descriptor_write_image_layouts, validate_descriptor_write,
+        DescriptorBindingResources, DescriptorBufferInfo, DescriptorSetResources,
+        DescriptorSetWithOffsets, DescriptorSetsCollection, DescriptorWriteInfo,
+        WriteDescriptorSet,
     },
     device::{DeviceOwned, QueueFlags},
     memory::is_aligned,
@@ -172,7 +173,9 @@ where
                             });
                         }
 
-                        if let Some((buffer, range)) = element {
+                        if let Some(info) = element {
+                            let DescriptorBufferInfo { buffer, range } = info;
+
                             // VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979
                             if offset as DeviceSize + range.end > buffer.size() {
                                 return Err(BindPushError::DynamicOffsetOutOfBufferBounds {
@@ -761,7 +764,15 @@ where
         set_num: u32,
         descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
     ) -> &mut Self {
-        let descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
+        let mut descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
+
+        // Set the image layouts
+        if let Some(set_layout) = pipeline_layout.set_layouts().get(set_num as usize) {
+            for write in &mut descriptor_writes {
+                set_descriptor_write_image_layouts(write, set_layout);
+            }
+        }
+
         self.validate_push_descriptor_set(
             pipeline_bind_point,
             &pipeline_layout,
@@ -842,7 +853,7 @@ where
         }
 
         for write in descriptor_writes {
-            check_descriptor_write(write, descriptor_set_layout, 0)?;
+            validate_descriptor_write(write, descriptor_set_layout, 0)?;
         }
 
         Ok(())
@@ -856,16 +867,17 @@ where
         set_num: u32,
         descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
     ) -> &mut Self {
-        let descriptor_writes: SmallVec<[WriteDescriptorSet; 8]> =
+        let mut descriptor_writes: SmallVec<[WriteDescriptorSet; 8]> =
             descriptor_writes.into_iter().collect();
 
         debug_assert!(self.device().enabled_extensions().khr_push_descriptor);
+        let set_layout = &pipeline_layout.set_layouts()[set_num as usize];
 
-        let (infos, mut writes): (SmallVec<[_; 8]>, SmallVec<[_; 8]>) = descriptor_writes
-            .iter()
+        let (infos_vk, mut writes_vk): (SmallVec<[_; 8]>, SmallVec<[_; 8]>) = descriptor_writes
+            .iter_mut()
             .map(|write| {
-                let binding =
-                    &pipeline_layout.set_layouts()[set_num as usize].bindings()[&write.binding()];
+                set_descriptor_write_image_layouts(write, set_layout);
+                let binding = &set_layout.bindings()[&write.binding()];
 
                 (
                     write.to_vulkan_info(binding.descriptor_type),
@@ -874,28 +886,28 @@ where
             })
             .unzip();
 
-        if writes.is_empty() {
+        if writes_vk.is_empty() {
             return self;
         }
 
         // Set the info pointers separately.
-        for (info, write) in infos.iter().zip(writes.iter_mut()) {
-            match info {
+        for (info_vk, write_vk) in infos_vk.iter().zip(writes_vk.iter_mut()) {
+            match info_vk {
                 DescriptorWriteInfo::Image(info) => {
-                    write.descriptor_count = info.len() as u32;
-                    write.p_image_info = info.as_ptr();
+                    write_vk.descriptor_count = info.len() as u32;
+                    write_vk.p_image_info = info.as_ptr();
                 }
                 DescriptorWriteInfo::Buffer(info) => {
-                    write.descriptor_count = info.len() as u32;
-                    write.p_buffer_info = info.as_ptr();
+                    write_vk.descriptor_count = info.len() as u32;
+                    write_vk.p_buffer_info = info.as_ptr();
                 }
                 DescriptorWriteInfo::BufferView(info) => {
-                    write.descriptor_count = info.len() as u32;
-                    write.p_texel_buffer_view = info.as_ptr();
+                    write_vk.descriptor_count = info.len() as u32;
+                    write_vk.p_texel_buffer_view = info.as_ptr();
                 }
             }
 
-            debug_assert!(write.descriptor_count != 0);
+            debug_assert!(write_vk.descriptor_count != 0);
         }
 
         let fns = self.device().fns();
@@ -904,8 +916,8 @@ where
             pipeline_bind_point.into(),
             pipeline_layout.handle(),
             set_num,
-            writes.len() as u32,
-            writes.as_ptr(),
+            writes_vk.len() as u32,
+            writes_vk.as_ptr(),
         );
 
         let state = self.builder_state.invalidate_descriptor_sets(

--- a/vulkano/src/command_buffer/standard/builder/pipeline.rs
+++ b/vulkano/src/command_buffer/standard/builder/pipeline.rs
@@ -18,7 +18,10 @@ use crate::{
         DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand,
         ResourceInCommand, ResourceUseRef, SubpassContents,
     },
-    descriptor_set::{layout::DescriptorType, DescriptorBindingResources},
+    descriptor_set::{
+        layout::DescriptorType, DescriptorBindingResources, DescriptorBufferInfo,
+        DescriptorImageViewInfo, DescriptorImageViewSamplerInfo,
+    },
     device::{DeviceOwned, QueueFlags},
     format::FormatFeatures,
     image::{ImageAccess, ImageAspects, ImageSubresourceRange, ImageViewAbstract, SampleCount},
@@ -40,7 +43,7 @@ use crate::{
     DeviceSize, RequiresOneOf, VulkanObject,
 };
 use ahash::HashMap;
-use std::{cmp::min, mem::size_of, ops::Range, sync::Arc};
+use std::{cmp::min, mem::size_of, sync::Arc};
 
 impl<L, A> CommandBufferBuilder<L, A>
 where
@@ -991,8 +994,7 @@ where
             let layout_binding =
                 &pipeline.layout().set_layouts()[set_num as usize].bindings()[&binding_num];
 
-            let check_buffer =
-                |_index: u32, (_buffer, _range): &(Subbuffer<[u8]>, Range<DeviceSize>)| Ok(());
+            let check_buffer = |_index: u32, _info: &DescriptorBufferInfo| Ok(());
 
             let check_buffer_view = |index: u32, buffer_view: &Arc<BufferView>| {
                 for desc_reqs in (binding_reqs.descriptors.get(&Some(index)).into_iter())
@@ -1189,7 +1191,12 @@ where
                 Ok(())
             };
 
-            let check_image_view = |index: u32, image_view: &Arc<dyn ImageViewAbstract>| {
+            let check_image_view = |index: u32, info: &DescriptorImageViewInfo| {
+                let DescriptorImageViewInfo {
+                    image_view,
+                    image_layout: _,
+                } = info;
+
                 check_image_view_common(index, image_view)?;
 
                 if let Some(sampler) = layout_binding.immutable_samplers.get(index as usize) {
@@ -1199,13 +1206,18 @@ where
                 Ok(())
             };
 
-            let check_image_view_sampler =
-                |index: u32, (image_view, sampler): &(Arc<dyn ImageViewAbstract>, Arc<Sampler>)| {
-                    check_image_view_common(index, image_view)?;
-                    check_sampler_common(index, sampler)?;
+            let check_image_view_sampler = |index: u32, info: &DescriptorImageViewSamplerInfo| {
+                let DescriptorImageViewSamplerInfo {
+                    image_view,
+                    image_layout: _,
+                    sampler,
+                } = info;
 
-                    Ok(())
-                };
+                check_image_view_common(index, image_view)?;
+                check_sampler_common(index, sampler)?;
+
+                Ok(())
+            };
 
             let check_sampler = |index: u32, sampler: &Arc<Sampler>| {
                 check_sampler_common(index, sampler)?;
@@ -1231,7 +1243,12 @@ where
                             })
                     });
 
-                    for (id, image_view) in iter {
+                    for (id, info) in iter {
+                        let DescriptorImageViewInfo {
+                            image_view,
+                            image_layout: _,
+                        } = info;
+
                         if let Err(error) = sampler.check_can_sample(image_view.as_ref()) {
                             return Err(
                                 DescriptorResourceInvalidError::SamplerImageViewIncompatible {
@@ -2065,7 +2082,9 @@ fn record_descriptor_sets_access(
                     let dynamic_offsets = descriptor_set_state.dynamic_offsets();
 
                     for (index, element) in elements.iter().enumerate() {
-                        if let Some((buffer, range)) = element {
+                        if let Some(info) = element {
+                            let DescriptorBufferInfo { buffer, range } = info;
+
                             let dynamic_offset = dynamic_offsets[index] as DeviceSize;
                             let (use_ref, stage_access_iter) = use_iter(index as u32);
 
@@ -2085,7 +2104,9 @@ fn record_descriptor_sets_access(
                     }
                 } else {
                     for (index, element) in elements.iter().enumerate() {
-                        if let Some((buffer, range)) = element {
+                        if let Some(info) = element {
+                            let DescriptorBufferInfo { buffer, range } = info;
+
                             let (use_ref, stage_access_iter) = use_iter(index as u32);
 
                             let mut range = range.clone();
@@ -2127,15 +2148,14 @@ fn record_descriptor_sets_access(
             }
             DescriptorBindingResources::ImageView(elements) => {
                 for (index, element) in elements.iter().enumerate() {
-                    if let Some(image_view) = element {
+                    if let Some(info) = element {
+                        let &DescriptorImageViewInfo {
+                            ref image_view,
+                            image_layout,
+                        } = info;
+
                         let image = image_view.image();
                         let image_inner = image.inner();
-                        let layout = image
-                            .descriptor_layouts()
-                            .expect(
-                                "descriptor_layouts must return Some when used in an image view",
-                            )
-                            .layout_for(descriptor_type);
                         let (use_ref, stage_access_iter) = use_iter(index as u32);
 
                         let mut subresource_range = image_view.subresource_range().clone();
@@ -2150,7 +2170,7 @@ fn record_descriptor_sets_access(
                                 image_inner.image,
                                 subresource_range.clone(),
                                 stage_access,
-                                layout,
+                                image_layout,
                             );
                         }
                     }
@@ -2158,15 +2178,15 @@ fn record_descriptor_sets_access(
             }
             DescriptorBindingResources::ImageViewSampler(elements) => {
                 for (index, element) in elements.iter().enumerate() {
-                    if let Some((image_view, _)) = element {
+                    if let Some(info) = element {
+                        let &DescriptorImageViewSamplerInfo {
+                            ref image_view,
+                            image_layout,
+                            sampler: _,
+                        } = info;
+
                         let image = image_view.image();
                         let image_inner = image.inner();
-                        let layout = image
-                            .descriptor_layouts()
-                            .expect(
-                                "descriptor_layouts must return Some when used in an image view",
-                            )
-                            .layout_for(descriptor_type);
                         let (use_ref, stage_access_iter) = use_iter(index as u32);
 
                         let mut subresource_range = image_view.subresource_range().clone();
@@ -2181,7 +2201,7 @@ fn record_descriptor_sets_access(
                                 image_inner.image,
                                 subresource_range.clone(),
                                 stage_access,
-                                layout,
+                                image_layout,
                             );
                         }
                     }


### PR DESCRIPTION
My attempt to get rid of one of the last methods of `ImageAccess`, to help with the image unification. An unsuccessful attempt so far, because the method is still there and is still being used, but at least I managed to reduce it to one single function. The current changes add the image layout to the `WriteDescriptorSet` element definitions, but there is no way for the user to provide the layout yet. That is what `descriptor_layouts()` is still used for as of now. I would like to make this user-settable now, but I'm not sure what would be a convenient API for the user to do this.

Adding `image_view_with_layout(_array)` and `image_view_sampler_with_layout(_array)` constructors to `WriteDescriptorSet` can work, but in the case of the latter the user would be required to provide an iterator of 3-tuples (image view, layout, sampler), which isn't the most intuitive. To keep the API close to Vulkan, it would be nice to ask for `DescriptorImageViewSamplerInfo` structs instead, but there is no equivalent struct for the `image_view_sampler(_array)` constructor, which doesn't take layouts.

All in all, still many design uncertainties for this one, so I'll leave it as a draft.