### PR TITLE
Fix reading from life_out output buffer instead of life_in.

### DIFF
--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -242,21 +242,21 @@ mod compute_life_cs {
                 ivec2 left = pos + ivec2(-1, 0);
 
                 int alive_count = 0;
-                if (life_out[get_index(up_left)] == 1) { alive_count += 1; }
-                if (life_out[get_index(up)] == 1) { alive_count += 1; }
-                if (life_out[get_index(up_right)] == 1) { alive_count += 1; }
-                if (life_out[get_index(right)] == 1) { alive_count += 1; }
-                if (life_out[get_index(down_right)] == 1) { alive_count += 1; }
-                if (life_out[get_index(down)] == 1) { alive_count += 1; }
-                if (life_out[get_index(down_left)] == 1) { alive_count += 1; }
-                if (life_out[get_index(left)] == 1) { alive_count += 1; }
+                if (life_in[get_index(up_left)] == 1) { alive_count += 1; }
+                if (life_in[get_index(up)] == 1) { alive_count += 1; }
+                if (life_in[get_index(up_right)] == 1) { alive_count += 1; }
+                if (life_in[get_index(right)] == 1) { alive_count += 1; }
+                if (life_in[get_index(down_right)] == 1) { alive_count += 1; }
+                if (life_in[get_index(down)] == 1) { alive_count += 1; }
+                if (life_in[get_index(down_left)] == 1) { alive_count += 1; }
+                if (life_in[get_index(left)] == 1) { alive_count += 1; }
 
                 // Dead becomes alive.
-                if (life_out[index] == 0 && alive_count == 3) {
+                if (life_in[index] == 0 && alive_count == 3) {
                     life_out[index] = 1;
                 }
                 // Becomes dead.
-                else if (life_out[index] == 1 && alive_count < 2 || alive_count > 3) {
+                else if (life_in[index] == 1 && alive_count < 2 || alive_count > 3) {
                     life_out[index] = 0;
                 }
                 // Else do nothing.


### PR DESCRIPTION
Game of life example GLSL code uses 2 buffers ( in and out) such that in is read and out written. Although the game seems to run correctly the out buffer is being read as input.

3. [x ] Run `cargo fmt` on the changes.

4. [ x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.
   
   Please remove any items from the template below that are not applicable.

5. [ x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown

### Bugs fixed
- Game of life logic corrected.
````
