### PR TITLE
Remove `ImageInner`

### DIFF
--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -821,7 +821,7 @@ impl UnsafeCommandBufferBuilder {
         let fns = self.device.fns();
         (fns.v1_0.cmd_clear_color_image)(
             self.handle,
-            image.inner().image.handle(),
+            image.inner().handle(),
             image_layout.into(),
             &clear_value,
             ranges.len() as u32,
@@ -857,7 +857,7 @@ impl UnsafeCommandBufferBuilder {
         let fns = self.device.fns();
         (fns.v1_0.cmd_clear_depth_stencil_image)(
             self.handle,
-            image.inner().image.handle(),
+            image.inner().handle(),
             image_layout.into(),
             &clear_value,
             ranges.len() as u32,

--- a/vulkano/src/command_buffer/standard/builder/clear.rs
+++ b/vulkano/src/command_buffer/standard/builder/clear.rs
@@ -202,7 +202,7 @@ where
         let fns = self.device().fns();
         (fns.v1_0.cmd_clear_color_image)(
             self.handle(),
-            image_inner.image.handle(),
+            image_inner.handle(),
             image_layout.into(),
             &clear_value,
             ranges.len() as u32,
@@ -218,15 +218,10 @@ where
             secondary_use_ref: None,
         };
 
-        for mut subresource_range in regions {
-            subresource_range.array_layers.start += image_inner.first_layer;
-            subresource_range.array_layers.end += image_inner.first_layer;
-            subresource_range.mip_levels.start += image_inner.first_mipmap_level;
-            subresource_range.mip_levels.end += image_inner.first_mipmap_level;
-
+        for subresource_range in regions {
             self.resources_usage_state.record_image_access(
                 &use_ref,
-                image_inner.image,
+                image_inner,
                 subresource_range,
                 PipelineStageAccess::Clear_TransferWrite,
                 image_layout,
@@ -435,7 +430,7 @@ where
         let fns = self.device().fns();
         (fns.v1_0.cmd_clear_depth_stencil_image)(
             self.handle(),
-            image_inner.image.handle(),
+            image_inner.handle(),
             image_layout.into(),
             &clear_value,
             ranges.len() as u32,
@@ -451,15 +446,10 @@ where
             secondary_use_ref: None,
         };
 
-        for mut subresource_range in regions {
-            subresource_range.array_layers.start += image_inner.first_layer;
-            subresource_range.array_layers.end += image_inner.first_layer;
-            subresource_range.mip_levels.start += image_inner.first_mipmap_level;
-            subresource_range.mip_levels.end += image_inner.first_mipmap_level;
-
+        for subresource_range in regions {
             self.resources_usage_state.record_image_access(
                 &use_ref,
-                image_inner.image,
+                image_inner,
                 subresource_range,
                 PipelineStageAccess::Clear_TransferWrite,
                 image_layout,

--- a/vulkano/src/command_buffer/standard/builder/pipeline.rs
+++ b/vulkano/src/command_buffer/standard/builder/pipeline.rs
@@ -2138,17 +2138,11 @@ fn record_descriptor_sets_access(
                             .layout_for(descriptor_type);
                         let (use_ref, stage_access_iter) = use_iter(index as u32);
 
-                        let mut subresource_range = image_view.subresource_range().clone();
-                        subresource_range.array_layers.start += image_inner.first_layer;
-                        subresource_range.array_layers.end += image_inner.first_layer;
-                        subresource_range.mip_levels.start += image_inner.first_mipmap_level;
-                        subresource_range.mip_levels.end += image_inner.first_mipmap_level;
-
                         for stage_access in stage_access_iter {
                             resources_usage_state.record_image_access(
                                 &use_ref,
-                                image_inner.image,
-                                subresource_range.clone(),
+                                image_inner,
+                                image_view.subresource_range().clone(),
                                 stage_access,
                                 layout,
                             );
@@ -2169,17 +2163,11 @@ fn record_descriptor_sets_access(
                             .layout_for(descriptor_type);
                         let (use_ref, stage_access_iter) = use_iter(index as u32);
 
-                        let mut subresource_range = image_view.subresource_range().clone();
-                        subresource_range.array_layers.start += image_inner.first_layer;
-                        subresource_range.array_layers.end += image_inner.first_layer;
-                        subresource_range.mip_levels.start += image_inner.first_mipmap_level;
-                        subresource_range.mip_levels.end += image_inner.first_mipmap_level;
-
                         for stage_access in stage_access_iter {
                             resources_usage_state.record_image_access(
                                 &use_ref,
-                                image_inner.image,
-                                subresource_range.clone(),
+                                image_inner,
+                                image_view.subresource_range().clone(),
                                 stage_access,
                                 layout,
                             );
@@ -2314,14 +2302,6 @@ fn record_subpass_attachments_access(
 
         let image = image_view.image();
         let image_inner = image.inner();
-        let mut subresource_range = ImageSubresourceRange {
-            aspects: ImageAspects::DEPTH,
-            ..image_view.subresource_range().clone()
-        };
-        subresource_range.array_layers.start += image_inner.first_layer;
-        subresource_range.array_layers.end += image_inner.first_layer;
-        subresource_range.mip_levels.start += image_inner.first_mipmap_level;
-        subresource_range.mip_levels.end += image_inner.first_mipmap_level;
 
         let use_ref = ResourceUseRef {
             command_index,
@@ -2333,8 +2313,11 @@ fn record_subpass_attachments_access(
         for &access in accesses {
             resources_usage_state.record_image_access(
                 &use_ref,
-                image_inner.image,
-                subresource_range.clone(),
+                image_inner,
+                ImageSubresourceRange {
+                    aspects: ImageAspects::DEPTH,
+                    ..image_view.subresource_range().clone()
+                },
                 access,
                 image_layout,
             );
@@ -2366,14 +2349,6 @@ fn record_subpass_attachments_access(
 
         let image = image_view.image();
         let image_inner = image.inner();
-        let mut subresource_range = ImageSubresourceRange {
-            aspects: ImageAspects::STENCIL,
-            ..image_view.subresource_range().clone()
-        };
-        subresource_range.array_layers.start += image_inner.first_layer;
-        subresource_range.array_layers.end += image_inner.first_layer;
-        subresource_range.mip_levels.start += image_inner.first_mipmap_level;
-        subresource_range.mip_levels.end += image_inner.first_mipmap_level;
 
         let use_ref = ResourceUseRef {
             command_index,
@@ -2385,8 +2360,11 @@ fn record_subpass_attachments_access(
         for &access in accesses {
             resources_usage_state.record_image_access(
                 &use_ref,
-                image_inner.image,
-                subresource_range.clone(),
+                image_inner,
+                ImageSubresourceRange {
+                    aspects: ImageAspects::STENCIL,
+                    ..image_view.subresource_range().clone()
+                },
                 access,
                 image_layout,
             );
@@ -2404,11 +2382,6 @@ fn record_subpass_attachments_access(
 
         let image = image_view.image();
         let image_inner = image.inner();
-        let mut subresource_range = image_view.subresource_range().clone();
-        subresource_range.array_layers.start += image_inner.first_layer;
-        subresource_range.array_layers.end += image_inner.first_layer;
-        subresource_range.mip_levels.start += image_inner.first_mipmap_level;
-        subresource_range.mip_levels.end += image_inner.first_mipmap_level;
 
         let use_ref = ResourceUseRef {
             command_index,
@@ -2422,8 +2395,8 @@ fn record_subpass_attachments_access(
         // TODO: is it possible to only read a color attachment but not write it?
         resources_usage_state.record_image_access(
             &use_ref,
-            image_inner.image,
-            subresource_range,
+            image_inner,
+            image_view.subresource_range().clone(),
             PipelineStageAccess::ColorAttachmentOutput_ColorAttachmentWrite,
             image_layout,
         );

--- a/vulkano/src/command_buffer/standard/builder/sync.rs
+++ b/vulkano/src/command_buffer/standard/builder/sync.rs
@@ -1032,7 +1032,7 @@ where
                 // The image is not known until you execute it in a primary command buffer.
                 if let Some(framebuffer) = &begin_render_pass_state.framebuffer {
                     let attachment_index = (framebuffer.attachments().iter())
-                        .position(|attachment| attachment.image().inner().image == &barrier.image)
+                        .position(|attachment| attachment.image().inner() == &barrier.image)
                         .ok_or(SynchronizationError::ImageMemoryBarrierNotInputAttachment {
                             barrier_index,
                         })? as u32;

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -529,8 +529,7 @@ pub(crate) fn check_descriptor_write<'a>(
                     if matches!(
                         image_view.view_type(),
                         ImageViewType::Dim2d | ImageViewType::Dim2dArray
-                    ) && image_view.image().inner().image.dimensions().image_type()
-                        == ImageType::Dim3d
+                    ) && image_view.image().inner().dimensions().image_type() == ImageType::Dim3d
                     {
                         return Err(DescriptorSetUpdateError::ImageView2dFrom3d {
                             binding: write.binding(),
@@ -623,8 +622,7 @@ pub(crate) fn check_descriptor_write<'a>(
                     if matches!(
                         image_view.view_type(),
                         ImageViewType::Dim2d | ImageViewType::Dim2dArray
-                    ) && image_view.image().inner().image.dimensions().image_type()
-                        == ImageType::Dim3d
+                    ) && image_view.image().inner().dimensions().image_type() == ImageType::Dim3d
                     {
                         return Err(DescriptorSetUpdateError::ImageView2dFrom3d {
                             binding: write.binding(),
@@ -682,8 +680,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 if matches!(
                     image_view.view_type(),
                     ImageViewType::Dim2d | ImageViewType::Dim2dArray
-                ) && image_view.image().inner().image.dimensions().image_type()
-                    == ImageType::Dim3d
+                ) && image_view.image().inner().dimensions().image_type() == ImageType::Dim3d
                 {
                     return Err(DescriptorSetUpdateError::ImageView2dFrom3d {
                         binding: write.binding(),
@@ -742,8 +739,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 if matches!(
                     image_view.view_type(),
                     ImageViewType::Dim2d | ImageViewType::Dim2dArray
-                ) && image_view.image().inner().image.dimensions().image_type()
-                    == ImageType::Dim3d
+                ) && image_view.image().inner().dimensions().image_type() == ImageType::Dim3d
                 {
                     return Err(DescriptorSetUpdateError::ImageView2dFrom3d {
                         binding: write.binding(),
@@ -947,8 +943,7 @@ pub(crate) fn check_descriptor_write<'a>(
                 if matches!(
                     image_view.view_type(),
                     ImageViewType::Dim2d | ImageViewType::Dim2dArray
-                ) && image_view.image().inner().image.dimensions().image_type()
-                    == ImageType::Dim3d
+                ) && image_view.image().inner().dimensions().image_type() == ImageType::Dim3d
                 {
                     return Err(DescriptorSetUpdateError::ImageView2dFrom3d {
                         binding: write.binding(),

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -267,7 +267,7 @@ impl<'a> QueueGuard<'a> {
                     .map(|(image, memory_binds)| {
                         (
                             ash::vk::SparseImageOpaqueMemoryBindInfo {
-                                image: image.inner().image.handle(),
+                                image: image.inner().handle(),
                                 bind_count: 0,
                                 p_binds: ptr::null(),
                             },
@@ -309,7 +309,7 @@ impl<'a> QueueGuard<'a> {
                         .map(|(image, memory_binds)| {
                             (
                                 ash::vk::SparseImageMemoryBindInfo {
-                                    image: image.inner().image.handle(),
+                                    image: image.inner().handle(),
                                     bind_count: 0,
                                     p_binds: ptr::null(),
                                 },
@@ -1452,14 +1452,14 @@ impl<'a> States<'a> {
             }
 
             for (image, _) in image_opaque_binds {
-                let image = &image.inner().image;
+                let image = image.inner();
                 images
                     .entry(image.handle())
                     .or_insert_with(|| image.state());
             }
 
             for (image, _) in image_binds {
-                let image = &image.inner().image;
+                let image = image.inner();
                 images
                     .entry(image.handle())
                     .or_insert_with(|| image.state());

--- a/vulkano/src/image/attachment.rs
+++ b/vulkano/src/image/attachment.rs
@@ -10,8 +10,8 @@
 use super::{
     sys::{Image, ImageMemory, RawImage},
     traits::ImageContent,
-    ImageAccess, ImageAspects, ImageDescriptorLayouts, ImageError, ImageInner, ImageLayout,
-    ImageUsage, SampleCount,
+    ImageAccess, ImageAspects, ImageDescriptorLayouts, ImageError, ImageLayout, ImageUsage,
+    SampleCount,
 };
 use crate::{
     device::{Device, DeviceOwned},
@@ -589,14 +589,8 @@ impl AttachmentImage {
 
 unsafe impl ImageAccess for AttachmentImage {
     #[inline]
-    fn inner(&self) -> ImageInner<'_> {
-        ImageInner {
-            image: &self.inner,
-            first_layer: 0,
-            num_layers: self.inner.dimensions().array_layers(),
-            first_mipmap_level: 0,
-            num_mipmap_levels: 1,
-        }
+    fn inner(&self) -> &Arc<Image> {
+        &self.inner
     }
 
     #[inline]

--- a/vulkano/src/image/immutable.rs
+++ b/vulkano/src/image/immutable.rs
@@ -10,7 +10,7 @@
 use super::{
     sys::{Image, RawImage},
     traits::ImageContent,
-    ImageAccess, ImageCreateFlags, ImageDescriptorLayouts, ImageDimensions, ImageError, ImageInner,
+    ImageAccess, ImageCreateFlags, ImageDescriptorLayouts, ImageDimensions, ImageError,
     ImageLayout, ImageSubresourceLayers, ImageUsage, MipmapsCount,
 };
 use crate::{
@@ -313,14 +313,8 @@ unsafe impl DeviceOwned for ImmutableImage {
 
 unsafe impl ImageAccess for ImmutableImage {
     #[inline]
-    fn inner(&self) -> ImageInner<'_> {
-        ImageInner {
-            image: &self.inner,
-            first_layer: 0,
-            num_layers: self.inner.dimensions().array_layers(),
-            first_mipmap_level: 0,
-            num_mipmap_levels: self.inner.mip_levels(),
-        }
+    fn inner(&self) -> &Arc<Image> {
+        &self.inner
     }
 
     #[inline]
@@ -384,7 +378,7 @@ unsafe impl DeviceOwned for ImmutableImageInitialization {
 
 unsafe impl ImageAccess for ImmutableImageInitialization {
     #[inline]
-    fn inner(&self) -> ImageInner<'_> {
+    fn inner(&self) -> &Arc<Image> {
         self.image.inner()
     }
 

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -54,7 +54,7 @@ pub use self::{
     storage::StorageImage,
     swapchain::SwapchainImage,
     sys::ImageError,
-    traits::{ImageAccess, ImageInner},
+    traits::ImageAccess,
     usage::ImageUsage,
     view::{ImageViewAbstract, ImageViewType},
 };
@@ -626,6 +626,18 @@ impl ImageSubresourceLayers {
 impl From<ImageSubresourceLayers> for ash::vk::ImageSubresourceLayers {
     #[inline]
     fn from(val: ImageSubresourceLayers) -> Self {
+        Self {
+            aspect_mask: val.aspects.into(),
+            mip_level: val.mip_level,
+            base_array_layer: val.array_layers.start,
+            layer_count: val.array_layers.end - val.array_layers.start,
+        }
+    }
+}
+
+impl From<&ImageSubresourceLayers> for ash::vk::ImageSubresourceLayers {
+    #[inline]
+    fn from(val: &ImageSubresourceLayers) -> Self {
         Self {
             aspect_mask: val.aspects.into(),
             mip_level: val.mip_level,

--- a/vulkano/src/image/storage.rs
+++ b/vulkano/src/image/storage.rs
@@ -11,7 +11,7 @@ use super::{
     sys::{Image, ImageMemory, RawImage},
     traits::ImageContent,
     ImageAccess, ImageAspects, ImageCreateFlags, ImageDescriptorLayouts, ImageDimensions,
-    ImageError, ImageInner, ImageLayout, ImageUsage,
+    ImageError, ImageLayout, ImageUsage,
 };
 use crate::{
     device::{Device, DeviceOwned, Queue},
@@ -468,14 +468,8 @@ unsafe impl DeviceOwned for StorageImage {
 
 unsafe impl ImageAccess for StorageImage {
     #[inline]
-    fn inner(&self) -> ImageInner<'_> {
-        ImageInner {
-            image: &self.inner,
-            first_layer: 0,
-            num_layers: self.inner.dimensions().array_layers(),
-            first_mipmap_level: 0,
-            num_mipmap_levels: 1,
-        }
+    fn inner(&self) -> &Arc<Image> {
+        &self.inner
     }
 
     #[inline]

--- a/vulkano/src/image/swapchain.rs
+++ b/vulkano/src/image/swapchain.rs
@@ -10,7 +10,7 @@
 use super::{
     sys::{Image, ImageMemory},
     traits::ImageContent,
-    ImageAccess, ImageDescriptorLayouts, ImageInner, ImageLayout,
+    ImageAccess, ImageDescriptorLayouts, ImageLayout,
 };
 use crate::{
     device::{Device, DeviceOwned},
@@ -70,14 +70,8 @@ unsafe impl DeviceOwned for SwapchainImage {
 }
 
 unsafe impl ImageAccess for SwapchainImage {
-    fn inner(&self) -> ImageInner<'_> {
-        ImageInner {
-            image: &self.inner,
-            first_layer: 0,
-            num_layers: self.inner.dimensions().array_layers(),
-            first_mipmap_level: 0,
-            num_mipmap_levels: 1,
-        }
+    fn inner(&self) -> &Arc<Image> {
+        &self.inner
     }
 
     fn initial_layout_requirement(&self) -> ImageLayout {

--- a/vulkano/src/image/traits.rs
+++ b/vulkano/src/image/traits.rs
@@ -25,82 +25,48 @@ use std::{
 /// Trait for types that represent the way a GPU can access an image.
 pub unsafe trait ImageAccess: DeviceOwned + Send + Sync {
     /// Returns the inner unsafe image object used by this image.
-    fn inner(&self) -> ImageInner<'_>;
+    fn inner(&self) -> &Arc<Image>;
 
     /// Returns the dimensions of the image.
     #[inline]
     fn dimensions(&self) -> ImageDimensions {
-        let inner = self.inner();
-
-        match self
-            .inner()
-            .image
-            .dimensions()
-            .mip_level_dimensions(inner.first_mipmap_level)
-            .unwrap()
-        {
-            ImageDimensions::Dim1d {
-                width,
-                array_layers: _,
-            } => ImageDimensions::Dim1d {
-                width,
-                array_layers: inner.num_layers,
-            },
-            ImageDimensions::Dim2d {
-                width,
-                height,
-                array_layers: _,
-            } => ImageDimensions::Dim2d {
-                width,
-                height,
-                array_layers: inner.num_layers,
-            },
-            ImageDimensions::Dim3d {
-                width,
-                height,
-                depth,
-            } => ImageDimensions::Dim3d {
-                width,
-                height,
-                depth,
-            },
-        }
+        self.inner().dimensions()
     }
 
     /// Returns the format of this image.
     #[inline]
     fn format(&self) -> Format {
-        self.inner().image.format().unwrap()
+        self.inner().format().unwrap()
     }
 
     /// Returns the features supported by the image's format.
     #[inline]
     fn format_features(&self) -> FormatFeatures {
-        self.inner().image.format_features()
+        self.inner().format_features()
     }
 
     /// Returns the number of mipmap levels of this image.
     #[inline]
     fn mip_levels(&self) -> u32 {
-        self.inner().num_mipmap_levels
+        self.inner().mip_levels()
     }
 
     /// Returns the number of samples of this image.
     #[inline]
     fn samples(&self) -> SampleCount {
-        self.inner().image.samples()
+        self.inner().samples()
     }
 
     /// Returns the usage the image was created with.
     #[inline]
     fn usage(&self) -> ImageUsage {
-        self.inner().image.usage()
+        self.inner().usage()
     }
 
     /// Returns the stencil usage the image was created with.
     #[inline]
     fn stencil_usage(&self) -> ImageUsage {
-        self.inner().image.stencil_usage()
+        self.inner().stencil_usage()
     }
 
     /// Returns an `ImageSubresourceLayers` covering the first mip level of the image. All aspects
@@ -145,7 +111,7 @@ pub unsafe trait ImageAccess: DeviceOwned + Send + Sync {
 
     #[inline]
     fn initial_layout(&self) -> ImageLayout {
-        self.inner().image.initial_layout()
+        self.inner().initial_layout()
     }
 
     /// Returns the layout that the image has when it is first used in a primary command buffer.
@@ -189,25 +155,6 @@ pub unsafe trait ImageAccess: DeviceOwned + Send + Sync {
     ///
     /// This must return `Some` if the image is to be used to create an image view.
     fn descriptor_layouts(&self) -> Option<ImageDescriptorLayouts>;
-}
-
-/// Inner information about an image.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ImageInner<'a> {
-    /// The underlying image object.
-    pub image: &'a Arc<Image>,
-
-    /// The first layer of `image` to consider.
-    pub first_layer: u32,
-
-    /// The number of layers of `image` to consider.
-    pub num_layers: u32,
-
-    /// The first mipmap level of `image` to consider.
-    pub first_mipmap_level: u32,
-
-    /// The number of mipmap levels of `image` to consider.
-    pub num_mipmap_levels: u32,
 }
 
 impl Debug for dyn ImageAccess {
@@ -254,7 +201,7 @@ unsafe impl<I> ImageAccess for ImageAccessFromUndefinedLayout<I>
 where
     I: ImageAccess,
 {
-    fn inner(&self) -> ImageInner<'_> {
+    fn inner(&self) -> &Arc<Image> {
         self.image.inner()
     }
 
@@ -305,7 +252,7 @@ where
     T: SafeDeref + Send + Sync,
     T::Target: ImageAccess,
 {
-    fn inner(&self) -> ImageInner<'_> {
+    fn inner(&self) -> &Arc<Image> {
         (**self).inner()
     }
 

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -99,7 +99,7 @@ where
             _ne: _,
         } = create_info;
 
-        let image_inner = image.inner().image;
+        let image_inner = image.inner();
         let device = image_inner.device();
         let format = format.unwrap();
 
@@ -526,8 +526,7 @@ where
         image: Arc<I>,
         create_info: ImageViewCreateInfo,
     ) -> Result<Arc<Self>, VulkanError> {
-        let format_features =
-            Self::get_format_features(create_info.format.unwrap(), image.inner().image);
+        let format_features = Self::get_format_features(create_info.format.unwrap(), image.inner());
         Self::new_unchecked_with_format_features(image, create_info, format_features)
     }
 
@@ -546,7 +545,7 @@ where
             _ne: _,
         } = &create_info;
 
-        let image_inner = image.inner().image;
+        let image_inner = image.inner();
         let device = image_inner.device();
 
         let default_usage = Self::get_default_usage(subresource_range.aspects, image_inner);
@@ -626,8 +625,7 @@ where
         handle: ash::vk::ImageView,
         create_info: ImageViewCreateInfo,
     ) -> Result<Arc<Self>, VulkanError> {
-        let format_features =
-            Self::get_format_features(create_info.format.unwrap(), image.inner().image);
+        let format_features = Self::get_format_features(create_info.format.unwrap(), image.inner());
         Self::from_handle_with_format_features(image, handle, create_info, format_features)
     }
 
@@ -647,7 +645,7 @@ where
             _ne: _,
         } = create_info;
 
-        let image_inner = image.inner().image;
+        let image_inner = image.inner();
         let device = image_inner.device();
 
         if usage.is_empty() {
@@ -794,7 +792,7 @@ where
     I: ImageAccess + ?Sized,
 {
     fn device(&self) -> &Arc<Device> {
-        self.image.inner().image.device()
+        self.image.inner().device()
     }
 }
 


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
- Removed the `ImageInner` type. The `inner` method of the `ImageAccess` trait now returns a reference to the inner image directly.
````

Another step towards image unification.