### PR TITLE
Add safe `Subbuffer::reinterpret[_ref]` methods

### DIFF
--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -153,7 +153,7 @@ impl<T: ?Sized> Subbuffer<T> {
     ///
     /// [`into_bytes`]: Self::into_bytes
     pub fn as_bytes(&self) -> &Subbuffer<[u8]> {
-        unsafe { self.reinterpret_ref_unchecked_inner() }
+        unsafe { self.reinterpret_unchecked_ref_inner() }
     }
 
     #[inline(always)]
@@ -163,7 +163,7 @@ impl<T: ?Sized> Subbuffer<T> {
     }
 
     #[inline(always)]
-    unsafe fn reinterpret_ref_unchecked_inner<U: ?Sized>(&self) -> &Subbuffer<U> {
+    unsafe fn reinterpret_unchecked_ref_inner<U: ?Sized>(&self) -> &Subbuffer<U> {
         assert!(size_of::<Subbuffer<T>>() == size_of::<Subbuffer<U>>());
         assert!(align_of::<Subbuffer<T>>() == align_of::<Subbuffer<U>>());
 
@@ -211,7 +211,7 @@ where
     ///
     /// [`reinterpret_unchecked`]: Self::reinterpret_unchecked
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn reinterpret_ref_unchecked<U>(&self) -> &Subbuffer<U>
+    pub unsafe fn reinterpret_unchecked_ref<U>(&self) -> &Subbuffer<U>
     where
         U: BufferContents + ?Sized,
     {
@@ -220,7 +220,7 @@ where
         debug_assert!(self.size >= U::LAYOUT.head_size());
         debug_assert!((self.size - U::LAYOUT.head_size()) % element_size == 0);
 
-        self.reinterpret_ref_unchecked_inner()
+        self.reinterpret_unchecked_ref_inner()
     }
 
     /// Locks the subbuffer in order to read its content from the host.
@@ -368,7 +368,7 @@ impl<T> Subbuffer<T> {
     ///
     /// [`into_slice`]: Self::into_slice
     pub fn as_slice(&self) -> &Subbuffer<[T]> {
-        unsafe { self.reinterpret_ref_unchecked_inner() }
+        unsafe { self.reinterpret_unchecked_ref_inner() }
     }
 }
 


### PR DESCRIPTION
The functions `Subbuffer::{try_cast, try_cast_slice, try_from_bytes}` were modelled after bytemuck, but the issue is that since #2132 we have the ability to represent arbitrary unsized types in subbuffers, not just sized types and slices. So for instance there is currently no way to safely turn a subbuffer of bytes to a subbuffer of some custom DST. This PR addresses that by replacing those functions with just one `Subbuffer::reinterpret[_ref]` that works for any combination of types.

Changelog:
```markdown
### Breaking changes
- The `Subbuffer::{try_cast, try_cast_slice, try_from_bytes}` functions were replaced by `Subbuffer::reinterpret[_ref]`.
````
