### PR TITLE
Improve error formatting

### DIFF
--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -348,23 +348,16 @@ impl Debug for ValidationError {
 
 impl Display for ValidationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        let Self {
-            context,
-            problem,
-            requires_one_of,
-            vuids,
-        } = self;
+        write!(f, "{}: {}", self.context, self.problem)?;
 
-        write!(f, "{}: {}", context, problem)?;
-
-        if let Some(requires_one_of) = requires_one_of {
-            write!(f, " -- Requires one of: {}", requires_one_of)?;
+        if let Some(requires_one_of) = self.requires_one_of {
+            write!(f, " -- {}", requires_one_of)?;
         }
 
-        if !vuids.is_empty() {
-            write!(f, " (Vulkan VUIDs: {}", vuids[0])?;
+        if let Some((first, rest)) = self.vuids.split_first() {
+            write!(f, " (Vulkan VUIDs: {}", first)?;
 
-            for vuid in &vuids[1..] {
+            for vuid in rest {
                 write!(f, ", {}", vuid)?;
             }
 
@@ -430,68 +423,52 @@ impl Debug for RequiresOneOf {
 
 impl Display for RequiresOneOf {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        let mut members_written = 0;
+        write!(f, "requires one of: ")?;
 
-        if let Some(version) = self.api_version {
-            write!(f, "Vulkan API version {}.{}", version.major, version.minor)?;
-            members_written += 1;
+        let mut written = false;
+
+        if let Some(Version { major, minor, .. }) = self.api_version {
+            write!(f, "Vulkan API version {}.{}", major, minor)?;
+            written = true;
         }
 
-        if let Some((last, rest)) = self.features.split_last() {
-            if members_written != 0 {
+        if let Some((first, rest)) = self.features.split_first() {
+            if written {
                 write!(f, ", ")?;
             }
 
-            members_written += 1;
+            write!(f, "feature `{}`", first)?;
 
-            if rest.is_empty() {
-                write!(f, "feature {}", last)?;
-            } else {
-                write!(f, "features ")?;
-
-                for feature in rest {
-                    write!(f, "{}, ", feature)?;
-                }
-
-                write!(f, "{}", last)?;
+            for feature in rest {
+                write!(f, ", feature `{}`", feature)?;
             }
+
+            written = true;
         }
 
-        if let Some((last, rest)) = self.device_extensions.split_last() {
-            if members_written != 0 {
+        if let Some((first, rest)) = self.device_extensions.split_first() {
+            if written {
                 write!(f, ", ")?;
             }
 
-            members_written += 1;
+            write!(f, "device extension `{}`", first)?;
 
-            if rest.is_empty() {
-                write!(f, "device extension {}", last)?;
-            } else {
-                write!(f, "device extensions ")?;
-
-                for feature in rest {
-                    write!(f, "{}, ", feature)?;
-                }
-
-                write!(f, "{}", last)?;
+            for extension in rest {
+                write!(f, ", device extension `{}`", extension)?;
             }
+
+            written = true;
         }
 
-        if let Some((last, rest)) = self.instance_extensions.split_last() {
-            if members_written != 0 {
+        if let Some((first, rest)) = self.instance_extensions.split_first() {
+            if written {
                 write!(f, ", ")?;
             }
 
-            if rest.is_empty() {
-                write!(f, "instance extension {}", last)?;
-            } else {
-                write!(f, "instance extensions ")?;
+            write!(f, "instance extension `{}`", first)?;
 
-                for feature in rest {
-                    write!(f, "{}, ", feature)?;
-                }
-
-                write!(f, "{}", last)?;
+            for extension in rest {
+                write!(f, ", instance extension `{}`", extension)?;
             }
         }
 
@@ -518,14 +495,12 @@ impl Error for OomError {}
 
 impl Display for OomError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        write!(
-            f,
-            "{}",
-            match self {
-                OomError::OutOfHostMemory => "no memory available on the host",
-                OomError::OutOfDeviceMemory => "no memory available on the graphical device",
-            }
-        )
+        let msg = match self {
+            OomError::OutOfHostMemory => "no memory available on the host",
+            OomError::OutOfDeviceMemory => "no memory available on the graphical device",
+        };
+
+        write!(f, "{msg}")
     }
 }
 
@@ -546,96 +521,100 @@ impl Error for RuntimeError {}
 
 impl Display for RuntimeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        write!(
-            f,
-            "{}",
-            match self {
-                RuntimeError::OutOfHostMemory => "a host memory allocation has failed",
-                RuntimeError::OutOfDeviceMemory => "a device memory allocation has failed",
-                RuntimeError::InitializationFailed => {
-                    "initialization of an object could not be completed for \
-                    implementation-specific reasons"
-                }
-                RuntimeError::DeviceLost => "the logical or physical device has been lost",
-                RuntimeError::MemoryMapFailed => "mapping of a memory object has failed",
-                RuntimeError::LayerNotPresent => {
-                    "a requested layer is not present or could not be loaded"
-                }
-                RuntimeError::ExtensionNotPresent => "a requested extension is not supported",
-                RuntimeError::FeatureNotPresent => "a requested feature is not supported",
-                RuntimeError::IncompatibleDriver => {
-                    "the requested version of Vulkan is not supported by the driver or is \
-                    otherwise incompatible for implementation-specific reasons"
-                }
-                RuntimeError::TooManyObjects => {
-                    "too many objects of the type have already been created"
-                }
-                RuntimeError::FormatNotSupported => {
-                    "a requested format is not supported on this device"
-                }
-                RuntimeError::FragmentedPool => {
-                    "a pool allocation has failed due to fragmentation of the pool's memory"
-                }
-                RuntimeError::Unknown => {
-                    "an unknown error has occurred; either the application has provided invalid \
-                    input, or an implementation failure has occurred"
-                }
-                RuntimeError::OutOfPoolMemory => "a pool memory allocation has failed",
-                RuntimeError::InvalidExternalHandle => {
-                    "an external handle is not a valid handle of the specified type"
-                }
-                RuntimeError::Fragmentation => {
-                    "a descriptor pool creation has failed due to fragmentation"
-                }
-                RuntimeError::InvalidOpaqueCaptureAddress => {
-                    "a buffer creation or memory allocation failed because the requested address \
-                    is not available. A shader group handle assignment failed because the \
-                    requested shader group handle information is no longer valid"
-                }
-                RuntimeError::IncompatibleDisplay => {
-                    "the display used by a swapchain does not use the same presentable image \
-                    layout, or is incompatible in a way that prevents sharing an image"
-                }
-                RuntimeError::NotPermitted => "a requested operation was not permitted",
-                RuntimeError::SurfaceLost => "a surface is no longer available",
-                RuntimeError::NativeWindowInUse => {
-                    "the requested window is already in use by Vulkan or another API in a manner \
-                    which prevents it from being used again"
-                }
-                RuntimeError::OutOfDate => {
-                    "a surface has changed in such a way that it is no longer compatible with the \
-                    swapchain, and further presentation requests using the swapchain will fail"
-                }
-                RuntimeError::ValidationFailed => "validation failed",
-                RuntimeError::FullScreenExclusiveModeLost => {
-                    "an operation on a swapchain created with application controlled full-screen \
-                    access failed as it did not have exclusive full-screen access"
-                }
-                RuntimeError::InvalidDrmFormatModifierPlaneLayout => {
-                    "the requested DRM format modifier plane layout is invalid"
-                }
-                RuntimeError::InvalidShader => "one or more shaders failed to compile or link",
-                RuntimeError::ImageUsageNotSupported =>
-                    "the requested `ImageUsage` are not supported",
-                RuntimeError::VideoPictureLayoutNotSupported =>
-                    "the requested video picture layout is not supported",
-                RuntimeError::VideoProfileOperationNotSupported =>
-                    "a video profile operation specified via \
-                    `VideoProfileInfo::video_codec_operation` is not supported",
-                RuntimeError::VideoProfileFormatNotSupported =>
-                    "format parameters in a requested `VideoProfileInfo` chain are not supported",
-                RuntimeError::VideoProfileCodecNotSupported =>
-                    "codec-specific parameters in a requested `VideoProfileInfo` chain are not \
-                    supported",
-                RuntimeError::VideoStdVersionNotSupported =>
-                    "the specified video Std header version is not supported",
-                RuntimeError::CompressionExhausted =>
-                    "an image creation failed because internal resources required for compression \
-                    are exhausted",
-                RuntimeError::Unnamed(result) =>
-                    return write!(f, "unnamed error, VkResult value {}", result.as_raw()),
+        let msg = match self {
+            RuntimeError::OutOfHostMemory => "a host memory allocation has failed",
+            RuntimeError::OutOfDeviceMemory => "a device memory allocation has failed",
+            RuntimeError::InitializationFailed => {
+                "initialization of an object could not be completed for implementation-specific \
+                reasons"
             }
-        )
+            RuntimeError::DeviceLost => "the logical or physical device has been lost",
+            RuntimeError::MemoryMapFailed => "mapping of a memory object has failed",
+            RuntimeError::LayerNotPresent => {
+                "a requested layer is not present or could not be loaded"
+            }
+            RuntimeError::ExtensionNotPresent => "a requested extension is not supported",
+            RuntimeError::FeatureNotPresent => "a requested feature is not supported",
+            RuntimeError::IncompatibleDriver => {
+                "the requested version of Vulkan is not supported by the driver or is otherwise \
+                incompatible for implementation-specific reasons"
+            }
+            RuntimeError::TooManyObjects => {
+                "too many objects of the type have already been created"
+            }
+            RuntimeError::FormatNotSupported => {
+                "a requested format is not supported on this device"
+            }
+            RuntimeError::FragmentedPool => {
+                "a pool allocation has failed due to fragmentation of the pool's memory"
+            }
+            RuntimeError::Unknown => {
+                "an unknown error has occurred; either the application has provided invalid input, \
+                or an implementation failure has occurred"
+            }
+            RuntimeError::OutOfPoolMemory => "a pool memory allocation has failed",
+            RuntimeError::InvalidExternalHandle => {
+                "an external handle is not a valid handle of the specified type"
+            }
+            RuntimeError::Fragmentation => {
+                "a descriptor pool creation has failed due to fragmentation"
+            }
+            RuntimeError::InvalidOpaqueCaptureAddress => {
+                "a buffer creation or memory allocation failed because the requested address is \
+                not available. A shader group handle assignment failed because the requested \
+                shader group handle information is no longer valid"
+            }
+            RuntimeError::IncompatibleDisplay => {
+                "the display used by a swapchain does not use the same presentable image layout, \
+                or is incompatible in a way that prevents sharing an image"
+            }
+            RuntimeError::NotPermitted => "a requested operation was not permitted",
+            RuntimeError::SurfaceLost => "a surface is no longer available",
+            RuntimeError::NativeWindowInUse => {
+                "the requested window is already in use by Vulkan or another API in a manner which \
+                prevents it from being used again"
+            }
+            RuntimeError::OutOfDate => {
+                "a surface has changed in such a way that it is no longer compatible with the \
+                swapchain, and further presentation requests using the swapchain will fail"
+            }
+            RuntimeError::ValidationFailed => "validation failed",
+            RuntimeError::FullScreenExclusiveModeLost => {
+                "an operation on a swapchain created with application controlled full-screen \
+                access failed as it did not have exclusive full-screen access"
+            }
+            RuntimeError::InvalidDrmFormatModifierPlaneLayout => {
+                "the requested DRM format modifier plane layout is invalid"
+            }
+            RuntimeError::InvalidShader => "one or more shaders failed to compile or link",
+            RuntimeError::ImageUsageNotSupported => "the requested `ImageUsage` are not supported",
+            RuntimeError::VideoPictureLayoutNotSupported => {
+                "the requested video picture layout is not supported"
+            }
+            RuntimeError::VideoProfileOperationNotSupported => {
+                "a video profile operation specified via `VideoProfileInfo::video_codec_operation` \
+                is not supported"
+            }
+            RuntimeError::VideoProfileFormatNotSupported => {
+                "format parameters in a requested `VideoProfileInfo` chain are not supported"
+            }
+            RuntimeError::VideoProfileCodecNotSupported => {
+                "codec-specific parameters in a requested `VideoProfileInfo` chain are not \
+                supported"
+            }
+            RuntimeError::VideoStdVersionNotSupported => {
+                "the specified video Std header version is not supported"
+            }
+            RuntimeError::CompressionExhausted => {
+                "an image creation failed because internal resources required for compression are \
+                exhausted"
+            }
+            RuntimeError::Unnamed(result) => {
+                return write!(f, "unnamed error, VkResult value {}", result.as_raw());
+            }
+        };
+
+        write!(f, "{msg}")
     }
 }
 


### PR DESCRIPTION
This PR mainly aims to address the issue that errors are not formatted nicely when using `Result::unwrap` or `Result::expect`.

The formatting now looks like this, using a random validation error:
```
called `Result::unwrap()` on an `Err` value: a validation error occurred

Caused by:
    `create_info.subpasses[0].view_mask`: is not `0`

Requires one of:
    The `multiview` feature

Vulkan VUIDs:
    VUID-VkSubpassDescription2-multiview-06558
```
I mainly took inspiration from anyhow for the formatting.

Runtime errors look like this:
```
called `Result::unwrap()` on an `Err` value: a runtime error occurred: a device memory allocation has failed
```
I also changed the existing `Display` implementation for `RequiresOneOf` a little, to make it clearer that e.g. you need of of the features, not all of the features.

It's important to note that old error types using `RequiresOneOf` are going to have a strange mix of the debug formattings until we replace them, so let's preferably do that soon. Not world-ending though.