### PR TITLE
Remove `vulkano-win` dependency from examples

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,9 +16,6 @@ vulkano-shaders = { path = "../vulkano-shaders" }
 # The Vulkan library doesn't provide any functionality to create and handle windows, as
 # this would be out of scope. In order to open a window, we are going to use the `winit` crate.
 winit = "0.28"
-# The `vulkano_win` crate is the link between `vulkano` and `winit`. Vulkano doesn't know about winit,
-# and winit doesn't know about vulkano, so import a crate that will provide a link between the two.
-vulkano-win = { path = "../vulkano-win" }
 vulkano-util = { path = "../vulkano-util" }
 
 cgmath = "0.18"


### PR DESCRIPTION
Since #2206, `vulkano-win` is no longer needed as a dependency for the examples.