### PR TITLE
Add support for acceleration structures and ray queries

### DIFF
--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -1,0 +1,1664 @@
+// Copyright (c) 2023 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+//! An opaque data structure that is used to accelerate spatial queries on geometry data.
+//!
+//! Acceleration structures contain geometry data, arranged in such a way that the device can
+//! easily search through the data and check for intersections between the geometry and rays
+//! (lines). The geometry data can consist of either triangles, or axis-aligned bounding boxes
+//! (AABBs).
+//!
+//! Acceleration structures come in two forms: top-level and bottom-level. A bottom-level
+//! acceleration structure holds the actual geometry data, while a top-level structure contains
+//! instances of (references to) one or more bottom-level structures. A top-level structure is
+//! intended to contain the whole rendered scene (or the relevant parts of it), while a
+//! bottom-level structure may contain individual objects within the scene. This two-level
+//! arrangement allows you to easily rearrange the scene, adding and removing parts of it as needed.
+//!
+//! # Building an acceleration structure
+//!
+//! When an acceleration structure object is created, it is in an uninitialized state and contains
+//! garbage data. To be able to use it for anything, you must first *build* the structure on the
+//! device, using the [`build_acceleration_structure`] or [`build_acceleration_structure_indirect`]
+//! command buffer commands. You use [`BuildAccelerationStructureMode::Build`] to build a structure
+//! from scratch.
+//!
+//! When specifying geometry data for an acceleration structure build, certain triangle, AABB or
+//! instance values mark that item as *inactive*. An inactive item is completely ignored within
+//! the acceleration structure, and acts as if it's not there. The following special values
+//! make an item inactive:
+//! - For triangles, if the vertex format is a floating-point type, then the triangle is inactive
+//!   if any of its vertices have NaN as their first coordinate. For integer vertex formats, it is
+//!   not possible to mark triangles as inactive.
+//! - For AABBs, if [`AabbPositions::min[0]`](AabbPositions::min) is NaN.
+//! - For instances, if [`AccelerationStructureInstance::acceleration_structure_reference`] is 0.
+//!
+//! # Updating an acceleration structure
+//!
+//! Once an acceleration structure is built, if it was built previously with the
+//! [`BuildAccelerationStructureFlags::ALLOW_UPDATE`] flag, then it is possible to update the
+//! structure with new data. You use [`BuildAccelerationStructureMode::Update`] for this, which
+//! specifies the source acceleration structure to use as a starting point for the update.
+//! This can be the same as the destination structure (the update will happen in-place), or a
+//! different one.
+//!
+//! An update operation is limited in which parts of the data it may change. You may change most
+//! buffers and their contents, as well as strides and offsets:
+//! - [`AccelerationStructureBuildGeometryInfo::scratch_data`]
+//! - [`AccelerationStructureGeometryTrianglesData::vertex_data`]
+//! - [`AccelerationStructureGeometryTrianglesData::vertex_stride`]
+//! - [`AccelerationStructureGeometryTrianglesData::transform_data`]
+//!   (but the variant of `Option` must not change)
+//! - [`AccelerationStructureGeometryAabbsData::data`]
+//! - [`AccelerationStructureGeometryAabbsData::stride`]
+//! - [`AccelerationStructureGeometryInstancesData::data`]
+//! - [`AccelerationStructureBuildRangeInfo::primitive_offset`]
+//! - [`AccelerationStructureBuildRangeInfo::first_vertex`] if no index buffer is used
+//! - [`AccelerationStructureBuildRangeInfo::transform_offset`]
+//!
+//! No other values may be changed, including in particular the variant or number of elements in
+//! [`AccelerationStructureBuildGeometryInfo::geometries`], and the value of
+//! [`AccelerationStructureBuildRangeInfo::primitive_count`].
+//! The enum variants and data in [`AccelerationStructureGeometryTrianglesData::index_data`] must
+//! not be changed, but it is allowed to specify a new index buffer, as long as it contains the
+//! exact same indices as the old one.
+//!
+//! An update operation may not change the inactive status of an item: active items must remain
+//! active in the update and inactive items must remain inactive.
+//!
+//! # Accessing an acceleration structure in a shader
+//!
+//! Acceleration structures can be bound to and accessed in any shader type. They are accessed
+//! as descriptors, like buffers and images, and are declared in GLSL with
+//! ```glsl
+//! layout (set = N, binding = N) uniform accelerationStructureEXT nameOfTheVariable;
+//! ```
+//! You must enable either the `GL_EXT_ray_query` or the `GL_EXT_ray_tracing` GLSL extensions in
+//! the shader to use this.
+//!
+//! On the Vulkano side, you can then create a descriptor set layout using
+//! [`DescriptorType::AccelerationStructure`] as a descriptor type, and write the
+//! acceleration structure to a descriptor set using [`WriteDescriptorSet::acceleration_structure`].
+//!
+//! [`build_acceleration_structure`]: crate::command_buffer::AutoCommandBufferBuilder::build_acceleration_structure
+//! [`build_acceleration_structure_indirect`]: crate::command_buffer::AutoCommandBufferBuilder::build_acceleration_structure_indirect
+//! [`DescriptorType::AccelerationStructure`]: crate::descriptor_set::layout::DescriptorType::AccelerationStructure
+//! [`WriteDescriptorSet::acceleration_structure`]: crate::descriptor_set::WriteDescriptorSet::acceleration_structure
+
+use crate::{
+    buffer::{BufferUsage, IndexBuffer, Subbuffer},
+    device::{Device, DeviceOwned},
+    format::{Format, FormatFeatures},
+    macros::{vulkan_bitflags, vulkan_enum},
+    DeviceSize, NonZeroDeviceSize, Packed24_8, RequiresOneOf, RuntimeError, ValidationError,
+    VulkanError, VulkanObject,
+};
+use bytemuck::{Pod, Zeroable};
+use std::{
+    fmt::Debug,
+    hash::{Hash, Hasher},
+    mem::MaybeUninit,
+    ptr,
+    sync::Arc,
+};
+
+/// An opaque data structure that is used to accelerate spatial queries on geometry data.
+#[derive(Debug)]
+pub struct AccelerationStructure {
+    device: Arc<Device>,
+    handle: ash::vk::AccelerationStructureKHR,
+
+    create_flags: AccelerationStructureCreateFlags,
+    buffer: Subbuffer<[u8]>,
+    ty: AccelerationStructureType,
+}
+
+impl AccelerationStructure {
+    /// Creates a new `AccelerationStructure`.
+    ///
+    /// The [`acceleration_structure`] feature must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - `create_info.buffer` (and any subbuffer it overlaps with) must not be accessed
+    ///   while it is bound to the acceleration structure.
+    ///
+    /// [`acceleration_structure`]: crate::device::Features::acceleration_structure
+    #[inline]
+    pub unsafe fn new(
+        device: Arc<Device>,
+        create_info: AccelerationStructureCreateInfo,
+    ) -> Result<Arc<Self>, VulkanError> {
+        Self::validate_new(&device, &create_info)?;
+
+        Ok(Self::new_unchecked(device, create_info)?)
+    }
+
+    fn validate_new(
+        device: &Device,
+        create_info: &AccelerationStructureCreateInfo,
+    ) -> Result<(), ValidationError> {
+        if !device.enabled_extensions().khr_acceleration_structure {
+            return Err(ValidationError {
+                requires_one_of: Some(RequiresOneOf {
+                    device_extensions: &["khr_acceleration_structure"],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        }
+
+        if !device.enabled_features().acceleration_structure {
+            return Err(ValidationError {
+                requires_one_of: Some(RequiresOneOf {
+                    features: &["acceleration_structure"],
+                    ..Default::default()
+                }),
+                vuids: &["VUID-vkCreateAccelerationStructureKHR-accelerationStructure-03611"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-vkCreateAccelerationStructureKHR-pCreateInfo-parameter
+        create_info
+            .validate(device)
+            .map_err(|err| ValidationError {
+                context: format!("create_info.{}", err.context).into(),
+                ..err
+            })?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn new_unchecked(
+        device: Arc<Device>,
+        create_info: AccelerationStructureCreateInfo,
+    ) -> Result<Arc<Self>, RuntimeError> {
+        let &AccelerationStructureCreateInfo {
+            create_flags,
+            ref buffer,
+            ty,
+            _ne: _,
+        } = &create_info;
+
+        let create_info_vk = ash::vk::AccelerationStructureCreateInfoKHR {
+            create_flags: create_flags.into(),
+            buffer: buffer.buffer().handle(),
+            offset: buffer.offset(),
+            size: buffer.size(),
+            ty: ty.into(),
+            device_address: 0, // TODO: allow user to specify
+            ..Default::default()
+        };
+
+        let handle = {
+            let fns = device.fns();
+            let mut output = MaybeUninit::uninit();
+            (fns.khr_acceleration_structure
+                .create_acceleration_structure_khr)(
+                device.handle(),
+                &create_info_vk,
+                ptr::null(),
+                output.as_mut_ptr(),
+            )
+            .result()
+            .map_err(RuntimeError::from)?;
+            output.assume_init()
+        };
+
+        Ok(Self::from_handle(device, handle, create_info))
+    }
+
+    /// Creates a new `AccelerationStructure` from a raw object handle.
+    ///
+    /// # Safety
+    ///
+    /// - `handle` must be a valid Vulkan object handle created from `device`.
+    /// - `create_info` must match the info used to create the object.
+    pub unsafe fn from_handle(
+        device: Arc<Device>,
+        handle: ash::vk::AccelerationStructureKHR,
+        create_info: AccelerationStructureCreateInfo,
+    ) -> Arc<Self> {
+        let AccelerationStructureCreateInfo {
+            create_flags,
+            buffer,
+            ty,
+            _ne: _,
+        } = create_info;
+
+        Arc::new(Self {
+            device,
+            handle,
+            create_flags,
+            buffer,
+            ty,
+        })
+    }
+
+    /// Returns the flags the acceleration structure was created with.
+    #[inline]
+    pub fn create_flags(&self) -> AccelerationStructureCreateFlags {
+        self.create_flags
+    }
+
+    /// Returns the subbuffer that the acceleration structure is stored on.
+    #[inline]
+    pub fn buffer(&self) -> &Subbuffer<[u8]> {
+        &self.buffer
+    }
+
+    /// Returns the size of the acceleration structure.
+    #[inline]
+    pub fn size(&self) -> DeviceSize {
+        self.buffer.size()
+    }
+
+    /// Returns the type of the acceleration structure.
+    #[inline]
+    pub fn ty(&self) -> AccelerationStructureType {
+        self.ty
+    }
+
+    /// Returns the device address of the acceleration structure.
+    ///
+    /// The device address of the acceleration structure may be different from the device address
+    /// of the underlying buffer.
+    pub fn device_address(&self) -> NonZeroDeviceSize {
+        let info_vk = ash::vk::AccelerationStructureDeviceAddressInfoKHR {
+            acceleration_structure: self.handle,
+            ..Default::default()
+        };
+        let ptr = unsafe {
+            let fns = self.device.fns();
+            (fns.khr_acceleration_structure
+                .get_acceleration_structure_device_address_khr)(
+                self.device.handle(), &info_vk
+            )
+        };
+
+        NonZeroDeviceSize::new(ptr).unwrap()
+    }
+}
+
+impl Drop for AccelerationStructure {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            let fns = self.device.fns();
+            (fns.khr_acceleration_structure
+                .destroy_acceleration_structure_khr)(
+                self.device.handle(), self.handle, ptr::null()
+            )
+        }
+    }
+}
+
+unsafe impl VulkanObject for AccelerationStructure {
+    type Handle = ash::vk::AccelerationStructureKHR;
+
+    #[inline]
+    fn handle(&self) -> Self::Handle {
+        self.handle
+    }
+}
+
+unsafe impl DeviceOwned for AccelerationStructure {
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        &self.device
+    }
+}
+
+impl PartialEq for AccelerationStructure {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle
+    }
+}
+
+impl Eq for AccelerationStructure {}
+
+impl Hash for AccelerationStructure {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.handle.hash(state);
+    }
+}
+
+vulkan_enum! {
+    #[non_exhaustive]
+
+    /// The type of an acceleration structure.
+    AccelerationStructureType = AccelerationStructureTypeKHR(i32);
+
+    /// Refers to bottom-level acceleration structures. This type can be bound to a descriptor.
+    TopLevel = TOP_LEVEL,
+
+    /// Contains AABBs or geometry to be intersected.
+    BottomLevel = BOTTOM_LEVEL,
+
+    /// The type is determined at build time.
+    ///
+    /// Use of this type is discouraged, it is preferred to specify the type at create time.
+    Generic = GENERIC,
+}
+
+/// Parameters to create a new `AccelerationStructure`.
+#[derive(Clone, Debug)]
+pub struct AccelerationStructureCreateInfo {
+    /// Specifies how to create the acceleration structure.
+    ///
+    /// The default value is empty.
+    pub create_flags: AccelerationStructureCreateFlags,
+
+    /// The subbuffer to store the acceleration structure on.
+    ///
+    /// The subbuffer must have an `offset` that is a multiple of 256, and its `usage` must include
+    /// [`BufferUsage::ACCELERATION_STRUCTURE_STORAGE`]. It must not be accessed while it is bound
+    /// to the acceleration structure.
+    ///
+    /// There is no default value.
+    pub buffer: Subbuffer<[u8]>,
+
+    /// The type of acceleration structure to create.
+    ///
+    /// The default value is [`AccelerationStructureType::Generic`].
+    pub ty: AccelerationStructureType,
+
+    /* TODO: enable
+    // TODO: document
+    pub device_address: DeviceAddress, */
+    pub _ne: crate::NonExhaustive,
+}
+
+impl AccelerationStructureCreateInfo {
+    /// Returns a `AccelerationStructureCreateInfo` with the specified `buffer`.
+    #[inline]
+    pub fn new(buffer: Subbuffer<[u8]>) -> Self {
+        Self {
+            create_flags: AccelerationStructureCreateFlags::empty(),
+            buffer,
+            ty: AccelerationStructureType::Generic,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            create_flags,
+            ref buffer,
+            ty,
+            _ne: _,
+        } = self;
+
+        create_flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "create_flags".into(),
+                vuids: &["VUID-VkAccelerationStructureCreateInfoKHR-createFlags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        ty.validate_device(device).map_err(|err| ValidationError {
+            context: "ty".into(),
+            vuids: &["VUID-VkAccelerationStructureCreateInfoKHR-type-parameter"],
+            ..ValidationError::from_requirement(err)
+        })?;
+
+        if !buffer
+            .buffer()
+            .usage()
+            .intersects(BufferUsage::ACCELERATION_STRUCTURE_STORAGE)
+        {
+            return Err(ValidationError {
+                context: "buffer".into(),
+                problem: "the buffer was not created with the `ACCELERATION_STRUCTURE_STORAGE` \
+                    usage"
+                    .into(),
+                vuids: &["VUID-VkAccelerationStructureCreateInfoKHR-buffer-03614"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-VkAccelerationStructureCreateInfoKHR-offset-03616
+        // Ensured by the definition of `Subbuffer`.
+
+        if buffer.offset() % 256 != 0 {
+            return Err(ValidationError {
+                context: "buffer".into(),
+                problem: "the offset of the buffer was not a multiple of 256".into(),
+                vuids: &["VUID-VkAccelerationStructureCreateInfoKHR-offset-03734"],
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Flags that control how an acceleration structure is created.
+    AccelerationStructureCreateFlags = AccelerationStructureCreateFlagsKHR(u32);
+
+    /* TODO: enable
+    // TODO: document
+    DEVICE_ADDRESS_CAPTURE_REPLAY = DEVICE_ADDRESS_CAPTURE_REPLAY_KHR, */
+
+    /* TODO: enable
+    // TODO: document
+    DESCRIPTOR_BUFFER_CAPTURE_REPLAY = DESCRIPTOR_BUFFER_CAPTURE_REPLAY_EXT {
+        device_extensions: [ext_descriptor_buffer],
+    },*/
+
+    /* TODO: enable
+    // TODO: document
+    MOTION = MOTION_NV {
+        device_extensions: [nv_ray_tracing_motion_blur],
+    },*/
+}
+
+/// Geometries and other parameters for an acceleration structure build operation.
+#[derive(Clone, Debug)]
+pub struct AccelerationStructureBuildGeometryInfo {
+    /// Specifies how to build the acceleration structure.
+    ///
+    /// The default value is empty.
+    pub flags: BuildAccelerationStructureFlags,
+
+    /// The mode that the build command should operate in.
+    ///
+    /// The default value is [`BuildAccelerationStructureMode::Build`].
+    pub mode: BuildAccelerationStructureMode,
+
+    /// The acceleration structure to build or update.
+    ///
+    /// There is no default value.
+    pub dst_acceleration_structure: Arc<AccelerationStructure>,
+
+    /// The geometries that will be built into `dst_acceleration_structure`.
+    ///
+    /// The geometry type must match the `ty` that was specified when the acceleration structure
+    /// was created:
+    /// - `Instances` must be used with `TopLevel` or `Generic`.
+    /// - `Triangles` and `Aabbs` must be used with `BottomLevel` or `Generic`.
+    ///
+    /// There is no default value.
+    pub geometries: AccelerationStructureGeometries,
+
+    /// Scratch memory to be used for the build.
+    ///
+    /// There is no default value.
+    pub scratch_data: Subbuffer<[u8]>,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl AccelerationStructureBuildGeometryInfo {
+    /// Returns a `AccelerationStructureBuildGeometryInfo` with the specified
+    /// `dst_acceleration_structure`, `geometries` and `scratch_data`.
+    #[inline]
+    pub fn new(
+        dst_acceleration_structure: Arc<AccelerationStructure>,
+        geometries: AccelerationStructureGeometries,
+        scratch_data: Subbuffer<[u8]>,
+    ) -> Self {
+        Self {
+            flags: BuildAccelerationStructureFlags::empty(),
+            mode: BuildAccelerationStructureMode::Build,
+            dst_acceleration_structure,
+            geometries,
+            scratch_data,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            flags,
+            ref mode,
+            ref dst_acceleration_structure,
+            ref geometries,
+            scratch_data: _,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        let max_geometry_count = device
+            .physical_device()
+            .properties()
+            .max_geometry_count
+            .unwrap();
+
+        match geometries {
+            // VUID-VkAccelerationStructureGeometryKHR-triangles-parameter
+            AccelerationStructureGeometries::Triangles(geometries) => {
+                for (index, triangles_data) in geometries.iter().enumerate() {
+                    triangles_data
+                        .validate(device)
+                        .map_err(|err| ValidationError {
+                            context: format!("geometries[{}].{}", index, err.context).into(),
+                            ..err
+                        })?;
+                }
+
+                if geometries.len() as u64 > max_geometry_count {
+                    return Err(ValidationError {
+                        context: "geometries".into(),
+                        problem: "the max_geometry_count limit has been exceeded".into(),
+                        vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03793"],
+                        ..Default::default()
+                    });
+                }
+
+                // VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03795
+                // Is checked in the top-level functions.
+            }
+
+            // VUID-VkAccelerationStructureGeometryKHR-aabbs-parameter
+            AccelerationStructureGeometries::Aabbs(geometries) => {
+                for (index, aabbs_data) in geometries.iter().enumerate() {
+                    aabbs_data.validate(device).map_err(|err| ValidationError {
+                        context: format!("geometries[{}].{}", index, err.context).into(),
+                        ..err
+                    })?;
+                }
+
+                if geometries.len() as u64 > max_geometry_count {
+                    return Err(ValidationError {
+                        context: "geometries".into(),
+                        problem: "the max_geometry_count limit has been exceeded".into(),
+                        vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03793"],
+                        ..Default::default()
+                    });
+                }
+
+                // VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03794
+                // Is checked in the top-level functions.
+            }
+
+            // VUID-VkAccelerationStructureGeometryKHR-instances-parameter
+            AccelerationStructureGeometries::Instances(instances_data) => {
+                instances_data
+                    .validate(device)
+                    .map_err(|err| ValidationError {
+                        context: format!("geometries.{}", err.context).into(),
+                        ..err
+                    })?;
+            }
+        }
+
+        // VUID-VkAccelerationStructureBuildGeometryInfoKHR-commonparent
+        assert_eq!(device, dst_acceleration_structure.device().as_ref());
+
+        if let BuildAccelerationStructureMode::Update(src_acceleration_structure) = mode {
+            assert_eq!(device, src_acceleration_structure.device().as_ref());
+        }
+
+        if flags.contains(
+            BuildAccelerationStructureFlags::PREFER_FAST_TRACE
+                | BuildAccelerationStructureFlags::PREFER_FAST_BUILD,
+        ) {
+            return Err(ValidationError {
+                context: "flags".into(),
+                problem: "contains both BuildAccelerationStructureFlags::PREFER_FAST_TRACE and \
+                    BuildAccelerationStructureFlags::PREFER_FAST_BUILD"
+                    .into(),
+                vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-03796"],
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn to_vulkan(
+        &self,
+    ) -> (
+        ash::vk::AccelerationStructureBuildGeometryInfoKHR,
+        Vec<ash::vk::AccelerationStructureGeometryKHR>,
+    ) {
+        let &Self {
+            flags,
+            ref mode,
+            ref dst_acceleration_structure,
+            ref geometries,
+            ref scratch_data,
+            _ne: _,
+        } = self;
+
+        let (ty, geometries_vk): (_, Vec<_>) = match geometries {
+            AccelerationStructureGeometries::Triangles(geometries) => (
+                ash::vk::AccelerationStructureTypeKHR::BOTTOM_LEVEL,
+                geometries
+                    .iter()
+                    .map(|triangles_data| {
+                        let &AccelerationStructureGeometryTrianglesData {
+                            flags,
+                            vertex_format,
+                            ref vertex_data,
+                            vertex_stride,
+                            max_vertex,
+                            ref index_data,
+                            ref transform_data,
+                            _ne,
+                        } = triangles_data;
+
+                        ash::vk::AccelerationStructureGeometryKHR {
+                            geometry_type: ash::vk::GeometryTypeKHR::TRIANGLES,
+                            geometry: ash::vk::AccelerationStructureGeometryDataKHR {
+                                triangles: ash::vk::AccelerationStructureGeometryTrianglesDataKHR {
+                                    vertex_format: vertex_format.into(),
+                                    vertex_data: ash::vk::DeviceOrHostAddressConstKHR {
+                                        device_address: vertex_data
+                                            .device_address()
+                                            .unwrap()
+                                            .into(),
+                                    },
+                                    vertex_stride: vertex_stride as DeviceSize,
+                                    max_vertex,
+                                    index_type: index_data
+                                        .as_ref()
+                                        .map_or(ash::vk::IndexType::NONE_KHR, |index_data| {
+                                            index_data.index_type().into()
+                                        }),
+                                    index_data: ash::vk::DeviceOrHostAddressConstKHR {
+                                        device_address: index_data.as_ref().map_or(
+                                            0,
+                                            |index_data| {
+                                                index_data
+                                                    .as_bytes()
+                                                    .device_address()
+                                                    .unwrap()
+                                                    .get()
+                                            },
+                                        ),
+                                    },
+                                    transform_data: ash::vk::DeviceOrHostAddressConstKHR {
+                                        device_address: transform_data.as_ref().map_or(
+                                            0,
+                                            |transform_data| {
+                                                transform_data.device_address().unwrap().get()
+                                            },
+                                        ),
+                                    },
+                                    ..Default::default()
+                                },
+                            },
+                            flags: flags.into(),
+                            ..Default::default()
+                        }
+                    })
+                    .collect(),
+            ),
+            AccelerationStructureGeometries::Aabbs(geometries) => (
+                ash::vk::AccelerationStructureTypeKHR::BOTTOM_LEVEL,
+                geometries
+                    .iter()
+                    .map(|aabbs_data| {
+                        let &AccelerationStructureGeometryAabbsData {
+                            flags,
+                            ref data,
+                            stride,
+                            _ne: _,
+                        } = aabbs_data;
+
+                        ash::vk::AccelerationStructureGeometryKHR {
+                            geometry_type: ash::vk::GeometryTypeKHR::AABBS,
+                            geometry: ash::vk::AccelerationStructureGeometryDataKHR {
+                                aabbs: ash::vk::AccelerationStructureGeometryAabbsDataKHR {
+                                    data: ash::vk::DeviceOrHostAddressConstKHR {
+                                        device_address: data.device_address().unwrap().get(),
+                                    },
+                                    stride: stride as DeviceSize,
+                                    ..Default::default()
+                                },
+                            },
+                            flags: flags.into(),
+                            ..Default::default()
+                        }
+                    })
+                    .collect(),
+            ),
+            AccelerationStructureGeometries::Instances(instances_data) => {
+                (ash::vk::AccelerationStructureTypeKHR::TOP_LEVEL, {
+                    let &AccelerationStructureGeometryInstancesData {
+                        flags,
+                        ref data,
+                        _ne: _,
+                    } = instances_data;
+
+                    let (array_of_pointers, data) = match data {
+                        AccelerationStructureGeometryInstancesDataType::Values(data) => (
+                            ash::vk::FALSE,
+                            ash::vk::DeviceOrHostAddressConstKHR {
+                                device_address: data.device_address().unwrap().get(),
+                            },
+                        ),
+                        AccelerationStructureGeometryInstancesDataType::Pointers(data) => (
+                            ash::vk::TRUE,
+                            ash::vk::DeviceOrHostAddressConstKHR {
+                                device_address: data.device_address().unwrap().get(),
+                            },
+                        ),
+                    };
+
+                    [ash::vk::AccelerationStructureGeometryKHR {
+                        geometry_type: ash::vk::GeometryTypeKHR::INSTANCES,
+                        geometry: ash::vk::AccelerationStructureGeometryDataKHR {
+                            instances: ash::vk::AccelerationStructureGeometryInstancesDataKHR {
+                                array_of_pointers,
+                                data,
+                                ..Default::default()
+                            },
+                        },
+                        flags: flags.into(),
+                        ..Default::default()
+                    }]
+                    .into_iter()
+                    .collect()
+                })
+            }
+        };
+
+        (
+            ash::vk::AccelerationStructureBuildGeometryInfoKHR {
+                ty,
+                flags: flags.into(),
+                mode: mode.into(),
+                src_acceleration_structure: match mode {
+                    BuildAccelerationStructureMode::Build => Default::default(),
+                    BuildAccelerationStructureMode::Update(src_acceleration_structure) => {
+                        src_acceleration_structure.handle()
+                    }
+                },
+                dst_acceleration_structure: dst_acceleration_structure.handle(),
+                geometry_count: 0,
+                p_geometries: ptr::null(),
+                pp_geometries: ptr::null(),
+                scratch_data: ash::vk::DeviceOrHostAddressKHR {
+                    device_address: scratch_data.device_address().unwrap().get(),
+                },
+                ..Default::default()
+            },
+            geometries_vk,
+        )
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Flags to control how an acceleration structure should be built.
+    BuildAccelerationStructureFlags = BuildAccelerationStructureFlagsKHR(u32);
+
+    /// The built acceleration structure can be updated later by building it again with
+    /// [`BuildAccelerationStructureMode::Update`].
+    ///
+    /// The building process may take more time and memory than normal.
+    ALLOW_UPDATE = ALLOW_UPDATE,
+
+    /// The built acceleration structure can be used later as the source in a copy operation with
+    /// [`CopyAccelerationStructureMode::Compact`].
+    ///
+    /// The building process may take more time and memory than normal.
+    ALLOW_COMPACTION = ALLOW_COMPACTION,
+
+    /// Prioritize for best trace performance, with possibly longer build times.
+    PREFER_FAST_TRACE = PREFER_FAST_TRACE,
+
+    /// Prioritize for shorter build time, with possibly suboptimal trace performance.
+    PREFER_FAST_BUILD = PREFER_FAST_BUILD,
+
+    /// Prioritize low acceleration structure and scratch memory size, with possibly longer build
+    /// times or suboptimal trace performance.
+    LOW_MEMORY = LOW_MEMORY,
+
+    /* TODO: enable
+    // TODO: document
+    MOTION = MOTION_NV {
+        device_extensions: [nv_ray_tracing_motion_blur],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    ALLOW_OPACITY_MICROMAP_UPDATE = ALLOW_OPACITY_MICROMAP_UPDATE_EXT {
+        device_extensions: [ext_opacity_micromap],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    ALLOW_DISABLE_OPACITY_MICROMAPS = ALLOW_DISABLE_OPACITY_MICROMAPS_EXT {
+        device_extensions: [ext_opacity_micromap],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    ALLOW_OPACITY_MICROMAP_DATA_UPDATE = ALLOW_OPACITY_MICROMAP_DATA_UPDATE_EXT {
+        device_extensions: [ext_opacity_micromap],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    ALLOW_DISPLACEMENT_MICROMAP_UPDATE = ALLOW_DISPLACEMENT_MICROMAP_UPDATE_NV {
+        device_extensions: [nv_displacement_micromap],
+    }, */
+}
+
+/// What mode an acceleration structure build command should operate in.
+#[derive(Clone, Debug)]
+#[repr(i32)]
+pub enum BuildAccelerationStructureMode {
+    /// Build a new acceleration structure from scratch.
+    Build = ash::vk::BuildAccelerationStructureModeKHR::BUILD.as_raw(),
+
+    /// Update a previously built source acceleration structure with new data, storing the
+    /// updated structure in the destination. The source and destination acceleration structures
+    /// may be the same, which will do the update in-place.
+    ///
+    /// The destination acceleration structure must have been built with the
+    /// [`BuildAccelerationStructureFlags::ALLOW_UPDATE`] flag.
+    Update(Arc<AccelerationStructure>) =
+        ash::vk::BuildAccelerationStructureModeKHR::UPDATE.as_raw(),
+}
+
+impl From<&BuildAccelerationStructureMode> for ash::vk::BuildAccelerationStructureModeKHR {
+    #[inline]
+    fn from(val: &BuildAccelerationStructureMode) -> Self {
+        match val {
+            BuildAccelerationStructureMode::Build => {
+                ash::vk::BuildAccelerationStructureModeKHR::BUILD
+            }
+            BuildAccelerationStructureMode::Update(_) => {
+                ash::vk::BuildAccelerationStructureModeKHR::UPDATE
+            }
+        }
+    }
+}
+
+/// The type of geometry data in an acceleration structure.
+#[derive(Clone, Debug)]
+pub enum AccelerationStructureGeometries {
+    /// The geometries consist of bottom-level triangles data.
+    Triangles(Vec<AccelerationStructureGeometryTrianglesData>),
+
+    /// The geometries consist of bottom-level axis-aligned bounding box data.
+    Aabbs(Vec<AccelerationStructureGeometryAabbsData>),
+
+    /// The geometries consist of top-level instance data.
+    Instances(AccelerationStructureGeometryInstancesData),
+}
+
+impl AccelerationStructureGeometries {
+    /// Returns the number of geometries.
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            AccelerationStructureGeometries::Triangles(geometries) => geometries.len(),
+            AccelerationStructureGeometries::Aabbs(geometries) => geometries.len(),
+            AccelerationStructureGeometries::Instances(_) => 1,
+        }
+    }
+}
+
+impl From<Vec<AccelerationStructureGeometryTrianglesData>> for AccelerationStructureGeometries {
+    #[inline]
+    fn from(value: Vec<AccelerationStructureGeometryTrianglesData>) -> Self {
+        Self::Triangles(value)
+    }
+}
+
+impl From<Vec<AccelerationStructureGeometryAabbsData>> for AccelerationStructureGeometries {
+    #[inline]
+    fn from(value: Vec<AccelerationStructureGeometryAabbsData>) -> Self {
+        Self::Aabbs(value)
+    }
+}
+
+impl From<AccelerationStructureGeometryInstancesData> for AccelerationStructureGeometries {
+    #[inline]
+    fn from(value: AccelerationStructureGeometryInstancesData) -> Self {
+        Self::Instances(value)
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Flags to control how an acceleration structure geometry should be built.
+    GeometryFlags = GeometryFlagsKHR(u32);
+
+    /// The geometry does not invoke the any-hit shaders, even if it is present in a hit group.
+    OPAQUE = OPAQUE,
+
+    /// The any-hit shader will never be called more than once for each primitive in the geometry.
+    NO_DUPLICATE_ANY_HIT_INVOCATION = NO_DUPLICATE_ANY_HIT_INVOCATION,
+}
+
+/// A bottom-level geometry consisting of triangles.
+#[derive(Clone, Debug)]
+pub struct AccelerationStructureGeometryTrianglesData {
+    /// Specifies how the geometry should be built.
+    ///
+    /// The default value is empty.
+    pub flags: GeometryFlags,
+
+    /// The format of each vertex in `vertex_data`.
+    ///
+    /// This works in the same way as formats for vertex buffers.
+    ///
+    /// There is no default value.
+    pub vertex_format: Format,
+
+    /// The vertex data itself, consisting of an array of `vertex_format` values.
+    ///
+    /// There is no default value.
+    pub vertex_data: Subbuffer<[u8]>,
+
+    /// The number of bytes between the start of successive elements in `vertex_data`.
+    ///
+    /// This must be a multiple of the smallest component size (in bytes) of `vertex_format`.
+    ///
+    /// The default value is 0, which must be overridden.
+    pub vertex_stride: u32,
+
+    /// The highest vertex index that may be read from `vertex_data`.
+    ///
+    /// The default value is 0, which must be overridden.
+    pub max_vertex: u32,
+
+    /// If indices are to be used, the buffer holding the index data.
+    ///
+    /// The indices will be used to index into the elements of `vertex_data`.
+    ///
+    /// The default value is `None`.
+    pub index_data: Option<IndexBuffer>,
+
+    /// Optionally, a 3x4 matrix that will be used to transform the vertices in
+    /// `vertex_data` to the space in which the acceleration structure is defined.
+    ///
+    /// The first three columns must be a 3x3 invertible matrix.
+    ///
+    /// The default value is `None`.
+    pub transform_data: Option<Subbuffer<TransformMatrix>>,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl AccelerationStructureGeometryTrianglesData {
+    /// Returns a `AccelerationStructureGeometryTrianglesData` with the specified
+    /// `vertex_format` and `vertex_data`.
+    #[inline]
+    pub fn new(vertex_format: Format, vertex_data: Subbuffer<[u8]>) -> Self {
+        Self {
+            flags: GeometryFlags::empty(),
+            vertex_format,
+            vertex_data,
+            vertex_stride: 0,
+            max_vertex: 0,
+            index_data: None,
+            transform_data: None,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            flags,
+            vertex_format,
+            vertex_data: _,
+            vertex_stride,
+            max_vertex: _,
+            ref index_data,
+            transform_data: _,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        vertex_format
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "vertex_format".into(),
+                vuids: &[
+                    "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-parameter",
+                ],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if unsafe {
+            !device
+                .physical_device()
+                .format_properties_unchecked(vertex_format)
+                .buffer_features
+                .intersects(FormatFeatures::ACCELERATION_STRUCTURE_VERTEX_BUFFER)
+        } {
+            return Err(ValidationError {
+                context: "vertex_format".into(),
+                problem: "format features do not contain \
+                    FormatFeature::ACCELERATION_STRUCTURE_VERTEX_BUFFER"
+                    .into(),
+                vuids: &["VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-03797"],
+                ..Default::default()
+            });
+        }
+
+        let smallest_component_bits = vertex_format
+            .components()
+            .into_iter()
+            .filter(|&c| c != 0)
+            .min()
+            .unwrap() as u32;
+        let smallest_component_bytes = (smallest_component_bits + 7) & !7;
+
+        if vertex_stride % smallest_component_bytes != 0 {
+            return Err(ValidationError {
+                problem: "vertex_stride is not a multiple of the byte size of the \
+                    smallest component of vertex_format"
+                    .into(),
+                vuids: &["VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03735"],
+                ..Default::default()
+            });
+        }
+
+        if let Some(index_data) = index_data.as_ref() {
+            if !matches!(index_data, IndexBuffer::U16(_) | IndexBuffer::U32(_)) {
+                return Err(ValidationError {
+                    context: "index_data".into(),
+                    problem: "is not IndexBuffer::U16 or IndexBuffer::U32".into(),
+                    vuids: &[
+                        "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-03798",
+                    ],
+                    ..Default::default()
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A 3x4 transformation matrix.
+///
+/// The first three columns must be a 3x3 invertible matrix.
+pub type TransformMatrix = [[f32; 4]; 3];
+
+/// A bottom-level geometry consisting of axis-aligned bounding boxes.
+#[derive(Clone, Debug)]
+pub struct AccelerationStructureGeometryAabbsData {
+    /// Specifies how the geometry should be built.
+    ///
+    /// The default value is empty.
+    pub flags: GeometryFlags,
+
+    /// The AABB data itself, consisting of an array of [`AabbPositions`] structs.
+    ///
+    /// There is no default value.
+    pub data: Subbuffer<[AabbPositions]>,
+
+    /// The number of bytes between the start of successive elements in `data`.
+    ///
+    /// This must be a multiple of 8.
+    ///
+    /// The default value is 0, which must be overridden.
+    pub stride: u32,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl AccelerationStructureGeometryAabbsData {
+    /// Returns a `AccelerationStructureGeometryAabbsData` with the specified `data`.
+    #[inline]
+    pub fn new(data: Subbuffer<[AabbPositions]>) -> Self {
+        Self {
+            flags: GeometryFlags::empty(),
+            data,
+            stride: 0,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            flags,
+            data: _,
+            stride,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if stride % 8 != 0 {
+            return Err(ValidationError {
+                context: "stride".into(),
+                problem: "is not a multiple of 8".into(),
+                vuids: &["VUID-VkAccelerationStructureGeometryAabbsDataKHR-stride-03545"],
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// Specifies two opposing corners of an axis-aligned bounding box.
+///
+/// Each value in `min` must be less than or equal to the corresponding value in `max`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Zeroable, Pod)]
+#[repr(C)]
+pub struct AabbPositions {
+    /// The minimum of the corner coordinates of the bounding box.
+    ///
+    /// The default value is `[0.0; 3]`.
+    pub min: [f32; 3],
+
+    /// The maximum of the corner coordinates of the bounding box.
+    ///
+    /// The default value is `[0.0; 3]`.
+    pub max: [f32; 3],
+}
+
+/// A top-level geometry consisting of instances of bottom-level acceleration structures.
+#[derive(Clone, Debug)]
+pub struct AccelerationStructureGeometryInstancesData {
+    /// Specifies how the geometry should be built.
+    ///
+    /// The default value is empty.
+    pub flags: GeometryFlags,
+
+    /// The instance data itself.
+    ///
+    /// There is no default value.
+    pub data: AccelerationStructureGeometryInstancesDataType,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl AccelerationStructureGeometryInstancesData {
+    /// Returns a `AccelerationStructureGeometryInstancesData` with the specified `data`.
+    #[inline]
+    pub fn new(data: AccelerationStructureGeometryInstancesDataType) -> Self {
+        Self {
+            flags: GeometryFlags::empty(),
+            data,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            flags,
+            data: _,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        Ok(())
+    }
+}
+
+/// The data type of an instances geometry.
+#[derive(Clone, Debug)]
+pub enum AccelerationStructureGeometryInstancesDataType {
+    /// The data buffer contains an array of [`AccelerationStructureInstance`] structures directly.
+    Values(Subbuffer<[AccelerationStructureInstance]>),
+
+    /// The data buffer contains an array of pointers to [`AccelerationStructureInstance`]
+    /// structures.
+    Pointers(Subbuffer<[DeviceSize]>),
+}
+
+impl From<Subbuffer<[AccelerationStructureInstance]>>
+    for AccelerationStructureGeometryInstancesDataType
+{
+    #[inline]
+    fn from(value: Subbuffer<[AccelerationStructureInstance]>) -> Self {
+        Self::Values(value)
+    }
+}
+
+impl From<Subbuffer<[DeviceSize]>> for AccelerationStructureGeometryInstancesDataType {
+    #[inline]
+    fn from(value: Subbuffer<[DeviceSize]>) -> Self {
+        Self::Pointers(value)
+    }
+}
+
+/// Specifies a bottom-level acceleration structure instance when
+/// building a top-level structure.
+#[derive(Clone, Copy, Debug, PartialEq, Zeroable, Pod)]
+#[repr(C)]
+pub struct AccelerationStructureInstance {
+    /// A 3x4 transformation matrix to be applied to the bottom-level acceleration structure.
+    ///
+    /// The first three columns must be a 3x3 invertible matrix.
+    ///
+    /// The default value is a 3x3 identity matrix, with the fourth column filled with zeroes.
+    pub transform: TransformMatrix,
+
+    /// Low 24 bits: A custom index value to be accessible via the `InstanceCustomIndexKHR`
+    /// built-in variable in ray shaders. The default value is 0.
+    ///
+    /// High 8 bits: A visibility mask for the geometry. The instance will not be hit if the
+    /// cull mask ANDed with this mask is zero. The default value is 0xFF.
+    pub instance_custom_index_and_mask: Packed24_8,
+
+    /// Low 24 bits: An offset used in calculating the binding table index of the hit shader.
+    /// The default value is 0.
+    ///
+    /// High 8 bits: [`GeometryInstanceFlags`] to apply to the instance. The `From` trait can be
+    /// used to convert the flags into a `u8` value. The default value is empty.
+    pub instance_shader_binding_table_record_offset_and_flags: Packed24_8,
+
+    /// The device address of the bottom-level acceleration structure in this instance.
+    ///
+    /// The default value is 0 (null).
+    pub acceleration_structure_reference: DeviceSize,
+}
+
+impl Default for AccelerationStructureInstance {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            transform: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ],
+            instance_custom_index_and_mask: Packed24_8::new(0, 0xff),
+            instance_shader_binding_table_record_offset_and_flags: Packed24_8::new(0, 0),
+            acceleration_structure_reference: 0,
+        }
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Flags for an instance in a top-level acceleration structure.
+    GeometryInstanceFlags = GeometryInstanceFlagsKHR(u32);
+
+    /// Disable face culling for the instance.
+    TRIANGLE_FACING_CULL_DISABLE = TRIANGLE_FACING_CULL_DISABLE,
+
+    /// Flip the facing (front vs back) of triangles.
+    TRIANGLE_FLIP_FACING = TRIANGLE_FLIP_FACING,
+
+    /// Geometries in this instance will act as if [`GeometryFlags::OPAQUE`] were specified.
+    FORCE_OPAQUE = FORCE_OPAQUE,
+
+    /// Geometries in this instance will act as if [`GeometryFlags::OPAQUE`] were not specified.
+    FORCE_NO_OPAQUE = FORCE_NO_OPAQUE,
+
+    /* TODO: enable
+    // TODO: document
+    FORCE_OPACITY_MICROMAP_2_STATE = FORCE_OPACITY_MICROMAP_2_STATE_EXT {
+        device_extensions: [ext_opacity_micromap],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    DISABLE_OPACITY_MICROMAPS = DISABLE_OPACITY_MICROMAPS_EXT {
+        device_extensions: [ext_opacity_micromap],
+    }, */
+}
+
+impl From<GeometryInstanceFlags> for u8 {
+    #[inline]
+    fn from(value: GeometryInstanceFlags) -> Self {
+        value.0 as u8
+    }
+}
+
+/// Counts and offsets for an acceleration structure build operation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Zeroable, Pod)]
+#[repr(C)]
+pub struct AccelerationStructureBuildRangeInfo {
+    /// The number of primitives.
+    ///
+    /// The default value is 0.
+    pub primitive_count: u32,
+
+    /// The offset (in bytes) into the buffer holding geometry data,
+    /// to where the first primitive is stored.
+    ///
+    /// The default value is 0.
+    pub primitive_offset: u32,
+
+    /// The index of the first vertex to build from.
+    ///
+    /// This is used only for triangle geometries.
+    ///
+    /// The default value is 0.
+    pub first_vertex: u32,
+
+    /// The offset (in bytes) into the buffer holding transform matrices,
+    /// to where the matrix is stored.
+    ///
+    /// This is used only for triangle geometries.
+    ///
+    /// The default value is 0.
+    pub transform_offset: u32,
+}
+
+/// Parameters for copying an acceleration structure.
+#[derive(Clone, Debug)]
+pub struct CopyAccelerationStructureInfo {
+    /// The acceleration structure to copy from.
+    ///
+    /// There is no default value.
+    pub src: Arc<AccelerationStructure>,
+
+    /// The acceleration structure to copy into.
+    ///
+    /// There is no default value.
+    pub dst: Arc<AccelerationStructure>,
+
+    /// Additional operations to perform during the copy.
+    ///
+    /// The default value is [`CopyAccelerationStructureMode::Clone`].
+    pub mode: CopyAccelerationStructureMode,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl CopyAccelerationStructureInfo {
+    /// Returns a `CopyAccelerationStructureInfo` with the specified `src` and `dst`.
+    #[inline]
+    pub fn new(src: Arc<AccelerationStructure>, dst: Arc<AccelerationStructure>) -> Self {
+        Self {
+            src,
+            dst,
+            mode: CopyAccelerationStructureMode::Clone,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            ref src,
+            ref dst,
+            mode,
+            _ne: _,
+        } = self;
+
+        // VUID-VkCopyAccelerationStructureInfoKHR-commonparent
+        assert_eq!(device, src.device().as_ref());
+        assert_eq!(device, dst.device().as_ref());
+
+        mode.validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "mode".into(),
+                vuids: &["VUID-VkCopyAccelerationStructureInfoKHR-mode-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if !matches!(
+            mode,
+            CopyAccelerationStructureMode::Compact | CopyAccelerationStructureMode::Clone
+        ) {
+            return Err(ValidationError {
+                context: "mode".into(),
+                problem: "is not CopyAccelerationStructureMode::Compact or \
+                    CopyAccelerationStructureMode::Clone"
+                    .into(),
+                vuids: &["VUID-VkCopyAccelerationStructureInfoKHR-mode-03410"],
+                ..Default::default()
+            });
+        }
+
+        if src.buffer() == dst.buffer() {
+            return Err(ValidationError {
+                problem: "src and dst share the same buffer".into(),
+                vuids: &["VUID-VkCopyAccelerationStructureInfoKHR-dst-07791"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-VkCopyAccelerationStructureInfoKHR-src-04963
+        // TODO: unsafe
+
+        // VUID-VkCopyAccelerationStructureInfoKHR-src-03411
+        // TODO: unsafe
+
+        Ok(())
+    }
+}
+
+/// Parameters for copying from an acceleration structure into memory.
+#[derive(Clone, Debug)]
+pub struct CopyAccelerationStructureToMemoryInfo {
+    /// The acceleration structure to copy from.
+    ///
+    /// There is no default value.
+    pub src: Arc<AccelerationStructure>,
+
+    /// The memory to copy the structure to.
+    ///
+    /// There is no default value.
+    pub dst: Subbuffer<[u8]>,
+
+    /// Additional operations to perform during the copy.
+    ///
+    /// The default value is [`CopyAccelerationStructureMode::Serialize`].
+    pub mode: CopyAccelerationStructureMode,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl CopyAccelerationStructureToMemoryInfo {
+    /// Returns a `CopyAccelerationStructureToMemoryInfo` with the specified `src` and `dst`.
+    #[inline]
+    pub fn new(src: Arc<AccelerationStructure>, dst: Subbuffer<[u8]>) -> Self {
+        Self {
+            src,
+            dst,
+            mode: CopyAccelerationStructureMode::Serialize,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            ref src,
+            ref dst,
+            mode,
+            _ne: _,
+        } = self;
+
+        assert_eq!(device, src.device().as_ref());
+        assert_eq!(device, dst.device().as_ref());
+
+        mode.validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "mode".into(),
+                vuids: &["VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if !matches!(mode, CopyAccelerationStructureMode::Serialize) {
+            return Err(ValidationError {
+                context: "mode".into(),
+                problem: "is not CopyAccelerationStructureMode::Serialize".into(),
+                vuids: &["VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-03412"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-04959
+        // TODO: unsafe
+
+        // VUID-VkCopyAccelerationStructureToMemoryInfoKHR-dst-03561
+        // TODO: unsafe
+
+        Ok(())
+    }
+}
+
+/// Parameters for copying from memory into an acceleration structure.
+#[derive(Clone, Debug)]
+pub struct CopyMemoryToAccelerationStructureInfo {
+    /// The memory to copy the structure from.
+    ///
+    /// There is no default value.
+    pub src: Subbuffer<[u8]>,
+
+    /// The acceleration structure to copy into.
+    ///
+    /// There is no default value.
+    pub dst: Arc<AccelerationStructure>,
+
+    /// Additional operations to perform during the copy.
+    ///
+    /// The default value is [`CopyAccelerationStructureMode::Deserialize`].
+    pub mode: CopyAccelerationStructureMode,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl CopyMemoryToAccelerationStructureInfo {
+    /// Returns a `CopyMemoryToAccelerationStructureInfo` with the specified `src` and `dst`.
+    #[inline]
+    pub fn new(src: Subbuffer<[u8]>, dst: Arc<AccelerationStructure>) -> Self {
+        Self {
+            src,
+            dst,
+            mode: CopyAccelerationStructureMode::Deserialize,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            ref src,
+            ref dst,
+            mode,
+            _ne: _,
+        } = self;
+
+        assert_eq!(device, src.device().as_ref());
+        assert_eq!(device, dst.device().as_ref());
+
+        mode.validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "mode".into(),
+                vuids: &["VUID-VkCopyMemoryToAccelerationStructureInfoKHR-mode-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if !matches!(mode, CopyAccelerationStructureMode::Deserialize) {
+            return Err(ValidationError {
+                context: "mode".into(),
+                problem: "is not CopyAccelerationStructureMode::Deserialize".into(),
+                vuids: &["VUID-VkCopyMemoryToAccelerationStructureInfoKHR-mode-03413"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-VkCopyMemoryToAccelerationStructureInfoKHR-src-04960
+        // TODO: unsafe
+
+        // VUID-VkCopyMemoryToAccelerationStructureInfoKHR-pInfo-03414
+        // TODO: unsafe
+
+        // VUID-VkCopyMemoryToAccelerationStructureInfoKHR-dst-03746
+        // TODO: unsafe
+
+        Ok(())
+    }
+}
+
+vulkan_enum! {
+    #[non_exhaustive]
+
+    /// What mode an acceleration structure copy command should operate in.
+    CopyAccelerationStructureMode = CopyAccelerationStructureModeKHR(i32);
+
+    /// Copy the source into the destination.
+    /// This is a shallow copy: if the source holds references to other acceleration structures,
+    /// only the references are copied, not the other acceleration structures.
+    ///
+    /// Both source and destination must have been created with the same
+    /// [`AccelerationStructureCreateInfo`].
+    Clone = CLONE,
+
+    /// Create a more compact version of the source in the destination.
+    /// This is a shallow copy: if the source holds references to other acceleration structures,
+    /// only the references are copied, not the other acceleration structures.
+    ///
+    /// The source acceleration structure must have been built with the
+    /// [`BuildAccelerationStructureFlags::ALLOW_COMPACTION`] flag.
+    Compact = COMPACT,
+
+    /// Serialize the acceleration structure into data in a semi-opaque format,
+    /// that can be deserialized by a compatible Vulkan implementation.
+    Serialize = SERIALIZE,
+
+    /// Deserialize data back into an acceleration structure.
+    Deserialize = DESERIALIZE,
+}
+
+vulkan_enum! {
+    #[non_exhaustive]
+
+    /// Where the building of an acceleration structure will take place.
+    AccelerationStructureBuildType = AccelerationStructureBuildTypeKHR(i32);
+
+    /// Building will take place on the host.
+    Host = HOST,
+
+    /// Building will take place on the device.
+    Device = DEVICE,
+
+    /// Building will take place on either the host or the device.
+    HostOrDevice = HOST_OR_DEVICE,
+}
+
+/// The minimum sizes needed for various resources during an acceleration structure build operation.
+#[derive(Clone, Debug)]
+pub struct AccelerationStructureBuildSizesInfo {
+    /// The minimum required size of the acceleration structure for a build or update operation.
+    pub acceleration_structure_size: DeviceSize,
+
+    /// The minimum required size of the scratch data buffer for an update operation.
+    pub update_scratch_size: DeviceSize,
+
+    /// The minimum required size of the scratch data buffer for a build operation.
+    pub build_scratch_size: DeviceSize,
+
+    pub _ne: crate::NonExhaustive,
+}

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -87,17 +87,15 @@ vulkan_bitflags! {
         device_extensions: [ext_conditional_rendering],
     },*/
 
-    /* TODO: enable
-    // TODO: document
-    ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR = ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR {
+    /// The buffer can be used as input data for an acceleration structure build operation.
+    ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY = ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR {
         device_extensions: [khr_acceleration_structure],
-    },*/
+    },
 
-    /* TODO: enable
-    // TODO: document
+    /// An acceleration structure can be created from the buffer.
     ACCELERATION_STRUCTURE_STORAGE = ACCELERATION_STRUCTURE_STORAGE_KHR {
         device_extensions: [khr_acceleration_structure],
-    },*/
+    },
 
     /* TODO: enable
     // TODO: document

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -12,7 +12,7 @@ use super::{
     SubmitState,
 };
 use crate::{
-    buffer::{Buffer, Subbuffer},
+    buffer::{Buffer, IndexBuffer, Subbuffer},
     command_buffer::{
         allocator::{CommandBufferAllocator, StandardCommandBufferAllocator},
         sys::{CommandBufferBeginInfo, UnsafeCommandBuffer, UnsafeCommandBufferBuilder},
@@ -35,14 +35,14 @@ use crate::{
         graphics::{
             color_blend::LogicOp,
             depth_stencil::{CompareOp, StencilOps},
-            input_assembly::{IndexType, PrimitiveTopology},
+            input_assembly::PrimitiveTopology,
             rasterization::{CullMode, DepthBias, FrontFace, LineStipple},
             subpass::PipelineRenderingCreateInfo,
             viewport::{Scissor, Viewport},
         },
         ComputePipeline, DynamicState, GraphicsPipeline, PipelineBindPoint, PipelineLayout,
     },
-    query::{QueryControlFlags, QueryType},
+    query::{QueryControlFlags, QueryPool},
     range_map::RangeMap,
     range_set::RangeSet,
     render_pass::{Framebuffer, Subpass},
@@ -1664,7 +1664,7 @@ pub(in crate::command_buffer) struct CommandBufferBuilderState {
 
     // Bind/push
     pub(in crate::command_buffer) descriptor_sets: HashMap<PipelineBindPoint, DescriptorSetState>,
-    pub(in crate::command_buffer) index_buffer: Option<(Subbuffer<[u8]>, IndexType)>,
+    pub(in crate::command_buffer) index_buffer: Option<IndexBuffer>,
     pub(in crate::command_buffer) pipeline_compute: Option<Arc<ComputePipeline>>,
     pub(in crate::command_buffer) pipeline_graphics: Option<Arc<GraphicsPipeline>>,
     pub(in crate::command_buffer) vertex_buffers: HashMap<u32, Subbuffer<[u8]>>,
@@ -2080,9 +2080,8 @@ pub(in crate::command_buffer) struct StencilOpStateDynamic {
 }
 
 pub(in crate::command_buffer) struct QueryState {
-    pub(in crate::command_buffer) query_pool: ash::vk::QueryPool,
+    pub(in crate::command_buffer) query_pool: Arc<QueryPool>,
     pub(in crate::command_buffer) query: u32,
-    pub(in crate::command_buffer) ty: QueryType,
     pub(in crate::command_buffer) flags: QueryControlFlags,
     pub(in crate::command_buffer) in_subpass: bool,
 }

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -1,0 +1,2267 @@
+// Copyright (c) 2023 The vulkano developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use crate::{
+    acceleration_structure::{
+        AccelerationStructure, AccelerationStructureBuildGeometryInfo,
+        AccelerationStructureBuildRangeInfo, AccelerationStructureBuildType,
+        AccelerationStructureGeometries, AccelerationStructureGeometryAabbsData,
+        AccelerationStructureGeometryInstancesData, AccelerationStructureGeometryInstancesDataType,
+        AccelerationStructureGeometryTrianglesData, AccelerationStructureInstance,
+        AccelerationStructureType, BuildAccelerationStructureMode, CopyAccelerationStructureInfo,
+        CopyAccelerationStructureToMemoryInfo, CopyMemoryToAccelerationStructureInfo,
+        TransformMatrix,
+    },
+    buffer::{BufferUsage, Subbuffer},
+    command_buffer::{
+        allocator::CommandBufferAllocator,
+        auto::{Resource, ResourceUseRef2},
+        sys::UnsafeCommandBufferBuilder,
+        AutoCommandBufferBuilder, ResourceInCommand,
+    },
+    device::{DeviceOwned, QueueFlags},
+    query::{QueryPool, QueryType},
+    sync::PipelineStageAccessFlags,
+    DeviceSize, RequiresOneOf, ValidationError, VulkanObject,
+};
+use smallvec::SmallVec;
+use std::{mem::size_of, sync::Arc};
+
+/// # Commands to do operations on acceleration structures.
+impl<L, A> AutoCommandBufferBuilder<L, A>
+where
+    A: CommandBufferAllocator,
+{
+    /// Builds or updates an acceleration structure.
+    ///
+    /// # Safety
+    ///
+    /// If `info.mode` is [`BuildAccelerationStructureMode::Update`], then the rest of `info` must
+    /// be valid for an update operation, as follows:
+    /// - The source acceleration structure must have been previously built, with
+    ///   [`BuildAccelerationStructureFlags::ALLOW_UPDATE`] included in
+    ///   [`AccelerationStructureBuildGeometryInfo::flags`].
+    /// - `info` must only differ from the `info` used to build the source acceleration structure,
+    ///   according to the allowed changes listed in the [`acceleration_structure`] module.
+    ///
+    /// If `info.geometries` is [`AccelerationStructureGeometries::Triangles`], then for each
+    /// geometry and the corresponding element in `build_range_infos`:
+    /// - If [`index_data`] is `Some`, then if `index_max` is the highest index value in the index
+    ///   buffer that is accessed, then the size of [`vertex_data`] must be at least<br/>
+    ///   [`vertex_stride`] * ([`first_vertex`] + `index_max` + 1).
+    /// - If [`transform_data`] is `Some`, then for the
+    ///   3x4 matrix in the buffer, the first three columns must be a 3x3 invertible matrix.
+    ///
+    /// If `info.geometries` is [`AccelerationStructureGeometries::Aabbs`], then for each geometry:
+    /// - For each accessed [`AabbPositions`] element in
+    ///   [`data`](AccelerationStructureGeometryAabbsData::data), each value in `min` must not be
+    ///   greater than the corresponding value in `max`.
+    ///
+    /// If `info.geometries` is [`AccelerationStructureGeometries::Instances`], then the contents
+    /// of the buffer in [`data`](AccelerationStructureGeometryInstancesData::data) must be valid,
+    /// as follows:
+    /// - Any [`AccelerationStructureInstance::acceleration_structure_reference`] address contained
+    ///   in or referenced by [`data`](AccelerationStructureGeometryInstancesData::data)
+    ///   must be either 0, or a device address that was returned from calling [`device_address`]
+    ///   on a bottom-level acceleration structure.
+    /// - If an [`AccelerationStructureInstance::acceleration_structure_reference`] address is
+    ///   not 0, then the corresponding acceleration structure object must be kept alive and not be
+    ///   dropped while it is bound to the top-level acceleration structure.
+    /// - If [`data`](AccelerationStructureGeometryInstancesData::data) is
+    ///   [`AccelerationStructureGeometryInstancesDataType::Pointers`], then the addresses in the
+    ///   buffer must be a multiple of 16.
+    ///
+    /// [`BuildAccelerationStructureFlags::ALLOW_UPDATE`]: crate::acceleration_structure::BuildAccelerationStructureFlags::ALLOW_UPDATE
+    /// [`acceleration_structure`]: crate::acceleration_structure#updating-an-acceleration-structure
+    /// [`index_data`]: AccelerationStructureGeometryTrianglesData::index_data
+    /// [`vertex_data`]: AccelerationStructureGeometryTrianglesData::vertex_data
+    /// [`vertex_stride`]: AccelerationStructureGeometryTrianglesData::vertex_stride
+    /// [`first_vertex`]: AccelerationStructureBuildRangeInfo::first_vertex
+    /// [`transform_data`]: AccelerationStructureGeometryTrianglesData::transform_data
+    /// [`AabbPositions`]: crate::acceleration_structure::AabbPositions
+    /// [`AccelerationStructureInstance::acceleration_structure_reference`]: crate::acceleration_structure::AccelerationStructureInstance::acceleration_structure_reference
+    /// [`AccelerationStructureGeometryInstancesData::data`]: crate::acceleration_structure::AccelerationStructureGeometryInstancesData::data
+    /// [`device_address`]: crate::acceleration_structure::AccelerationStructure::device_address
+    /// [`AccelerationStructureGeometryInstancesDataType::Pointers`]: crate::acceleration_structure::AccelerationStructureGeometryInstancesDataType::Pointers
+    #[inline]
+    pub unsafe fn build_acceleration_structure(
+        &mut self,
+        info: AccelerationStructureBuildGeometryInfo,
+        build_range_infos: SmallVec<[AccelerationStructureBuildRangeInfo; 8]>,
+    ) -> Result<&mut Self, ValidationError> {
+        self.validate_build_acceleration_structure(&info, &build_range_infos)?;
+
+        Ok(self.build_acceleration_structure_unchecked(info, build_range_infos))
+    }
+
+    fn validate_build_acceleration_structure(
+        &self,
+        info: &AccelerationStructureBuildGeometryInfo,
+        build_range_infos: &[AccelerationStructureBuildRangeInfo],
+    ) -> Result<(), ValidationError> {
+        if !self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "queue family does not support compute operations".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-commandBuffer-cmdpool"],
+                ..Default::default()
+            });
+        }
+
+        if self.builder_state.render_pass.is_some() {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "a render pass instance is active".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-renderpass"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-parameter
+        info.validate(self.device())
+            .map_err(|err| ValidationError {
+                context: format!("info.{}", err.context).into(),
+                ..err
+            })?;
+
+        let &AccelerationStructureBuildGeometryInfo {
+            flags: _,
+            ref mode,
+            ref dst_acceleration_structure,
+            ref geometries,
+            ref scratch_data,
+            _ne,
+        } = info;
+
+        // VUID-vkCmdBuildAccelerationStructuresKHR-mode-04628
+        // Ensured as long as `BuildAccelerationStructureMode` is exhaustive.
+
+        // VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-04630
+        // Ensured by the definition of `BuildAccelerationStructureMode`.
+
+        // VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03403
+        // VUID-vkCmdBuildAccelerationStructuresKHR-None-03407
+        // VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03698
+        // VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702
+        // VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704
+        // Ensured as long as only one element is provided in `info`.
+
+        // VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03668
+        // VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03701
+        // VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703
+        // VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03706
+        // VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705
+        // Ensured by unsafe on `AccelerationStructure::new`.
+
+        if !scratch_data
+            .buffer()
+            .usage()
+            .intersects(BufferUsage::STORAGE_BUFFER)
+        {
+            return Err(ValidationError {
+                context: "info.scratch_data".into(),
+                problem: "the buffer was not created with the `STORAGE_BUFFER` usage".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674"],
+                ..Default::default()
+            });
+        }
+
+        let min_acceleration_structure_scratch_offset_alignment = self
+            .device()
+            .physical_device()
+            .properties()
+            .min_acceleration_structure_scratch_offset_alignment
+            .unwrap();
+
+        if scratch_data.device_address().unwrap().get()
+            % min_acceleration_structure_scratch_offset_alignment as u64
+            != 0
+        {
+            return Err(ValidationError {
+                context: "info.scratch_data".into(),
+                problem: "the device address of the buffer was not a multiple of the \
+                    min_acceleration_structure_scratch_offset_alignment device property"
+                    .into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03710"],
+                ..Default::default()
+            });
+        }
+
+        match dst_acceleration_structure.ty() {
+            AccelerationStructureType::TopLevel => {
+                if !matches!(geometries, AccelerationStructureGeometries::Instances(_)) {
+                    return Err(ValidationError {
+                        context: "info".into(),
+                        problem: "dst_acceleration_structure is a top-level \
+                            acceleration structure, but geometries is not \
+                            AccelerationStructureGeometries::Instances"
+                            .into(),
+                        vuids: &[
+                            "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03789",
+                            "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03699",
+                        ],
+                        ..Default::default()
+                    });
+                }
+            }
+            AccelerationStructureType::BottomLevel => {
+                if matches!(geometries, AccelerationStructureGeometries::Instances(_)) {
+                    return Err(ValidationError {
+                        context: "info".into(),
+                        problem: "dst_acceleration_structure is a bottom-level \
+                            acceleration structure, but geometries is \
+                            AccelerationStructureGeometries::Instances"
+                            .into(),
+                        vuids: &[
+                            "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03791",
+                            "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03700",
+                        ],
+                        ..Default::default()
+                    });
+                }
+            }
+            AccelerationStructureType::Generic => (),
+        }
+
+        if geometries.len() != build_range_infos.len() {
+            return Err(ValidationError {
+                problem: "info.geometries and build_range_infos do not have the same length".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-03676"],
+                ..Default::default()
+            });
+        }
+
+        let max_primitive_count = self
+            .device()
+            .physical_device()
+            .properties()
+            .max_primitive_count
+            .unwrap();
+        let max_instance_count = self
+            .device()
+            .physical_device()
+            .properties()
+            .max_instance_count
+            .unwrap();
+
+        match geometries {
+            AccelerationStructureGeometries::Triangles(geometries) => {
+                for (geometry_index, (triangles_data, build_range_info)) in
+                    geometries.iter().zip(build_range_infos).enumerate()
+                {
+                    let &AccelerationStructureGeometryTrianglesData {
+                        flags: _,
+                        vertex_format,
+                        ref vertex_data,
+                        vertex_stride,
+                        max_vertex: _,
+                        ref index_data,
+                        ref transform_data,
+                        _ne,
+                    } = triangles_data;
+
+                    let &AccelerationStructureBuildRangeInfo {
+                        primitive_count,
+                        primitive_offset,
+                        first_vertex,
+                        transform_offset,
+                    } = build_range_info;
+
+                    if primitive_count as u64 > max_primitive_count {
+                        return Err(ValidationError {
+                            context: format!(
+                                "build_range_infos[{}].primitive_count",
+                                geometry_index
+                            )
+                            .into(),
+                            problem: "the max_primitive_count limit has been exceeded".into(),
+                            vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03795"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if !vertex_data
+                        .buffer()
+                        .usage()
+                        .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                    {
+                        return Err(ValidationError {
+                            context: format!("info.geometries[{}].vertex_data", geometry_index)
+                                .into(),
+                            problem: "the buffer was not created with the \
+                                `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                .into(),
+                            vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
+                            ..Default::default()
+                        });
+                    }
+
+                    let smallest_component_bits = vertex_format
+                        .components()
+                        .into_iter()
+                        .filter(|&c| c != 0)
+                        .min()
+                        .unwrap() as u32;
+                    let smallest_component_bytes = (smallest_component_bits + 7) & !7;
+
+                    if vertex_data.device_address().unwrap().get() % smallest_component_bytes as u64
+                        != 0
+                    {
+                        return Err(ValidationError {
+                            context: format!("info.geometries[{}].vertex_data", geometry_index)
+                                .into(),
+                            problem: "the buffer's device address is not a multiple of the byte \
+                                size of the smallest component of vertex_format"
+                                .into(),
+                            vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03711"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if let Some(index_data) = index_data {
+                        if !index_data
+                            .as_bytes()
+                            .buffer()
+                            .usage()
+                            .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                        {
+                            return Err(ValidationError {
+                                context: format!("info.geometries[{}].index_data", geometry_index)
+                                    .into(),
+                                problem: "the buffer was not created with the \
+                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if index_data.as_bytes().device_address().unwrap().get()
+                            % index_data.index_type().size()
+                            != 0
+                        {
+                            return Err(ValidationError {
+                                context: format!("info.geometries[{}].index_data", geometry_index)
+                                    .into(),
+                                problem: "the buffer's device address is not a multiple \
+                                    of the size of the index type"
+                                    .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03712"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if primitive_offset as u64 % index_data.index_type().size() != 0 {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "info.geometries is \
+                                    AccelerationStructureGeometries::Triangles, and
+                                    build_range_infos[{}].primitive_offset is not a multiple of \
+                                    the size of the index type of info.geometries[{0}].index_data",
+                                    geometry_index,
+                                )
+                                .into(),
+                                vuids: &["VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03656"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if primitive_offset as DeviceSize
+                            + 3 * primitive_count as DeviceSize
+                                * index_data.index_type().size() as DeviceSize
+                            > vertex_data.size()
+                        {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "infos.geometries is \
+                                    AccelerationStructureGeometries::Triangles, \
+                                    info.geometries[{0}].index_data is Some, \
+                                    and build_range_infos[{0}].primitive_offset + \
+                                    3 * build_range_infos[{0}].primitive_count * \
+                                    info.geometries[{0}].index_data.index_type().size is greater \
+                                    than the size of infos.geometries[{0}].index_data",
+                                    geometry_index,
+                                )
+                                .into(),
+                                ..Default::default()
+                            });
+                        }
+                    } else {
+                        if primitive_offset % smallest_component_bytes != 0 {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "info.geometries is \
+                                    AccelerationStructureGeometries::Triangles, and
+                                    build_range_infos[{}].primitive_offset is not a multiple of \
+                                    the byte size of the smallest component of \
+                                    info.geometries[{0}].vertex_format",
+                                    geometry_index,
+                                )
+                                .into(),
+                                vuids: &["VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03657"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if primitive_offset as DeviceSize
+                            + (first_vertex as DeviceSize + 3 * primitive_count as DeviceSize)
+                                * vertex_stride as DeviceSize
+                            > vertex_data.size()
+                        {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "infos.geometries is \
+                                    AccelerationStructureGeometries::Triangles, \
+                                    info.geometries[{0}].index_data is None, \
+                                    and build_range_infos[{0}].primitive_offset + \
+                                    (build_range_infos[{0}].first_vertex + 3 * \
+                                    build_range_infos[{0}].primitive_count) * \
+                                    info.geometries[{0}].vertex_stride is greater than the size \
+                                    of infos.geometries[{0}].vertex_data",
+                                    geometry_index,
+                                )
+                                .into(),
+                                ..Default::default()
+                            });
+                        }
+                    }
+
+                    if let Some(transform_data) = transform_data {
+                        if !transform_data
+                            .buffer()
+                            .usage()
+                            .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                        {
+                            return Err(ValidationError {
+                                context: format!(
+                                    "info.geometries[{}].transform_data",
+                                    geometry_index
+                                )
+                                .into(),
+                                problem: "the buffer was not created with the \
+                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if transform_data.device_address().unwrap().get() % 16 != 0 {
+                            return Err(ValidationError {
+                                context: format!(
+                                    "info.geometries[{}].transform_data",
+                                    geometry_index
+                                )
+                                .into(),
+                                problem: "the buffer's device address is not a multiple of 16"
+                                    .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03810"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if transform_offset % 16 != 0 {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "info.geometries is \
+                                    AccelerationStructureGeometries::Triangles, and
+                                    build_range_infos[{}].transform_offset is not a multiple of 16",
+                                    geometry_index,
+                                )
+                                .into(),
+                                vuids: &["VUID-VkAccelerationStructureBuildRangeInfoKHR-transformOffset-03658"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if transform_offset as DeviceSize
+                            + size_of::<TransformMatrix>() as DeviceSize
+                            > transform_data.size()
+                        {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "infos.geometries is \
+                                    AccelerationStructureGeometries::Triangles, and \
+                                    build_range_infos[{0}].transform_offset + \
+                                    size_of::<TransformMatrix> is greater than the size of \
+                                    infos.geometries[{0}].transform_data",
+                                    geometry_index,
+                                )
+                                .into(),
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
+            }
+            AccelerationStructureGeometries::Aabbs(geometries) => {
+                for (geometry_index, (aabbs_data, build_range_info)) in
+                    geometries.iter().zip(build_range_infos).enumerate()
+                {
+                    let &AccelerationStructureGeometryAabbsData {
+                        flags: _,
+                        ref data,
+                        stride,
+                        _ne,
+                    } = aabbs_data;
+
+                    let &AccelerationStructureBuildRangeInfo {
+                        primitive_count,
+                        primitive_offset,
+                        first_vertex: _,
+                        transform_offset: _,
+                    } = build_range_info;
+
+                    if primitive_count as u64 > max_primitive_count {
+                        return Err(ValidationError {
+                            context: format!("build_range_infos[{}]", geometry_index).into(),
+                            problem: "the max_primitive_count limit has been exceeded".into(),
+                            vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03794"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if !data
+                        .buffer()
+                        .usage()
+                        .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                    {
+                        return Err(ValidationError {
+                            context: format!("info.geometries[{}].data", geometry_index).into(),
+                            problem: "the buffer was not created with the \
+                                `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                .into(),
+                            vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if data.device_address().unwrap().get() % 8 != 0 {
+                        return Err(ValidationError {
+                            context: format!("info.geometries[{}].data", geometry_index).into(),
+                            problem: "the buffer's device address is not a multiple of 8".into(),
+                            vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03714"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if primitive_offset % 8 != 0 {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "info.geometries is \
+                                AccelerationStructureGeometries::Aabbs, and
+                                build_range_infos[{}].primitive_offset is not a multiple of 8",
+                                geometry_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03659"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if primitive_offset as DeviceSize
+                        + primitive_count as DeviceSize * stride as DeviceSize
+                        > data.size()
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "infos.geometries is AccelerationStructureGeometries::Aabbs,
+                                and build_range_infos[{0}].primitive_offset + \
+                                build_range_infos[{0}].primitive_count * \
+                                info.geometries[{0}].stride is greater than the size of
+                                infos.geometries[{0}].data",
+                                geometry_index,
+                            )
+                            .into(),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            AccelerationStructureGeometries::Instances(instances_data) => {
+                let &AccelerationStructureGeometryInstancesData {
+                    flags: _,
+                    ref data,
+                    _ne,
+                } = instances_data;
+
+                let &AccelerationStructureBuildRangeInfo {
+                    primitive_count,
+                    primitive_offset,
+                    first_vertex: _,
+                    transform_offset: _,
+                } = &build_range_infos[0];
+
+                if primitive_count as u64 > max_instance_count {
+                    return Err(ValidationError {
+                        context: "build_range_infos[0]".into(),
+                        problem: "the max_instance_count limit has been exceeded".into(),
+                        vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03801"],
+                        ..Default::default()
+                    });
+                }
+
+                if primitive_offset % 16 != 0 {
+                    return Err(ValidationError {
+                        problem: "info.geometries is \
+                            AccelerationStructureGeometries::Instances, and
+                            build_range_infos[0].primitive_offset is not a multiple of 16"
+                            .into(),
+                        vuids: &[
+                            "VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03660",
+                        ],
+                        ..Default::default()
+                    });
+                }
+
+                let data_buffer = match data {
+                    AccelerationStructureGeometryInstancesDataType::Values(data) => {
+                        if data.device_address().unwrap().get() % 16 != 0 {
+                            return Err(ValidationError {
+                                context: "info.geometries.data".into(),
+                                problem: "is AccelerationStructureGeometryInstancesDataType::\
+                                    Values, and the buffer's device address is not a multiple of \
+                                    16"
+                                .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03715"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if primitive_offset as DeviceSize
+                            + primitive_count as DeviceSize
+                                * size_of::<AccelerationStructureInstance>() as DeviceSize
+                            > data.size()
+                        {
+                            return Err(ValidationError {
+                                problem: "infos.geometries is
+                                    AccelerationStructureGeometries::Instances, \
+                                    infos.geometries.data is \
+                                    AccelerationStructureGeometryInstancesDataType::Values, and \
+                                    build_range_infos[0].primitive_offset + \
+                                    build_range_infos[0].primitive_count * \
+                                    size_of::<AccelerationStructureInstance>() is greater than the \
+                                    size of infos.geometries.data"
+                                    .into(),
+                                ..Default::default()
+                            });
+                        }
+
+                        data.buffer()
+                    }
+                    AccelerationStructureGeometryInstancesDataType::Pointers(data) => {
+                        if !data
+                            .buffer()
+                            .usage()
+                            .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                        {
+                            return Err(ValidationError {
+                                context: "info.geometries.data".into(),
+                                problem: "the buffer was not created with the \
+                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if data.device_address().unwrap().get() % 8 != 0 {
+                            return Err(ValidationError {
+                                context: "info.geometries.data".into(),
+                                problem:
+                                    "is AccelerationStructureGeometryInstancesDataType::\
+                                    Pointers and the buffer's device address is not a multiple of 8"
+                                        .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03716"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if primitive_offset as DeviceSize
+                            + primitive_count as DeviceSize * size_of::<DeviceSize>() as DeviceSize
+                            > data.size()
+                        {
+                            return Err(ValidationError {
+                                problem: "infos.geometries is
+                                    AccelerationStructureGeometries::Instances, \
+                                    infos.geometries.data is \
+                                    AccelerationStructureGeometryInstancesDataType::Pointers, and \
+                                    build_range_infos[0].primitive_offset + \
+                                    build_range_infos[0].primitive_count * \
+                                    size_of::<DeviceSize>() is greater than the \
+                                    size of infos.geometries.data"
+                                    .into(),
+                                ..Default::default()
+                            });
+                        }
+
+                        // VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03717
+                        // unsafe
+
+                        data.buffer()
+                    }
+                };
+
+                if !data_buffer
+                    .usage()
+                    .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                {
+                    return Err(ValidationError {
+                        context: "info.geometries.data".into(),
+                        problem: "the buffer was not created with the \
+                            `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                            .into(),
+                        vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
+                        ..Default::default()
+                    });
+                }
+
+                // VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-06707
+                // unsafe
+            }
+        }
+
+        let build_size_info = unsafe {
+            self.device().acceleration_structure_build_sizes_unchecked(
+                AccelerationStructureBuildType::Device,
+                info,
+                &build_range_infos
+                    .iter()
+                    .map(|info| info.primitive_count)
+                    .collect::<SmallVec<[_; 8]>>(),
+            )
+        };
+
+        if dst_acceleration_structure.size() < build_size_info.acceleration_structure_size {
+            return Err(ValidationError {
+                context: "info.dst_acceleration_structure".into(),
+                problem: "size is too small to hold the resulting acceleration structure data"
+                    .into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03675"],
+                ..Default::default()
+            });
+        }
+
+        match mode {
+            BuildAccelerationStructureMode::Build => {
+                if scratch_data.size() < build_size_info.build_scratch_size {
+                    return Err(ValidationError {
+                        context: "info.scratch_data".into(),
+                        problem: "size is too small for the build operation".into(),
+                        vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03671"],
+                        ..Default::default()
+                    });
+                }
+            }
+            BuildAccelerationStructureMode::Update(_src_acceleration_structure) => {
+                if scratch_data.size() < build_size_info.update_scratch_size {
+                    return Err(ValidationError {
+                        context: "info.scratch_data".into(),
+                        problem: "size is too small for the update operation".into(),
+                        vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03672"],
+                        ..Default::default()
+                    });
+                }
+
+                // VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03667
+                // unsafe
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn build_acceleration_structure_unchecked(
+        &mut self,
+        info: AccelerationStructureBuildGeometryInfo,
+        build_range_infos: SmallVec<[AccelerationStructureBuildRangeInfo; 8]>,
+    ) -> &mut Self {
+        let mut used_resources = Vec::new();
+        add_build_geometry_resources(&mut used_resources, &info);
+
+        self.add_command(
+            "build_acceleration_structure",
+            used_resources,
+            move |out: &mut UnsafeCommandBufferBuilder<A>| {
+                out.build_acceleration_structure(&info, &build_range_infos);
+            },
+        );
+
+        self
+    }
+
+    /// Builds or updates an acceleration structure, using range info stored in an indirect buffer.
+    ///
+    /// # Safety
+    ///
+    /// The same requirements as for [`build_acceleration_structure`]. In addition, the following
+    /// requirements apply for each [`AccelerationStructureBuildRangeInfo`] element contained in
+    /// `indirect_buffer`:
+    /// - [`primitive_count`] must not be greater than the corresponding element of
+    ///   `max_primitive_counts`.
+    /// - If `info.geometries` is [`AccelerationStructureGeometries::Instances`], then
+    ///   [`primitive_count`] must not be greater than the [`max_instance_count`] limit.
+    ///   Otherwise, it must not be greater than the [`max_primitive_count`] limit.
+    ///
+    /// If `info.geometries` is [`AccelerationStructureGeometries::Triangles`], then:
+    /// - [`primitive_offset`] must be a multiple of:
+    ///   - [`index_data.index_type().size()`] if [`index_data`] is `Some`.
+    ///   - The byte size of the smallest component of [`vertex_format`] if [`index_data`] is
+    ///     `None`.
+    /// - [`transform_offset`] must be a multiple of 16.
+    /// - The size of [`vertex_data`] must be at least<br/>
+    ///   [`primitive_offset`] + ([`first_vertex`] + 3 * [`primitive_count`]) * [`vertex_stride`]
+    ///   <br/>if [`index_data`] is `None`, and as in [`build_acceleration_structure`] if
+    ///   [`index_data`] is `Some`.
+    /// - The size of [`index_data`] must be at least<br/>
+    ///   [`primitive_offset`] + 3 * [`primitive_count`] *
+    ///   [`index_data.index_type().size()`].
+    /// - The size of [`transform_data`] must be at least<br/>
+    ///   [`transform_offset`] + `size_of::<TransformMatrix>()`.
+    ///
+    /// If `info.geometries` is [`AccelerationStructureGeometries::Aabbs`], then:
+    /// - [`primitive_offset`] must be a multiple of 8.
+    /// - The size of [`data`](AccelerationStructureGeometryAabbsData::data) must be at least<br/>
+    ///   [`primitive_offset`] + [`primitive_count`] *
+    ///   [`stride`](AccelerationStructureGeometryAabbsData::stride).
+    ///
+    /// If `info.geometries` is [`AccelerationStructureGeometries::Instances`], then:
+    /// - [`primitive_offset`] must be a multiple of 16.
+    /// - The size of [`data`](AccelerationStructureGeometryInstancesData::data) must be at least:
+    ///   - [`primitive_offset`] + [`primitive_count`] *
+    ///     `size_of::<AccelerationStructureInstance>()`<br/> if
+    ///     [`data`](AccelerationStructureGeometryInstancesData::data) is
+    ///     [`AccelerationStructureGeometryInstancesDataType::Values`].
+    ///   - [`primitive_offset`] + [`primitive_count`] *
+    ///     `size_of::<DeviceSize>()`<br/> if
+    ///     [`data`](AccelerationStructureGeometryInstancesData::data) is
+    ///     [`AccelerationStructureGeometryInstancesDataType::Pointers`].
+    ///
+    /// [`build_acceleration_structure`]: Self::build_acceleration_structure
+    /// [`primitive_count`]: AccelerationStructureBuildRangeInfo::primitive_count
+    /// [`max_instance_count`]: crate::device::Properties::max_instance_count
+    /// [`max_primitive_count`]: crate::device::Properties::max_primitive_count
+    /// [`primitive_offset`]: AccelerationStructureBuildRangeInfo::primitive_offset
+    /// [`index_data.index_type().size()`]: AccelerationStructureGeometryTrianglesData::index_data
+    /// [`index_data`]: AccelerationStructureGeometryTrianglesData::index_data
+    /// [`vertex_format`]: AccelerationStructureGeometryTrianglesData::vertex_format
+    /// [`transform_offset`]: AccelerationStructureBuildRangeInfo::transform_offset
+    /// [`vertex_data`]: AccelerationStructureGeometryTrianglesData::vertex_data
+    /// [`first_vertex`]: AccelerationStructureBuildRangeInfo::first_vertex
+    /// [`vertex_stride`]: AccelerationStructureGeometryTrianglesData::vertex_stride
+    /// [`transform_data`]: AccelerationStructureGeometryTrianglesData::transform_data
+    pub unsafe fn build_acceleration_structure_indirect(
+        &mut self,
+        info: AccelerationStructureBuildGeometryInfo,
+        indirect_buffer: Subbuffer<[AccelerationStructureBuildRangeInfo]>,
+        stride: u32,
+        max_primitive_counts: SmallVec<[u32; 8]>,
+    ) -> Result<&mut Self, ValidationError> {
+        self.validate_build_acceleration_structure_indirect(
+            &info,
+            &indirect_buffer,
+            stride,
+            &max_primitive_counts,
+        )?;
+
+        Ok(self.build_acceleration_structure_indirect_unchecked(
+            info,
+            indirect_buffer,
+            stride,
+            max_primitive_counts,
+        ))
+    }
+
+    fn validate_build_acceleration_structure_indirect(
+        &self,
+        info: &AccelerationStructureBuildGeometryInfo,
+        indirect_buffer: &Subbuffer<[AccelerationStructureBuildRangeInfo]>,
+        stride: u32,
+        max_primitive_counts: &[u32],
+    ) -> Result<(), ValidationError> {
+        if !self
+            .device()
+            .enabled_features()
+            .acceleration_structure_indirect_build
+        {
+            return Err(ValidationError {
+                requires_one_of: Some(RequiresOneOf {
+                    features: &["acceleration_structure_indirect_build"],
+                    ..Default::default()
+                }),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-accelerationStructureIndirectBuild-03650"],
+                ..Default::default()
+            });
+        }
+
+        if !self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "queue family does not support compute operations".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-commandBuffer-cmdpool"],
+                ..Default::default()
+            });
+        }
+
+        if self.builder_state.render_pass.is_some() {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "a render pass instance is active".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-renderpass"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-parameter
+        info.validate(self.device())
+            .map_err(|err| ValidationError {
+                context: format!("info.{}", err.context).into(),
+                ..err
+            })?;
+
+        let &AccelerationStructureBuildGeometryInfo {
+            flags: _,
+            ref mode,
+            ref dst_acceleration_structure,
+            ref geometries,
+            ref scratch_data,
+            _ne,
+        } = info;
+
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-mode-04628
+        // Ensured as long as `BuildAccelerationStructureMode` is exhaustive.
+
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-04630
+        // Ensured by the definition of `BuildAccelerationStructureMode`.
+
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03403
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-None-03407
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03698
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03702
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-scratchData-03704
+        // Ensured as long as only one element is provided in `info`.
+
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03668
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03701
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03703
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03706
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-scratchData-03705
+        // Ensured by unsafe on `AccelerationStructure::new`.
+
+        if !scratch_data
+            .buffer()
+            .usage()
+            .intersects(BufferUsage::STORAGE_BUFFER)
+        {
+            return Err(ValidationError {
+                context: "info.scratch_data".into(),
+                problem: "the buffer was not created with the `STORAGE_BUFFER` usage".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03674"],
+                ..Default::default()
+            });
+        }
+
+        let min_acceleration_structure_scratch_offset_alignment = self
+            .device()
+            .physical_device()
+            .properties()
+            .min_acceleration_structure_scratch_offset_alignment
+            .unwrap();
+
+        if scratch_data.device_address().unwrap().get()
+            % min_acceleration_structure_scratch_offset_alignment as u64
+            != 0
+        {
+            return Err(ValidationError {
+                context: "info.scratch_data".into(),
+                problem: "the device address of the buffer was not a multiple of the \
+                    min_acceleration_structure_scratch_offset_alignment device property"
+                    .into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03710"],
+                ..Default::default()
+            });
+        }
+
+        match dst_acceleration_structure.ty() {
+            AccelerationStructureType::TopLevel => {
+                if !matches!(geometries, AccelerationStructureGeometries::Instances(_)) {
+                    return Err(ValidationError {
+                        context: "info".into(),
+                        problem: "dst_acceleration_structure is a top-level \
+                            acceleration structure, but geometries is not \
+                            AccelerationStructureGeometries::Instances"
+                            .into(),
+                        vuids: &[
+                            "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03789",
+                            "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03699",
+                        ],
+                        ..Default::default()
+                    });
+                }
+            }
+            AccelerationStructureType::BottomLevel => {
+                if matches!(geometries, AccelerationStructureGeometries::Instances(_)) {
+                    return Err(ValidationError {
+                        context: "info".into(),
+                        problem: "dst_acceleration_structure is a bottom-level \
+                            acceleration structure, but geometries is \
+                            AccelerationStructureGeometries::Instances"
+                            .into(),
+                        vuids: &[
+                            "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03791",
+                            "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03700",
+                        ],
+                        ..Default::default()
+                    });
+                }
+            }
+            AccelerationStructureType::Generic => (),
+        }
+
+        if geometries.len() != max_primitive_counts.len() {
+            return Err(ValidationError {
+                problem: "info.geometries and max_primitive_counts do not have the same length"
+                    .into(),
+                vuids: &[
+                    "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-ppMaxPrimitiveCounts-parameter",
+                ],
+                ..Default::default()
+            });
+        }
+
+        match geometries {
+            AccelerationStructureGeometries::Triangles(geometries) => {
+                for (geometry_index, triangles_data) in geometries.iter().enumerate() {
+                    let &AccelerationStructureGeometryTrianglesData {
+                        flags: _,
+                        vertex_format,
+                        ref vertex_data,
+                        vertex_stride: _,
+                        max_vertex: _,
+                        ref index_data,
+                        ref transform_data,
+                        _ne,
+                    } = triangles_data;
+
+                    // VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03795
+                    // unsafe
+
+                    if !vertex_data
+                        .buffer()
+                        .usage()
+                        .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                    {
+                        return Err(ValidationError {
+                            context: format!("info.geometries[{}].vertex_data", geometry_index)
+                                .into(),
+                            problem: "the buffer was not created with the \
+                                `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                .into(),
+                            vuids: &[
+                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673",
+                            ],
+                            ..Default::default()
+                        });
+                    }
+
+                    let smallest_component_bits = vertex_format
+                        .components()
+                        .into_iter()
+                        .filter(|&c| c != 0)
+                        .min()
+                        .unwrap() as u32;
+                    let smallest_component_bytes = (smallest_component_bits + 7) & !7;
+
+                    if vertex_data.device_address().unwrap().get() % smallest_component_bytes as u64
+                        != 0
+                    {
+                        return Err(ValidationError {
+                            context: format!("info.geometries[{}].vertex_data", geometry_index)
+                                .into(),
+                            problem: "the buffer's device address is not a multiple of the byte \
+                                size of the smallest component of vertex_format"
+                                .into(),
+                            vuids: &[
+                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03711",
+                            ],
+                            ..Default::default()
+                        });
+                    }
+
+                    if let Some(index_data) = index_data {
+                        if !index_data
+                            .as_bytes()
+                            .buffer()
+                            .usage()
+                            .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                        {
+                            return Err(ValidationError {
+                                context: format!("info.geometries[{}].index_data", geometry_index)
+                                    .into(),
+                                problem: "the buffer was not created with the \
+                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if index_data.as_bytes().device_address().unwrap().get()
+                            % index_data.index_type().size()
+                            != 0
+                        {
+                            return Err(ValidationError {
+                                context: format!("info.geometries[{}].index_data", geometry_index)
+                                    .into(),
+                                problem: "the buffer's device address is not a multiple \
+                                    of the size of the index type"
+                                    .into(),
+                                vuids: &[
+                                    "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03712",
+                                ],
+                                ..Default::default()
+                            });
+                        }
+
+                        // VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03656
+                        // unsafe
+                    } else {
+                        // VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03657
+                        // unsafe
+                    }
+
+                    if let Some(transform_data) = transform_data {
+                        if !transform_data
+                            .buffer()
+                            .usage()
+                            .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                        {
+                            return Err(ValidationError {
+                                context: format!(
+                                    "info.geometries[{}].transform_data",
+                                    geometry_index
+                                )
+                                .into(),
+                                problem: "the buffer was not created with the \
+                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if transform_data.device_address().unwrap().get() % 16 != 0 {
+                            return Err(ValidationError {
+                                context: format!(
+                                    "info.geometries[{}].transform_data",
+                                    geometry_index
+                                )
+                                .into(),
+                                problem: "the buffer's device address is not a multiple of 16"
+                                    .into(),
+                                vuids: &[
+                                    "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03810",
+                                ],
+                                ..Default::default()
+                            });
+                        }
+
+                        // VUID-VkAccelerationStructureBuildRangeInfoKHR-transformOffset-03658
+                        // unsafe
+                    }
+                }
+            }
+            AccelerationStructureGeometries::Aabbs(geometries) => {
+                for (geometry_index, aabbs_data) in geometries.iter().enumerate() {
+                    let &AccelerationStructureGeometryAabbsData {
+                        flags: _,
+                        ref data,
+                        stride: _,
+                        _ne,
+                    } = aabbs_data;
+
+                    // VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03794
+                    // unsafe
+
+                    if !data
+                        .buffer()
+                        .usage()
+                        .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                    {
+                        return Err(ValidationError {
+                            context: format!("info.geometries[{}].data", geometry_index).into(),
+                            problem: "the buffer was not created with the \
+                                `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                .into(),
+                            vuids: &[
+                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673",
+                            ],
+                            ..Default::default()
+                        });
+                    }
+
+                    if data.device_address().unwrap().get() % 8 != 0 {
+                        return Err(ValidationError {
+                            context: format!("info.geometries[{}].data", geometry_index).into(),
+                            problem: "the buffer's device address is not a multiple of 8".into(),
+                            vuids: &[
+                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03714",
+                            ],
+                            ..Default::default()
+                        });
+                    }
+
+                    // VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03659
+                    // unsafe
+                }
+            }
+            AccelerationStructureGeometries::Instances(instances_data) => {
+                let &AccelerationStructureGeometryInstancesData {
+                    flags: _,
+                    ref data,
+                    _ne,
+                } = instances_data;
+
+                // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03801
+                // unsafe
+
+                let data_buffer = match data {
+                    AccelerationStructureGeometryInstancesDataType::Values(data) => {
+                        if data.device_address().unwrap().get() % 16 != 0 {
+                            return Err(ValidationError {
+                                context: "info.geometries.data".into(),
+                                problem: "is AccelerationStructureGeometryInstancesDataType::\
+                                    Values and the buffer's device address is not a multiple of 16"
+                                    .into(),
+                                vuids: &[
+                                    "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03715",
+                                ],
+                                ..Default::default()
+                            });
+                        }
+
+                        data.buffer()
+                    }
+                    AccelerationStructureGeometryInstancesDataType::Pointers(data) => {
+                        if !data
+                            .buffer()
+                            .usage()
+                            .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                        {
+                            return Err(ValidationError {
+                                context: "info.geometries.data".into(),
+                                problem: "the buffer was not created with the \
+                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    .into(),
+                                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if data.device_address().unwrap().get() % 8 != 0 {
+                            return Err(ValidationError {
+                                context: "info.geometries.data".into(),
+                                problem:
+                                    "is AccelerationStructureGeometryInstancesDataType::\
+                                    Pointers and the buffer's device address is not a multiple of 8"
+                                        .into(),
+                                vuids: &[
+                                    "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03716",
+                                ],
+                                ..Default::default()
+                            });
+                        }
+
+                        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03717
+                        // unsafe
+
+                        data.buffer()
+                    }
+                };
+
+                if !data_buffer
+                    .usage()
+                    .intersects(BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY)
+                {
+                    return Err(ValidationError {
+                        context: "info.geometries.data".into(),
+                        problem: "the buffer was not created with the \
+                            `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                            .into(),
+                        vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"],
+                        ..Default::default()
+                    });
+                }
+
+                // VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03660
+                // unsafe
+
+                // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-06707
+                // unsafe
+            }
+        }
+
+        let build_size_info = unsafe {
+            self.device().acceleration_structure_build_sizes_unchecked(
+                AccelerationStructureBuildType::Device,
+                info,
+                max_primitive_counts,
+            )
+        };
+
+        if dst_acceleration_structure.size() < build_size_info.acceleration_structure_size {
+            return Err(ValidationError {
+                context: "info.dst_acceleration_structure".into(),
+                problem: "size is too small to hold the resulting acceleration structure data"
+                    .into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03652"],
+                ..Default::default()
+            });
+        }
+
+        match mode {
+            BuildAccelerationStructureMode::Build => {
+                if scratch_data.size() < build_size_info.build_scratch_size {
+                    return Err(ValidationError {
+                        context: "info.scratch_data".into(),
+                        problem: "size is too small for the build operation".into(),
+                        vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03671"],
+                        ..Default::default()
+                    });
+                }
+            }
+            BuildAccelerationStructureMode::Update(_src_acceleration_structure) => {
+                if scratch_data.size() < build_size_info.update_scratch_size {
+                    return Err(ValidationError {
+                        context: "info.scratch_data".into(),
+                        problem: "size is too small for the update operation".into(),
+                        vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03672"],
+                        ..Default::default()
+                    });
+                }
+
+                // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03667
+                // unsafe
+            }
+        }
+
+        if geometries.len() as DeviceSize * stride as DeviceSize > indirect_buffer.size() {
+            return Err(ValidationError {
+                problem: "info.geometries.len() * stride is greater than the size of indirect_buffer".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03646"],
+                ..Default::default()
+            });
+        }
+
+        if !indirect_buffer
+            .buffer()
+            .usage()
+            .intersects(BufferUsage::INDIRECT_BUFFER)
+        {
+            return Err(ValidationError {
+                context: "indirect_buffer".into(),
+                problem: "the buffer was not created with the `INDIRECT_BUFFER` usage".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03647"],
+                ..Default::default()
+            });
+        }
+
+        if indirect_buffer.device_address().unwrap().get() % 4 != 0 {
+            return Err(ValidationError {
+                context: "indirect_buffer".into(),
+                problem: "the buffer's device address is not a multiple of 4".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03648"],
+                ..Default::default()
+            });
+        }
+
+        if stride % 4 != 0 {
+            return Err(ValidationError {
+                context: "stride".into(),
+                problem: "is not a multiple of 4".into(),
+                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectStrides-03787"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03651
+        // unsafe
+
+        // VUID-vkCmdBuildAccelerationStructuresIndirectKHR-ppMaxPrimitiveCounts-03653
+        // unsafe
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn build_acceleration_structure_indirect_unchecked(
+        &mut self,
+        info: AccelerationStructureBuildGeometryInfo,
+        indirect_buffer: Subbuffer<[AccelerationStructureBuildRangeInfo]>,
+        stride: u32,
+        max_primitive_counts: SmallVec<[u32; 8]>,
+    ) -> &mut Self {
+        let mut used_resources = Vec::new();
+        add_build_geometry_resources(&mut used_resources, &info);
+        add_indirect_buffer_resources(&mut used_resources, &indirect_buffer);
+
+        self.add_command(
+            "build_acceleration_structure_indirect",
+            used_resources,
+            move |out: &mut UnsafeCommandBufferBuilder<A>| {
+                out.build_acceleration_structure_indirect(
+                    &info,
+                    &indirect_buffer,
+                    stride,
+                    &max_primitive_counts,
+                );
+            },
+        );
+
+        self
+    }
+
+    /// Copies the data of one acceleration structure to another.
+    ///
+    /// # Safety
+    ///
+    /// - `info.src` must have been built when this command is executed.
+    /// - If `info.mode` is [`CopyAccelerationStructureMode::Compact`], then `info.src` must have
+    ///   been built with [`BuildAccelerationStructureFlags::ALLOW_COMPACTION`].
+    ///
+    /// [`CopyAccelerationStructureMode::Compact`]: crate::acceleration_structure::CopyAccelerationStructureMode::Compact
+    /// [`BuildAccelerationStructureFlags::ALLOW_COMPACTION`]: crate::acceleration_structure::BuildAccelerationStructureFlags::ALLOW_COMPACTION
+    #[inline]
+    pub unsafe fn copy_acceleration_structure(
+        &mut self,
+        info: CopyAccelerationStructureInfo,
+    ) -> Result<&mut Self, ValidationError> {
+        self.validate_copy_acceleration_structure(&info)?;
+
+        Ok(self.copy_acceleration_structure_unchecked(info))
+    }
+
+    fn validate_copy_acceleration_structure(
+        &self,
+        info: &CopyAccelerationStructureInfo,
+    ) -> Result<(), ValidationError> {
+        if !self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "queue family does not support compute operations".into(),
+                vuids: &["VUID-vkCmdCopyAccelerationStructureKHR-commandBuffer-cmdpool"],
+                ..Default::default()
+            });
+        }
+
+        if self.builder_state.render_pass.is_some() {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "a render pass instance is active".into(),
+                vuids: &["VUID-vkCmdCopyAccelerationStructureKHR-renderpass"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-vkCmdCopyAccelerationStructureKHR-pInfo-parameter
+        info.validate(self.device())
+            .map_err(|err| ValidationError {
+                context: format!("info.{}", err.context).into(),
+                ..err
+            })?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn copy_acceleration_structure_unchecked(
+        &mut self,
+        info: CopyAccelerationStructureInfo,
+    ) -> &mut Self {
+        let &CopyAccelerationStructureInfo {
+            ref src,
+            ref dst,
+            mode: _,
+            _ne: _,
+        } = &info;
+
+        let src_buffer = src.buffer();
+        let dst_buffer = dst.buffer();
+        self.add_command(
+            "copy_acceleration_structure",
+            [
+                (
+                    ResourceInCommand::Source.into(),
+                    Resource::Buffer {
+                        buffer: src_buffer.clone(),
+                        range: 0..src_buffer.size(), // TODO:
+                        memory_access:
+                            PipelineStageAccessFlags::AccelerationStructureCopy_AccelerationStructureRead,
+                    },
+                ),
+                (
+                    ResourceInCommand::Destination.into(),
+                    Resource::Buffer {
+                        buffer: dst_buffer.clone(),
+                        range: 0..dst_buffer.size(), // TODO:
+                        memory_access:
+                            PipelineStageAccessFlags::AccelerationStructureCopy_AccelerationStructureWrite,
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            move |out: &mut UnsafeCommandBufferBuilder<A>| {
+                out.copy_acceleration_structure(&info);
+            },
+        );
+
+        self
+    }
+
+    /// Serializes the data of an acceleration structure and writes it to a buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `info.src` must have been built when this command is executed.
+    /// - `info.dst` must be large enough to hold the serialized form of `info.src`. This can be
+    ///   queried using [`write_acceleration_structures_properties`] with a query pool whose type is
+    ///   [`QueryType::AccelerationStructureSerializationSize`].
+    ///
+    /// [`write_acceleration_structures_properties`]: Self::write_acceleration_structures_properties
+    #[inline]
+    pub unsafe fn copy_acceleration_structure_to_memory(
+        &mut self,
+        info: CopyAccelerationStructureToMemoryInfo,
+    ) -> Result<&mut Self, ValidationError> {
+        self.validate_copy_acceleration_structure_to_memory(&info)?;
+
+        Ok(self.copy_acceleration_structure_to_memory_unchecked(info))
+    }
+
+    fn validate_copy_acceleration_structure_to_memory(
+        &self,
+        info: &CopyAccelerationStructureToMemoryInfo,
+    ) -> Result<(), ValidationError> {
+        if !self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "queue family does not support compute operations".into(),
+                vuids: &["VUID-vkCmdCopyAccelerationStructureToMemoryKHR-commandBuffer-cmdpool"],
+                ..Default::default()
+            });
+        }
+
+        if self.builder_state.render_pass.is_some() {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "a render pass instance is active".into(),
+                vuids: &["VUID-vkCmdCopyAccelerationStructureToMemoryKHR-renderpass"],
+                ..Default::default()
+            });
+        }
+
+        if info.dst.device_address().unwrap().get() % 256 != 0 {
+            return Err(ValidationError {
+                context: "info.dst".into(),
+                problem: "the device address of the buffer was not a multiple of 256".into(),
+                vuids: &["VUID-vkCmdCopyAccelerationStructureToMemoryKHR-pInfo-03740"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-vkCmdCopyAccelerationStructureToMemoryKHR-pInfo-parameter
+        info.validate(self.device())
+            .map_err(|err| ValidationError {
+                context: format!("info.{}", err.context).into(),
+                ..err
+            })?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn copy_acceleration_structure_to_memory_unchecked(
+        &mut self,
+        info: CopyAccelerationStructureToMemoryInfo,
+    ) -> &mut Self {
+        let &CopyAccelerationStructureToMemoryInfo {
+            ref src,
+            ref dst,
+            mode: _,
+            _ne: _,
+        } = &info;
+
+        let src_buffer = src.buffer();
+        self.add_command(
+            "copy_acceleration_structure_to_memory",
+            [
+                (
+                    ResourceInCommand::Source.into(),
+                    Resource::Buffer {
+                        buffer: src_buffer.clone(),
+                        range: 0..src_buffer.size(), // TODO:
+                        memory_access:
+                            PipelineStageAccessFlags::AccelerationStructureCopy_AccelerationStructureRead,
+                    },
+                ),
+                (
+                    ResourceInCommand::Destination.into(),
+                    Resource::Buffer {
+                        buffer: dst.clone(),
+                        range: 0..dst.size(), // TODO:
+                        memory_access:
+                            PipelineStageAccessFlags::AccelerationStructureCopy_TransferWrite,
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            move |out: &mut UnsafeCommandBufferBuilder<A>| {
+                out.copy_acceleration_structure_to_memory(&info);
+            },
+        );
+
+        self
+    }
+
+    /// Reads data of a previously serialized acceleration structure from a buffer, and
+    /// deserializes it back into an acceleration structure.
+    ///
+    /// # Safety
+    ///
+    /// - `info.src` must contain data previously serialized using
+    ///   [`copy_acceleration_structure_to_memory`], and must have a format compatible with the
+    ///   device (as queried by [`Device::acceleration_structure_is_compatible`]).
+    /// - `info.dst.size()` must be at least the size that the structure in `info.src` had
+    ///   before it was serialized.
+    ///
+    /// [`copy_acceleration_structure_to_memory`]: Self::copy_acceleration_structure_to_memory
+    /// [`Device::acceleration_structure_is_compatible`]: crate::device::Device::acceleration_structure_is_compatible
+    #[inline]
+    pub unsafe fn copy_memory_to_acceleration_structure(
+        &mut self,
+        info: CopyMemoryToAccelerationStructureInfo,
+    ) -> Result<&mut Self, ValidationError> {
+        self.validate_copy_memory_to_acceleration_structure(&info)?;
+
+        Ok(self.copy_memory_to_acceleration_structure_unchecked(info))
+    }
+
+    fn validate_copy_memory_to_acceleration_structure(
+        &self,
+        info: &CopyMemoryToAccelerationStructureInfo,
+    ) -> Result<(), ValidationError> {
+        if !self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "queue family does not support compute operations".into(),
+                vuids: &["VUID-vkCmdCopyMemoryToAccelerationStructureKHR-commandBuffer-cmdpool"],
+                ..Default::default()
+            });
+        }
+
+        if self.builder_state.render_pass.is_some() {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "a render pass instance is active".into(),
+                vuids: &["VUID-vkCmdCopyMemoryToAccelerationStructureKHR-renderpass"],
+                ..Default::default()
+            });
+        }
+
+        if info.src.device_address().unwrap().get() % 256 != 0 {
+            return Err(ValidationError {
+                context: "info.src".into(),
+                problem: "the device address of the buffer was not a multiple of 256".into(),
+                vuids: &["VUID-vkCmdCopyMemoryToAccelerationStructureKHR-pInfo-03743"],
+                ..Default::default()
+            });
+        }
+
+        // VUID-vkCmdCopyMemoryToAccelerationStructureKHR-pInfo-parameter
+        info.validate(self.device())
+            .map_err(|err| ValidationError {
+                context: format!("info.{}", err.context).into(),
+                ..err
+            })?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn copy_memory_to_acceleration_structure_unchecked(
+        &mut self,
+        info: CopyMemoryToAccelerationStructureInfo,
+    ) -> &mut Self {
+        let &CopyMemoryToAccelerationStructureInfo {
+            ref src,
+            ref dst,
+            mode: _,
+            _ne: _,
+        } = &info;
+
+        let dst_buffer = dst.buffer();
+        self.add_command(
+            "copy_memory_to_acceleration_structure",
+            [
+                (
+                    ResourceInCommand::Source.into(),
+                    Resource::Buffer {
+                        buffer: src.clone(),
+                        range: 0..src.size(), // TODO:
+                        memory_access:
+                            PipelineStageAccessFlags::AccelerationStructureCopy_TransferRead,
+                    },
+                ),
+                (
+                    ResourceInCommand::Destination.into(),
+                    Resource::Buffer {
+                        buffer: dst_buffer.clone(),
+                        range: 0..dst_buffer.size(), // TODO:
+                        memory_access:
+                            PipelineStageAccessFlags::AccelerationStructureCopy_AccelerationStructureWrite,
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            move |out: &mut UnsafeCommandBufferBuilder<A>| {
+                out.copy_memory_to_acceleration_structure(&info);
+            },
+        );
+
+        self
+    }
+
+    /// Writes the properties of one or more acceleration structures to a query.
+    ///
+    /// For each element in `acceleration_structures`, one query is written, in numeric order
+    /// starting at `first_query`.
+    ///
+    /// # Safety
+    ///
+    /// - All elements of `acceleration_structures` must have been built when this command is
+    ///   executed.
+    /// - If `query_pool.query_type()` is [`QueryType::AccelerationStructureCompactedSize`],
+    ///   all elements of `acceleration_structures` must have been built with
+    ///   [`BuildAccelerationStructureFlags::ALLOW_COMPACTION`].
+    /// - The queries must be unavailable, ensured by calling [`reset_query_pool`].
+    ///
+    /// [`BuildAccelerationStructureFlags::ALLOW_COMPACTION`]: crate::acceleration_structure::BuildAccelerationStructureFlags::ALLOW_COMPACTION
+    /// [`reset_query_pool`]: Self::reset_query_pool
+    #[inline]
+    pub unsafe fn write_acceleration_structures_properties(
+        &mut self,
+        acceleration_structures: SmallVec<[Arc<AccelerationStructure>; 4]>,
+        query_pool: Arc<QueryPool>,
+        first_query: u32,
+    ) -> Result<&mut Self, ValidationError> {
+        self.validate_write_acceleration_structures_properties(
+            &acceleration_structures,
+            &query_pool,
+            first_query,
+        )?;
+
+        Ok(self.write_acceleration_structures_properties_unchecked(
+            acceleration_structures,
+            query_pool,
+            first_query,
+        ))
+    }
+
+    fn validate_write_acceleration_structures_properties(
+        &self,
+        acceleration_structures: &[Arc<AccelerationStructure>],
+        query_pool: &QueryPool,
+        first_query: u32,
+    ) -> Result<(), ValidationError> {
+        if acceleration_structures.is_empty() {
+            return Ok(());
+        }
+
+        if !self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "queue family does not support compute operations".into(),
+                vuids: &[
+                    "VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-commandBuffer-cmdpool",
+                ],
+                ..Default::default()
+            });
+        }
+
+        if self.builder_state.render_pass.is_some() {
+            return Err(ValidationError {
+                context: "self".into(),
+                problem: "a render pass instance is active".into(),
+                vuids: &["VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-renderpass"],
+                ..Default::default()
+            });
+        }
+
+        for acs in acceleration_structures {
+            // VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-commonparent
+            assert_eq!(self.device(), acs.device());
+
+            // VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-04964
+            // unsafe
+
+            // VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431
+            // unsafe
+        }
+
+        // VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-commonparent
+        assert_eq!(self.device(), query_pool.device());
+
+        // VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-queryPool-02494
+        // unsafe
+
+        if first_query as usize + acceleration_structures.len() > query_pool.query_count() as usize
+        {
+            return Err(ValidationError {
+                problem: "first_query + acceleration_structures.len() is greater than \
+                    query_pool.query_count"
+                    .into(),
+                vuids: &["VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-query-04880"],
+                ..Default::default()
+            });
+        }
+
+        if !matches!(
+            query_pool.query_type(),
+            QueryType::AccelerationStructureSize
+                | QueryType::AccelerationStructureSerializationBottomLevelPointers
+                | QueryType::AccelerationStructureCompactedSize
+                | QueryType::AccelerationStructureSerializationSize,
+        ) {
+            return Err(ValidationError {
+                context: "query_pool.query_type()".into(),
+                problem: "is not an acceleration structure query".into(),
+                vuids: &["VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-queryType-06742"],
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn write_acceleration_structures_properties_unchecked(
+        &mut self,
+        acceleration_structures: SmallVec<[Arc<AccelerationStructure>; 4]>,
+        query_pool: Arc<QueryPool>,
+        first_query: u32,
+    ) -> &mut Self {
+        if acceleration_structures.is_empty() {
+            return self;
+        }
+
+        self.add_command(
+            "write_acceleration_structures_properties",
+            acceleration_structures.iter().enumerate().map(|(index, acs)| {
+                let index = index as u32;
+                let buffer = acs.buffer();
+
+                (
+                    ResourceInCommand::AccelerationStructure { index }.into(),
+                    Resource::Buffer {
+                        buffer: buffer.clone(),
+                        range: 0..buffer.size(), // TODO:
+                        memory_access:
+                            PipelineStageAccessFlags::AccelerationStructureCopy_AccelerationStructureRead,
+                    },
+                )
+            }).collect(),
+            move |out: &mut UnsafeCommandBufferBuilder<A>| {
+                out.write_acceleration_structures_properties(
+                    &acceleration_structures,
+                    &query_pool,
+                    first_query,
+                );
+            },
+        );
+
+        self
+    }
+}
+
+fn add_build_geometry_resources(
+    used_resources: &mut Vec<(ResourceUseRef2, Resource)>,
+    info: &AccelerationStructureBuildGeometryInfo,
+) {
+    let &AccelerationStructureBuildGeometryInfo {
+        flags: _,
+        ref mode,
+        ref dst_acceleration_structure,
+        ref geometries,
+        ref scratch_data,
+        _ne: _,
+    } = &info;
+
+    match geometries {
+        AccelerationStructureGeometries::Triangles(geometries) => {
+            used_resources.extend(
+                geometries.iter().enumerate().flat_map(|(index, triangles_data)| {
+                    let index = index as u32;
+                    let &AccelerationStructureGeometryTrianglesData {
+                        flags: _,
+                        vertex_format: _,
+                        ref vertex_data,
+                        vertex_stride: _,
+                        max_vertex: _,
+                        ref index_data,
+                        ref transform_data,
+                        _ne,
+                    } = triangles_data;
+
+                    [
+                        (
+                            ResourceInCommand::GeometryTrianglesVertexData { index }.into(),
+                            Resource::Buffer {
+                                buffer: vertex_data.clone(),
+                                range: 0..vertex_data.size(), // TODO:
+                                memory_access: PipelineStageAccessFlags::AccelerationStructureBuild_ShaderSampledRead
+                                    | PipelineStageAccessFlags::AccelerationStructureBuild_ShaderStorageRead,
+                            },
+                        ),
+                    ].into_iter()
+                    .chain(index_data.as_ref().map(|index_data| {
+                        let index_data_bytes = index_data.as_bytes();
+
+                        (
+                            ResourceInCommand::GeometryTrianglesIndexData { index }.into(),
+                            Resource::Buffer {
+                                buffer: index_data_bytes.clone(),
+                                range: 0..index_data_bytes.size(), // TODO:
+                                memory_access: PipelineStageAccessFlags::AccelerationStructureBuild_ShaderSampledRead
+                                    | PipelineStageAccessFlags::AccelerationStructureBuild_ShaderStorageRead,
+                            },
+                        )
+                    }))
+                    .chain(transform_data.as_ref().map(|transform_data| {
+                        (
+                            ResourceInCommand::GeometryTrianglesTransformData { index }.into(),
+                            Resource::Buffer {
+                                buffer: transform_data.as_bytes().clone(),
+                                range: 0..transform_data.size(), // TODO:
+                                memory_access: PipelineStageAccessFlags::AccelerationStructureBuild_ShaderSampledRead
+                                    | PipelineStageAccessFlags::AccelerationStructureBuild_ShaderStorageRead,
+                            },
+                        )
+                    }))
+                })
+            );
+        }
+        AccelerationStructureGeometries::Aabbs(geometries) => {
+            used_resources.extend(geometries.iter().enumerate().map(|(index, aabbs_data)| {
+                let index = index as u32;
+                let &AccelerationStructureGeometryAabbsData {
+                    flags: _,
+                    ref data,
+                    stride: _,
+                    _ne: _,
+                } = aabbs_data;
+
+                (
+                    ResourceInCommand::GeometryAabbsData { index }.into(),
+                    Resource::Buffer {
+                        buffer: data.as_bytes().clone(),
+                        range: 0..data.size(), // TODO:
+                        memory_access: PipelineStageAccessFlags::AccelerationStructureBuild_ShaderSampledRead
+                            | PipelineStageAccessFlags::AccelerationStructureBuild_ShaderStorageRead,
+                    },
+                )
+            }));
+        }
+        AccelerationStructureGeometries::Instances(instances_data) => {
+            let &AccelerationStructureGeometryInstancesData {
+                flags: _,
+                ref data,
+                _ne: _,
+            } = instances_data;
+
+            let data = match data {
+                AccelerationStructureGeometryInstancesDataType::Values(data) => data.as_bytes(),
+                AccelerationStructureGeometryInstancesDataType::Pointers(data) => data.as_bytes(),
+            };
+            let size = data.size();
+
+            used_resources.push((
+                ResourceInCommand::GeometryInstancesData.into(),
+                Resource::Buffer {
+                    buffer: data.clone(),
+                    range: 0..size, // TODO:
+                    memory_access: PipelineStageAccessFlags::AccelerationStructureBuild_ShaderSampledRead
+                        | PipelineStageAccessFlags::AccelerationStructureBuild_ShaderStorageRead,
+                },
+            ));
+        }
+    };
+
+    if let BuildAccelerationStructureMode::Update(src_acceleration_structure) = mode {
+        let src_buffer = src_acceleration_structure.buffer();
+        used_resources.push((
+            ResourceInCommand::Source.into(),
+            Resource::Buffer {
+                buffer: src_buffer.clone(),
+                range: 0..src_buffer.size(), // TODO:
+                memory_access:
+                    PipelineStageAccessFlags::AccelerationStructureBuild_AccelerationStructureRead,
+            },
+        ));
+    }
+
+    let dst_buffer = dst_acceleration_structure.buffer();
+    used_resources.push((
+        ResourceInCommand::Destination.into(),
+        Resource::Buffer {
+            buffer: dst_buffer.clone(),
+            range: 0..dst_buffer.size(), // TODO:
+            memory_access:
+                PipelineStageAccessFlags::AccelerationStructureBuild_AccelerationStructureWrite,
+        },
+    ));
+    used_resources.push((
+        ResourceInCommand::ScratchData.into(),
+        Resource::Buffer {
+            buffer: scratch_data.clone(),
+            range: 0..scratch_data.size(), // TODO:
+            memory_access: PipelineStageAccessFlags::AccelerationStructureBuild_AccelerationStructureRead
+                | PipelineStageAccessFlags::AccelerationStructureBuild_AccelerationStructureWrite,
+        },
+    ));
+}
+
+fn add_indirect_buffer_resources(
+    used_resources: &mut Vec<(ResourceUseRef2, Resource)>,
+    indirect_buffer: &Subbuffer<[AccelerationStructureBuildRangeInfo]>,
+) {
+    used_resources.push((
+        ResourceInCommand::IndirectBuffer.into(),
+        Resource::Buffer {
+            buffer: indirect_buffer.as_bytes().clone(),
+            range: 0..indirect_buffer.size(), // TODO:
+            memory_access: PipelineStageAccessFlags::AccelerationStructureBuild_IndirectCommandRead,
+        },
+    ));
+}
+
+impl<A> UnsafeCommandBufferBuilder<A>
+where
+    A: CommandBufferAllocator,
+{
+    pub unsafe fn build_acceleration_structure(
+        &mut self,
+        info: &AccelerationStructureBuildGeometryInfo,
+        build_range_infos: &[AccelerationStructureBuildRangeInfo],
+    ) -> &mut Self {
+        let (mut info_vk, geometries_vk) = info.to_vulkan();
+        info_vk = ash::vk::AccelerationStructureBuildGeometryInfoKHR {
+            geometry_count: geometries_vk.len() as u32,
+            p_geometries: geometries_vk.as_ptr(),
+            ..info_vk
+        };
+
+        let build_range_info_elements_vk: SmallVec<[_; 8]> = build_range_infos
+            .iter()
+            .map(|build_range_info| {
+                let &AccelerationStructureBuildRangeInfo {
+                    primitive_count,
+                    primitive_offset,
+                    first_vertex,
+                    transform_offset,
+                } = build_range_info;
+
+                ash::vk::AccelerationStructureBuildRangeInfoKHR {
+                    primitive_count,
+                    primitive_offset,
+                    first_vertex,
+                    transform_offset,
+                }
+            })
+            .collect();
+        let build_range_info_pointers_vk: SmallVec<[_; 8]> = build_range_info_elements_vk
+            .iter()
+            .map(|element| element as *const _)
+            .collect();
+
+        let fns = self.device().fns();
+        (fns.khr_acceleration_structure
+            .cmd_build_acceleration_structures_khr)(
+            self.handle(),
+            1,
+            &info_vk,
+            build_range_info_pointers_vk.as_ptr(),
+        );
+
+        self
+    }
+
+    pub unsafe fn build_acceleration_structure_indirect(
+        &mut self,
+        info: &AccelerationStructureBuildGeometryInfo,
+        indirect_buffer: &Subbuffer<[AccelerationStructureBuildRangeInfo]>,
+        stride: u32,
+        max_primitive_counts: &[u32],
+    ) -> &mut Self {
+        let (mut info_vk, geometries_vk) = info.to_vulkan();
+        info_vk = ash::vk::AccelerationStructureBuildGeometryInfoKHR {
+            geometry_count: geometries_vk.len() as u32,
+            p_geometries: geometries_vk.as_ptr(),
+            ..info_vk
+        };
+
+        let fns = self.device().fns();
+        (fns.khr_acceleration_structure
+            .cmd_build_acceleration_structures_indirect_khr)(
+            self.handle(),
+            1,
+            &info_vk,
+            &indirect_buffer.device_address().unwrap().get(),
+            &stride,
+            &max_primitive_counts.as_ptr(),
+        );
+
+        self
+    }
+
+    pub unsafe fn copy_acceleration_structure(
+        &mut self,
+        info: &CopyAccelerationStructureInfo,
+    ) -> &mut Self {
+        let &CopyAccelerationStructureInfo {
+            ref src,
+            ref dst,
+            mode,
+            _ne: _,
+        } = info;
+
+        let info_vk = ash::vk::CopyAccelerationStructureInfoKHR {
+            src: src.handle(),
+            dst: dst.handle(),
+            mode: mode.into(),
+            ..Default::default()
+        };
+
+        let fns = self.device().fns();
+        (fns.khr_acceleration_structure
+            .cmd_copy_acceleration_structure_khr)(self.handle(), &info_vk);
+
+        self
+    }
+
+    pub unsafe fn copy_acceleration_structure_to_memory(
+        &mut self,
+        info: &CopyAccelerationStructureToMemoryInfo,
+    ) -> &mut Self {
+        let &CopyAccelerationStructureToMemoryInfo {
+            ref src,
+            ref dst,
+            mode,
+            _ne: _,
+        } = info;
+
+        let info_vk = ash::vk::CopyAccelerationStructureToMemoryInfoKHR {
+            src: src.handle(),
+            dst: ash::vk::DeviceOrHostAddressKHR {
+                device_address: dst.device_address().unwrap().get(),
+            },
+            mode: mode.into(),
+            ..Default::default()
+        };
+
+        let fns = self.device().fns();
+        (fns.khr_acceleration_structure
+            .cmd_copy_acceleration_structure_to_memory_khr)(self.handle(), &info_vk);
+
+        self
+    }
+
+    pub unsafe fn copy_memory_to_acceleration_structure(
+        &mut self,
+        info: &CopyMemoryToAccelerationStructureInfo,
+    ) -> &mut Self {
+        let &CopyMemoryToAccelerationStructureInfo {
+            ref src,
+            ref dst,
+            mode,
+            _ne: _,
+        } = info;
+
+        let info_vk = ash::vk::CopyMemoryToAccelerationStructureInfoKHR {
+            src: ash::vk::DeviceOrHostAddressConstKHR {
+                device_address: src.device_address().unwrap().get(),
+            },
+            dst: dst.handle(),
+            mode: mode.into(),
+            ..Default::default()
+        };
+
+        let fns = self.device().fns();
+        (fns.khr_acceleration_structure
+            .cmd_copy_memory_to_acceleration_structure_khr)(self.handle(), &info_vk);
+
+        self
+    }
+
+    pub unsafe fn write_acceleration_structures_properties(
+        &mut self,
+        acceleration_structures: &[Arc<AccelerationStructure>],
+        query_pool: &QueryPool,
+        first_query: u32,
+    ) -> &mut Self {
+        if acceleration_structures.is_empty() {
+            return self;
+        }
+
+        let acceleration_structures_vk: SmallVec<[_; 4]> = acceleration_structures
+            .iter()
+            .map(VulkanObject::handle)
+            .collect();
+
+        let fns = self.device().fns();
+        (fns.khr_acceleration_structure
+            .cmd_write_acceleration_structures_properties_khr)(
+            self.handle(),
+            acceleration_structures_vk.len() as u32,
+            acceleration_structures_vk.as_ptr(),
+            query_pool.query_type().into(),
+            query_pool.handle(),
+            first_query,
+        );
+
+        self
+    }
+}

--- a/vulkano/src/command_buffer/commands/mod.rs
+++ b/vulkano/src/command_buffer/commands/mod.rs
@@ -7,6 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+pub(super) mod acceleration_structure;
 pub(super) mod bind_push;
 pub(super) mod clear;
 pub(super) mod copy;

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -311,7 +311,7 @@ where
         }
 
         for state in self.builder_state.queries.values() {
-            match state.ty {
+            match state.query_pool.query_type() {
                 QueryType::Occlusion => {
                     // VUID-vkCmdExecuteCommands-commandBuffer-00102
                     let inherited_flags = command_buffer.inheritance_info().occlusion_query.ok_or(
@@ -332,7 +332,7 @@ where
                         });
                     }
                 }
-                QueryType::PipelineStatistics(state_flags) => {
+                &QueryType::PipelineStatistics(state_flags) => {
                     let inherited_flags = command_buffer.inheritance_info().query_statistics_flags;
                     let inherited_flags_vk =
                         ash::vk::QueryPipelineStatisticFlags::from(inherited_flags);
@@ -349,7 +349,7 @@ where
                         );
                     }
                 }
-                QueryType::Timestamp => (),
+                _ => (),
             }
         }
 

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -587,6 +587,7 @@ impl From<ResourceUseRef> for SecondaryResourceUseRef {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum ResourceInCommand {
+    AccelerationStructure { index: u32 },
     ColorAttachment { index: u32 },
     ColorResolveAttachment { index: u32 },
     DepthStencilAttachment,
@@ -594,9 +595,15 @@ pub enum ResourceInCommand {
     DescriptorSet { set: u32, binding: u32, index: u32 },
     Destination,
     FramebufferAttachment { index: u32 },
+    GeometryAabbsData { index: u32 },
+    GeometryInstancesData,
+    GeometryTrianglesTransformData { index: u32 },
+    GeometryTrianglesIndexData { index: u32 },
+    GeometryTrianglesVertexData { index: u32 },
     ImageMemoryBarrier { index: u32 },
     IndexBuffer,
     IndirectBuffer,
+    ScratchData,
     SecondaryCommandBuffer { index: u32 },
     Source,
     VertexBuffer { binding: u32 },

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -833,11 +833,10 @@ vulkan_enum! {
         device_extensions: [ext_inline_uniform_block],
     },*/
 
-    /* TODO: enable
-    // TODO: document
+    /// Gives read access to an acceleration structure, for performing ray queries and ray tracing.
     AccelerationStructure = ACCELERATION_STRUCTURE_KHR {
         device_extensions: [khr_acceleration_structure],
-    },*/
+    },
 
     /* TODO: enable
     // TODO: document

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -108,14 +108,21 @@ pub use self::{
     properties::Properties,
     queue::{Queue, QueueError, QueueFamilyProperties, QueueFlags, QueueGuard},
 };
+use crate::{
+    acceleration_structure::{
+        AccelerationStructureBuildGeometryInfo, AccelerationStructureBuildSizesInfo,
+        AccelerationStructureBuildType, AccelerationStructureGeometries,
+    },
+    instance::Instance,
+    macros::impl_id_counter,
+    memory::ExternalMemoryHandleType,
+    OomError, RequirementNotMet, RequiresOneOf, RuntimeError, ValidationError, Version,
+    VulkanObject,
+};
 pub use crate::{
     device::extensions::DeviceExtensions,
     extensions::{ExtensionRestriction, ExtensionRestrictionError},
     fns::DeviceFunctions,
-};
-use crate::{
-    instance::Instance, macros::impl_id_counter, memory::ExternalMemoryHandleType, OomError,
-    RequirementNotMet, RequiresOneOf, RuntimeError, Version, VulkanObject,
 };
 use ash::vk::Handle;
 use parking_lot::Mutex;
@@ -509,6 +516,239 @@ impl Device {
 
     pub(crate) fn event_pool(&self) -> &Mutex<Vec<ash::vk::Event>> {
         &self.event_pool
+    }
+
+    /// For the given acceleration structure build info and primitive counts, returns the
+    /// minimum size required to build the acceleration structure, and the minimum size of the
+    /// scratch buffer used during the build operation.
+    #[inline]
+    pub fn acceleration_structure_build_sizes(
+        &self,
+        build_type: AccelerationStructureBuildType,
+        build_info: &AccelerationStructureBuildGeometryInfo,
+        max_primitive_counts: &[u32],
+    ) -> Result<AccelerationStructureBuildSizesInfo, ValidationError> {
+        self.validate_acceleration_structure_build_sizes(
+            build_type,
+            build_info,
+            max_primitive_counts,
+        )?;
+
+        unsafe {
+            Ok(self.acceleration_structure_build_sizes_unchecked(
+                build_type,
+                build_info,
+                max_primitive_counts,
+            ))
+        }
+    }
+
+    fn validate_acceleration_structure_build_sizes(
+        &self,
+        build_type: AccelerationStructureBuildType,
+        build_info: &AccelerationStructureBuildGeometryInfo,
+        max_primitive_counts: &[u32],
+    ) -> Result<(), ValidationError> {
+        if !self.enabled_extensions().khr_acceleration_structure {
+            return Err(ValidationError {
+                requires_one_of: Some(RequiresOneOf {
+                    device_extensions: &["khr_acceleration_structure"],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        }
+
+        if !(self.enabled_features().ray_tracing_pipeline || self.enabled_features().ray_query) {
+            return Err(ValidationError {
+                requires_one_of: Some(RequiresOneOf {
+                    features: &["ray_tracing_pipeline", "ray_query"],
+                    ..Default::default()
+                }),
+                vuids: &["VUID-vkGetAccelerationStructureBuildSizesKHR-rayTracingPipeline-03617"],
+                ..Default::default()
+            });
+        }
+
+        build_type
+            .validate_device(self)
+            .map_err(|err| ValidationError {
+                context: "build_type".into(),
+                vuids: &["VUID-vkGetAccelerationStructureBuildSizesKHR-buildType-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        // VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-parameter
+        build_info.validate(self).map_err(|err| ValidationError {
+            context: format!("build_info.{}", err.context).into(),
+            ..err
+        })?;
+
+        let max_primitive_count = self
+            .physical_device()
+            .properties()
+            .max_primitive_count
+            .unwrap();
+        let max_instance_count = self
+            .physical_device()
+            .properties()
+            .max_instance_count
+            .unwrap();
+
+        let geometry_count = match &build_info.geometries {
+            AccelerationStructureGeometries::Triangles(geometries) => {
+                for (index, &primitive_count) in max_primitive_counts.iter().enumerate() {
+                    if primitive_count as u64 > max_primitive_count {
+                        return Err(ValidationError {
+                            context: format!("max_primitive_counts[{}]", index).into(),
+                            problem: "the max_primitive_count limit has been exceeded".into(),
+                            vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03795"],
+                            ..Default::default()
+                        });
+                    }
+                }
+
+                geometries.len()
+            }
+            AccelerationStructureGeometries::Aabbs(geometries) => {
+                for (index, &primitive_count) in max_primitive_counts.iter().enumerate() {
+                    if primitive_count as u64 > max_primitive_count {
+                        return Err(ValidationError {
+                            context: format!("max_primitive_counts[{}]", index).into(),
+                            problem: "the max_primitive_count limit has been exceeded".into(),
+                            vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03794"],
+                            ..Default::default()
+                        });
+                    }
+                }
+
+                geometries.len()
+            }
+            AccelerationStructureGeometries::Instances(_) => {
+                for (index, &instance_count) in max_primitive_counts.iter().enumerate() {
+                    if instance_count as u64 > max_instance_count {
+                        return Err(ValidationError {
+                            context: format!("max_primitive_counts[{}]", index).into(),
+                            problem: "the max_instance_count limit has been exceeded".into(),
+                            vuids: &[
+                                "VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03785",
+                            ],
+                            ..Default::default()
+                        });
+                    }
+                }
+
+                1
+            }
+        };
+
+        if max_primitive_counts.len() != geometry_count {
+            return Err(ValidationError {
+                problem: "build_info.geometries and max_primitive_counts \
+                    do not have the same length"
+                    .into(),
+                vuids: &["VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03619"],
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn acceleration_structure_build_sizes_unchecked(
+        &self,
+        build_type: AccelerationStructureBuildType,
+        build_info: &AccelerationStructureBuildGeometryInfo,
+        max_primitive_counts: &[u32],
+    ) -> AccelerationStructureBuildSizesInfo {
+        let (mut build_info_vk, geometries_vk) = build_info.to_vulkan();
+        build_info_vk = ash::vk::AccelerationStructureBuildGeometryInfoKHR {
+            geometry_count: geometries_vk.len() as u32,
+            p_geometries: geometries_vk.as_ptr(),
+            ..build_info_vk
+        };
+
+        let mut build_sizes_info_vk = ash::vk::AccelerationStructureBuildSizesInfoKHR::default();
+
+        let fns = self.fns();
+        (fns.khr_acceleration_structure
+            .get_acceleration_structure_build_sizes_khr)(
+            self.handle,
+            build_type.into(),
+            &build_info_vk,
+            max_primitive_counts.as_ptr(),
+            &mut build_sizes_info_vk,
+        );
+
+        AccelerationStructureBuildSizesInfo {
+            acceleration_structure_size: build_sizes_info_vk.acceleration_structure_size,
+            update_scratch_size: build_sizes_info_vk.update_scratch_size,
+            build_scratch_size: build_sizes_info_vk.build_scratch_size,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    /// Returns whether a serialized acceleration structure with the specified version data
+    /// is compatible with this device.
+    #[inline]
+    pub fn acceleration_structure_is_compatible(
+        &self,
+        version_data: &[u8; 2 * ash::vk::UUID_SIZE],
+    ) -> Result<bool, ValidationError> {
+        self.validate_acceleration_structure_is_compatible(version_data)?;
+
+        unsafe { Ok(self.acceleration_structure_is_compatible_unchecked(version_data)) }
+    }
+
+    fn validate_acceleration_structure_is_compatible(
+        &self,
+        _version_data: &[u8; 2 * ash::vk::UUID_SIZE],
+    ) -> Result<(), ValidationError> {
+        if !self.enabled_extensions().khr_acceleration_structure {
+            return Err(ValidationError {
+                requires_one_of: Some(RequiresOneOf {
+                    device_extensions: &["khr_acceleration_structure"],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        }
+
+        if !(self.enabled_features().ray_tracing_pipeline || self.enabled_features().ray_query) {
+            return Err(ValidationError {
+                requires_one_of: Some(RequiresOneOf {
+                    features: &["ray_tracing_pipeline", "ray_query"],
+                    ..Default::default()
+                }),
+                vuids: &["VUID-vkGetDeviceAccelerationStructureCompatibilityKHR-rayTracingPipeline-03661"],
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn acceleration_structure_is_compatible_unchecked(
+        &self,
+        version_data: &[u8; 2 * ash::vk::UUID_SIZE],
+    ) -> bool {
+        let version_info_vk = ash::vk::AccelerationStructureVersionInfoKHR {
+            p_version_data: version_data,
+            ..Default::default()
+        };
+        let mut compatibility_vk = ash::vk::AccelerationStructureCompatibilityKHR::default();
+
+        let fns = self.fns();
+        (fns.khr_acceleration_structure
+            .get_device_acceleration_structure_compatibility_khr)(
+            self.handle,
+            &version_info_vk,
+            &mut compatibility_vk,
+        );
+
+        compatibility_vk == ash::vk::AccelerationStructureCompatibilityKHR::COMPATIBLE
     }
 
     /// Retrieves the properties of an external file descriptor when imported as a given external

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -967,7 +967,7 @@ vulkan_bitflags! {
     /// pipeline.
     VERTEX_BUFFER = VERTEX_BUFFER,
 
-    /// Can be used with the vertex buffer of an acceleration structure.
+    /// Can be used as the vertex format when building an acceleration structure.
     ACCELERATION_STRUCTURE_VERTEX_BUFFER = ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR {
         device_extensions: [khr_acceleration_structure],
     },

--- a/vulkano/src/pipeline/graphics/input_assembly.rs
+++ b/vulkano/src/pipeline/graphics/input_assembly.rs
@@ -10,10 +10,8 @@
 //! Configures how input vertices are assembled into primitives.
 
 use crate::{
-    buffer::BufferContents,
     macros::vulkan_enum,
     pipeline::{PartialStateMode, StateMode},
-    DeviceSize,
 };
 
 /// The state in a graphics pipeline describing how the input assembly stage should behave.
@@ -194,69 +192,6 @@ impl PrimitiveTopologyClass {
             Self::Line => PrimitiveTopology::LineList,
             Self::Triangle => PrimitiveTopology::TriangleList,
             Self::Patch => PrimitiveTopology::PatchList,
-        }
-    }
-}
-
-/// Trait for types that can be used as indices by the GPU.
-pub unsafe trait Index: BufferContents + Sized {
-    /// Returns the type of data.
-    fn ty() -> IndexType;
-}
-
-unsafe impl Index for u8 {
-    #[inline(always)]
-    fn ty() -> IndexType {
-        IndexType::U8
-    }
-}
-
-unsafe impl Index for u16 {
-    #[inline(always)]
-    fn ty() -> IndexType {
-        IndexType::U16
-    }
-}
-
-unsafe impl Index for u32 {
-    #[inline(always)]
-    fn ty() -> IndexType {
-        IndexType::U32
-    }
-}
-
-vulkan_enum! {
-    #[non_exhaustive]
-
-    /// An enumeration of all valid index types.
-    IndexType = IndexType(i32);
-
-    // TODO: document
-    U8 = UINT8_EXT {
-        device_extensions: [ext_index_type_uint8],
-    },
-
-    // TODO: document
-    U16 = UINT16,
-
-    // TODO: document
-    U32 = UINT32,
-
-    /* TODO: enable
-    // TODO: document
-    None = NONE_KHR {
-        device_extensions: [khr_acceleration_structure, nv_ray_tracing],
-    },*/
-}
-
-impl IndexType {
-    /// Returns the size in bytes of indices of this type.
-    #[inline]
-    pub fn size(self) -> DeviceSize {
-        match self {
-            IndexType::U8 => 1,
-            IndexType::U16 => 2,
-            IndexType::U32 => 4,
         }
     }
 }

--- a/vulkano/src/shader/reflect.rs
+++ b/vulkano/src/shader/reflect.rs
@@ -925,6 +925,12 @@ fn descriptor_binding_requirements_of(spirv: &Spirv, variable_id: Id) -> Descrip
                 Some(image_type)
             }
 
+            Instruction::TypeAccelerationStructureKHR { .. } => {
+                reqs.descriptor_types = vec![DescriptorType::AccelerationStructure];
+
+                None
+            }
+
             Instruction::TypeArray {
                 element_type,
                 length,
@@ -949,8 +955,6 @@ fn descriptor_binding_requirements_of(spirv: &Spirv, variable_id: Id) -> Descrip
 
                 Some(element_type)
             }
-
-            Instruction::TypeAccelerationStructureKHR { .. } => None, // FIXME temporary workaround
 
             _ => {
                 let name = variable_id_info


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
- Index buffers are now specified using the `IndexBuffer` enum instead of the `Index` trait.

### Additions
- Added support for the `khr_acceleration_structure` and `khr_ray_query` extensions.
````

This _finally_ adds support for acceleration structures and ray queries! It's a pretty big addition, with a lot of potential for errors, so I hope that people will try it out and help test it before 0.34 is released. There's a lot of `unsafe` here, because many things rely on data in device buffers that Vulkano can't check.