### PR TITLE
GenericMemoryAllocatorCreateInfo set prefers_dedicated_allocation to false if dedicated_allocation is false

### DIFF
--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1248,6 +1248,7 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
 
         if !self.dedicated_allocation {
             dedicated_allocation = None;
+            prefers_dedicated_allocation = false;
         }
 
         let export_handle_types = if self.export_handle_types.is_empty() {


### PR DESCRIPTION
If GenericMemoryAllocator was created with dedicated_allocation = false, then the prefers_dedicated_allocation from the buffer memory requirements will be set to false. This seems like expected behavior given the docs for GenericMemoryAllocatorCreateInfo: 

"
dedicated_allocation: [bool](https://doc.rust-lang.org/nightly/std/primitive.bool.html)

Whether the allocator should use the dedicated allocation APIs.

This means that when the allocator decides that an allocation should not be suballocated, but rather have its own block of [DeviceMemory](https://docs.rs/vulkano/0.33.0/vulkano/memory/struct.DeviceMemory.html), that that allocation will be made a dedicated allocation. Otherwise they are still made free-standing ([root](https://docs.rs/vulkano/0.33.0/vulkano/memory/allocator/suballocator/struct.MemoryAlloc.html#method.is_root)) allocations, just not [dedicated](https://docs.rs/vulkano/0.33.0/vulkano/memory/allocator/suballocator/struct.MemoryAlloc.html#method.is_dedicated) ones.

Dedicated allocations are an optimization which may result in better performance, so there really is no reason to disable this option, unless the restrictions that they bring with them are a problem. Namely, a dedicated allocation must only be used for the resource it was created for. Meaning that [reusing the memory](https://docs.rs/vulkano/0.33.0/vulkano/memory/allocator/suballocator/struct.MemoryAlloc.html#method.try_unwrap) for something else is not possible, [suballocating it](https://docs.rs/vulkano/0.33.0/vulkano/memory/allocator/suballocator/trait.Suballocator.html) is not possible, and [aliasing it](https://docs.rs/vulkano/0.33.0/vulkano/memory/allocator/suballocator/struct.MemoryAlloc.html#method.alias) is also not possible.

This option is silently ignored (treated as false) if the device API version is below 1.1 and the [khr_dedicated_allocation](https://docs.rs/vulkano/0.33.0/vulkano/device/struct.DeviceExtensions.html#structfield.khr_dedicated_allocation) extension is not enabled on the device.

The default value is true.
"

This change keeps current behavior of using a dedicated allocation if required or as a fallback. The docs imply imo that dedicated allocations won't be used if false, so potentially the docs could be clarified or the behavior modified more drastically. 

Note that dedicated allocations can be really expensive (because they can't be reused) and undermine the utility of the allocator, so at least allowing the user to opt out can dramatically improve performance when dynamically allocating in a hot loop. 
