### PR TITLE
Fix dedicated allocation not getting created even when required

### DIFF
--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1356,16 +1356,9 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
         &self,
         memory_type_index: u32,
         allocation_size: DeviceSize,
-        mut dedicated_allocation: Option<DedicatedAllocation<'_>>,
+        dedicated_allocation: Option<DedicatedAllocation<'_>>,
         export_handle_types: ExternalMemoryHandleTypes,
     ) -> Result<MemoryAlloc, AllocationCreationError> {
-        // Providers of `VkMemoryDedicatedAllocateInfo`
-        if !(self.device.api_version() >= Version::V1_1
-            || self.device.enabled_extensions().khr_dedicated_allocation)
-        {
-            dedicated_allocation = None;
-        }
-
         let allocate_info = MemoryAllocateInfo {
             allocation_size,
             memory_type_index,

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1246,7 +1246,7 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
             .find_memory_type_index(memory_type_bits, filter)
             .expect("couldn't find a suitable memory type");
 
-        if !self.dedicated_allocation {
+        if !self.dedicated_allocation && !requires_dedicated_allocation {
             dedicated_allocation = None;
         }
 
@@ -1262,6 +1262,8 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
 
             let res = match allocate_preference {
                 MemoryAllocatePreference::Unknown => {
+                    // VUID-vkBindBufferMemory-buffer-01444
+                    // VUID-vkBindImageMemory-image-01445
                     if requires_dedicated_allocation {
                         self.allocate_dedicated_unchecked(
                             memory_type_index,


### PR DESCRIPTION
#2214 made me realize that we have a bug when a dedicated allocation is required but the user configured the allocator with `dedicated_allocation: false`, in which case the allocation isn't made dedicated.

Changelog:
```markdown
### Bugs fixed
- Fixed a bug when using `GenericMemoryAllocator` configured not to use dedicated allocation, where a dedicated allocation wasn't created even when required.
```