### PR TITLE
Fixes all examples to use at least two swapchain buffers

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -237,7 +237,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -141,7 +141,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -119,7 +119,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -141,7 +141,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -534,7 +534,8 @@ mod linux {
                 device.clone(),
                 surface,
                 SwapchainCreateInfo {
-                    min_image_count: surface_capabilities.min_image_count,
+                    // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                    min_image_count: surface_capabilities.min_image_count.max(2),
                     image_format,
                     image_extent: window.inner_size().into(),
                     image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -145,7 +145,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -143,7 +143,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -149,7 +149,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -158,7 +158,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -157,7 +157,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -166,7 +166,8 @@ fn main() {
             device.clone(),
             surface.clone(),
             SwapchainCreateInfo {
-                min_image_count: surface_caps.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,
@@ -374,7 +375,8 @@ fn main() {
                     device.clone(),
                     surface,
                     SwapchainCreateInfo {
-                        min_image_count: surface_caps.min_image_count,
+                        // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                        min_image_count: surface_caps.min_image_count.max(2),
                         image_format,
                         image_extent: window.inner_size().into(),
                         image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -139,7 +139,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -139,7 +139,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -146,7 +146,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -150,7 +150,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -157,7 +157,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: [WINDOW_WIDTH, WINDOW_HEIGHT],
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -146,7 +146,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -251,7 +251,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -145,7 +145,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -253,7 +253,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
 
                 image_format,
 

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -222,7 +222,8 @@ fn main() {
             device.clone(),
             surface,
             SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                // Some drivers report `min_image_count=1` but fullscreen mode requires at least 2.
+                min_image_count: surface_capabilities.min_image_count.max(2),
 
                 image_format,
 

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -115,7 +115,7 @@ impl VulkanoWindowRenderer {
         );
         let (swapchain, images) = Swapchain::new(device, surface, {
             let mut create_info = SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count,
+                min_image_count: surface_capabilities.min_image_count.max(2),
                 image_format,
                 image_extent: window.inner_size().into(),
                 image_usage: ImageUsage::COLOR_ATTACHMENT,


### PR DESCRIPTION
This PR only fixes Vulkano examples. They now all force at least double buffering. AMD drivers crash in full screen without this patch, because they report `VkSurfaceCapabilitiesKHR.minImageCount = 1` which doesn't work in fullscreen.

Closes #1159 

Changelog:
```markdown
### Bugs fixed
- Vulkano examples crash on AMD GPUs in fullscreen on Windows.
````