### PR TITLE
Add support for descriptor set copies and other things

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -488,6 +488,7 @@ fn main() {
                 &descriptor_set_allocator,
                 pipeline.layout().set_layouts()[0].clone(),
                 [WriteDescriptorSet::buffer(0, buffer.clone())],
+                [],
             )
             .unwrap()
         })
@@ -504,6 +505,7 @@ fn main() {
                 ImageView::new_default(texture).unwrap(),
                 sampler.clone(),
             )],
+            [],
         )
         .unwrap()
     });

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -192,6 +192,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::buffer(0, data_buffer.clone())],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -174,6 +174,7 @@ impl AmbientLightingSystem {
             &self.descriptor_set_allocator,
             layout.clone(),
             [WriteDescriptorSet::image_view(0, color_input)],
+            [],
         )
         .unwrap();
 

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -190,6 +190,7 @@ impl DirectionalLightingSystem {
                 WriteDescriptorSet::image_view(0, color_input),
                 WriteDescriptorSet::image_view(1, normals_input),
             ],
+            [],
         )
         .unwrap();
 

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -201,6 +201,7 @@ impl PointLightingSystem {
                 WriteDescriptorSet::image_view(1, normals_input),
                 WriteDescriptorSet::image_view(2, depth_input),
             ],
+            [],
         )
         .unwrap();
 

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -233,6 +233,7 @@ fn main() {
             ),
             WriteDescriptorSet::buffer(1, output_buffer.clone()),
         ],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -232,6 +232,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::image_view(0, view)],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -233,6 +233,7 @@ mod linux {
             [WriteDescriptorSet::image_view_sampler(
                 0, image_view, sampler,
             )],
+            [],
         )
         .unwrap();
 

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -386,6 +386,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -312,6 +312,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -333,6 +333,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::image_view(0, texture)],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -459,6 +459,7 @@ fn main() {
                         WriteDescriptorSet::buffer(0, vertices.clone()),
                         WriteDescriptorSet::buffer(1, indirect_buffer.clone()),
                     ],
+                    [],
                 )
                 .unwrap();
 

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -153,6 +153,7 @@ impl FractalComputePipeline {
                 WriteDescriptorSet::image_view(0, image),
                 WriteDescriptorSet::buffer(1, self.palette.clone()),
             ],
+            [],
         )
         .unwrap();
         let mut builder = AutoCommandBufferBuilder::primary(

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -197,6 +197,7 @@ impl PixelsDrawPipeline {
                 image.clone(),
                 sampler,
             )],
+            [],
         )
         .unwrap()
     }

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -184,6 +184,7 @@ impl GameOfLifeComputePipeline {
                 WriteDescriptorSet::buffer(1, self.life_in.clone()),
                 WriteDescriptorSet::buffer(2, self.life_out.clone()),
             ],
+            [],
         )
         .unwrap();
 

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -193,6 +193,7 @@ impl PixelsDrawPipeline {
                 image.clone(),
                 sampler,
             )],
+            [],
         )
         .unwrap()
     }

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -167,6 +167,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::buffer(0, data_buffer.clone())],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -14,7 +14,7 @@ use vulkano::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
-    descriptor_set::WriteDescriptorSet,
+    descriptor_set::{layout::DescriptorSetLayoutCreateFlags, WriteDescriptorSet},
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
         QueueFlags,
@@ -276,7 +276,7 @@ fn main() {
             let mut layout_create_info =
                 PipelineDescriptorSetLayoutCreateInfo::from_stages(&stages);
             let set_layout = &mut layout_create_info.set_layouts[0];
-            set_layout.push_descriptor = true;
+            set_layout.flags |= DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR;
             set_layout.bindings.get_mut(&0).unwrap().immutable_samplers = vec![sampler];
 
             PipelineLayout::new(

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -15,7 +15,8 @@ use vulkano::{
         PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassContents,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, layout::DescriptorBindingFlags,
+        PersistentDescriptorSet, WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Features,
@@ -374,7 +375,7 @@ fn main() {
                 .bindings
                 .get_mut(&0)
                 .unwrap();
-            binding.variable_descriptor_count = true;
+            binding.binding_flags |= DescriptorBindingFlags::VARIABLE_DESCRIPTOR_COUNT;
             binding.descriptor_count = 2;
 
             PipelineLayout::new(
@@ -419,6 +420,7 @@ fn main() {
                 (vulkano_texture as _, sampler),
             ],
         )],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -160,6 +160,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::buffer(0, data_buffer.clone())],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -167,6 +167,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::buffer(0, data_buffer.clone())],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -197,6 +197,7 @@ fn main() {
             descriptor_set_allocator,
             layout.clone(),
             [WriteDescriptorSet::buffer(0, data_buffer)],
+            [],
         )
         .unwrap();
 

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -453,6 +453,7 @@ fn main() {
             // 0 is the binding of the data in this set. We bind the `Buffer` of vertices here.
             WriteDescriptorSet::buffer(0, vertex_buffer.clone()),
         ],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -167,6 +167,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::buffer(0, data_buffer.clone())],
+        [],
     )
     .unwrap();
 

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -346,6 +346,7 @@ fn main() {
                     &descriptor_set_allocator,
                     layout.clone(),
                     [WriteDescriptorSet::buffer(0, uniform_buffer_subbuffer)],
+                    [],
                 )
                 .unwrap();
 

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -317,6 +317,7 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
+        [],
     )
     .unwrap();
 

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -779,6 +779,7 @@ mod tests {
                     Sampler::new(device.clone(), SamplerCreateInfo::simple_repeat_linear())
                         .unwrap(),
                 )],
+                [],
             )
             .unwrap();
 
@@ -848,6 +849,7 @@ mod tests {
                     0,
                     Sampler::new(device, SamplerCreateInfo::simple_repeat_linear()).unwrap(),
                 )],
+                [],
             )
             .unwrap();
 

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -113,6 +113,9 @@ use crate::{
         AccelerationStructureBuildGeometryInfo, AccelerationStructureBuildSizesInfo,
         AccelerationStructureBuildType, AccelerationStructureGeometries,
     },
+    descriptor_set::layout::{
+        DescriptorSetLayoutBinding, DescriptorSetLayoutCreateInfo, DescriptorSetLayoutSupport,
+    },
     instance::Instance,
     macros::impl_id_counter,
     memory::ExternalMemoryHandleType,
@@ -748,6 +751,153 @@ impl Device {
         );
 
         compatibility_vk == ash::vk::AccelerationStructureCompatibilityKHR::COMPATIBLE
+    }
+
+    /// Returns whether a descriptor set layout with the given `create_info` could be created
+    /// on the device, and additional supported properties where relevant. `Some` is returned if
+    /// the descriptor set layout is supported, `None` if it is not.
+    ///
+    /// This is primarily useful for checking whether the device supports a descriptor set layout
+    /// that goes beyond the [`max_per_set_descriptors`] limit. A layout that does not exceed
+    /// that limit is guaranteed to be supported, otherwise this function can be called.
+    ///
+    /// The device API version must be at least 1.1, or the [`khr_maintenance3`] extension must
+    /// be enabled on the device.
+    ///
+    /// [`max_per_set_descriptors`]: crate::device::Properties::max_per_set_descriptors
+    /// [`khr_maintenance3`]: crate::device::DeviceExtensions::khr_maintenance3
+    #[inline]
+    pub fn descriptor_set_layout_support(
+        &self,
+        create_info: &DescriptorSetLayoutCreateInfo,
+    ) -> Result<Option<DescriptorSetLayoutSupport>, ValidationError> {
+        self.validate_descriptor_set_layout_support(create_info)?;
+
+        unsafe { Ok(self.descriptor_set_layout_support_unchecked(create_info)) }
+    }
+
+    fn validate_descriptor_set_layout_support(
+        &self,
+        create_info: &DescriptorSetLayoutCreateInfo,
+    ) -> Result<(), ValidationError> {
+        if !(self.api_version() >= Version::V1_1 || self.enabled_extensions().khr_maintenance3) {
+            return Err(ValidationError {
+                requires_one_of: Some(RequiresOneOf {
+                    api_version: Some(Version::V1_1),
+                    device_extensions: &["khr_maintenance3"],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+        }
+
+        // VUID-vkGetDescriptorSetLayoutSupport-pCreateInfo-parameter
+        create_info
+            .validate(self)
+            .map_err(|err| err.add_context("create_info"))?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn descriptor_set_layout_support_unchecked(
+        &self,
+        create_info: &DescriptorSetLayoutCreateInfo,
+    ) -> Option<DescriptorSetLayoutSupport> {
+        let &DescriptorSetLayoutCreateInfo {
+            flags,
+            ref bindings,
+            _ne: _,
+        } = create_info;
+
+        struct PerBinding {
+            immutable_samplers_vk: Vec<ash::vk::Sampler>,
+        }
+
+        let mut bindings_vk = Vec::with_capacity(bindings.len());
+        let mut per_binding_vk = Vec::with_capacity(bindings.len());
+        let mut binding_flags_info_vk = None;
+        let mut binding_flags_vk = Vec::with_capacity(bindings.len());
+
+        let mut support_vk = ash::vk::DescriptorSetLayoutSupport::default();
+        let mut variable_descriptor_count_support_vk = None;
+
+        for (&binding_num, binding) in bindings.iter() {
+            let &DescriptorSetLayoutBinding {
+                binding_flags,
+                descriptor_type,
+                descriptor_count,
+                stages,
+                ref immutable_samplers,
+                _ne: _,
+            } = binding;
+
+            bindings_vk.push(ash::vk::DescriptorSetLayoutBinding {
+                binding: binding_num,
+                descriptor_type: descriptor_type.into(),
+                descriptor_count,
+                stage_flags: stages.into(),
+                p_immutable_samplers: ptr::null(),
+            });
+            per_binding_vk.push(PerBinding {
+                immutable_samplers_vk: immutable_samplers
+                    .iter()
+                    .map(VulkanObject::handle)
+                    .collect(),
+            });
+            binding_flags_vk.push(binding_flags.into());
+        }
+
+        for (binding_vk, per_binding_vk) in bindings_vk.iter_mut().zip(per_binding_vk.iter_mut()) {
+            binding_vk.p_immutable_samplers = per_binding_vk.immutable_samplers_vk.as_ptr();
+        }
+
+        let mut create_info_vk = ash::vk::DescriptorSetLayoutCreateInfo {
+            flags: flags.into(),
+            binding_count: bindings_vk.len() as u32,
+            p_bindings: bindings_vk.as_ptr(),
+            ..Default::default()
+        };
+
+        if self.api_version() >= Version::V1_2 || self.enabled_extensions().ext_descriptor_indexing
+        {
+            let next =
+                binding_flags_info_vk.insert(ash::vk::DescriptorSetLayoutBindingFlagsCreateInfo {
+                    binding_count: binding_flags_vk.len() as u32,
+                    p_binding_flags: binding_flags_vk.as_ptr(),
+                    ..Default::default()
+                });
+
+            next.p_next = create_info_vk.p_next;
+            create_info_vk.p_next = next as *const _ as *const _;
+
+            let next = variable_descriptor_count_support_vk
+                .insert(ash::vk::DescriptorSetVariableDescriptorCountLayoutSupport::default());
+
+            next.p_next = support_vk.p_next;
+            support_vk.p_next = next as *mut _ as *mut _;
+        }
+
+        let fns = self.fns();
+
+        if self.api_version() >= Version::V1_1 {
+            (fns.v1_1.get_descriptor_set_layout_support)(
+                self.handle(),
+                &create_info_vk,
+                &mut support_vk,
+            )
+        } else {
+            (fns.khr_maintenance3.get_descriptor_set_layout_support_khr)(
+                self.handle(),
+                &create_info_vk,
+                &mut support_vk,
+            )
+        }
+
+        (support_vk.supported != ash::vk::FALSE).then(|| DescriptorSetLayoutSupport {
+            max_variable_descriptor_count: variable_descriptor_count_support_vk
+                .map_or(0, |s| s.max_variable_descriptor_count),
+        })
     }
 
     /// Retrieves the properties of an external file descriptor when imported as a given external


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to descriptor sets and descriptor set layouts:
- `PersistentDescriptorSet::new` now takes an additional parameter, specifying descriptor set copy operations.
- `DescriptorSetLayoutCreateInfo::push_descriptor` has been replaced with a more generic `flags` field.
- `DescriptorSetLayoutBinding::variable_descriptor_count` has been replaced with a more generic `flags` field.

### Additions
- `PipelineLayoutCreateInfo` now has a `flags` field.
- Added `Device::descriptor_set_layout_support` from the `khr_maintenance3` extension.
````

Descriptor set copies are a Vulkan 1.0 feature, but were never implemented in Vulkano for some reason. This PR adds them. It also rearranges some of the descriptor set and pipeline layout stuff to match Vulkan a bit better, and converts all the error handling to use `ValidationError`.