### PR TITLE
Fixed some examples freezing on fullscreen mode on MacOS for #2208

### DIFF
--- a/examples/src/bin/interactive_fractal/main.rs
+++ b/examples/src/bin/interactive_fractal/main.rs
@@ -75,7 +75,7 @@ fn main() {
     app.print_guide();
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        *control_flow = ControlFlow::Poll;
 
         let renderer = windows.get_primary_renderer_mut().unwrap();
 


### PR DESCRIPTION
This pull request solves the problem of freezing when going fullscreen for MacOS.
It was caused due to Winit behaving unexpectedly when using event loops that are managed by `run_return()`. Winit crate generally discourages the use of `run_return()` and recommends using `run()` instead.
(see: <https://docs.rs/winit/latest/winit/platform/run_return/trait.EventLoopExtRunReturn.html#tymethod.run_return>).

Changelog:
```markdown
### Bugs fixed
- Fixed the problem on MacOS of window completely freezing when setting the window to fullscreen mode for examples `interactive_fractal` and `multi_window_game_of_life`.
````
