### PR TITLE
Reorganise render pass objects, add support for some extensions

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -412,10 +412,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -420,7 +420,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -211,10 +211,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -219,7 +219,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -138,10 +138,10 @@ fn main() {
     let render_pass = vulkano::single_pass_renderpass!(device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -146,7 +146,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -107,31 +107,31 @@ impl FrameSystem {
                 // The image that will contain the final rendering (in this example the swapchain
                 // image, but it could be another image).
                 final_color: {
-                    load: Clear,
-                    store: Store,
                     format: final_output_format,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: Store,
                 },
                 // Will be bound to `self.diffuse_buffer`.
                 diffuse: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::A2B10G10R10_UNORM_PACK32,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
                 // Will be bound to `self.normals_buffer`.
                 normals: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R16G16B16A16_SFLOAT,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
                 // Will be bound to `self.depth_buffer`.
                 depth: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::D16_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
             },
             passes: [

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -138,13 +138,15 @@ impl FrameSystem {
                 // Write to the diffuse, normals and depth attachments.
                 {
                     color: [diffuse, normals],
-                    depth_stencil: {depth},
+                    depth: {depth},
+                    stencil: {},
                     input: [],
                 },
                 // Apply lighting by reading these three attachments and writing to `final_color`.
                 {
                     color: [final_color],
-                    depth_stencil: {},
+                    depth: {},
+                    stencil: {},
                     input: [diffuse, normals, depth],
                 },
             ],

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -592,7 +592,8 @@ mod linux {
             },
             pass: {
                 color: [color],
-                depth_stencil: {},
+                depth: {},
+                stencil: {},
             },
         )
         .unwrap();

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -584,10 +584,10 @@ mod linux {
         let render_pass = vulkano::single_pass_renderpass!(device.clone(),
             attachments: {
                 color: {
-                    load: Clear,
-                    store: Store,
                     format: swapchain.image_format(),
                     samples: 1,
+                    load_op: Clear,
+                    store_op: Store,
                 },
             },
             pass: {

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -201,10 +201,10 @@ fn main() {
     let render_pass = vulkano::single_pass_renderpass!(device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -209,7 +209,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -200,10 +200,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -208,7 +208,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -214,7 +214,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -206,10 +206,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -300,7 +300,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -292,10 +292,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -289,7 +289,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -281,10 +281,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/interactive_fractal/place_over_frame.rs
+++ b/examples/src/bin/interactive_fractal/place_over_frame.rs
@@ -44,10 +44,10 @@ impl RenderPassPlaceOverFrame {
             gfx_queue.device().clone(),
             attachments: {
                 color: {
-                    load: Clear,
-                    store: Store,
                     format: output_format,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: Store,
                 },
             },
             pass: {

--- a/examples/src/bin/interactive_fractal/place_over_frame.rs
+++ b/examples/src/bin/interactive_fractal/place_over_frame.rs
@@ -52,7 +52,8 @@ impl RenderPassPlaceOverFrame {
             },
             pass: {
                 color: [color],
-                depth_stencil: {},
+                depth: {},
+                stencil: {},
             },
         )
         .unwrap();

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -191,19 +191,19 @@ fn main() {
         attachments: {
             // The first framebuffer attachment is the intermediary image.
             intermediary: {
-                load: Clear,
-                store: DontCare,
                 format: Format::R8G8B8A8_UNORM,
                 // This has to match the image definition.
                 samples: 4,
+                load_op: Clear,
+                store_op: DontCare,
             },
             // The second framebuffer attachment is the final image.
             color: {
-                load: DontCare,
-                store: Store,
                 format: Format::R8G8B8A8_UNORM,
                 // Same here, this has to match.
                 samples: 1,
+                load_op: DontCare,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -208,14 +208,17 @@ fn main() {
         },
         pass: {
             // When drawing, we have only one output which is the intermediary image.
-            color: [intermediary],
-            depth_stencil: {},
-            // The `resolve` array here must contain either zero entry (if you don't use
-            // multisampling), or one entry per color attachment. At the end of the pass, each
-            // color attachment will be *resolved* into the given image. In other words, here, at
-            // the end of the pass, the `intermediary` attachment will be copied to the attachment
-            // named `color`.
-            resolve: [color],
+            //
+            // At the end of the pass, each color attachment will be *resolved* into the image
+            // given after ->. In other words, here, at the end of the pass, the `intermediary`
+            // attachment will be copied to the attachment named `color`.
+            //
+            // The value after : indicates the resolve mode. For a floating-point color format,
+            // which we are using here, Average is the only allowed option.
+            // You can choose multiple modes for depth/stencil formats.
+            color: [intermediary -> color:Average],
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -250,10 +250,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -258,7 +258,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/multi_window_game_of_life/main.rs
+++ b/examples/src/bin/multi_window_game_of_life/main.rs
@@ -92,10 +92,11 @@ pub fn process_event(
     mouse_pressed_w1: &mut bool,
     mouse_pressed_w2: &mut bool,
 ) -> bool {
-    match &event {
-        Event::WindowEvent {
-            event, window_id, ..
-        } => match event {
+    if let Event::WindowEvent {
+        event, window_id, ..
+    } = &event
+    {
+        match event {
             WindowEvent::CloseRequested => {
                 if *window_id == app.windows.primary_window_id().unwrap() {
                     return true;
@@ -130,8 +131,7 @@ pub fn process_event(
                 }
             }
             _ => (),
-        },
-        _ => (),
+        }
     }
     false
 }

--- a/examples/src/bin/multi_window_game_of_life/render_pass.rs
+++ b/examples/src/bin/multi_window_game_of_life/render_pass.rs
@@ -40,10 +40,10 @@ impl RenderPassPlaceOverFrame {
             gfx_queue.device().clone(),
             attachments: {
                 color: {
-                    load: Clear,
-                    store: Store,
                     format: output_format,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: Store,
                 },
             },
             pass: {

--- a/examples/src/bin/multi_window_game_of_life/render_pass.rs
+++ b/examples/src/bin/multi_window_game_of_life/render_pass.rs
@@ -48,7 +48,8 @@ impl RenderPassPlaceOverFrame {
             },
             pass: {
                 color: [color],
-                depth_stencil: {},
+                depth: {},
+                stencil: {},
             },
         )
         .unwrap();

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -44,9 +44,9 @@ use vulkano::{
         GraphicsPipeline, PipelineLayout,
     },
     render_pass::{
-        AttachmentDescription, AttachmentReference, Framebuffer, FramebufferCreateInfo, LoadOp,
-        RenderPass, RenderPassCreateInfo, ResolvableAttachmentReference, StoreOp, Subpass,
-        SubpassDescription,
+        AttachmentDescription, AttachmentLoadOp, AttachmentReference, AttachmentStoreOp,
+        Framebuffer, FramebufferCreateInfo, RenderPass, RenderPassCreateInfo,
+        ResolvableAttachmentReference, Subpass, SubpassDescription,
     },
     shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
@@ -225,10 +225,10 @@ fn main() {
         attachments: vec![AttachmentDescription {
             format: Some(image.format()),
             samples: SampleCount::Sample1,
-            load_op: LoadOp::Clear,
-            store_op: StoreOp::Store,
-            stencil_load_op: LoadOp::Clear,
-            stencil_store_op: StoreOp::Store,
+            load_op: AttachmentLoadOp::Clear,
+            store_op: AttachmentStoreOp::Store,
+            stencil_load_op: AttachmentLoadOp::Clear,
+            stencil_store_op: AttachmentStoreOp::Store,
             initial_layout: ImageLayout::ColorAttachmentOptimal,
             final_layout: ImageLayout::ColorAttachmentOptimal,
             ..Default::default()

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -45,7 +45,8 @@ use vulkano::{
     },
     render_pass::{
         AttachmentDescription, AttachmentReference, Framebuffer, FramebufferCreateInfo, LoadOp,
-        RenderPass, RenderPassCreateInfo, StoreOp, Subpass, SubpassDescription,
+        RenderPass, RenderPassCreateInfo, ResolvableAttachmentReference, StoreOp, Subpass,
+        SubpassDescription,
     },
     shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
@@ -236,10 +237,13 @@ fn main() {
             // The view mask indicates which layers of the framebuffer should be rendered for each
             // subpass.
             view_mask: 0b11,
-            color_attachments: vec![Some(AttachmentReference {
-                attachment: 0,
-                layout: ImageLayout::ColorAttachmentOptimal,
-                ..Default::default()
+            color_attachments: vec![Some(ResolvableAttachmentReference {
+                attachment_ref: AttachmentReference {
+                    attachment: 0,
+                    layout: ImageLayout::ColorAttachmentOptimal,
+                    ..Default::default()
+                },
+                resolve: None,
             })],
             ..Default::default()
         }],

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -285,16 +285,16 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
             depth: {
-                load: Clear,
-                store: DontCare,
                 format: Format::D16_UNORM,
                 samples: 1,
+                load_op: Clear,
+                store_op: DontCare,
             },
         },
         pass: {

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -299,7 +299,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {depth},
+            depth: {depth},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -204,7 +204,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -196,10 +196,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -174,7 +174,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -166,10 +166,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -268,7 +268,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -260,10 +260,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -178,10 +178,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -186,7 +186,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -230,7 +230,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {depth},
+            depth: {depth},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -216,16 +216,16 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
             depth: {
-                load: Clear,
-                store: DontCare,
                 format: Format::D16_UNORM,
                 samples: 1,
+                load_op: Clear,
+                store_op: DontCare,
             },
         },
         pass: {

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -331,7 +331,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -323,10 +323,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -202,10 +202,10 @@ fn main() {
         device.clone(),
         attachments: {
             color: {
-                load: Clear,
-                store: Store,
                 format: swapchain.image_format(),
                 samples: 1,
+                load_op: Clear,
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -210,7 +210,8 @@ fn main() {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -49,7 +49,7 @@ use vulkano::{
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, PipelineLayout,
     },
-    render_pass::{LoadOp, StoreOp},
+    render_pass::{AttachmentLoadOp, AttachmentStoreOp},
     shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
@@ -617,10 +617,10 @@ fn main() {
                         color_attachments: vec![Some(RenderingAttachmentInfo {
                             // `Clear` means that we ask the GPU to clear the content of this
                             // attachment at the start of rendering.
-                            load_op: LoadOp::Clear,
+                            load_op: AttachmentLoadOp::Clear,
                             // `Store` means that we ask the GPU to store the rendered output in
                             // the attachment image. We could also ask it to discard the result.
-                            store_op: StoreOp::Store,
+                            store_op: AttachmentStoreOp::Store,
                             // The value to clear the attachment with. Here we clear it with a blue
                             // color.
                             //

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -351,12 +351,6 @@ fn main() {
         attachments: {
             // `color` is a custom name we give to the first and only attachment.
             color: {
-                // `load: Clear` means that we ask the GPU to clear the content of this attachment
-                // at the start of the drawing.
-                load: Clear,
-                // `store: Store` means that we ask the GPU to store the output of the draw in the
-                // actual image. We could also ask it to discard the result.
-                store: Store,
                 // `format: <ty>` indicates the type of the format of the image. This has to be one
                 // of the types of the `vulkano::format` module (or alternatively one of your
                 // structs that implements the `FormatDesc` trait). Here we use the same format as
@@ -367,6 +361,12 @@ fn main() {
                 // (multisampling) for antialiasing. An example of this can be found in
                 // msaa-renderpass.rs.
                 samples: 1,
+                // `load_op: Clear` means that we ask the GPU to clear the content of this
+                // attachment at the start of the drawing.
+                load_op: Clear,
+                // `store_op: Store` means that we ask the GPU to store the output of the draw in
+                // the actual image. We could also ask it to discard the result.
+                store_op: Store,
             },
         },
         pass: {

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -373,7 +373,8 @@ fn main() {
             // We use the attachment named `color` as the one and only color attachment.
             color: [color],
             // No depth-stencil attachment is indicated with empty brackets.
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     )
     .unwrap();

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -22,8 +22,8 @@ use crate::{
     image::{ImageAspect, ImageAspects, ImageLayout, ImageUsage, ImageViewAbstract, SampleCount},
     pipeline::graphics::subpass::PipelineRenderingCreateInfo,
     render_pass::{
-        AttachmentDescription, Framebuffer, LoadOp, RenderPass, ResolveMode, StoreOp,
-        SubpassDescription,
+        AttachmentDescription, AttachmentLoadOp, AttachmentStoreOp, Framebuffer, RenderPass,
+        ResolveMode, SubpassDescription,
     },
     sync::PipelineStageAccessFlags,
     RequirementNotMet, RequiresOneOf, Version, VulkanObject,
@@ -333,15 +333,15 @@ where
             let attachment_index = attachment_index as u32;
             let attachment_format = attachment_desc.format.unwrap();
 
-            if attachment_desc.load_op == LoadOp::Clear
-                || attachment_desc.stencil_load_op == LoadOp::Clear
+            if attachment_desc.load_op == AttachmentLoadOp::Clear
+                || attachment_desc.stencil_load_op == AttachmentLoadOp::Clear
             {
                 let clear_value = match clear_value {
                     Some(x) => x,
                     None => return Err(RenderPassError::ClearValueMissing { attachment_index }),
                 };
 
-                if let (Some(numeric_type), LoadOp::Clear) =
+                if let (Some(numeric_type), AttachmentLoadOp::Clear) =
                     (attachment_format.type_color(), attachment_desc.load_op)
                 {
                     match numeric_type {
@@ -382,9 +382,9 @@ where
                 } else {
                     let attachment_aspects = attachment_format.aspects();
                     let need_depth = attachment_aspects.intersects(ImageAspects::DEPTH)
-                        && attachment_desc.load_op == LoadOp::Clear;
+                        && attachment_desc.load_op == AttachmentLoadOp::Clear;
                     let need_stencil = attachment_aspects.intersects(ImageAspects::STENCIL)
-                        && attachment_desc.stencil_load_op == LoadOp::Clear;
+                        && attachment_desc.stencil_load_op == AttachmentLoadOp::Clear;
 
                     if need_depth && need_stencil {
                         if !matches!(clear_value, ClearValue::DepthStencil(_)) {
@@ -2364,12 +2364,12 @@ pub struct RenderingAttachmentInfo {
     /// What the implementation should do with the attachment at the start of rendering.
     ///
     /// The default value is [`LoadOp::DontCare`].
-    pub load_op: LoadOp,
+    pub load_op: AttachmentLoadOp,
 
     /// What the implementation should do with the attachment at the end of rendering.
     ///
     /// The default value is [`StoreOp::DontCare`].
-    pub store_op: StoreOp,
+    pub store_op: AttachmentStoreOp,
 
     /// If `load_op` is [`LoadOp::Clear`], specifies the clear value that should be used for the
     /// attachment.
@@ -2397,8 +2397,8 @@ impl RenderingAttachmentInfo {
             image_view,
             image_layout,
             resolve_info: None,
-            load_op: LoadOp::DontCare,
-            store_op: StoreOp::DontCare,
+            load_op: AttachmentLoadOp::DontCare,
+            store_op: AttachmentStoreOp::DontCare,
             clear_value: None,
             _ne: crate::NonExhaustive(()),
         }

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -644,7 +644,9 @@ impl WriteDescriptorSet {
                                 | ImageLayout::ShaderReadOnlyOptimal
                                 | ImageLayout::General
                                 | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                                | ImageLayout::DepthAttachmentStencilReadOnlyOptimal,
+                                | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+                                | ImageLayout::DepthReadOnlyOptimal
+                                | ImageLayout::StencilReadOnlyOptimal,
                         ) {
                             return Err(ValidationError {
                                 context: format!("elements[{}]", index).into(),
@@ -755,7 +757,9 @@ impl WriteDescriptorSet {
                                 | ImageLayout::ShaderReadOnlyOptimal
                                 | ImageLayout::General
                                 | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                                | ImageLayout::DepthAttachmentStencilReadOnlyOptimal,
+                                | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+                                | ImageLayout::DepthReadOnlyOptimal
+                                | ImageLayout::StencilReadOnlyOptimal,
                         ) {
                             return Err(ValidationError {
                                 context: format!("elements[{}]", index).into(),
@@ -825,7 +829,9 @@ impl WriteDescriptorSet {
                             | ImageLayout::ShaderReadOnlyOptimal
                             | ImageLayout::General
                             | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                            | ImageLayout::DepthAttachmentStencilReadOnlyOptimal,
+                            | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+                            | ImageLayout::DepthReadOnlyOptimal
+                            | ImageLayout::StencilReadOnlyOptimal,
                     ) {
                         return Err(ValidationError {
                             context: format!("elements[{}]", index).into(),
@@ -1161,7 +1167,9 @@ impl WriteDescriptorSet {
                             | ImageLayout::ShaderReadOnlyOptimal
                             | ImageLayout::General
                             | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                            | ImageLayout::DepthAttachmentStencilReadOnlyOptimal,
+                            | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
+                            | ImageLayout::DepthReadOnlyOptimal
+                            | ImageLayout::StencilReadOnlyOptimal,
                     ) {
                         return Err(ValidationError {
                             context: format!("elements[{}]", index).into(),

--- a/vulkano/src/pipeline/graphics/subpass.rs
+++ b/vulkano/src/pipeline/graphics/subpass.rs
@@ -10,7 +10,6 @@
 use crate::{
     command_buffer::{CommandBufferInheritanceRenderingInfo, RenderingInfo},
     format::Format,
-    image::ImageAspects,
     render_pass::Subpass,
 };
 
@@ -93,18 +92,28 @@ impl PipelineRenderingCreateInfo {
         Self {
             view_mask: subpass_desc.view_mask,
             color_attachment_formats: (subpass_desc.color_attachments.iter())
-                .map(|atch_ref| {
-                    atch_ref.as_ref().map(|atch_ref| {
-                        rp_attachments[atch_ref.attachment as usize].format.unwrap()
+                .map(|resolvable_attachment| {
+                    resolvable_attachment.as_ref().map(|resolvable_attachment| {
+                        rp_attachments[resolvable_attachment.attachment_ref.attachment as usize]
+                            .format
+                            .unwrap()
                     })
                 })
                 .collect(),
-            depth_attachment_format: (subpass_desc.depth_stencil_attachment.as_ref())
-                .map(|atch_ref| rp_attachments[atch_ref.attachment as usize].format.unwrap())
-                .filter(|format| format.aspects().intersects(ImageAspects::DEPTH)),
-            stencil_attachment_format: (subpass_desc.depth_stencil_attachment.as_ref())
-                .map(|atch_ref| rp_attachments[atch_ref.attachment as usize].format.unwrap())
-                .filter(|format| format.aspects().intersects(ImageAspects::STENCIL)),
+            depth_attachment_format: (subpass_desc.depth_attachment.as_ref()).map(
+                |resolvable_attachment| {
+                    rp_attachments[resolvable_attachment.attachment_ref.attachment as usize]
+                        .format
+                        .unwrap()
+                },
+            ),
+            stencil_attachment_format: (subpass_desc.stencil_attachment.as_ref()).map(
+                |resolvable_attachment| {
+                    rp_attachments[resolvable_attachment.attachment_ref.attachment as usize]
+                        .format
+                        .unwrap()
+                },
+            ),
             _ne: crate::NonExhaustive(()),
         }
     }

--- a/vulkano/src/pipeline/graphics/tests.rs
+++ b/vulkano/src/pipeline/graphics/tests.rs
@@ -310,7 +310,8 @@ mod simple_rp {
         },
         pass: {
             color: [color],
-            depth_stencil: {},
+            depth: {},
+            stencil: {},
         },
     }
 }

--- a/vulkano/src/render_pass/create.rs
+++ b/vulkano/src/render_pass/create.rs
@@ -7,1198 +7,546 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::{
-    AttachmentDescription, AttachmentReference, LoadOp, RenderPass, RenderPassCreateInfo,
-    SubpassDependency, SubpassDescription,
-};
+use super::{AttachmentDescription, AttachmentReference, RenderPass, RenderPassCreateInfo};
 use crate::{
     device::Device,
-    format::FormatFeatures,
-    image::{ImageAspects, ImageLayout, SampleCount},
-    sync::{AccessFlags, DependencyFlags, PipelineStages},
-    OomError, RequirementNotMet, RequiresOneOf, RuntimeError, Version, VulkanObject,
+    image::ImageAspects,
+    render_pass::{
+        InputAttachmentReference, ResolvableAttachmentReference, ResolveAttachmentReference,
+        SubpassDependency, SubpassDescription,
+    },
+    RuntimeError, Version, VulkanObject,
 };
 use smallvec::SmallVec;
-use std::{
-    error::Error,
-    fmt::{Display, Error as FmtError, Formatter},
-    mem::MaybeUninit,
-    ptr,
-};
+use std::{mem::MaybeUninit, ptr};
 
 impl RenderPass {
-    pub(super) fn validate(
-        device: &Device,
-        create_info: &mut RenderPassCreateInfo,
-    ) -> Result<(), RenderPassCreationError> {
-        let properties = device.physical_device().properties();
-
-        let RenderPassCreateInfo {
-            attachments,
-            subpasses,
-            dependencies,
-            correlated_view_masks,
-            _ne: _,
-        } = create_info;
-
-        /*
-            Attachments
-        */
-
-        let mut attachment_potential_format_features = Vec::with_capacity(attachments.len());
-
-        for (atch_num, attachment) in attachments.iter().enumerate() {
-            let &AttachmentDescription {
-                format,
-                samples,
-                load_op,
-                store_op,
-                stencil_load_op,
-                stencil_store_op,
-                initial_layout,
-                final_layout,
-                _ne: _,
-            } = attachment;
-            let atch_num = atch_num as u32;
-
-            // VUID-VkAttachmentDescription2-finalLayout-03061
-            if matches!(
-                final_layout,
-                ImageLayout::Undefined | ImageLayout::Preinitialized
-            ) {
-                return Err(RenderPassCreationError::AttachmentLayoutInvalid {
-                    attachment: atch_num,
-                });
-            }
-
-            let format = format.unwrap();
-            let aspects = format.aspects();
-
-            // VUID-VkAttachmentDescription2-format-parameter
-            format.validate_device(device)?;
-
-            // VUID-VkAttachmentDescription2-samples-parameter
-            samples.validate_device(device)?;
-
-            for load_op in [load_op, stencil_load_op] {
-                // VUID-VkAttachmentDescription2-loadOp-parameter
-                // VUID-VkAttachmentDescription2-stencilLoadOp-parameter
-                load_op.validate_device(device)?;
-            }
-
-            for store_op in [store_op, stencil_store_op] {
-                // VUID-VkAttachmentDescription2-storeOp-parameter
-                // VUID-VkAttachmentDescription2-stencilStoreOp-parameter
-                store_op.validate_device(device)?;
-            }
-
-            for layout in [initial_layout, final_layout] {
-                // VUID-VkAttachmentDescription2-initialLayout-parameter
-                // VUID-VkAttachmentDescription2-finalLayout-parameter
-                layout.validate_device(device)?;
-
-                if aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
-                    // VUID-VkAttachmentDescription2-format-03281
-                    // VUID-VkAttachmentDescription2-format-03283
-                    if matches!(layout, ImageLayout::ColorAttachmentOptimal) {
-                        return Err(RenderPassCreationError::AttachmentLayoutInvalid {
-                            attachment: atch_num,
-                        });
-                    }
-                } else {
-                    // VUID-VkAttachmentDescription2-format-03280
-                    // VUID-VkAttachmentDescription2-format-03282
-                    // VUID-VkAttachmentDescription2-format-06487
-                    // VUID-VkAttachmentDescription2-format-06488
-                    if matches!(
-                        layout,
-                        ImageLayout::DepthStencilAttachmentOptimal
-                            | ImageLayout::DepthStencilReadOnlyOptimal
-                            | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
-                            | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                    ) {
-                        return Err(RenderPassCreationError::AttachmentLayoutInvalid {
-                            attachment: atch_num,
-                        });
-                    }
-                }
-            }
-
-            // Use unchecked, because all validation has been done above.
-            attachment_potential_format_features.push(unsafe {
-                device
-                    .physical_device()
-                    .format_properties_unchecked(format)
-                    .potential_format_features()
-            });
-        }
-
-        /*
-            Subpasses
-        */
-
-        // VUID-VkRenderPassCreateInfo2-subpassCount-arraylength
-        assert!(!subpasses.is_empty());
-
-        let is_multiview = subpasses[0].view_mask != 0;
-
-        // VUID-VkSubpassDescription2-multiview-06558
-        if is_multiview && !device.enabled_features().multiview {
-            return Err(RenderPassCreationError::RequirementNotMet {
-                required_for: "`create_info.subpasses[0].view_mask` is not `0`",
-                requires_one_of: RequiresOneOf {
-                    features: &["multiview"],
-                    ..Default::default()
-                },
-            });
-        }
-
-        let mut attachment_used = vec![false; attachments.len()];
-
-        for (subpass_num, subpass) in subpasses.iter_mut().enumerate() {
-            let &mut SubpassDescription {
-                view_mask,
-                ref mut input_attachments,
-                ref color_attachments,
-                ref resolve_attachments,
-                ref depth_stencil_attachment,
-                ref preserve_attachments,
-                _ne: _,
-            } = subpass;
-            let subpass_num = subpass_num as u32;
-
-            // VUID-VkRenderPassCreateInfo2-viewMask-03058
-            if (view_mask != 0) != is_multiview {
-                return Err(RenderPassCreationError::SubpassMultiviewMismatch {
-                    subpass: subpass_num,
-                    multiview: subpass.view_mask != 0,
-                    first_subpass_multiview: is_multiview,
-                });
-            }
-
-            let view_count = u32::BITS - view_mask.leading_zeros();
-
-            // VUID-VkSubpassDescription2-viewMask-06706
-            if view_count > properties.max_multiview_view_count.unwrap_or(0) {
-                return Err(
-                    RenderPassCreationError::SubpassMaxMultiviewViewCountExceeded {
-                        subpass: subpass_num,
-                        view_count,
-                        max: properties.max_multiview_view_count.unwrap_or(0),
-                    },
-                );
-            }
-
-            // VUID-VkSubpassDescription2-colorAttachmentCount-03063
-            if color_attachments.len() as u32 > properties.max_color_attachments {
-                return Err(
-                    RenderPassCreationError::SubpassMaxColorAttachmentsExceeded {
-                        subpass: subpass_num,
-                        color_attachment_count: color_attachments.len() as u32,
-                        max: properties.max_color_attachments,
-                    },
-                );
-            }
-
-            // Track the layout of each attachment used in this subpass
-            let mut layouts = vec![None; attachments.len()];
-
-            // Common checks for all attachment types
-            let mut check_attachment = |atch_ref: &AttachmentReference| {
-                // VUID-VkAttachmentReference2-layout-parameter
-                atch_ref.layout.validate_device(device)?;
-
-                // VUID?
-                atch_ref.aspects.validate_device(device)?;
-
-                // VUID-VkRenderPassCreateInfo2-attachment-03051
-                let atch = attachments.get(atch_ref.attachment as usize).ok_or(
-                    RenderPassCreationError::SubpassAttachmentOutOfRange {
-                        subpass: subpass_num,
-                        attachment: atch_ref.attachment,
-                    },
-                )?;
-
-                // VUID-VkSubpassDescription2-layout-02528
-                match &mut layouts[atch_ref.attachment as usize] {
-                    Some(layout) if *layout == atch_ref.layout => (),
-                    Some(_) => {
-                        return Err(RenderPassCreationError::SubpassAttachmentLayoutMismatch {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                        })
-                    }
-                    layout @ None => *layout = Some(atch_ref.layout),
-                }
-
-                let first_use =
-                    !std::mem::replace(&mut attachment_used[atch_ref.attachment as usize], true);
-
-                if first_use {
-                    // VUID-VkRenderPassCreateInfo2-pAttachments-02522
-                    if atch.load_op == LoadOp::Clear
-                        && matches!(
-                            atch_ref.layout,
-                            ImageLayout::ShaderReadOnlyOptimal
-                                | ImageLayout::DepthStencilReadOnlyOptimal
-                                | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                        )
-                    {
-                        return Err(RenderPassCreationError::AttachmentFirstUseLoadOpInvalid {
-                            attachment: atch_ref.attachment,
-                            first_use_subpass: subpass_num,
-                        });
-                    }
-
-                    // VUID-VkRenderPassCreateInfo2-pAttachments-02523
-                    if atch.stencil_load_op == LoadOp::Clear
-                        && matches!(
-                            atch_ref.layout,
-                            ImageLayout::ShaderReadOnlyOptimal
-                                | ImageLayout::DepthStencilReadOnlyOptimal
-                                | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
-                        )
-                    {
-                        return Err(RenderPassCreationError::AttachmentFirstUseLoadOpInvalid {
-                            attachment: atch_ref.attachment,
-                            first_use_subpass: subpass_num,
-                        });
-                    }
-                }
-
-                let potential_format_features =
-                    &attachment_potential_format_features[atch_ref.attachment as usize];
-
-                Ok((atch, potential_format_features, first_use))
-            };
-
-            /*
-                Check color attachments
-            */
-
-            let mut color_samples = None;
-
-            for atch_ref in color_attachments.iter().flatten() {
-                let (atch, features, _first_use) = check_attachment(atch_ref)?;
-
-                // VUID-VkSubpassDescription2-pColorAttachments-02898
-                if !features.intersects(FormatFeatures::COLOR_ATTACHMENT) {
-                    return Err(
-                        RenderPassCreationError::SubpassAttachmentFormatUsageNotSupported {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                            usage: "color",
-                        },
-                    );
-                }
-
-                // VUID-VkAttachmentReference2-layout-03077
-                // VUID-VkSubpassDescription2-attachment-06913
-                // VUID-VkSubpassDescription2-attachment-06916
-                if matches!(
-                    atch_ref.layout,
-                    ImageLayout::Undefined
-                        | ImageLayout::Preinitialized
-                        | ImageLayout::PresentSrc
-                        | ImageLayout::DepthStencilAttachmentOptimal
-                        | ImageLayout::ShaderReadOnlyOptimal
-                        | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
-                        | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                ) {
-                    return Err(RenderPassCreationError::SubpassAttachmentLayoutInvalid {
-                        subpass: subpass_num,
-                        attachment: atch_ref.attachment,
-                        usage: "color",
-                    });
-                }
-
-                // Not required by spec, but enforced by Vulkano for sanity.
-                if !atch_ref.aspects.is_empty() {
-                    return Err(RenderPassCreationError::SubpassAttachmentAspectsNotEmpty {
-                        subpass: subpass_num,
-                        attachment: atch_ref.attachment,
-                    });
-                }
-
-                // VUID-VkSubpassDescription2-pColorAttachments-03069
-                match &mut color_samples {
-                    Some(samples) if *samples == atch.samples => (),
-                    Some(samples) => {
-                        return Err(
-                            RenderPassCreationError::SubpassColorDepthStencilAttachmentSamplesMismatch {
-                                subpass: subpass_num,
-                                attachment: atch_ref.attachment,
-                                samples: atch.samples,
-                                first_samples: *samples,
-                            },
-                        )
-                    }
-                    samples @ None => *samples = Some(atch.samples),
-                }
-            }
-
-            /*
-                Check depth/stencil attachment
-            */
-
-            if let Some(atch_ref) = depth_stencil_attachment.as_ref() {
-                let (atch, features, _first_use) = check_attachment(atch_ref)?;
-
-                // VUID-VkSubpassDescription2-pDepthStencilAttachment-02900
-                if !features.intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT) {
-                    return Err(
-                        RenderPassCreationError::SubpassAttachmentFormatUsageNotSupported {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                            usage: "depth/stencil",
-                        },
-                    );
-                }
-
-                // VUID-VkAttachmentReference2-layout-03077
-                // VUID-VkSubpassDescription2-attachment-06915
-                if matches!(
-                    atch_ref.layout,
-                    ImageLayout::Undefined
-                        | ImageLayout::Preinitialized
-                        | ImageLayout::PresentSrc
-                        | ImageLayout::ColorAttachmentOptimal
-                        | ImageLayout::ShaderReadOnlyOptimal
-                ) {
-                    return Err(RenderPassCreationError::SubpassAttachmentLayoutInvalid {
-                        subpass: subpass_num,
-                        attachment: atch_ref.attachment,
-                        usage: "depth/stencil",
-                    });
-                }
-
-                // Not required by spec, but enforced by Vulkano for sanity.
-                if !atch_ref.aspects.is_empty() {
-                    return Err(RenderPassCreationError::SubpassAttachmentAspectsNotEmpty {
-                        subpass: subpass_num,
-                        attachment: atch_ref.attachment,
-                    });
-                }
-
-                // VUID-VkSubpassDescription2-pDepthStencilAttachment-04440
-                if color_attachments
-                    .iter()
-                    .flatten()
-                    .any(|color_atch_ref| color_atch_ref.attachment == atch_ref.attachment)
-                {
-                    return Err(
-                        RenderPassCreationError::SubpassAttachmentUsageColorDepthStencil {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                        },
-                    );
-                }
-
-                // VUID-VkSubpassDescription2-pDepthStencilAttachment-03071
-                if let Some(samples) = color_samples.filter(|samples| *samples != atch.samples) {
-                    return Err(
-                        RenderPassCreationError::SubpassColorDepthStencilAttachmentSamplesMismatch {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                            samples: atch.samples,
-                            first_samples: samples,
-                        },
-                    );
-                }
-            }
-
-            /*
-                Check input attachments
-                This must be placed after color and depth/stencil checks so that `first_use`
-                will be true for VUID-VkSubpassDescription2-loadOp-03064.
-            */
-
-            for atch_ref in input_attachments.iter_mut().flatten() {
-                let (atch, features, first_use) = check_attachment(atch_ref)?;
-
-                // VUID-VkSubpassDescription2-pInputAttachments-02897
-                if !features.intersects(
-                    FormatFeatures::COLOR_ATTACHMENT | FormatFeatures::DEPTH_STENCIL_ATTACHMENT,
-                ) {
-                    return Err(
-                        RenderPassCreationError::SubpassAttachmentFormatUsageNotSupported {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                            usage: "input",
-                        },
-                    );
-                }
-
-                // VUID-VkAttachmentReference2-layout-03077
-                // VUID-VkSubpassDescription2-attachment-06912
-                if matches!(
-                    atch_ref.layout,
-                    ImageLayout::Undefined
-                        | ImageLayout::Preinitialized
-                        | ImageLayout::PresentSrc
-                        | ImageLayout::ColorAttachmentOptimal
-                        | ImageLayout::DepthStencilAttachmentOptimal
-                ) {
-                    return Err(RenderPassCreationError::SubpassAttachmentLayoutInvalid {
-                        subpass: subpass_num,
-                        attachment: atch_ref.attachment,
-                        usage: "input",
-                    });
-                }
-
-                let atch_aspects = atch.format.unwrap().aspects();
-
-                if atch_ref.aspects.is_empty() {
-                    // VUID-VkSubpassDescription2-attachment-02800
-                    atch_ref.aspects = atch_aspects;
-                } else if atch_ref.aspects != atch_aspects {
-                    if !(device.api_version() >= Version::V1_1
-                        || device.enabled_extensions().khr_create_renderpass2
-                        || device.enabled_extensions().khr_maintenance2)
-                    {
-                        return Err(RenderPassCreationError::RequirementNotMet {
-                            required_for: "`create_info.subpasses` has an element, where \
-                                `input_attachments` has an element that is `Some(atch_ref)`, \
-                                where `atch_ref.aspects` does not match the aspects of the \
-                                attachment itself",
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_1),
-                                device_extensions: &["khr_create_renderpass2", "khr_maintenance2"],
-                                ..Default::default()
-                            },
-                        });
-                    }
-
-                    // VUID-VkSubpassDescription2-attachment-02801
-                    // VUID-VkSubpassDescription2-attachment-04563
-                    // VUID-VkRenderPassCreateInfo2-attachment-02525
-                    if !atch_aspects.contains(atch_ref.aspects) {
-                        return Err(
-                            RenderPassCreationError::SubpassInputAttachmentAspectsNotCompatible {
-                                subpass: subpass_num,
-                                attachment: atch_ref.attachment,
-                            },
-                        );
-                    }
-                }
-
-                // VUID-VkSubpassDescription2-loadOp-03064
-                if first_use && atch.load_op == LoadOp::Clear {
-                    return Err(RenderPassCreationError::AttachmentFirstUseLoadOpInvalid {
-                        attachment: atch_ref.attachment,
-                        first_use_subpass: subpass_num,
-                    });
-                }
-            }
-
-            /*
-                Check resolve attachments
-            */
-
-            // VUID-VkSubpassDescription2-pResolveAttachments-parameter
-            if !(resolve_attachments.is_empty()
-                || resolve_attachments.len() == color_attachments.len())
-            {
-                return Err(
-                    RenderPassCreationError::SubpassResolveAttachmentsColorAttachmentsLenMismatch {
-                        subpass: subpass_num,
-                    },
-                );
-            }
-
-            for (atch_ref, color_atch_ref) in resolve_attachments
-                .iter()
-                .zip(subpass.color_attachments.iter())
-                .filter_map(|(r, c)| r.as_ref().map(|r| (r, c.as_ref())))
-            {
-                let (atch, features, _first_use) = check_attachment(atch_ref)?;
-
-                // VUID-VkSubpassDescription2-pResolveAttachments-02899
-                if !features.intersects(FormatFeatures::COLOR_ATTACHMENT) {
-                    return Err(
-                        RenderPassCreationError::SubpassAttachmentFormatUsageNotSupported {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                            usage: "resolve",
-                        },
-                    );
-                }
-
-                // VUID-VkAttachmentReference2-layout-03077
-                // VUID-VkSubpassDescription2-attachment-06914
-                // VUID-VkSubpassDescription2-attachment-06917
-                if matches!(
-                    atch_ref.layout,
-                    ImageLayout::Undefined
-                        | ImageLayout::Preinitialized
-                        | ImageLayout::PresentSrc
-                        | ImageLayout::DepthStencilAttachmentOptimal
-                        | ImageLayout::ShaderReadOnlyOptimal
-                        | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
-                        | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                ) {
-                    return Err(RenderPassCreationError::SubpassAttachmentLayoutInvalid {
-                        subpass: subpass_num,
-                        attachment: atch_ref.attachment,
-                        usage: "resolve",
-                    });
-                }
-
-                // Not required by spec, but enforced by Vulkano for sanity.
-                if !atch_ref.aspects.is_empty() {
-                    return Err(RenderPassCreationError::SubpassAttachmentAspectsNotEmpty {
-                        subpass: subpass_num,
-                        attachment: atch_ref.attachment,
-                    });
-                }
-
-                // VUID-VkSubpassDescription2-pResolveAttachments-03065
-                let color_atch_ref = color_atch_ref.ok_or({
-                    RenderPassCreationError::SubpassResolveAttachmentWithoutColorAttachment {
-                        subpass: subpass_num,
-                    }
-                })?;
-                let color_atch = &attachments[color_atch_ref.attachment as usize];
-
-                // VUID-VkSubpassDescription2-pResolveAttachments-03067
-                if atch.samples != SampleCount::Sample1 {
-                    return Err(
-                        RenderPassCreationError::SubpassResolveAttachmentMultisampled {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                        },
-                    );
-                }
-
-                // VUID-VkSubpassDescription2-pResolveAttachments-03066
-                if color_atch.samples == SampleCount::Sample1 {
-                    return Err(
-                        RenderPassCreationError::SubpassColorAttachmentWithResolveNotMultisampled {
-                            subpass: subpass_num,
-                            attachment: atch_ref.attachment,
-                        },
-                    );
-                }
-
-                // VUID-VkSubpassDescription2-pResolveAttachments-03068
-                if atch.format != color_atch.format {
-                    return Err(
-                        RenderPassCreationError::SubpassResolveAttachmentFormatMismatch {
-                            subpass: subpass_num,
-                            resolve_attachment: atch_ref.attachment,
-                            color_attachment: color_atch_ref.attachment,
-                        },
-                    );
-                }
-            }
-
-            /*
-                Check preserve attachments
-            */
-
-            for &atch in preserve_attachments {
-                // VUID-VkRenderPassCreateInfo2-attachment-03051
-                if atch as usize >= attachments.len() {
-                    return Err(RenderPassCreationError::SubpassAttachmentOutOfRange {
-                        subpass: subpass_num,
-                        attachment: atch,
-                    });
-                }
-
-                // VUID-VkSubpassDescription2-pPreserveAttachments-03074
-                if layouts[atch as usize].is_some() {
-                    return Err(
-                        RenderPassCreationError::SubpassPreserveAttachmentUsedElsewhere {
-                            subpass: subpass_num,
-                            attachment: atch,
-                        },
-                    );
-                }
-            }
-        }
-
-        /*
-            Dependencies
-        */
-
-        for (dependency_num, dependency) in dependencies.iter().enumerate() {
-            let &SubpassDependency {
-                src_subpass,
-                dst_subpass,
-                src_stages,
-                dst_stages,
-                src_access,
-                dst_access,
-                dependency_flags,
-                view_offset,
-                _ne: _,
-            } = dependency;
-            let dependency_num = dependency_num as u32;
-
-            for (stages, access) in [(src_stages, src_access), (dst_stages, dst_access)] {
-                if !device.enabled_features().synchronization2 {
-                    if stages.contains_flags2() {
-                        return Err(RenderPassCreationError::RequirementNotMet {
-                            required_for: "`create_info.dependencies` has an element where \
-                                `src_stages` or `dst_stages` contains flags from \
-                                `VkPipelineStageFlagBits2`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["synchronization2"],
-                                ..Default::default()
-                            },
-                        });
-                    }
-
-                    if access.contains_flags2() {
-                        return Err(RenderPassCreationError::RequirementNotMet {
-                            required_for: "`create_info.dependencies` has an element where \
-                                `src_access` or `dst_access` contains flags from \
-                                `VkAccessFlagBits2`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["synchronization2"],
-                                ..Default::default()
-                            },
-                        });
-                    }
-                } else if !(device.api_version() >= Version::V1_2
-                    || device.enabled_extensions().khr_create_renderpass2)
-                {
-                    // If synchronization2 is enabled but we don't have create_renderpass2,
-                    // we are unable to use extension structs, so we can't use the
-                    // extra flag bits.
-
-                    if stages.contains_flags2() {
-                        return Err(RenderPassCreationError::RequirementNotMet {
-                            required_for: "`create_info.dependencies` has an element where \
-                                `src_stages` or `dst_stages` contains flags from \
-                                `VkPipelineStageFlagBits2`",
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_2),
-                                device_extensions: &["khr_create_renderpass2"],
-                                ..Default::default()
-                            },
-                        });
-                    }
-
-                    if access.contains_flags2() {
-                        return Err(RenderPassCreationError::RequirementNotMet {
-                            required_for: "`create_info.dependencies` has an element where \
-                                `src_access` or `dst_access` contains flags from \
-                                `VkAccessFlagBits2`",
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_2),
-                                device_extensions: &["khr_create_renderpass2"],
-                                ..Default::default()
-                            },
-                        });
-                    }
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-parameter
-                // VUID-VkMemoryBarrier2-dstStageMask-parameter
-                stages.validate_device(device)?;
-
-                // VUID-VkMemoryBarrier2-srcAccessMask-parameter
-                // VUID-VkMemoryBarrier2-dstAccessMask-parameter
-                access.validate_device(device)?;
-
-                // VUID-VkMemoryBarrier2-srcStageMask-03929
-                // VUID-VkMemoryBarrier2-dstStageMask-03929
-                if stages.intersects(PipelineStages::GEOMETRY_SHADER)
-                    && !device.enabled_features().geometry_shader
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::GEOMETRY_SHADER`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["geometry_shader"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-03930
-                // VUID-VkMemoryBarrier2-dstStageMask-03930
-                if stages.intersects(
-                    PipelineStages::TESSELLATION_CONTROL_SHADER
-                        | PipelineStages::TESSELLATION_EVALUATION_SHADER,
-                ) && !device.enabled_features().tessellation_shader
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::TESSELLATION_CONTROL_SHADER` or \
-                            `PipelineStages::TESSELLATION_EVALUATION_SHADER`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["tessellation_shader"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-03931
-                // VUID-VkMemoryBarrier2-dstStageMask-03931
-                if stages.intersects(PipelineStages::CONDITIONAL_RENDERING)
-                    && !device.enabled_features().conditional_rendering
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::CONDITIONAL_RENDERING`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["conditional_rendering"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-03932
-                // VUID-VkMemoryBarrier2-dstStageMask-03932
-                if stages.intersects(PipelineStages::FRAGMENT_DENSITY_PROCESS)
-                    && !device.enabled_features().fragment_density_map
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::FRAGMENT_DENSITY_PROCESS`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["fragment_density_map"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-03933
-                // VUID-VkMemoryBarrier2-dstStageMask-03933
-                if stages.intersects(PipelineStages::TRANSFORM_FEEDBACK)
-                    && !device.enabled_features().transform_feedback
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::TRANSFORM_FEEDBACK`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["transform_feedback"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-03934
-                // VUID-VkMemoryBarrier2-dstStageMask-03934
-                if stages.intersects(PipelineStages::MESH_SHADER)
-                    && !device.enabled_features().mesh_shader
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::MESH_SHADER`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["mesh_shader"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-03935
-                // VUID-VkMemoryBarrier2-dstStageMask-03935
-                if stages.intersects(PipelineStages::TASK_SHADER)
-                    && !device.enabled_features().task_shader
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::TASK_SHADER`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["task_shader"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-shadingRateImage-07316
-                // VUID-VkMemoryBarrier2-shadingRateImage-07316
-                if stages.intersects(PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT)
-                    && !(device.enabled_features().attachment_fragment_shading_rate
-                        || device.enabled_features().shading_rate_image)
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["attachment_fragment_shading_rate", "shading_rate_image"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-04957
-                // VUID-VkMemoryBarrier2-dstStageMask-04957
-                if stages.intersects(PipelineStages::SUBPASS_SHADING)
-                    && !device.enabled_features().subpass_shading
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::SUBPASS_SHADING`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["subpass_shading"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkMemoryBarrier2-srcStageMask-04995
-                // VUID-VkMemoryBarrier2-dstStageMask-04995
-                if stages.intersects(PipelineStages::INVOCATION_MASK)
-                    && !device.enabled_features().invocation_mask
-                {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            contains `PipelineStages::INVOCATION_MASK`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["invocation_mask"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkSubpassDependency2-srcStageMask-03937
-                // VUID-VkSubpassDependency2-dstStageMask-03937
-                if stages.is_empty() && !device.enabled_features().synchronization2 {
-                    return Err(RenderPassCreationError::RequirementNotMet {
-                        required_for: "`create_info.dependencies` has an element where `stages` \
-                            is empty",
-                        requires_one_of: RequiresOneOf {
-                            features: &["synchronization2"],
-                            ..Default::default()
-                        },
-                    });
-                }
-
-                // VUID-VkSubpassDependency2-srcAccessMask-03088
-                // VUID-VkSubpassDependency2-dstAccessMask-03089
-                if !AccessFlags::from(stages).contains(access) {
-                    return Err(
-                        RenderPassCreationError::DependencyAccessNotSupportedByStages {
-                            dependency: dependency_num,
-                        },
-                    );
-                }
-            }
-
-            if dependency_flags.intersects(DependencyFlags::VIEW_LOCAL) {
-                // VUID-VkRenderPassCreateInfo2-viewMask-03059
-                if !is_multiview {
-                    return Err(
-                        RenderPassCreationError::DependencyViewLocalMultiviewNotEnabled {
-                            dependency: dependency_num,
-                        },
-                    );
-                }
-            } else {
-                // VUID-VkSubpassDependency2-dependencyFlags-03092
-                if view_offset != 0 {
-                    return Err(
-                        RenderPassCreationError::DependencyViewOffzetNonzeroWithoutViewLocal {
-                            dependency: dependency_num,
-                        },
-                    );
-                }
-            }
-
-            // VUID-VkSubpassDependency2-srcSubpass-03085
-            if src_subpass.is_none() && dst_subpass.is_none() {
-                return Err(RenderPassCreationError::DependencyBothSubpassesExternal {
-                    dependency: dependency_num,
-                });
-            }
-
-            for (subpass, stages) in [(src_subpass, src_stages), (dst_subpass, dst_stages)] {
-                if let Some(subpass) = subpass {
-                    // VUID-VkRenderPassCreateInfo2-srcSubpass-02526
-                    // VUID-VkRenderPassCreateInfo2-dstSubpass-02527
-                    if subpass as usize >= subpasses.len() {
-                        return Err(RenderPassCreationError::DependencySubpassOutOfRange {
-                            dependency: dependency_num,
-                            subpass,
-                        });
-                    }
-
-                    let remaining_stages = stages
-                        - (PipelineStages::DRAW_INDIRECT
-                            | PipelineStages::INDEX_INPUT
-                            | PipelineStages::VERTEX_ATTRIBUTE_INPUT
-                            | PipelineStages::VERTEX_SHADER
-                            | PipelineStages::TESSELLATION_CONTROL_SHADER
-                            | PipelineStages::TESSELLATION_EVALUATION_SHADER
-                            | PipelineStages::GEOMETRY_SHADER
-                            | PipelineStages::TRANSFORM_FEEDBACK
-                            | PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT
-                            | PipelineStages::EARLY_FRAGMENT_TESTS
-                            | PipelineStages::FRAGMENT_SHADER
-                            | PipelineStages::LATE_FRAGMENT_TESTS
-                            | PipelineStages::COLOR_ATTACHMENT_OUTPUT
-                            | PipelineStages::ALL_GRAPHICS);
-
-                    // VUID-VkRenderPassCreateInfo2-pDependencies-03054
-                    // VUID-VkRenderPassCreateInfo2-pDependencies-03055
-                    if !remaining_stages.is_empty() {
-                        return Err(RenderPassCreationError::DependencyStageNotSupported {
-                            dependency: dependency_num,
-                        });
-                    }
-                } else {
-                    // VUID-VkSubpassDependency2-dependencyFlags-03090
-                    // VUID-VkSubpassDependency2-dependencyFlags-03091
-                    if dependency_flags.intersects(DependencyFlags::VIEW_LOCAL) {
-                        return Err(
-                            RenderPassCreationError::DependencyViewLocalExternalDependency {
-                                dependency: dependency_num,
-                            },
-                        );
-                    }
-                }
-            }
-
-            if let (Some(src_subpass), Some(dst_subpass)) = (src_subpass, dst_subpass) {
-                // VUID-VkSubpassDependency2-srcSubpass-03084
-                if src_subpass > dst_subpass {
-                    return Err(
-                        RenderPassCreationError::DependencySourceSubpassAfterDestinationSubpass {
-                            dependency: dependency_num,
-                        },
-                    );
-                }
-
-                if src_subpass == dst_subpass {
-                    let framebuffer_stages = PipelineStages::EARLY_FRAGMENT_TESTS
-                        | PipelineStages::FRAGMENT_SHADER
-                        | PipelineStages::LATE_FRAGMENT_TESTS
-                        | PipelineStages::COLOR_ATTACHMENT_OUTPUT;
-
-                    // VUID-VkSubpassDependency2-srcSubpass-06810
-                    if src_stages.intersects(framebuffer_stages)
-                        && !(dst_stages - framebuffer_stages).is_empty()
-                    {
-                        return Err(
-                            RenderPassCreationError::DependencySelfDependencySourceStageAfterDestinationStage {
-                                dependency: dependency_num,
-                            },
-                        );
-                    }
-
-                    // VUID-VkSubpassDependency2-srcSubpass-02245
-                    if src_stages.intersects(framebuffer_stages)
-                        && dst_stages.intersects(framebuffer_stages)
-                        && !dependency_flags.intersects(DependencyFlags::BY_REGION)
-                    {
-                        return Err(
-                            RenderPassCreationError::DependencySelfDependencyFramebufferStagesWithoutByRegion {
-                                dependency: dependency_num,
-                            },
-                        );
-                    }
-
-                    if dependency_flags.intersects(DependencyFlags::VIEW_LOCAL) {
-                        // VUID-VkSubpassDependency2-viewOffset-02530
-                        if view_offset != 0 {
-                            return Err(
-                                RenderPassCreationError::DependencySelfDependencyViewLocalNonzeroViewOffset {
-                                    dependency: dependency_num,
-                                },
-                            );
-                        }
-                    } else {
-                        // VUID-VkRenderPassCreateInfo2-pDependencies-03060
-                        if subpasses[src_subpass as usize].view_mask.count_ones() > 1 {
-                            return Err(
-                                RenderPassCreationError::DependencySelfDependencyViewMaskMultiple {
-                                    dependency: dependency_num,
-                                    subpass: src_subpass,
-                                },
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        /*
-            Correlated view masks
-        */
-
-        // VUID-VkRenderPassCreateInfo2-viewMask-03057
-        if !correlated_view_masks.is_empty() {
-            if !is_multiview {
-                return Err(RenderPassCreationError::CorrelatedViewMasksMultiviewNotEnabled);
-            }
-
-            // VUID-VkRenderPassCreateInfo2-pCorrelatedViewMasks-03056
-            correlated_view_masks.iter().try_fold(0, |total, &mask| {
-                if total & mask != 0 {
-                    Err(RenderPassCreationError::CorrelatedViewMasksOverlapping)
-                } else {
-                    Ok(total | mask)
-                }
-            })?;
-        }
-
-        Ok(())
-    }
-
     pub(super) unsafe fn create_v2(
         device: &Device,
         create_info: &RenderPassCreateInfo,
-    ) -> Result<ash::vk::RenderPass, RenderPassCreationError> {
-        let RenderPassCreateInfo {
-            attachments,
-            subpasses,
-            dependencies,
-            correlated_view_masks,
+    ) -> Result<ash::vk::RenderPass, RuntimeError> {
+        let &RenderPassCreateInfo {
+            flags,
+            ref attachments,
+            ref subpasses,
+            ref dependencies,
+            ref correlated_view_masks,
             _ne: _,
         } = create_info;
 
-        let attachments_vk = attachments
-            .iter()
-            .map(|attachment| ash::vk::AttachmentDescription2 {
-                flags: ash::vk::AttachmentDescriptionFlags::empty(),
-                format: attachment
-                    .format
-                    .map_or(ash::vk::Format::UNDEFINED, |f| f.into()),
-                samples: attachment.samples.into(),
-                load_op: attachment.load_op.into(),
-                store_op: attachment.store_op.into(),
-                stencil_load_op: attachment.stencil_load_op.into(),
-                stencil_store_op: attachment.stencil_store_op.into(),
-                initial_layout: attachment.initial_layout.into(),
-                final_layout: attachment.final_layout.into(),
-                ..Default::default()
-            })
-            .collect::<SmallVec<[_; 4]>>();
+        struct PerAttachment {
+            stencil_layout_vk: Option<ash::vk::AttachmentDescriptionStencilLayout>,
+        }
 
-        let attachment_references_vk = subpasses
-            .iter()
-            .flat_map(|subpass| {
-                (subpass.input_attachments.iter())
-                    .chain(subpass.color_attachments.iter())
-                    .chain(subpass.resolve_attachments.iter())
-                    .map(Option::as_ref)
-                    .chain(subpass.depth_stencil_attachment.iter().map(Some))
-                    .map(|atch_ref| {
-                        if let Some(atch_ref) = atch_ref {
-                            ash::vk::AttachmentReference2 {
-                                attachment: atch_ref.attachment,
-                                layout: atch_ref.layout.into(),
-                                aspect_mask: atch_ref.aspects.into(),
-                                ..Default::default()
-                            }
-                        } else {
-                            ash::vk::AttachmentReference2 {
-                                attachment: ash::vk::ATTACHMENT_UNUSED,
-                                ..Default::default()
-                            }
-                        }
-                    })
-            })
-            .collect::<SmallVec<[_; 8]>>();
-
-        let subpasses_vk = {
-            // `ref_index` is increased during the loop and points to the next element to use
-            // in `attachment_references_vk`.
-            let mut ref_index = 0usize;
-            let out: SmallVec<[_; 4]> = subpasses
+        let (mut attachments_vk, mut per_attachment_vk): (SmallVec<[_; 4]>, SmallVec<[_; 4]>) =
+            attachments
                 .iter()
-                .map(|subpass| {
-                    let input_attachments = attachment_references_vk.as_ptr().add(ref_index);
-                    ref_index += subpass.input_attachments.len();
-                    let color_attachments = attachment_references_vk.as_ptr().add(ref_index);
-                    ref_index += subpass.color_attachments.len();
-                    let resolve_attachments = attachment_references_vk.as_ptr().add(ref_index);
-                    ref_index += subpass.resolve_attachments.len();
-                    let depth_stencil = if subpass.depth_stencil_attachment.is_some() {
-                        let a = attachment_references_vk.as_ptr().add(ref_index);
-                        ref_index += 1;
-                        a
+                .map(|attachment| {
+                    let &AttachmentDescription {
+                        flags,
+                        format,
+                        samples,
+                        load_op,
+                        store_op,
+                        initial_layout,
+                        final_layout,
+                        stencil_load_op,
+                        stencil_store_op,
+                        stencil_initial_layout,
+                        stencil_final_layout,
+                        _ne: _,
+                    } = attachment;
+
+                    let aspects = format.unwrap().aspects();
+
+                    let (initial_layout_vk, final_layout_vk, stencil_layout_vk) = if aspects
+                        .contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
+                        && (initial_layout != stencil_initial_layout
+                            || final_layout != stencil_final_layout)
+                    {
+                        (
+                            initial_layout,
+                            final_layout,
+                            Some(ash::vk::AttachmentDescriptionStencilLayout {
+                                stencil_initial_layout: stencil_initial_layout.into(),
+                                stencil_final_layout: stencil_final_layout.into(),
+                                ..Default::default()
+                            }),
+                        )
+                    } else if aspects.intersects(ImageAspects::STENCIL) {
+                        (stencil_initial_layout, stencil_final_layout, None)
                     } else {
-                        ptr::null()
+                        (initial_layout, final_layout, None)
                     };
 
-                    ash::vk::SubpassDescription2 {
-                        flags: ash::vk::SubpassDescriptionFlags::empty(),
-                        pipeline_bind_point: ash::vk::PipelineBindPoint::GRAPHICS, // TODO: any need to make this user-specifiable?
-                        view_mask: subpass.view_mask,
-                        input_attachment_count: subpass.input_attachments.len() as u32,
-                        p_input_attachments: if subpass.input_attachments.is_empty() {
-                            ptr::null()
-                        } else {
-                            input_attachments
+                    (
+                        ash::vk::AttachmentDescription2 {
+                            flags: flags.into(),
+                            format: format.map_or(ash::vk::Format::UNDEFINED, |f| f.into()),
+                            samples: samples.into(),
+                            load_op: load_op.into(),
+                            store_op: store_op.into(),
+                            stencil_load_op: stencil_load_op.into(),
+                            stencil_store_op: stencil_store_op.into(),
+                            initial_layout: initial_layout_vk.into(),
+                            final_layout: final_layout_vk.into(),
+                            ..Default::default()
                         },
-                        color_attachment_count: subpass.color_attachments.len() as u32,
-                        p_color_attachments: if subpass.color_attachments.is_empty() {
-                            ptr::null()
-                        } else {
-                            color_attachments
-                        },
-                        p_resolve_attachments: if subpass.resolve_attachments.is_empty() {
-                            ptr::null()
-                        } else {
-                            resolve_attachments
-                        },
-                        p_depth_stencil_attachment: depth_stencil,
-                        preserve_attachment_count: subpass.preserve_attachments.len() as u32,
-                        p_preserve_attachments: if subpass.preserve_attachments.is_empty() {
-                            ptr::null()
-                        } else {
-                            subpass.preserve_attachments.as_ptr()
-                        },
-                        ..Default::default()
-                    }
+                        PerAttachment { stencil_layout_vk },
+                    )
                 })
-                .collect();
+                .unzip();
 
-            // If this assertion fails, there's a serious bug in the code above ^.
-            debug_assert!(ref_index == attachment_references_vk.len());
+        for (attachment_vk, per_attachment_vk) in
+            attachments_vk.iter_mut().zip(per_attachment_vk.iter_mut())
+        {
+            let PerAttachment { stencil_layout_vk } = per_attachment_vk;
 
-            out
-        };
+            if let Some(next) = stencil_layout_vk {
+                next.p_next = attachment_vk.p_next as *mut _;
+                attachment_vk.p_next = next as *const _ as *const _;
+            }
+        }
 
-        let memory_barriers_vk: SmallVec<[_; 4]> = if device.enabled_features().synchronization2 {
-            debug_assert!(
-                device.api_version() >= Version::V1_3
-                    || device.enabled_extensions().khr_synchronization2
-            );
+        struct PerSubpass {
+            input_attachments_vk: SmallVec<[ash::vk::AttachmentReference2; 4]>,
+            color_attachments_vk: SmallVec<[ash::vk::AttachmentReference2; 4]>,
+            resolve_attachments_vk: SmallVec<[ash::vk::AttachmentReference2; 4]>,
+            depth_stencil_attachment_vk: DepthStencilAttachment,
+            depth_stencil_resolve_vk: Option<ash::vk::SubpassDescriptionDepthStencilResolve>,
+            depth_stencil_resolve_attachment_vk: DepthStencilAttachment,
+        }
+
+        struct DepthStencilAttachment {
+            attachment_reference_vk: ash::vk::AttachmentReference2,
+            stencil_layout_vk: Option<ash::vk::AttachmentReferenceStencilLayout>,
+        }
+
+        let (mut subpasses_vk, mut per_subpass_vk): (SmallVec<[_; 4]>, SmallVec<[_; 4]>) =
+            subpasses
+                .iter()
+                .map(|subpass| {
+                    let &SubpassDescription {
+                        flags,
+                        view_mask,
+                        ref input_attachments,
+                        ref color_attachments,
+                        ref depth_attachment,
+                        ref stencil_attachment,
+                        ref preserve_attachments,
+                        _ne: _,
+                    } = subpass;
+
+                    (
+                        ash::vk::SubpassDescription2 {
+                            flags: flags.into(),
+                            pipeline_bind_point: ash::vk::PipelineBindPoint::GRAPHICS, // TODO: any need to make this user-specifiable?
+                            view_mask,
+                            input_attachment_count: 0,
+                            p_input_attachments: ptr::null(),
+                            color_attachment_count: 0,
+                            p_color_attachments: ptr::null(),
+                            p_resolve_attachments: ptr::null(),
+                            p_depth_stencil_attachment: ptr::null(),
+                            preserve_attachment_count: preserve_attachments.len() as u32,
+                            p_preserve_attachments: if preserve_attachments.is_empty() {
+                                ptr::null()
+                            } else {
+                                preserve_attachments.as_ptr()
+                            },
+                            ..Default::default()
+                        },
+                        PerSubpass {
+                            input_attachments_vk: input_attachments
+                                .iter()
+                                .map(|input_attachment| {
+                                    if let Some(input_attachment) = input_attachment {
+                                        let &InputAttachmentReference {
+                                            attachment_ref:
+                                                AttachmentReference {
+                                                    attachment,
+                                                    layout,
+                                                    _ne: _,
+                                                },
+                                            aspects,
+                                        } = input_attachment;
+
+                                        ash::vk::AttachmentReference2 {
+                                            attachment,
+                                            layout: layout.into(),
+                                            aspect_mask: aspects.into(),
+                                            ..Default::default()
+                                        }
+                                    } else {
+                                        ash::vk::AttachmentReference2 {
+                                            attachment: ash::vk::ATTACHMENT_UNUSED,
+                                            ..Default::default()
+                                        }
+                                    }
+                                })
+                                .collect(),
+                            color_attachments_vk: color_attachments
+                                .iter()
+                                .map(|color_attachment| {
+                                    if let Some(color_attachment) = color_attachment {
+                                        let &ResolvableAttachmentReference {
+                                            attachment_ref:
+                                                AttachmentReference {
+                                                    attachment,
+                                                    layout,
+                                                    _ne: _,
+                                                },
+                                            resolve: _,
+                                        } = color_attachment;
+
+                                        ash::vk::AttachmentReference2 {
+                                            attachment,
+                                            layout: layout.into(),
+                                            ..Default::default()
+                                        }
+                                    } else {
+                                        ash::vk::AttachmentReference2 {
+                                            attachment: ash::vk::ATTACHMENT_UNUSED,
+                                            ..Default::default()
+                                        }
+                                    }
+                                })
+                                .collect(),
+                            resolve_attachments_vk: color_attachments
+                                .iter()
+                                .map(|color_attachment| {
+                                    if let Some(&ResolvableAttachmentReference {
+                                        attachment_ref: _,
+                                        resolve:
+                                            Some(ResolveAttachmentReference {
+                                                attachment_ref:
+                                                    AttachmentReference {
+                                                        attachment,
+                                                        layout,
+                                                        _ne: _,
+                                                    },
+                                                mode: _,
+                                            }),
+                                    }) = color_attachment.as_ref()
+                                    {
+                                        ash::vk::AttachmentReference2 {
+                                            attachment,
+                                            layout: layout.into(),
+                                            ..Default::default()
+                                        }
+                                    } else {
+                                        ash::vk::AttachmentReference2 {
+                                            attachment: ash::vk::ATTACHMENT_UNUSED,
+                                            ..Default::default()
+                                        }
+                                    }
+                                })
+                                .collect(),
+                            depth_stencil_attachment_vk: {
+                                match (depth_attachment.as_ref(), stencil_attachment.as_ref()) {
+                                    (
+                                        Some(&ResolvableAttachmentReference {
+                                            attachment_ref:
+                                                AttachmentReference {
+                                                    attachment,
+                                                    layout: depth_layout,
+                                                    _ne: _,
+                                                },
+                                            resolve: _,
+                                        }),
+                                        Some(&ResolvableAttachmentReference {
+                                            attachment_ref:
+                                                AttachmentReference {
+                                                    attachment: _,
+                                                    layout: stencil_layout,
+                                                    _ne: _,
+                                                },
+                                            resolve: _,
+                                        }),
+                                    ) => DepthStencilAttachment {
+                                        attachment_reference_vk: ash::vk::AttachmentReference2 {
+                                            attachment,
+                                            layout: depth_layout.into(),
+                                            ..Default::default()
+                                        },
+                                        stencil_layout_vk: (depth_layout != stencil_layout)
+                                            .then_some(ash::vk::AttachmentReferenceStencilLayout {
+                                                stencil_layout: stencil_layout.into(),
+                                                ..Default::default()
+                                            }),
+                                    },
+                                    (
+                                        Some(&ResolvableAttachmentReference {
+                                            attachment_ref:
+                                                AttachmentReference {
+                                                    attachment,
+                                                    layout,
+                                                    _ne: _,
+                                                },
+                                            resolve: _,
+                                        }),
+                                        None,
+                                    )
+                                    | (
+                                        None,
+                                        Some(&ResolvableAttachmentReference {
+                                            attachment_ref:
+                                                AttachmentReference {
+                                                    attachment,
+                                                    layout,
+                                                    _ne: _,
+                                                },
+                                            resolve: _,
+                                        }),
+                                    ) => DepthStencilAttachment {
+                                        attachment_reference_vk: ash::vk::AttachmentReference2 {
+                                            attachment,
+                                            layout: layout.into(),
+                                            ..Default::default()
+                                        },
+                                        stencil_layout_vk: None,
+                                    },
+                                    _ => DepthStencilAttachment {
+                                        attachment_reference_vk: ash::vk::AttachmentReference2 {
+                                            attachment: ash::vk::ATTACHMENT_UNUSED,
+                                            ..Default::default()
+                                        },
+                                        stencil_layout_vk: None,
+                                    },
+                                }
+                            },
+                            depth_stencil_resolve_vk: {
+                                let depth_resolve_mode = depth_attachment
+                                    .as_ref()
+                                    .and_then(|attachment| attachment.resolve.as_ref())
+                                    .map(|resolve| resolve.mode);
+                                let stencil_resolve_mode = stencil_attachment
+                                    .as_ref()
+                                    .and_then(|attachment| attachment.resolve.as_ref())
+                                    .map(|resolve| resolve.mode);
+
+                                // VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03178
+                                (depth_resolve_mode.is_some() || stencil_resolve_mode.is_some())
+                                    .then_some(ash::vk::SubpassDescriptionDepthStencilResolve {
+                                        depth_resolve_mode: depth_resolve_mode
+                                            .map_or(ash::vk::ResolveModeFlags::NONE, Into::into),
+                                        stencil_resolve_mode: stencil_resolve_mode
+                                            .map_or(ash::vk::ResolveModeFlags::NONE, Into::into),
+                                        p_depth_stencil_resolve_attachment: ptr::null(),
+                                        ..Default::default()
+                                    })
+                            },
+                            depth_stencil_resolve_attachment_vk: {
+                                match (depth_attachment.as_ref(), stencil_attachment.as_ref()) {
+                                    (
+                                        Some(&ResolvableAttachmentReference {
+                                            attachment_ref: _,
+                                            resolve:
+                                                Some(ResolveAttachmentReference {
+                                                    attachment_ref:
+                                                        AttachmentReference {
+                                                            attachment,
+                                                            layout: depth_layout,
+                                                            _ne: _,
+                                                        },
+                                                    mode: _,
+                                                }),
+                                        }),
+                                        Some(&ResolvableAttachmentReference {
+                                            attachment_ref: _,
+                                            resolve:
+                                                Some(ResolveAttachmentReference {
+                                                    attachment_ref:
+                                                        AttachmentReference {
+                                                            attachment: _,
+                                                            layout: stencil_layout,
+                                                            _ne: _,
+                                                        },
+                                                    mode: _,
+                                                }),
+                                        }),
+                                    ) => DepthStencilAttachment {
+                                        attachment_reference_vk: ash::vk::AttachmentReference2 {
+                                            attachment,
+                                            layout: depth_layout.into(),
+                                            ..Default::default()
+                                        },
+                                        stencil_layout_vk: (depth_layout != stencil_layout)
+                                            .then_some(ash::vk::AttachmentReferenceStencilLayout {
+                                                stencil_layout: stencil_layout.into(),
+                                                ..Default::default()
+                                            }),
+                                    },
+                                    (
+                                        Some(&ResolvableAttachmentReference {
+                                            attachment_ref: _,
+                                            resolve:
+                                                Some(ResolveAttachmentReference {
+                                                    attachment_ref:
+                                                        AttachmentReference {
+                                                            attachment,
+                                                            layout,
+                                                            _ne: _,
+                                                        },
+                                                    mode: _,
+                                                }),
+                                        }),
+                                        None
+                                        | Some(&ResolvableAttachmentReference {
+                                            attachment_ref: _,
+                                            resolve: None,
+                                        }),
+                                    )
+                                    | (
+                                        None
+                                        | Some(&ResolvableAttachmentReference {
+                                            attachment_ref: _,
+                                            resolve: None,
+                                        }),
+                                        Some(&ResolvableAttachmentReference {
+                                            attachment_ref: _,
+                                            resolve:
+                                                Some(ResolveAttachmentReference {
+                                                    attachment_ref:
+                                                        AttachmentReference {
+                                                            attachment,
+                                                            layout,
+                                                            _ne: _,
+                                                        },
+                                                    mode: _,
+                                                }),
+                                        }),
+                                    ) => DepthStencilAttachment {
+                                        attachment_reference_vk: ash::vk::AttachmentReference2 {
+                                            attachment,
+                                            layout: layout.into(),
+                                            ..Default::default()
+                                        },
+                                        stencil_layout_vk: None,
+                                    },
+                                    _ => DepthStencilAttachment {
+                                        attachment_reference_vk: ash::vk::AttachmentReference2 {
+                                            attachment: ash::vk::ATTACHMENT_UNUSED,
+                                            ..Default::default()
+                                        },
+                                        stencil_layout_vk: None,
+                                    },
+                                }
+                            },
+                        },
+                    )
+                })
+                .unzip();
+
+        for (subpass_vk, per_subpass_vk) in subpasses_vk.iter_mut().zip(per_subpass_vk.iter_mut()) {
+            let PerSubpass {
+                input_attachments_vk,
+                color_attachments_vk,
+                resolve_attachments_vk,
+                depth_stencil_attachment_vk,
+                depth_stencil_resolve_attachment_vk,
+                depth_stencil_resolve_vk,
+            } = per_subpass_vk;
+
+            if let Some(next) = &mut depth_stencil_attachment_vk.stencil_layout_vk {
+                next.p_next = depth_stencil_attachment_vk.attachment_reference_vk.p_next as *mut _;
+                depth_stencil_attachment_vk.attachment_reference_vk.p_next =
+                    next as *const _ as *const _;
+            }
+
+            *subpass_vk = ash::vk::SubpassDescription2 {
+                input_attachment_count: input_attachments_vk.len() as u32,
+                p_input_attachments: input_attachments_vk.as_ptr(),
+                color_attachment_count: color_attachments_vk.len() as u32,
+                p_color_attachments: color_attachments_vk.as_ptr(),
+                p_resolve_attachments: resolve_attachments_vk.as_ptr(),
+                p_depth_stencil_attachment: &depth_stencil_attachment_vk.attachment_reference_vk,
+                ..*subpass_vk
+            };
+
+            if let Some(next) = depth_stencil_resolve_vk {
+                *next = ash::vk::SubpassDescriptionDepthStencilResolve {
+                    p_depth_stencil_resolve_attachment: &depth_stencil_resolve_attachment_vk
+                        .attachment_reference_vk,
+                    ..*next
+                };
+
+                next.p_next = subpass_vk.p_next;
+                subpass_vk.p_next = next as *const _ as *const _;
+
+                if let Some(next) = &mut depth_stencil_resolve_attachment_vk.stencil_layout_vk {
+                    next.p_next = depth_stencil_resolve_attachment_vk
+                        .attachment_reference_vk
+                        .p_next as *mut _;
+                    depth_stencil_resolve_attachment_vk
+                        .attachment_reference_vk
+                        .p_next = next as *const _ as *const _;
+                }
+            }
+        }
+
+        struct PerDependency {
+            memory_barrier_vk: Option<ash::vk::MemoryBarrier2>,
+        }
+
+        let (mut dependencies_vk, mut per_dependency_vk): (SmallVec<[_; 4]>, SmallVec<[_; 4]>) =
             dependencies
                 .iter()
-                .map(|dependency| ash::vk::MemoryBarrier2 {
-                    src_stage_mask: dependency.src_stages.into(),
-                    src_access_mask: dependency.src_access.into(),
-                    dst_stage_mask: dependency.dst_stages.into(),
-                    dst_access_mask: dependency.dst_access.into(),
-                    ..Default::default()
-                })
-                .collect()
-        } else {
-            SmallVec::new()
-        };
+                .map(|dependency| {
+                    let &SubpassDependency {
+                        src_subpass,
+                        dst_subpass,
+                        src_stages,
+                        dst_stages,
+                        src_access,
+                        dst_access,
+                        dependency_flags,
+                        view_offset,
+                        _ne: _,
+                    } = dependency;
 
-        let dependencies_vk = dependencies
-            .iter()
-            .enumerate()
-            .map(|(index, dependency)| {
-                ash::vk::SubpassDependency2 {
-                    p_next: memory_barriers_vk
-                        .get(index)
-                        .map_or(ptr::null(), |mb| mb as *const _ as *const _),
-                    src_subpass: dependency.src_subpass.unwrap_or(ash::vk::SUBPASS_EXTERNAL),
-                    dst_subpass: dependency.dst_subpass.unwrap_or(ash::vk::SUBPASS_EXTERNAL),
-                    src_stage_mask: dependency.src_stages.into(),
-                    dst_stage_mask: dependency.dst_stages.into(),
-                    src_access_mask: dependency.src_access.into(),
-                    dst_access_mask: dependency.dst_access.into(),
-                    dependency_flags: dependency.dependency_flags.into(),
-                    // VUID-VkSubpassDependency2-dependencyFlags-03092
-                    view_offset: dependency.view_offset,
-                    ..Default::default()
-                }
-            })
-            .collect::<SmallVec<[_; 4]>>();
+                    (
+                        ash::vk::SubpassDependency2 {
+                            src_subpass: src_subpass.unwrap_or(ash::vk::SUBPASS_EXTERNAL),
+                            dst_subpass: dst_subpass.unwrap_or(ash::vk::SUBPASS_EXTERNAL),
+                            src_stage_mask: src_stages.into(),
+                            dst_stage_mask: dst_stages.into(),
+                            src_access_mask: src_access.into(),
+                            dst_access_mask: dst_access.into(),
+                            dependency_flags: dependency_flags.into(),
+                            // VUID-VkSubpassDependency2-dependencyFlags-03092
+                            view_offset,
+                            ..Default::default()
+                        },
+                        PerDependency {
+                            memory_barrier_vk: device
+                                .enabled_features()
+                                .synchronization2
+                                .then_some(ash::vk::MemoryBarrier2 {
+                                    src_stage_mask: src_stages.into(),
+                                    src_access_mask: src_access.into(),
+                                    dst_stage_mask: dst_stages.into(),
+                                    dst_access_mask: dst_access.into(),
+                                    ..Default::default()
+                                }),
+                        },
+                    )
+                })
+                .unzip();
+
+        for (dependency_vk, per_dependency_vk) in
+            dependencies_vk.iter_mut().zip(&mut per_dependency_vk)
+        {
+            let PerDependency { memory_barrier_vk } = per_dependency_vk;
+
+            if let Some(next) = memory_barrier_vk {
+                next.p_next = dependency_vk.p_next;
+                dependency_vk.p_next = next as *const _ as *const _;
+            }
+        }
 
         let create_info = ash::vk::RenderPassCreateInfo2 {
-            flags: ash::vk::RenderPassCreateFlags::empty(),
+            flags: flags.into(),
             attachment_count: attachments_vk.len() as u32,
             p_attachments: if attachments_vk.is_empty() {
                 ptr::null()
@@ -1251,203 +599,257 @@ impl RenderPass {
     pub(super) unsafe fn create_v1(
         device: &Device,
         create_info: &RenderPassCreateInfo,
-    ) -> Result<ash::vk::RenderPass, RenderPassCreationError> {
-        let RenderPassCreateInfo {
-            attachments,
-            subpasses,
-            dependencies,
-            correlated_view_masks,
+    ) -> Result<ash::vk::RenderPass, RuntimeError> {
+        let &RenderPassCreateInfo {
+            flags,
+            ref attachments,
+            ref subpasses,
+            ref dependencies,
+            ref correlated_view_masks,
             _ne: _,
         } = create_info;
 
         let attachments_vk = attachments
             .iter()
-            .map(|attachment| ash::vk::AttachmentDescription {
-                flags: ash::vk::AttachmentDescriptionFlags::empty(),
-                format: attachment
-                    .format
-                    .map_or(ash::vk::Format::UNDEFINED, |f| f.into()),
-                samples: attachment.samples.into(),
-                load_op: attachment.load_op.into(),
-                store_op: attachment.store_op.into(),
-                stencil_load_op: attachment.stencil_load_op.into(),
-                stencil_store_op: attachment.stencil_store_op.into(),
-                initial_layout: attachment.initial_layout.into(),
-                final_layout: attachment.final_layout.into(),
+            .map(|attachment| {
+                let &AttachmentDescription {
+                    flags,
+                    format,
+                    samples,
+                    load_op,
+                    store_op,
+                    initial_layout,
+                    final_layout,
+                    stencil_load_op,
+                    stencil_store_op,
+                    stencil_initial_layout,
+                    stencil_final_layout,
+                    _ne: _,
+                } = attachment;
+
+                let aspects = format.unwrap().aspects();
+
+                let (initial_layout_vk, final_layout_vk) = if aspects
+                    .intersects(ImageAspects::STENCIL)
+                    && !aspects.intersects(ImageAspects::DEPTH)
+                {
+                    (stencil_initial_layout, stencil_final_layout)
+                } else {
+                    (initial_layout, final_layout)
+                };
+
+                ash::vk::AttachmentDescription {
+                    flags: flags.into(),
+                    format: format.map_or(ash::vk::Format::UNDEFINED, |f| f.into()),
+                    samples: samples.into(),
+                    load_op: load_op.into(),
+                    store_op: store_op.into(),
+                    stencil_load_op: stencil_load_op.into(),
+                    stencil_store_op: stencil_store_op.into(),
+                    initial_layout: initial_layout_vk.into(),
+                    final_layout: final_layout_vk.into(),
+                }
             })
             .collect::<SmallVec<[_; 4]>>();
 
-        let attachment_references_vk = subpasses
+        struct PerSubpass {
+            input_attachments_vk: SmallVec<[ash::vk::AttachmentReference; 4]>,
+            color_attachments_vk: SmallVec<[ash::vk::AttachmentReference; 4]>,
+            resolve_attachments_vk: SmallVec<[ash::vk::AttachmentReference; 4]>,
+            depth_stencil_attachment_vk: ash::vk::AttachmentReference,
+        }
+
+        let (mut subpasses_vk, per_subpass_vk): (SmallVec<[_; 4]>, SmallVec<[_; 4]>) = subpasses
             .iter()
-            .flat_map(|subpass| {
-                (subpass.input_attachments.iter())
-                    .chain(subpass.color_attachments.iter())
-                    .chain(subpass.resolve_attachments.iter())
-                    .map(Option::as_ref)
-                    .chain(subpass.depth_stencil_attachment.iter().map(Some))
-                    .map(|atch_ref| {
-                        if let Some(atch_ref) = atch_ref {
+            .map(|subpass| {
+                let &SubpassDescription {
+                    flags,
+                    view_mask: _,
+                    ref input_attachments,
+                    ref color_attachments,
+                    ref depth_attachment,
+                    ref stencil_attachment,
+                    ref preserve_attachments,
+                    _ne: _,
+                } = subpass;
+
+                (
+                    ash::vk::SubpassDescription {
+                        flags: flags.into(),
+                        pipeline_bind_point: ash::vk::PipelineBindPoint::GRAPHICS,
+                        input_attachment_count: 0,
+                        p_input_attachments: ptr::null(),
+                        color_attachment_count: 0,
+                        p_color_attachments: ptr::null(),
+                        p_resolve_attachments: ptr::null(),
+                        p_depth_stencil_attachment: ptr::null(),
+                        preserve_attachment_count: preserve_attachments.len() as u32,
+                        p_preserve_attachments: if preserve_attachments.is_empty() {
+                            ptr::null()
+                        } else {
+                            preserve_attachments.as_ptr()
+                        },
+                    },
+                    PerSubpass {
+                        input_attachments_vk: input_attachments
+                            .iter()
+                            .map(|input_attachment| {
+                                if let Some(input_attachment) = input_attachment {
+                                    let &InputAttachmentReference {
+                                        attachment_ref:
+                                            AttachmentReference {
+                                                attachment,
+                                                layout,
+                                                _ne: _,
+                                            },
+                                        aspects: _,
+                                    } = input_attachment;
+
+                                    ash::vk::AttachmentReference {
+                                        attachment,
+                                        layout: layout.into(),
+                                    }
+                                } else {
+                                    ash::vk::AttachmentReference {
+                                        attachment: ash::vk::ATTACHMENT_UNUSED,
+                                        ..Default::default()
+                                    }
+                                }
+                            })
+                            .collect(),
+                        color_attachments_vk: color_attachments
+                            .iter()
+                            .map(|color_attachment| {
+                                if let Some(color_attachment) = color_attachment {
+                                    let &ResolvableAttachmentReference {
+                                        attachment_ref:
+                                            AttachmentReference {
+                                                attachment,
+                                                layout,
+                                                _ne: _,
+                                            },
+                                        resolve: _,
+                                    } = color_attachment;
+
+                                    ash::vk::AttachmentReference {
+                                        attachment,
+                                        layout: layout.into(),
+                                    }
+                                } else {
+                                    ash::vk::AttachmentReference {
+                                        attachment: ash::vk::ATTACHMENT_UNUSED,
+                                        ..Default::default()
+                                    }
+                                }
+                            })
+                            .collect(),
+                        resolve_attachments_vk: color_attachments
+                            .iter()
+                            .map(|color_attachment| {
+                                if let Some(&ResolvableAttachmentReference {
+                                    attachment_ref: _,
+                                    resolve:
+                                        Some(ResolveAttachmentReference {
+                                            attachment_ref:
+                                                AttachmentReference {
+                                                    attachment,
+                                                    layout,
+                                                    _ne: _,
+                                                },
+                                            mode: _,
+                                        }),
+                                }) = color_attachment.as_ref()
+                                {
+                                    ash::vk::AttachmentReference {
+                                        attachment,
+                                        layout: layout.into(),
+                                    }
+                                } else {
+                                    ash::vk::AttachmentReference {
+                                        attachment: ash::vk::ATTACHMENT_UNUSED,
+                                        ..Default::default()
+                                    }
+                                }
+                            })
+                            .collect(),
+                        depth_stencil_attachment_vk: if let Some(depth_stencil_attachment) =
+                            depth_attachment.as_ref().or(stencil_attachment.as_ref())
+                        {
+                            let &ResolvableAttachmentReference {
+                                attachment_ref:
+                                    AttachmentReference {
+                                        attachment,
+                                        layout,
+                                        _ne: _,
+                                    },
+                                resolve: _,
+                            } = depth_stencil_attachment;
+
                             ash::vk::AttachmentReference {
-                                attachment: atch_ref.attachment,
-                                layout: atch_ref.layout.into(),
+                                attachment,
+                                layout: layout.into(),
                             }
                         } else {
                             ash::vk::AttachmentReference {
                                 attachment: ash::vk::ATTACHMENT_UNUSED,
-                                layout: Default::default(),
+                                ..Default::default()
                             }
-                        }
-                    })
+                        },
+                    },
+                )
             })
-            .collect::<SmallVec<[_; 8]>>();
+            .unzip();
 
-        let subpasses_vk = {
-            // `ref_index` is increased during the loop and points to the next element to use
-            // in `attachment_references_vk`.
-            let mut ref_index = 0usize;
-            let out: SmallVec<[_; 4]> = subpasses
-                .iter()
-                .map(|subpass| {
-                    let input_attachments = attachment_references_vk.as_ptr().add(ref_index);
-                    ref_index += subpass.input_attachments.len();
-                    let color_attachments = attachment_references_vk.as_ptr().add(ref_index);
-                    ref_index += subpass.color_attachments.len();
-                    let resolve_attachments = attachment_references_vk.as_ptr().add(ref_index);
-                    ref_index += subpass.resolve_attachments.len();
-                    let depth_stencil = if subpass.depth_stencil_attachment.is_some() {
-                        let a = attachment_references_vk.as_ptr().add(ref_index);
-                        ref_index += 1;
-                        a
-                    } else {
-                        ptr::null()
-                    };
+        for (subpass_vk, per_subpass_vk) in subpasses_vk.iter_mut().zip(&per_subpass_vk) {
+            let PerSubpass {
+                input_attachments_vk,
+                color_attachments_vk,
+                resolve_attachments_vk,
+                depth_stencil_attachment_vk,
+            } = per_subpass_vk;
 
-                    ash::vk::SubpassDescription {
-                        flags: ash::vk::SubpassDescriptionFlags::empty(),
-                        pipeline_bind_point: ash::vk::PipelineBindPoint::GRAPHICS,
-                        input_attachment_count: subpass.input_attachments.len() as u32,
-                        p_input_attachments: if subpass.input_attachments.is_empty() {
-                            ptr::null()
-                        } else {
-                            input_attachments
-                        },
-                        color_attachment_count: subpass.color_attachments.len() as u32,
-                        p_color_attachments: if subpass.color_attachments.is_empty() {
-                            ptr::null()
-                        } else {
-                            color_attachments
-                        },
-                        p_resolve_attachments: if subpass.resolve_attachments.is_empty() {
-                            ptr::null()
-                        } else {
-                            resolve_attachments
-                        },
-                        p_depth_stencil_attachment: depth_stencil,
-                        preserve_attachment_count: subpass.preserve_attachments.len() as u32,
-                        p_preserve_attachments: if subpass.preserve_attachments.is_empty() {
-                            ptr::null()
-                        } else {
-                            subpass.preserve_attachments.as_ptr()
-                        },
-                    }
-                })
-                .collect();
-
-            // If this assertion fails, there's a serious bug in the code above ^.
-            debug_assert!(ref_index == attachment_references_vk.len());
-
-            out
-        };
+            *subpass_vk = ash::vk::SubpassDescription {
+                input_attachment_count: input_attachments_vk.len() as u32,
+                p_input_attachments: input_attachments_vk.as_ptr(),
+                color_attachment_count: color_attachments_vk.len() as u32,
+                p_color_attachments: color_attachments_vk.as_ptr(),
+                p_resolve_attachments: resolve_attachments_vk.as_ptr(),
+                p_depth_stencil_attachment: depth_stencil_attachment_vk,
+                ..*subpass_vk
+            };
+        }
 
         let dependencies_vk = dependencies
             .iter()
-            .map(|dependency| ash::vk::SubpassDependency {
-                src_subpass: dependency.src_subpass.unwrap_or(ash::vk::SUBPASS_EXTERNAL),
-                dst_subpass: dependency.dst_subpass.unwrap_or(ash::vk::SUBPASS_EXTERNAL),
-                src_stage_mask: dependency.src_stages.into(),
-                dst_stage_mask: dependency.dst_stages.into(),
-                src_access_mask: dependency.src_access.into(),
-                dst_access_mask: dependency.dst_access.into(),
-                dependency_flags: dependency.dependency_flags.into(),
+            .map(|dependency| {
+                let &SubpassDependency {
+                    src_subpass,
+                    dst_subpass,
+                    src_stages,
+                    dst_stages,
+                    src_access,
+                    dst_access,
+                    dependency_flags,
+                    view_offset: _,
+                    _ne: _,
+                } = dependency;
+
+                ash::vk::SubpassDependency {
+                    src_subpass: src_subpass.unwrap_or(ash::vk::SUBPASS_EXTERNAL),
+                    dst_subpass: dst_subpass.unwrap_or(ash::vk::SUBPASS_EXTERNAL),
+                    src_stage_mask: src_stages.into(),
+                    dst_stage_mask: dst_stages.into(),
+                    src_access_mask: src_access.into(),
+                    dst_access_mask: dst_access.into(),
+                    dependency_flags: dependency_flags.into(),
+                }
             })
             .collect::<SmallVec<[_; 4]>>();
 
-        /* Input attachment aspect */
-
-        let input_attachment_aspect_references: SmallVec<[_; 8]> = if device.api_version()
-            >= Version::V1_1
-            || device.enabled_extensions().khr_maintenance2
-        {
-            subpasses
-                .iter()
-                .enumerate()
-                .flat_map(|(subpass_num, subpass)| {
-                    subpass.input_attachments.iter().enumerate().flat_map(
-                        move |(atch_num, atch_ref)| {
-                            atch_ref.as_ref().map(|atch_ref| {
-                                ash::vk::InputAttachmentAspectReference {
-                                    subpass: subpass_num as u32,
-                                    input_attachment_index: atch_num as u32,
-                                    aspect_mask: atch_ref.aspects.into(),
-                                }
-                            })
-                        },
-                    )
-                })
-                .collect()
-        } else {
-            SmallVec::new()
-        };
-
-        let mut input_attachment_aspect_create_info =
-            if !input_attachment_aspect_references.is_empty() {
-                Some(ash::vk::RenderPassInputAttachmentAspectCreateInfo {
-                    aspect_reference_count: input_attachment_aspect_references.len() as u32,
-                    p_aspect_references: input_attachment_aspect_references.as_ptr(),
-                    ..Default::default()
-                })
-            } else {
-                None
-            };
-
-        /* Multiview */
-
-        let is_multiview = subpasses[0].view_mask != 0;
-
-        let (multiview_view_masks, multiview_view_offsets): (SmallVec<[_; 4]>, SmallVec<[_; 4]>) =
-            if is_multiview {
-                (
-                    subpasses.iter().map(|subpass| subpass.view_mask).collect(),
-                    dependencies
-                        .iter()
-                        .map(|dependency| dependency.view_offset)
-                        .collect(),
-                )
-            } else {
-                (SmallVec::new(), SmallVec::new())
-            };
-
-        let mut multiview_create_info = if is_multiview {
-            debug_assert!(multiview_view_masks.len() == subpasses.len());
-            debug_assert!(multiview_view_offsets.len() == dependencies.len());
-
-            Some(ash::vk::RenderPassMultiviewCreateInfo {
-                subpass_count: multiview_view_masks.len() as u32,
-                p_view_masks: multiview_view_masks.as_ptr(),
-                dependency_count: multiview_view_offsets.len() as u32,
-                p_view_offsets: multiview_view_offsets.as_ptr(),
-                correlation_mask_count: correlated_view_masks.len() as u32,
-                p_correlation_masks: correlated_view_masks.as_ptr(),
-                ..Default::default()
-            })
-        } else {
-            None
-        };
-
         /* Create */
 
-        let mut create_info = ash::vk::RenderPassCreateInfo {
-            flags: ash::vk::RenderPassCreateFlags::empty(),
+        let mut create_info_vk = ash::vk::RenderPassCreateInfo {
+            flags: flags.into(),
             attachment_count: attachments_vk.len() as u32,
             p_attachments: if attachments_vk.is_empty() {
                 ptr::null()
@@ -1469,16 +871,79 @@ impl RenderPass {
             ..Default::default()
         };
 
-        if let Some(input_attachment_aspect_create_info) =
-            input_attachment_aspect_create_info.as_mut()
-        {
-            input_attachment_aspect_create_info.p_next = create_info.p_next;
-            create_info.p_next = input_attachment_aspect_create_info as *const _ as *const _;
+        /* Input attachment aspect */
+
+        let input_attachment_aspect_references_vk: SmallVec<[_; 8]>;
+        let mut input_attachment_aspect_create_info_vk = None;
+
+        if device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance2 {
+            input_attachment_aspect_references_vk = subpasses
+                .iter()
+                .enumerate()
+                .flat_map(|(subpass_num, subpass)| {
+                    subpass.input_attachments.iter().enumerate().flat_map(
+                        move |(atch_num, input_attachment)| {
+                            input_attachment.as_ref().map(|input_attachment| {
+                                let &InputAttachmentReference {
+                                    attachment_ref: _,
+                                    aspects,
+                                } = input_attachment;
+
+                                ash::vk::InputAttachmentAspectReference {
+                                    subpass: subpass_num as u32,
+                                    input_attachment_index: atch_num as u32,
+                                    aspect_mask: aspects.into(),
+                                }
+                            })
+                        },
+                    )
+                })
+                .collect();
+
+            if !input_attachment_aspect_references_vk.is_empty() {
+                let next = input_attachment_aspect_create_info_vk.insert(
+                    ash::vk::RenderPassInputAttachmentAspectCreateInfo {
+                        aspect_reference_count: input_attachment_aspect_references_vk.len() as u32,
+                        p_aspect_references: input_attachment_aspect_references_vk.as_ptr(),
+                        ..Default::default()
+                    },
+                );
+
+                next.p_next = create_info_vk.p_next;
+                create_info_vk.p_next = next as *const _ as *const _;
+            }
         }
 
-        if let Some(multiview_create_info) = multiview_create_info.as_mut() {
-            multiview_create_info.p_next = create_info.p_next;
-            create_info.p_next = multiview_create_info as *const _ as *const _;
+        /* Multiview */
+
+        let mut multiview_create_info_vk = None;
+        let multiview_view_masks_vk: SmallVec<[_; 4]>;
+        let multiview_view_offsets_vk: SmallVec<[_; 4]>;
+
+        let is_multiview = subpasses[0].view_mask != 0;
+
+        if is_multiview {
+            multiview_view_masks_vk = subpasses.iter().map(|subpass| subpass.view_mask).collect();
+            multiview_view_offsets_vk = dependencies
+                .iter()
+                .map(|dependency| dependency.view_offset)
+                .collect();
+
+            debug_assert!(multiview_view_masks_vk.len() == subpasses.len());
+            debug_assert!(multiview_view_offsets_vk.len() == dependencies.len());
+
+            let next = multiview_create_info_vk.insert(ash::vk::RenderPassMultiviewCreateInfo {
+                subpass_count: multiview_view_masks_vk.len() as u32,
+                p_view_masks: multiview_view_masks_vk.as_ptr(),
+                dependency_count: multiview_view_offsets_vk.len() as u32,
+                p_view_offsets: multiview_view_offsets_vk.as_ptr(),
+                correlation_mask_count: correlated_view_masks.len() as u32,
+                p_correlation_masks: correlated_view_masks.as_ptr(),
+                ..Default::default()
+            });
+
+            next.p_next = create_info_vk.p_next;
+            create_info_vk.p_next = next as *const _ as *const _;
         }
 
         Ok({
@@ -1486,7 +951,7 @@ impl RenderPass {
             let mut output = MaybeUninit::uninit();
             (fns.v1_0.create_render_pass)(
                 device.handle(),
-                &create_info,
+                &create_info_vk,
                 ptr::null(),
                 output.as_mut_ptr(),
             )
@@ -1494,486 +959,5 @@ impl RenderPass {
             .map_err(RuntimeError::from)?;
             output.assume_init()
         })
-    }
-}
-
-/// Error that can happen when creating a `RenderPass`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RenderPassCreationError {
-    /// Not enough memory.
-    OomError(OomError),
-
-    RequirementNotMet {
-        required_for: &'static str,
-        requires_one_of: RequiresOneOf,
-    },
-
-    /// An attachment is first used in the render pass with a read-only layout or as an input
-    /// attachment, but its `load_op` or `stencil_load_op` is [`LoadOp::Clear`].
-    AttachmentFirstUseLoadOpInvalid {
-        attachment: u32,
-        first_use_subpass: u32,
-    },
-
-    /// An attachment has an `initial_layout` or `final_layout` value that is invalid for the
-    /// provided `format`.
-    AttachmentLayoutInvalid { attachment: u32 },
-
-    /// Correlated view masks were included, but multiview is not enabled on the render pass.
-    CorrelatedViewMasksMultiviewNotEnabled,
-
-    /// The provided correlated view masks contain a bit that is set in more than one element.
-    CorrelatedViewMasksOverlapping,
-
-    /// A subpass dependency specified an access type that was not supported by the given stages.
-    DependencyAccessNotSupportedByStages { dependency: u32 },
-
-    /// A subpass dependency has both `src_subpass` and `dst_subpass` set to `None`.
-    DependencyBothSubpassesExternal { dependency: u32 },
-
-    /// A subpass dependency specifies a subpass self-dependency and includes framebuffer stages in
-    /// both `src_stages` and `dst_stages`, but the `by_region` dependency was not enabled.
-    DependencySelfDependencyFramebufferStagesWithoutByRegion { dependency: u32 },
-
-    /// A subpass dependency specifies a subpass self-dependency and includes
-    /// non-framebuffer stages, but the latest stage in `src_stages` is after the earliest stage
-    /// in `dst_stages`.
-    DependencySelfDependencySourceStageAfterDestinationStage { dependency: u32 },
-
-    /// A subpass dependency specifies a subpass self-dependency and has the `view_local` dependency
-    /// enabled, but the inner offset value was not 0.
-    DependencySelfDependencyViewLocalNonzeroViewOffset { dependency: u32 },
-
-    /// A subpass dependency specifies a subpass self-dependency without the `view_local`
-    /// dependency, but the referenced subpass has more than one bit set in its `view_mask`.
-    DependencySelfDependencyViewMaskMultiple { dependency: u32, subpass: u32 },
-
-    /// A subpass dependency has a `src_subpass` that is later than the `dst_subpass`.
-    DependencySourceSubpassAfterDestinationSubpass { dependency: u32 },
-
-    /// A subpass dependency has a bit set in the `src_stages` or `dst_stages` that is
-    /// not supported for graphics pipelines.
-    DependencyStageNotSupported { dependency: u32 },
-
-    /// A subpass index in a subpass dependency is not less than the number of subpasses in the
-    /// render pass.
-    DependencySubpassOutOfRange { dependency: u32, subpass: u32 },
-
-    /// In a subpass dependency, `dependency_flags` contains [`VIEW_LOCAL`], but `src_subpass` or
-    /// `dst_subpass` were set to `None`.
-    ///
-    /// [`VIEW_LOCAL`]: crate::sync::DependencyFlags::VIEW_LOCAL
-    DependencyViewLocalExternalDependency { dependency: u32 },
-
-    /// In a subpass dependency, `dependency_flags` contains [`VIEW_LOCAL`], but multiview is not
-    /// enabled on the render pass.
-    ///
-    /// [`VIEW_LOCAL`]: crate::sync::DependencyFlags::VIEW_LOCAL
-    DependencyViewLocalMultiviewNotEnabled { dependency: u32 },
-
-    /// In a subpass dependency, `view_offset` is not zero, but `dependency_flags` does not contain
-    /// [`VIEW_LOCAL`].
-    ///
-    /// [`VIEW_LOCAL`]: crate::sync::DependencyFlags::VIEW_LOCAL
-    DependencyViewOffzetNonzeroWithoutViewLocal { dependency: u32 },
-
-    /// A reference to an attachment used other than as an input attachment in a subpass has
-    /// one or more aspects selected.
-    SubpassAttachmentAspectsNotEmpty { subpass: u32, attachment: u32 },
-
-    /// An attachment used as an attachment in a subpass has a layout that is not supported for
-    /// that usage.
-    SubpassAttachmentLayoutInvalid {
-        subpass: u32,
-        attachment: u32,
-        usage: &'static str,
-    },
-
-    /// The layouts of all uses of an attachment in a subpass do not match.
-    SubpassAttachmentLayoutMismatch { subpass: u32, attachment: u32 },
-
-    /// An attachment index in a subpass is not less than the number of attachments in the render
-    /// pass.
-    SubpassAttachmentOutOfRange { subpass: u32, attachment: u32 },
-
-    /// An attachment is used as both a color attachment and a depth/stencil attachment in a
-    /// subpass.
-    SubpassAttachmentUsageColorDepthStencil { subpass: u32, attachment: u32 },
-
-    /// An attachment used as an attachment in a subpass has a format that does not support that
-    /// usage.
-    SubpassAttachmentFormatUsageNotSupported {
-        subpass: u32,
-        attachment: u32,
-        usage: &'static str,
-    },
-
-    /// An attachment used as a color attachment in a subpass with resolve attachments has a
-    /// `samples` value of [`SampleCount::Sample1`].
-    SubpassColorAttachmentWithResolveNotMultisampled { subpass: u32, attachment: u32 },
-
-    /// An attachment used as a color or depth/stencil attachment in a subpass has a `samples` value
-    /// that is different from the first color attachment.
-    SubpassColorDepthStencilAttachmentSamplesMismatch {
-        subpass: u32,
-        attachment: u32,
-        samples: SampleCount,
-        first_samples: SampleCount,
-    },
-
-    /// A reference to an attachment used as an input attachment in a subpass selects aspects that
-    /// are not present in the format of the attachment.
-    SubpassInputAttachmentAspectsNotCompatible { subpass: u32, attachment: u32 },
-
-    /// The `max_color_attachments` limit has been exceeded for a subpass.
-    SubpassMaxColorAttachmentsExceeded {
-        subpass: u32,
-        color_attachment_count: u32,
-        max: u32,
-    },
-
-    /// The `max_multiview_view_count` limit has been exceeded for a subpass.
-    SubpassMaxMultiviewViewCountExceeded {
-        subpass: u32,
-        view_count: u32,
-        max: u32,
-    },
-
-    /// The multiview state (whether `view_mask` is nonzero) of a subpass is different from the
-    /// first subpass.
-    SubpassMultiviewMismatch {
-        subpass: u32,
-        multiview: bool,
-        first_subpass_multiview: bool,
-    },
-
-    /// An attachment marked as a preserve attachment in a subpass is also used as an attachment
-    /// in that subpass.
-    SubpassPreserveAttachmentUsedElsewhere { subpass: u32, attachment: u32 },
-
-    /// The `resolve_attachments` field of a subpass was not empty, but its length did not match
-    /// the length of `color_attachments`.
-    SubpassResolveAttachmentsColorAttachmentsLenMismatch { subpass: u32 },
-
-    /// An attachment used as a resolve attachment in a subpass has a `format` value different from
-    /// the corresponding color attachment.
-    SubpassResolveAttachmentFormatMismatch {
-        subpass: u32,
-        resolve_attachment: u32,
-        color_attachment: u32,
-    },
-
-    /// An attachment used as a resolve attachment in a subpass has a `samples` value other than
-    /// [`SampleCount::Sample1`].
-    SubpassResolveAttachmentMultisampled { subpass: u32, attachment: u32 },
-
-    /// A resolve attachment in a subpass is `Some`, but the corresponding color attachment is
-    /// `None`.
-    SubpassResolveAttachmentWithoutColorAttachment { subpass: u32 },
-}
-
-impl Error for RenderPassCreationError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            RenderPassCreationError::OomError(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl Display for RenderPassCreationError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        match self {
-            Self::OomError(_) => write!(f, "not enough memory available"),
-            Self::RequirementNotMet {
-                required_for,
-                requires_one_of,
-            } => write!(
-                f,
-                "a requirement was not met for: {}; requires one of: {}",
-                required_for, requires_one_of,
-            ),
-            Self::AttachmentFirstUseLoadOpInvalid {
-                attachment,
-                first_use_subpass,
-            } => write!(
-                f,
-                "attachment {} is first used in the render pass in subpass {} with a read-only \
-                layout or as an input attachment, but its `load_op` or `stencil_load_op` is \
-                `LoadOp::Clear`",
-                attachment, first_use_subpass,
-            ),
-            Self::AttachmentLayoutInvalid { attachment } => write!(
-                f,
-                "attachment {} has an `initial_layout` or `final_layout` value that is invalid for \
-                the provided `format`",
-                attachment,
-            ),
-            Self::CorrelatedViewMasksMultiviewNotEnabled => write!(
-                f,
-                "correlated view masks were included, but multiview is not enabled on the render \
-                pass",
-            ),
-            Self::CorrelatedViewMasksOverlapping => write!(
-                f,
-                "the provided correlated view masks contain a bit that is set in more than one \
-                element",
-            ),
-            Self::DependencyAccessNotSupportedByStages { dependency } => write!(
-                f,
-                "subpass dependency {} specified an access type that was not supported by the \
-                given stages",
-                dependency,
-            ),
-            Self::DependencySelfDependencyFramebufferStagesWithoutByRegion { dependency } => {
-                write!(
-                    f,
-                    "subpass dependency {} specifies a subpass self-dependency and includes \
-                    framebuffer stages in both `src_stages` and `dst_stages`, but the \
-                    `by_region` dependency was not enabled",
-                    dependency,
-                )
-            }
-            Self::DependencySelfDependencySourceStageAfterDestinationStage { dependency } => {
-                write!(
-                    f,
-                    "subpass dependency {} specifies a subpass self-dependency and includes \
-                    non-framebuffer stages, but the latest stage in `src_stages` is after the \
-                    earliest stage in `dst_stages`",
-                    dependency,
-                )
-            }
-            Self::DependencySelfDependencyViewLocalNonzeroViewOffset { dependency } => write!(
-                f,
-                "subpass dependency {} specifies a subpass self-dependency and has the \
-                `view_local` dependency enabled, but the inner offset value was not 0",
-                dependency,
-            ),
-            Self::DependencySelfDependencyViewMaskMultiple {
-                dependency,
-                subpass,
-            } => write!(
-                f,
-                "subpass dependency {} specifies a subpass self-dependency without the \
-                `view_local` dependency, but the referenced subpass {} has more than one bit set \
-                in its `view_mask`",
-                dependency, subpass,
-            ),
-            Self::DependencySourceSubpassAfterDestinationSubpass { dependency } => write!(
-                f,
-                "subpass dependency {} has a `src_subpass` that is later than the \
-                `dst_subpass`",
-                dependency,
-            ),
-            Self::DependencyStageNotSupported { dependency } => write!(
-                f,
-                "subpass dependency {} has a bit set in the `src_stages` or \
-                `dst_stages` that is not supported for graphics pipelines",
-                dependency,
-            ),
-            Self::DependencyBothSubpassesExternal { dependency } => write!(
-                f,
-                "subpass dependency {} has both `src_subpass` and `dst_subpass` set to \
-                `None`",
-                dependency,
-            ),
-            Self::DependencySubpassOutOfRange {
-                dependency,
-                subpass,
-            } => write!(
-                f,
-                "the subpass index {} in subpass dependency {} is not less than the number of \
-                subpasses in the render pass",
-                subpass, dependency,
-            ),
-            Self::DependencyViewLocalExternalDependency { dependency } => write!(
-                f,
-                "in subpass dependency {}, `dependency_flags` contains `VIEW_LOCAL`, but \
-                `src_subpass` or `dst_subpass` were set to `None`",
-                dependency,
-            ),
-            Self::DependencyViewLocalMultiviewNotEnabled { dependency } => write!(
-                f,
-                "in subpass dependency {}, `dependency_flags` contains `VIEW_LOCAL`, but \
-                multiview is not enabled on the render pass",
-                dependency,
-            ),
-            Self::DependencyViewOffzetNonzeroWithoutViewLocal { dependency } => write!(
-                f,
-                "in subpass dependency {}, `view_offset` is not zero, but `dependency_flags` does \
-                not contain `VIEW_LOCAL`",
-                dependency,
-            ),
-            Self::SubpassAttachmentAspectsNotEmpty {
-                subpass,
-                attachment,
-            } => write!(
-                f,
-                "a reference to attachment {} used other than as an input attachment in subpass {} \
-                has one or more aspects selected",
-                attachment, subpass,
-            ),
-            Self::SubpassAttachmentLayoutMismatch {
-                subpass,
-                attachment,
-            } => write!(
-                f,
-                "the layouts of all uses of attachment {} in subpass {} do not match.",
-                attachment, subpass,
-            ),
-            Self::SubpassAttachmentLayoutInvalid {
-                subpass,
-                attachment,
-                usage,
-            } => write!(
-                f,
-                "attachment {} used as {} attachment in subpass {} has a layout that is not \
-                supported for that usage",
-                attachment, usage, subpass,
-            ),
-            Self::SubpassAttachmentOutOfRange {
-                subpass,
-                attachment,
-            } => write!(
-                f,
-                "the attachment index {} in subpass {} is not less than the number of attachments \
-                in the render pass",
-                attachment, subpass,
-            ),
-            Self::SubpassAttachmentUsageColorDepthStencil {
-                subpass,
-                attachment,
-            } => write!(
-                f,
-                "attachment {} is used as both a color attachment and a depth/stencil attachment \
-                in subpass {}",
-                attachment, subpass,
-            ),
-            Self::SubpassAttachmentFormatUsageNotSupported {
-                subpass,
-                attachment,
-                usage,
-            } => write!(
-                f,
-                "attachment {} used as {} attachment in subpass {} has a format that does not \
-                support that usage",
-                attachment, usage, subpass,
-            ),
-            Self::SubpassColorAttachmentWithResolveNotMultisampled {
-                subpass,
-                attachment,
-            } => write!(
-                f,
-                "attachment {} used as a color attachment in subpass {} with resolve attachments \
-                has a `samples` value of `SampleCount::Sample1`",
-                attachment, subpass,
-            ),
-            Self::SubpassColorDepthStencilAttachmentSamplesMismatch {
-                subpass,
-                attachment,
-                samples,
-                first_samples,
-            } => write!(
-                f,
-                "attachment {} used as a color or depth/stencil attachment in subpass {} has a \
-                `samples` value {:?} that is different from the first color attachment ({:?})",
-                attachment, subpass, samples, first_samples,
-            ),
-            Self::SubpassInputAttachmentAspectsNotCompatible {
-                subpass,
-                attachment,
-            } => write!(
-                f,
-                "a reference to attachment {} used as an input attachment in subpass {} selects \
-                aspects that are not present in the format of the attachment",
-                attachment, subpass,
-            ),
-            Self::SubpassMaxColorAttachmentsExceeded { .. } => {
-                write!(f, "the `max_color_attachments` limit has been exceeded")
-            }
-            Self::SubpassMaxMultiviewViewCountExceeded { .. } => write!(
-                f,
-                "the `max_multiview_view_count` limit has been exceeded for a subpass",
-            ),
-            Self::SubpassMultiviewMismatch {
-                subpass,
-                multiview,
-                first_subpass_multiview,
-            } => write!(
-                f,
-                "the multiview state (whether `view_mask` is nonzero) of subpass {} is {}, which \
-                is different from the first subpass ({})",
-                subpass, multiview, first_subpass_multiview,
-            ),
-            Self::SubpassPreserveAttachmentUsedElsewhere {
-                subpass,
-                attachment,
-            } => write!(
-                f,
-                "attachment {} marked as a preserve attachment in subpass {} is also used as an \
-                attachment in that subpass",
-                attachment, subpass,
-            ),
-            Self::SubpassResolveAttachmentsColorAttachmentsLenMismatch { subpass } => write!(
-                f,
-                "the `resolve_attachments` field of subpass {} was not empty, but its length did \
-                not match the length of `color_attachments`",
-                subpass,
-            ),
-            Self::SubpassResolveAttachmentFormatMismatch {
-                subpass,
-                resolve_attachment,
-                color_attachment,
-            } => write!(
-                f,
-                "attachment {} used as a resolve attachment in subpass {} has a `format` value \
-                different from the corresponding color attachment {}",
-                subpass, resolve_attachment, color_attachment,
-            ),
-            Self::SubpassResolveAttachmentMultisampled {
-                subpass,
-                attachment,
-            } => write!(
-                f,
-                "attachment {} used as a resolve attachment in subpass {} has a `samples` value \
-                other than `SampleCount::Sample1`",
-                attachment, subpass,
-            ),
-            Self::SubpassResolveAttachmentWithoutColorAttachment { subpass } => write!(
-                f,
-                "a resolve attachment in subpass {} is `Some`, but the corresponding color \
-                attachment is `None`",
-                subpass,
-            ),
-        }
-    }
-}
-
-impl From<OomError> for RenderPassCreationError {
-    fn from(err: OomError) -> RenderPassCreationError {
-        RenderPassCreationError::OomError(err)
-    }
-}
-
-impl From<RuntimeError> for RenderPassCreationError {
-    fn from(err: RuntimeError) -> RenderPassCreationError {
-        match err {
-            err @ RuntimeError::OutOfHostMemory => {
-                RenderPassCreationError::OomError(OomError::from(err))
-            }
-            err @ RuntimeError::OutOfDeviceMemory => {
-                RenderPassCreationError::OomError(OomError::from(err))
-            }
-            _ => panic!("unexpected error: {:?}", err),
-        }
-    }
-}
-
-impl From<RequirementNotMet> for RenderPassCreationError {
-    fn from(err: RequirementNotMet) -> Self {
-        Self::RequirementNotMet {
-            required_for: err.required_for,
-            requires_one_of: err.requires_one_of,
-        }
     }
 }

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -734,10 +734,10 @@ mod tests {
             device.clone(),
             attachments: {
                 color: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
             },
             pass: {
@@ -811,10 +811,10 @@ mod tests {
             device.clone(),
             attachments: {
                 color: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
             },
             pass: {
@@ -853,10 +853,10 @@ mod tests {
             device.clone(),
             attachments: {
                 color: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
             },
             pass: {
@@ -893,10 +893,10 @@ mod tests {
             device.clone(),
             attachments: {
                 color: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
             },
             pass: {
@@ -935,16 +935,16 @@ mod tests {
             device.clone(),
             attachments: {
                 a: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
                 b: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
             },
             pass: {
@@ -988,16 +988,16 @@ mod tests {
             device.clone(),
             attachments: {
                 a: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
                 b: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
             },
             pass: {
@@ -1039,10 +1039,10 @@ mod tests {
             device.clone(),
             attachments: {
                 a: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
             },
             pass: {

--- a/vulkano/src/render_pass/macros.rs
+++ b/vulkano/src/render_pass/macros.rs
@@ -73,10 +73,10 @@ macro_rules! ordered_passes_renderpass {
         attachments: {
             $(
                 $atch_name:ident: {
-                    load: $load:ident,
-                    store: $store:ident,
                     format: $format:expr,
-                    samples: $samples:expr
+                    samples: $samples:expr,
+                    load_op: $load_op:ident,
+                    store_op: $store_op:ident
                     $(,initial_layout: $init_layout:expr)?
                     $(,final_layout: $final_layout:expr)?
                     $(,)?
@@ -279,10 +279,8 @@ macro_rules! ordered_passes_renderpass {
                     $crate::render_pass::AttachmentDescription {
                         format: Some($format),
                         samples: $crate::image::SampleCount::try_from($samples).unwrap(),
-                        load_op: $crate::render_pass::LoadOp::$load,
-                        store_op: $crate::render_pass::StoreOp::$store,
-                        stencil_load_op: $crate::render_pass::LoadOp::$load,
-                        stencil_store_op: $crate::render_pass::StoreOp::$store,
+                        load_op: $crate::render_pass::AttachmentLoadOp::$load_op,
+                        store_op: $crate::render_pass::AttachmentStoreOp::$store_op,
                         initial_layout: layout.0.expect(
                             format!(
                                 "Attachment {} is missing initial_layout, this is normally \
@@ -293,6 +291,26 @@ macro_rules! ordered_passes_renderpass {
                             .as_ref(),
                         ),
                         final_layout: layout.1.expect(
+                            format!(
+                                "Attachment {} is missing final_layout, this is normally \
+                                automatically determined but you can manually specify it for an individual \
+                                attachment in the single_pass_renderpass! macro",
+                                attachment_num
+                            )
+                            .as_ref(),
+                        ),
+                        stencil_load_op: $crate::render_pass::AttachmentLoadOp::$load_op,
+                        stencil_store_op: $crate::render_pass::AttachmentStoreOp::$store_op,
+                        stencil_initial_layout: layout.0.expect(
+                            format!(
+                                "Attachment {} is missing initial_layout, this is normally \
+                                automatically determined but you can manually specify it for an individual \
+                                attachment in the single_pass_renderpass! macro",
+                                attachment_num
+                            )
+                            .as_ref(),
+                        ),
+                        stencil_final_layout: layout.1.expect(
                             format!(
                                 "Attachment {} is missing final_layout, this is normally \
                                 automatically determined but you can manually specify it for an individual \
@@ -329,16 +347,16 @@ mod tests {
             device,
             attachments: {
                 a: {
-                    load: Clear,
-                    store: DontCare,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 4,
+                    load_op: Clear,
+                    store_op: DontCare,
                 },
                 b: {
-                    load: DontCare,
-                    store: Store,
                     format: Format::R8G8B8A8_UNORM,
                     samples: 1,
+                    load_op: DontCare,
+                    store_op: Store,
                 },
             },
             pass: {

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -25,20 +25,25 @@
 //! Consequently you can create graphics pipelines from a render pass object alone.
 //! A `Framebuffer` object is only needed when you actually add draw commands to a command buffer.
 
-pub use self::{
-    create::RenderPassCreationError,
-    framebuffer::{Framebuffer, FramebufferCreateInfo, FramebufferCreationError},
-};
+pub use self::framebuffer::{Framebuffer, FramebufferCreateInfo, FramebufferCreationError};
 use crate::{
-    device::{Device, DeviceOwned},
-    format::Format,
-    image::{ImageAspects, ImageLayout, SampleCount},
-    macros::{impl_id_counter, vulkan_bitflags_enum, vulkan_enum},
+    device::{Device, DeviceOwned, QueueFlags},
+    format::{Format, FormatFeatures, NumericType},
+    image::{ImageAspect, ImageAspects, ImageLayout, SampleCount},
+    macros::{impl_id_counter, vulkan_bitflags, vulkan_bitflags_enum, vulkan_enum},
     shader::ShaderInterface,
-    sync::{AccessFlags, DependencyFlags, PipelineStages},
-    Version, VulkanObject,
+    sync::{AccessFlags, DependencyFlags, MemoryBarrier, PipelineStages},
+    RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError, VulkanObject,
 };
-use std::{cmp::max, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use ahash::HashMap;
+use std::{
+    cmp::max,
+    collections::hash_map::Entry,
+    mem::{replace, MaybeUninit},
+    num::NonZeroU64,
+    ptr,
+    sync::Arc,
+};
 
 #[macro_use]
 mod macros;
@@ -92,7 +97,8 @@ mod framebuffer;
 ///     },
 ///     pass: {
 ///         color: [foo],       // Repeat the attachment name here.
-///         depth_stencil: {},
+///         depth: {},
+///         stencil: {},
 ///     },
 /// )
 /// .unwrap();
@@ -106,6 +112,7 @@ pub struct RenderPass {
     device: Arc<Device>,
     id: NonZeroU64,
 
+    flags: RenderPassCreateFlags,
     attachments: Vec<AttachmentDescription>,
     subpasses: Vec<SubpassDescription>,
     dependencies: Vec<SubpassDependency>,
@@ -125,8 +132,54 @@ impl RenderPass {
     pub fn new(
         device: Arc<Device>,
         mut create_info: RenderPassCreateInfo,
-    ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
-        Self::validate(&device, &mut create_info)?;
+    ) -> Result<Arc<RenderPass>, VulkanError> {
+        for subpass in create_info.subpasses.iter_mut() {
+            for input_attachment in subpass.input_attachments.iter_mut().flatten() {
+                if input_attachment.aspects.is_empty() {
+                    if let Some(attachment_desc) = create_info
+                        .attachments
+                        .get(input_attachment.attachment_ref.attachment as usize)
+                    {
+                        input_attachment.aspects = attachment_desc.format.unwrap().aspects();
+                    }
+                }
+            }
+        }
+
+        Self::validate_new(&device, &create_info)?;
+
+        unsafe { Ok(Self::new_unchecked(device, create_info)?) }
+    }
+
+    fn validate_new(
+        device: &Device,
+        create_info: &RenderPassCreateInfo,
+    ) -> Result<(), ValidationError> {
+        // VUID-vkCreateRenderPass2-pCreateInfo-parameter
+        create_info
+            .validate(device)
+            .map_err(|err| err.add_context("create_info"))?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn new_unchecked(
+        device: Arc<Device>,
+        mut create_info: RenderPassCreateInfo,
+    ) -> Result<Arc<RenderPass>, RuntimeError> {
+        for subpass in create_info.subpasses.iter_mut() {
+            for input_attachment in subpass.input_attachments.iter_mut().flatten() {
+                if input_attachment.aspects.is_empty() {
+                    if let Some(attachment_desc) = create_info
+                        .attachments
+                        .get(input_attachment.attachment_ref.attachment as usize)
+                    {
+                        input_attachment.aspects = attachment_desc.format.unwrap().aspects();
+                    }
+                }
+            }
+        }
 
         let handle = unsafe {
             if device.api_version() >= Version::V1_2
@@ -141,35 +194,19 @@ impl RenderPass {
         unsafe { Ok(Self::from_handle(device, handle, create_info)) }
     }
 
-    /// Builds a render pass with one subpass and no attachment.
-    ///
-    /// This method is useful for quick tests.
-    #[inline]
-    pub fn empty_single_pass(
-        device: Arc<Device>,
-    ) -> Result<Arc<RenderPass>, RenderPassCreationError> {
-        RenderPass::new(
-            device,
-            RenderPassCreateInfo {
-                subpasses: vec![SubpassDescription::default()],
-                ..Default::default()
-            },
-        )
-    }
-
     /// Creates a new `RenderPass` from a raw object handle.
     ///
     /// # Safety
     ///
     /// - `handle` must be a valid Vulkan object handle created from `device`.
     /// - `create_info` must match the info used to create the object.
-    #[inline]
     pub unsafe fn from_handle(
         device: Arc<Device>,
         handle: ash::vk::RenderPass,
         create_info: RenderPassCreateInfo,
     ) -> Arc<RenderPass> {
         let RenderPassCreateInfo {
+            flags,
             attachments,
             subpasses,
             dependencies,
@@ -192,6 +229,7 @@ impl RenderPass {
             device,
             id: Self::next_id(),
 
+            flags,
             attachments,
             subpasses,
             dependencies,
@@ -211,6 +249,12 @@ impl RenderPass {
         debug_assert_ne!(out.width, 0);
         debug_assert_ne!(out.height, 0);
         [out.width, out.height]
+    }
+
+    /// Returns the flags that the render pass was created with.
+    #[inline]
+    pub fn flags(&self) -> RenderPassCreateFlags {
+        self.flags
     }
 
     /// Returns the attachments of the render pass.
@@ -274,10 +318,13 @@ impl RenderPass {
             handle: _,
             device: _,
             id: _,
+
+            flags: flags1,
             attachments: attachments1,
             subpasses: subpasses1,
             dependencies: dependencies1,
             correlated_view_masks: correlated_view_masks1,
+
             granularity: _,
             views_used: _,
         } = self;
@@ -285,13 +332,20 @@ impl RenderPass {
             handle: _,
             device: _,
             id: _,
+
+            flags: flags2,
             attachments: attachments2,
             subpasses: subpasses2,
             dependencies: dependencies2,
             correlated_view_masks: correlated_view_masks2,
+
             granularity: _,
             views_used: _,
         } = other;
+
+        if flags1 != flags2 {
+            return false;
+        }
 
         if attachments1.len() != attachments2.len() {
             return false;
@@ -302,77 +356,84 @@ impl RenderPass {
             .zip(attachments2)
             .all(|(attachment_desc1, attachment_desc2)| {
                 let AttachmentDescription {
+                    flags: flags1,
                     format: format1,
                     samples: samples1,
                     load_op: _,
                     store_op: _,
-                    stencil_load_op: _,
-                    stencil_store_op: _,
                     initial_layout: _,
                     final_layout: _,
+                    stencil_load_op: _,
+                    stencil_store_op: _,
+                    stencil_initial_layout: _,
+                    stencil_final_layout: _,
                     _ne: _,
                 } = attachment_desc1;
                 let AttachmentDescription {
+                    flags: flags2,
                     format: format2,
                     samples: samples2,
                     load_op: _,
                     store_op: _,
-                    stencil_load_op: _,
-                    stencil_store_op: _,
                     initial_layout: _,
                     final_layout: _,
+                    stencil_load_op: _,
+                    stencil_store_op: _,
+                    stencil_initial_layout: _,
+                    stencil_final_layout: _,
                     _ne: _,
                 } = attachment_desc2;
 
-                format1 == format2 && samples1 == samples2
+                flags1 == flags2 && format1 == format2 && samples1 == samples2
             })
         {
             return false;
         }
 
-        let are_atch_refs_compatible = |atch_ref1, atch_ref2| match (atch_ref1, atch_ref2) {
-            (None, None) => true,
-            (Some(atch_ref1), Some(atch_ref2)) => {
+        let are_atch_refs_compatible =
+            |atch_ref1: &AttachmentReference, atch_ref2: &AttachmentReference| {
                 let &AttachmentReference {
                     attachment: attachment1,
                     layout: _,
-                    aspects: aspects1,
                     _ne: _,
                 } = atch_ref1;
                 let AttachmentDescription {
+                    flags: flags1,
                     format: format1,
                     samples: samples1,
                     load_op: _,
                     store_op: _,
-                    stencil_load_op: _,
-                    stencil_store_op: _,
                     initial_layout: _,
                     final_layout: _,
+                    stencil_load_op: _,
+                    stencil_store_op: _,
+                    stencil_initial_layout: _,
+                    stencil_final_layout: _,
                     _ne: _,
                 } = &attachments1[attachment1 as usize];
 
                 let &AttachmentReference {
                     attachment: attachment2,
                     layout: _,
-                    aspects: aspects2,
                     _ne: _,
                 } = atch_ref2;
                 let AttachmentDescription {
+                    flags: flags2,
                     format: format2,
                     samples: samples2,
                     load_op: _,
                     store_op: _,
-                    stencil_load_op: _,
-                    stencil_store_op: _,
                     initial_layout: _,
                     final_layout: _,
+                    stencil_load_op: _,
+                    stencil_store_op: _,
+                    stencil_initial_layout: _,
+                    stencil_final_layout: _,
                     _ne: _,
                 } = &attachments2[attachment2 as usize];
 
-                format1 == format2 && samples1 == samples2 && aspects1 == aspects2
-            }
-            _ => false,
-        };
+                flags1 == flags2 && format1 == format2 && samples1 == samples2
+            };
 
         if subpasses1.len() != subpasses2.len() {
             return false;
@@ -382,57 +443,165 @@ impl RenderPass {
             .zip(subpasses2.iter())
             .all(|(subpass1, subpass2)| {
                 let SubpassDescription {
+                    flags: flags1,
                     view_mask: view_mask1,
                     input_attachments: input_attachments1,
                     color_attachments: color_attachments1,
-                    resolve_attachments: resolve_attachments1,
-                    depth_stencil_attachment: depth_stencil_attachment1,
+                    depth_attachment: depth_attachment1,
+                    stencil_attachment: stencil_attachment1,
                     preserve_attachments: _,
                     _ne: _,
                 } = subpass1;
                 let SubpassDescription {
+                    flags: flags2,
                     view_mask: view_mask2,
                     input_attachments: input_attachments2,
                     color_attachments: color_attachments2,
-                    resolve_attachments: resolve_attachments2,
-                    depth_stencil_attachment: depth_stencil_attachment2,
+                    depth_attachment: depth_attachment2,
+                    stencil_attachment: stencil_attachment2,
                     preserve_attachments: _,
                     _ne: _,
                 } = subpass2;
 
+                if flags1 != flags2 {
+                    return false;
+                }
+
                 if !(0..max(input_attachments1.len(), input_attachments2.len())).all(|i| {
-                    are_atch_refs_compatible(
+                    match (
                         input_attachments1.get(i).and_then(|x| x.as_ref()),
                         input_attachments2.get(i).and_then(|x| x.as_ref()),
-                    )
+                    ) {
+                        (None, None) => true,
+                        (Some(input_attachment1), Some(input_attachment2)) => {
+                            let &InputAttachmentReference {
+                                attachment_ref: ref attachment_ref1,
+                                aspects: aspects1,
+                            } = input_attachment1;
+                            let &InputAttachmentReference {
+                                attachment_ref: ref attachment_ref2,
+                                aspects: aspects2,
+                            } = input_attachment2;
+
+                            are_atch_refs_compatible(attachment_ref1, attachment_ref2)
+                                && aspects1 == aspects2
+                        }
+                        _ => false,
+                    }
                 }) {
                     return false;
                 }
 
                 if !(0..max(color_attachments1.len(), color_attachments2.len())).all(|i| {
-                    are_atch_refs_compatible(
+                    match (
                         color_attachments1.get(i).and_then(|x| x.as_ref()),
                         color_attachments2.get(i).and_then(|x| x.as_ref()),
-                    )
+                    ) {
+                        (None, None) => true,
+                        (Some(resolvable_attachment1), Some(resolvable_attachment2)) => {
+                            let &ResolvableAttachmentReference {
+                                attachment_ref: ref attachment_ref1,
+                                resolve: ref resolve1,
+                            } = resolvable_attachment1;
+                            let &ResolvableAttachmentReference {
+                                attachment_ref: ref attachment_ref2,
+                                resolve: ref resolve2,
+                            } = resolvable_attachment2;
+
+                            are_atch_refs_compatible(attachment_ref1, attachment_ref2)
+                                && match (resolve1, resolve2) {
+                                    (None, None) => true,
+                                    (Some(resolve_attachment1), Some(resolve_attachment2)) => {
+                                        let &ResolveAttachmentReference {
+                                            attachment_ref: ref attachment_ref1,
+                                            mode: mode1,
+                                        } = resolve_attachment1;
+                                        let &ResolveAttachmentReference {
+                                            attachment_ref: ref attachment_ref2,
+                                            mode: mode2,
+                                        } = resolve_attachment2;
+
+                                        are_atch_refs_compatible(attachment_ref1, attachment_ref2)
+                                            && mode1 == mode2
+                                    }
+                                    _ => false,
+                                }
+                        }
+                        _ => false,
+                    }
                 }) {
                     return false;
                 }
 
-                if subpasses1.len() > 1
-                    && !(0..max(resolve_attachments1.len(), resolve_attachments2.len())).all(|i| {
-                        are_atch_refs_compatible(
-                            resolve_attachments1.get(i).and_then(|x| x.as_ref()),
-                            resolve_attachments2.get(i).and_then(|x| x.as_ref()),
-                        )
-                    })
-                {
+                if !match (depth_attachment1.as_ref(), depth_attachment2.as_ref()) {
+                    (None, None) => true,
+                    (Some(resolvable_attachment1), Some(resolvable_attachment2)) => {
+                        let &ResolvableAttachmentReference {
+                            attachment_ref: ref attachment_ref1,
+                            resolve: ref resolve1,
+                        } = resolvable_attachment1;
+                        let &ResolvableAttachmentReference {
+                            attachment_ref: ref attachment_ref2,
+                            resolve: ref resolve2,
+                        } = resolvable_attachment2;
+
+                        are_atch_refs_compatible(attachment_ref1, attachment_ref2)
+                            && match (resolve1, resolve2) {
+                                (None, None) => true,
+                                (Some(resolve_attachment1), Some(resolve_attachment2)) => {
+                                    let &ResolveAttachmentReference {
+                                        attachment_ref: ref attachment_ref1,
+                                        mode: mode1,
+                                    } = resolve_attachment1;
+                                    let &ResolveAttachmentReference {
+                                        attachment_ref: ref attachment_ref2,
+                                        mode: mode2,
+                                    } = resolve_attachment2;
+
+                                    are_atch_refs_compatible(attachment_ref1, attachment_ref2)
+                                        && mode1 == mode2
+                                }
+                                _ => false,
+                            }
+                    }
+                    _ => false,
+                } {
                     return false;
                 }
 
-                if !are_atch_refs_compatible(
-                    depth_stencil_attachment1.as_ref(),
-                    depth_stencil_attachment2.as_ref(),
-                ) {
+                if !match (stencil_attachment1.as_ref(), stencil_attachment2.as_ref()) {
+                    (None, None) => true,
+                    (Some(resolvable_attachment1), Some(resolvable_attachment2)) => {
+                        let &ResolvableAttachmentReference {
+                            attachment_ref: ref attachment_ref1,
+                            resolve: ref resolve1,
+                        } = resolvable_attachment1;
+                        let &ResolvableAttachmentReference {
+                            attachment_ref: ref attachment_ref2,
+                            resolve: ref resolve2,
+                        } = resolvable_attachment2;
+
+                        are_atch_refs_compatible(attachment_ref1, attachment_ref2)
+                            && match (resolve1, resolve2) {
+                                (None, None) => true,
+                                (Some(resolve_attachment1), Some(resolve_attachment2)) => {
+                                    let &ResolveAttachmentReference {
+                                        attachment_ref: ref attachment_ref1,
+                                        mode: mode1,
+                                    } = resolve_attachment1;
+                                    let &ResolveAttachmentReference {
+                                        attachment_ref: ref attachment_ref2,
+                                        mode: mode2,
+                                    } = resolve_attachment2;
+
+                                    are_atch_refs_compatible(attachment_ref1, attachment_ref2)
+                                        && mode1 == mode2
+                                }
+                                _ => false,
+                            }
+                    }
+                    _ => false,
+                } {
                     return false;
                 }
 
@@ -475,7 +644,9 @@ impl RenderPass {
 
             for location in location_range {
                 let attachment_id = match subpass_descr.color_attachments.get(location as usize) {
-                    Some(Some(atch_ref)) => atch_ref.attachment,
+                    Some(Some(resolvable_atch_ref)) => {
+                        resolvable_atch_ref.attachment_ref.attachment
+                    }
                     _ => return false,
                 };
 
@@ -583,92 +754,10 @@ impl Subpass {
         self.subpass_id = next_id;
     }
 
-    #[inline]
-    fn attachment_desc(&self, atch_num: u32) -> &AttachmentDescription {
-        &self.render_pass.attachments()[atch_num as usize]
-    }
-
     /// Returns the number of color attachments in this subpass.
     #[inline]
     pub fn num_color_attachments(&self) -> u32 {
         self.subpass_desc().color_attachments.len() as u32
-    }
-
-    /// Returns true if the subpass has a depth attachment or a depth-stencil attachment.
-    #[inline]
-    pub fn has_depth(&self) -> bool {
-        let subpass_desc = self.subpass_desc();
-        let atch_num = match &subpass_desc.depth_stencil_attachment {
-            Some(atch_ref) => atch_ref.attachment,
-            None => return false,
-        };
-
-        self.attachment_desc(atch_num)
-            .format
-            .map_or(false, |f| f.aspects().intersects(ImageAspects::DEPTH))
-    }
-
-    /// Returns true if the subpass has a depth attachment or a depth-stencil attachment whose
-    /// layout does not have a read-only depth layout.
-    #[inline]
-    pub fn has_writable_depth(&self) -> bool {
-        let subpass_desc = self.subpass_desc();
-        let atch_num = match &subpass_desc.depth_stencil_attachment {
-            Some(atch_ref) => {
-                if matches!(
-                    atch_ref.layout,
-                    ImageLayout::DepthStencilReadOnlyOptimal
-                        | ImageLayout::DepthReadOnlyStencilAttachmentOptimal
-                ) {
-                    return false;
-                }
-                atch_ref.attachment
-            }
-            None => return false,
-        };
-
-        self.attachment_desc(atch_num)
-            .format
-            .map_or(false, |f| f.aspects().intersects(ImageAspects::DEPTH))
-    }
-
-    /// Returns true if the subpass has a stencil attachment or a depth-stencil attachment.
-    #[inline]
-    pub fn has_stencil(&self) -> bool {
-        let subpass_desc = self.subpass_desc();
-        let atch_num = match &subpass_desc.depth_stencil_attachment {
-            Some(atch_ref) => atch_ref.attachment,
-            None => return false,
-        };
-
-        self.attachment_desc(atch_num)
-            .format
-            .map_or(false, |f| f.aspects().intersects(ImageAspects::STENCIL))
-    }
-
-    /// Returns true if the subpass has a stencil attachment or a depth-stencil attachment whose
-    /// layout does not have a read-only stencil layout.
-    #[inline]
-    pub fn has_writable_stencil(&self) -> bool {
-        let subpass_desc = self.subpass_desc();
-
-        let atch_num = match &subpass_desc.depth_stencil_attachment {
-            Some(atch_ref) => {
-                if matches!(
-                    atch_ref.layout,
-                    ImageLayout::DepthStencilReadOnlyOptimal
-                        | ImageLayout::DepthAttachmentStencilReadOnlyOptimal
-                ) {
-                    return false;
-                }
-                atch_ref.attachment
-            }
-            None => return false,
-        };
-
-        self.attachment_desc(atch_num)
-            .format
-            .map_or(false, |f| f.aspects().intersects(ImageAspects::STENCIL))
     }
 
     /// Returns the number of samples in the color and/or depth/stencil attachments. Returns `None`
@@ -678,15 +767,13 @@ impl Subpass {
         let subpass_desc = self.subpass_desc();
 
         // TODO: chain input attachments as well?
-        subpass_desc
-            .color_attachments
-            .iter()
-            .flatten()
-            .chain(subpass_desc.depth_stencil_attachment.iter())
-            .filter_map(|atch_ref| {
+        (subpass_desc.color_attachments.iter().flatten())
+            .chain(subpass_desc.depth_attachment.iter())
+            .chain(subpass_desc.stencil_attachment.iter())
+            .filter_map(|resolvable_attachment| {
                 self.render_pass
                     .attachments()
-                    .get(atch_ref.attachment as usize)
+                    .get(resolvable_attachment.attachment_ref.attachment as usize)
             })
             .next()
             .map(|atch_desc| atch_desc.samples)
@@ -711,6 +798,11 @@ impl From<Subpass> for (Arc<RenderPass>, u32) {
 /// Parameters to create a new `RenderPass`.
 #[derive(Clone, Debug)]
 pub struct RenderPassCreateInfo {
+    /// Additional properties of the render pass.
+    ///
+    /// The default value is empty.
+    pub flags: RenderPassCreateFlags,
+
     /// The attachments available for the render pass.
     ///
     /// The default value is empty.
@@ -749,6 +841,7 @@ impl Default for RenderPassCreateInfo {
     #[inline]
     fn default() -> Self {
         Self {
+            flags: RenderPassCreateFlags::empty(),
             attachments: Vec::new(),
             subpasses: Vec::new(),
             dependencies: Vec::new(),
@@ -758,9 +851,1052 @@ impl Default for RenderPassCreateInfo {
     }
 }
 
+impl RenderPassCreateInfo {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            flags,
+            ref attachments,
+            ref subpasses,
+            ref dependencies,
+            ref correlated_view_masks,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkRenderPassCreateInfo2-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        let mut attachment_potential_format_features =
+            vec![FormatFeatures::empty(); attachments.len()];
+
+        for (attachment_index, attachment) in attachments.iter().enumerate() {
+            // VUID-VkRenderPassCreateInfo2-pAttachments-parameter
+            attachment
+                .validate(device)
+                .map_err(|err| err.add_context(format!("attachments[{}]", attachment_index)))?;
+
+            let &AttachmentDescription {
+                flags: _,
+                format,
+                samples: _,
+                load_op: _,
+                store_op: _,
+                initial_layout: _,
+                final_layout: _,
+                stencil_load_op: _,
+                stencil_store_op: _,
+                stencil_initial_layout: _,
+                stencil_final_layout: _,
+                _ne: _,
+            } = attachment;
+
+            // Safety: attachment has been validated
+            attachment_potential_format_features[attachment_index] = unsafe {
+                device
+                    .physical_device()
+                    .format_properties_unchecked(format.unwrap())
+                    .potential_format_features()
+            };
+        }
+
+        if subpasses.is_empty() {
+            return Err(ValidationError {
+                context: "subpasses".into(),
+                problem: "is empty".into(),
+                vuids: &["VUID-VkRenderPassCreateInfo2-subpassCount-arraylength"],
+                ..Default::default()
+            });
+        }
+
+        let mut attachment_is_used = vec![false; attachments.len()];
+
+        for (subpass_index, subpass_desc) in subpasses.iter().enumerate() {
+            // VUID-VkRenderPassCreateInfo2-pSubpasses-parameter
+            subpass_desc
+                .validate(device)
+                .map_err(|err| err.add_context(format!("subpasses[{}]", subpass_index)))?;
+
+            let &SubpassDescription {
+                flags: _,
+                view_mask,
+                ref input_attachments,
+                ref color_attachments,
+                ref depth_attachment,
+                ref stencil_attachment,
+                ref preserve_attachments,
+                _ne: _,
+            } = subpass_desc;
+
+            if (view_mask != 0) != (subpasses[0].view_mask != 0) {
+                return Err(ValidationError {
+                    problem: format!(
+                        "`subpasses[{}].view_mask != 0` does not equal \
+                        `subpasses[0].view_mask != 0`",
+                        subpass_index
+                    )
+                    .into(),
+                    vuids: &["VUID-VkRenderPassCreateInfo2-viewMask-03058"],
+                    ..Default::default()
+                });
+            }
+
+            let mut color_samples = None;
+
+            for (ref_index, color_attachment) in color_attachments
+                .iter()
+                .enumerate()
+                .flat_map(|(i, a)| a.as_ref().map(|a| (i, a)))
+            {
+                let &ResolvableAttachmentReference {
+                    attachment_ref:
+                        AttachmentReference {
+                            attachment,
+                            layout,
+                            _ne: _,
+                        },
+                    ref resolve,
+                } = color_attachment;
+
+                let attachment_desc =
+                    attachments
+                        .get(attachment as usize)
+                        .ok_or_else(|| ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].color_attachments[{}].attachment_ref.attachment` \
+                                is not less than the length of `attachments`",
+                                subpass_index, ref_index
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                            ..Default::default()
+                        })?;
+
+                let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
+
+                if is_first_use
+                    && attachment_desc.load_op == LoadOp::Clear
+                    && !layout.is_writable(ImageAspect::Color)
+                {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "attachment {0} is first used in subpass {1} in \
+                            `color_attachments[{2}].attachment_ref`, and \
+                            `attachments[{0}].load_op` is `LoadOp::Clear`, but \
+                            `color_attachments[{2}].attachment_ref.layout` \
+                            does not have a writable color aspect",
+                            attachment, subpass_index, ref_index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-pAttachments-02522"],
+                        ..Default::default()
+                    });
+                }
+
+                if !attachment_potential_format_features[attachment as usize]
+                    .intersects(FormatFeatures::COLOR_ATTACHMENT)
+                {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "attachment {} is used in subpass {} in \
+                            `color_attachments[{}].attachment_ref`, \
+                            but the potential format features of `attachments[{0}].format` \
+                            do not include `FormatFeatures::COLOR_ATTACHMENT`",
+                            attachment, subpass_index, ref_index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkSubpassDescription2-pColorAttachments-02898"],
+                        ..Default::default()
+                    });
+                }
+
+                match color_samples {
+                    Some(samples) => {
+                        if samples != attachment_desc.samples {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "`subpasses[{}].color_attachments[{}].attachment_ref` uses \
+                                    an attachment with a different number of samples than other \
+                                    color and depth/stencil attachments in the subpass",
+                                    subpass_index, ref_index
+                                )
+                                .into(),
+                                vuids: &["VUID-VkSubpassDescription2-pColorAttachments-03069"],
+                                ..Default::default()
+                            });
+                        }
+                    }
+                    None => color_samples = Some(attachment_desc.samples),
+                }
+
+                if let Some(resolve) = resolve {
+                    let &ResolveAttachmentReference {
+                        attachment_ref:
+                            AttachmentReference {
+                                attachment: resolve_attachment,
+                                layout: resolve_layout,
+                                _ne: _,
+                            },
+                        mode,
+                    } = resolve;
+
+                    let resolve_attachment_desc = attachments
+                        .get(resolve_attachment as usize)
+                        .ok_or_else(|| ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].color_attachments[{}].resolve.attachment_ref\
+                                .attachment` is not less than the length of `attachments`",
+                                subpass_index, ref_index
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                            ..Default::default()
+                        })?;
+
+                    let is_first_use =
+                        !replace(&mut attachment_is_used[resolve_attachment as usize], true);
+
+                    if is_first_use
+                        && attachment_desc.load_op == LoadOp::Clear
+                        && !resolve_layout.is_writable(ImageAspect::Color)
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {0} is first used in subpass {1} in \
+                                `color_attachments[{2}].resolve.attachment_ref`, and \
+                                `attachments[{0}].load_op` is `LoadOp::Clear`, but \
+                                `color_attachments[{2}].resolve.attachment_ref.layout` \
+                                does not have a writable color aspect",
+                                attachment, subpass_index, ref_index
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-pAttachments-02522"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if !attachment_potential_format_features[resolve_attachment as usize]
+                        .intersects(FormatFeatures::COLOR_ATTACHMENT)
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {} is used in subpass {} in \
+                                `color_attachments[{}].resolve.attachment_ref`, \
+                                but the potential format features of `attachments[{0}].format` \
+                                do not include `FormatFeatures::COLOR_ATTACHMENT`",
+                                resolve_attachment, subpass_index, ref_index
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescription2-pResolveAttachments-02899"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if resolve_attachment_desc.samples != SampleCount::Sample1 {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {} is used in subpass {} in \
+                                `color_attachments[{}].resolve.attachment_ref`, but \
+                                `attachments[{0}].samples` is not `SampleCount::Sample1`",
+                                resolve_attachment, subpass_index, ref_index
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescription2-pResolveAttachments-03067"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if attachment_desc.samples == SampleCount::Sample1 {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {0} is used in subpass {1} in \
+                                `color_attachments[{2}].attachment_ref`, and
+                                `color_attachments[{2}].resolve.attachment_ref` is not \
+                                `None`, but `attachments[{0}].samples` is `SampleCount::Sample1`",
+                                attachment, subpass_index, ref_index
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescription2-pResolveAttachments-03066"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if resolve_attachment_desc.format != attachment_desc.format {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "`attachments[\
+                                subpasses[{0}].color_attachments[{1}].resolve.attachment_ref\
+                                .attachment].format` is not equal to \
+                                `attachments[\
+                                subpasses[{0}].color_attachments[{1}].attachment_ref\
+                                .attachment].format`",
+                                subpass_index, ref_index
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescription2-pResolveAttachments-03068"],
+                            ..Default::default()
+                        });
+                    }
+
+                    match resolve_attachment_desc
+                        .format
+                        .unwrap()
+                        .type_color()
+                        .unwrap()
+                    {
+                        NumericType::SFLOAT
+                        | NumericType::UFLOAT
+                        | NumericType::SNORM
+                        | NumericType::UNORM
+                        | NumericType::SSCALED
+                        | NumericType::USCALED
+                        | NumericType::SRGB => {
+                            if mode != ResolveMode::Average {
+                                return Err(ValidationError {
+                                    problem: format!(
+                                        "`attachments[\
+                                        subpasses[{0}].color_attachments[{1}].resolve\
+                                        .attachment_ref.attachment].format` is a floating-point
+                                        color format, but \
+                                        `subpasses[{0}].color_attachments[{1}].resolve\
+                                        .attachment_ref.attachment` is not \
+                                        `ResolveMode::Average`",
+                                        subpass_index, ref_index,
+                                    )
+                                    .into(),
+                                    // vuids?
+                                    ..Default::default()
+                                });
+                            }
+                        }
+                        NumericType::SINT | NumericType::UINT => {
+                            if mode != ResolveMode::SampleZero {
+                                return Err(ValidationError {
+                                    problem: format!(
+                                        "`attachments[\
+                                        subpasses[{0}].color_attachments[{1}].resolve\
+                                        .attachment_ref.attachment].format` is an integer
+                                        color format, but \
+                                        `subpasses[{0}].color_attachments[{1}].resolve\
+                                        .attachment_ref.attachment` is not \
+                                        `ResolveMode::SampleZero`",
+                                        subpass_index, ref_index,
+                                    )
+                                    .into(),
+                                    // vuids?
+                                    ..Default::default()
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(depth_attachment) = depth_attachment.as_ref() {
+                let &ResolvableAttachmentReference {
+                    attachment_ref:
+                        AttachmentReference {
+                            attachment,
+                            layout,
+                            _ne: _,
+                        },
+                    ref resolve,
+                } = depth_attachment;
+
+                let attachment_desc =
+                    attachments
+                        .get(attachment as usize)
+                        .ok_or_else(|| ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].depth_attachment.attachment_ref.attachment` \
+                                is not less than the length of `attachments`",
+                                subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                            ..Default::default()
+                        })?;
+
+                let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
+
+                if is_first_use
+                    && attachment_desc.load_op == LoadOp::Clear
+                    && !layout.is_writable(ImageAspect::Depth)
+                {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "attachment {0} is first used in subpass {1} in \
+                            `depth_attachment.attachment_ref`, and \
+                            `attachments[{0}].load_op` is `LoadOp::Clear`, but \
+                            `depth_attachment.attachment_ref.layout` \
+                            does not have a writable depth aspect",
+                            attachment, subpass_index,
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-pAttachments-02522"],
+                        ..Default::default()
+                    });
+                }
+
+                if !attachment_potential_format_features[attachment as usize]
+                    .intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT)
+                {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "attachment {} is used in subpass {} in \
+                            `depth_attachment.attachment_ref`, \
+                            but the potential format features of `attachments[{0}].format` \
+                            do not include `FormatFeatures::DEPTH_STENCIL_ATTACHMENT`",
+                            attachment, subpass_index,
+                        )
+                        .into(),
+                        vuids: &["VUID-VkSubpassDescription2-pDepthStencilAttachment-02900"],
+                        ..Default::default()
+                    });
+                }
+
+                if let Some(samples) = color_samples {
+                    if samples != attachment_desc.samples {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].depth_attachment.attachment_ref` uses an \
+                                attachment with a different number of samples than other color,
+                                depth and stencil attachments in the subpass",
+                                subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescription2-pColorAttachments-03069"],
+                            ..Default::default()
+                        });
+                    }
+                }
+
+                if let Some(resolve) = resolve {
+                    let &ResolveAttachmentReference {
+                        attachment_ref:
+                            AttachmentReference {
+                                attachment: resolve_attachment,
+                                layout: resolve_layout,
+                                _ne: _,
+                            },
+                        mode: _,
+                    } = resolve;
+
+                    let resolve_attachment_desc = attachments
+                        .get(resolve_attachment as usize)
+                        .ok_or_else(|| ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].depth_attachment.resolve.attachment_ref\
+                                .attachment` is not less than the length of `attachments`",
+                                subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-pSubpasses-06473"],
+                            ..Default::default()
+                        })?;
+
+                    let is_first_use =
+                        !replace(&mut attachment_is_used[resolve_attachment as usize], true);
+
+                    if is_first_use
+                        && attachment_desc.load_op == LoadOp::Clear
+                        && !resolve_layout.is_writable(ImageAspect::Depth)
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {0} is first used in subpass {1} in \
+                                `depth_attachment.resolve.attachment_ref`, and \
+                                `attachments[{0}].load_op` is `LoadOp::Clear`, but \
+                                `depth_attachment.resolve.attachment_ref.layout` \
+                                does not have a writable depth aspect",
+                                attachment, subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-pAttachments-02522"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if !attachment_potential_format_features[attachment as usize]
+                        .intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT)
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {} is used in subpass {} in \
+                                `depth_attachment.resolve.attachment_ref`, \
+                                but the potential format features of `attachments[{0}].format` \
+                                do not include `FormatFeatures::DEPTH_STENCIL_ATTACHMENT`",
+                                attachment, subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-02651"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if resolve_attachment_desc.samples != SampleCount::Sample1 {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {} is used in subpass {} in \
+                                `depth_attachment.resolve.attachment_ref`, but \
+                                `attachments[{0}].samples` is not `SampleCount::Sample1`",
+                                resolve_attachment, subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03180"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if attachment_desc.samples == SampleCount::Sample1 {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {0} is used in subpass {1} in \
+                                `depth_attachments.attachment_ref`, and
+                                `depth_attachments.resolve.attachment_ref` is not \
+                                `None`, but `attachments[{0}].samples` is `SampleCount::Sample1`",
+                                attachment, subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03179"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if !(resolve_attachment_desc.format.unwrap().components()[0]
+                        == attachment_desc.format.unwrap().components()[0]
+                        && resolve_attachment_desc.format.unwrap().type_depth()
+                            == attachment_desc.format.unwrap().type_depth())
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "the number of bits and numeric type of the depth component of \
+                                `attachments[\
+                                subpasses[{0}].depth_attachment.resolve.attachment_ref\
+                                .attachment].format` is not equal to \
+                                the number of bits and numeric type of the depth component of \
+                                `attachments[\
+                                subpasses[{0}].depth_attachment.attachment_ref\
+                                .attachment].format`",
+                                subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03181"],
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+
+            if let Some(stencil_attachment) = stencil_attachment.as_ref() {
+                let &ResolvableAttachmentReference {
+                    attachment_ref:
+                        AttachmentReference {
+                            attachment,
+                            layout,
+                            _ne: _,
+                        },
+                    ref resolve,
+                } = stencil_attachment;
+
+                let attachment_desc =
+                    attachments
+                        .get(attachment as usize)
+                        .ok_or_else(|| ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].stencil_attachment.attachment_ref.attachment` \
+                                is not less than the length of `attachments`",
+                                subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                            ..Default::default()
+                        })?;
+
+                let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
+
+                if is_first_use
+                    && attachment_desc.stencil_load_op == LoadOp::Clear
+                    && !layout.is_writable(ImageAspect::Stencil)
+                {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "attachment {0} is first used in subpass {1} in \
+                            `stencil_attachment.attachment_ref`, and \
+                            `attachments[{0}].stencil_load_op` is `LoadOp::Clear`, but \
+                            `stencil_attachment.attachment_ref.layout` \
+                            does not have a writable stencil aspect",
+                            attachment, subpass_index,
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-pAttachments-02522"],
+                        ..Default::default()
+                    });
+                }
+
+                if !attachment_potential_format_features[attachment as usize]
+                    .intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT)
+                {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "attachment {} is used in subpass {} in \
+                            `stencil_attachment.attachment_ref`, \
+                            but the potential format features of `attachments[{0}].format` \
+                            do not include `FormatFeatures::DEPTH_STENCIL_ATTACHMENT`",
+                            attachment, subpass_index,
+                        )
+                        .into(),
+                        vuids: &["VUID-VkSubpassDescription2-pDepthStencilAttachment-02900"],
+                        ..Default::default()
+                    });
+                }
+
+                if let Some(samples) = color_samples {
+                    if samples != attachment_desc.samples {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].stencil_attachment.attachment_ref` uses an \
+                                attachment with a different number of samples than other color,
+                                depth and stencil attachments in the subpass",
+                                subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescription2-pColorAttachments-03069"],
+                            ..Default::default()
+                        });
+                    }
+                }
+
+                if let Some(resolve) = resolve {
+                    let &ResolveAttachmentReference {
+                        attachment_ref:
+                            AttachmentReference {
+                                attachment: resolve_attachment,
+                                layout: resolve_layout,
+                                _ne: _,
+                            },
+                        mode: _,
+                    } = resolve;
+
+                    let resolve_attachment_desc = attachments
+                        .get(resolve_attachment as usize)
+                        .ok_or_else(|| ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].stencil_attachment.resolve.attachment_ref\
+                                .attachment` is not less than the length of `attachments`",
+                                subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-pSubpasses-06473"],
+                            ..Default::default()
+                        })?;
+
+                    let is_first_use =
+                        !replace(&mut attachment_is_used[resolve_attachment as usize], true);
+
+                    if is_first_use
+                        && attachment_desc.stencil_load_op == LoadOp::Clear
+                        && !resolve_layout.is_writable(ImageAspect::Stencil)
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {0} is first used in subpass {1} in \
+                                `stencil_attachment.resolve.attachment_ref`, and \
+                                `attachments[{0}].stencil_load_op` is `LoadOp::Clear`, but \
+                                `stencil_attachment.resolve.attachment_ref.layout` \
+                                does not have a writable stencil aspect",
+                                attachment, subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-pAttachments-02522"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if !attachment_potential_format_features[attachment as usize]
+                        .intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT)
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {} is used in subpass {} in \
+                                `stencil_attachment.resolve.attachment_ref`, \
+                                but the potential format features of `attachments[{0}].format` \
+                                do not include `FormatFeatures::DEPTH_STENCIL_ATTACHMENT`",
+                                attachment, subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-02651"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if resolve_attachment_desc.samples != SampleCount::Sample1 {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {} is used in subpass {} in \
+                                `stencil_attachment.resolve.attachment_ref`, but \
+                                `attachments[{0}].samples` is not `SampleCount::Sample1`",
+                                resolve_attachment, subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03180"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if attachment_desc.samples == SampleCount::Sample1 {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {0} is used in subpass {1} in \
+                                `stencil_attachments.attachment_ref`, and
+                                `stencil_attachments.resolve.attachment_ref` is not \
+                                `None`, but `attachments[{0}].samples` is `SampleCount::Sample1`",
+                                attachment, subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03179"],
+                            ..Default::default()
+                        });
+                    }
+
+                    if !(resolve_attachment_desc.format.unwrap().components()[1]
+                        == attachment_desc.format.unwrap().components()[1]
+                        && resolve_attachment_desc.format.unwrap().type_stencil()
+                            == attachment_desc.format.unwrap().type_stencil())
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "the number of bits and numeric type of the stencil component of \
+                                `attachments[\
+                                subpasses[{0}].stencil_attachment.resolve.attachment_ref\
+                                .attachment].format` is not equal to \
+                                the number of bits and numeric type of the stencil component of \
+                                `attachments[\
+                                subpasses[{0}].stencil_attachment.attachment_ref\
+                                .attachment].format`",
+                                subpass_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03181"],
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+
+            for (ref_index, input_attachment) in input_attachments
+                .iter()
+                .enumerate()
+                .flat_map(|(i, a)| a.as_ref().map(|a| (i, a)))
+            {
+                let &InputAttachmentReference {
+                    attachment_ref:
+                        AttachmentReference {
+                            attachment,
+                            layout: _,
+                            _ne: _,
+                        },
+                    aspects,
+                } = input_attachment;
+
+                let attachment_desc =
+                    attachments
+                        .get(attachment as usize)
+                        .ok_or_else(|| ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].input_attachments[{}].attachment_ref.attachment` \
+                                is not less than the length of `attachments`",
+                                subpass_index, ref_index
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                            ..Default::default()
+                        })?;
+
+                let format_aspects = attachment_desc.format.unwrap().aspects();
+                let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
+
+                if is_first_use {
+                    if attachment_desc.load_op == LoadOp::Clear {
+                        if format_aspects.intersects(ImageAspects::COLOR) {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "attachment {0} has a color component, \
+                                    is first used in subpass {1} in \
+                                    `input_attachments[{2}].attachment_ref`, and \
+                                    `attachments[{0}].load_op` is `LoadOp::Clear`",
+                                    attachment, subpass_index, ref_index
+                                )
+                                .into(),
+                                vuids: &["VUID-VkSubpassDescription2-loadOp-03064"],
+                                ..Default::default()
+                            });
+                        }
+
+                        if format_aspects.intersects(ImageAspects::DEPTH) {
+                            return Err(ValidationError {
+                                problem: format!(
+                                    "attachment {0} has a depth component, \
+                                    is first used in subpass {1} in \
+                                    `input_attachments[{2}].attachment_ref`, and \
+                                    `attachments[{0}].load_op` is `LoadOp::Clear`",
+                                    attachment, subpass_index, ref_index
+                                )
+                                .into(),
+                                vuids: &["VUID-VkSubpassDescription2-loadOp-03064"],
+                                ..Default::default()
+                            });
+                        }
+                    }
+
+                    if attachment_desc.stencil_load_op == LoadOp::Clear
+                        && format_aspects.intersects(ImageAspects::STENCIL)
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "attachment {0} has a stencil component, \
+                                is first used in subpass {1} in \
+                                `input_attachments[{2}].attachment_ref`, and \
+                                `attachments[{0}].stencil_load_op` is `LoadOp::Clear`",
+                                attachment, subpass_index, ref_index
+                            )
+                            .into(),
+                            // vuids?
+                            ..Default::default()
+                        });
+                    }
+                }
+
+                if !attachment_potential_format_features[attachment as usize].intersects(
+                    FormatFeatures::COLOR_ATTACHMENT | FormatFeatures::DEPTH_STENCIL_ATTACHMENT,
+                ) {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "attachment {} is used in subpass {} in \
+                            `input_attachments[{}].attachment_ref`, \
+                            but the potential format features of `attachments[{0}].format` \
+                            do not include `FormatFeatures::COLOR_ATTACHMENT` or \
+                            `FormatFeatures::DEPTH_STENCIL_ATTACHMENT`",
+                            attachment, subpass_index, ref_index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkSubpassDescription2-pInputAttachments-02897"],
+                        ..Default::default()
+                    });
+                }
+
+                if aspects != format_aspects {
+                    if !(device.api_version() >= Version::V1_1
+                        || device.enabled_extensions().khr_create_renderpass2
+                        || device.enabled_extensions().khr_maintenance2)
+                    {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].input_attachments[{}].aspects` does not \
+                                equal the aspects of \
+                                `attachments[subpasses[{0}].input_attachments[{1}].attachment]\
+                                .format`",
+                                subpass_index, ref_index,
+                            )
+                            .into(),
+                            requires_one_of: RequiresOneOf {
+                                api_version: Some(Version::V1_1),
+                                device_extensions: &["khr_create_renderpass2", "khr_maintenance2"],
+                                ..Default::default()
+                            },
+                            // vuids?
+                            ..Default::default()
+                        });
+                    }
+
+                    if !format_aspects.contains(aspects) {
+                        return Err(ValidationError {
+                            problem: format!(
+                                "`subpasses[{}].input_attachments[{}].aspects` is not a subset of \
+                                the aspects of \
+                                `attachments[subpasses[{0}].input_attachments[{1}].attachment]\
+                                .format`",
+                                subpass_index, ref_index,
+                            )
+                            .into(),
+                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-02525"],
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+
+            for (ref_index, &atch) in preserve_attachments.iter().enumerate() {
+                if atch as usize >= attachments.len() {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "`subpasses[{}].preserve_attachments[{}]` \
+                            is not less than the length of `attachments`",
+                            subpass_index, ref_index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        for (dependency_index, dependency) in dependencies.iter().enumerate() {
+            // VUID-VkRenderPassCreateInfo2-pDependencies-parameter
+            dependency
+                .validate(device)
+                .map_err(|err| err.add_context(format!("dependencies[{}]", dependency_index)))?;
+
+            let &SubpassDependency {
+                src_subpass,
+                dst_subpass,
+                src_stages,
+                dst_stages,
+                src_access: _,
+                dst_access: _,
+                dependency_flags,
+                view_offset: _,
+                _ne: _,
+            } = dependency;
+
+            if subpasses[0].view_mask == 0
+                && dependency_flags.intersects(DependencyFlags::VIEW_LOCAL)
+            {
+                return Err(ValidationError {
+                    problem: format!(
+                        "`subpasses[0].view_mask` is 0, and `dependencies[{}].dependency_flags` \
+                        includes `DependencyFlags::VIEW_LOCAL`",
+                        dependency_index,
+                    )
+                    .into(),
+                    vuids: &["VUID-VkRenderPassCreateInfo2-viewMask-03059"],
+                    ..Default::default()
+                });
+            }
+
+            if let Some(src_subpass) = src_subpass {
+                if src_subpass as usize >= subpasses.len() {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "`dependencies[{}].src_subpass` is not less than the length of 
+                            `subpasses`",
+                            dependency_index,
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-srcSubpass-02526"],
+                        ..Default::default()
+                    });
+                }
+            }
+
+            if let Some(dst_subpass) = dst_subpass {
+                if dst_subpass as usize >= subpasses.len() {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "`dependencies[{}].dst_subpass` is not less than the length of 
+                            `subpasses`",
+                            dependency_index,
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-dstSubpass-02527"],
+                        ..Default::default()
+                    });
+                }
+            }
+
+            if !PipelineStages::from(QueueFlags::GRAPHICS).contains(src_stages) {
+                return Err(ValidationError {
+                    context: format!("dependencies[{}].src_stages", dependency_index,).into(),
+                    problem: "contains a non-graphics stage".into(),
+                    vuids: &["VUID-VkRenderPassCreateInfo2-pDependencies-03054"],
+                    ..Default::default()
+                });
+            }
+
+            if !PipelineStages::from(QueueFlags::GRAPHICS).contains(dst_stages) {
+                return Err(ValidationError {
+                    context: format!("dependencies[{}].dst_stages", dependency_index,).into(),
+                    problem: "contains a non-graphics stage".into(),
+                    vuids: &["VUID-VkRenderPassCreateInfo2-pDependencies-03055"],
+                    ..Default::default()
+                });
+            }
+
+            if let (Some(src_subpass), Some(dst_subpass)) = (src_subpass, dst_subpass) {
+                if src_subpass == dst_subpass
+                    && subpasses[src_subpass as usize].view_mask.count_ones() > 1
+                    && !dependency_flags.intersects(DependencyFlags::VIEW_LOCAL)
+                {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "`dependencies[{0}].src_subpass` equals \
+                            `dependencies[{0}].dst_subpass`, and \
+                            `subpasses[dependencies[{0}].src_subpass].view_mask` has more than \
+                            one bit set, and `dependencies[{0}].dependency_flags` does not \
+                            contain `DependencyFlags::VIEW_LOCAL`",
+                            dependency_index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-pDependencies-03060"],
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        if !correlated_view_masks.is_empty() {
+            if subpasses[0].view_mask == 0 {
+                return Err(ValidationError {
+                    problem: "`correlated_view_masks` is not empty, but \
+                        `subpasses[0].view_mask` is zero"
+                        .into(),
+                    vuids: &["VUID-VkRenderPassCreateInfo2-viewMask-03057"],
+                    ..Default::default()
+                });
+            }
+
+            correlated_view_masks.iter().try_fold(0, |total, &mask| {
+                if total & mask != 0 {
+                    Err(ValidationError {
+                        context: "correlated_view_masks".into(),
+                        problem: "the bit masks overlap with each other".into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-pCorrelatedViewMasks-03056"],
+                        ..Default::default()
+                    })
+                } else {
+                    Ok(total | mask)
+                }
+            })?;
+        }
+
+        Ok(())
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    RenderPassCreateFlags = RenderPassCreateFlags(u32);
+
+    /* TODO: enable
+    // TODO: document
+    TRANSFORM = TRANSFORM_QCOM {
+        device_extensions: [qcom_render_pass_transform],
+    }, */
+}
+
 /// Describes an attachment that will be used in a render pass.
 #[derive(Clone, Copy, Debug)]
 pub struct AttachmentDescription {
+    /// Additional properties of the attachment.
+    ///
+    /// The default value is empty.
+    pub flags: AttachmentDescriptionFlags,
+
     /// The format of the image that is going to be bound.
     ///
     /// The default value is `None`, which must be overridden.
@@ -783,6 +1919,19 @@ pub struct AttachmentDescription {
     /// The default value is [`StoreOp::DontCare`].
     pub store_op: StoreOp,
 
+    /// The layout that the image must in at the start of the render pass.
+    ///
+    /// The vulkano library will automatically switch to the correct layout if necessary, but it
+    /// is more efficient to set this to the correct value.
+    ///
+    /// The default value is [`ImageLayout::Undefined`].
+    pub initial_layout: ImageLayout,
+
+    /// The layout that the image will be transitioned to at the end of the render pass.
+    ///
+    /// The default value is [`ImageLayout::Undefined`], which must be overridden.
+    pub final_layout: ImageLayout,
+
     /// The equivalent of `load_op` for the stencil component of the attachment, if any. Irrelevant
     /// if there is no stencil component.
     ///
@@ -795,18 +1944,25 @@ pub struct AttachmentDescription {
     /// The default value is [`StoreOp::DontCare`].
     pub stencil_store_op: StoreOp,
 
-    /// The layout that the image must in at the start of the render pass.
+    /// The equivalent of `initial_layout` for the stencil component of the attachment, if any.
+    /// Irrelevant if there is no stencil component.
     ///
-    /// The vulkano library will automatically switch to the correct layout if necessary, but it
-    /// is more efficient to set this to the correct value.
+    /// If this is not the same as `initial_layout`, the
+    /// [`separate_depth_stencil_layouts`](crate::device::Features::separate_depth_stencil_layouts)
+    /// feature must be enabled on the device.
     ///
-    /// The default value is [`ImageLayout::Undefined`], which must be overridden.
-    pub initial_layout: ImageLayout,
+    /// The default value is [`ImageLayout::Undefined`].
+    pub stencil_initial_layout: ImageLayout,
 
-    /// The layout that the image will be transitioned to at the end of the render pass.
+    /// The equivalent of `final_layout` for the stencil component of the attachment, if any.
+    /// Irrelevant if there is no stencil component.
+    ///
+    /// If this is not the same as `final_layout`, the
+    /// [`separate_depth_stencil_layouts`](crate::device::Features::separate_depth_stencil_layouts)
+    /// feature must be enabled on the device.
     ///
     /// The default value is [`ImageLayout::Undefined`], which must be overridden.
-    pub final_layout: ImageLayout,
+    pub stencil_final_layout: ImageLayout,
 
     pub _ne: crate::NonExhaustive,
 }
@@ -815,17 +1971,298 @@ impl Default for AttachmentDescription {
     #[inline]
     fn default() -> Self {
         Self {
+            flags: AttachmentDescriptionFlags::empty(),
             format: None,
             samples: SampleCount::Sample1,
             load_op: LoadOp::DontCare,
             store_op: StoreOp::DontCare,
-            stencil_load_op: LoadOp::DontCare,
-            stencil_store_op: StoreOp::DontCare,
             initial_layout: ImageLayout::Undefined,
             final_layout: ImageLayout::Undefined,
+            stencil_load_op: LoadOp::DontCare,
+            stencil_store_op: StoreOp::DontCare,
+            stencil_initial_layout: ImageLayout::Undefined,
+            stencil_final_layout: ImageLayout::Undefined,
             _ne: crate::NonExhaustive(()),
         }
     }
+}
+
+impl AttachmentDescription {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            flags,
+            format,
+            samples,
+            load_op,
+            store_op,
+            initial_layout,
+            final_layout,
+            stencil_load_op,
+            stencil_store_op,
+            stencil_initial_layout,
+            stencil_final_layout,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkAttachmentDescription2-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        let format = format.ok_or_else(|| ValidationError {
+            context: "format".into(),
+            problem: "is None".into(),
+            vuids: &["VUID-VkAttachmentDescription2-format-06698"],
+            ..Default::default()
+        })?;
+
+        format
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "format".into(),
+                vuids: &["VUID-VkAttachmentDescription2-format-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        samples
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "samples".into(),
+                vuids: &["VUID-VkAttachmentDescription2-samples-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        load_op
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "load_op".into(),
+                vuids: &["VUID-VkAttachmentDescription2-loadOp-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        store_op
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "store_op".into(),
+                vuids: &["VUID-VkAttachmentDescription2-storeOp-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        initial_layout
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "initial_layout".into(),
+                vuids: &["VUID-VkAttachmentDescription2-initialLayout-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        final_layout
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "final_layout".into(),
+                vuids: &["VUID-VkAttachmentDescription2-finalLayout-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        stencil_load_op
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "stencil_load_op".into(),
+                vuids: &["VUID-VkAttachmentDescription2-stencilLoadOp-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        stencil_store_op
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "stencil_store_op".into(),
+                vuids: &["VUID-VkAttachmentDescription2-stencilStoreOp-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        stencil_initial_layout
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "stencil_initial_layout".into(),
+                vuids: &[
+                    "VUID-VkAttachmentDescriptionStencilLayout-stencilInitialLayout-parameter",
+                ],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        stencil_final_layout
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "stencil_final_layout".into(),
+                vuids: &["VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        let aspects = format.aspects();
+
+        if matches!(
+            final_layout,
+            ImageLayout::Undefined | ImageLayout::Preinitialized
+        ) {
+            return Err(ValidationError {
+                context: "final_layout".into(),
+                problem: "is `ImageLayout::Undefined` or `ImageLayout::Preinitialized`".into(),
+                vuids: &["VUID-VkAttachmentDescription2-finalLayout-03061"],
+                ..Default::default()
+            });
+        }
+
+        if aspects.intersects(ImageAspects::COLOR) {
+            if initial_layout.layout_for(ImageAspect::Color).is_none() {
+                return Err(ValidationError {
+                    problem: "`format` has a color component, but `initial_layout` cannot be \
+                        used with color formats"
+                        .into(),
+                    vuids: &[
+                        "VUID-VkAttachmentDescription2-format-03280",
+                        "VUID-VkAttachmentDescription2-format-06487",
+                    ],
+                    ..Default::default()
+                });
+            }
+
+            if final_layout.layout_for(ImageAspect::Color).is_none() {
+                return Err(ValidationError {
+                    problem: "`format` has a color component, but `final_layout` cannot be \
+                        used with color formats"
+                        .into(),
+                    vuids: &[
+                        "VUID-VkAttachmentDescription2-format-03282",
+                        "VUID-VkAttachmentDescription2-format-06488",
+                    ],
+                    ..Default::default()
+                });
+            }
+
+            if load_op == LoadOp::Load && initial_layout == ImageLayout::Undefined {
+                return Err(ValidationError {
+                    problem: "`format` has a color component, `load_op` is \
+                        `LoadOp::Load`, and `initial_layout` is `ImageLayout::Undefined`"
+                        .into(),
+                    vuids: &["VUID-VkAttachmentDescription2-format-06699"],
+                    ..Default::default()
+                });
+            }
+        }
+
+        if aspects.intersects(ImageAspects::DEPTH) {
+            if initial_layout.layout_for(ImageAspect::Depth).is_none() {
+                return Err(ValidationError {
+                    problem: "`format` has a depth component, but `initial_layout` cannot be \
+                        used with depth formats"
+                        .into(),
+                    vuids: &["VUID-VkAttachmentDescription2-format-03281"],
+                    ..Default::default()
+                });
+            }
+
+            if final_layout.layout_for(ImageAspect::Depth).is_none() {
+                return Err(ValidationError {
+                    problem: "`format` has a depth component, but `final_layout` cannot be \
+                        used with depth formats"
+                        .into(),
+                    vuids: &["VUID-VkAttachmentDescription2-format-03283"],
+                    ..Default::default()
+                });
+            }
+
+            if load_op == LoadOp::Load && initial_layout == ImageLayout::Undefined {
+                return Err(ValidationError {
+                    problem: "`format` has a depth component, `load_op` is \
+                        `LoadOp::Load`, and `initial_layout` is `ImageLayout::Undefined`"
+                        .into(),
+                    vuids: &["VUID-VkAttachmentDescription2-format-06699"],
+                    ..Default::default()
+                });
+            }
+        }
+
+        if aspects.intersects(ImageAspects::STENCIL) {
+            if initial_layout.layout_for(ImageAspect::Stencil).is_none() {
+                return Err(ValidationError {
+                    problem: "`format` has a stencil component, but `initial_layout` cannot be \
+                        used with stencil formats"
+                        .into(),
+                    vuids: &["VUID-VkAttachmentDescription2-format-03281"],
+                    ..Default::default()
+                });
+            }
+
+            if final_layout.layout_for(ImageAspect::Stencil).is_none() {
+                return Err(ValidationError {
+                    problem: "`format` has a stencil component, but `final_layout` cannot be \
+                        used with stencil formats"
+                        .into(),
+                    vuids: &["VUID-VkAttachmentDescription2-format-03283"],
+                    ..Default::default()
+                });
+            }
+
+            if stencil_load_op == LoadOp::Load && initial_layout == ImageLayout::Undefined {
+                return Err(ValidationError {
+                    problem: "`format` has a stencil component, `stencil_load_op` is \
+                        `LoadOp::Load`, and `initial_layout` is `ImageLayout::Undefined`"
+                        .into(),
+                    vuids: &["VUID-VkAttachmentDescription2-pNext-06704"],
+                    ..Default::default()
+                });
+            }
+        }
+
+        if aspects.contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
+            && !device.enabled_features().separate_depth_stencil_layouts
+        {
+            if initial_layout != stencil_initial_layout {
+                return Err(ValidationError {
+                    problem: "`format` has both a depth and a stencil component, and \
+                        `initial_layout` does not equal `stencil_initial_layout`"
+                        .into(),
+                    requires_one_of: RequiresOneOf {
+                        features: &["separate_depth_stencil_layouts"],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+            }
+
+            if final_layout != stencil_final_layout {
+                return Err(ValidationError {
+                    problem: "`format` has both a depth and a stencil component, and \
+                        `final_layout` does not equal `stencil_final_layout`"
+                        .into(),
+                    requires_one_of: RequiresOneOf {
+                        features: &["separate_depth_stencil_layouts"],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+            }
+        }
+
+        // VUID-VkAttachmentDescription2-samples-08745
+        // TODO: How do you check this?
+
+        Ok(())
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Flags specifying additional properties of a render pass attachment description.
+    AttachmentDescriptionFlags = AttachmentDescriptionFlags(u32);
+
+    /* TODO: enable
+    // TODO: document
+    MAY_ALIAS = MAY_ALIAS, */
 }
 
 /// Describes one of the subpasses of a render pass.
@@ -842,6 +2279,11 @@ impl Default for AttachmentDescription {
 /// the same as well.
 #[derive(Debug, Clone)]
 pub struct SubpassDescription {
+    /// Additional properties of the subpass.
+    ///
+    /// The default value is empty.
+    pub flags: SubpassDescriptionFlags,
+
     /// If not `0`, enables multiview rendering, and specifies the view indices that are rendered to
     /// in this subpass. The value is a bitmask, so that that for example `0b11` will draw to the
     /// first two views and `0b101` will draw to the first and third view.
@@ -859,7 +2301,7 @@ pub struct SubpassDescription {
     /// must not be [`LoadOp::Clear`].
     ///
     /// The default value is empty.
-    pub input_attachments: Vec<Option<AttachmentReference>>,
+    pub input_attachments: Vec<Option<InputAttachmentReference>>,
 
     /// The attachments of the render pass that are to be used as color attachments in this subpass.
     ///
@@ -868,28 +2310,43 @@ pub struct SubpassDescription {
     /// physical device. All color attachments must have the same `samples` value.
     ///
     /// The default value is empty.
-    pub color_attachments: Vec<Option<AttachmentReference>>,
+    pub color_attachments: Vec<Option<ResolvableAttachmentReference>>,
 
-    /// The attachments of the render pass that are to be used as resolve attachments in this
-    /// subpass.
-    ///
-    /// This list must either be empty or have the same length as `color_attachments`. If it's not
-    /// empty, then each resolve attachment is paired with the color attachment of the same index.
-    /// The resolve attachments must all have a `samples` value of [`SampleCount::Sample1`], while
-    /// the color attachments must have a `samples` value other than [`SampleCount::Sample1`].
-    /// Each resolve attachment must have the same `format` as the corresponding color attachment.
-    ///
-    /// The default value is empty.
-    pub resolve_attachments: Vec<Option<AttachmentReference>>,
-
-    /// The single attachment of the render pass that is to be used as depth-stencil attachment in
+    /// The single attachment of the render pass that is to be used as depth attachment in
     /// this subpass.
     ///
     /// If set to `Some`, the referenced attachment must have the same `samples` value as those in
-    /// `color_attachments`.
+    /// `color_attachments`. If the resolve attachment is also `Some`, then the device API version
+    /// must be at least 1.1, or the
+    /// [`khr_depth_stencil_resolve`](crate::device::DeviceExtensions::khr_depth_stencil_resolve)
+    /// extension must be enabled on the device.
+    ///
+    /// If both `depth_attachment` and `stencil_attachment` are `Some`, then the attachment and
+    /// resolve attachment must be the same, but they can have different layouts and resolve modes.
+    /// If the layouts differ, then the
+    /// [`separate_depth_stencil_layouts`](crate::device::Features::separate_depth_stencil_layouts)
+    /// feature must be enabled on the device.
     ///
     /// The default value is `None`.
-    pub depth_stencil_attachment: Option<AttachmentReference>,
+    pub depth_attachment: Option<ResolvableAttachmentReference>,
+
+    /// The single attachment of the render pass that is to be used as stencil attachment in
+    /// this subpass.
+    ///
+    /// If set to `Some`, the referenced attachment must have the same `samples` value as those in
+    /// `color_attachments`. If the resolve attachment is also `Some`, then the device API version
+    /// must be at least 1.1, or the
+    /// [`khr_depth_stencil_resolve`](crate::device::DeviceExtensions::khr_depth_stencil_resolve)
+    /// extension must be enabled on the device.
+    ///
+    /// If both `depth_attachment` and `stencil_attachment` are `Some`, then the attachment and
+    /// resolve attachment must be the same, but they can have different layouts and resolve modes.
+    /// If the layouts differ, then the
+    /// [`separate_depth_stencil_layouts`](crate::device::Features::separate_depth_stencil_layouts)
+    /// feature must be enabled on the device.
+    ///
+    /// The default value is `None`.
+    pub stencil_attachment: Option<ResolvableAttachmentReference>,
 
     /// The indices of attachments of the render pass that will be preserved during this subpass.
     ///
@@ -905,18 +2362,880 @@ impl Default for SubpassDescription {
     #[inline]
     fn default() -> Self {
         Self {
+            flags: SubpassDescriptionFlags::empty(),
             view_mask: 0,
             color_attachments: Vec::new(),
-            depth_stencil_attachment: None,
+            depth_attachment: None,
+            stencil_attachment: None,
             input_attachments: Vec::new(),
-            resolve_attachments: Vec::new(),
             preserve_attachments: Vec::new(),
             _ne: crate::NonExhaustive(()),
         }
     }
 }
 
-/// A reference in a subpass description to a particular attachment of the render pass.
+impl SubpassDescription {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let properties = device.physical_device().properties();
+
+        let &Self {
+            flags,
+            view_mask,
+            ref input_attachments,
+            ref color_attachments,
+            ref depth_attachment,
+            ref stencil_attachment,
+            ref preserve_attachments,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkSubpassDescription2-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if color_attachments.len() as u32 > properties.max_color_attachments {
+            return Err(ValidationError {
+                context: "color_attachments".into(),
+                problem: "the number of elements is greater than the `max_color_attachments` limit"
+                    .into(),
+                vuids: &["VUID-VkSubpassDescription2-colorAttachmentCount-03063"],
+                ..Default::default()
+            });
+        }
+
+        // Track the layout of each attachment used in this subpass
+        let mut layouts = HashMap::default();
+
+        for (ref_index, color_attachment) in color_attachments
+            .iter()
+            .enumerate()
+            .flat_map(|(i, a)| a.as_ref().map(|a| (i, a)))
+        {
+            // VUID-VkSubpassDescription2-pColorAttachments-parameter
+            // VUID-VkSubpassDescription2-pResolveAttachments-parameter
+            color_attachment
+                .validate(device)
+                .map_err(|err| err.add_context(format!("color_attachments[{}]", ref_index)))?;
+
+            let &ResolvableAttachmentReference {
+                attachment_ref:
+                    AttachmentReference {
+                        attachment,
+                        layout,
+                        _ne: _,
+                    },
+                ref resolve,
+            } = color_attachment;
+
+            if preserve_attachments.contains(&attachment) {
+                return Err(ValidationError {
+                    problem: format!(
+                        "`color_attachments[{}].attachment_ref.attachment` also occurs in \
+                        `preserve_attachments`",
+                        ref_index
+                    )
+                    .into(),
+                    vuids: &["VUID-VkSubpassDescription2-pPreserveAttachments-03074"],
+                    ..Default::default()
+                });
+            }
+
+            if matches!(layout, ImageLayout::ShaderReadOnlyOptimal) {
+                return Err(ValidationError {
+                    context: format!("color_attachments[{}].attachment_ref.layout", ref_index)
+                        .into(),
+                    problem: "is `ImageLayout::ShaderReadOnlyOptimal`".into(),
+                    vuids: &["VUID-VkSubpassDescription2-attachment-06913"],
+                    ..Default::default()
+                });
+            }
+
+            if layout.layout_for(ImageAspect::Color).is_none() {
+                return Err(ValidationError {
+                    context: format!("color_attachments[{}].attachment_ref.layout", ref_index)
+                        .into(),
+                    problem: "cannot be used with color attachments".into(),
+                    vuids: &[
+                        "VUID-VkSubpassDescription2-attachment-06913",
+                        "VUID-VkSubpassDescription2-attachment-06916",
+                        "VUID-VkSubpassDescription2-attachment-06919",
+                    ],
+                    ..Default::default()
+                });
+            }
+
+            match layouts.entry(attachment) {
+                Entry::Occupied(entry) => {
+                    if *entry.get() != layout {
+                        return Err(ValidationError {
+                            context: format!(
+                                "color_attachments[{}].attachment_ref.layout",
+                                ref_index
+                            )
+                            .into(),
+                            problem: "is not equal to the layout used for this attachment \
+                                elsewhere in this subpass"
+                                .into(),
+                            vuids: &["VUID-VkSubpassDescription2-layout-02528"],
+                            ..Default::default()
+                        });
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(layout);
+                }
+            }
+
+            if let Some(resolve) = resolve {
+                let &ResolveAttachmentReference {
+                    attachment_ref:
+                        AttachmentReference {
+                            attachment: resolve_attachment,
+                            layout: resolve_layout,
+                            _ne: _,
+                        },
+                    mode: _,
+                } = resolve;
+
+                if preserve_attachments.contains(&resolve_attachment) {
+                    return Err(ValidationError {
+                        problem: format!(
+                            "`color_attachments[{}].resolve.attachment_ref.attachment` \
+                            also occurs in `preserve_attachments`",
+                            ref_index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkSubpassDescription2-pPreserveAttachments-03074"],
+                        ..Default::default()
+                    });
+                }
+
+                if matches!(resolve_layout, ImageLayout::ShaderReadOnlyOptimal) {
+                    return Err(ValidationError {
+                        context: format!(
+                            "color_attachments[{}].resolve.attachment_ref.layout",
+                            ref_index
+                        )
+                        .into(),
+                        problem: "is `ImageLayout::ShaderReadOnlyOptimal`".into(),
+                        vuids: &["VUID-VkSubpassDescription2-attachment-06914"],
+                        ..Default::default()
+                    });
+                }
+
+                if resolve_layout.layout_for(ImageAspect::Color).is_none() {
+                    return Err(ValidationError {
+                        context: format!(
+                            "color_attachments[{}].resolve.attachment_ref.layout",
+                            ref_index
+                        )
+                        .into(),
+                        problem: "cannot be used with color attachments".into(),
+                        vuids: &[
+                            "VUID-VkSubpassDescription2-attachment-06914",
+                            "VUID-VkSubpassDescription2-attachment-06917",
+                            "VUID-VkSubpassDescription2-attachment-06920",
+                        ],
+                        ..Default::default()
+                    });
+                }
+
+                match layouts.entry(resolve_attachment) {
+                    Entry::Occupied(entry) => {
+                        if *entry.get() != resolve_layout {
+                            return Err(ValidationError {
+                                context: format!(
+                                    "color_attachments[{}].resolve.attachment_ref.layout",
+                                    ref_index
+                                )
+                                .into(),
+                                problem: "is not equal to the layout used for this attachment \
+                                    elsewhere in this subpass"
+                                    .into(),
+                                vuids: &["VUID-VkSubpassDescription2-layout-02528"],
+                                ..Default::default()
+                            });
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(resolve_layout);
+                    }
+                }
+            }
+        }
+
+        if let Some(depth_attachment) = depth_attachment.as_ref() {
+            // VUID-VkSubpassDescription2-pDepthStencilAttachment-parameter
+            depth_attachment
+                .validate(device)
+                .map_err(|err| err.add_context("depth_attachment"))?;
+
+            let &ResolvableAttachmentReference {
+                attachment_ref:
+                    AttachmentReference {
+                        attachment,
+                        layout,
+                        _ne: _,
+                    },
+                ref resolve,
+            } = depth_attachment;
+
+            if preserve_attachments.contains(&attachment) {
+                return Err(ValidationError {
+                    problem: "`depth_attachment.attachment_ref.attachment` also occurs in \
+                        `preserve_attachments`"
+                        .into(),
+                    vuids: &["VUID-VkSubpassDescription2-pPreserveAttachments-03074"],
+                    ..Default::default()
+                });
+            }
+
+            if matches!(layout, ImageLayout::ShaderReadOnlyOptimal) {
+                return Err(ValidationError {
+                    context: "depth_attachment.attachment_ref.layout".into(),
+                    problem: "is `ImageLayout::ShaderReadOnlyOptimal`".into(),
+                    vuids: &["VUID-VkSubpassDescription2-attachment-06915"],
+                    ..Default::default()
+                });
+            }
+
+            if layout.layout_for(ImageAspect::Depth).is_none() {
+                return Err(ValidationError {
+                    context: "depth_attachment.attachment_ref.layout".into(),
+                    problem: "cannot be used with depth attachments".into(),
+                    vuids: &["VUID-VkSubpassDescription2-attachment-06915"],
+                    ..Default::default()
+                });
+            }
+
+            match layouts.entry(attachment) {
+                Entry::Occupied(entry) => {
+                    if *entry.get() != layout {
+                        return Err(ValidationError {
+                            context: "depth_attachment.attachment_ref.layout".into(),
+                            problem: "is not equal to the layout used for this attachment \
+                                elsewhere in this subpass"
+                                .into(),
+                            vuids: &["VUID-VkSubpassDescription2-layout-02528"],
+                            ..Default::default()
+                        });
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(layout);
+                }
+            }
+
+            if color_attachments
+                .iter()
+                .flatten()
+                .any(|color_atch_ref| color_atch_ref.attachment_ref.attachment == attachment)
+            {
+                return Err(ValidationError {
+                    problem: "`depth_attachment.attachment_ref.attachment` also occurs in \
+                        `color_attachments`"
+                        .into(),
+                    vuids: &["VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"],
+                    ..Default::default()
+                });
+            }
+
+            if let Some(resolve) = resolve {
+                if !(device.api_version() >= Version::V1_1
+                    || device.enabled_extensions().khr_depth_stencil_resolve)
+                {
+                    return Err(ValidationError {
+                        context: "depth_attachment.resolve".into(),
+                        problem: "is `Some`".into(),
+                        requires_one_of: RequiresOneOf {
+                            api_version: Some(Version::V1_1),
+                            device_extensions: &["khr_depth_stencil_resolve"],
+                            ..Default::default()
+                        },
+                        // vuids?
+                        ..Default::default()
+                    });
+                }
+
+                let &ResolveAttachmentReference {
+                    attachment_ref:
+                        AttachmentReference {
+                            attachment: resolve_attachment,
+                            layout: resolve_layout,
+                            _ne: _,
+                        },
+                    mode,
+                } = resolve;
+
+                if preserve_attachments.contains(&resolve_attachment) {
+                    return Err(ValidationError {
+                        problem: "`depth_attachment.resolve.attachment_ref.attachment` \
+                            also occurs in `preserve_attachments`"
+                            .into(),
+                        vuids: &["VUID-VkSubpassDescription2-pPreserveAttachments-03074"],
+                        ..Default::default()
+                    });
+                }
+
+                if matches!(resolve_layout, ImageLayout::ShaderReadOnlyOptimal) {
+                    return Err(ValidationError {
+                        context: "depth_attachment.resolve.attachment_ref.layout".into(),
+                        problem: "is `ImageLayout::ShaderReadOnlyOptimal`".into(),
+                        vuids: &["VUID-VkSubpassDescription2-attachment-06914"],
+                        ..Default::default()
+                    });
+                }
+
+                if resolve_layout.layout_for(ImageAspect::Depth).is_none() {
+                    return Err(ValidationError {
+                        context: "depth_attachment.resolve.attachment_ref.layout".into(),
+                        problem: "cannot be used with depth attachments".into(),
+                        vuids: &[
+                            "VUID-VkSubpassDescription2-attachment-06914",
+                            "VUID-VkSubpassDescription2-attachment-06917",
+                            "VUID-VkSubpassDescription2-attachment-06920",
+                        ],
+                        ..Default::default()
+                    });
+                }
+
+                match layouts.entry(resolve_attachment) {
+                    Entry::Occupied(entry) => {
+                        if *entry.get() != resolve_layout {
+                            return Err(ValidationError {
+                                context: "depth_attachment.resolve.attachment_ref.layout".into(),
+                                problem: "is not equal to the layout used for this attachment \
+                                    elsewhere in this subpass"
+                                    .into(),
+                                vuids: &["VUID-VkSubpassDescription2-layout-02528"],
+                                ..Default::default()
+                            });
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(resolve_layout);
+                    }
+                }
+
+                if !device
+                    .physical_device()
+                    .properties()
+                    .supported_depth_resolve_modes
+                    .unwrap_or_default()
+                    .contains_enum(mode)
+                {
+                    return Err(ValidationError {
+                        problem: "depth_attachment.resolve.mode` is not one of the \
+                            modes in the `supported_depth_resolve_modes` device property"
+                            .into(),
+                        vuids: &[
+                            "VUID-VkSubpassDescriptionDepthStencilResolve-depthResolveMode-03183",
+                        ],
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        if let Some(stencil_attachment) = stencil_attachment.as_ref() {
+            // VUID-VkSubpassDescription2-pDepthStencilAttachment-parameter
+            stencil_attachment
+                .validate(device)
+                .map_err(|err| err.add_context("stencil_attachment"))?;
+
+            let &ResolvableAttachmentReference {
+                attachment_ref:
+                    AttachmentReference {
+                        attachment,
+                        layout,
+                        _ne: _,
+                    },
+                ref resolve,
+            } = stencil_attachment;
+
+            if preserve_attachments.contains(&attachment) {
+                return Err(ValidationError {
+                    problem: "`stencil_attachment.attachment_ref.attachment` also occurs in \
+                        `preserve_attachments`"
+                        .into(),
+                    vuids: &["VUID-VkSubpassDescription2-pPreserveAttachments-03074"],
+                    ..Default::default()
+                });
+            }
+
+            if matches!(layout, ImageLayout::ShaderReadOnlyOptimal) {
+                return Err(ValidationError {
+                    context: "stencil_attachment.attachment_ref.layout".into(),
+                    problem: "is `ImageLayout::ShaderReadOnlyOptimal`".into(),
+                    vuids: &["VUID-VkSubpassDescription2-attachment-06915"],
+                    ..Default::default()
+                });
+            }
+
+            if layout.layout_for(ImageAspect::Stencil).is_none() {
+                return Err(ValidationError {
+                    context: "stencil_attachment.attachment_ref.layout".into(),
+                    problem: "cannot be used with stencil attachments".into(),
+                    vuids: &["VUID-VkSubpassDescription2-attachment-06915"],
+                    ..Default::default()
+                });
+            }
+
+            match layouts.entry(attachment) {
+                Entry::Occupied(entry) => {
+                    if *entry.get() != layout {
+                        return Err(ValidationError {
+                            context: "stencil_attachment.attachment_ref.layout".into(),
+                            problem: "is not equal to the layout used for this attachment \
+                                elsewhere in this subpass"
+                                .into(),
+                            vuids: &["VUID-VkSubpassDescription2-layout-02528"],
+                            ..Default::default()
+                        });
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(layout);
+                }
+            }
+
+            if color_attachments
+                .iter()
+                .flatten()
+                .any(|color_atch_ref| color_atch_ref.attachment_ref.attachment == attachment)
+            {
+                return Err(ValidationError {
+                    problem: "`stencil_attachment.attachment_ref.attachment` also occurs in \
+                        `color_attachments`"
+                        .into(),
+                    vuids: &["VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"],
+                    ..Default::default()
+                });
+            }
+
+            if let Some(resolve) = resolve {
+                if !(device.api_version() >= Version::V1_1
+                    || device.enabled_extensions().khr_depth_stencil_resolve)
+                {
+                    return Err(ValidationError {
+                        context: "stencil_attachment.resolve".into(),
+                        problem: "is `Some`".into(),
+                        requires_one_of: RequiresOneOf {
+                            api_version: Some(Version::V1_1),
+                            device_extensions: &["khr_depth_stencil_resolve"],
+                            ..Default::default()
+                        },
+                        // vuids?
+                        ..Default::default()
+                    });
+                }
+
+                let &ResolveAttachmentReference {
+                    attachment_ref:
+                        AttachmentReference {
+                            attachment: resolve_attachment,
+                            layout: resolve_layout,
+                            _ne: _,
+                        },
+                    mode,
+                } = resolve;
+
+                if preserve_attachments.contains(&resolve_attachment) {
+                    return Err(ValidationError {
+                        problem: "`stencil_attachment.resolve.attachment_ref.attachment` \
+                            also occurs in `preserve_attachments`"
+                            .into(),
+                        vuids: &["VUID-VkSubpassDescription2-pPreserveAttachments-03074"],
+                        ..Default::default()
+                    });
+                }
+
+                if matches!(resolve_layout, ImageLayout::ShaderReadOnlyOptimal) {
+                    return Err(ValidationError {
+                        context: "stencil_attachment.resolve.attachment_ref.layout".into(),
+                        problem: "is `ImageLayout::ShaderReadOnlyOptimal`".into(),
+                        vuids: &["VUID-VkSubpassDescription2-attachment-06914"],
+                        ..Default::default()
+                    });
+                }
+
+                if resolve_layout.layout_for(ImageAspect::Stencil).is_none() {
+                    return Err(ValidationError {
+                        context: "stencil_attachment.resolve.attachment_ref.layout".into(),
+                        problem: "cannot be used with stencil attachments".into(),
+                        vuids: &[
+                            "VUID-VkSubpassDescription2-attachment-06914",
+                            "VUID-VkSubpassDescription2-attachment-06917",
+                            "VUID-VkSubpassDescription2-attachment-06920",
+                        ],
+                        ..Default::default()
+                    });
+                }
+
+                match layouts.entry(resolve_attachment) {
+                    Entry::Occupied(entry) => {
+                        if *entry.get() != resolve_layout {
+                            return Err(ValidationError {
+                                context: "stencil_attachment.resolve.attachment_ref.layout".into(),
+                                problem: "is not equal to the layout used for this attachment \
+                                    elsewhere in this subpass"
+                                    .into(),
+                                vuids: &["VUID-VkSubpassDescription2-layout-02528"],
+                                ..Default::default()
+                            });
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(resolve_layout);
+                    }
+                }
+
+                if !device
+                    .physical_device()
+                    .properties()
+                    .supported_stencil_resolve_modes
+                    .unwrap_or_default()
+                    .contains_enum(mode)
+                {
+                    return Err(ValidationError {
+                        problem: "stencil_attachment.resolve.mode` is not one of the \
+                            modes in the `supported_stencil_resolve_modes` device property"
+                            .into(),
+                        vuids: &[
+                            "VUID-VkSubpassDescriptionDepthStencilResolve-stencilResolveMode-03184",
+                        ],
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        if let (Some(depth_attachment), Some(stencil_attachment)) =
+            (depth_attachment, stencil_attachment)
+        {
+            let &ResolvableAttachmentReference {
+                attachment_ref:
+                    AttachmentReference {
+                        attachment: depth_attachment,
+                        layout: depth_layout,
+                        _ne: _,
+                    },
+                resolve: ref depth_resolve,
+            } = depth_attachment;
+            let &ResolvableAttachmentReference {
+                attachment_ref:
+                    AttachmentReference {
+                        attachment: stencil_attachment,
+                        layout: stencil_layout,
+                        _ne: _,
+                    },
+                resolve: ref stencil_resolve,
+            } = stencil_attachment;
+
+            if depth_attachment != stencil_attachment {
+                return Err(ValidationError {
+                    problem: "`depth_attachment` and `stencil_attachment` are both \
+                        `Some`, and `depth_attachment.attachment_ref.attachment` does not 
+                        equal `stencil_attachment.attachment_ref.attachment`"
+                        .into(),
+                    // vuids?
+                    ..Default::default()
+                });
+            }
+
+            if depth_layout != stencil_layout
+                && !device.enabled_features().separate_depth_stencil_layouts
+            {
+                return Err(ValidationError {
+                    problem: "`depth_attachment` and `stencil_attachment` are both \
+                        `Some`, and `depth_attachment.attachment_ref.layout` does not \
+                        equal `stencil_attachment.attachment_ref.layout`"
+                        .into(),
+                    requires_one_of: RequiresOneOf {
+                        features: &["separate_depth_stencil_layouts"],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+            }
+
+            match (depth_resolve, stencil_resolve) {
+                (None, None) => (),
+                (None, Some(_)) | (Some(_), None) => {
+                    if !properties.independent_resolve_none.unwrap_or(false) {
+                        return Err(ValidationError {
+                            problem: "`depth_attachment` and `stencil_attachment` are both \
+                                `Some`, and the `independent_resolve_none` device property is \
+                                `false`, but one of `depth_attachment.resolve` and \
+                                `stencil_attachment.resolve` is `Some` while the other is `None`"
+                                .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03186"],
+                            ..Default::default()
+                        });
+                    }
+                }
+                (Some(depth_resolve), Some(stencil_resolve)) => {
+                    let &ResolveAttachmentReference {
+                        attachment_ref:
+                            AttachmentReference {
+                                attachment: depth_resolve_attachment,
+                                layout: depth_resolve_layout,
+                                _ne: _,
+                            },
+                        mode: depth_mode,
+                    } = depth_resolve;
+                    let &ResolveAttachmentReference {
+                        attachment_ref:
+                            AttachmentReference {
+                                attachment: stencil_resolve_attachment,
+                                layout: stencil_resolve_layout,
+                                _ne: _,
+                            },
+                        mode: stencil_mode,
+                    } = stencil_resolve;
+
+                    if depth_resolve_attachment != stencil_resolve_attachment {
+                        return Err(ValidationError {
+                            problem: "`depth_attachment` and `stencil_attachment` are both \
+                                `Some`, and `depth_attachment.resolve` and \
+                                `stencil_attachment.resolve` are also both `Some`, and \
+                                `depth_attachment.resolve.attachment_ref.attachment` does not \
+                                equal `stencil_attachment.resolve.attachment_ref.attachment`"
+                                .into(),
+                            // vuids?
+                            ..Default::default()
+                        });
+                    }
+
+                    if depth_resolve_layout != stencil_resolve_layout
+                        && !device.enabled_features().separate_depth_stencil_layouts
+                    {
+                        return Err(ValidationError {
+                            problem: "`depth_attachment` and `stencil_attachment` are both \
+                                `Some`, and `depth_attachment.resolve` and \
+                                `stencil_attachment.resolve` are also both `Some`, and \
+                                `depth_attachment.resolve.attachment_ref.layout` does not \
+                                equal `stencil_attachment.resolve.attachment_ref.layout`"
+                                .into(),
+                            requires_one_of: RequiresOneOf {
+                                features: &["separate_depth_stencil_layouts"],
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        });
+                    }
+
+                    if depth_mode != stencil_mode
+                        && !properties.independent_resolve.unwrap_or(false)
+                    {
+                        return Err(ValidationError {
+                            problem: "`depth_attachment` and `stencil_attachment` are both \
+                                `Some`, and `depth_attachment.resolve` and \
+                                `stencil_attachment.resolve` are also both `Some`,
+                                the `independent_resolve` device property is `false`, but \
+                                `depth_attachment.resolve.mode` does not equal \
+                                `stencil_attachment.resolve.mode`"
+                                .into(),
+                            vuids: &["VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-03185"],
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+        }
+
+        for (ref_index, input_attachment) in input_attachments
+            .iter()
+            .enumerate()
+            .flat_map(|(i, a)| a.as_ref().map(|a| (i, a)))
+        {
+            // VUID-VkSubpassDescription2-pInputAttachments-parameter
+            input_attachment
+                .validate(device)
+                .map_err(|err| err.add_context(format!("input_attachments[{}]", ref_index)))?;
+
+            let &InputAttachmentReference {
+                attachment_ref:
+                    AttachmentReference {
+                        attachment,
+                        layout,
+                        _ne: _,
+                    },
+                aspects,
+            } = input_attachment;
+
+            if preserve_attachments.contains(&attachment) {
+                return Err(ValidationError {
+                    problem: format!(
+                        "`input_attachments[{}].attachment` also occurs in \
+                        `preserve_attachments`",
+                        ref_index
+                    )
+                    .into(),
+                    vuids: &["VUID-VkSubpassDescription2-pPreserveAttachments-03074"],
+                    ..Default::default()
+                });
+            }
+
+            if matches!(
+                layout,
+                ImageLayout::ColorAttachmentOptimal
+                    | ImageLayout::DepthStencilAttachmentOptimal
+                    | ImageLayout::DepthAttachmentOptimal
+                    | ImageLayout::StencilAttachmentOptimal
+            ) {
+                return Err(ValidationError {
+                    context: format!("input_attachments[{}].layout", ref_index).into(),
+                    problem: "cannot be used with input attachments".into(),
+                    vuids: &[
+                        "VUID-VkSubpassDescription2-attachment-06912",
+                        "VUID-VkSubpassDescription2-attachment-06918",
+                    ],
+                    ..Default::default()
+                });
+            }
+
+            match layouts.entry(attachment) {
+                Entry::Occupied(entry) => {
+                    if *entry.get() != layout {
+                        return Err(ValidationError {
+                            context: format!("input_attachments[{}].layout", ref_index).into(),
+                            problem: "is not equal to the layout used for this attachment \
+                                elsewhere in this subpass"
+                                .into(),
+                            vuids: &["VUID-VkSubpassDescription2-layout-02528"],
+                            ..Default::default()
+                        });
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(layout);
+                }
+            }
+
+            if aspects.is_empty() {
+                return Err(ValidationError {
+                    context: format!("input_attachments[{}].aspects", ref_index).into(),
+                    problem: "is empty for an input attachment".into(),
+                    vuids: &["VUID-VkSubpassDescription2-attachment-02800"],
+                    ..Default::default()
+                });
+            }
+
+            if aspects.intersects(ImageAspects::METADATA) {
+                return Err(ValidationError {
+                    context: format!("input_attachments[{}].aspects", ref_index).into(),
+                    problem: "contains `ImageAspects::METADATA`".into(),
+                    vuids: &["VUID-VkSubpassDescription2-attachment-02801"],
+                    ..Default::default()
+                });
+            }
+
+            if aspects.intersects(
+                ImageAspects::MEMORY_PLANE_0
+                    | ImageAspects::MEMORY_PLANE_1
+                    | ImageAspects::MEMORY_PLANE_2,
+            ) {
+                return Err(ValidationError {
+                    context: format!("input_attachments[{}].aspects", ref_index).into(),
+                    problem: "contains `ImageAspects::MEMORY_PLANE_0`, \
+                        `ImageAspects::MEMORY_PLANE_1` or `ImageAspects::MEMORY_PLANE_2`"
+                        .into(),
+                    vuids: &["VUID-VkSubpassDescription2-attachment-04563"],
+                    ..Default::default()
+                });
+            }
+        }
+
+        if !device.enabled_features().multiview && view_mask != 0 {
+            return Err(ValidationError {
+                context: "view_mask".into(),
+                problem: "is not 0".into(),
+                requires_one_of: RequiresOneOf {
+                    features: &["multiview"],
+                    ..Default::default()
+                },
+                vuids: &["VUID-VkSubpassDescription2-multiview-06558"],
+            });
+        }
+
+        let highest_view_index = u32::BITS - view_mask.leading_zeros();
+
+        if highest_view_index >= properties.max_multiview_view_count.unwrap_or(0) {
+            return Err(ValidationError {
+                context: "view_mask".into(),
+                problem: "the highest enabled view index is not less than the \
+                    `max_multiview_view_count` limit"
+                    .into(),
+                vuids: &["VUID-VkSubpassDescription2-viewMask-06706"],
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Flags specifying additional properties of a render pass subpass description.
+    SubpassDescriptionFlags = SubpassDescriptionFlags(u32);
+
+    /* TODO: enable
+    // TODO: document
+    PER_VIEW_ATTRIBUTES = PER_VIEW_ATTRIBUTES_NVX {
+        device_extensions: [nvx_multiview_per_view_attributes],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    PER_VIEW_POSITION_X_ONLY = PER_VIEW_POSITION_X_ONLY_NVX{
+        device_extensions: [nvx_multiview_per_view_attributes],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    FRAGMENT_REGION = FRAGMENT_REGION_QCOM {
+        device_extensions: [qcom_render_pass_shader_resolve],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    SHADER_RESOLVE = SHADER_RESOLVE_QCOM {
+        device_extensions: [qcom_render_pass_shader_resolve],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    RASTERIZATION_ORDER_ATTACHMENT_COLOR_ACCESS = RASTERIZATION_ORDER_ATTACHMENT_COLOR_ACCESS_EXT {
+        device_extensions: [ext_rasterization_order_attachment_access, arm_rasterization_order_attachment_access],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS = RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_EXT {
+        device_extensions: [ext_rasterization_order_attachment_access, arm_rasterization_order_attachment_access],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS = RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_EXT {
+        device_extensions: [ext_rasterization_order_attachment_access, arm_rasterization_order_attachment_access],
+    }, */
+
+    /* TODO: enable
+    // TODO: document
+    ENABLE_LEGACY_DITHERING = ENABLE_LEGACY_DITHERING_EXT {
+        device_extensions: [ext_legacy_dithering],
+    }, */
+}
+
+/// A reference to an attachment in a subpass description of a render pass.
 #[derive(Clone, Debug)]
 pub struct AttachmentReference {
     /// The number of the attachment being referred to.
@@ -933,8 +3252,141 @@ pub struct AttachmentReference {
     /// The default value is [`ImageLayout::Undefined`], which must be overridden.
     pub layout: ImageLayout,
 
-    /// For references to input attachments, the aspects of the image that should be selected.
-    /// For attachment types other than input attachments, the value must be empty.
+    pub _ne: crate::NonExhaustive,
+}
+
+impl Default for AttachmentReference {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            attachment: 0,
+            layout: ImageLayout::Undefined,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+}
+
+impl AttachmentReference {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            attachment: _,
+            layout,
+            _ne,
+        } = self;
+
+        layout
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "layout".into(),
+                vuids: &["VUID-VkAttachmentReference2-layout-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if matches!(
+            layout,
+            ImageLayout::Undefined | ImageLayout::Preinitialized | ImageLayout::PresentSrc
+        ) {
+            return Err(ValidationError {
+                context: "layout".into(),
+                problem: "is ImageLayout::Undefined, ImageLayout::Preinitialized or \
+                    ImageLayout::PresentSrc"
+                    .into(),
+                vuids: &["VUID-VkAttachmentReference2-layout-03077"],
+                ..Default::default()
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// A reference to a color, depth or stencil attachment in a subpass description of a render pass.
+#[derive(Clone, Debug, Default)]
+pub struct ResolvableAttachmentReference {
+    /// The regular color, depth or stencil attachment.
+    pub attachment_ref: AttachmentReference,
+
+    /// The resolve attachment, if any.
+    ///
+    /// If this is `Some`, then the referenced attachment must the same `format` as the attachment
+    /// referenced by `attachment_ref`. `resolve_attachment_ref` must have a `samples` value of
+    /// [`SampleCount::Sample1`], and `attachment_ref` must have a `samples` value other than
+    /// [`SampleCount::Sample1`].
+    pub resolve: Option<ResolveAttachmentReference>,
+}
+
+impl ResolvableAttachmentReference {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            ref attachment_ref,
+            ref resolve,
+        } = self;
+
+        attachment_ref
+            .validate(device)
+            .map_err(|err| err.add_context("attachment_ref"))?;
+
+        if let Some(resolve) = resolve {
+            resolve
+                .validate(device)
+                .map_err(|err| err.add_context("resolve"))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A reference to a resolve attachment in a subpass description of a render pass.
+#[derive(Clone, Debug)]
+pub struct ResolveAttachmentReference {
+    /// The resolve attachment.
+    pub attachment_ref: AttachmentReference,
+
+    /// How the resolve operation should be performed.
+    ///
+    /// The default value is [`ResolveMode::Average`].
+    pub mode: ResolveMode,
+}
+
+impl Default for ResolveAttachmentReference {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            attachment_ref: Default::default(),
+            mode: ResolveMode::Average,
+        }
+    }
+}
+
+impl ResolveAttachmentReference {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            ref attachment_ref,
+            mode,
+        } = self;
+
+        attachment_ref
+            .validate(device)
+            .map_err(|err| err.add_context("attachment_ref"))?;
+
+        mode.validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "mode".into(),
+                // vuids?
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        Ok(())
+    }
+}
+
+/// A reference to an input attachment in a subpass description of a render pass.
+#[derive(Clone, Debug, Default)]
+pub struct InputAttachmentReference {
+    /// The regular input attachment.
+    pub attachment_ref: AttachmentReference,
+
+    /// The aspects of the image that should be selected.
     ///
     /// If empty, all aspects available in the input attachment's `format` will be selected.
     /// If any fields are set, they must be aspects that are available in the `format` of the
@@ -948,19 +3400,28 @@ pub struct AttachmentReference {
     ///
     /// The default value is [`ImageAspects::empty()`].
     pub aspects: ImageAspects,
-
-    pub _ne: crate::NonExhaustive,
 }
 
-impl Default for AttachmentReference {
-    #[inline]
-    fn default() -> Self {
-        Self {
-            attachment: 0,
-            layout: ImageLayout::Undefined,
-            aspects: ImageAspects::empty(),
-            _ne: crate::NonExhaustive(()),
-        }
+impl InputAttachmentReference {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            ref attachment_ref,
+            aspects,
+        } = self;
+
+        attachment_ref
+            .validate(device)
+            .map_err(|err| err.add_context("aspects"))?;
+
+        aspects
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "aspects".into(),
+                // vuids?
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        Ok(())
     }
 }
 
@@ -1071,6 +3532,212 @@ impl Default for SubpassDependency {
     }
 }
 
+impl SubpassDependency {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), ValidationError> {
+        let &Self {
+            src_subpass,
+            dst_subpass,
+            src_stages,
+            dst_stages,
+            src_access,
+            dst_access,
+            dependency_flags,
+            view_offset,
+            _ne: _,
+        } = self;
+
+        // A hack to let us re-use the validation of MemoryBarrier
+        // without using it directly inside SubpassDependency.
+        let temp_barrier = MemoryBarrier {
+            src_stages,
+            src_access,
+            dst_stages,
+            dst_access,
+            ..Default::default()
+        };
+        temp_barrier.validate(device)?;
+
+        // To use the extra flag bits from synchronization 2, we also need create_renderpass2,
+        // for the ability to use extension structs.
+        if !(device.api_version() >= Version::V1_2
+            || device.enabled_extensions().khr_create_renderpass2)
+        {
+            if src_stages.contains_flags2() {
+                return Err(ValidationError {
+                    context: "src_stages".into(),
+                    problem: "contains flags from `VkPipelineStageFlagBits2`".into(),
+                    requires_one_of: RequiresOneOf {
+                        api_version: Some(Version::V1_2),
+                        device_extensions: &["khr_create_renderpass2"],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+            }
+
+            if dst_stages.contains_flags2() {
+                return Err(ValidationError {
+                    context: "dst_stages".into(),
+                    problem: "contains flags from `VkPipelineStageFlagBits2`".into(),
+                    requires_one_of: RequiresOneOf {
+                        api_version: Some(Version::V1_2),
+                        device_extensions: &["khr_create_renderpass2"],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+            }
+
+            if src_access.contains_flags2() {
+                return Err(ValidationError {
+                    context: "src_access".into(),
+                    problem: "contains flags from `VkAccessFlagBits2`".into(),
+                    requires_one_of: RequiresOneOf {
+                        api_version: Some(Version::V1_2),
+                        device_extensions: &["khr_create_renderpass2"],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+            }
+
+            if dst_access.contains_flags2() {
+                return Err(ValidationError {
+                    context: "dst_access".into(),
+                    problem: "contains flags from `VkAccessFlagBits2`".into(),
+                    requires_one_of: RequiresOneOf {
+                        api_version: Some(Version::V1_2),
+                        device_extensions: &["khr_create_renderpass2"],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+            }
+        }
+
+        if !device.enabled_features().synchronization2 {
+            if src_stages.is_empty() {
+                return Err(ValidationError {
+                    context: "src_stages".into(),
+                    problem: "is empty".into(),
+                    requires_one_of: RequiresOneOf {
+                        features: &["synchronization2"],
+                        ..Default::default()
+                    },
+                    vuids: &["VUID-VkSubpassDependency2-srcStageMask-03937"],
+                });
+            }
+
+            if dst_stages.is_empty() {
+                return Err(ValidationError {
+                    context: "dst_stages".into(),
+                    problem: "is empty".into(),
+                    requires_one_of: RequiresOneOf {
+                        features: &["synchronization2"],
+                        ..Default::default()
+                    },
+                    vuids: &["VUID-VkSubpassDependency2-dstStageMask-03937"],
+                });
+            }
+        }
+
+        if src_subpass.is_none() && dst_subpass.is_none() {
+            return Err(ValidationError {
+                problem: "`src_subpass` and `dst_subpass` are both `None`".into(),
+                vuids: &["VUID-VkSubpassDependency2-srcSubpass-03085"],
+                ..Default::default()
+            });
+        }
+
+        if let (Some(src_subpass), Some(dst_subpass)) = (src_subpass, dst_subpass) {
+            if src_subpass > dst_subpass {
+                return Err(ValidationError {
+                    problem: "`src_subpass` is greater than `dst_subpass`".into(),
+                    vuids: &["VUID-VkSubpassDependency2-srcSubpass-03084"],
+                    ..Default::default()
+                });
+            }
+
+            if src_subpass == dst_subpass {
+                let framebuffer_stages = PipelineStages::EARLY_FRAGMENT_TESTS
+                    | PipelineStages::FRAGMENT_SHADER
+                    | PipelineStages::LATE_FRAGMENT_TESTS
+                    | PipelineStages::COLOR_ATTACHMENT_OUTPUT;
+
+                if src_stages.intersects(framebuffer_stages)
+                    && !(dst_stages - framebuffer_stages).is_empty()
+                {
+                    return Err(ValidationError {
+                        problem: "`src_subpass` equals `dst_subpass`, and `src_stages` includes \
+                            a framebuffer-space stage, and `dst_stages` does not contain only \
+                            framebuffer-space stages"
+                            .into(),
+                        vuids: &["VUID-VkSubpassDependency2-srcSubpass-06810"],
+                        ..Default::default()
+                    });
+                }
+
+                if src_stages.intersects(framebuffer_stages)
+                    && dst_stages.intersects(framebuffer_stages)
+                    && !dependency_flags.intersects(DependencyFlags::BY_REGION)
+                {
+                    return Err(ValidationError {
+                        problem: "`src_subpass` equals `dst_subpass`, and \
+                            `src_stages` and `dst_stages` both include a framebuffer-space stage, \
+                            and `dependency_flags` does not include `DependencyFlags::BY_REGION`"
+                            .into(),
+                        vuids: &["VUID-VkSubpassDependency2-srcSubpass-02245"],
+                        ..Default::default()
+                    });
+                }
+
+                if view_offset != 0 {
+                    return Err(ValidationError {
+                        problem: "`src_subpass` equals `dst_subpass`, and `view_offset` is 0"
+                            .into(),
+                        vuids: &["VUID-VkSubpassDependency2-viewOffset-02530"],
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        if dependency_flags.intersects(DependencyFlags::VIEW_LOCAL) {
+            if src_subpass.is_none() {
+                return Err(ValidationError {
+                    problem: "`dependency_flags` includes `DependencyFlags::VIEW_LOCAL`, and \
+                        `src_subpass` is `None`"
+                        .into(),
+                    vuids: &["VUID-VkSubpassDependency2-dependencyFlags-03090"],
+                    ..Default::default()
+                });
+            }
+
+            if dst_subpass.is_none() {
+                return Err(ValidationError {
+                    problem: "`dependency_flags` includes `DependencyFlags::VIEW_LOCAL`, and \
+                        `dst_subpass` is `None`"
+                        .into(),
+                    vuids: &["VUID-VkSubpassDependency2-dependencyFlags-03091"],
+                    ..Default::default()
+                });
+            }
+        } else {
+            if view_offset != 0 {
+                return Err(ValidationError {
+                    problem: "`dependency_flags` does not include `DependencyFlags::VIEW_LOCAL`, \
+                        and `view_offset` is not 0"
+                        .into(),
+                    vuids: &["VUID-VkSubpassDependency2-dependencyFlags-03092"],
+                    ..Default::default()
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
 vulkan_enum! {
     #[non_exhaustive]
 
@@ -1172,15 +3839,20 @@ vulkan_bitflags_enum! {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        format::Format,
-        render_pass::{RenderPass, RenderPassCreationError},
-    };
+    use super::{RenderPassCreateInfo, SubpassDescription};
+    use crate::{format::Format, render_pass::RenderPass};
 
     #[test]
     fn empty() {
         let (device, _) = gfx_dev_and_queue!();
-        let _ = RenderPass::empty_single_pass(device).unwrap();
+        let _ = RenderPass::new(
+            device,
+            RenderPassCreateInfo {
+                subpasses: vec![SubpassDescription::default()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1191,7 +3863,7 @@ mod tests {
             return; // test ignored
         }
 
-        let rp = single_pass_renderpass!(
+        single_pass_renderpass!(
             device,
             attachments: {
                 a1: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
@@ -1207,14 +3879,11 @@ mod tests {
             },
             pass: {
                 color: [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10],
-                depth_stencil: {},
+                depth: {},
+                stencil: {},
             },
-        );
-
-        match rp {
-            Err(RenderPassCreationError::SubpassMaxColorAttachmentsExceeded { .. }) => (),
-            _ => panic!(),
-        }
+        )
+        .unwrap_err();
     }
 
     #[test]
@@ -1228,7 +3897,8 @@ mod tests {
             },
             pass: {
                 color: [a],
-                depth_stencil: {},
+                depth: {},
+                stencil: {},
             },
         )
         .unwrap();

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -978,7 +978,7 @@ impl RenderPassCreateInfo {
                 let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
 
                 if is_first_use
-                    && attachment_desc.load_op == LoadOp::Clear
+                    && attachment_desc.load_op == AttachmentLoadOp::Clear
                     && !layout.is_writable(ImageAspect::Color)
                 {
                     return Err(ValidationError {
@@ -1060,7 +1060,7 @@ impl RenderPassCreateInfo {
                         !replace(&mut attachment_is_used[resolve_attachment as usize], true);
 
                     if is_first_use
-                        && attachment_desc.load_op == LoadOp::Clear
+                        && attachment_desc.load_op == AttachmentLoadOp::Clear
                         && !resolve_layout.is_writable(ImageAspect::Color)
                     {
                         return Err(ValidationError {
@@ -1223,7 +1223,7 @@ impl RenderPassCreateInfo {
                 let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
 
                 if is_first_use
-                    && attachment_desc.load_op == LoadOp::Clear
+                    && attachment_desc.load_op == AttachmentLoadOp::Clear
                     && !layout.is_writable(ImageAspect::Depth)
                 {
                     return Err(ValidationError {
@@ -1302,7 +1302,7 @@ impl RenderPassCreateInfo {
                         !replace(&mut attachment_is_used[resolve_attachment as usize], true);
 
                     if is_first_use
-                        && attachment_desc.load_op == LoadOp::Clear
+                        && attachment_desc.load_op == AttachmentLoadOp::Clear
                         && !resolve_layout.is_writable(ImageAspect::Depth)
                     {
                         return Err(ValidationError {
@@ -1419,7 +1419,7 @@ impl RenderPassCreateInfo {
                 let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
 
                 if is_first_use
-                    && attachment_desc.stencil_load_op == LoadOp::Clear
+                    && attachment_desc.stencil_load_op == AttachmentLoadOp::Clear
                     && !layout.is_writable(ImageAspect::Stencil)
                 {
                     return Err(ValidationError {
@@ -1498,7 +1498,7 @@ impl RenderPassCreateInfo {
                         !replace(&mut attachment_is_used[resolve_attachment as usize], true);
 
                     if is_first_use
-                        && attachment_desc.stencil_load_op == LoadOp::Clear
+                        && attachment_desc.stencil_load_op == AttachmentLoadOp::Clear
                         && !resolve_layout.is_writable(ImageAspect::Stencil)
                     {
                         return Err(ValidationError {
@@ -1620,7 +1620,7 @@ impl RenderPassCreateInfo {
                 let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
 
                 if is_first_use {
-                    if attachment_desc.load_op == LoadOp::Clear {
+                    if attachment_desc.load_op == AttachmentLoadOp::Clear {
                         if format_aspects.intersects(ImageAspects::COLOR) {
                             return Err(ValidationError {
                                 problem: format!(
@@ -1652,7 +1652,7 @@ impl RenderPassCreateInfo {
                         }
                     }
 
-                    if attachment_desc.stencil_load_op == LoadOp::Clear
+                    if attachment_desc.stencil_load_op == AttachmentLoadOp::Clear
                         && format_aspects.intersects(ImageAspects::STENCIL)
                     {
                         return Err(ValidationError {
@@ -1911,13 +1911,13 @@ pub struct AttachmentDescription {
     /// uses it.
     ///
     /// The default value is [`LoadOp::DontCare`].
-    pub load_op: LoadOp,
+    pub load_op: AttachmentLoadOp,
 
     /// What the implementation should do with the attachment at the end of the subpass that last
     /// uses it.
     ///
     /// The default value is [`StoreOp::DontCare`].
-    pub store_op: StoreOp,
+    pub store_op: AttachmentStoreOp,
 
     /// The layout that the image must in at the start of the render pass.
     ///
@@ -1936,13 +1936,13 @@ pub struct AttachmentDescription {
     /// if there is no stencil component.
     ///
     /// The default value is [`LoadOp::DontCare`].
-    pub stencil_load_op: LoadOp,
+    pub stencil_load_op: AttachmentLoadOp,
 
     /// The equivalent of `store_op` for the stencil component of the attachment, if any. Irrelevant
     /// if there is no stencil component.
     ///
     /// The default value is [`StoreOp::DontCare`].
-    pub stencil_store_op: StoreOp,
+    pub stencil_store_op: AttachmentStoreOp,
 
     /// The equivalent of `initial_layout` for the stencil component of the attachment, if any.
     /// Irrelevant if there is no stencil component.
@@ -1974,12 +1974,12 @@ impl Default for AttachmentDescription {
             flags: AttachmentDescriptionFlags::empty(),
             format: None,
             samples: SampleCount::Sample1,
-            load_op: LoadOp::DontCare,
-            store_op: StoreOp::DontCare,
+            load_op: AttachmentLoadOp::DontCare,
+            store_op: AttachmentStoreOp::DontCare,
             initial_layout: ImageLayout::Undefined,
             final_layout: ImageLayout::Undefined,
-            stencil_load_op: LoadOp::DontCare,
-            stencil_store_op: StoreOp::DontCare,
+            stencil_load_op: AttachmentLoadOp::DontCare,
+            stencil_store_op: AttachmentStoreOp::DontCare,
             stencil_initial_layout: ImageLayout::Undefined,
             stencil_final_layout: ImageLayout::Undefined,
             _ne: crate::NonExhaustive(()),
@@ -2142,7 +2142,7 @@ impl AttachmentDescription {
                 });
             }
 
-            if load_op == LoadOp::Load && initial_layout == ImageLayout::Undefined {
+            if load_op == AttachmentLoadOp::Load && initial_layout == ImageLayout::Undefined {
                 return Err(ValidationError {
                     problem: "`format` has a color component, `load_op` is \
                         `LoadOp::Load`, and `initial_layout` is `ImageLayout::Undefined`"
@@ -2174,7 +2174,7 @@ impl AttachmentDescription {
                 });
             }
 
-            if load_op == LoadOp::Load && initial_layout == ImageLayout::Undefined {
+            if load_op == AttachmentLoadOp::Load && initial_layout == ImageLayout::Undefined {
                 return Err(ValidationError {
                     problem: "`format` has a depth component, `load_op` is \
                         `LoadOp::Load`, and `initial_layout` is `ImageLayout::Undefined`"
@@ -2206,7 +2206,8 @@ impl AttachmentDescription {
                 });
             }
 
-            if stencil_load_op == LoadOp::Load && initial_layout == ImageLayout::Undefined {
+            if stencil_load_op == AttachmentLoadOp::Load && initial_layout == ImageLayout::Undefined
+            {
                 return Err(ValidationError {
                     problem: "`format` has a stencil component, `stencil_load_op` is \
                         `LoadOp::Load`, and `initial_layout` is `ImageLayout::Undefined`"
@@ -3742,7 +3743,7 @@ vulkan_enum! {
     #[non_exhaustive]
 
     /// Describes what the implementation should do with an attachment at the start of the subpass.
-    LoadOp = AttachmentLoadOp(i32);
+    AttachmentLoadOp = AttachmentLoadOp(i32);
 
     /// The content of the attachment will be loaded from memory. This is what you want if you want
     /// to draw over something existing.
@@ -3778,7 +3779,7 @@ vulkan_enum! {
 
     /// Describes what the implementation should do with an attachment after all the subpasses have
     /// completed.
-    StoreOp = AttachmentStoreOp(i32);
+    AttachmentStoreOp = AttachmentStoreOp(i32);
 
     /// The attachment will be stored. This is what you usually want.
     ///
@@ -3866,16 +3867,16 @@ mod tests {
         single_pass_renderpass!(
             device,
             attachments: {
-                a1: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a2: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a3: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a4: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a5: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a6: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a7: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a8: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a9: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
-                a10: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
+                a1: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a2: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a3: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a4: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a5: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a6: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a7: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a8: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a9: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
+                a10: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
             },
             pass: {
                 color: [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10],
@@ -3893,7 +3894,7 @@ mod tests {
         let rp = single_pass_renderpass!(
             device,
             attachments: {
-                a: { load: Clear, store: DontCare, format: Format::R8G8B8A8_UNORM, samples: 1, },
+                a: { format: Format::R8G8B8A8_UNORM, samples: 1, load_op: Clear, store_op: DontCare, },
             },
             pass: {
                 color: [a],


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to render pass objects:
- Resolve attachments are now provided as `ResolvableAttachmentReference` values, as part of the `color_attachments`, `depth_attachment` and `stencil_attachment` values. In the `single_pass_renderpass` and `ordered_passes_renderpass` macros, the resolve attachment is indicated by a single arrow, and the resolve mode by a following colon, for example `[color -> color_resolve:Average]`.
- Depth and stencil attachments are now provided separately. They must still use the same attachment, but their layouts and resolve modes can differ.
- Input attachments are now provided as `InputAttachmentReference` values.
- If an attachment has a format with a stencil component, you must now provide `stencil_initial_layout` and `stencil_final_layout` to `AttachmentDescription`, in the same way as `stencil_load_op` and `stencil_store_op`.
- Renamed `LoadOp` and `StoreOp` to `AttachmentLoadOp` and `AttachmentStoreOp` to match the Vulkan names.
- In the `single_pass_renderpass` and `ordered_passes_renderpass` macros, the `load` and `store fields for attachments are renamed to `load_op` and `store_op`, and ordered below the `format` and `samples` fields, to match the fields of the `AttachmentDescription` structure.

### Additions
- Support for the `khr_depth_stencil_resolve` extension.
- Support for the `khr_separate_depth_stencil_layouts` extension.
- Added `flags` to `RenderPassCreateInfo`, `AttachmentDescription` and `SubpassDescription`.
````
