### PR TITLE
ValidationError-ify `GraphicsPipeline`

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -79,10 +79,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Sampler, SamplerCreateInfo},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -438,8 +438,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -471,9 +471,9 @@ fn main() {
     };
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
@@ -850,7 +850,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -30,8 +30,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     VulkanLibrary,
 };
@@ -142,7 +142,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+        let stage = PipelineShaderStageCreateInfo::new(cs);
         let layout = PipelineLayout::new(
             device.clone(),
             PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage])

--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -40,10 +40,9 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -237,8 +236,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -267,9 +266,9 @@ fn main() {
     };
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
     let mut recreate_swapchain = false;
@@ -435,7 +434,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -32,9 +32,9 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::Subpass,
-    shader::PipelineShaderStageCreateInfo,
 };
 
 use super::LightingVertex;
@@ -99,8 +99,8 @@ impl AmbientLightingSystem {
                 .definition(&vs.info().input_interface)
                 .unwrap();
             let stages = [
-                PipelineShaderStageCreateInfo::entry_point(vs),
-                PipelineShaderStageCreateInfo::entry_point(fs),
+                PipelineShaderStageCreateInfo::new(vs),
+                PipelineShaderStageCreateInfo::new(fs),
             ];
             let layout = PipelineLayout::new(
                 device.clone(),
@@ -122,12 +122,12 @@ impl AmbientLightingSystem {
                     color_blend_state: Some(
                         ColorBlendState::new(subpass.num_color_attachments()).blend(
                             AttachmentBlend {
-                                color_op: BlendOp::Add,
-                                color_source: BlendFactor::One,
-                                color_destination: BlendFactor::One,
-                                alpha_op: BlendOp::Max,
-                                alpha_source: BlendFactor::One,
-                                alpha_destination: BlendFactor::One,
+                                color_blend_op: BlendOp::Add,
+                                src_color_blend_factor: BlendFactor::One,
+                                dst_color_blend_factor: BlendFactor::One,
+                                alpha_blend_op: BlendOp::Max,
+                                src_alpha_blend_factor: BlendFactor::One,
+                                dst_alpha_blend_factor: BlendFactor::One,
                             },
                         ),
                     ),
@@ -179,9 +179,9 @@ impl AmbientLightingSystem {
         .unwrap();
 
         let viewport = Viewport {
-            origin: [0.0, 0.0],
-            dimensions: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
-            depth_range: 0.0..1.0,
+            offset: [0.0, 0.0],
+            extent: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
+            depth_range: 0.0..=1.0,
         };
 
         let mut builder = AutoCommandBufferBuilder::secondary(

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -33,9 +33,9 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::Subpass,
-    shader::PipelineShaderStageCreateInfo,
 };
 
 use super::LightingVertex;
@@ -102,8 +102,8 @@ impl DirectionalLightingSystem {
                 .definition(&vs.info().input_interface)
                 .unwrap();
             let stages = [
-                PipelineShaderStageCreateInfo::entry_point(vs),
-                PipelineShaderStageCreateInfo::entry_point(fs),
+                PipelineShaderStageCreateInfo::new(vs),
+                PipelineShaderStageCreateInfo::new(fs),
             ];
             let layout = PipelineLayout::new(
                 device.clone(),
@@ -125,12 +125,12 @@ impl DirectionalLightingSystem {
                     color_blend_state: Some(
                         ColorBlendState::new(subpass.num_color_attachments()).blend(
                             AttachmentBlend {
-                                color_op: BlendOp::Add,
-                                color_source: BlendFactor::One,
-                                color_destination: BlendFactor::One,
-                                alpha_op: BlendOp::Max,
-                                alpha_source: BlendFactor::One,
-                                alpha_destination: BlendFactor::One,
+                                color_blend_op: BlendOp::Add,
+                                src_color_blend_factor: BlendFactor::One,
+                                dst_color_blend_factor: BlendFactor::One,
+                                alpha_blend_op: BlendOp::Max,
+                                src_alpha_blend_factor: BlendFactor::One,
+                                dst_alpha_blend_factor: BlendFactor::One,
                             },
                         ),
                     ),
@@ -195,9 +195,9 @@ impl DirectionalLightingSystem {
         .unwrap();
 
         let viewport = Viewport {
-            origin: [0.0, 0.0],
-            dimensions: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
-            depth_range: 0.0..1.0,
+            offset: [0.0, 0.0],
+            extent: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
+            depth_range: 0.0..=1.0,
         };
 
         let mut builder = AutoCommandBufferBuilder::secondary(

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -33,9 +33,9 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::Subpass,
-    shader::PipelineShaderStageCreateInfo,
 };
 
 use super::LightingVertex;
@@ -99,8 +99,8 @@ impl PointLightingSystem {
                 .definition(&vs.info().input_interface)
                 .unwrap();
             let stages = [
-                PipelineShaderStageCreateInfo::entry_point(vs),
-                PipelineShaderStageCreateInfo::entry_point(fs),
+                PipelineShaderStageCreateInfo::new(vs),
+                PipelineShaderStageCreateInfo::new(fs),
             ];
             let layout = PipelineLayout::new(
                 device.clone(),
@@ -122,12 +122,12 @@ impl PointLightingSystem {
                     color_blend_state: Some(
                         ColorBlendState::new(subpass.num_color_attachments()).blend(
                             AttachmentBlend {
-                                color_op: BlendOp::Add,
-                                color_source: BlendFactor::One,
-                                color_destination: BlendFactor::One,
-                                alpha_op: BlendOp::Max,
-                                alpha_source: BlendFactor::One,
-                                alpha_destination: BlendFactor::One,
+                                color_blend_op: BlendOp::Add,
+                                src_color_blend_factor: BlendFactor::One,
+                                dst_color_blend_factor: BlendFactor::One,
+                                alpha_blend_op: BlendOp::Max,
+                                src_alpha_blend_factor: BlendFactor::One,
+                                dst_alpha_blend_factor: BlendFactor::One,
                             },
                         ),
                     ),
@@ -206,9 +206,9 @@ impl PointLightingSystem {
         .unwrap();
 
         let viewport = Viewport {
-            origin: [0.0, 0.0],
-            dimensions: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
-            depth_range: 0.0..1.0,
+            offset: [0.0, 0.0],
+            extent: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
+            depth_range: 0.0..=1.0,
         };
 
         let mut builder = AutoCommandBufferBuilder::secondary(

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -28,10 +28,9 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::Subpass,
-    shader::PipelineShaderStageCreateInfo,
 };
 
 pub struct TriangleDrawSystem {
@@ -89,8 +88,8 @@ impl TriangleDrawSystem {
                 .definition(&vs.info().input_interface)
                 .unwrap();
             let stages = [
-                PipelineShaderStageCreateInfo::entry_point(vs),
-                PipelineShaderStageCreateInfo::entry_point(fs),
+                PipelineShaderStageCreateInfo::new(vs),
+                PipelineShaderStageCreateInfo::new(fs),
             ];
             let layout = PipelineLayout::new(
                 device.clone(),
@@ -143,9 +142,9 @@ impl TriangleDrawSystem {
             .set_viewport(
                 0,
                 [Viewport {
-                    origin: [0.0, 0.0],
-                    dimensions: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
-                    depth_range: 0.0..1.0,
+                    offset: [0.0, 0.0],
+                    extent: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
+                    depth_range: 0.0..=1.0,
                 }]
                 .into_iter()
                 .collect(),

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -32,8 +32,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     DeviceSize, VulkanLibrary,
 };
@@ -127,7 +127,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+        let stage = PipelineShaderStageCreateInfo::new(cs);
         let layout = {
             let mut layout_create_info =
                 PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage]);

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -34,8 +34,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     VulkanLibrary,
 };
@@ -192,7 +192,7 @@ fn main() {
             ]
             .into_iter()
             .collect(),
-            ..PipelineShaderStageCreateInfo::entry_point(cs)
+            ..PipelineShaderStageCreateInfo::new(cs)
         };
         let layout = PipelineLayout::new(
             device.clone(),

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -42,10 +42,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -348,8 +348,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -391,9 +391,9 @@ fn main() {
     .unwrap();
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
@@ -527,7 +527,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -40,10 +40,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -274,8 +274,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -317,9 +317,9 @@ fn main() {
     .unwrap();
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
@@ -453,7 +453,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -49,10 +49,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -280,8 +280,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = {
             let mut layout_create_info =
@@ -338,9 +338,9 @@ fn main() {
     .unwrap();
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
@@ -474,7 +474,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -56,9 +56,9 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     single_pass_renderpass,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
@@ -272,7 +272,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+        let stage = PipelineShaderStageCreateInfo::new(cs);
         let layout = PipelineLayout::new(
             device.clone(),
             PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage])
@@ -327,8 +327,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -357,9 +357,9 @@ fn main() {
     };
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
     let mut recreate_swapchain = false;
@@ -541,7 +541,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -37,10 +37,9 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     single_pass_renderpass,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
@@ -307,8 +306,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -339,9 +338,9 @@ fn main() {
     };
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
     let mut recreate_swapchain = false;
@@ -476,7 +475,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -25,8 +25,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::GpuFuture,
 };
 use vulkano_util::renderer::DeviceImageView;
@@ -80,7 +80,7 @@ impl FractalComputePipeline {
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+            let stage = PipelineShaderStageCreateInfo::new(cs);
             let layout = PipelineLayout::new(
                 device.clone(),
                 PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage])

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -32,10 +32,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::Subpass,
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode},
-    shader::PipelineShaderStageCreateInfo,
 };
 
 /// Vertex for textured quads.
@@ -133,8 +133,8 @@ impl PixelsDrawPipeline {
                 .definition(&vs.info().input_interface)
                 .unwrap();
             let stages = [
-                PipelineShaderStageCreateInfo::entry_point(vs),
-                PipelineShaderStageCreateInfo::entry_point(fs),
+                PipelineShaderStageCreateInfo::new(vs),
+                PipelineShaderStageCreateInfo::new(fs),
             ];
             let layout = PipelineLayout::new(
                 device.clone(),
@@ -223,9 +223,9 @@ impl PixelsDrawPipeline {
             .set_viewport(
                 0,
                 [Viewport {
-                    origin: [0.0, 0.0],
-                    dimensions: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
-                    depth_range: 0.0..1.0,
+                    offset: [0.0, 0.0],
+                    extent: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
+                    depth_range: 0.0..=1.0,
                 }]
                 .into_iter()
                 .collect(),

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -88,10 +88,9 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     sync::GpuFuture,
     VulkanLibrary,
 };
@@ -315,8 +314,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -348,9 +347,9 @@ fn main() {
     };
 
     let viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [1024.0, 1024.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [1024.0, 1024.0],
+        depth_range: 0.0..=1.0,
     };
 
     let command_buffer_allocator = StandardCommandBufferAllocator::new(device, Default::default());

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -41,10 +41,9 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -276,8 +275,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -306,9 +305,9 @@ fn main() {
     };
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
 
     let command_buffer_allocator =
@@ -516,7 +515,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -27,8 +27,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::GpuFuture,
 };
 use vulkano_util::renderer::DeviceImageView;
@@ -77,7 +77,7 @@ impl GameOfLifeComputePipeline {
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+            let stage = PipelineShaderStageCreateInfo::new(cs);
             let layout = PipelineLayout::new(
                 device.clone(),
                 PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage])

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -33,10 +33,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::Subpass,
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode},
-    shader::PipelineShaderStageCreateInfo,
 };
 
 /// Vertex for textured quads.
@@ -129,8 +129,8 @@ impl PixelsDrawPipeline {
                 .definition(&vs.info().input_interface)
                 .unwrap();
             let stages = [
-                PipelineShaderStageCreateInfo::entry_point(vs),
-                PipelineShaderStageCreateInfo::entry_point(fs),
+                PipelineShaderStageCreateInfo::new(vs),
+                PipelineShaderStageCreateInfo::new(fs),
             ];
             let layout = PipelineLayout::new(
                 device.clone(),
@@ -219,9 +219,9 @@ impl PixelsDrawPipeline {
             .set_viewport(
                 0,
                 [Viewport {
-                    origin: [0.0, 0.0],
-                    dimensions: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
-                    depth_range: 0.0..1.0,
+                    offset: [0.0, 0.0],
+                    extent: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
+                    depth_range: 0.0..=1.0,
                 }]
                 .into_iter()
                 .collect(),

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -41,14 +41,13 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{
         AttachmentDescription, AttachmentLoadOp, AttachmentReference, AttachmentStoreOp,
         Framebuffer, FramebufferCreateInfo, RenderPass, RenderPassCreateInfo, Subpass,
         SubpassDescription,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     VulkanLibrary,
 };
@@ -272,8 +271,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -292,12 +291,12 @@ fn main() {
                 input_assembly_state: Some(InputAssemblyState::default()),
                 viewport_state: Some(ViewportState::viewport_fixed_scissor_irrelevant([
                     Viewport {
-                        origin: [0.0, 0.0],
-                        dimensions: [
+                        offset: [0.0, 0.0],
+                        extent: [
                             image.dimensions().width() as f32,
                             image.dimensions().height() as f32,
                         ],
-                        depth_range: 0.0..1.0,
+                        depth_range: 0.0..=1.0,
                     },
                 ])),
                 rasterization_state: Some(RasterizationState::default()),

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -38,11 +38,10 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     query::{QueryControlFlags, QueryPool, QueryPoolCreateInfo, QueryResultFlags, QueryType},
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -317,8 +316,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -351,9 +350,9 @@ fn main() {
     };
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
 
     let command_buffer_allocator =
@@ -569,7 +568,7 @@ fn window_size_dependent_setup(
     memory_allocator: &StandardMemoryAllocator,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     let depth_attachment = ImageView::new_default(
         AttachmentImage::with_usage(

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -29,8 +29,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     VulkanLibrary,
 };
@@ -124,7 +124,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+        let stage = PipelineShaderStageCreateInfo::new(cs);
         let layout = PipelineLayout::new(
             device.clone(),
             PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage])

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -38,10 +38,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -269,8 +269,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = {
             let mut layout_create_info =
@@ -311,9 +311,9 @@ fn main() {
     };
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
@@ -449,7 +449,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -46,10 +46,10 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::{PipelineShaderStageCreateInfo, ShaderModule},
+    shader::ShaderModule,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -208,8 +208,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -288,9 +288,9 @@ fn main() {
     // TODO: Outdated ^
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
     let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
@@ -412,7 +412,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -41,10 +41,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -363,8 +363,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = {
             let mut layout_create_info =
@@ -425,9 +425,9 @@ fn main() {
     .unwrap();
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
@@ -561,7 +561,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -29,8 +29,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     VulkanLibrary,
 };
@@ -116,7 +116,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+        let stage = PipelineShaderStageCreateInfo::new(cs);
         let layout = PipelineLayout::new(
             device.clone(),
             PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage])

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -28,8 +28,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     VulkanLibrary,
 };
@@ -124,7 +124,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+        let stage = PipelineShaderStageCreateInfo::new(cs);
         let layout = PipelineLayout::new(
             device.clone(),
             PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage])

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -43,8 +43,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     VulkanLibrary,
 };
@@ -257,7 +257,7 @@ fn main() {
             .unwrap();
         let stage = PipelineShaderStageCreateInfo {
             specialization_info: [(0, true.into())].into_iter().collect(),
-            ..PipelineShaderStageCreateInfo::entry_point(cs)
+            ..PipelineShaderStageCreateInfo::new(cs)
         };
         let layout = PipelineLayout::new(
             device.clone(),
@@ -282,7 +282,7 @@ fn main() {
             .unwrap();
         let stage = PipelineShaderStageCreateInfo {
             specialization_info: [(0, true.into())].into_iter().collect(),
-            ..PipelineShaderStageCreateInfo::entry_point(cs)
+            ..PipelineShaderStageCreateInfo::new(cs)
         };
         let layout = PipelineLayout::new(
             device.clone(),

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -42,9 +42,9 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, GraphicsPipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, PresentMode, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainPresentInfo,
@@ -422,7 +422,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let stage = PipelineShaderStageCreateInfo::entry_point(cs);
+        let stage = PipelineShaderStageCreateInfo::new(cs);
         let layout = PipelineLayout::new(
             device.clone(),
             PipelineDescriptorSetLayoutCreateInfo::from_stages([&stage])
@@ -459,9 +459,9 @@ fn main() {
 
     // Fixed viewport dimensions.
     let viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [WINDOW_WIDTH as f32, WINDOW_HEIGHT as f32],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [WINDOW_WIDTH as f32, WINDOW_HEIGHT as f32],
+        depth_range: 0.0..=1.0,
     };
 
     // Create a basic graphics pipeline for rendering particles.
@@ -478,8 +478,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -26,8 +26,8 @@ use vulkano::{
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
-    shader::PipelineShaderStageCreateInfo,
     sync::{self, GpuFuture},
     VulkanLibrary,
 };
@@ -123,7 +123,7 @@ fn main() {
             specialization_info: [(0, 1i32.into()), (1, 1.0f32.into()), (2, true.into())]
                 .into_iter()
                 .collect(),
-            ..PipelineShaderStageCreateInfo::entry_point(cs)
+            ..PipelineShaderStageCreateInfo::new(cs)
         };
         let layout = PipelineLayout::new(
             device.clone(),

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -43,9 +43,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::{EntryPoint, PipelineShaderStageCreateInfo},
+    shader::EntryPoint,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -470,8 +471,8 @@ fn window_size_dependent_setup(
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -490,9 +491,9 @@ fn window_size_dependent_setup(
                 input_assembly_state: Some(InputAssemblyState::default()),
                 viewport_state: Some(ViewportState::viewport_fixed_scissor_irrelevant([
                     Viewport {
-                        origin: [0.0, 0.0],
-                        dimensions: [dimensions[0] as f32, dimensions[1] as f32],
-                        depth_range: 0.0..1.0,
+                        offset: [0.0, 0.0],
+                        extent: [dimensions[0] as f32, dimensions[1] as f32],
+                        depth_range: 0.0..=1.0,
                     },
                 ])),
                 rasterization_state: Some(RasterizationState::default()),

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -47,10 +47,9 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -357,10 +356,10 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(tcs),
-            PipelineShaderStageCreateInfo::entry_point(tes),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(tcs),
+            PipelineShaderStageCreateInfo::new(tes),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -402,9 +401,9 @@ fn main() {
     let mut recreate_swapchain = false;
     let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
@@ -525,7 +524,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -40,10 +40,10 @@ use vulkano::{
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
         GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
+        PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sampler::{Sampler, SamplerCreateInfo},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -279,8 +279,8 @@ fn main() {
             .definition(&vs.info().input_interface)
             .unwrap();
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
         let layout = PipelineLayout::new(
             device.clone(),
@@ -322,9 +322,9 @@ fn main() {
     .unwrap();
 
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
     let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
 
@@ -458,7 +458,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -47,10 +47,9 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{AttachmentLoadOp, AttachmentStoreOp},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -401,8 +400,8 @@ fn main() {
 
         // Make a list of the shader stages that the pipeline will have.
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
 
         // We must now create a **pipeline layout** object, which describes the locations and types of
@@ -472,9 +471,9 @@ fn main() {
     // Dynamic viewports allow us to recreate just the viewport when the window is resized.
     // Otherwise we would have to recreate the whole pipeline.
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
 
     // When creating the swapchain, we only created plain images. To use them as an attachment for
@@ -697,7 +696,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<ImageView<SwapchainImage>>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -41,10 +41,9 @@ use vulkano::{
             GraphicsPipelineCreateInfo,
         },
         layout::PipelineDescriptorSetLayoutCreateInfo,
-        GraphicsPipeline, PipelineLayout,
+        GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    shader::PipelineShaderStageCreateInfo,
     swapchain::{
         acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
         SwapchainCreationError, SwapchainPresentInfo,
@@ -405,8 +404,8 @@ fn main() {
 
         // Make a list of the shader stages that the pipeline will have.
         let stages = [
-            PipelineShaderStageCreateInfo::entry_point(vs),
-            PipelineShaderStageCreateInfo::entry_point(fs),
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
         ];
 
         // We must now create a **pipeline layout** object, which describes the locations and types of
@@ -467,9 +466,9 @@ fn main() {
     // Dynamic viewports allow us to recreate just the viewport when the window is resized.
     // Otherwise we would have to recreate the whole pipeline.
     let mut viewport = Viewport {
-        origin: [0.0, 0.0],
-        dimensions: [0.0, 0.0],
-        depth_range: 0.0..1.0,
+        offset: [0.0, 0.0],
+        extent: [0.0, 0.0],
+        depth_range: 0.0..=1.0,
     };
 
     // The render pass we created above only describes the layout of our framebuffers. Before we
@@ -692,7 +691,7 @@ fn window_size_dependent_setup(
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
     let dimensions = images[0].dimensions().width_height();
-    viewport.dimensions = [dimensions[0] as f32, dimensions[1] as f32];
+    viewport.extent = [dimensions[0] as f32, dimensions[1] as f32];
 
     images
         .iter()

--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -96,8 +96,8 @@ use crate::{
     device::{Device, DeviceOwned},
     format::{Format, FormatFeatures},
     macros::{impl_id_counter, vulkan_bitflags, vulkan_enum},
-    DeviceSize, NonZeroDeviceSize, Packed24_8, RequiresOneOf, RuntimeError, ValidationError,
-    VulkanError, VulkanObject,
+    DeviceSize, NonZeroDeviceSize, Packed24_8, Requires, RequiresAllOf, RequiresOneOf,
+    RuntimeError, ValidationError, VulkanError, VulkanObject,
 };
 use bytemuck::{Pod, Zeroable};
 use std::{fmt::Debug, hash::Hash, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
@@ -141,20 +141,18 @@ impl AccelerationStructure {
     ) -> Result<(), ValidationError> {
         if !device.enabled_extensions().khr_acceleration_structure {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_acceleration_structure"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_acceleration_structure",
+                )])]),
                 ..Default::default()
             });
         }
 
         if !device.enabled_features().acceleration_structure {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    features: &["acceleration_structure"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "acceleration_structure",
+                )])]),
                 vuids: &["VUID-vkCreateAccelerationStructureKHR-accelerationStructure-03611"],
                 ..Default::default()
             });
@@ -436,15 +434,17 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    DESCRIPTOR_BUFFER_CAPTURE_REPLAY = DESCRIPTOR_BUFFER_CAPTURE_REPLAY_EXT {
-        device_extensions: [ext_descriptor_buffer],
-    },*/
+    DESCRIPTOR_BUFFER_CAPTURE_REPLAY = DESCRIPTOR_BUFFER_CAPTURE_REPLAY_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_descriptor_buffer)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    MOTION = MOTION_NV {
-        device_extensions: [nv_ray_tracing_motion_blur],
-    },*/
+    MOTION = MOTION_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_ray_tracing_motion_blur)]),
+    ]),*/
 }
 
 /// Geometries and other parameters for an acceleration structure build operation.
@@ -805,33 +805,38 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    MOTION = MOTION_NV {
-        device_extensions: [nv_ray_tracing_motion_blur],
-    }, */
+    MOTION = MOTION_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_ray_tracing_motion_blur)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    ALLOW_OPACITY_MICROMAP_UPDATE = ALLOW_OPACITY_MICROMAP_UPDATE_EXT {
-        device_extensions: [ext_opacity_micromap],
-    }, */
+    ALLOW_OPACITY_MICROMAP_UPDATE = ALLOW_OPACITY_MICROMAP_UPDATE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    ALLOW_DISABLE_OPACITY_MICROMAPS = ALLOW_DISABLE_OPACITY_MICROMAPS_EXT {
-        device_extensions: [ext_opacity_micromap],
-    }, */
+    ALLOW_DISABLE_OPACITY_MICROMAPS = ALLOW_DISABLE_OPACITY_MICROMAPS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    ALLOW_OPACITY_MICROMAP_DATA_UPDATE = ALLOW_OPACITY_MICROMAP_DATA_UPDATE_EXT {
-        device_extensions: [ext_opacity_micromap],
-    }, */
+    ALLOW_OPACITY_MICROMAP_DATA_UPDATE = ALLOW_OPACITY_MICROMAP_DATA_UPDATE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    ALLOW_DISPLACEMENT_MICROMAP_UPDATE = ALLOW_DISPLACEMENT_MICROMAP_UPDATE_NV {
-        device_extensions: [nv_displacement_micromap],
-    }, */
+    ALLOW_DISPLACEMENT_MICROMAP_UPDATE = ALLOW_DISPLACEMENT_MICROMAP_UPDATE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_displacement_micromap)]),
+    ]), */
 }
 
 /// What mode an acceleration structure build command should operate in.
@@ -1300,15 +1305,17 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    FORCE_OPACITY_MICROMAP_2_STATE = FORCE_OPACITY_MICROMAP_2_STATE_EXT {
-        device_extensions: [ext_opacity_micromap],
-    }, */
+    FORCE_OPACITY_MICROMAP_2_STATE = FORCE_OPACITY_MICROMAP_2_STATE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    DISABLE_OPACITY_MICROMAPS = DISABLE_OPACITY_MICROMAPS_EXT {
-        device_extensions: [ext_opacity_micromap],
-    }, */
+    DISABLE_OPACITY_MICROMAPS = DISABLE_OPACITY_MICROMAPS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]), */
 }
 
 impl From<GeometryInstanceFlags> for u8 {

--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -412,7 +412,7 @@ impl AccelerationStructureCreateInfo {
         if buffer.offset() % 256 != 0 {
             return Err(ValidationError {
                 context: "buffer".into(),
-                problem: "the offset of the buffer was not a multiple of 256".into(),
+                problem: "the offset of the buffer is not a multiple of 256".into(),
                 vuids: &["VUID-VkAccelerationStructureCreateInfoKHR-offset-03734"],
                 ..Default::default()
             });
@@ -538,7 +538,7 @@ impl AccelerationStructureBuildGeometryInfo {
                 if geometries.len() as u64 > max_geometry_count {
                     return Err(ValidationError {
                         context: "geometries".into(),
-                        problem: "the max_geometry_count limit has been exceeded".into(),
+                        problem: "the length exceeds the `max_geometry_count` limit".into(),
                         vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03793"],
                         ..Default::default()
                     });
@@ -559,7 +559,7 @@ impl AccelerationStructureBuildGeometryInfo {
                 if geometries.len() as u64 > max_geometry_count {
                     return Err(ValidationError {
                         context: "geometries".into(),
-                        problem: "the max_geometry_count limit has been exceeded".into(),
+                        problem: "the length exceeds the `max_geometry_count` limit".into(),
                         vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03793"],
                         ..Default::default()
                     });
@@ -590,8 +590,8 @@ impl AccelerationStructureBuildGeometryInfo {
         ) {
             return Err(ValidationError {
                 context: "flags".into(),
-                problem: "contains both BuildAccelerationStructureFlags::PREFER_FAST_TRACE and \
-                    BuildAccelerationStructureFlags::PREFER_FAST_BUILD"
+                problem: "contains both `BuildAccelerationStructureFlags::PREFER_FAST_TRACE` and \
+                    `BuildAccelerationStructureFlags::PREFER_FAST_BUILD`"
                     .into(),
                 vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-03796"],
                 ..Default::default()
@@ -1036,7 +1036,7 @@ impl AccelerationStructureGeometryTrianglesData {
             return Err(ValidationError {
                 context: "vertex_format".into(),
                 problem: "format features do not contain \
-                    FormatFeature::ACCELERATION_STRUCTURE_VERTEX_BUFFER"
+                    `FormatFeature::ACCELERATION_STRUCTURE_VERTEX_BUFFER`"
                     .into(),
                 vuids: &["VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-03797"],
                 ..Default::default()
@@ -1053,8 +1053,8 @@ impl AccelerationStructureGeometryTrianglesData {
 
         if vertex_stride % smallest_component_bytes != 0 {
             return Err(ValidationError {
-                problem: "vertex_stride is not a multiple of the byte size of the \
-                    smallest component of vertex_format"
+                problem: "`vertex_stride` is not a multiple of the byte size of the \
+                    smallest component of `vertex_format`"
                     .into(),
                 vuids: &["VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03735"],
                 ..Default::default()
@@ -1065,7 +1065,7 @@ impl AccelerationStructureGeometryTrianglesData {
             if !matches!(index_data, IndexBuffer::U16(_) | IndexBuffer::U32(_)) {
                 return Err(ValidationError {
                     context: "index_data".into(),
-                    problem: "is not IndexBuffer::U16 or IndexBuffer::U32".into(),
+                    problem: "is not `IndexBuffer::U16` or `IndexBuffer::U32`".into(),
                     vuids: &[
                         "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-03798",
                     ],
@@ -1414,8 +1414,8 @@ impl CopyAccelerationStructureInfo {
         ) {
             return Err(ValidationError {
                 context: "mode".into(),
-                problem: "is not CopyAccelerationStructureMode::Compact or \
-                    CopyAccelerationStructureMode::Clone"
+                problem: "is not `CopyAccelerationStructureMode::Compact` or \
+                    `CopyAccelerationStructureMode::Clone`"
                     .into(),
                 vuids: &["VUID-VkCopyAccelerationStructureInfoKHR-mode-03410"],
                 ..Default::default()
@@ -1424,7 +1424,7 @@ impl CopyAccelerationStructureInfo {
 
         if src.buffer() == dst.buffer() {
             return Err(ValidationError {
-                problem: "src and dst share the same buffer".into(),
+                problem: "`src` and `dst` share the same buffer".into(),
                 vuids: &["VUID-VkCopyAccelerationStructureInfoKHR-dst-07791"],
                 ..Default::default()
             });
@@ -1494,7 +1494,7 @@ impl CopyAccelerationStructureToMemoryInfo {
         if !matches!(mode, CopyAccelerationStructureMode::Serialize) {
             return Err(ValidationError {
                 context: "mode".into(),
-                problem: "is not CopyAccelerationStructureMode::Serialize".into(),
+                problem: "is not `CopyAccelerationStructureMode::Serialize`".into(),
                 vuids: &["VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-03412"],
                 ..Default::default()
             });
@@ -1564,7 +1564,7 @@ impl CopyMemoryToAccelerationStructureInfo {
         if !matches!(mode, CopyAccelerationStructureMode::Deserialize) {
             return Err(ValidationError {
                 context: "mode".into(),
-                problem: "is not CopyAccelerationStructureMode::Deserialize".into(),
+                problem: "is not `CopyAccelerationStructureMode::Deserialize`".into(),
                 vuids: &["VUID-VkCopyMemoryToAccelerationStructureInfoKHR-mode-03413"],
                 ..Default::default()
             });

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -123,8 +123,8 @@ use crate::{
     },
     range_map::RangeMap,
     sync::{future::AccessError, CurrentAccess, Sharing},
-    DeviceSize, NonZeroDeviceSize, RequirementNotMet, RequiresOneOf, RuntimeError, ValidationError,
-    Version, VulkanObject,
+    DeviceSize, NonZeroDeviceSize, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf,
+    RuntimeError, ValidationError, Version, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
@@ -506,10 +506,9 @@ impl Buffer {
         if !device.enabled_features().buffer_device_address {
             return Err(BufferError::RequirementNotMet {
                 required_for: "`Buffer::device_address`",
-                requires_one_of: RequiresOneOf {
-                    features: &["buffer_device_address"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "buffer_device_address",
+                )])]),
             });
         }
 
@@ -1072,9 +1071,10 @@ vulkan_bitflags! {
     /// protected objects.
     ///
     /// The device API version must be at least 1.1.
-    PROTECTED = PROTECTED {
-        api_version: V1_1,
-    },*/
+    PROTECTED = PROTECTED
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+    ]),*/
 
     /* TODO: enable
     /// The buffer's device address can be saved and reused on a subsequent run.
@@ -1167,9 +1167,10 @@ vulkan_enum! {
     IndexType = IndexType(i32);
 
     /// Indices are 8-bit unsigned integers.
-    U8 = UINT8_EXT {
-        device_extensions: [ext_index_type_uint8],
-    },
+    U8 = UINT8_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_index_type_uint8)]),
+    ]),
 
     /// Indices are 16-bit unsigned integers.
     U16 = UINT16,

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -23,7 +23,7 @@ use crate::{
         MemoryPropertyFlags, MemoryRequirements,
     },
     sync::Sharing,
-    DeviceSize, RequiresOneOf, RuntimeError, Version, VulkanObject,
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, Version, VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
@@ -104,10 +104,7 @@ impl RawBuffer {
             if !device.enabled_features().sparse_binding {
                 return Err(BufferError::RequirementNotMet {
                     required_for: "`create_info.sparse` is `Some`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["sparse_binding"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("sparse_binding")])]),
                 });
             }
 
@@ -116,10 +113,7 @@ impl RawBuffer {
                 return Err(BufferError::RequirementNotMet {
                     required_for: "`create_info.sparse` is `Some(sparse_level)`, where \
                         `sparse_level` contains `BufferCreateFlags::SPARSE_RESIDENCY`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["sparse_residency_buffer"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("sparse_residency_buffer")])]),
                 });
             }
 
@@ -128,10 +122,7 @@ impl RawBuffer {
                 return Err(BufferError::RequirementNotMet {
                     required_for: "`create_info.sparse` is `Some(sparse_level)`, where \
                         `sparse_level` contains `BufferCreateFlags::SPARSE_ALIASED`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["sparse_residency_aliased"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("sparse_residency_aliased")])]),
                 });
             }
 
@@ -178,11 +169,10 @@ impl RawBuffer {
             {
                 return Err(BufferError::RequirementNotMet {
                     required_for: "`create_info.external_memory_handle_types` is not empty",
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_1),
-                        device_extensions: &["khr_external_memory"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_external_memory")]),
+                    ]),
                 });
             }
 

--- a/vulkano/src/buffer/usage.rs
+++ b/vulkano/src/buffer/usage.rs
@@ -52,96 +52,114 @@ vulkan_bitflags! {
     ///
     /// [`MemoryAllocateFlags::DEVICE_ADDRESS`]: crate::memory::MemoryAllocateFlags::DEVICE_ADDRESS
     /// [`ext_buffer_device_address`]: crate::device::DeviceExtensions::ext_buffer_device_address
-    SHADER_DEVICE_ADDRESS = SHADER_DEVICE_ADDRESS {
-        api_version: V1_2,
-        device_extensions: [khr_buffer_device_address, ext_buffer_device_address],
-    },
+    SHADER_DEVICE_ADDRESS = SHADER_DEVICE_ADDRESS
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(khr_buffer_device_address)]),
+        RequiresAllOf([DeviceExtension(ext_buffer_device_address)]),
+    ]),
 
     /* TODO: enable
     // TODO: document
-    VIDEO_DECODE_SRC = VIDEO_DECODE_SRC_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },*/
+    VIDEO_DECODE_SRC = VIDEO_DECODE_SRC_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VIDEO_DECODE_DST = VIDEO_DECODE_DST_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },*/
+    VIDEO_DECODE_DST = VIDEO_DECODE_DST_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    TRANSFORM_FEEDBACK_BUFFER = TRANSFORM_FEEDBACK_BUFFER_EXT {
-        device_extensions: [ext_transform_feedback],
-    },*/
+    TRANSFORM_FEEDBACK_BUFFER = TRANSFORM_FEEDBACK_BUFFER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_transform_feedback)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    TRANSFORM_FEEDBACK_COUNTER_BUFFER = TRANSFORM_FEEDBACK_COUNTER_BUFFER_EXT {
-        device_extensions: [ext_transform_feedback],
-    },*/
+    TRANSFORM_FEEDBACK_COUNTER_BUFFER = TRANSFORM_FEEDBACK_COUNTER_BUFFER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_transform_feedback)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    CONDITIONAL_RENDERING = CONDITIONAL_RENDERING_EXT {
-        device_extensions: [ext_conditional_rendering],
-    },*/
+    CONDITIONAL_RENDERING = CONDITIONAL_RENDERING_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_conditional_rendering)]),
+    ]),*/
 
     /// The buffer can be used as input data for an acceleration structure build operation.
-    ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY = ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR {
-        device_extensions: [khr_acceleration_structure],
-    },
+    ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY = ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_acceleration_structure)]),
+    ]),
 
     /// An acceleration structure can be created from the buffer.
-    ACCELERATION_STRUCTURE_STORAGE = ACCELERATION_STRUCTURE_STORAGE_KHR {
-        device_extensions: [khr_acceleration_structure],
-    },
+    ACCELERATION_STRUCTURE_STORAGE = ACCELERATION_STRUCTURE_STORAGE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_acceleration_structure)]),
+    ]),
 
     /* TODO: enable
     // TODO: document
-    SHADER_BINDING_TABLE = SHADER_BINDING_TABLE_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },*/
+    SHADER_BINDING_TABLE = SHADER_BINDING_TABLE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VIDEO_ENCODE_DST = VIDEO_ENCODE_DST_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },*/
+    VIDEO_ENCODE_DST = VIDEO_ENCODE_DST_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VIDEO_ENCODE_SRC = VIDEO_ENCODE_SRC_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },*/
+    VIDEO_ENCODE_SRC = VIDEO_ENCODE_SRC_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SAMPLER_DESCRIPTOR_BUFFER = SAMPLER_DESCRIPTOR_BUFFER_EXT {
-        device_extensions: [ext_descriptor_buffer],
-    },*/
+    SAMPLER_DESCRIPTOR_BUFFER = SAMPLER_DESCRIPTOR_BUFFER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_descriptor_buffer)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RESOURCE_DESCRIPTOR_BUFFER = RESOURCE_DESCRIPTOR_BUFFER_EXT {
-        device_extensions: [ext_descriptor_buffer],
-    },*/
+    RESOURCE_DESCRIPTOR_BUFFER = RESOURCE_DESCRIPTOR_BUFFER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_descriptor_buffer)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER = PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_EXT {
-        device_extensions: [ext_descriptor_buffer],
-    },*/
+    PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER = PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_descriptor_buffer)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    MICROMAP_BUILD_INPUT_READ_ONLY = MICROMAP_BUILD_INPUT_READ_ONLY_EXT {
-        device_extensions: [ext_opacity_micromap],
-    },*/
+    MICROMAP_BUILD_INPUT_READ_ONLY = MICROMAP_BUILD_INPUT_READ_ONLY_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    MICROMAP_STORAGE = MICROMAP_STORAGE_EXT {
-        device_extensions: [ext_opacity_micromap],
-    },*/
+    MICROMAP_STORAGE = MICROMAP_STORAGE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]),*/
 }

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -1491,7 +1491,7 @@ impl AutoSyncState {
                                     if !self.device.enabled_features().synchronization2 {
                                         panic!(
                                             "The command requires the `Preinitialized` layout, \
-                                            but this is not allowed in pipeline barriers without
+                                            but this is not allowed in pipeline barriers without \
                                             the `synchronization2` feature enabled"
                                         );
                                     }

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -50,7 +50,7 @@ use crate::{
         AccessFlags, BufferMemoryBarrier, DependencyInfo, ImageMemoryBarrier,
         PipelineStageAccessFlags, PipelineStages,
     },
-    DeviceSize, OomError, RequirementNotMet, RequiresOneOf,
+    DeviceSize, OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf,
 };
 use ahash::HashMap;
 use parking_lot::Mutex;
@@ -274,10 +274,9 @@ where
                                 required_for: "`inheritance_info.render_pass` is \
                                     `CommandBufferInheritanceRenderPassType::BeginRendering`, \
                                     where `view_mask` is not `0`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["multiview"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("multiview"),
+                                ])]),
                             });
                         }
 
@@ -387,10 +386,9 @@ where
                 if !device.enabled_features().inherited_queries {
                     return Err(CommandBufferBeginError::RequirementNotMet {
                         required_for: "`inheritance_info.occlusion_query` is `Some`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["inherited_queries"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "inherited_queries",
+                        )])]),
                     });
                 }
 
@@ -402,10 +400,9 @@ where
                         required_for: "`inheritance_info.occlusion_query` is \
                             `Some(control_flags)`, where `control_flags` contains \
                             `QueryControlFlags::PRECISE`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["occlusion_query_precise"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "occlusion_query_precise",
+                        )])]),
                     });
                 }
             }
@@ -419,10 +416,9 @@ where
             {
                 return Err(CommandBufferBeginError::RequirementNotMet {
                     required_for: "`inheritance_info.query_statistics_flags` is not empty",
-                    requires_one_of: RequiresOneOf {
-                        features: &["pipeline_statistics_query"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "pipeline_statistics_query",
+                    )])]),
                 });
             }
         } else {

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -167,7 +167,8 @@ where
         {
             return Err(ValidationError {
                 context: "info.scratch_data".into(),
-                problem: "the buffer was not created with the `STORAGE_BUFFER` usage".into(),
+                problem: "the buffer was not created with the `BufferUsage::STORAGE_BUFFER` usage"
+                    .into(),
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674"],
                 ..Default::default()
             });
@@ -186,8 +187,8 @@ where
         {
             return Err(ValidationError {
                 context: "info.scratch_data".into(),
-                problem: "the device address of the buffer was not a multiple of the \
-                    min_acceleration_structure_scratch_offset_alignment device property"
+                problem: "the device address of the buffer is not a multiple of the \
+                    `min_acceleration_structure_scratch_offset_alignment` device property"
                     .into(),
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03710"],
                 ..Default::default()
@@ -199,9 +200,9 @@ where
                 if !matches!(geometries, AccelerationStructureGeometries::Instances(_)) {
                     return Err(ValidationError {
                         context: "info".into(),
-                        problem: "dst_acceleration_structure is a top-level \
-                            acceleration structure, but geometries is not \
-                            AccelerationStructureGeometries::Instances"
+                        problem: "`dst_acceleration_structure` is a top-level \
+                            acceleration structure, but `geometries` is not \
+                            `AccelerationStructureGeometries::Instances`"
                             .into(),
                         vuids: &[
                             "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03789",
@@ -215,9 +216,9 @@ where
                 if matches!(geometries, AccelerationStructureGeometries::Instances(_)) {
                     return Err(ValidationError {
                         context: "info".into(),
-                        problem: "dst_acceleration_structure is a bottom-level \
-                            acceleration structure, but geometries is \
-                            AccelerationStructureGeometries::Instances"
+                        problem: "`dst_acceleration_structure` is a bottom-level \
+                            acceleration structure, but `geometries` is \
+                            `AccelerationStructureGeometries::Instances`"
                             .into(),
                         vuids: &[
                             "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03791",
@@ -232,7 +233,8 @@ where
 
         if geometries.len() != build_range_infos.len() {
             return Err(ValidationError {
-                problem: "info.geometries and build_range_infos do not have the same length".into(),
+                problem: "`info.geometries` and `build_range_infos` do not have the same length"
+                    .into(),
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-03676"],
                 ..Default::default()
             });
@@ -281,7 +283,7 @@ where
                                 geometry_index
                             )
                             .into(),
-                            problem: "the max_primitive_count limit has been exceeded".into(),
+                            problem: "exceeds the `max_primitive_count` limit".into(),
                             vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03795"],
                             ..Default::default()
                         });
@@ -296,7 +298,7 @@ where
                             context: format!("info.geometries[{}].vertex_data", geometry_index)
                                 .into(),
                             problem: "the buffer was not created with the \
-                                `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
                                 .into(),
                             vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
                             ..Default::default()
@@ -318,7 +320,7 @@ where
                             context: format!("info.geometries[{}].vertex_data", geometry_index)
                                 .into(),
                             problem: "the buffer's device address is not a multiple of the byte \
-                                size of the smallest component of vertex_format"
+                                size of the smallest component of `vertex_format`"
                                 .into(),
                             vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03711"],
                             ..Default::default()
@@ -336,7 +338,8 @@ where
                                 context: format!("info.geometries[{}].index_data", geometry_index)
                                     .into(),
                                 problem: "the buffer was not created with the \
-                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` \
+                                    usage"
                                     .into(),
                                 vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
                                 ..Default::default()
@@ -361,10 +364,11 @@ where
                         if primitive_offset as u64 % index_data.index_type().size() != 0 {
                             return Err(ValidationError {
                                 problem: format!(
-                                    "info.geometries is \
-                                    AccelerationStructureGeometries::Triangles, and
-                                    build_range_infos[{}].primitive_offset is not a multiple of \
-                                    the size of the index type of info.geometries[{0}].index_data",
+                                    "`info.geometries` is \
+                                    `AccelerationStructureGeometries::Triangles`, and \
+                                    `build_range_infos[{}].primitive_offset` is not a multiple of \
+                                    the size of the index type of \
+                                    `info.geometries[{0}].index_data`",
                                     geometry_index,
                                 )
                                 .into(),
@@ -380,13 +384,13 @@ where
                         {
                             return Err(ValidationError {
                                 problem: format!(
-                                    "infos.geometries is \
-                                    AccelerationStructureGeometries::Triangles, \
-                                    info.geometries[{0}].index_data is Some, \
-                                    and build_range_infos[{0}].primitive_offset + \
-                                    3 * build_range_infos[{0}].primitive_count * \
-                                    info.geometries[{0}].index_data.index_type().size is greater \
-                                    than the size of infos.geometries[{0}].index_data",
+                                    "`infos.geometries` is \
+                                    `AccelerationStructureGeometries::Triangles`, \
+                                    `info.geometries[{0}].index_data` is `Some`, and \
+                                    `build_range_infos[{0}].primitive_offset` + \
+                                    3 * `build_range_infos[{0}].primitive_count` * \
+                                    `info.geometries[{0}].index_data.index_type().size` is \
+                                    greater than the size of `infos.geometries[{0}].index_data`",
                                     geometry_index,
                                 )
                                 .into(),
@@ -397,11 +401,11 @@ where
                         if primitive_offset % smallest_component_bytes != 0 {
                             return Err(ValidationError {
                                 problem: format!(
-                                    "info.geometries is \
-                                    AccelerationStructureGeometries::Triangles, and
-                                    build_range_infos[{}].primitive_offset is not a multiple of \
+                                    "`info.geometries` is \
+                                    `AccelerationStructureGeometries::Triangles`, and
+                                    `build_range_infos[{}].primitive_offset` is not a multiple of \
                                     the byte size of the smallest component of \
-                                    info.geometries[{0}].vertex_format",
+                                    `info.geometries[{0}].vertex_format`",
                                     geometry_index,
                                 )
                                 .into(),
@@ -417,14 +421,14 @@ where
                         {
                             return Err(ValidationError {
                                 problem: format!(
-                                    "infos.geometries is \
-                                    AccelerationStructureGeometries::Triangles, \
-                                    info.geometries[{0}].index_data is None, \
-                                    and build_range_infos[{0}].primitive_offset + \
-                                    (build_range_infos[{0}].first_vertex + 3 * \
-                                    build_range_infos[{0}].primitive_count) * \
-                                    info.geometries[{0}].vertex_stride is greater than the size \
-                                    of infos.geometries[{0}].vertex_data",
+                                    "`infos.geometries` is \
+                                    `AccelerationStructureGeometries::Triangles`, \
+                                    `info.geometries[{0}].index_data` is `None`, \
+                                    and `build_range_infos[{0}].primitive_offset` + \
+                                    (`build_range_infos[{0}].first_vertex` + 3 * \
+                                    `build_range_infos[{0}].primitive_count`) * \
+                                    `info.geometries[{0}].vertex_stride` is greater than the size \
+                                    of `infos.geometries[{0}].vertex_data`",
                                     geometry_index,
                                 )
                                 .into(),
@@ -446,7 +450,8 @@ where
                                 )
                                 .into(),
                                 problem: "the buffer was not created with the \
-                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` \
+                                    usage"
                                     .into(),
                                 vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
                                 ..Default::default()
@@ -470,9 +475,10 @@ where
                         if transform_offset % 16 != 0 {
                             return Err(ValidationError {
                                 problem: format!(
-                                    "info.geometries is \
-                                    AccelerationStructureGeometries::Triangles, and
-                                    build_range_infos[{}].transform_offset is not a multiple of 16",
+                                    "`info.geometries` is \
+                                    `AccelerationStructureGeometries::Triangles`, and \
+                                    `build_range_infos[{}].transform_offset` is not a multiple of \
+                                    16",
                                     geometry_index,
                                 )
                                 .into(),
@@ -487,11 +493,11 @@ where
                         {
                             return Err(ValidationError {
                                 problem: format!(
-                                    "infos.geometries is \
-                                    AccelerationStructureGeometries::Triangles, and \
-                                    build_range_infos[{0}].transform_offset + \
-                                    size_of::<TransformMatrix> is greater than the size of \
-                                    infos.geometries[{0}].transform_data",
+                                    "`infos.geometries` is \
+                                    `AccelerationStructureGeometries::Triangles`, and \
+                                    `build_range_infos[{0}].transform_offset` + \
+                                    `size_of::<TransformMatrix>` is greater than the size of \
+                                    `infos.geometries[{0}].transform_data`",
                                     geometry_index,
                                 )
                                 .into(),
@@ -522,7 +528,7 @@ where
                     if primitive_count as u64 > max_primitive_count {
                         return Err(ValidationError {
                             context: format!("build_range_infos[{}]", geometry_index).into(),
-                            problem: "the max_primitive_count limit has been exceeded".into(),
+                            problem: "exceeds the `max_primitive_count` limit".into(),
                             vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03794"],
                             ..Default::default()
                         });
@@ -536,7 +542,8 @@ where
                         return Err(ValidationError {
                             context: format!("info.geometries[{}].data", geometry_index).into(),
                             problem: "the buffer was not created with the \
-                                `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` \
+                                usage"
                                 .into(),
                             vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
                             ..Default::default()
@@ -555,9 +562,9 @@ where
                     if primitive_offset % 8 != 0 {
                         return Err(ValidationError {
                             problem: format!(
-                                "info.geometries is \
-                                AccelerationStructureGeometries::Aabbs, and
-                                build_range_infos[{}].primitive_offset is not a multiple of 8",
+                                "`info.geometries` is \
+                                `AccelerationStructureGeometries::Aabbs`, and \
+                                `build_range_infos[{}].primitive_offset` is not a multiple of 8",
                                 geometry_index,
                             )
                             .into(),
@@ -572,11 +579,11 @@ where
                     {
                         return Err(ValidationError {
                             problem: format!(
-                                "infos.geometries is AccelerationStructureGeometries::Aabbs,
-                                and build_range_infos[{0}].primitive_offset + \
-                                build_range_infos[{0}].primitive_count * \
-                                info.geometries[{0}].stride is greater than the size of
-                                infos.geometries[{0}].data",
+                                "`infos.geometries` is `AccelerationStructureGeometries::Aabbs`,
+                                and `build_range_infos[{0}].primitive_offset` + \
+                                `build_range_infos[{0}].primitive_count` * \
+                                `info.geometries[{0}].stride` is greater than the size of \
+                                `infos.geometries[{0}].data`",
                                 geometry_index,
                             )
                             .into(),
@@ -602,7 +609,7 @@ where
                 if primitive_count as u64 > max_instance_count {
                     return Err(ValidationError {
                         context: "build_range_infos[0]".into(),
-                        problem: "the max_instance_count limit has been exceeded".into(),
+                        problem: "exceeds the the `max_instance_count` limit".into(),
                         vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03801"],
                         ..Default::default()
                     });
@@ -610,9 +617,9 @@ where
 
                 if primitive_offset % 16 != 0 {
                     return Err(ValidationError {
-                        problem: "info.geometries is \
-                            AccelerationStructureGeometries::Instances, and
-                            build_range_infos[0].primitive_offset is not a multiple of 16"
+                        problem: "`info.geometries is` \
+                            `AccelerationStructureGeometries::Instances`, and \
+                            `build_range_infos[0].primitive_offset` is not a multiple of 16"
                             .into(),
                         vuids: &[
                             "VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03660",
@@ -626,8 +633,8 @@ where
                         if data.device_address().unwrap().get() % 16 != 0 {
                             return Err(ValidationError {
                                 context: "info.geometries.data".into(),
-                                problem: "is AccelerationStructureGeometryInstancesDataType::\
-                                    Values, and the buffer's device address is not a multiple of \
+                                problem: "is `AccelerationStructureGeometryInstancesDataType::\
+                                    Values`, and the buffer's device address is not a multiple of \
                                     16"
                                 .into(),
                                 vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03715"],
@@ -641,14 +648,14 @@ where
                             > data.size()
                         {
                             return Err(ValidationError {
-                                problem: "infos.geometries is
-                                    AccelerationStructureGeometries::Instances, \
-                                    infos.geometries.data is \
-                                    AccelerationStructureGeometryInstancesDataType::Values, and \
-                                    build_range_infos[0].primitive_offset + \
-                                    build_range_infos[0].primitive_count * \
-                                    size_of::<AccelerationStructureInstance>() is greater than the \
-                                    size of infos.geometries.data"
+                                problem: "`infos.geometries` is \
+                                    `AccelerationStructureGeometries::Instances`, \
+                                    `infos.geometries.data` is \
+                                    `AccelerationStructureGeometryInstancesDataType::Values`, and \
+                                    `build_range_infos[0].primitive_offset` + \
+                                    `build_range_infos[0].primitive_count` * \
+                                    `size_of::<AccelerationStructureInstance>()` is greater than \
+                                    the size of `infos.geometries.data`"
                                     .into(),
                                 ..Default::default()
                             });
@@ -665,7 +672,8 @@ where
                             return Err(ValidationError {
                                 context: "info.geometries.data".into(),
                                 problem: "the buffer was not created with the \
-                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` \
+                                    usage"
                                     .into(),
                                 vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
                                 ..Default::default()
@@ -675,10 +683,10 @@ where
                         if data.device_address().unwrap().get() % 8 != 0 {
                             return Err(ValidationError {
                                 context: "info.geometries.data".into(),
-                                problem:
-                                    "is AccelerationStructureGeometryInstancesDataType::\
-                                    Pointers and the buffer's device address is not a multiple of 8"
-                                        .into(),
+                                problem: "is `AccelerationStructureGeometryInstancesDataType::\
+                                    Pointers` and the buffer's device address is not a multiple \
+                                    of 8"
+                                    .into(),
                                 vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03716"],
                                 ..Default::default()
                             });
@@ -689,14 +697,14 @@ where
                             > data.size()
                         {
                             return Err(ValidationError {
-                                problem: "infos.geometries is
-                                    AccelerationStructureGeometries::Instances, \
-                                    infos.geometries.data is \
-                                    AccelerationStructureGeometryInstancesDataType::Pointers, and \
-                                    build_range_infos[0].primitive_offset + \
-                                    build_range_infos[0].primitive_count * \
-                                    size_of::<DeviceSize>() is greater than the \
-                                    size of infos.geometries.data"
+                                problem: "`infos.geometries` is \
+                                    `AccelerationStructureGeometries::Instances`, \
+                                    `infos.geometries.data` is \
+                                    `AccelerationStructureGeometryInstancesDataType::Pointers`, \
+                                    and `build_range_infos[0].primitive_offset` + \
+                                    `build_range_infos[0].primitive_count` * \
+                                    `size_of::<DeviceSize>()` is greater than the \
+                                    size of `infos.geometries.data`"
                                     .into(),
                                 ..Default::default()
                             });
@@ -716,7 +724,7 @@ where
                     return Err(ValidationError {
                         context: "info.geometries.data".into(),
                         problem: "the buffer was not created with the \
-                            `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                            `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
                             .into(),
                         vuids: &["VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673"],
                         ..Default::default()
@@ -962,7 +970,8 @@ where
         {
             return Err(ValidationError {
                 context: "info.scratch_data".into(),
-                problem: "the buffer was not created with the `STORAGE_BUFFER` usage".into(),
+                problem: "the buffer was not created with the `BufferUsage::STORAGE_BUFFER` usage"
+                    .into(),
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03674"],
                 ..Default::default()
             });
@@ -981,8 +990,8 @@ where
         {
             return Err(ValidationError {
                 context: "info.scratch_data".into(),
-                problem: "the device address of the buffer was not a multiple of the \
-                    min_acceleration_structure_scratch_offset_alignment device property"
+                problem: "the device address of the buffer is not a multiple of the \
+                    `min_acceleration_structure_scratch_offset_alignment` device property"
                     .into(),
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03710"],
                 ..Default::default()
@@ -994,9 +1003,9 @@ where
                 if !matches!(geometries, AccelerationStructureGeometries::Instances(_)) {
                     return Err(ValidationError {
                         context: "info".into(),
-                        problem: "dst_acceleration_structure is a top-level \
-                            acceleration structure, but geometries is not \
-                            AccelerationStructureGeometries::Instances"
+                        problem: "`dst_acceleration_structure` is a top-level \
+                            acceleration structure, but `geometries` is not \
+                            `AccelerationStructureGeometries::Instances`"
                             .into(),
                         vuids: &[
                             "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03789",
@@ -1010,9 +1019,9 @@ where
                 if matches!(geometries, AccelerationStructureGeometries::Instances(_)) {
                     return Err(ValidationError {
                         context: "info".into(),
-                        problem: "dst_acceleration_structure is a bottom-level \
-                            acceleration structure, but geometries is \
-                            AccelerationStructureGeometries::Instances"
+                        problem: "`dst_acceleration_structure` is a bottom-level \
+                            acceleration structure, but `geometries` is \
+                            `AccelerationStructureGeometries::Instances`"
                             .into(),
                         vuids: &[
                             "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03791",
@@ -1027,7 +1036,7 @@ where
 
         if geometries.len() != max_primitive_counts.len() {
             return Err(ValidationError {
-                problem: "info.geometries and max_primitive_counts do not have the same length"
+                problem: "`info.geometries` and `max_primitive_counts` do not have the same length"
                     .into(),
                 vuids: &[
                     "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-ppMaxPrimitiveCounts-parameter",
@@ -1062,7 +1071,7 @@ where
                             context: format!("info.geometries[{}].vertex_data", geometry_index)
                                 .into(),
                             problem: "the buffer was not created with the \
-                                `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
                                 .into(),
                             vuids: &[
                                 "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673",
@@ -1086,7 +1095,7 @@ where
                             context: format!("info.geometries[{}].vertex_data", geometry_index)
                                 .into(),
                             problem: "the buffer's device address is not a multiple of the byte \
-                                size of the smallest component of vertex_format"
+                                size of the smallest component of `vertex_format`"
                                 .into(),
                             vuids: &[
                                 "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03711",
@@ -1106,7 +1115,8 @@ where
                                 context: format!("info.geometries[{}].index_data", geometry_index)
                                     .into(),
                                 problem: "the buffer was not created with the \
-                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` \
+                                    usage"
                                     .into(),
                                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"],
                                 ..Default::default()
@@ -1150,7 +1160,8 @@ where
                                 )
                                 .into(),
                                 problem: "the buffer was not created with the \
-                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` \
+                                    usage"
                                     .into(),
                                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"],
                                 ..Default::default()
@@ -1198,7 +1209,7 @@ where
                         return Err(ValidationError {
                             context: format!("info.geometries[{}].data", geometry_index).into(),
                             problem: "the buffer was not created with the \
-                                `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
                                 .into(),
                             vuids: &[
                                 "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673",
@@ -1237,9 +1248,10 @@ where
                         if data.device_address().unwrap().get() % 16 != 0 {
                             return Err(ValidationError {
                                 context: "info.geometries.data".into(),
-                                problem: "is AccelerationStructureGeometryInstancesDataType::\
-                                    Values and the buffer's device address is not a multiple of 16"
-                                    .into(),
+                                problem: "is `AccelerationStructureGeometryInstancesDataType::\
+                                    Values` and the buffer's device address is not a multiple of \
+                                    16"
+                                .into(),
                                 vuids: &[
                                     "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03715",
                                 ],
@@ -1258,7 +1270,8 @@ where
                             return Err(ValidationError {
                                 context: "info.geometries.data".into(),
                                 problem: "the buffer was not created with the \
-                                    `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                                    `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` \
+                                    usage"
                                     .into(),
                                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"],
                                 ..Default::default()
@@ -1268,10 +1281,10 @@ where
                         if data.device_address().unwrap().get() % 8 != 0 {
                             return Err(ValidationError {
                                 context: "info.geometries.data".into(),
-                                problem:
-                                    "is AccelerationStructureGeometryInstancesDataType::\
-                                    Pointers and the buffer's device address is not a multiple of 8"
-                                        .into(),
+                                problem: "is `AccelerationStructureGeometryInstancesDataType::\
+                                    Pointers` and the buffer's device address is not a multiple \
+                                    of 8"
+                                    .into(),
                                 vuids: &[
                                     "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03716",
                                 ],
@@ -1293,7 +1306,7 @@ where
                     return Err(ValidationError {
                         context: "info.geometries.data".into(),
                         problem: "the buffer was not created with the \
-                            `ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
+                            `BufferUsage::ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY` usage"
                             .into(),
                         vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"],
                         ..Default::default()
@@ -1354,7 +1367,8 @@ where
 
         if geometries.len() as DeviceSize * stride as DeviceSize > indirect_buffer.size() {
             return Err(ValidationError {
-                problem: "info.geometries.len() * stride is greater than the size of indirect_buffer".into(),
+                problem: "`info.geometries.len()` * `stride` is greater than the size of \
+                    `indirect_buffer`".into(),
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03646"],
                 ..Default::default()
             });
@@ -1367,7 +1381,7 @@ where
         {
             return Err(ValidationError {
                 context: "indirect_buffer".into(),
-                problem: "the buffer was not created with the `INDIRECT_BUFFER` usage".into(),
+                problem: "the buffer was not created with the `BufferUsage::INDIRECT_BUFFER` usage".into(),
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03647"],
                 ..Default::default()
             });
@@ -1576,7 +1590,7 @@ where
         if info.dst.device_address().unwrap().get() % 256 != 0 {
             return Err(ValidationError {
                 context: "info.dst".into(),
-                problem: "the device address of the buffer was not a multiple of 256".into(),
+                problem: "the device address of the buffer is not a multiple of 256".into(),
                 vuids: &["VUID-vkCmdCopyAccelerationStructureToMemoryKHR-pInfo-03740"],
                 ..Default::default()
             });
@@ -1686,7 +1700,7 @@ where
         if info.src.device_address().unwrap().get() % 256 != 0 {
             return Err(ValidationError {
                 context: "info.src".into(),
-                problem: "the device address of the buffer was not a multiple of 256".into(),
+                problem: "the device address of the buffer is not a multiple of 256".into(),
                 vuids: &["VUID-vkCmdCopyMemoryToAccelerationStructureKHR-pInfo-03743"],
                 ..Default::default()
             });
@@ -1834,8 +1848,8 @@ where
         if first_query as usize + acceleration_structures.len() > query_pool.query_count() as usize
         {
             return Err(ValidationError {
-                problem: "first_query + acceleration_structures.len() is greater than \
-                    query_pool.query_count"
+                problem: "`first_query` + `acceleration_structures.len()` is greater than \
+                    `query_pool.query_count`"
                     .into(),
                 vuids: &["VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-query-04880"],
                 ..Default::default()

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -28,7 +28,7 @@ use crate::{
     device::{DeviceOwned, QueueFlags},
     query::{QueryPool, QueryType},
     sync::PipelineStageAccessFlags,
-    DeviceSize, RequiresOneOf, ValidationError, VulkanObject,
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{mem::size_of, sync::Arc};
@@ -894,10 +894,7 @@ where
             .acceleration_structure_indirect_build
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    features: &["acceleration_structure_indirect_build"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("acceleration_structure_indirect_build")])]),
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-accelerationStructureIndirectBuild-03650"],
                 ..Default::default()
             });

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -27,7 +27,8 @@ use crate::{
         graphics::{subpass::PipelineSubpassType, vertex_input::VertexBuffersCollection},
         ComputePipeline, GraphicsPipeline, PipelineBindPoint, PipelineLayout,
     },
-    DeviceSize, RequirementNotMet, RequiresOneOf, ValidationError, VulkanObject,
+    DeviceSize, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, ValidationError,
+    VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{
@@ -317,10 +318,9 @@ where
         {
             return Err(BindPushError::RequirementNotMet {
                 required_for: "`index_buffer` is `IndexBuffer::U8`",
-                requires_one_of: RequiresOneOf {
-                    features: &["index_type_uint8"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "index_type_uint8",
+                )])]),
             });
         }
 
@@ -769,10 +769,9 @@ where
     ) -> Result<(), ValidationError> {
         if !self.device().enabled_extensions().khr_push_descriptor {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_push_descriptor"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_push_descriptor",
+                )])]),
                 ..Default::default()
             });
         }

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -17,7 +17,8 @@ use crate::{
     format::{ClearColorValue, ClearDepthStencilValue, Format, FormatFeatures},
     image::{ImageAccess, ImageAspects, ImageLayout, ImageSubresourceRange, ImageUsage},
     sync::PipelineStageAccessFlags,
-    DeviceSize, RequirementNotMet, RequiresOneOf, SafeDeref, Version, VulkanObject,
+    DeviceSize, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, SafeDeref, Version,
+    VulkanObject,
 };
 use smallvec::{smallvec, SmallVec};
 use std::{
@@ -301,10 +302,9 @@ where
             return Err(ClearError::RequirementNotMet {
                 required_for: "`clear_info.clear_value.depth` is not between `0.0` and `1.0` \
                     inclusive",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["ext_depth_range_unrestricted"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "ext_depth_range_unrestricted",
+                )])]),
             });
         }
 

--- a/vulkano/src/command_buffer/commands/debug.rs
+++ b/vulkano/src/command_buffer/commands/debug.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     device::{DeviceOwned, QueueFlags},
     instance::debug::DebugUtilsLabel,
-    RequiresOneOf, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, VulkanObject,
 };
 use std::{
     error::Error,
@@ -57,10 +57,9 @@ where
         {
             return Err(DebugUtilsError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::begin_debug_utils_label`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_debug_utils"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_debug_utils",
+                )])]),
             });
         }
 
@@ -117,10 +116,9 @@ where
         {
             return Err(DebugUtilsError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::end_debug_utils_label`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_debug_utils"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_debug_utils",
+                )])]),
             });
         }
 
@@ -182,10 +180,9 @@ where
         {
             return Err(DebugUtilsError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::insert_debug_utils_label`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_debug_utils"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_debug_utils",
+                )])]),
             });
         }
 

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -2341,7 +2341,6 @@ where
     ) -> &mut Self {
         let rectangles = rectangles
             .iter()
-            .copied()
             .map(|v| v.into())
             .collect::<SmallVec<[_; 2]>>();
         if rectangles.is_empty() {
@@ -2550,7 +2549,6 @@ where
     pub unsafe fn set_scissor(&mut self, first_scissor: u32, scissors: &[Scissor]) -> &mut Self {
         let scissors = scissors
             .iter()
-            .copied()
             .map(ash::vk::Rect2D::from)
             .collect::<SmallVec<[_; 2]>>();
         if scissors.is_empty() {
@@ -2574,7 +2572,6 @@ where
     pub unsafe fn set_scissor_with_count(&mut self, scissors: &[Scissor]) -> &mut Self {
         let scissors = scissors
             .iter()
-            .copied()
             .map(ash::vk::Rect2D::from)
             .collect::<SmallVec<[_; 2]>>();
         if scissors.is_empty() {
@@ -2611,7 +2608,6 @@ where
     ) -> &mut Self {
         let viewports = viewports
             .iter()
-            .cloned()
             .map(|v| v.into())
             .collect::<SmallVec<[_; 2]>>();
         if viewports.is_empty() {
@@ -2635,7 +2631,6 @@ where
     pub unsafe fn set_viewport_with_count(&mut self, viewports: &[Viewport]) -> &mut Self {
         let viewports = viewports
             .iter()
-            .cloned()
             .map(|v| v.into())
             .collect::<SmallVec<[_; 2]>>();
         if viewports.is_empty() {

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -23,7 +23,7 @@ use crate::{
         },
         DynamicState,
     },
-    RequirementNotMet, RequiresOneOf, Version, VulkanObject,
+    RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, Version, VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{
@@ -149,10 +149,9 @@ where
         if !self.device().enabled_features().color_write_enable {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_color_write_enable`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["ext_color_write_enable"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "ext_color_write_enable",
+                )])]),
             });
         }
 
@@ -235,11 +234,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_cull_mode`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -306,10 +304,9 @@ where
         if clamp != 0.0 && !self.device().enabled_features().depth_bias_clamp {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`clamp` is not `0.0`",
-                requires_one_of: RequiresOneOf {
-                    features: &["depth_bias_clamp"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "depth_bias_clamp",
+                )])]),
             });
         }
 
@@ -377,11 +374,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_depth_bias_enable`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state2"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state2")]),
+                ]),
             });
         }
 
@@ -448,10 +444,9 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`bounds` is not between `0.0` and `1.0` inclusive",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["ext_depth_range_unrestricted"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "ext_depth_range_unrestricted",
+                )])]),
             });
         }
 
@@ -513,11 +508,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_depth_bounds_test_enable`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -582,11 +576,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_depth_compare_op`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -645,11 +638,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_depth_test_enable`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -708,11 +700,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_depth_write_enable`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -780,10 +771,9 @@ where
         if self.device().enabled_extensions().ext_discard_rectangles {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_discard_rectangle`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["ext_discard_rectangles"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "ext_discard_rectangles",
+                )])]),
             });
         }
 
@@ -873,11 +863,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_front_face`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -937,10 +926,9 @@ where
         if !self.device().enabled_extensions().ext_line_rasterization {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_line_stipple`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["ext_line_rasterization"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "ext_line_rasterization",
+                )])]),
             });
         }
 
@@ -1001,10 +989,9 @@ where
         if !self.device().enabled_features().wide_lines && line_width != 1.0 {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`line_width` is not `1.0`",
-                requires_one_of: RequiresOneOf {
-                    features: &["wide_lines"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "wide_lines",
+                )])]),
             });
         }
 
@@ -1068,10 +1055,9 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_logic_op`",
-                requires_one_of: RequiresOneOf {
-                    features: &["extended_dynamic_state2_logic_op"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "extended_dynamic_state2_logic_op",
+                )])]),
             });
         }
 
@@ -1136,10 +1122,9 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_patch_control_points`",
-                requires_one_of: RequiresOneOf {
-                    features: &["extended_dynamic_state2_patch_control_points"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "extended_dynamic_state2_patch_control_points",
+                )])]),
             });
         }
 
@@ -1222,11 +1207,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_primitive_restart_enable`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state2"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state2")]),
+                ]),
             });
         }
 
@@ -1295,11 +1279,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_primitive_topology`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -1314,10 +1297,9 @@ where
                     return Err(SetDynamicStateError::RequirementNotMet {
                         required_for: "this device is a portability subset device, and `topology` \
                             is `PrimitiveTopology::TriangleFan`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["triangle_fans"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "triangle_fans",
+                        )])]),
                     });
                 }
             }
@@ -1328,10 +1310,9 @@ where
                 if !self.device().enabled_features().geometry_shader {
                     return Err(SetDynamicStateError::RequirementNotMet {
                         required_for: "`topology` is `PrimitiveTopology::*WithAdjacency`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["geometry_shader"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "geometry_shader",
+                        )])]),
                     });
                 }
             }
@@ -1339,10 +1320,9 @@ where
                 if !self.device().enabled_features().tessellation_shader {
                     return Err(SetDynamicStateError::RequirementNotMet {
                         required_for: "`topology` is `PrimitiveTopology::PatchList`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["tessellation_shader"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "tessellation_shader",
+                        )])]),
                     });
                 }
             }
@@ -1410,11 +1390,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_rasterizer_discard_enable`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state2"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state2")]),
+                ]),
             });
         }
 
@@ -1491,10 +1470,9 @@ where
             if first_scissor != 0 {
                 return Err(SetDynamicStateError::RequirementNotMet {
                     required_for: "`first_scissor` is not `0`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["multi_viewport"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "multi_viewport",
+                    )])]),
                 });
             }
 
@@ -1502,10 +1480,9 @@ where
             if scissors.len() > 1 {
                 return Err(SetDynamicStateError::RequirementNotMet {
                     required_for: "`scissors.len()` is greater than `1`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["multi_viewport"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "multi_viewport",
+                    )])]),
                 });
             }
         }
@@ -1582,11 +1559,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_scissor_with_count`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -1602,10 +1578,9 @@ where
         if !self.device().enabled_features().multi_viewport && scissors.len() > 1 {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`scissors.len()` is greater than `1`",
-                requires_one_of: RequiresOneOf {
-                    features: &["multi_viewport"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "multi_viewport",
+                )])]),
             });
         }
 
@@ -1768,11 +1743,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_stencil_op`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -1924,11 +1898,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_stencil_test_enable`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -2073,10 +2046,9 @@ where
             if first_viewport != 0 {
                 return Err(SetDynamicStateError::RequirementNotMet {
                     required_for: "`first_scissors` is not `0`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["multi_viewport"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "multi_viewport",
+                    )])]),
                 });
             }
 
@@ -2084,10 +2056,9 @@ where
             if viewports.len() > 1 {
                 return Err(SetDynamicStateError::RequirementNotMet {
                     required_for: "`viewports.len()` is greater than `1`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["multi_viewport"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "multi_viewport",
+                    )])]),
                 });
             }
         }
@@ -2162,11 +2133,10 @@ where
         {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::set_viewport_with_count`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    features: &["extended_dynamic_state"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                ]),
             });
         }
 
@@ -2182,10 +2152,9 @@ where
         if !self.device().enabled_features().multi_viewport && viewports.len() > 1 {
             return Err(SetDynamicStateError::RequirementNotMet {
                 required_for: "`viewports.len()` is greater than `1`",
-                requires_one_of: RequiresOneOf {
-                    features: &["multi_viewport"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "multi_viewport",
+                )])]),
             });
         }
 

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -37,7 +37,7 @@ use crate::{
     sampler::Sampler,
     shader::{DescriptorBindingRequirements, ShaderScalarType, ShaderStage, ShaderStages},
     sync::{PipelineStageAccess, PipelineStageAccessFlags},
-    DeviceSize, RequiresOneOf, ValidationError, VulkanObject,
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
 use std::{
     cmp::min,
@@ -382,10 +382,9 @@ where
         if draw_count > 1 && !self.device().enabled_features().multi_draw_indirect {
             return Err(PipelineExecutionError::RequirementNotMet {
                 required_for: "`draw_count` is greater than `1`",
-                requires_one_of: RequiresOneOf {
-                    features: &["multi_draw_indirect"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "multi_draw_indirect",
+                )])]),
             });
         }
 
@@ -642,10 +641,9 @@ where
         if draw_count > 1 && !self.device().enabled_features().multi_draw_indirect {
             return Err(PipelineExecutionError::RequirementNotMet {
                 required_for: "`draw_count` is greater than `1`",
-                requires_one_of: RequiresOneOf {
-                    features: &["multi_draw_indirect"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "multi_draw_indirect",
+                )])]),
             });
         }
 
@@ -1404,10 +1402,7 @@ where
                                             `DynamicState::PrimitiveRestartEnable` and the \
                                             current primitive topology is \
                                             `PrimitiveTopology::*List`",
-                                        requires_one_of: RequiresOneOf {
-                                            features: &["primitive_topology_list_restart"],
-                                            ..Default::default()
-                                        },
+                                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("primitive_topology_list_restart")])]),
                                     });
                                 }
                             }
@@ -1422,10 +1417,7 @@ where
                                             `DynamicState::PrimitiveRestartEnable` and the \
                                             current primitive topology is \
                                             `PrimitiveTopology::PatchList`",
-                                        requires_one_of: RequiresOneOf {
-                                            features: &["primitive_topology_patch_list_restart"],
-                                            ..Default::default()
-                                        },
+                                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("primitive_topology_patch_list_restart")])]),
                                     });
                                 }
                             }

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -18,7 +18,7 @@ use crate::{
     device::{DeviceOwned, QueueFlags},
     query::{QueryControlFlags, QueryPool, QueryResultElement, QueryResultFlags, QueryType},
     sync::{PipelineStage, PipelineStageAccessFlags, PipelineStages},
-    DeviceSize, RequirementNotMet, RequiresOneOf, Version, VulkanObject,
+    DeviceSize, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, Version, VulkanObject,
 };
 use std::{
     error::Error,
@@ -97,10 +97,9 @@ where
                 {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`flags` contains `QueryControlFlags::PRECISE`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["occlusion_query_precise"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "occlusion_query_precise",
+                        )])]),
                     });
                 }
             }
@@ -298,10 +297,9 @@ where
         {
             return Err(QueryError::RequirementNotMet {
                 required_for: "`stage` has flags set from `VkPipelineStageFlagBits2`",
-                requires_one_of: RequiresOneOf {
-                    features: &["synchronization2"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "synchronization2",
+                )])]),
             });
         }
 
@@ -337,10 +335,9 @@ where
                 if !device.enabled_features().geometry_shader {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::GeometryShader`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["geometry_shadere"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "geometry_shadere",
+                        )])]),
                     });
                 }
             }
@@ -351,10 +348,9 @@ where
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::TessellationControlShader` or \
                             `PipelineStage::TessellationEvaluationShader`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["tessellation_shader"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "tessellation_shader",
+                        )])]),
                     });
                 }
             }
@@ -363,10 +359,9 @@ where
                 if !device.enabled_features().conditional_rendering {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::ConditionalRendering`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["conditional_rendering"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "conditional_rendering",
+                        )])]),
                     });
                 }
             }
@@ -375,10 +370,9 @@ where
                 if !device.enabled_features().fragment_density_map {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::FragmentDensityProcess`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["fragment_density_map"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "fragment_density_map",
+                        )])]),
                     });
                 }
             }
@@ -387,10 +381,9 @@ where
                 if !device.enabled_features().transform_feedback {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::TransformFeedback`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["transform_feedback"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "transform_feedback",
+                        )])]),
                     });
                 }
             }
@@ -399,10 +392,9 @@ where
                 if !device.enabled_features().mesh_shader {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::MeshShader`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["mesh_shader"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "mesh_shader",
+                        )])]),
                     });
                 }
             }
@@ -411,10 +403,9 @@ where
                 if !device.enabled_features().task_shader {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::TaskShader`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["task_shader"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "task_shader",
+                        )])]),
                     });
                 }
             }
@@ -425,10 +416,10 @@ where
                 {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::FragmentShadingRateAttachment`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["attachment_fragment_shading_rate", "shading_rate_image"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[
+                            RequiresAllOf(&[Requires::Feature("attachment_fragment_shading_rate")]),
+                            RequiresAllOf(&[Requires::Feature("shading_rate_image")]),
+                        ]),
                     });
                 }
             }
@@ -437,10 +428,9 @@ where
                 if !device.enabled_features().subpass_shading {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::SubpassShading`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["subpass_shading"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "subpass_shading",
+                        )])]),
                     });
                 }
             }
@@ -449,10 +439,9 @@ where
                 if !device.enabled_features().invocation_mask {
                     return Err(QueryError::RequirementNotMet {
                         required_for: "`stage` is `PipelineStage::InvocationMask`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["invocation_mask"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "invocation_mask",
+                        )])]),
                     });
                 }
             }

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -26,7 +26,7 @@ use crate::{
         ResolveMode, SubpassDescription,
     },
     sync::PipelineStageAccessFlags,
-    RequirementNotMet, RequiresOneOf, Version, VulkanObject,
+    RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, Version, VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{
@@ -698,10 +698,9 @@ where
         if !device.enabled_features().dynamic_rendering {
             return Err(RenderPassError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::begin_rendering`",
-                requires_one_of: RequiresOneOf {
-                    features: &["dynamic_rendering"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "dynamic_rendering",
+                )])]),
             });
         }
 
@@ -751,10 +750,7 @@ where
         if view_mask != 0 && !device.enabled_features().multiview {
             return Err(RenderPassError::RequirementNotMet {
                 required_for: "`rendering_info.viewmask` is not `0`",
-                requires_one_of: RequiresOneOf {
-                    features: &["multiview"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("multiview")])]),
             });
         }
 
@@ -1267,10 +1263,9 @@ where
                         `rendering_info.stencil_attachment` are both \
                         `Some`, and `rendering_info.depth_attachment.image_layout` does not \
                         equal `rendering_info.stencil_attachment.attachment_ref.layout`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["separate_depth_stencil_layouts"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "separate_depth_stencil_layouts",
+                    )])]),
                 });
             }
 
@@ -1300,10 +1295,9 @@ where
                                 `rendering_info.depth_attachment.resolve_info.image_layout` \
                                 does not equal \
                                 `rendering_info.stencil_attachment.resolve_info.image_layout`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["separate_depth_stencil_layouts"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "separate_depth_stencil_layouts",
+                            )])]),
                         });
                     }
 

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -20,7 +20,7 @@ use crate::{
     format::Format,
     image::SampleCount,
     query::{QueryControlFlags, QueryPipelineStatisticFlags, QueryType},
-    RequiresOneOf, SafeDeref, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, SafeDeref, VulkanObject,
 };
 use smallvec::{smallvec, SmallVec};
 use std::{
@@ -303,10 +303,9 @@ where
         {
             return Err(ExecuteCommandsError::RequirementNotMet {
                 required_for: "`AutoCommandBufferBuilder::execute_commands` when a query is active",
-                requires_one_of: RequiresOneOf {
-                    features: &["inherited_queries"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "inherited_queries",
+                )])]),
             });
         }
 

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -19,7 +19,7 @@ use crate::{
     command_buffer::CommandBufferLevel,
     device::{Device, DeviceOwned},
     macros::impl_id_counter,
-    OomError, RequiresOneOf, RuntimeError, Version, VulkanObject,
+    OomError, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, Version, VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{
@@ -286,11 +286,10 @@ impl CommandPool {
         {
             return Err(CommandPoolTrimError::RequirementNotMet {
                 required_for: "`CommandPool::trim`",
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_1),
-                    device_extensions: &["khr_maintenance1"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                    RequiresAllOf(&[Requires::DeviceExtension("khr_maintenance1")]),
+                ]),
             });
         }
 
@@ -535,7 +534,7 @@ mod tests {
     };
     use crate::{
         command_buffer::{pool::CommandBufferAllocateInfo, CommandBufferLevel},
-        RequiresOneOf, Version,
+        Requires, RequiresAllOf, RequiresOneOf, Version,
     };
 
     #[test]
@@ -596,11 +595,11 @@ mod tests {
             if matches!(
                 pool.trim(),
                 Err(CommandPoolTrimError::RequirementNotMet {
-                    requires_one_of: RequiresOneOf {
-                        device_extensions,
-                        ..
-                    }, ..
-                }) if device_extensions.contains(&"khr_maintenance1")
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf([Requires::DeviceExtension(
+                        "khr_maintenance1"
+                    )]),]),
+                    ..
+                })
             ) {
                 panic!()
             }
@@ -608,11 +607,11 @@ mod tests {
             if !matches!(
                 pool.trim(),
                 Err(CommandPoolTrimError::RequirementNotMet {
-                    requires_one_of: RequiresOneOf {
-                        device_extensions,
-                        ..
-                    }, ..
-                }) if device_extensions.contains(&"khr_maintenance1")
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf([Requires::DeviceExtension(
+                        "khr_maintenance1"
+                    )]),]),
+                    ..
+                })
             ) {
                 panic!()
             }

--- a/vulkano/src/deferred.rs
+++ b/vulkano/src/deferred.rs
@@ -18,7 +18,7 @@
 
 use crate::{
     device::{Device, DeviceOwned},
-    RequiresOneOf, RuntimeError, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, RuntimeError, VulkanObject,
 };
 use std::{
     error::Error,
@@ -55,10 +55,9 @@ impl DeferredOperation {
         if !device.enabled_extensions().khr_deferred_host_operations {
             return Err(DeferredOperationCreateError::RequirementNotMet {
                 required_for: "`DeferredOperation::new`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_deferred_host_operations"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_deferred_host_operations",
+                )])]),
             });
         }
 

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -441,7 +441,7 @@ impl DescriptorSetLayoutCreateInfo {
         {
             return Err(ValidationError {
                 problem: "`flags` contains `DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR`, and \
-                    the total number of descriptors in `bindings` exceeds the
+                    the total number of descriptors in `bindings` exceeds the \
                     `max_push_descriptors` limit"
                     .into(),
                 vuids: &["VUID-VkDescriptorSetLayoutCreateInfo-flags-00281"],
@@ -648,7 +648,7 @@ impl DescriptorSetLayoutBinding {
             if !device.enabled_features().inline_uniform_block {
                 return Err(ValidationError {
                     context: "descriptor_type".into(),
-                    problem: "DescriptorType::InlineUniformBlock".into(),
+                    problem: "`DescriptorType::InlineUniformBlock`".into(),
                     requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
                         "inline_uniform_block",
                     )])]),

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -17,7 +17,8 @@ use crate::{
     macros::{impl_id_counter, vulkan_bitflags, vulkan_enum},
     sampler::Sampler,
     shader::{DescriptorBindingRequirements, ShaderStages},
-    RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError,
+    VulkanObject,
 };
 use ahash::HashMap;
 use std::{
@@ -471,10 +472,11 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    UPDATE_AFTER_BIND_POOL = UPDATE_AFTER_BIND_POOL {
-        api_version: V1_2,
-        device_extensions: [ext_descriptor_indexing],
-    }, */
+    UPDATE_AFTER_BIND_POOL = UPDATE_AFTER_BIND_POOL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(ext_descriptor_indexing)]),
+    ]), */
 
     /// Whether the descriptor set layout should be created for push descriptors.
     ///
@@ -487,27 +489,32 @@ vulkan_bitflags! {
     /// - There must be no bindings with `variable_descriptor_count` enabled.
     /// - The total number of descriptors across all bindings must be less than the
     ///   [`max_push_descriptors`](crate::device::Properties::max_push_descriptors) limit.
-    PUSH_DESCRIPTOR = PUSH_DESCRIPTOR_KHR {
-        device_extensions: [khr_push_descriptor],
-    },
+    PUSH_DESCRIPTOR = PUSH_DESCRIPTOR_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_push_descriptor)]),
+    ]),
 
     /* TODO: enable
     // TODO: document
-    DESCRIPTOR_BUFFER = DESCRIPTOR_BUFFER_EXT {
-        device_extensions: [ext_descriptor_buffer],
-    }, */
+    DESCRIPTOR_BUFFER = DESCRIPTOR_BUFFER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_descriptor_buffer)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    EMBEDDED_IMMUTABLE_SAMPLERS = EMBEDDED_IMMUTABLE_SAMPLERS_EXT {
-        device_extensions: [ext_descriptor_buffer],
-    }, */
+    EMBEDDED_IMMUTABLE_SAMPLERS = EMBEDDED_IMMUTABLE_SAMPLERS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_descriptor_buffer)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    HOST_ONLY_POOL = HOST_ONLY_POOL_EXT {
-        device_extensions: [ext_mutable_descriptor_type, valve_mutable_descriptor_type],
-    }, */
+    HOST_ONLY_POOL = HOST_ONLY_POOL_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_mutable_descriptor_type)]),
+        RequiresAllOf([DeviceExtension(valve_mutable_descriptor_type)]),
+    ]), */
 }
 
 /// A binding in a descriptor set layout.
@@ -642,10 +649,9 @@ impl DescriptorSetLayoutBinding {
                 return Err(ValidationError {
                     context: "descriptor_type".into(),
                     problem: "DescriptorType::InlineUniformBlock".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["inline_uniform_block"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "inline_uniform_block",
+                    )])]),
                     vuids: &["VUID-VkDescriptorSetLayoutBinding-descriptorType-04604"],
                 });
             }
@@ -754,10 +760,9 @@ impl DescriptorSetLayoutBinding {
                 return Err(ValidationError {
                     context: "binding_flags".into(),
                     problem: "contains `DescriptorBindingFlags::VARIABLE_DESCRIPTOR_COUNT`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["descriptor_binding_variable_descriptor_count"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::Feature("descriptor_binding_variable_descriptor_count")])
+                    ]),
                     vuids: &["VUID-VkDescriptorSetLayoutBindingFlagsCreateInfo-descriptorBindingVariableDescriptorCount-03014"],
                 });
             }
@@ -806,24 +811,27 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    UPDATE_AFTER_BIND = UPDATE_AFTER_BIND {
-        api_version: V1_2,
-        device_extensions: [ext_descriptor_indexing],
-    }, */
+    UPDATE_AFTER_BIND = UPDATE_AFTER_BIND
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(ext_descriptor_indexing)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    UPDATE_UNUSED_WHILE_PENDING = UPDATE_UNUSED_WHILE_PENDING {
-        api_version: V1_2,
-        device_extensions: [ext_descriptor_indexing],
-    }, */
+    UPDATE_UNUSED_WHILE_PENDING = UPDATE_UNUSED_WHILE_PENDING
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(ext_descriptor_indexing)]),
+    ]), */
 
     /* TODO: enable
     // TODO: document
-    PARTIALLY_BOUND = PARTIALLY_BOUND {
-        api_version: V1_2,
-        device_extensions: [ext_descriptor_indexing],
-    }, */
+    PARTIALLY_BOUND = PARTIALLY_BOUND
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(ext_descriptor_indexing)]),
+    ]), */
 
     /// Whether the binding has a variable number of descriptors.
     ///
@@ -836,10 +844,11 @@ vulkan_bitflags! {
     /// [`DescriptorType::UniformBufferDynamic`] or [`DescriptorType::StorageBufferDynamic`].
     ///
     /// [`descriptor_binding_variable_descriptor_count`]: crate::device::Features::descriptor_binding_variable_descriptor_count
-    VARIABLE_DESCRIPTOR_COUNT = VARIABLE_DESCRIPTOR_COUNT {
-        api_version: V1_2,
-        device_extensions: [ext_descriptor_indexing],
-    },
+    VARIABLE_DESCRIPTOR_COUNT = VARIABLE_DESCRIPTOR_COUNT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(ext_descriptor_indexing)]),
+    ]),
 }
 
 vulkan_enum! {
@@ -905,39 +914,53 @@ vulkan_enum! {
     /// - The `first_array_element` value when writing a descriptor set specifies the byte offset
     ///   into the inline buffer.
     /// These values must always be a multiple of 4.
-    InlineUniformBlock = INLINE_UNIFORM_BLOCK {
-        api_version: V1_3,
-        device_extensions: [ext_inline_uniform_block],
-    },
+    InlineUniformBlock = INLINE_UNIFORM_BLOCK
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_inline_uniform_block)]),
+    ]),
+
+    /* TODO: enable
+    // TODO: document
+    InlineUniformBlock = INLINE_UNIFORM_BLOCK
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_inline_uniform_block)]),
+    ]),*/
 
     /// Gives read access to an acceleration structure, for performing ray queries and ray tracing.
-    AccelerationStructure = ACCELERATION_STRUCTURE_KHR {
-        device_extensions: [khr_acceleration_structure],
-    },
+    AccelerationStructure = ACCELERATION_STRUCTURE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_acceleration_structure)]),
+    ]),
 
     /* TODO: enable
     // TODO: document
-    AccelerationStructureNV = ACCELERATION_STRUCTURE_NV {
-        device_extensions: [nv_ray_tracing],
-    },*/
+    AccelerationStructureNV = ACCELERATION_STRUCTURE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SampleWeightImage = SAMPLE_WEIGHT_IMAGE_QCOM {
-        device_extensions: [qcom_image_processing],
-    },*/
+    SampleWeightImage = SAMPLE_WEIGHT_IMAGE_QCOM
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(qcom_image_processing)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    BlockMatchImage = BLOCK_MATCH_IMAGE_QCOM {
-        device_extensions: [qcom_image_processing],
-    },*/
+    BlockMatchImage = BLOCK_MATCH_IMAGE_QCOM
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(qcom_image_processing)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Mutable = MUTABLE_VALVE {
-        device_extensions: [valve_mutable_descriptor_type],
-    },*/
+    Mutable = MUTABLE_VALVE
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(valve_mutable_descriptor_type)]),
+    ]),*/
 }
 
 impl DescriptorType {

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -14,7 +14,8 @@ use crate::{
     },
     device::{Device, DeviceOwned},
     macros::{impl_id_counter, vulkan_bitflags},
-    RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError,
+    VulkanObject,
 };
 use ahash::HashMap;
 use smallvec::SmallVec;
@@ -468,11 +469,10 @@ impl DescriptorPoolCreateInfo {
             return Err(ValidationError {
                 context: "max_inline_uniform_block_bindings".into(),
                 problem: "is not zero".into(),
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    device_extensions: &["ext_inline_uniform_block"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::DeviceExtension("ext_inline_uniform_block")]),
+                ]),
                 // vuids?
                 ..Default::default()
             });

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -20,7 +20,7 @@ use crate::{
         view::ImageViewType, ImageAspects, ImageLayout, ImageType, ImageUsage, ImageViewAbstract,
     },
     sampler::Sampler,
-    DeviceSize, RequiresOneOf, ValidationError, VulkanObject,
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
 use smallvec::SmallVec;
 use std::{ops::Range, ptr, sync::Arc};
@@ -452,10 +452,9 @@ impl WriteDescriptorSet {
                                             layout_binding.descriptor_type,
                                         )
                                         .into(),
-                                        requires_one_of: RequiresOneOf {
-                                            features: &["image2_d_view_of3_d"],
-                                            ..Default::default()
-                                        },
+                                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                            Requires::Feature("image2_d_view_of3_d"),
+                                        ])]),
                                         vuids: &["VUID-VkDescriptorImageInfo-descriptorType-06713"],
                                     });
                                 }
@@ -471,10 +470,9 @@ impl WriteDescriptorSet {
                                             layout_binding.descriptor_type,
                                         )
                                         .into(),
-                                        requires_one_of: RequiresOneOf {
-                                            features: &["sampler2_d_view_of3_d"],
-                                            ..Default::default()
-                                        },
+                                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                            Requires::Feature("sampler2_d_view_of3_d"),
+                                        ])]),
                                         vuids: &["VUID-VkDescriptorImageInfo-descriptorType-06714"],
                                     });
                                 }
@@ -593,10 +591,9 @@ impl WriteDescriptorSet {
                             problem: "this device is a portability subset device, and \
                                 the sampler has depth comparison enabled"
                                 .into(),
-                            requires_one_of: RequiresOneOf {
-                                features: &["mutable_comparison_samplers"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "mutable_comparison_samplers",
+                            )])]),
                             vuids: &["VUID-VkDescriptorImageInfo-mutableComparisonSamplers-04450"],
                         });
                     }
@@ -680,10 +677,9 @@ impl WriteDescriptorSet {
                                 problem: "this device is a portability subset device, and \
                                     the sampler has depth comparison enabled"
                                     .into(),
-                                requires_one_of: RequiresOneOf {
-                                    features: &["mutable_comparison_samplers"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("mutable_comparison_samplers"),
+                                ])]),
                                 vuids: &[
                                     "VUID-VkDescriptorImageInfo-mutableComparisonSamplers-04450",
                                 ],

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -623,13 +623,14 @@ impl Device {
             });
         }
 
-        if !(self.enabled_features().ray_tracing_pipeline || self.enabled_features().ray_query) {
+        if !self.enabled_features().acceleration_structure {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf(&[
-                    RequiresAllOf(&[Requires::Feature("ray_tracing_pipeline")]),
-                    RequiresAllOf(&[Requires::Feature("ray_query")]),
-                ]),
-                vuids: &["VUID-vkGetAccelerationStructureBuildSizesKHR-rayTracingPipeline-03617"],
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "acceleration_structure",
+                )])]),
+                vuids: &[
+                    "VUID-vkGetAccelerationStructureBuildSizesKHR-accelerationStructure-08933",
+                ],
                 ..Default::default()
             });
         }
@@ -777,13 +778,12 @@ impl Device {
             });
         }
 
-        if !(self.enabled_features().ray_tracing_pipeline || self.enabled_features().ray_query) {
+        if !self.enabled_features().acceleration_structure {
             return Err(ValidationError {
                 requires_one_of: RequiresOneOf(&[
-                    RequiresAllOf(&[Requires::Feature("ray_tracing_pipeline")]),
-                    RequiresAllOf(&[Requires::Feature("ray_query")]),
+                    RequiresAllOf(&[Requires::Feature("acceleration_structure")]),
                 ]),
-                vuids: &["VUID-vkGetDeviceAccelerationStructureCompatibilityKHR-rayTracingPipeline-03661"],
+                vuids: &["VUID-vkGetDeviceAccelerationStructureCompatibilityKHR-accelerationStructure-08928"],
                 ..Default::default()
             });
         }

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -664,7 +664,7 @@ impl Device {
                     if primitive_count as u64 > max_primitive_count {
                         return Err(ValidationError {
                             context: format!("max_primitive_counts[{}]", index).into(),
-                            problem: "the max_primitive_count limit has been exceeded".into(),
+                            problem: "exceeds the `max_primitive_count` limit".into(),
                             vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03795"],
                             ..Default::default()
                         });
@@ -678,7 +678,7 @@ impl Device {
                     if primitive_count as u64 > max_primitive_count {
                         return Err(ValidationError {
                             context: format!("max_primitive_counts[{}]", index).into(),
-                            problem: "the max_primitive_count limit has been exceeded".into(),
+                            problem: "exceeds the `max_primitive_count` limit".into(),
                             vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03794"],
                             ..Default::default()
                         });
@@ -692,7 +692,7 @@ impl Device {
                     if instance_count as u64 > max_instance_count {
                         return Err(ValidationError {
                             context: format!("max_primitive_counts[{}]", index).into(),
-                            problem: "the max_instance_count limit has been exceeded".into(),
+                            problem: "exceeds the `max_instance_count` limit".into(),
                             vuids: &[
                                 "VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03785",
                             ],
@@ -707,7 +707,7 @@ impl Device {
 
         if max_primitive_counts.len() != geometry_count {
             return Err(ValidationError {
-                problem: "build_info.geometries and max_primitive_counts \
+                problem: "`build_info.geometries` and `max_primitive_counts` \
                     do not have the same length"
                     .into(),
                 vuids: &["VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03619"],

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -28,8 +28,8 @@ use crate::{
         fence::{ExternalFenceInfo, ExternalFenceProperties},
         semaphore::{ExternalSemaphoreInfo, ExternalSemaphoreProperties},
     },
-    ExtensionProperties, RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError,
-    VulkanObject,
+    ExtensionProperties, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, ValidationError,
+    Version, VulkanError, VulkanObject,
 };
 use bytemuck::cast_slice;
 use std::{
@@ -442,10 +442,9 @@ impl PhysicalDevice {
     ) -> Result<(), ValidationError> {
         if !self.instance.enabled_extensions().ext_directfb_surface {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_directfb_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_directfb_surface",
+                )])]),
                 ..Default::default()
             });
         }
@@ -514,11 +513,12 @@ impl PhysicalDevice {
                 .khr_external_memory_capabilities)
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_1),
-                    instance_extensions: &["khr_external_memory_capabilities"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                    RequiresAllOf(&[Requires::InstanceExtension(
+                        "khr_external_memory_capabilities",
+                    )]),
+                ]),
                 ..Default::default()
             });
         }
@@ -613,11 +613,12 @@ impl PhysicalDevice {
                 .khr_external_fence_capabilities)
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_1),
-                    instance_extensions: &["khr_external_fence_capabilities"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                    RequiresAllOf(&[Requires::InstanceExtension(
+                        "khr_external_fence_capabilities",
+                    )]),
+                ]),
                 ..Default::default()
             });
         }
@@ -715,11 +716,12 @@ impl PhysicalDevice {
                 .khr_external_semaphore_capabilities)
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_1),
-                    instance_extensions: &["khr_external_semaphore_capabilities"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                    RequiresAllOf(&[Requires::InstanceExtension(
+                        "khr_external_semaphore_capabilities",
+                    )]),
+                ]),
                 ..Default::default()
             });
         }
@@ -1109,10 +1111,9 @@ impl PhysicalDevice {
     ) -> Result<(), ValidationError> {
         if !self.instance.enabled_extensions().qnx_screen_surface {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["qnx_screen_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "qnx_screen_surface",
+                )])]),
                 ..Default::default()
             });
         }
@@ -1358,10 +1359,10 @@ impl PhysicalDevice {
             || self.instance.enabled_extensions().khr_surface)
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_get_surface_capabilities2", "khr_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::InstanceExtension("khr_get_surface_capabilities2")]),
+                    RequiresAllOf(&[Requires::InstanceExtension("khr_surface")]),
+                ]),
                 ..Default::default()
             });
         }
@@ -1606,10 +1607,10 @@ impl PhysicalDevice {
             || self.instance.enabled_extensions().khr_surface)
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_get_surface_capabilities2", "khr_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::InstanceExtension("khr_get_surface_capabilities2")]),
+                    RequiresAllOf(&[Requires::InstanceExtension("khr_surface")]),
+                ]),
                 ..Default::default()
             });
         }
@@ -1644,10 +1645,9 @@ impl PhysicalDevice {
                 return Err(ValidationError {
                     context: "surface_info.full_screen_exclusive".into(),
                     problem: "is not `FullScreenExclusive::Default`".into(),
-                    requires_one_of: RequiresOneOf {
-                        instance_extensions: &["khr_get_surface_capabilities2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                        Requires::InstanceExtension("khr_get_surface_capabilities2"),
+                    ])]),
                     ..Default::default()
                 });
             }
@@ -1656,10 +1656,9 @@ impl PhysicalDevice {
                 return Err(ValidationError {
                     context: "surface_info.win32_monitor".into(),
                     problem: "is `Some`".into(),
-                    requires_one_of: RequiresOneOf {
-                        instance_extensions: &["khr_get_surface_capabilities2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                        Requires::InstanceExtension("khr_get_surface_capabilities2"),
+                    ])]),
                     ..Default::default()
                 });
             }
@@ -1858,10 +1857,9 @@ impl PhysicalDevice {
     fn validate_surface_present_modes(&self, surface: &Surface) -> Result<(), ValidationError> {
         if !self.instance.enabled_extensions().khr_surface {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_surface",
+                )])]),
                 ..Default::default()
             });
         }
@@ -1956,10 +1954,9 @@ impl PhysicalDevice {
     ) -> Result<(), ValidationError> {
         if !self.instance.enabled_extensions().khr_surface {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_surface",
+                )])]),
                 ..Default::default()
             });
         }
@@ -2020,11 +2017,10 @@ impl PhysicalDevice {
     fn validate_tool_properties(&self) -> Result<(), ValidationError> {
         if !(self.api_version() >= Version::V1_3 || self.supported_extensions().ext_tooling_info) {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    api_version: Some(Version::V1_3),
-                    device_extensions: &["ext_tooling_info"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[
+                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                    RequiresAllOf(&[Requires::DeviceExtension("ext_tooling_info")]),
+                ]),
                 ..Default::default()
             });
         }
@@ -2131,10 +2127,9 @@ impl PhysicalDevice {
     ) -> Result<(), ValidationError> {
         if !self.instance.enabled_extensions().khr_wayland_surface {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_wayland_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_wayland_surface",
+                )])]),
                 ..Default::default()
             });
         }
@@ -2190,10 +2185,9 @@ impl PhysicalDevice {
     ) -> Result<(), ValidationError> {
         if !self.instance.enabled_extensions().khr_win32_surface {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_win32_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_win32_surface",
+                )])]),
                 ..Default::default()
             });
         }
@@ -2248,10 +2242,9 @@ impl PhysicalDevice {
     ) -> Result<(), ValidationError> {
         if !self.instance.enabled_extensions().khr_xcb_surface {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_xcb_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_xcb_surface",
+                )])]),
                 ..Default::default()
             });
         }
@@ -2316,10 +2309,9 @@ impl PhysicalDevice {
     ) -> Result<(), ValidationError> {
         if !self.instance.enabled_extensions().khr_xlib_surface {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_xlib_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_xlib_surface",
+                )])]),
                 ..Default::default()
             });
         }
@@ -2578,16 +2570,19 @@ vulkan_bitflags! {
 
     /// The tool reports information to the user via a
     /// [`DebugUtilsMessenger`](crate::instance::debug::DebugUtilsMessenger).
-    DEBUG_REPORTING = DEBUG_REPORTING_EXT {
-        instance_extensions: [ext_debug_utils, ext_debug_report],
-    },
+    DEBUG_REPORTING = DEBUG_REPORTING_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_debug_utils)]),
+        RequiresAllOf([InstanceExtension(ext_debug_report)]),
+    ]),
 
     /// The tool consumes debug markers or object debug annotation, queue labels or command buffer
     /// labels.
-    DEBUG_MARKERS = DEBUG_MARKERS_EXT {
-        device_extensions: [ext_debug_marker],
-        instance_extensions: [ext_debug_utils],
-    },
+    DEBUG_MARKERS = DEBUG_MARKERS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_debug_marker)]),
+        RequiresAllOf([InstanceExtension(ext_debug_utils)]),
+    ]),
 }
 
 vulkan_bitflags! {
@@ -2621,9 +2616,10 @@ vulkan_bitflags! {
     QUAD = QUAD,
 
     // TODO: document
-    PARTITIONED = PARTITIONED_NV {
-        device_extensions: [nv_shader_subgroup_partitioned],
-    },
+    PARTITIONED = PARTITIONED_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_shader_subgroup_partitioned)]),
+    ]),
 }
 
 vulkan_enum! {

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -26,7 +26,8 @@ use crate::{
         future::{AccessCheckError, FlushError, GpuFuture},
         semaphore::SemaphoreState,
     },
-    OomError, RequiresOneOf, RuntimeError, ValidationError, Version, VulkanObject,
+    OomError, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, ValidationError, Version,
+    VulkanObject,
 };
 use ahash::HashMap;
 use parking_lot::{Mutex, MutexGuard};
@@ -1155,10 +1156,9 @@ impl<'a> QueueGuard<'a> {
             .ext_debug_utils
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_debug_utils"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_debug_utils",
+                )])]),
                 ..Default::default()
             });
         }
@@ -1212,10 +1212,9 @@ impl<'a> QueueGuard<'a> {
             .ext_debug_utils
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_debug_utils"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_debug_utils",
+                )])]),
                 ..Default::default()
             });
         }
@@ -1262,10 +1261,9 @@ impl<'a> QueueGuard<'a> {
             .ext_debug_utils
         {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_debug_utils"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_debug_utils",
+                )])]),
                 ..Default::default()
             });
         }
@@ -1655,24 +1653,28 @@ vulkan_bitflags! {
     SPARSE_BINDING = SPARSE_BINDING,
 
     /// Queues of this family can be created using the `protected` flag.
-    PROTECTED = PROTECTED {
-        api_version: V1_1,
-    },
+    PROTECTED = PROTECTED
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+    ]),
 
     /// Queues of this family can execute video decode operations.
-    VIDEO_DECODE = VIDEO_DECODE_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },
+    VIDEO_DECODE = VIDEO_DECODE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),
 
     /// Queues of this family can execute video encode operations.
-    VIDEO_ENCODE = VIDEO_ENCODE_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },
+    VIDEO_ENCODE = VIDEO_ENCODE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),
 
     /// Queues of this family can execute optical flow operations.
-    OPTICAL_FLOW = OPTICAL_FLOW_NV {
-        device_extensions: [nv_optical_flow],
-    },
+    OPTICAL_FLOW = OPTICAL_FLOW_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_optical_flow)]),
+    ]),
 }
 
 #[cfg(test)]

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -761,17 +761,19 @@ vulkan_bitflags! {
 
     /// Can be used with a storage image descriptor for reading, without specifying a format on the
     /// image view.
-    STORAGE_READ_WITHOUT_FORMAT = STORAGE_READ_WITHOUT_FORMAT {
-        api_version: V1_3,
-        device_extensions: [khr_format_feature_flags2],
-    },
+    STORAGE_READ_WITHOUT_FORMAT = STORAGE_READ_WITHOUT_FORMAT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_format_feature_flags2)]),
+    ]),
 
     /// Can be used with a storage image descriptor for writing, without specifying a format on the
     /// image view.
-    STORAGE_WRITE_WITHOUT_FORMAT = STORAGE_WRITE_WITHOUT_FORMAT {
-        api_version: V1_3,
-        device_extensions: [khr_format_feature_flags2],
-    },
+    STORAGE_WRITE_WITHOUT_FORMAT = STORAGE_WRITE_WITHOUT_FORMAT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_format_feature_flags2)]),
+    ]),
 
     /// Can be used with a color attachment in a framebuffer, or with an input attachment
     /// descriptor.
@@ -786,26 +788,30 @@ vulkan_bitflags! {
     DEPTH_STENCIL_ATTACHMENT = DEPTH_STENCIL_ATTACHMENT,
 
     /// Can be used with a fragment density map attachment in a framebuffer.
-    FRAGMENT_DENSITY_MAP = FRAGMENT_DENSITY_MAP_EXT {
-        device_extensions: [ext_fragment_density_map],
-    },
+    FRAGMENT_DENSITY_MAP = FRAGMENT_DENSITY_MAP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_fragment_density_map)]),
+    ]),
 
     /// Can be used with a fragment shading rate attachment in a framebuffer.
-    FRAGMENT_SHADING_RATE_ATTACHMENT = FRAGMENT_SHADING_RATE_ATTACHMENT_KHR {
-        device_extensions: [khr_fragment_shading_rate],
-    },
+    FRAGMENT_SHADING_RATE_ATTACHMENT = FRAGMENT_SHADING_RATE_ATTACHMENT_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_fragment_shading_rate)]),
+    ]),
 
     /// Can be used with the source image in a transfer (copy) operation.
-    TRANSFER_SRC = TRANSFER_SRC {
-        api_version: V1_1,
-        device_extensions: [khr_maintenance1],
-    },
+    TRANSFER_SRC = TRANSFER_SRC
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_maintenance1)]),
+    ]),
 
     /// Can be used with the destination image in a transfer (copy) operation.
-    TRANSFER_DST = TRANSFER_DST {
-        api_version: V1_1,
-        device_extensions: [khr_maintenance1],
-    },
+    TRANSFER_DST = TRANSFER_DST
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_maintenance1)]),
+    ]),
 
     /// Can be used with the source image in a blit operation.
     BLIT_SRC = BLIT_SRC,
@@ -821,136 +827,215 @@ vulkan_bitflags! {
 
     /// Can be used with samplers or as a blit source, using the
     /// [`Cubic`](crate::sampler::Filter::Cubic) filter.
-    SAMPLED_IMAGE_FILTER_CUBIC = SAMPLED_IMAGE_FILTER_CUBIC_EXT {
-        device_extensions: [ext_filter_cubic, img_filter_cubic],
-    },
+    SAMPLED_IMAGE_FILTER_CUBIC = SAMPLED_IMAGE_FILTER_CUBIC_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_filter_cubic)]),
+        RequiresAllOf([DeviceExtension(img_filter_cubic)]),
+    ]),
 
     /// Can be used with samplers using a reduction mode of
     /// [`Min`](crate::sampler::SamplerReductionMode::Min) or
     /// [`Max`](crate::sampler::SamplerReductionMode::Max).
-    SAMPLED_IMAGE_FILTER_MINMAX = SAMPLED_IMAGE_FILTER_MINMAX {
-        api_version: V1_2,
-        device_extensions: [ext_sampler_filter_minmax],
-    },
+    SAMPLED_IMAGE_FILTER_MINMAX = SAMPLED_IMAGE_FILTER_MINMAX
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(ext_sampler_filter_minmax)]),
+    ]),
 
     /// Can be used with sampler YCbCr conversions using a chroma offset of
     /// [`Midpoint`](crate::sampler::ycbcr::ChromaLocation::Midpoint).
-    MIDPOINT_CHROMA_SAMPLES = MIDPOINT_CHROMA_SAMPLES {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    MIDPOINT_CHROMA_SAMPLES = MIDPOINT_CHROMA_SAMPLES
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// Can be used with sampler YCbCr conversions using a chroma offset of
     /// [`CositedEven`](crate::sampler::ycbcr::ChromaLocation::CositedEven).
-    COSITED_CHROMA_SAMPLES = COSITED_CHROMA_SAMPLES {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    COSITED_CHROMA_SAMPLES = COSITED_CHROMA_SAMPLES
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// Can be used with sampler YCbCr conversions using the
     /// [`Linear`](crate::sampler::Filter::Linear) chroma filter.
-    SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER = SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER = SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// Can be used with sampler YCbCr conversions whose chroma filter differs from the filters of
     /// the base sampler.
-    SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER = SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER = SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// When used with a sampler YCbCr conversion, the implementation will always perform
     /// explicit chroma reconstruction.
-    SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT = SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT = SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// Can be used with sampler YCbCr conversions with forced explicit reconstruction.
-    SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE = SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE = SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// Can be used with samplers using depth comparison.
-    SAMPLED_IMAGE_DEPTH_COMPARISON = SAMPLED_IMAGE_DEPTH_COMPARISON {
-        api_version: V1_3,
-        device_extensions: [khr_format_feature_flags2],
-    },
+    SAMPLED_IMAGE_DEPTH_COMPARISON = SAMPLED_IMAGE_DEPTH_COMPARISON
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_format_feature_flags2)]),
+    ]),
 
     /* Video */
 
     /// Can be used with the output image of a video decode operation.
-    VIDEO_DECODE_OUTPUT = VIDEO_DECODE_OUTPUT_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },
+    VIDEO_DECODE_OUTPUT = VIDEO_DECODE_OUTPUT_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),
 
     /// Can be used with the DPB image of a video decode operation.
-    VIDEO_DECODE_DPB = VIDEO_DECODE_DPB_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },
+    VIDEO_DECODE_DPB = VIDEO_DECODE_DPB_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),
 
     /// Can be used with the input image of a video encode operation.
-    VIDEO_ENCODE_INPUT = VIDEO_ENCODE_INPUT_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },
+    VIDEO_ENCODE_INPUT = VIDEO_ENCODE_INPUT_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),
 
     /// Can be used with the DPB image of a video encode operation.
-    VIDEO_ENCODE_DPB = VIDEO_ENCODE_DPB_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },
+    VIDEO_ENCODE_DPB = VIDEO_ENCODE_DPB_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),
 
     /* Misc image features */
 
     /// For multi-planar formats, can be used with images created with the [`DISJOINT`] flag.
     ///
     /// [`DISJOINT`]: crate::image::ImageCreateFlags::DISJOINT
-    DISJOINT = DISJOINT {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    DISJOINT = DISJOINT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     // TODO: document
-    LINEAR_COLOR_ATTACHMENT = LINEAR_COLOR_ATTACHMENT_NV {
-        device_extensions: [nv_linear_color_attachment],
-    },
+    LINEAR_COLOR_ATTACHMENT = LINEAR_COLOR_ATTACHMENT_NV
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(nv_linear_color_attachment),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_format_feature_flags2),
+            DeviceExtension(nv_linear_color_attachment),
+        ]),
+    ]),
 
     // TODO: document
-    WEIGHT_IMAGE = WEIGHT_IMAGE_QCOM {
-        device_extensions: [qcom_image_processing],
-    },
+    WEIGHT_IMAGE = WEIGHT_IMAGE_QCOM
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(qcom_image_processing),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_format_feature_flags2),
+            DeviceExtension(qcom_image_processing),
+        ]),
+    ]),
 
     // TODO: document
-    WEIGHT_SAMPLED_IMAGE = WEIGHT_SAMPLED_IMAGE_QCOM {
-        device_extensions: [qcom_image_processing],
-    },
+    WEIGHT_SAMPLED_IMAGE = WEIGHT_SAMPLED_IMAGE_QCOM
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(qcom_image_processing),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_format_feature_flags2),
+            DeviceExtension(qcom_image_processing),
+        ]),
+    ]),
 
     // TODO: document
-    BLOCK_MATCHING = BLOCK_MATCHING_QCOM {
-        device_extensions: [qcom_image_processing],
-    },
+    BLOCK_MATCHING = BLOCK_MATCHING_QCOM
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(qcom_image_processing),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_format_feature_flags2),
+            DeviceExtension(qcom_image_processing),
+        ]),
+    ]),
 
     // TODO: document
-    BOX_FILTER_SAMPLED = BOX_FILTER_SAMPLED_QCOM {
-        device_extensions: [qcom_image_processing],
-    },
+    BOX_FILTER_SAMPLED = BOX_FILTER_SAMPLED_QCOM
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(qcom_image_processing),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_format_feature_flags2),
+            DeviceExtension(qcom_image_processing),
+        ]),
+    ]),
 
     // TODO: document
-    OPTICAL_FLOW_IMAGE = OPTICAL_FLOW_IMAGE_NV {
-        device_extensions: [nv_optical_flow],
-    },
+    OPTICAL_FLOW_IMAGE = OPTICAL_FLOW_IMAGE_NV
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(nv_optical_flow),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_format_feature_flags2),
+            DeviceExtension(nv_optical_flow),
+        ]),
+    ]),
 
     // TODO: document
-    OPTICAL_FLOW_VECTOR = OPTICAL_FLOW_VECTOR_NV {
-        device_extensions: [nv_optical_flow],
-    },
+    OPTICAL_FLOW_VECTOR = OPTICAL_FLOW_VECTOR_NV
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(nv_optical_flow),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_format_feature_flags2),
+            DeviceExtension(nv_optical_flow),
+        ]),
+    ]),
 
     // TODO: document
-    OPTICAL_FLOW_COST = OPTICAL_FLOW_COST_NV {
-        device_extensions: [nv_optical_flow],
-    },
+    OPTICAL_FLOW_COST = OPTICAL_FLOW_COST_NV
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(nv_optical_flow),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_format_feature_flags2),
+            DeviceExtension(nv_optical_flow),
+        ]),
+    ]),
 
     /* Buffer usage  */
 
@@ -968,9 +1053,10 @@ vulkan_bitflags! {
     VERTEX_BUFFER = VERTEX_BUFFER,
 
     /// Can be used as the vertex format when building an acceleration structure.
-    ACCELERATION_STRUCTURE_VERTEX_BUFFER = ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR {
-        device_extensions: [khr_acceleration_structure],
-    },
+    ACCELERATION_STRUCTURE_VERTEX_BUFFER = ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_acceleration_structure)]),
+    ]),
 }
 
 impl From<ash::vk::FormatFeatureFlags> for FormatFeatures {

--- a/vulkano/src/image/aspect.rs
+++ b/vulkano/src/image/aspect.rs
@@ -49,48 +49,54 @@ vulkan_bitflags_enum! {
     /// The first plane of an image with a multi-planar [format], holding the green color component.
     ///
     /// [format]: crate::format::Format
-    PLANE_0, Plane0 = PLANE_0 {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    PLANE_0, Plane0 = PLANE_0
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// The second plane of an image with a multi-planar [format], holding the blue color component
     /// if the format has three planes, and a combination of blue and red if the format has two
     /// planes.
     ///
     /// [format]: crate::format::Format
-    PLANE_1, Plane1 = PLANE_1 {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    PLANE_1, Plane1 = PLANE_1
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// The third plane of an image with a multi-planar [format], holding the red color component.
-    PLANE_2, Plane2 = PLANE_2 {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    PLANE_2, Plane2 = PLANE_2
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /// The first memory plane of images created through the [`ext_image_drm_format_modifier`]
     /// extension.
     ///
     /// [`ext_image_drm_format_modifier`]: crate::device::DeviceExtensions::ext_image_drm_format_modifier
-    MEMORY_PLANE_0, MemoryPlane0 = MEMORY_PLANE_0_EXT {
-        device_extensions: [ext_image_drm_format_modifier],
-    },
+    MEMORY_PLANE_0, MemoryPlane0 = MEMORY_PLANE_0_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_image_drm_format_modifier)]),
+    ]),
 
     /// The second memory plane of images created through the [`ext_image_drm_format_modifier`]
     /// extension.
     ///
     /// [`ext_image_drm_format_modifier`]: crate::device::DeviceExtensions::ext_image_drm_format_modifier
-    MEMORY_PLANE_1, MemoryPlane1 = MEMORY_PLANE_1_EXT {
-        device_extensions: [ext_image_drm_format_modifier],
-    },
+    MEMORY_PLANE_1, MemoryPlane1 = MEMORY_PLANE_1_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_image_drm_format_modifier)]),
+    ]),
 
     /// The third memory plane of images created through the [`ext_image_drm_format_modifier`]
     /// extension.
     ///
     /// [`ext_image_drm_format_modifier`]: crate::device::DeviceExtensions::ext_image_drm_format_modifier
-    MEMORY_PLANE_2, MemoryPlane2 = MEMORY_PLANE_2_EXT {
-        device_extensions: [ext_image_drm_format_modifier],
-    },
+    MEMORY_PLANE_2, MemoryPlane2 = MEMORY_PLANE_2_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_image_drm_format_modifier)]),
+    ]),
 }

--- a/vulkano/src/image/layout.rs
+++ b/vulkano/src/image/layout.rs
@@ -79,124 +79,143 @@ vulkan_enum! {
 
     /// A combination of `DepthReadOnlyOptimal` for the depth aspect of the image,
     /// and `StencilAttachmentOptimal` for the stencil aspect of the image.
-    DepthReadOnlyStencilAttachmentOptimal = DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL {
-        api_version: V1_1,
-        device_extensions: [khr_maintenance2],
-    },
+    DepthReadOnlyStencilAttachmentOptimal = DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_maintenance2)]),
+    ]),
 
     /// A combination of `DepthAttachmentOptimal` for the depth aspect of the image,
     /// and `StencilReadOnlyOptimal` for the stencil aspect of the image.
-    DepthAttachmentStencilReadOnlyOptimal = DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL {
-        api_version: V1_1,
-        device_extensions: [khr_maintenance2],
-    },
+    DepthAttachmentStencilReadOnlyOptimal = DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_maintenance2)]),
+    ]),
 
     /// For a depth image used as a depth attachment in a framebuffer.
-    DepthAttachmentOptimal = DEPTH_ATTACHMENT_OPTIMAL {
-        api_version: V1_2,
-        device_extensions: [khr_separate_depth_stencil_layouts],
-    },
+    DepthAttachmentOptimal = DEPTH_ATTACHMENT_OPTIMAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(khr_separate_depth_stencil_layouts)]),
+    ]),
 
     /// For a depth image used as a read-only depth attachment in a framebuffer, or
     /// as a (combined) sampled image or input attachment in a shader.
-    DepthReadOnlyOptimal = DEPTH_READ_ONLY_OPTIMAL {
-        api_version: V1_2,
-        device_extensions: [khr_separate_depth_stencil_layouts],
-    },
+    DepthReadOnlyOptimal = DEPTH_READ_ONLY_OPTIMAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(khr_separate_depth_stencil_layouts)]),
+    ]),
 
     /// For a stencil image used as a stencil attachment in a framebuffer.
-    StencilAttachmentOptimal = STENCIL_ATTACHMENT_OPTIMAL {
-        api_version: V1_2,
-        device_extensions: [khr_separate_depth_stencil_layouts],
-    },
+    StencilAttachmentOptimal = STENCIL_ATTACHMENT_OPTIMAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(khr_separate_depth_stencil_layouts)]),
+    ]),
 
     /// For a stencil image used as a read-only stencil attachment in a framebuffer, or
     /// as a (combined) sampled image or input attachment in a shader.
-    StencilReadOnlyOptimal = STENCIL_READ_ONLY_OPTIMAL {
-        api_version: V1_2,
-        device_extensions: [khr_separate_depth_stencil_layouts],
-    },
+    StencilReadOnlyOptimal = STENCIL_READ_ONLY_OPTIMAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(khr_separate_depth_stencil_layouts)]),
+    ]),
 
     /* TODO: enable
     // TODO: document
-    ReadOnlyOptimal = READ_ONLY_OPTIMAL {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },*/
+    ReadOnlyOptimal = READ_ONLY_OPTIMAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    AttachmentOptimal = ATTACHMENT_OPTIMAL {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },*/
+    AttachmentOptimal = ATTACHMENT_OPTIMAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),*/
 
     /// The layout of images that are held in a swapchain. Images are in this layout when they are
     /// acquired from the swapchain, and must be transitioned back into this layout before
     /// presenting them.
-    PresentSrc = PRESENT_SRC_KHR {
-        device_extensions: [khr_swapchain],
-    },
+    PresentSrc = PRESENT_SRC_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_swapchain)]),
+    ]),
 
     /* TODO: enable
     // TODO: document
-    VideoDecodeDst = VIDEO_DECODE_DST_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },*/
+    VideoDecodeDst = VIDEO_DECODE_DST_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VideoDecodeSrc = VIDEO_DECODE_SRC_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },*/
+    VideoDecodeSrc = VIDEO_DECODE_SRC_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VideoDecodeDpb = VIDEO_DECODE_DPB_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },*/
+    VideoDecodeDpb = VIDEO_DECODE_DPB_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SharedPresent = SHARED_PRESENT_KHR {
-        device_extensions: [khr_shared_presentable_image],
-    },*/
+    SharedPresent = SHARED_PRESENT_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_shared_presentable_image)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    FragmentDensityMapOptimal = FRAGMENT_DENSITY_MAP_OPTIMAL_EXT {
-        device_extensions: [ext_fragment_density_map],
-    },*/
+    FragmentDensityMapOptimal = FRAGMENT_DENSITY_MAP_OPTIMAL_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_fragment_density_map)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    FragmentShadingRateAttachmentOptimal = FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR {
-        device_extensions: [khr_fragment_shading_rate],
-    },*/
+    FragmentShadingRateAttachmentOptimal = FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_fragment_shading_rate)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VideoEncodeDst = VIDEO_ENCODE_DST_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },*/
+    VideoEncodeDst = VIDEO_ENCODE_DST_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VideoEncodeSrc = VIDEO_ENCODE_SRC_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },*/
+    VideoEncodeSrc = VIDEO_ENCODE_SRC_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VideoEncodeDpb = VIDEO_ENCODE_DPB_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },*/
+    VideoEncodeDpb = VIDEO_ENCODE_DPB_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    AttachmentFeedbackLoopOptimal = ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT {
-        device_extensions: [ext_attachment_feedback_loop_layout],
-    },*/
+    AttachmentFeedbackLoopOptimal = ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_attachment_feedback_loop_layout)]),
+    ]),*/
 }
 
 impl Default for ImageLayout {

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -67,7 +67,7 @@ use crate::{
     format::Format,
     macros::{vulkan_bitflags, vulkan_bitflags_enum, vulkan_enum},
     memory::{ExternalMemoryHandleType, ExternalMemoryProperties},
-    DeviceSize, RequiresOneOf, ValidationError, Version,
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version,
 };
 use std::{cmp, ops::Range};
 
@@ -145,17 +145,19 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    ALIAS = ALIAS {
-        api_version: V1_1,
-        device_extensions: [khr_bind_memory2],
-    },*/
+    ALIAS = ALIAS
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_bind_memory2)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SPLIT_INSTANCE_BIND_REGIONS = SPLIT_INSTANCE_BIND_REGIONS {
-        api_version: V1_1,
-        device_extensions: [khr_device_group],
-    },*/
+    SPLIT_INSTANCE_BIND_REGIONS = SPLIT_INSTANCE_BIND_REGIONS
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_device_group)]),
+    ]),*/
 
     /// For 3D images, whether an image view of type [`ImageViewType::Dim2d`] or
     /// [`ImageViewType::Dim2dArray`] can be created from the image.
@@ -167,76 +169,87 @@ vulkan_bitflags! {
     /// [`ImageViewType::Dim2dArray`]: crate::image::view::ImageViewType::Dim2dArray
     /// [portability subset]: crate::instance#portability-subset-devices-and-the-enumerate_portability-flag
     /// [`image_view2_d_on3_d_image`]: crate::device::Features::image_view2_d_on3_d_image
-    ARRAY_2D_COMPATIBLE = TYPE_2D_ARRAY_COMPATIBLE {
-        api_version: V1_1,
-        device_extensions: [khr_maintenance1],
-    },
+    ARRAY_2D_COMPATIBLE = TYPE_2D_ARRAY_COMPATIBLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_maintenance1)]),
+    ]),
 
     /// For images with a compressed format, whether an image view with an uncompressed
     /// format can be created from the image, where each texel in the view will correspond to a
     /// compressed texel block in the image.
     ///
     /// Requires `mutable_format`.
-    BLOCK_TEXEL_VIEW_COMPATIBLE = BLOCK_TEXEL_VIEW_COMPATIBLE {
-        api_version: V1_1,
-        device_extensions: [khr_maintenance2],
-    },
+    BLOCK_TEXEL_VIEW_COMPATIBLE = BLOCK_TEXEL_VIEW_COMPATIBLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_maintenance2)]),
+    ]),
 
     /* TODO: enable
     // TODO: document
-    EXTENDED_USAGE = EXTENDED_USAGE {
-        api_version: V1_1,
-        device_extensions: [khr_maintenance2],
-    },*/
+    EXTENDED_USAGE = EXTENDED_USAGE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_maintenance2)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    PROTECTED = PROTECTED {
-        api_version: V1_1,
-    },*/
+    PROTECTED = PROTECTED
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+    ]),*/
 
     /// For images with a multi-planar format, whether each plane will have its memory bound
     /// separately, rather than having a single memory binding for the whole image.
-    DISJOINT = DISJOINT {
-        api_version: V1_1,
-        device_extensions: [khr_sampler_ycbcr_conversion],
-    },
+    DISJOINT = DISJOINT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_ycbcr_conversion)]),
+    ]),
 
     /* TODO: enable
     // TODO: document
-    CORNER_SAMPLED = CORNER_SAMPLED_NV {
-        device_extensions: [nv_corner_sampled_image],
-    },*/
+    CORNER_SAMPLED = CORNER_SAMPLED_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_corner_sampled_image)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SAMPLE_LOCATIONS_COMPATIBLE_DEPTH = SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_EXT {
-        device_extensions: [ext_sample_locations],
-    },*/
+    SAMPLE_LOCATIONS_COMPATIBLE_DEPTH = SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_sample_locations)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SUBSAMPLED = SUBSAMPLED_EXT {
-        device_extensions: [ext_fragment_density_map],
-    },*/
+    SUBSAMPLED = SUBSAMPLED_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_fragment_density_map)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED = MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_EXT {
-        device_extensions: [ext_multisampled_render_to_single_sampled],
-    },*/
+    MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED = MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_multisampled_render_to_single_sampled)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    TYPE_2D_VIEW_COMPATIBLE = TYPE_2D_VIEW_COMPATIBLE_EXT {
-        device_extensions: [ext_image_2d_view_of_3d],
-    },*/
+    TYPE_2D_VIEW_COMPATIBLE = TYPE_2D_VIEW_COMPATIBLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_image_2d_view_of_3d)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    FRAGMENT_DENSITY_MAP_OFFSET = FRAGMENT_DENSITY_MAP_OFFSET_QCOM {
-        device_extensions: [qcom_fragment_density_map_offset],
-    },*/
+    FRAGMENT_DENSITY_MAP_OFFSET = FRAGMENT_DENSITY_MAP_OFFSET_QCOM
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(qcom_fragment_density_map_offset)]),
+    ]),*/
 }
 
 vulkan_bitflags_enum! {
@@ -373,9 +386,10 @@ vulkan_enum! {
     Linear = LINEAR,
 
     // TODO: document
-    DrmFormatModifier = DRM_FORMAT_MODIFIER_EXT {
-        device_extensions: [ext_image_drm_format_modifier],
-    },
+    DrmFormatModifier = DRM_FORMAT_MODIFIER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_image_drm_format_modifier)]),
+    ]),
 }
 
 /// The dimensions of an image.
@@ -909,11 +923,10 @@ impl ImageFormatInfo {
                     problem: "`stencil_usage` is `Some`, and `format` has both a depth and a \
                         stencil aspect"
                         .into(),
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_2),
-                        device_extensions: &["ext_separate_stencil_usage"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_2)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("ext_separate_stencil_usage")]),
+                    ]),
                     ..Default::default()
                 });
             }
@@ -945,11 +958,12 @@ impl ImageFormatInfo {
             {
                 return Err(ValidationError {
                     problem: "`external_memory_handle_type` is `Some`".into(),
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_1),
-                        instance_extensions: &["khr_external_memory_capabilities"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                        RequiresAllOf(&[Requires::InstanceExtension(
+                            "khr_external_memory_capabilities",
+                        )]),
+                    ]),
                     ..Default::default()
                 });
             }
@@ -967,10 +981,9 @@ impl ImageFormatInfo {
             if !physical_device.supported_extensions().ext_filter_cubic {
                 return Err(ValidationError {
                     problem: "`image_view_type` is `Some`".into(),
-                    requires_one_of: RequiresOneOf {
-                        device_extensions: &["ext_filter_cubic"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                        "ext_filter_cubic",
+                    )])]),
                     ..Default::default()
                 });
             }

--- a/vulkano/src/image/usage.rs
+++ b/vulkano/src/image/usage.rs
@@ -51,73 +51,85 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    VIDEO_DECODE_DST = VIDEO_DECODE_DST_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },*/
+    VIDEO_DECODE_DST = VIDEO_DECODE_DST_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VIDEO_DECODE_SRC = VIDEO_DECODE_SRC_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },*/
+    VIDEO_DECODE_SRC = VIDEO_DECODE_SRC_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VIDEO_DECODE_DPB = VIDEO_DECODE_DPB_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },*/
+    VIDEO_DECODE_DPB = VIDEO_DECODE_DPB_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    FRAGMENT_DENSITY_MAP = FRAGMENT_DENSITY_MAP_EXT {
-        device_extensions: [ext_fragment_density_map],
-    },*/
+    FRAGMENT_DENSITY_MAP = FRAGMENT_DENSITY_MAP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_fragment_density_map)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    FRAGMENT_SHADING_RATE_ATTACHMENT = FRAGMENT_SHADING_RATE_ATTACHMENT_KHR {
-        device_extensions: [khr_fragment_shading_rate],
-    },*/
+    FRAGMENT_SHADING_RATE_ATTACHMENT = FRAGMENT_SHADING_RATE_ATTACHMENT_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_fragment_shading_rate)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VIDEO_ENCODE_DST = VIDEO_ENCODE_DST_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },*/
+    VIDEO_ENCODE_DST = VIDEO_ENCODE_DST_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VIDEO_ENCODE_SRC = VIDEO_ENCODE_SRC_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },*/
+    VIDEO_ENCODE_SRC = VIDEO_ENCODE_SRC_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    VIDEO_ENCODE_DPB = VIDEO_ENCODE_DPB_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },*/
+    VIDEO_ENCODE_DPB = VIDEO_ENCODE_DPB_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    ATTACHMENT_FEEDBACK_LOOP = ATTACHMENT_FEEDBACK_LOOP_EXT {
-        device_extensions: [ext_attachment_feedback_loop_layout],
-    },*/
+    ATTACHMENT_FEEDBACK_LOOP = ATTACHMENT_FEEDBACK_LOOP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_attachment_feedback_loop_layout)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    INVOCATION_MASK = INVOCATION_MASK_HUAWEI {
-        device_extensions: [huawei_invocation_mask],
-    },*/
+    INVOCATION_MASK = INVOCATION_MASK_HUAWEI
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(huawei_invocation_mask)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SAMPLE_WEIGHT = SAMPLE_WEIGHT_QCOM {
-        device_extensions: [qcom_image_processing],
-    },*/
+    SAMPLE_WEIGHT = SAMPLE_WEIGHT_QCOM
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(qcom_image_processing)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SAMPLE_BLOCK_MATCH = SAMPLE_BLOCK_MATCH_QCOM {
-        device_extensions: [qcom_image_processing],
-    },*/
+    SAMPLE_BLOCK_MATCH = SAMPLE_BLOCK_MATCH_QCOM
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(qcom_image_processing)]),
+    ]),*/
 }

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -22,7 +22,8 @@ use crate::{
     image::{ImageAspects, ImageCreateFlags, ImageTiling, ImageType, SampleCount},
     macros::{impl_id_counter, vulkan_enum},
     sampler::{ycbcr::SamplerYcbcrConversion, ComponentMapping},
-    OomError, RequirementNotMet, RequiresOneOf, RuntimeError, Version, VulkanObject,
+    OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, Version,
+    VulkanObject,
 };
 use std::{
     error::Error,
@@ -206,10 +207,9 @@ where
         if view_type == ImageViewType::CubeArray && !device.enabled_features().image_cube_array {
             return Err(ImageViewCreationError::RequirementNotMet {
                 required_for: "`create_info.viewtype` is `ImageViewType::CubeArray`",
-                requires_one_of: RequiresOneOf {
-                    features: &["image_cube_array"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "image_cube_array",
+                )])]),
             });
         }
 
@@ -279,11 +279,10 @@ where
             {
                 return Err(ImageViewCreationError::RequirementNotMet {
                     required_for: "`create_info.usage` is not the default value",
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_1),
-                        device_extensions: &["khr_maintenance2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_maintenance2")]),
+                    ]),
                 });
             }
 
@@ -383,10 +382,9 @@ where
                     required_for: "this device is a portability subset device, and the format of \
                         the image view does not have the same components and number of bits per \
                         component as the parent image",
-                    requires_one_of: RequiresOneOf {
-                        features: &["image_view_format_reinterpretation"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "image_view_format_reinterpretation",
+                    )])]),
                 });
             }
 
@@ -467,10 +465,9 @@ where
             return Err(ImageViewCreationError::RequirementNotMet {
                 required_for: "this device is a portability subset device, and \
                     `create_info.component_mapping` is not the identity mapping",
-                requires_one_of: RequiresOneOf {
-                    features: &["image_view_format_swizzle"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "image_view_format_swizzle",
+                )])]),
             });
         }
 

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -44,7 +44,8 @@
 use super::{Instance, InstanceExtensions};
 use crate::{
     macros::{vulkan_bitflags, vulkan_enum},
-    RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError,
+    VulkanObject,
 };
 use std::{
     ffi::{c_void, CStr},
@@ -92,10 +93,9 @@ impl DebugUtilsMessenger {
     ) -> Result<(), ValidationError> {
         if !instance.enabled_extensions().ext_debug_utils {
             return Err(ValidationError {
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_debug_utils"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_debug_utils",
+                )])]),
                 ..Default::default()
             });
         }

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -234,7 +234,7 @@ use super::{
 };
 use crate::{
     device::{Device, DeviceOwned},
-    DeviceSize, RequirementNotMet, RequiresOneOf, RuntimeError, Version,
+    DeviceSize, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, Version,
 };
 use ash::vk::{MAX_MEMORY_HEAPS, MAX_MEMORY_TYPES};
 use parking_lot::RwLock;
@@ -728,11 +728,10 @@ impl<S: Suballocator> GenericMemoryAllocator<S> {
             {
                 return Err(GenericMemoryAllocatorCreationError::RequirementNotMet {
                     required_for: "`create_info.export_handle_types` is not empty",
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_1),
-                        device_extensions: &["khr_external_memory"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_external_memory")]),
+                    ]),
                 });
             }
 

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -246,32 +246,36 @@ vulkan_bitflags! {
     /// [`HOST_VISIBLE`]: MemoryPropertyFlags::HOST_VISIBLE
     /// [`HOST_COHERENT`]: MemoryPropertyFlags::HOST_COHERENT
     /// [`HOST_CACHED`]: MemoryPropertyFlags::HOST_CACHED
-    PROTECTED = PROTECTED {
-        api_version: V1_1,
-    },
+    PROTECTED = PROTECTED
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+    ]),
 
     /// Device accesses to the memory are automatically made available and visible to other device
     /// accesses.
     ///
     /// Memory of this type is slower to access by the device, so it is best avoided for general
     /// purpose use. Because of its coherence properties, however, it may be useful for debugging.
-    DEVICE_COHERENT = DEVICE_COHERENT_AMD {
-        device_extensions: [amd_device_coherent_memory],
-    },
+    DEVICE_COHERENT = DEVICE_COHERENT_AMD
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(amd_device_coherent_memory)]),
+    ]),
 
     /// The memory is not cached on the device.
     ///
     /// `DEVICE_UNCACHED` memory is always also [`DEVICE_COHERENT`].
     ///
     /// [`DEVICE_COHERENT`]: MemoryPropertyFlags::DEVICE_COHERENT
-    DEVICE_UNCACHED = DEVICE_UNCACHED_AMD {
-        device_extensions: [amd_device_coherent_memory],
-    },
+    DEVICE_UNCACHED = DEVICE_UNCACHED_AMD
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(amd_device_coherent_memory)]),
+    ]),
 
     /// Other devices can access the memory via remote direct memory access (RDMA).
-    RDMA_CAPABLE = RDMA_CAPABLE_NV {
-        device_extensions: [nv_external_memory_rdma],
-    },
+    RDMA_CAPABLE = RDMA_CAPABLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_external_memory_rdma)]),
+    ]),
 }
 
 /// A memory heap in a physical device.
@@ -296,10 +300,11 @@ vulkan_bitflags! {
 
     /// If used on a logical device that represents more than one physical device, allocations are
     /// replicated across each physical device's instance of this heap.
-    MULTI_INSTANCE = MULTI_INSTANCE {
-        api_version: V1_1,
-        instance_extensions: [khr_device_group_creation],
-    },
+    MULTI_INSTANCE = MULTI_INSTANCE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([InstanceExtension(khr_device_group_creation)]),
+    ]),
 }
 
 /// Represents requirements expressed by the Vulkan implementation when it comes to binding memory

--- a/vulkano/src/pipeline/graphics/color_blend.rs
+++ b/vulkano/src/pipeline/graphics/color_blend.rs
@@ -424,279 +424,325 @@ vulkan_enum! {
 
     /* TODO: enable
     // TODO: document
-    Zero = ZERO_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Zero = ZERO_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Src = SRC_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Src = SRC_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Dst = DST_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Dst = DST_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SrcOver = SRC_OVER_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    SrcOver = SRC_OVER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    DstOver = DST_OVER_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    DstOver = DST_OVER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SrcIn = SRC_IN_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    SrcIn = SRC_IN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    DstIn = DST_IN_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    DstIn = DST_IN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SrcOut = SRC_OUT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    SrcOut = SRC_OUT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    DstOut = DST_OUT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    DstOut = DST_OUT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SrcAtop = SRC_ATOP_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    SrcAtop = SRC_ATOP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    DstAtop = DST_ATOP_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    DstAtop = DST_ATOP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Xor = XOR_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Xor = XOR_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Multiply = MULTIPLY_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Multiply = MULTIPLY_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Screen = SCREEN_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Screen = SCREEN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Overlay = OVERLAY_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Overlay = OVERLAY_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Darken = DARKEN_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Darken = DARKEN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Lighten = LIGHTEN_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Lighten = LIGHTEN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Colordodge = COLORDODGE_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Colordodge = COLORDODGE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Colorburn = COLORBURN_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Colorburn = COLORBURN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Hardlight = HARDLIGHT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Hardlight = HARDLIGHT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Softlight = SOFTLIGHT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Softlight = SOFTLIGHT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Difference = DIFFERENCE_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Difference = DIFFERENCE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Exclusion = EXCLUSION_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Exclusion = EXCLUSION_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Invert = INVERT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Invert = INVERT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    InvertRgb = INVERT_RGB_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    InvertRgb = INVERT_RGB_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Lineardodge = LINEARDODGE_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Lineardodge = LINEARDODGE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Linearburn = LINEARBURN_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Linearburn = LINEARBURN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Vividlight = VIVIDLIGHT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Vividlight = VIVIDLIGHT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Linearlight = LINEARLIGHT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Linearlight = LINEARLIGHT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Pinlight = PINLIGHT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Pinlight = PINLIGHT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Hardmix = HARDMIX_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Hardmix = HARDMIX_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    HslHue = HSL_HUE_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    HslHue = HSL_HUE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    HslSaturation = HSL_SATURATION_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    HslSaturation = HSL_SATURATION_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    HslColor = HSL_COLOR_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    HslColor = HSL_COLOR_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    HslLuminosity = HSL_LUMINOSITY_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    HslLuminosity = HSL_LUMINOSITY_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Plus = PLUS_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Plus = PLUS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    PlusClamped = PLUS_CLAMPED_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    PlusClamped = PLUS_CLAMPED_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    PlusClampedAlpha = PLUS_CLAMPED_ALPHA_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    PlusClampedAlpha = PLUS_CLAMPED_ALPHA_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    PlusDarker = PLUS_DARKER_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    PlusDarker = PLUS_DARKER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Minus = MINUS_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Minus = MINUS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    MinusClamped = MINUS_CLAMPED_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    MinusClamped = MINUS_CLAMPED_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Contrast = CONTRAST_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Contrast = CONTRAST_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    InvertOvg = INVERT_OVG_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    InvertOvg = INVERT_OVG_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Red = RED_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Red = RED_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Green = GREEN_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Green = GREEN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    Blue = BLUE_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },*/
+    Blue = BLUE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),*/
 }
 
 vulkan_bitflags! {

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -95,7 +95,8 @@ use crate::{
         PipelineShaderStageCreateInfo, ShaderExecution, ShaderInterfaceMismatchError,
         ShaderScalarType, ShaderStage, ShaderStages, SpecializationConstant,
     },
-    DeviceSize, OomError, RequirementNotMet, RequiresOneOf, RuntimeError, Version, VulkanObject,
+    DeviceSize, OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError,
+    Version, VulkanObject,
 };
 use ahash::HashMap;
 use smallvec::SmallVec;
@@ -579,10 +580,9 @@ impl GraphicsPipeline {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for: "`stages` contains a `TessellationControl` or \
                                 `TessellationEvaluation` shader stage",
-                            requires_one_of: RequiresOneOf {
-                                features: &["tessellation_shader"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "tessellation_shader",
+                            )])]),
                         });
                     }
 
@@ -594,10 +594,9 @@ impl GraphicsPipeline {
                     if !device.enabled_features().geometry_shader {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for: "`stages` contains a `Geometry` shader stage",
-                            requires_one_of: RequiresOneOf {
-                                features: &["geometry_shader"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "geometry_shader",
+                            )])]),
                         });
                     }
 
@@ -754,10 +753,9 @@ impl GraphicsPipeline {
                                 required_for: "`vertex_input_state.bindings` has an element \
                                     where `input_rate` is `VertexInputRate::Instance`, where \
                                     `divisor` is not `1`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["vertex_attribute_instance_rate_divisor"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("vertex_attribute_instance_rate_divisor"),
+                                ])]),
                             });
                         }
 
@@ -771,10 +769,11 @@ impl GraphicsPipeline {
                                 required_for: "`vertex_input_state.bindings` has an element \
                                     where `input_rate` is `VertexInputRate::Instance`, where \
                                     `divisor` is `0`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["vertex_attribute_instance_rate_zero_divisor"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature(
+                                        "vertex_attribute_instance_rate_zero_divisor",
+                                    ),
+                                ])]),
                             });
                         }
 
@@ -881,10 +880,9 @@ impl GraphicsPipeline {
                             `vertex_input_state.attributes` has an element where \
                             `offset + format.block_size()` is greater than the `stride` of \
                             `binding`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["vertex_attribute_access_beyond_stride"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "vertex_attribute_access_beyond_stride",
+                        )])]),
                     });
                 }
             }
@@ -911,10 +909,9 @@ impl GraphicsPipeline {
                                     required_for: "this device is a portability subset \
                                             device, and `input_assembly_state.topology` is \
                                             `StateMode::Fixed(PrimitiveTopology::TriangleFan)`",
-                                    requires_one_of: RequiresOneOf {
-                                        features: &["triangle_fans"],
-                                        ..Default::default()
-                                    },
+                                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                        Requires::Feature("triangle_fans"),
+                                    ])]),
                                 });
                             }
                         }
@@ -927,10 +924,9 @@ impl GraphicsPipeline {
                                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                     required_for: "`input_assembly_state.topology` is \
                                             `StateMode::Fixed(PrimitiveTopology::*WithAdjacency)`",
-                                    requires_one_of: RequiresOneOf {
-                                        features: &["geometry_shader"],
-                                        ..Default::default()
-                                    },
+                                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                        Requires::Feature("geometry_shader"),
+                                    ])]),
                                 });
                             }
                         }
@@ -940,10 +936,9 @@ impl GraphicsPipeline {
                                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                     required_for: "`input_assembly_state.topology` is \
                                             `StateMode::Fixed(PrimitiveTopology::PatchList)`",
-                                    requires_one_of: RequiresOneOf {
-                                        features: &["tessellation_shader"],
-                                        ..Default::default()
-                                    },
+                                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                        Requires::Feature("tessellation_shader"),
+                                    ])]),
                                 });
                             }
 
@@ -964,11 +959,10 @@ impl GraphicsPipeline {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for: "`input_assembly_state.topology` is \
                                     `PartialStateMode::Dynamic`",
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_3),
-                                features: &["extended_dynamic_state"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[
+                                RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                            ]),
                         });
                     }
                 }
@@ -993,10 +987,9 @@ impl GraphicsPipeline {
                                                 is `StateMode::Fixed(true)` and \
                                                 `input_assembly_state.topology` is \
                                                 `StateMode::Fixed(PrimitiveTopology::*List)`",
-                                        requires_one_of: RequiresOneOf {
-                                            features: &["primitive_topology_list_restart"],
-                                            ..Default::default()
-                                        },
+                                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                            Requires::Feature("primitive_topology_list_restart"),
+                                        ])]),
                                     });
                                 }
                             }
@@ -1012,10 +1005,11 @@ impl GraphicsPipeline {
                                                 is `StateMode::Fixed(true)` and \
                                                 `input_assembly_state.topology` is \
                                                 `StateMode::Fixed(PrimitiveTopology::PatchList)`",
-                                        requires_one_of: RequiresOneOf {
-                                            features: &["primitive_topology_patch_list_restart"],
-                                            ..Default::default()
-                                        },
+                                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                            Requires::Feature(
+                                                "primitive_topology_patch_list_restart",
+                                            ),
+                                        ])]),
                                     });
                                 }
                             }
@@ -1031,11 +1025,10 @@ impl GraphicsPipeline {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for: "`input_assembly_state.primitive_restart_enable` is \
                                     `StateMode::Dynamic`",
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_3),
-                                features: &["extended_dynamic_state2"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[
+                                RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                RequiresAllOf(&[Requires::Feature("extended_dynamic_state2")]),
+                            ]),
                         });
                     }
                 }
@@ -1066,10 +1059,9 @@ impl GraphicsPipeline {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for: "`tessellation_state.patch_control_points` is \
                                 `StateMode::Dynamic`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["extended_dynamic_state2_patch_control_points"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "extended_dynamic_state2_patch_control_points",
+                            )])]),
                         });
                     }
                 }
@@ -1085,11 +1077,10 @@ impl GraphicsPipeline {
                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                     required_for: "`tessellation_state.domain_origin` is not \
                         `TessellationDomainOrigin::UpperLeft`",
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_1),
-                        device_extensions: &["khr_maintenance2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_2)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_maintenance2")]),
+                    ]),
                 });
             }
         }
@@ -1160,11 +1151,10 @@ impl GraphicsPipeline {
                                 required_for: "`viewport_state` is \
                                     `ViewportState::FixedViewport`, where `scissor_count_dynamic` \
                                     is set",
-                                requires_one_of: RequiresOneOf {
-                                    api_version: Some(Version::V1_3),
-                                    features: &["extended_dynamic_state"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[
+                                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                                ]),
                             });
                         }
 
@@ -1194,11 +1184,10 @@ impl GraphicsPipeline {
                                 required_for: "`viewport_state` is \
                                     `ViewportState::FixedScissor`, where `viewport_count_dynamic` \
                                     is set",
-                                requires_one_of: RequiresOneOf {
-                                    api_version: Some(Version::V1_3),
-                                    features: &["extended_dynamic_state"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[
+                                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                                ]),
                             });
                         }
 
@@ -1234,11 +1223,10 @@ impl GraphicsPipeline {
                                 required_for: "`viewport_state` is \
                                     `ViewportState::Dynamic`, where `viewport_count_dynamic` \
                                     is set",
-                                requires_one_of: RequiresOneOf {
-                                    api_version: Some(Version::V1_3),
-                                    features: &["extended_dynamic_state"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[
+                                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                                ]),
                             });
                         }
 
@@ -1257,11 +1245,10 @@ impl GraphicsPipeline {
                                 required_for: "`viewport_state` is \
                                     `ViewportState::Dynamic`, where `scissor_count_dynamic` \
                                     is set",
-                                requires_one_of: RequiresOneOf {
-                                    api_version: Some(Version::V1_3),
-                                    features: &["extended_dynamic_state"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[
+                                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                                ]),
                             });
                         }
 
@@ -1286,10 +1273,9 @@ impl GraphicsPipeline {
                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                     required_for: "`viewport_state` has a fixed viewport/scissor count that is \
                         greater than `1`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["multi_viewport"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "multi_viewport",
+                    )])]),
                 });
             }
 
@@ -1327,10 +1313,9 @@ impl GraphicsPipeline {
             if depth_clamp_enable && !device.enabled_features().depth_clamp {
                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                     required_for: "`rasterization_state.depth_clamp_enable` is set",
-                    requires_one_of: RequiresOneOf {
-                        features: &["depth_clamp"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "depth_clamp",
+                    )])]),
                 });
             }
 
@@ -1343,11 +1328,10 @@ impl GraphicsPipeline {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for: "`rasterization_state.rasterizer_discard_enable` is \
                                     `StateMode::Dynamic`",
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_3),
-                                features: &["extended_dynamic_state"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[
+                                RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                            ]),
                         });
                     }
                 }
@@ -1362,10 +1346,9 @@ impl GraphicsPipeline {
                                     `rasterization_state.rasterizer_discard_enable` is \
                                     `StateMode::Fixed(false)` and \
                                     `rasterization_state.polygon_mode` is `PolygonMode::Point`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["point_polygons"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "point_polygons",
+                            )])]),
                         });
                     }
                 }
@@ -1377,10 +1360,9 @@ impl GraphicsPipeline {
                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                     required_for: "`rasterization_state.polygon_mode` is not \
                             `PolygonMode::Fill`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["fill_mode_non_solid"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "fill_mode_non_solid",
+                    )])]),
                 });
             }
 
@@ -1397,11 +1379,10 @@ impl GraphicsPipeline {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for: "`rasterization_state.cull_mode` is \
                                     `StateMode::Dynamic`",
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_3),
-                                features: &["extended_dynamic_state"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[
+                                RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                            ]),
                         });
                     }
                 }
@@ -1420,11 +1401,10 @@ impl GraphicsPipeline {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for: "`rasterization_state.front_face` is \
                                     `StateMode::Dynamic`",
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_3),
-                                features: &["extended_dynamic_state"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[
+                                RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                            ]),
                         });
                     }
                 }
@@ -1445,11 +1425,10 @@ impl GraphicsPipeline {
                         required_for: "`rasterization_state.depth_bias` is \
                                 `Some(depth_bias_state)`, where `depth_bias_state.enable_dynamic` \
                                 is set",
-                        requires_one_of: RequiresOneOf {
-                            api_version: Some(Version::V1_3),
-                            features: &["extended_dynamic_state2"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[
+                            RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                            RequiresAllOf(&[Requires::Feature("extended_dynamic_state2")]),
+                        ]),
                     });
                 }
 
@@ -1461,10 +1440,9 @@ impl GraphicsPipeline {
                         required_for: "`rasterization_state.depth_bias` is \
                             `Some(depth_bias_state)`, where `depth_bias_state.bias` is \
                             `StateMode::Fixed(bias)`, where `bias.clamp` is not `0.0`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["depth_bias_clamp"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "depth_bias_clamp",
+                        )])]),
                     });
                 }
             }
@@ -1476,10 +1454,9 @@ impl GraphicsPipeline {
                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                     required_for: "`rasterization_state.line_width` is \
                             `StateMode::Fixed(line_width)`, where `line_width` is not `1.0`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["wide_lines"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "wide_lines",
+                    )])]),
                 });
             }
 
@@ -1495,10 +1472,9 @@ impl GraphicsPipeline {
                             return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                 required_for: "`rasterization_state.line_rasterization_mode` \
                                         is `LineRasterizationMode::Rectangular`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["rectangular_lines"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("rectangular_lines"),
+                                ])]),
                             });
                         }
                     }
@@ -1508,10 +1484,9 @@ impl GraphicsPipeline {
                             return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                 required_for: "`rasterization_state.line_rasterization_mode` \
                                         is `LineRasterizationMode::Bresenham`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["bresenham_lines"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("bresenham_lines"),
+                                ])]),
                             });
                         }
                     }
@@ -1521,10 +1496,9 @@ impl GraphicsPipeline {
                             return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                 required_for: "`rasterization_state.line_rasterization_mode` \
                                         is `LineRasterizationMode::RectangularSmooth`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["smooth_lines"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("smooth_lines"),
+                                ])]),
                             });
                         }
                     }
@@ -1540,10 +1514,9 @@ impl GraphicsPipeline {
                                             `Some` and \
                                             `rasterization_state.line_rasterization_mode` \
                                             is `LineRasterizationMode::Default`",
-                                    requires_one_of: RequiresOneOf {
-                                        features: &["stippled_rectangular_lines"],
-                                        ..Default::default()
-                                    },
+                                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                        Requires::Feature("stippled_rectangular_lines"),
+                                    ])]),
                                 });
                             }
 
@@ -1560,10 +1533,9 @@ impl GraphicsPipeline {
                                             `Some` and \
                                             `rasterization_state.line_rasterization_mode` \
                                             is `LineRasterizationMode::Rectangular`",
-                                    requires_one_of: RequiresOneOf {
-                                        features: &["stippled_rectangular_lines"],
-                                        ..Default::default()
-                                    },
+                                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                        Requires::Feature("stippled_rectangular_lines"),
+                                    ])]),
                                 });
                             }
                         }
@@ -1575,10 +1547,9 @@ impl GraphicsPipeline {
                                             `Some` and \
                                             `rasterization_state.line_rasterization_mode` \
                                             is `LineRasterizationMode::Bresenham`",
-                                    requires_one_of: RequiresOneOf {
-                                        features: &["stippled_bresenham_lines"],
-                                        ..Default::default()
-                                    },
+                                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                        Requires::Feature("stippled_bresenham_lines"),
+                                    ])]),
                                 });
                             }
                         }
@@ -1590,10 +1561,9 @@ impl GraphicsPipeline {
                                             `Some` and \
                                             `rasterization_state.line_rasterization_mode` \
                                             is `LineRasterizationMode::RectangularSmooth`",
-                                    requires_one_of: RequiresOneOf {
-                                        features: &["stippled_smooth_lines"],
-                                        ..Default::default()
-                                    },
+                                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                        Requires::Feature("stippled_smooth_lines"),
+                                    ])]),
                                 });
                             }
                         }
@@ -1610,20 +1580,18 @@ impl GraphicsPipeline {
                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                         required_for: "`rasterization_state.line_rasterization_mode` is not \
                                 `LineRasterizationMode::Default`",
-                        requires_one_of: RequiresOneOf {
-                            device_extensions: &["ext_line_rasterization"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                            Requires::DeviceExtension("ext_line_rasterization"),
+                        ])]),
                     });
                 }
 
                 if line_stipple.is_some() {
                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                         required_for: "`rasterization_state.line_stipple` is `Some`",
-                        requires_one_of: RequiresOneOf {
-                            device_extensions: &["ext_line_rasterization"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                            Requires::DeviceExtension("ext_line_rasterization"),
+                        ])]),
                     });
                 }
             }
@@ -1652,10 +1620,9 @@ impl GraphicsPipeline {
                 if !device.enabled_features().sample_rate_shading {
                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                         required_for: "`multisample_state.sample_shading` is `Some`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["sample_rate_shading"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "sample_rate_shading",
+                        )])]),
                     });
                 }
 
@@ -1668,10 +1635,9 @@ impl GraphicsPipeline {
             if alpha_to_one_enable && !device.enabled_features().alpha_to_one {
                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                     required_for: "`multisample_state.alpha_to_one_enable` is set",
-                    requires_one_of: RequiresOneOf {
-                        features: &["alpha_to_one"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "alpha_to_one",
+                    )])]),
                 });
             }
 
@@ -1701,11 +1667,10 @@ impl GraphicsPipeline {
                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                         required_for: "`depth_stencil_state.depth` is `Some(depth_state)`, where \
                              `depth_state.enable_dynamic` is set",
-                        requires_one_of: RequiresOneOf {
-                            api_version: Some(Version::V1_3),
-                            features: &["extended_dynamic_state"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[
+                            RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                            RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                        ]),
                     });
                 }
 
@@ -1720,11 +1685,10 @@ impl GraphicsPipeline {
                                 required_for: "`depth_stencil_state.depth` is \
                                     `Some(depth_state)`, where `depth_state.write_enable` is \
                                     `StateMode::Dynamic`",
-                                requires_one_of: RequiresOneOf {
-                                    api_version: Some(Version::V1_3),
-                                    features: &["extended_dynamic_state"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[
+                                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                                ]),
                             });
                         }
                     }
@@ -1744,11 +1708,10 @@ impl GraphicsPipeline {
                                 required_for: "`depth_stencil_state.depth` is \
                                     `Some(depth_state)`, where `depth_state.compare_op` is \
                                         `StateMode::Dynamic`",
-                                requires_one_of: RequiresOneOf {
-                                    api_version: Some(Version::V1_3),
-                                    features: &["extended_dynamic_state"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[
+                                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                                ]),
                             });
                         }
                     }
@@ -1765,10 +1728,9 @@ impl GraphicsPipeline {
                 if !device.enabled_features().depth_bounds {
                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                         required_for: "`depth_stencil_state.depth_bounds` is `Some`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["depth_bounds"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "depth_bounds",
+                        )])]),
                     });
                 }
 
@@ -1781,11 +1743,10 @@ impl GraphicsPipeline {
                         required_for: "`depth_stencil_state.depth_bounds` is \
                             `Some(depth_bounds_state)`, where `depth_bounds_state.enable_dynamic` \
                             is set",
-                        requires_one_of: RequiresOneOf {
-                            api_version: Some(Version::V1_3),
-                            features: &["extended_dynamic_state"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[
+                            RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                            RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                        ]),
                     });
                 }
 
@@ -1799,10 +1760,9 @@ impl GraphicsPipeline {
                             required_for: "`depth_stencil_state.depth_bounds` is \
                                 `Some(depth_bounds_state)`, where `depth_bounds_state.bounds` is \
                                 not between `0.0` and `1.0` inclusive",
-                            requires_one_of: RequiresOneOf {
-                                device_extensions: &["ext_depth_range_unrestricted"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                Requires::DeviceExtension("ext_depth_range_unrestricted"),
+                            ])]),
                         });
                     }
                 }
@@ -1823,11 +1783,10 @@ impl GraphicsPipeline {
                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                         required_for: "`depth_stencil_state.stencil` is `Some(stencil_state)`, \
                             where `stencil_state.enable_dynamic` is set",
-                        requires_one_of: RequiresOneOf {
-                            api_version: Some(Version::V1_3),
-                            features: &["extended_dynamic_state"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[
+                            RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                            RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                        ]),
                     });
                 }
 
@@ -1863,11 +1822,10 @@ impl GraphicsPipeline {
                                 required_for: "`depth_stencil_state.stencil` is \
                                     `Some(stencil_state)`, where `stencil_state.front.ops` and \
                                     `stencil_state.back.ops` are `StateMode::Dynamic`",
-                                requires_one_of: RequiresOneOf {
-                                    api_version: Some(Version::V1_3),
-                                    features: &["extended_dynamic_state"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[
+                                    RequiresAllOf(&[Requires::APIVersion(Version::V1_3)]),
+                                    RequiresAllOf(&[Requires::Feature("extended_dynamic_state")]),
+                                ]),
                             });
                         }
                     }
@@ -1915,10 +1873,9 @@ impl GraphicsPipeline {
                 if !device.enabled_features().logic_op {
                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                         required_for: "`color_blend_state.logic_op` is `Some`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["logic_op"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "logic_op",
+                        )])]),
                     });
                 }
 
@@ -1933,10 +1890,9 @@ impl GraphicsPipeline {
                             return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                 required_for: "`color_blend_state.logic_op` is \
                                     `Some(StateMode::Dynamic)`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["extended_dynamic_state2_logic_op"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("extended_dynamic_state2_logic_op"),
+                                ])]),
                             });
                         }
                     }
@@ -1955,10 +1911,9 @@ impl GraphicsPipeline {
                     return Err(GraphicsPipelineCreationError::RequirementNotMet {
                         required_for: "`color_blend_state.attachments` has elements where \
                             `blend` and `color_write_mask` do not match the other elements",
-                        requires_one_of: RequiresOneOf {
-                            features: &["independent_blend"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "independent_blend",
+                        )])]),
                     });
                 }
             }
@@ -2022,10 +1977,9 @@ impl GraphicsPipeline {
                                 `blend` is `Some(blend)`, where `blend.color_source`, \
                                 `blend.color_destination`, `blend.alpha_source` or \
                                 `blend.alpha_destination` is `BlendFactor::Src1*`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["dual_src_blend"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "dual_src_blend",
+                            )])]),
                         });
                     }
 
@@ -2048,10 +2002,9 @@ impl GraphicsPipeline {
                                 `blend.color_source` or `blend.color_destination` is \
                                 `BlendFactor::ConstantAlpha` or \
                                 `BlendFactor::OneMinusConstantAlpha`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["constant_alpha_color_blend_factors"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "constant_alpha_color_blend_factors",
+                            )])]),
                         });
                     }
                 }
@@ -2063,10 +2016,9 @@ impl GraphicsPipeline {
                             return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                 required_for: "`color_blend_state.attachments` has an element \
                                     where `color_write_enable` is `StateMode::Fixed(false)`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["color_write_enable"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("color_write_enable"),
+                                ])]),
                             });
                         }
                     }
@@ -2076,10 +2028,9 @@ impl GraphicsPipeline {
                             return Err(GraphicsPipelineCreationError::RequirementNotMet {
                                 required_for: "`color_blend_state.attachments` has an element \
                                     where `color_write_enable` is `StateMode::Dynamic`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["color_write_enable"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("color_write_enable"),
+                                ])]),
                             });
                         }
                     }
@@ -2104,10 +2055,9 @@ impl GraphicsPipeline {
                                 required_for:
                                     "`tessellation_shaders` are provided and `render_pass` has a \
                                     subpass where `view_mask` is not `0`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["multiview_tessellation_shader"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("multiview_tessellation_shader"),
+                                ])]),
                             });
                         }
 
@@ -2119,10 +2069,9 @@ impl GraphicsPipeline {
                                 required_for:
                                     "`geometry_shader` is provided and `render_pass` has a \
                                     subpass where `view_mask` is not `0`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["multiview_geometry_shader"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("multiview_geometry_shader"),
+                                ])]),
                             });
                         }
                     }
@@ -2141,10 +2090,9 @@ impl GraphicsPipeline {
                         return Err(GraphicsPipelineCreationError::RequirementNotMet {
                             required_for:
                                 "`render_pass` is `PipelineRenderPassType::BeginRendering`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["dynamic_rendering"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "dynamic_rendering",
+                            )])]),
                         });
                     }
 
@@ -2154,10 +2102,9 @@ impl GraphicsPipeline {
                             required_for:
                                 "`render_pass` is `PipelineRenderPassType::BeginRendering` \
                             where `view_mask` is not `0`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["multiview"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "multiview",
+                            )])]),
                         });
                     }
 
@@ -2267,10 +2214,9 @@ impl GraphicsPipeline {
                                 required_for:
                                     "`tessellation_shaders` are provided and `render_pass` has a \
                                     subpass where `view_mask` is not `0`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["multiview_tessellation_shader"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("multiview_tessellation_shader"),
+                                ])]),
                             });
                         }
 
@@ -2282,10 +2228,9 @@ impl GraphicsPipeline {
                                 required_for:
                                     "`geometry_shader` is provided and `render_pass` has a \
                                     subpass where `view_mask` is not `0`",
-                                requires_one_of: RequiresOneOf {
-                                    features: &["multiview_geometry_shader"],
-                                    ..Default::default()
-                                },
+                                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                                    Requires::Feature("multiview_geometry_shader"),
+                                ])]),
                             });
                         }
                     }
@@ -2297,10 +2242,9 @@ impl GraphicsPipeline {
             if !device.enabled_extensions().ext_discard_rectangles {
                 return Err(GraphicsPipelineCreationError::RequirementNotMet {
                     required_for: "`discard_rectangle_state` is `Some`",
-                    requires_one_of: RequiresOneOf {
-                        device_extensions: &["ext_discard_rectangles"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                        "ext_discard_rectangles",
+                    )])]),
                 });
             }
 
@@ -2473,10 +2417,9 @@ impl GraphicsPipeline {
                                     `depth_stencil_state.stencil` is `Some(stencil_state)`, \
                                     where `stencil_state.front.reference` does not equal \
                                     `stencil_state.back.reference`",
-                            requires_one_of: RequiresOneOf {
-                                features: &["separate_stencil_mask_ref"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                                "separate_stencil_mask_ref",
+                            )])]),
                         });
                     }
                 }

--- a/vulkano/src/pipeline/graphics/rasterization.rs
+++ b/vulkano/src/pipeline/graphics/rasterization.rs
@@ -250,9 +250,10 @@ vulkan_enum! {
 
     /* TODO: enable
     // TODO: document
-    FillRectangle = FILL_RECTANGLE_NV {
-        device_extensions: [nv_fill_rectangle],
-    },*/
+    FillRectangle = FILL_RECTANGLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_fill_rectangle)]),
+    ]),*/
 }
 
 impl Default for PolygonMode {

--- a/vulkano/src/pipeline/graphics/vertex_input/buffers.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/buffers.rs
@@ -9,10 +9,9 @@
 
 use super::VertexBufferDescription;
 use crate::{
-    pipeline::graphics::vertex_input::{
-        IncompatibleVertexDefinitionError, Vertex, VertexDefinition, VertexInputState,
-    },
+    pipeline::graphics::vertex_input::{Vertex, VertexDefinition, VertexInputState},
     shader::ShaderInterface,
+    ValidationError,
 };
 
 /// A vertex definition for any number of vertex and instance buffers.
@@ -63,10 +62,7 @@ impl BuffersDefinition {
 #[allow(deprecated)]
 unsafe impl VertexDefinition for BuffersDefinition {
     #[inline]
-    fn definition(
-        &self,
-        interface: &ShaderInterface,
-    ) -> Result<VertexInputState, IncompatibleVertexDefinitionError> {
+    fn definition(&self, interface: &ShaderInterface) -> Result<VertexInputState, ValidationError> {
         self.0.definition(interface)
     }
 }

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -757,9 +757,10 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    INDEPENDENT_SETS = INDEPENDENT_SETS_EXT {
-        device_extensions: [ext_graphics_pipeline_library],
-    }, */
+    INDEPENDENT_SETS = INDEPENDENT_SETS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_graphics_pipeline_library)]),
+    ]), */
 }
 
 /// Description of a range of the push constants of a pipeline layout.

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -68,15 +68,18 @@ vulkan_enum! {
 
     /* TODO: enable
     // TODO: document
-    RayTracing = RAY_TRACING_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },*/
+    RayTracing = RAY_TRACING_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SubpassShading = SUBPASS_SHADING_HUAWEI {
-        device_extensions: [huawei_subpass_shading],
-    },*/
+    SubpassShading = SUBPASS_SHADING_HUAWEI
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(huawei_subpass_shading)]),
+    ]),*/
 }
 
 vulkan_bitflags! {
@@ -98,31 +101,35 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    VIEW_INDEX_FROM_DEVICE_INDEX = VIEW_INDEX_FROM_DEVICE_INDEX {
-        api_version: V1_1,
-        device_extensions: [khr_device_group],
-    },*/
+    VIEW_INDEX_FROM_DEVICE_INDEX = VIEW_INDEX_FROM_DEVICE_INDEX
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_device_group)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    DISPATCH_BASE = DISPATCH_BASE {
-        api_version: V1_1,
-        device_extensions: [khr_device_group],
-    },*/
+    DISPATCH_BASE = DISPATCH_BASE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_device_group)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    FAIL_ON_PIPELINE_COMPILE_REQUIRED = FAIL_ON_PIPELINE_COMPILE_REQUIRED {
-        api_version: V1_3,
-        device_extensions: [ext_pipeline_creation_cache_control],
-    },*/
+    FAIL_ON_PIPELINE_COMPILE_REQUIRED = FAIL_ON_PIPELINE_COMPILE_REQUIRED
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_pipeline_creation_cache_control)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    EARLY_RETURN_ON_FAILURE = EARLY_RETURN_ON_FAILURE {
-        api_version: V1_3,
-        device_extensions: [ext_pipeline_creation_cache_control],
-    },
+    EARLY_RETURN_ON_FAILURE = EARLY_RETURN_ON_FAILURE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_pipeline_creation_cache_control)]),
+    ]),
     */
 
     /* TODO: enable
@@ -139,57 +146,66 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_NO_NULL_ANY_HIT_SHADERS = RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_KHR {
-        device_extensions: [khr_ray_tracing_pipeline],
-    },*/
+    RAY_TRACING_NO_NULL_ANY_HIT_SHADERS = RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS = RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_KHR {
-        device_extensions: [khr_ray_tracing_pipeline],
-    },*/
+    RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS = RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_NO_NULL_MISS_SHADERS = RAY_TRACING_NO_NULL_MISS_SHADERS_KHR {
-        device_extensions: [khr_ray_tracing_pipeline],
-    },*/
+    RAY_TRACING_NO_NULL_MISS_SHADERS = RAY_TRACING_NO_NULL_MISS_SHADERS_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_NO_NULL_INTERSECTION_SHADERS = RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_KHR {
-        device_extensions: [khr_ray_tracing_pipeline],
-    },*/
+    RAY_TRACING_NO_NULL_INTERSECTION_SHADERS = RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_SKIP_TRIANGLES = RAY_TRACING_SKIP_TRIANGLES_KHR {
-        device_extensions: [khr_ray_tracing_pipeline],
-    },*/
+    RAY_TRACING_SKIP_TRIANGLES = RAY_TRACING_SKIP_TRIANGLES_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_SKIP_AABBS = RAY_TRACING_SKIP_AABBS_KHR {
-        device_extensions: [khr_ray_tracing_pipeline],
-    },*/
+    RAY_TRACING_SKIP_AABBS = RAY_TRACING_SKIP_AABBS_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY = RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_KHR {
-        device_extensions: [khr_ray_tracing_pipeline],
-    },*/
+    RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY = RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    DEFER_COMPILE = DEFER_COMPILE_NV {
-        device_extensions: [nv_ray_tracing],
-    },*/
+    DEFER_COMPILE = DEFER_COMPILE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    CAPTURE_STATISTICS = CAPTURE_STATISTICS_KHR {
-        device_extensions: [khr_pipeline_executable_properties],
-    },*/
+    CAPTURE_STATISTICS = CAPTURE_STATISTICS_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_pipeline_executable_properties)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
@@ -205,69 +221,80 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    LIBRARY = LIBRARY_KHR {
-        device_extensions: [khr_pipeline_library],
-    },*/
+    LIBRARY = LIBRARY_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_pipeline_library)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    DESCRIPTOR_BUFFER = DESCRIPTOR_BUFFER_EXT {
-        device_extensions: [ext_descriptor_buffer],
-    },*/
+    DESCRIPTOR_BUFFER = DESCRIPTOR_BUFFER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_descriptor_buffer)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RETAIN_LINK_TIME_OPTIMIZATION_INFO = RETAIN_LINK_TIME_OPTIMIZATION_INFO_EXT {
-        device_extensions: [ext_graphics_pipeline_library],
-    },*/
+    RETAIN_LINK_TIME_OPTIMIZATION_INFO = RETAIN_LINK_TIME_OPTIMIZATION_INFO_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_graphics_pipeline_library)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    LINK_TIME_OPTIMIZATION = LINK_TIME_OPTIMIZATION_EXT {
-        device_extensions: [ext_graphics_pipeline_library],
-    },*/
+    LINK_TIME_OPTIMIZATION = LINK_TIME_OPTIMIZATION_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_graphics_pipeline_library)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_ALLOW_MOTION = RAY_TRACING_ALLOW_MOTION_NV {
-        device_extensions: [nv_ray_tracing_motion_blur],
-    },*/
+    RAY_TRACING_ALLOW_MOTION = RAY_TRACING_ALLOW_MOTION_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_ray_tracing_motion_blur)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    COLOR_ATTACHMENT_FEEDBACK_LOOP = COLOR_ATTACHMENT_FEEDBACK_LOOP_EXT {
-        device_extensions: [ext_attachment_feedback_loop_layout],
-    },*/
+    COLOR_ATTACHMENT_FEEDBACK_LOOP = COLOR_ATTACHMENT_FEEDBACK_LOOP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_attachment_feedback_loop_layout)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP = DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_EXT {
-        device_extensions: [ext_attachment_feedback_loop_layout],
-    },*/
+    DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP = DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_attachment_feedback_loop_layout)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_OPACITY_MICROMAP = RAY_TRACING_OPACITY_MICROMAP_EXT {
-        device_extensions: [ext_opacity_micromap],
-    },*/
+    RAY_TRACING_OPACITY_MICROMAP = RAY_TRACING_OPACITY_MICROMAP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    RAY_TRACING_DISPLACEMENT_MICROMAP = RAY_TRACING_DISPLACEMENT_MICROMAP_NV {
-        device_extensions: [nv_displacement_micromap],
-    },*/
+    RAY_TRACING_DISPLACEMENT_MICROMAP = RAY_TRACING_DISPLACEMENT_MICROMAP_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_displacement_micromap)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    NO_PROTECTED_ACCESS = NO_PROTECTED_ACCESS_EXT {
-        device_extensions: [ext_pipeline_protected_access],
-    },*/
+    NO_PROTECTED_ACCESS = NO_PROTECTED_ACCESS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_pipeline_protected_access)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    PROTECTED_ACCESS_ONLY = PROTECTED_ACCESS_ONLY_EXT {
-        device_extensions: [ext_pipeline_protected_access],
-    },*/
+    PROTECTED_ACCESS_ONLY = PROTECTED_ACCESS_ONLY_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_pipeline_protected_access)]),
+    ]),*/
 }
 
 vulkan_enum! {
@@ -305,314 +332,373 @@ vulkan_enum! {
     StencilReference = STENCIL_REFERENCE,
 
     // TODO: document
-    CullMode = CULL_MODE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    CullMode = CULL_MODE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    FrontFace = FRONT_FACE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    FrontFace = FRONT_FACE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    PrimitiveTopology = PRIMITIVE_TOPOLOGY {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    PrimitiveTopology = PRIMITIVE_TOPOLOGY
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    ViewportWithCount = VIEWPORT_WITH_COUNT {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    ViewportWithCount = VIEWPORT_WITH_COUNT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    ScissorWithCount = SCISSOR_WITH_COUNT {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    ScissorWithCount = SCISSOR_WITH_COUNT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    VertexInputBindingStride = VERTEX_INPUT_BINDING_STRIDE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    VertexInputBindingStride = VERTEX_INPUT_BINDING_STRIDE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    DepthTestEnable = DEPTH_TEST_ENABLE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    DepthTestEnable = DEPTH_TEST_ENABLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    DepthWriteEnable = DEPTH_WRITE_ENABLE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    DepthWriteEnable = DEPTH_WRITE_ENABLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    DepthCompareOp = DEPTH_COMPARE_OP {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    DepthCompareOp = DEPTH_COMPARE_OP
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    DepthBoundsTestEnable = DEPTH_BOUNDS_TEST_ENABLE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    DepthBoundsTestEnable = DEPTH_BOUNDS_TEST_ENABLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    StencilTestEnable = STENCIL_TEST_ENABLE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    StencilTestEnable = STENCIL_TEST_ENABLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    StencilOp = STENCIL_OP {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state],
-    },
+    StencilOp = STENCIL_OP
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state)]),
+    ]),
 
     // TODO: document
-    RasterizerDiscardEnable = RASTERIZER_DISCARD_ENABLE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state2],
-    },
+    RasterizerDiscardEnable = RASTERIZER_DISCARD_ENABLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state2)]),
+    ]),
 
     // TODO: document
-    DepthBiasEnable = DEPTH_BIAS_ENABLE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state2],
-    },
+    DepthBiasEnable = DEPTH_BIAS_ENABLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state2)]),
+    ]),
 
     // TODO: document
-    PrimitiveRestartEnable = PRIMITIVE_RESTART_ENABLE {
-        api_version: V1_3,
-        device_extensions: [ext_extended_dynamic_state2],
-    },
+    PrimitiveRestartEnable = PRIMITIVE_RESTART_ENABLE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state2)]),
+    ]),
 
     // TODO: document
-    ViewportWScaling = VIEWPORT_W_SCALING_NV {
-        device_extensions: [nv_clip_space_w_scaling],
-    },
+    ViewportWScaling = VIEWPORT_W_SCALING_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_clip_space_w_scaling)]),
+    ]),
 
     // TODO: document
-    DiscardRectangle = DISCARD_RECTANGLE_EXT {
-        device_extensions: [ext_discard_rectangles],
-    },
+    DiscardRectangle = DISCARD_RECTANGLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_discard_rectangles)]),
+    ]),
 
     // TODO: document
-    SampleLocations = SAMPLE_LOCATIONS_EXT {
-        device_extensions: [ext_sample_locations],
-    },
+    SampleLocations = SAMPLE_LOCATIONS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_sample_locations)]),
+    ]),
 
     // TODO: document
-    RayTracingPipelineStackSize = RAY_TRACING_PIPELINE_STACK_SIZE_KHR {
-        device_extensions: [khr_ray_tracing_pipeline],
-    },
+    RayTracingPipelineStackSize = RAY_TRACING_PIPELINE_STACK_SIZE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+    ]),
 
     // TODO: document
-    ViewportShadingRatePalette = VIEWPORT_SHADING_RATE_PALETTE_NV {
-        device_extensions: [nv_shading_rate_image],
-    },
+    ViewportShadingRatePalette = VIEWPORT_SHADING_RATE_PALETTE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_shading_rate_image)]),
+    ]),
 
     // TODO: document
-    ViewportCoarseSampleOrder = VIEWPORT_COARSE_SAMPLE_ORDER_NV {
-        device_extensions: [nv_shading_rate_image],
-    },
+    ViewportCoarseSampleOrder = VIEWPORT_COARSE_SAMPLE_ORDER_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_shading_rate_image)]),
+    ]),
 
     // TODO: document
-    ExclusiveScissor = EXCLUSIVE_SCISSOR_NV {
-        device_extensions: [nv_scissor_exclusive],
-    },
+    ExclusiveScissor = EXCLUSIVE_SCISSOR_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_scissor_exclusive)]),
+    ]),
 
     // TODO: document
-    FragmentShadingRate = FRAGMENT_SHADING_RATE_KHR {
-        device_extensions: [khr_fragment_shading_rate],
-    },
+    FragmentShadingRate = FRAGMENT_SHADING_RATE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_fragment_shading_rate)]),
+    ]),
 
     // TODO: document
-    LineStipple = LINE_STIPPLE_EXT {
-        device_extensions: [ext_line_rasterization],
-    },
+    LineStipple = LINE_STIPPLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_line_rasterization)]),
+    ]),
 
     // TODO: document
-    VertexInput = VERTEX_INPUT_EXT {
-        device_extensions: [ext_vertex_input_dynamic_state],
-    },
+    VertexInput = VERTEX_INPUT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_vertex_input_dynamic_state)]),
+    ]),
 
     // TODO: document
-    PatchControlPoints = PATCH_CONTROL_POINTS_EXT {
-        device_extensions: [ext_extended_dynamic_state2],
-    },
+    PatchControlPoints = PATCH_CONTROL_POINTS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state2)]),
+    ]),
 
     // TODO: document
-    LogicOp = LOGIC_OP_EXT {
-        device_extensions: [ext_extended_dynamic_state2],
-    },
+    LogicOp = LOGIC_OP_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state2)]),
+    ]),
 
     // TODO: document
-    ColorWriteEnable = COLOR_WRITE_ENABLE_EXT {
-        device_extensions: [ext_color_write_enable],
-    },
+    ColorWriteEnable = COLOR_WRITE_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_color_write_enable)]),
+    ]),
 
     // TODO: document
-    TessellationDomainOrigin = TESSELLATION_DOMAIN_ORIGIN_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    TessellationDomainOrigin = TESSELLATION_DOMAIN_ORIGIN_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    DepthClampEnable = DEPTH_CLAMP_ENABLE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    DepthClampEnable = DEPTH_CLAMP_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    PolygonMode = POLYGON_MODE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    PolygonMode = POLYGON_MODE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    RasterizationSamples = RASTERIZATION_SAMPLES_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    RasterizationSamples = RASTERIZATION_SAMPLES_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    SampleMask = SAMPLE_MASK_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    SampleMask = SAMPLE_MASK_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    AlphaToCoverageEnable = ALPHA_TO_COVERAGE_ENABLE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    AlphaToCoverageEnable = ALPHA_TO_COVERAGE_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    AlphaToOneEnable = ALPHA_TO_ONE_ENABLE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    AlphaToOneEnable = ALPHA_TO_ONE_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    LogicOpEnable = LOGIC_OP_ENABLE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    LogicOpEnable = LOGIC_OP_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ColorBlendEnable = COLOR_BLEND_ENABLE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ColorBlendEnable = COLOR_BLEND_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ColorBlendEquation = COLOR_BLEND_EQUATION_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ColorBlendEquation = COLOR_BLEND_EQUATION_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ColorWriteMask = COLOR_WRITE_MASK_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ColorWriteMask = COLOR_WRITE_MASK_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    RasterizationStream = RASTERIZATION_STREAM_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    RasterizationStream = RASTERIZATION_STREAM_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ConservativeRasterizationMode = CONSERVATIVE_RASTERIZATION_MODE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ConservativeRasterizationMode = CONSERVATIVE_RASTERIZATION_MODE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ExtraPrimitiveOverestimationSize = EXTRA_PRIMITIVE_OVERESTIMATION_SIZE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ExtraPrimitiveOverestimationSize = EXTRA_PRIMITIVE_OVERESTIMATION_SIZE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    DepthClipEnable = DEPTH_CLIP_ENABLE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    DepthClipEnable = DEPTH_CLIP_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    SampleLocationsEnable = SAMPLE_LOCATIONS_ENABLE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    SampleLocationsEnable = SAMPLE_LOCATIONS_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ColorBlendAdvanced = COLOR_BLEND_ADVANCED_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ColorBlendAdvanced = COLOR_BLEND_ADVANCED_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ProvokingVertexMode = PROVOKING_VERTEX_MODE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ProvokingVertexMode = PROVOKING_VERTEX_MODE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    LineRasterizationMode = LINE_RASTERIZATION_MODE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    LineRasterizationMode = LINE_RASTERIZATION_MODE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    LineStippleEnable = LINE_STIPPLE_ENABLE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    LineStippleEnable = LINE_STIPPLE_ENABLE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    DepthClipNegativeOneToOne = DEPTH_CLIP_NEGATIVE_ONE_TO_ONE_EXT {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    DepthClipNegativeOneToOne = DEPTH_CLIP_NEGATIVE_ONE_TO_ONE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ViewportWScalingEnable = VIEWPORT_W_SCALING_ENABLE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ViewportWScalingEnable = VIEWPORT_W_SCALING_ENABLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ViewportSwizzle = VIEWPORT_SWIZZLE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ViewportSwizzle = VIEWPORT_SWIZZLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    CoverageToColorEnable = COVERAGE_TO_COLOR_ENABLE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    CoverageToColorEnable = COVERAGE_TO_COLOR_ENABLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    CoverageToColorLocation = COVERAGE_TO_COLOR_LOCATION_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    CoverageToColorLocation = COVERAGE_TO_COLOR_LOCATION_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    CoverageModulationMode = COVERAGE_MODULATION_MODE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    CoverageModulationMode = COVERAGE_MODULATION_MODE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    CoverageModulationTableEnable = COVERAGE_MODULATION_TABLE_ENABLE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    CoverageModulationTableEnable = COVERAGE_MODULATION_TABLE_ENABLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    CoverageModulationTable = COVERAGE_MODULATION_TABLE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    CoverageModulationTable = COVERAGE_MODULATION_TABLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    ShadingRateImageEnable = SHADING_RATE_IMAGE_ENABLE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    ShadingRateImageEnable = SHADING_RATE_IMAGE_ENABLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    RepresentativeFragmentTestEnable = REPRESENTATIVE_FRAGMENT_TEST_ENABLE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    RepresentativeFragmentTestEnable = REPRESENTATIVE_FRAGMENT_TEST_ENABLE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 
     // TODO: document
-    CoverageReductionMode = COVERAGE_REDUCTION_MODE_NV {
-        device_extensions: [ext_extended_dynamic_state3],
-    },
+    CoverageReductionMode = COVERAGE_REDUCTION_MODE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_extended_dynamic_state3)]),
+    ]),
 }
 
 /// Specifies how a dynamic state is handled by a graphics pipeline.

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -17,7 +17,8 @@ use crate::{
     buffer::BufferContents,
     device::{Device, DeviceOwned},
     macros::{impl_id_counter, vulkan_bitflags},
-    DeviceSize, OomError, RequirementNotMet, RequiresOneOf, RuntimeError, VulkanObject,
+    DeviceSize, OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError,
+    VulkanObject,
 };
 use std::{
     error::Error,
@@ -632,10 +633,9 @@ impl QueryType {
                 if !device.enabled_extensions().khr_acceleration_structure {
                     return Err(crate::RequirementNotMet {
                         required_for: "QueryType::AccelerationStructureCompactedSize",
-                        requires_one_of: RequiresOneOf {
-                            device_extensions: &["khr_acceleration_structure"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                            Requires::DeviceExtension("khr_acceleration_structure"),
+                        ])]),
                     });
                 }
             }
@@ -643,10 +643,9 @@ impl QueryType {
                 if !device.enabled_extensions().khr_acceleration_structure {
                     return Err(crate::RequirementNotMet {
                         required_for: "QueryType::AccelerationStructureSerializationSize",
-                        requires_one_of: RequiresOneOf {
-                            device_extensions: &["khr_acceleration_structure"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                            Requires::DeviceExtension("khr_acceleration_structure"),
+                        ])]),
                     });
                 }
             }
@@ -655,10 +654,9 @@ impl QueryType {
                     return Err(crate::RequirementNotMet {
                         required_for:
                             "QueryType::AccelerationStructureSerializationBottomLevelPointers",
-                        requires_one_of: RequiresOneOf {
-                            device_extensions: &["khr_ray_tracing_maintenance1"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                            Requires::DeviceExtension("khr_ray_tracing_maintenance1"),
+                        ])]),
                     });
                 }
             }
@@ -666,10 +664,9 @@ impl QueryType {
                 if !device.enabled_extensions().khr_ray_tracing_maintenance1 {
                     return Err(crate::RequirementNotMet {
                         required_for: "QueryType::AccelerationStructureSize",
-                        requires_one_of: RequiresOneOf {
-                            device_extensions: &["khr_ray_tracing_maintenance1"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[
+                            Requires::DeviceExtension("khr_ray_tracing_maintenance1"),
+                        ])]),
                     });
                 }
             }
@@ -779,15 +776,17 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    TASK_SHADER_INVOCATIONS = TASK_SHADER_INVOCATIONS_NV {
-        device_extensions: [nv_mesh_shader],
-    },*/
+    TASK_SHADER_INVOCATIONS = TASK_SHADER_INVOCATIONS_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_mesh_shader)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    MESH_SHADER_INVOCATIONS = MESH_SHADER_INVOCATIONS_NV {
-        device_extensions: [nv_mesh_shader],
-    },*/
+    MESH_SHADER_INVOCATIONS = MESH_SHADER_INVOCATIONS_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_mesh_shader)]),
+    ]),*/
 }
 
 vulkan_bitflags! {
@@ -814,9 +813,10 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    WITH_STATUS = WITH_STATUS_KHR {
-        device_extensions: [khr_video_queue],
-    },*/
+    WITH_STATUS = WITH_STATUS_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_queue)]),
+    ]),*/
 }
 
 #[cfg(test)]

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -33,7 +33,8 @@ use crate::{
     macros::{impl_id_counter, vulkan_bitflags, vulkan_bitflags_enum, vulkan_enum},
     shader::ShaderInterface,
     sync::{AccessFlags, DependencyFlags, MemoryBarrier, PipelineStages},
-    RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, RuntimeError, ValidationError, Version, VulkanError,
+    VulkanObject,
 };
 use ahash::HashMap;
 use std::{
@@ -1450,11 +1451,13 @@ impl RenderPassCreateInfo {
                                 subpass_index, ref_index,
                             )
                             .into(),
-                            requires_one_of: RequiresOneOf {
-                                api_version: Some(Version::V1_1),
-                                device_extensions: &["khr_create_renderpass2", "khr_maintenance2"],
-                                ..Default::default()
-                            },
+                            requires_one_of: RequiresOneOf(&[
+                                RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                                RequiresAllOf(&[Requires::DeviceExtension(
+                                    "khr_create_renderpass2",
+                                )]),
+                                RequiresAllOf(&[Requires::DeviceExtension("khr_maintenance2")]),
+                            ]),
                             // vuids?
                             ..Default::default()
                         });
@@ -1840,10 +1843,9 @@ impl AttachmentDescription {
                     problem: "specifies a layout for only the depth aspect or only the \
                         stencil aspect"
                         .into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["separate_depth_stencil_layouts"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "separate_depth_stencil_layouts",
+                    )])]),
                     vuids: &["VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03284"],
                 });
             }
@@ -1860,10 +1862,9 @@ impl AttachmentDescription {
                     problem: "specifies a layout for only the depth aspect or only the \
                         stencil aspect"
                         .into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["separate_depth_stencil_layouts"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "separate_depth_stencil_layouts",
+                    )])]),
                     vuids: &["VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03285"],
                 });
             }
@@ -1903,10 +1904,9 @@ impl AttachmentDescription {
                 return Err(ValidationError {
                     context: "stencil_initial_layout".into(),
                     problem: "is `Some`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["separate_depth_stencil_layouts"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "separate_depth_stencil_layouts",
+                    )])]),
                     ..Default::default()
                 });
             }
@@ -1947,10 +1947,9 @@ impl AttachmentDescription {
                 return Err(ValidationError {
                     context: "stencil_final_layout".into(),
                     problem: "is `Some`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["separate_depth_stencil_layouts"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "separate_depth_stencil_layouts",
+                    )])]),
                     ..Default::default()
                 });
             }
@@ -2706,11 +2705,12 @@ impl SubpassDescription {
                     return Err(ValidationError {
                         context: "depth_stencil_resolve_attachment".into(),
                         problem: "is `Some`".into(),
-                        requires_one_of: RequiresOneOf {
-                            api_version: Some(Version::V1_2),
-                            device_extensions: &["khr_depth_stencil_resolve"],
-                            ..Default::default()
-                        },
+                        requires_one_of: RequiresOneOf(&[
+                            RequiresAllOf(&[Requires::APIVersion(Version::V1_2)]),
+                            RequiresAllOf(&[Requires::DeviceExtension(
+                                "khr_depth_stencil_resolve",
+                            )]),
+                        ]),
                         // vuids?
                         ..Default::default()
                     });
@@ -2998,10 +2998,7 @@ impl SubpassDescription {
             return Err(ValidationError {
                 context: "view_mask".into(),
                 problem: "is not 0".into(),
-                requires_one_of: RequiresOneOf {
-                    features: &["multiview"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("multiview")])]),
                 vuids: &["VUID-VkSubpassDescription2-multiview-06558"],
             });
         }
@@ -3184,10 +3181,9 @@ impl AttachmentReference {
                 context: "layout".into(),
                 problem: "specifies a layout for only the depth aspect or only the stencil aspect"
                     .into(),
-                requires_one_of: RequiresOneOf {
-                    features: &["separate_depth_stencil_layouts"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "separate_depth_stencil_layouts",
+                )])]),
                 vuids: &["VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313"],
             });
         }
@@ -3197,10 +3193,9 @@ impl AttachmentReference {
                 return Err(ValidationError {
                     context: "stencil_layout".into(),
                     problem: "is `Some`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["separate_depth_stencil_layouts"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "separate_depth_stencil_layouts",
+                    )])]),
                     ..Default::default()
                 });
             }
@@ -3410,11 +3405,10 @@ impl SubpassDependency {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains flags from `VkPipelineStageFlagBits2`".into(),
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_2),
-                        device_extensions: &["khr_create_renderpass2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_2)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_create_renderpass2")]),
+                    ]),
                     ..Default::default()
                 });
             }
@@ -3423,11 +3417,10 @@ impl SubpassDependency {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains flags from `VkPipelineStageFlagBits2`".into(),
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_2),
-                        device_extensions: &["khr_create_renderpass2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_2)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_create_renderpass2")]),
+                    ]),
                     ..Default::default()
                 });
             }
@@ -3436,11 +3429,10 @@ impl SubpassDependency {
                 return Err(ValidationError {
                     context: "src_access".into(),
                     problem: "contains flags from `VkAccessFlagBits2`".into(),
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_2),
-                        device_extensions: &["khr_create_renderpass2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_2)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_create_renderpass2")]),
+                    ]),
                     ..Default::default()
                 });
             }
@@ -3449,11 +3441,10 @@ impl SubpassDependency {
                 return Err(ValidationError {
                     context: "dst_access".into(),
                     problem: "contains flags from `VkAccessFlagBits2`".into(),
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_2),
-                        device_extensions: &["khr_create_renderpass2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_2)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_create_renderpass2")]),
+                    ]),
                     ..Default::default()
                 });
             }
@@ -3464,10 +3455,9 @@ impl SubpassDependency {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "is empty".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["synchronization2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "synchronization2",
+                    )])]),
                     vuids: &["VUID-VkSubpassDependency2-srcStageMask-03937"],
                 });
             }
@@ -3476,10 +3466,9 @@ impl SubpassDependency {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "is empty".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["synchronization2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "synchronization2",
+                    )])]),
                     vuids: &["VUID-VkSubpassDependency2-dstStageMask-03937"],
                 });
             }
@@ -3612,9 +3601,10 @@ vulkan_enum! {
 
     /* TODO: enable
     // TODO: document
-    None = NONE_EXT {
-        device_extensions: [ext_load_store_op_none],
-    },*/
+    None = NONE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_load_store_op_none)]),
+    ]),*/
 }
 
 vulkan_enum! {

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -530,7 +530,7 @@ impl Sampler {
                 return Err(ValidationError {
                     problem: "the sampler has depth comparison enabled, and \
                         the image view's format features do not include \
-                        FormatFeatures::SAMPLED_IMAGE_DEPTH_COMPARISON"
+                        `FormatFeatures::SAMPLED_IMAGE_DEPTH_COMPARISON`"
                         .into(),
                     ..Default::default()
                 });
@@ -546,7 +546,7 @@ impl Sampler {
             {
                 return Err(ValidationError {
                     problem: "the sampler has depth comparison enabled, and \
-                        the image view's aspects do not include ImageAspects::DEPTH"
+                        the image view's aspects do not include `ImageAspects::DEPTH`"
                         .into(),
                     ..Default::default()
                 });
@@ -559,9 +559,9 @@ impl Sampler {
                 // VUID-vkCmdDispatch-magFilter-04553
                 if self.mag_filter == Filter::Linear || self.min_filter == Filter::Linear {
                     return Err(ValidationError {
-                        problem: "the sampler's mag_filter or min_filter is Filter::Linear, and \
-                            the image view's format features do not include \
-                            FormatFeatures::SAMPLED_IMAGE_FILTER_LINEAR"
+                        problem: "the sampler's `mag_filter` or `min_filter` is `Filter::Linear`, \
+                            and the image view's format features do not include \
+                            `FormatFeatures::SAMPLED_IMAGE_FILTER_LINEAR`"
                             .into(),
                         ..Default::default()
                     });
@@ -570,9 +570,9 @@ impl Sampler {
                 // VUID-vkCmdDispatch-mipmapMode-04770
                 if self.mipmap_mode == SamplerMipmapMode::Linear {
                     return Err(ValidationError {
-                        problem: "the sampler's mipmap_mode is SamplerMipmapMpde::Linear, and \
+                        problem: "the sampler's `mipmap_mode` is `SamplerMipmapMpde::Linear`, and \
                             the image view's format features do not include \
-                            FormatFeatures::SAMPLED_IMAGE_FILTER_LINEAR"
+                            `FormatFeatures::SAMPLED_IMAGE_FILTER_LINEAR`"
                             .into(),
                         ..Default::default()
                     });
@@ -587,9 +587,9 @@ impl Sampler {
                 .intersects(FormatFeatures::SAMPLED_IMAGE_FILTER_CUBIC)
             {
                 return Err(ValidationError {
-                    problem: "the sampler's mag_filter or min_filter is Filter::Cubic, and \
+                    problem: "the sampler's `mag_filter` or `min_filter` is `Filter::Cubic`, and \
                         the image view's format features do not include \
-                        FormatFeatures::SAMPLED_IMAGE_FILTER_CUBIC"
+                        `FormatFeatures::SAMPLED_IMAGE_FILTER_CUBIC`"
                         .into(),
                     ..Default::default()
                 });
@@ -598,9 +598,9 @@ impl Sampler {
             // VUID-vkCmdDispatch-filterCubic-02694
             if !image_view.filter_cubic() {
                 return Err(ValidationError {
-                    problem: "the sampler's mag_filter or min_filter is Filter::Cubic, and \
+                    problem: "the sampler's `mag_filter` or `min_filter` is Filter::Cubic, and \
                         the image view does not support this, as returned by \
-                        PhysicalDevice::image_format_properties"
+                        `PhysicalDevice::image_format_properties`"
                         .into(),
                     ..Default::default()
                 });
@@ -613,11 +613,11 @@ impl Sampler {
             ) && !image_view.filter_cubic_minmax()
             {
                 return Err(ValidationError {
-                    problem: "the sampler's mag_filter or min_filter is Filter::Cubic, and \
-                        the its reduction_mode is SamplerReductionMode::Min or \
-                        SamplerReductionMode::Max, and
+                    problem: "the sampler's `mag_filter` or `min_filter` is `Filter::Cubic`, and \
+                        the its `reduction_mode` is `SamplerReductionMode::Min` or \
+                        `SamplerReductionMode::Max`, and \
                         the image view does not support this, as returned by \
-                        PhysicalDevice::image_format_properties"
+                        `PhysicalDevice::image_format_properties`"
                         .into(),
                     ..Default::default()
                 });
@@ -715,7 +715,8 @@ impl Sampler {
             ) {
                 return Err(ValidationError {
                     problem: "the sampler uses unnormalized coordinates, and \
-                        the image view's type is not ImageViewtype::Dim1d or ImageViewType::Dim2d"
+                        the image view's type is not `ImageViewtype::Dim1d` or \
+                        `ImageViewType::Dim2d`"
                         .into(),
                     ..Default::default()
                 });

--- a/vulkano/src/sampler/mod.rs
+++ b/vulkano/src/sampler/mod.rs
@@ -54,7 +54,8 @@ use crate::{
     macros::{impl_id_counter, vulkan_enum},
     pipeline::graphics::depth_stencil::CompareOp,
     shader::ShaderScalarType,
-    OomError, RequirementNotMet, RequiresOneOf, RuntimeError, ValidationError, VulkanObject,
+    OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError,
+    ValidationError, VulkanObject,
 };
 use std::{
     error::Error,
@@ -164,17 +165,18 @@ impl Sampler {
         }
 
         if address_mode.contains(&SamplerAddressMode::MirrorClampToEdge) {
-            if !device.enabled_features().sampler_mirror_clamp_to_edge
-                && !device.enabled_extensions().khr_sampler_mirror_clamp_to_edge
+            if !(device.enabled_features().sampler_mirror_clamp_to_edge
+                || device.enabled_extensions().khr_sampler_mirror_clamp_to_edge)
             {
                 return Err(SamplerCreationError::RequirementNotMet {
                     required_for: "`create_info.address_mode` contains \
                         `SamplerAddressMode::MirrorClampToEdge`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["sampler_mirror_clamp_to_edge"],
-                        device_extensions: &["khr_sampler_mirror_clamp_to_edge"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::Feature("sampler_mirror_clamp_to_edge")]),
+                        RequiresAllOf(&[Requires::DeviceExtension(
+                            "khr_sampler_mirror_clamp_to_edge",
+                        )]),
+                    ]),
                 });
             }
         }
@@ -198,10 +200,9 @@ impl Sampler {
             return Err(SamplerCreationError::RequirementNotMet {
                 required_for: "this device is a portability subset device, and \
                     `create_info.mip_lod_bias` is not zero",
-                requires_one_of: RequiresOneOf {
-                    features: &["sampler_mip_lod_bias"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "sampler_mip_lod_bias",
+                )])]),
             });
         }
 
@@ -211,10 +212,9 @@ impl Sampler {
             if !device.enabled_features().sampler_anisotropy {
                 return Err(SamplerCreationError::RequirementNotMet {
                     required_for: "`create_info.anisotropy` is `Some`",
-                    requires_one_of: RequiresOneOf {
-                        features: &["sampler_anisotropy"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "sampler_anisotropy",
+                    )])]),
                 });
             }
 
@@ -296,32 +296,32 @@ impl Sampler {
             }
         }
 
-        let mut sampler_reduction_mode_create_info =
-            if reduction_mode != SamplerReductionMode::WeightedAverage {
-                if !(device.enabled_features().sampler_filter_minmax
-                    || device.enabled_extensions().ext_sampler_filter_minmax)
-                {
-                    return Err(SamplerCreationError::RequirementNotMet {
-                        required_for: "`create_info.reduction_mode` is not \
+        let mut sampler_reduction_mode_create_info = if reduction_mode
+            != SamplerReductionMode::WeightedAverage
+        {
+            if !(device.enabled_features().sampler_filter_minmax
+                || device.enabled_extensions().ext_sampler_filter_minmax)
+            {
+                return Err(SamplerCreationError::RequirementNotMet {
+                    required_for: "`create_info.reduction_mode` is not \
                             `SamplerReductionMode::WeightedAverage`",
-                        requires_one_of: RequiresOneOf {
-                            features: &["sampler_filter_minmax"],
-                            device_extensions: &["ext_sampler_filter_minmax"],
-                            ..Default::default()
-                        },
-                    });
-                }
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::Feature("sampler_filter_minmax")]),
+                        RequiresAllOf(&[Requires::DeviceExtension("ext_sampler_filter_minmax")]),
+                    ]),
+                });
+            }
 
-                // VUID-VkSamplerReductionModeCreateInfo-reductionMode-parameter
-                reduction_mode.validate_device(&device)?;
+            // VUID-VkSamplerReductionModeCreateInfo-reductionMode-parameter
+            reduction_mode.validate_device(&device)?;
 
-                Some(ash::vk::SamplerReductionModeCreateInfo {
-                    reduction_mode: reduction_mode.into(),
-                    ..Default::default()
-                })
-            } else {
-                None
-            };
+            Some(ash::vk::SamplerReductionModeCreateInfo {
+                reduction_mode: reduction_mode.into(),
+                ..Default::default()
+            })
+        } else {
+            None
+        };
 
         // Don't need to check features because you can't create a conversion object without the
         // feature anyway.
@@ -1410,9 +1410,11 @@ vulkan_enum! {
     /// The [`ext_filter_cubic`](crate::device::DeviceExtensions::ext_filter_cubic) extension must
     /// be enabled on the device, and anisotropy must be disabled. Sampled image views must have
     /// a type of [`Dim2d`](crate::image::view::ImageViewType::Dim2d).
-    Cubic = CUBIC_EXT {
-        device_extensions: [ext_filter_cubic, img_filter_cubic],
-    },
+    Cubic = CUBIC_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_filter_cubic)]),
+        RequiresAllOf([DeviceExtension(img_filter_cubic)]),
+    ]),
 }
 
 vulkan_enum! {
@@ -1465,10 +1467,11 @@ vulkan_enum! {
     /// feature or the
     /// [`khr_sampler_mirror_clamp_to_edge`](crate::device::DeviceExtensions::khr_sampler_mirror_clamp_to_edge)
     /// extension must be enabled on the device.
-    MirrorClampToEdge = MIRROR_CLAMP_TO_EDGE {
-        api_version: V1_2,
-        device_extensions: [khr_sampler_mirror_clamp_to_edge],
-    },
+    MirrorClampToEdge = MIRROR_CLAMP_TO_EDGE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_2)]),
+        RequiresAllOf([DeviceExtension(khr_sampler_mirror_clamp_to_edge)]),
+    ]),
 }
 
 vulkan_enum! {
@@ -1502,15 +1505,17 @@ vulkan_enum! {
 
     /* TODO: enable
     // TODO: document
-    FloatCustom = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT {
-        device_extensions: [ext_custom_border_color],
-    },*/
+    FloatCustom = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_custom_border_color)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    IntCustom = INT_CUSTOM_EXT {
-        device_extensions: [ext_custom_border_color],
-    },*/
+    IntCustom = INT_CUSTOM_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_custom_border_color)]),
+    ]),*/
 }
 
 vulkan_enum! {
@@ -1549,7 +1554,7 @@ mod tests {
             Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerCreationError,
             SamplerReductionMode,
         },
-        RequiresOneOf,
+        Requires, RequiresAllOf, RequiresOneOf,
     };
 
     #[test]
@@ -1681,9 +1686,10 @@ mod tests {
 
         match r {
             Err(SamplerCreationError::RequirementNotMet {
-                requires_one_of: RequiresOneOf { features, .. },
+                requires_one_of:
+                    RequiresOneOf([RequiresAllOf([Requires::Feature("sampler_anisotropy")])]),
                 ..
-            }) if features.contains(&"sampler_anisotropy") => (),
+            }) => (),
             _ => panic!(),
         }
     }
@@ -1752,14 +1758,13 @@ mod tests {
         match r {
             Err(SamplerCreationError::RequirementNotMet {
                 requires_one_of:
-                    RequiresOneOf {
-                        features,
-                        device_extensions,
-                        ..
-                    },
+                    RequiresOneOf(
+                        [RequiresAllOf([Requires::Feature("sampler_mirror_clamp_to_edge")]), RequiresAllOf(
+                            [Requires::DeviceExtension("khr_sampler_mirror_clamp_to_edge")],
+                        )],
+                    ),
                 ..
-            }) if features.contains(&"sampler_mirror_clamp_to_edge")
-                && device_extensions.contains(&"khr_sampler_mirror_clamp_to_edge") => {}
+            }) => {}
             _ => panic!(),
         }
     }
@@ -1781,14 +1786,11 @@ mod tests {
         match r {
             Err(SamplerCreationError::RequirementNotMet {
                 requires_one_of:
-                    RequiresOneOf {
-                        features,
-                        device_extensions,
-                        ..
-                    },
+                    RequiresOneOf(
+                        [RequiresAllOf([Requires::Feature("sampler_filter_minmax")]), RequiresAllOf([Requires::DeviceExtension("ext_sampler_filter_minmax")])],
+                    ),
                 ..
-            }) if features.contains(&"sampler_filter_minmax")
-                && device_extensions.contains(&"ext_sampler_filter_minmax") => {}
+            }) => {}
             _ => panic!(),
         }
     }

--- a/vulkano/src/sampler/ycbcr.rs
+++ b/vulkano/src/sampler/ycbcr.rs
@@ -95,7 +95,8 @@ use crate::{
     format::{ChromaSampling, Format, FormatFeatures, NumericType},
     macros::{impl_id_counter, vulkan_enum},
     sampler::{ComponentMapping, ComponentSwizzle, Filter},
-    OomError, RequirementNotMet, RequiresOneOf, RuntimeError, Version, VulkanObject,
+    OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, Version,
+    VulkanObject,
 };
 use std::{
     error::Error,
@@ -145,10 +146,9 @@ impl SamplerYcbcrConversion {
         if !device.enabled_features().sampler_ycbcr_conversion {
             return Err(SamplerYcbcrConversionCreationError::RequirementNotMet {
                 required_for: "`SamplerYcbcrConversion::new`",
-                requires_one_of: RequiresOneOf {
-                    features: &["sampler_ycbcr_conversion"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                    "sampler_ycbcr_conversion",
+                )])]),
             });
         }
 
@@ -791,7 +791,7 @@ vulkan_enum! {
 #[cfg(test)]
 mod tests {
     use super::{SamplerYcbcrConversion, SamplerYcbcrConversionCreationError};
-    use crate::RequiresOneOf;
+    use crate::{Requires, RequiresAllOf, RequiresOneOf};
 
     #[test]
     fn feature_not_enabled() {
@@ -801,9 +801,10 @@ mod tests {
 
         match r {
             Err(SamplerYcbcrConversionCreationError::RequirementNotMet {
-                requires_one_of: RequiresOneOf { features, .. },
+                requires_one_of:
+                    RequiresOneOf([RequiresAllOf([Requires::Feature("sampler_ycbcr_conversion")])]),
                 ..
-            }) if features.contains(&"sampler_ycbcr_conversion") => (),
+            }) => (),
             _ => panic!(),
         }
     }

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -774,18 +774,20 @@ vulkan_bitflags! {
 
     /* TODO: enable
     // TODO: document
-    ALLOW_VARYING_SUBGROUP_SIZE = ALLOW_VARYING_SUBGROUP_SIZE {
-        api_version: V1_3,
-        device_extensions: [ext_subgroup_size_control],
-    },
+    ALLOW_VARYING_SUBGROUP_SIZE = ALLOW_VARYING_SUBGROUP_SIZE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_subgroup_size_control)]),
+    ]),
     */
 
     /* TODO: enable
     // TODO: document
-    REQUIRE_FULL_SUBGROUPS = REQUIRE_FULL_SUBGROUPS {
-        api_version: V1_3,
-        device_extensions: [ext_subgroup_size_control],
-    },
+    REQUIRE_FULL_SUBGROUPS = REQUIRE_FULL_SUBGROUPS
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(ext_subgroup_size_control)]),
+    ]),
     */
 }
 
@@ -1108,49 +1110,66 @@ vulkan_bitflags_enum! {
     COMPUTE, Compute = COMPUTE,
 
     // TODO: document
-    RAYGEN, Raygen = RAYGEN_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },
+    RAYGEN, Raygen = RAYGEN_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     // TODO: document
-    ANY_HIT, AnyHit = ANY_HIT_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },
+    ANY_HIT, AnyHit = ANY_HIT_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     // TODO: document
-    CLOSEST_HIT, ClosestHit = CLOSEST_HIT_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },
+    CLOSEST_HIT, ClosestHit = CLOSEST_HIT_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     // TODO: document
-    MISS, Miss = MISS_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },
+    MISS, Miss = MISS_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     // TODO: document
-    INTERSECTION, Intersection = INTERSECTION_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },
+    INTERSECTION, Intersection = INTERSECTION_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     // TODO: document
-    CALLABLE, Callable = CALLABLE_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },
+    CALLABLE, Callable = CALLABLE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     // TODO: document
-    TASK, Task = TASK_EXT {
-        device_extensions: [ext_mesh_shader, nv_mesh_shader],
-    },
+    TASK, Task = TASK_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_mesh_shader)]),
+        RequiresAllOf([DeviceExtension(nv_mesh_shader)]),
+    ]),
 
     // TODO: document
-    MESH, Mesh = MESH_EXT {
-        device_extensions: [ext_mesh_shader, nv_mesh_shader],
-    },
+    MESH, Mesh = MESH_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_mesh_shader)]),
+        RequiresAllOf([DeviceExtension(nv_mesh_shader)]),
+    ]),
 
     // TODO: document
-    SUBPASS_SHADING, SubpassShading = SUBPASS_SHADING_HUAWEI {
-        device_extensions: [huawei_subpass_shading],
-    },
+    SUBPASS_SHADING, SubpassShading = SUBPASS_SHADING_HUAWEI
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(huawei_subpass_shading)]),
+    ]),
 }
 
 impl From<&ShaderExecution> for ShaderStage {

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -136,7 +136,7 @@ use crate::{
     device::{Device, DeviceOwned},
     format::{Format, NumericType},
     image::view::ImageViewType,
-    macros::{impl_id_counter, vulkan_bitflags, vulkan_bitflags_enum},
+    macros::{impl_id_counter, vulkan_bitflags_enum},
     pipeline::{graphics::input_assembly::PrimitiveTopology, layout::PushConstantRange},
     shader::spirv::{Capability, Spirv, SpirvError},
     sync::PipelineStages,
@@ -725,70 +725,6 @@ impl DescriptorRequirements {
         sampler_with_images.extend(&other.sampler_with_images);
         *storage_image_atomic |= other.storage_image_atomic;
     }
-}
-
-/// Specifies a single shader stage when creating a pipeline.
-#[derive(Clone, Debug)]
-pub struct PipelineShaderStageCreateInfo {
-    /// Specifies how to create the shader stage.
-    ///
-    /// The default value is empty.
-    pub flags: PipelineShaderStageCreateFlags,
-
-    /// The shader entry point for the stage.
-    ///
-    /// There is no default value.
-    pub entry_point: EntryPoint,
-
-    /// Values for the specialization constants in the shader, indexed by their `constant_id`.
-    ///
-    /// Specialization constants are constants whose value can be overridden when you create
-    /// a pipeline. When provided, they must have the same type as defined in the shader.
-    /// Constants that are not given a value here will have the default value that was specified
-    /// for them in the shader code.
-    ///
-    /// The default value is empty.
-    pub specialization_info: HashMap<u32, SpecializationConstant>,
-
-    pub _ne: crate::NonExhaustive,
-}
-
-impl PipelineShaderStageCreateInfo {
-    /// Returns a `PipelineShaderStageCreateInfo` with the specified `entry_point`.
-    #[inline]
-    pub fn entry_point(entry_point: EntryPoint) -> Self {
-        Self {
-            flags: PipelineShaderStageCreateFlags::empty(),
-            entry_point,
-            specialization_info: HashMap::default(),
-            _ne: crate::NonExhaustive(()),
-        }
-    }
-}
-
-vulkan_bitflags! {
-    #[non_exhaustive]
-
-    /// Flags that control how a pipeline shader stage is created.
-    PipelineShaderStageCreateFlags = PipelineShaderStageCreateFlags(u32);
-
-    /* TODO: enable
-    // TODO: document
-    ALLOW_VARYING_SUBGROUP_SIZE = ALLOW_VARYING_SUBGROUP_SIZE
-    RequiresOneOf([
-        RequiresAllOf([APIVersion(V1_3)]),
-        RequiresAllOf([DeviceExtension(ext_subgroup_size_control)]),
-    ]),
-    */
-
-    /* TODO: enable
-    // TODO: document
-    REQUIRE_FULL_SUBGROUPS = REQUIRE_FULL_SUBGROUPS
-    RequiresOneOf([
-        RequiresAllOf([APIVersion(V1_3)]),
-        RequiresAllOf([DeviceExtension(ext_subgroup_size_control)]),
-    ]),
-    */
 }
 
 /// The value to provide for a specialization constant, when creating a pipeline.

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -19,7 +19,7 @@ use crate::{
         display::{DisplayMode, DisplayPlane},
         SurfaceSwapchainLock,
     },
-    OomError, RequiresOneOf, RuntimeError, ValidationError, VulkanObject,
+    OomError, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, ValidationError, VulkanObject,
 };
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use objc::{class, msg_send, runtime::Object, sel, sel_impl};
@@ -185,10 +185,9 @@ impl Surface {
         if !instance.enabled_extensions().ext_headless_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::headless`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_headless_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_headless_surface",
+                )])]),
             });
         }
 
@@ -255,10 +254,9 @@ impl Surface {
         {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_display_plane`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_display"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_display",
+                )])]),
             });
         }
 
@@ -340,10 +338,9 @@ impl Surface {
         if !instance.enabled_extensions().khr_android_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_android`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_android_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_android_surface",
+                )])]),
             });
         }
 
@@ -416,10 +413,9 @@ impl Surface {
         if !instance.enabled_extensions().ext_directfb_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_directfb`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_directfb_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_directfb_surface",
+                )])]),
             });
         }
 
@@ -496,10 +492,9 @@ impl Surface {
         if !instance.enabled_extensions().fuchsia_imagepipe_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_fuchsia_image_pipe`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["fuchsia_imagepipe_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "fuchsia_imagepipe_surface",
+                )])]),
             });
         }
 
@@ -572,10 +567,9 @@ impl Surface {
         if !instance.enabled_extensions().ggp_stream_descriptor_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_ggp_stream_descriptor`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ggp_stream_descriptor_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ggp_stream_descriptor_surface",
+                )])]),
             });
         }
 
@@ -647,10 +641,9 @@ impl Surface {
         if !instance.enabled_extensions().mvk_ios_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_ios`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["mvk_ios_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "mvk_ios_surface",
+                )])]),
             });
         }
 
@@ -725,10 +718,9 @@ impl Surface {
         if !instance.enabled_extensions().mvk_macos_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_mac_os`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["mvk_macos_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "mvk_macos_surface",
+                )])]),
             });
         }
 
@@ -800,10 +792,9 @@ impl Surface {
         if !instance.enabled_extensions().ext_metal_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_metal`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["ext_metal_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "ext_metal_surface",
+                )])]),
             });
         }
 
@@ -873,10 +864,9 @@ impl Surface {
         if !instance.enabled_extensions().qnx_screen_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_qnx_screen`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["qnx_screen_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "qnx_screen_surface",
+                )])]),
             });
         }
 
@@ -949,10 +939,9 @@ impl Surface {
         if !instance.enabled_extensions().nn_vi_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_vi`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["nn_vi_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "nn_vi_surface",
+                )])]),
             });
         }
 
@@ -1027,10 +1016,9 @@ impl Surface {
         if !instance.enabled_extensions().khr_wayland_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_wayland`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_wayland_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_wayland_surface",
+                )])]),
             });
         }
 
@@ -1110,10 +1098,9 @@ impl Surface {
         if !instance.enabled_extensions().khr_win32_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_win32`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_win32_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_win32_surface",
+                )])]),
             });
         }
 
@@ -1193,10 +1180,9 @@ impl Surface {
         if !instance.enabled_extensions().khr_xcb_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_xcb`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_xcb_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_xcb_surface",
+                )])]),
             });
         }
 
@@ -1276,10 +1262,9 @@ impl Surface {
         if !instance.enabled_extensions().khr_xlib_surface {
             return Err(SurfaceCreationError::RequirementNotMet {
                 required_for: "`Surface::from_xlib`",
-                requires_one_of: RequiresOneOf {
-                    instance_extensions: &["khr_xlib_surface"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::InstanceExtension(
+                    "khr_xlib_surface",
+                )])]),
             });
         }
 
@@ -1619,15 +1604,17 @@ vulkan_enum! {
 
     /* TODO: enable
     // TODO: document
-    SharedDemandRefresh = SHARED_DEMAND_REFRESH_KHR {
-        device_extensions: [khr_shared_presentable_image],
-    },*/
+    SharedDemandRefresh = SHARED_DEMAND_REFRESH_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_shared_presentable_image)]),
+    ]),*/
 
     /* TODO: enable
     // TODO: document
-    SharedContinuousRefresh = SHARED_CONTINUOUS_REFRESH_KHR {
-        device_extensions: [khr_shared_presentable_image],
-    },*/
+    SharedContinuousRefresh = SHARED_CONTINUOUS_REFRESH_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_shared_presentable_image)]),
+    ]),*/
 }
 
 vulkan_bitflags_enum! {
@@ -1799,79 +1786,94 @@ vulkan_enum! {
     SrgbNonLinear = SRGB_NONLINEAR,
 
     // TODO: document
-    DisplayP3NonLinear = DISPLAY_P3_NONLINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    DisplayP3NonLinear = DISPLAY_P3_NONLINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    ExtendedSrgbLinear = EXTENDED_SRGB_LINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    ExtendedSrgbLinear = EXTENDED_SRGB_LINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    ExtendedSrgbNonLinear = EXTENDED_SRGB_NONLINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    ExtendedSrgbNonLinear = EXTENDED_SRGB_NONLINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    DisplayP3Linear = DISPLAY_P3_LINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    DisplayP3Linear = DISPLAY_P3_LINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    DciP3NonLinear = DCI_P3_NONLINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    DciP3NonLinear = DCI_P3_NONLINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    Bt709Linear = BT709_LINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    Bt709Linear = BT709_LINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    Bt709NonLinear = BT709_NONLINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    Bt709NonLinear = BT709_NONLINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    Bt2020Linear = BT2020_LINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    Bt2020Linear = BT2020_LINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    Hdr10St2084 = HDR10_ST2084_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    Hdr10St2084 = HDR10_ST2084_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    DolbyVision = DOLBYVISION_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    DolbyVision = DOLBYVISION_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    Hdr10Hlg = HDR10_HLG_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    Hdr10Hlg = HDR10_HLG_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    AdobeRgbLinear = ADOBERGB_LINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    AdobeRgbLinear = ADOBERGB_LINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    AdobeRgbNonLinear = ADOBERGB_NONLINEAR_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    AdobeRgbNonLinear = ADOBERGB_NONLINEAR_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    PassThrough = PASS_THROUGH_EXT {
-        instance_extensions: [ext_swapchain_colorspace],
-    },
+    PassThrough = PASS_THROUGH_EXT
+    RequiresOneOf([
+        RequiresAllOf([InstanceExtension(ext_swapchain_colorspace)]),
+    ]),
 
     // TODO: document
-    DisplayNative = DISPLAY_NATIVE_AMD {
-        device_extensions: [amd_display_native_hdr],
-    },
+    DisplayNative = DISPLAY_NATIVE_AMD
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(amd_display_native_hdr)]),
+    ]),
 }
 
 /// Parameters for [`PhysicalDevice::surface_capabilities`] and [`PhysicalDevice::surface_formats`].
@@ -1912,10 +1914,9 @@ impl SurfaceInfo {
             return Err(ValidationError {
                 context: "full_screen_exclusive".into(),
                 problem: "is not `FullScreenExclusive::Default`".into(),
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["ext_full_screen_exclusive"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "ext_full_screen_exclusive",
+                )])]),
                 ..Default::default()
             });
         }
@@ -2008,7 +2009,7 @@ pub struct SurfaceCapabilities {
 mod tests {
     use crate::{
         swapchain::{Surface, SurfaceCreationError},
-        RequiresOneOf,
+        Requires, RequiresAllOf, RequiresOneOf,
     };
     use std::ptr;
 
@@ -2018,12 +2019,9 @@ mod tests {
         match unsafe { Surface::from_win32(instance, ptr::null::<u8>(), ptr::null::<u8>(), None) } {
             Err(SurfaceCreationError::RequirementNotMet {
                 requires_one_of:
-                    RequiresOneOf {
-                        instance_extensions,
-                        ..
-                    },
+                    RequiresOneOf([RequiresAllOf([Requires::InstanceExtension("khr_win32_surface")])]),
                 ..
-            }) if instance_extensions.contains(&"khr_win32_surface") => (),
+            }) => (),
             _ => panic!(),
         }
     }
@@ -2034,12 +2032,9 @@ mod tests {
         match unsafe { Surface::from_xcb(instance, ptr::null::<u8>(), 0, None) } {
             Err(SurfaceCreationError::RequirementNotMet {
                 requires_one_of:
-                    RequiresOneOf {
-                        instance_extensions,
-                        ..
-                    },
+                    RequiresOneOf([RequiresAllOf([Requires::InstanceExtension("khr_xcb_surface")])]),
                 ..
-            }) if instance_extensions.contains(&"khr_xcb_surface") => (),
+            }) => (),
             _ => panic!(),
         }
     }
@@ -2050,12 +2045,9 @@ mod tests {
         match unsafe { Surface::from_xlib(instance, ptr::null::<u8>(), 0, None) } {
             Err(SurfaceCreationError::RequirementNotMet {
                 requires_one_of:
-                    RequiresOneOf {
-                        instance_extensions,
-                        ..
-                    },
+                    RequiresOneOf([RequiresAllOf([Requires::InstanceExtension("khr_xlib_surface")])]),
                 ..
-            }) if instance_extensions.contains(&"khr_xlib_surface") => (),
+            }) => (),
             _ => panic!(),
         }
     }
@@ -2067,12 +2059,9 @@ mod tests {
         {
             Err(SurfaceCreationError::RequirementNotMet {
                 requires_one_of:
-                    RequiresOneOf {
-                        instance_extensions,
-                        ..
-                    },
+                    RequiresOneOf([RequiresAllOf([Requires::InstanceExtension("khr_wayland_surface")])]),
                 ..
-            }) if instance_extensions.contains(&"khr_wayland_surface") => (),
+            }) => (),
             _ => panic!(),
         }
     }
@@ -2083,12 +2072,9 @@ mod tests {
         match unsafe { Surface::from_android(instance, ptr::null::<u8>(), None) } {
             Err(SurfaceCreationError::RequirementNotMet {
                 requires_one_of:
-                    RequiresOneOf {
-                        instance_extensions,
-                        ..
-                    },
+                    RequiresOneOf([RequiresAllOf([Requires::InstanceExtension("khr_android_surface")])]),
                 ..
-            }) if instance_extensions.contains(&"khr_android_surface") => (),
+            }) => (),
             _ => panic!(),
         }
     }

--- a/vulkano/src/swapchain/swapchain.rs
+++ b/vulkano/src/swapchain/swapchain.rs
@@ -27,7 +27,8 @@ use crate::{
         semaphore::{Semaphore, SemaphoreError},
         Sharing,
     },
-    DeviceSize, OomError, RequirementNotMet, RequiresOneOf, RuntimeError, VulkanObject,
+    DeviceSize, OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError,
+    VulkanObject,
 };
 use parking_lot::Mutex;
 use smallvec::{smallvec, SmallVec};
@@ -299,10 +300,9 @@ impl Swapchain {
         if !device.enabled_extensions().khr_swapchain {
             return Err(SwapchainCreationError::RequirementNotMet {
                 required_for: "`Swapchain::new`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_swapchain"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_swapchain",
+                )])]),
             });
         }
 
@@ -331,10 +331,9 @@ impl Swapchain {
                 return Err(SwapchainCreationError::RequirementNotMet {
                     required_for: "`create_info.full_screen_exclusive` is not \
                         `FullScreenExclusive::Default`",
-                    requires_one_of: RequiresOneOf {
-                        device_extensions: &["ext_full_screen_exclusive"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                        "ext_full_screen_exclusive",
+                    )])]),
                 });
             }
 
@@ -1577,10 +1576,7 @@ pub fn wait_for_present(
     if !swapchain.device.enabled_features().present_wait {
         return Err(PresentWaitError::RequirementNotMet {
             required_for: "`wait_for_present`",
-            requires_one_of: RequiresOneOf {
-                features: &["present_wait"],
-                ..Default::default()
-            },
+            requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("present_wait")])]),
         });
     }
 

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -27,7 +27,7 @@
 use crate::{
     device::{Device, DeviceOwned},
     macros::impl_id_counter,
-    OomError, RequiresOneOf, RuntimeError, VulkanObject,
+    OomError, Requires, RequiresAllOf, RequiresOneOf, RuntimeError, VulkanObject,
 };
 use std::{
     error::Error,
@@ -66,10 +66,7 @@ impl Event {
             return Err(EventError::RequirementNotMet {
                 required_for: "this device is a portability subset device, and `Event::new` was \
                     called",
-                requires_one_of: RequiresOneOf {
-                    features: &["events"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("events")])]),
             });
         }
 

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -13,8 +13,8 @@
 use crate::{
     device::{physical::PhysicalDevice, Device, DeviceOwned, Queue},
     macros::{impl_id_counter, vulkan_bitflags, vulkan_bitflags_enum},
-    OomError, RequirementNotMet, RequiresOneOf, RuntimeError, ValidationError, Version,
-    VulkanObject,
+    OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError,
+    ValidationError, Version, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
@@ -90,11 +90,10 @@ impl Fence {
             {
                 return Err(FenceError::RequirementNotMet {
                     required_for: "`create_info.export_handle_types` is not empty",
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_1),
-                        device_extensions: &["khr_external_fence"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_external_fence")]),
+                    ]),
                 });
             }
 
@@ -589,10 +588,9 @@ impl Fence {
         if !self.device.enabled_extensions().khr_external_fence_fd {
             return Err(FenceError::RequirementNotMet {
                 required_for: "`Fence::export_fd`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_external_fence_fd"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_external_fence_fd",
+                )])]),
             });
         }
 
@@ -714,10 +712,9 @@ impl Fence {
         if !self.device.enabled_extensions().khr_external_fence_win32 {
             return Err(FenceError::RequirementNotMet {
                 required_for: "`Fence::export_win32_handle`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_external_fence_win32"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_external_fence_win32",
+                )])]),
             });
         }
 
@@ -850,10 +847,9 @@ impl Fence {
         if !self.device.enabled_extensions().khr_external_fence_fd {
             return Err(FenceError::RequirementNotMet {
                 required_for: "`Fence::import_fd`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_external_fence_fd"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_external_fence_fd",
+                )])]),
             });
         }
 
@@ -969,10 +965,9 @@ impl Fence {
         if !self.device.enabled_extensions().khr_external_fence_win32 {
             return Err(FenceError::RequirementNotMet {
                 required_for: "`Fence::import_win32_handle`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_external_fence_win32"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_external_fence_win32",
+                )])]),
             });
         }
 

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -14,7 +14,7 @@ use crate::{
     image::{sys::Image, ImageAspects, ImageLayout, ImageSubresourceRange},
     macros::{vulkan_bitflags, vulkan_bitflags_enum},
     shader::ShaderStages,
-    DeviceSize, RequiresOneOf, ValidationError,
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError,
 };
 use ahash::HashMap;
 use once_cell::sync::Lazy;
@@ -256,41 +256,47 @@ vulkan_bitflags_enum! {
 
     /// The `copy_buffer`, `copy_image`, `copy_buffer_to_image`, `copy_image_to_buffer` and
     /// `copy_query_pool_results` commands are executed.
-    COPY, Copy = COPY {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    COPY, Copy = COPY
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// The `resolve_image` command is executed.
-    RESOLVE, Resolve = RESOLVE {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    RESOLVE, Resolve = RESOLVE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// The `blit_image` command is executed.
-    BLIT, Blit = BLIT {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    BLIT, Blit = BLIT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// The `clear_color_image`, `clear_depth_stencil_image`, `fill_buffer` and `update_buffer`
     /// commands are executed.
-    CLEAR, Clear = CLEAR {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    CLEAR, Clear = CLEAR
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// Index buffers are read.
-    INDEX_INPUT, IndexInput = INDEX_INPUT {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    INDEX_INPUT, IndexInput = INDEX_INPUT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// Vertex buffers are read.
-    VERTEX_ATTRIBUTE_INPUT, VertexAttributeInput = VERTEX_ATTRIBUTE_INPUT {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    VERTEX_ATTRIBUTE_INPUT, VertexAttributeInput = VERTEX_ATTRIBUTE_INPUT
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// The various pre-rasterization shader types are executed.
     ///
@@ -303,92 +309,127 @@ vulkan_bitflags_enum! {
     /// - `geometry_shader`
     /// - `task_shader`
     /// - `mesh_shader`
-    PRE_RASTERIZATION_SHADERS, PreRasterizationShaders = PRE_RASTERIZATION_SHADERS {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    PRE_RASTERIZATION_SHADERS, PreRasterizationShaders = PRE_RASTERIZATION_SHADERS
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// Video decode operations are performed.
-    VIDEO_DECODE, VideoDecode = VIDEO_DECODE_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },
+    VIDEO_DECODE, VideoDecode = VIDEO_DECODE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_decode_queue)]),
+    ]),
 
     /// Video encode operations are performed.
-    VIDEO_ENCODE, VideoEncode = VIDEO_ENCODE_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },
+    VIDEO_ENCODE, VideoEncode = VIDEO_ENCODE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_video_encode_queue)]),
+    ]),
 
     /// Vertex attribute output values are written to the transform feedback buffers.
-    TRANSFORM_FEEDBACK, TransformFeedback = TRANSFORM_FEEDBACK_EXT {
-        device_extensions: [ext_transform_feedback],
-    },
+    TRANSFORM_FEEDBACK, TransformFeedback = TRANSFORM_FEEDBACK_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_transform_feedback)]),
+    ]),
 
     /// The predicate of conditional rendering is read.
-    CONDITIONAL_RENDERING, ConditionalRendering = CONDITIONAL_RENDERING_EXT {
-        device_extensions: [ext_conditional_rendering],
-    },
+    CONDITIONAL_RENDERING, ConditionalRendering = CONDITIONAL_RENDERING_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_conditional_rendering)]),
+    ]),
 
     /// Acceleration_structure commands are executed.
-    ACCELERATION_STRUCTURE_BUILD, AccelerationStructureBuild = ACCELERATION_STRUCTURE_BUILD_KHR {
-        device_extensions: [khr_acceleration_structure, nv_ray_tracing],
-    },
+    ACCELERATION_STRUCTURE_BUILD, AccelerationStructureBuild = ACCELERATION_STRUCTURE_BUILD_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_acceleration_structure)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     /// The various ray tracing shader types are executed.
-    RAY_TRACING_SHADER, RayTracingShader = RAY_TRACING_SHADER_KHR {
-        device_extensions: [khr_ray_tracing_pipeline, nv_ray_tracing],
-    },
+    RAY_TRACING_SHADER, RayTracingShader = RAY_TRACING_SHADER_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_pipeline)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     /// The fragment density map is read to generate the fragment areas.
-    FRAGMENT_DENSITY_PROCESS, FragmentDensityProcess = FRAGMENT_DENSITY_PROCESS_EXT {
-        device_extensions: [ext_fragment_density_map],
-    },
+    FRAGMENT_DENSITY_PROCESS, FragmentDensityProcess = FRAGMENT_DENSITY_PROCESS_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_fragment_density_map)]),
+    ]),
 
     /// The fragment shading rate attachment or shading rate image is read to determine the
     /// fragment shading rate for portions of a rasterized primitive.
-    FRAGMENT_SHADING_RATE_ATTACHMENT, FragmentShadingRateAttachment = FRAGMENT_SHADING_RATE_ATTACHMENT_KHR {
-        device_extensions: [khr_fragment_shading_rate],
-    },
+    FRAGMENT_SHADING_RATE_ATTACHMENT, FragmentShadingRateAttachment = FRAGMENT_SHADING_RATE_ATTACHMENT_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_fragment_shading_rate)]),
+    ]),
 
     /// Device-side preprocessing for generated commands via the `preprocess_generated_commands`
     /// command is handled.
-    COMMAND_PREPROCESS, CommandPreprocess = COMMAND_PREPROCESS_NV {
-        device_extensions: [nv_device_generated_commands],
-    },
+    COMMAND_PREPROCESS, CommandPreprocess = COMMAND_PREPROCESS_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_device_generated_commands)]),
+    ]),
 
     /// Task shaders are executed.
-    TASK_SHADER, TaskShader = TASK_SHADER_EXT {
-        device_extensions: [ext_mesh_shader, nv_mesh_shader],
-    },
+    TASK_SHADER, TaskShader = TASK_SHADER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_mesh_shader)]),
+        RequiresAllOf([DeviceExtension(nv_mesh_shader)]),
+    ]),
 
     /// Mesh shaders are executed.
-    MESH_SHADER, MeshShader = MESH_SHADER_EXT {
-        device_extensions: [ext_mesh_shader, nv_mesh_shader],
-    },
+    MESH_SHADER, MeshShader = MESH_SHADER_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_mesh_shader)]),
+        RequiresAllOf([DeviceExtension(nv_mesh_shader)]),
+    ]),
 
     /// Subpass shading shaders are executed.
-    SUBPASS_SHADING, SubpassShading = SUBPASS_SHADING_HUAWEI {
-        device_extensions: [huawei_subpass_shading],
-    },
+    SUBPASS_SHADING, SubpassShading = SUBPASS_SHADING_HUAWEI
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(huawei_subpass_shading),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(huawei_subpass_shading),
+        ]),
+    ]),
 
     /// The invocation mask image is read to optimize ray dispatch.
-    INVOCATION_MASK, InvocationMask = INVOCATION_MASK_HUAWEI {
-        device_extensions: [huawei_invocation_mask],
-    },
+    INVOCATION_MASK, InvocationMask = INVOCATION_MASK_HUAWEI
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(huawei_invocation_mask),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(huawei_invocation_mask),
+        ]),
+    ]),
 
     /// The `copy_acceleration_structure` command is executed.
-    ACCELERATION_STRUCTURE_COPY, AccelerationStructureCopy = ACCELERATION_STRUCTURE_COPY_KHR {
-        device_extensions: [khr_ray_tracing_maintenance1],
-    },
+    ACCELERATION_STRUCTURE_COPY, AccelerationStructureCopy = ACCELERATION_STRUCTURE_COPY_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_ray_tracing_maintenance1)]),
+    ]),
 
     /// Micromap commands are executed.
-    MICROMAP_BUILD, MicromapBuild = MICROMAP_BUILD_EXT {
-        device_extensions: [ext_opacity_micromap],
-    },
+    MICROMAP_BUILD, MicromapBuild = MICROMAP_BUILD_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_opacity_micromap)]),
+    ]),
 
     /// Optical flow operations are performed.
-    OPTICAL_FLOW, OpticalFlow = OPTICAL_FLOW_NV {
-        device_extensions: [nv_optical_flow],
-    },
+    OPTICAL_FLOW, OpticalFlow = OPTICAL_FLOW_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_optical_flow)]),
+    ]),
 }
 
 impl From<PipelineStage> for ash::vk::PipelineStageFlags {
@@ -685,130 +726,228 @@ vulkan_bitflags! {
     MEMORY_WRITE = MEMORY_WRITE,
 
     /// Read access to a uniform texel buffer or sampled image in a shader.
-    SHADER_SAMPLED_READ = SHADER_SAMPLED_READ {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    SHADER_SAMPLED_READ = SHADER_SAMPLED_READ
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// Read access to a storage buffer, storage texel buffer or storage image in a shader.
-    SHADER_STORAGE_READ = SHADER_STORAGE_READ {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    SHADER_STORAGE_READ = SHADER_STORAGE_READ
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// Write access to a storage buffer, storage texel buffer or storage image in a shader.
-    SHADER_STORAGE_WRITE = SHADER_STORAGE_WRITE {
-        api_version: V1_3,
-        device_extensions: [khr_synchronization2],
-    },
+    SHADER_STORAGE_WRITE = SHADER_STORAGE_WRITE
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_3)]),
+        RequiresAllOf([DeviceExtension(khr_synchronization2)]),
+    ]),
 
     /// Read access to an image or buffer as part of a video decode operation.
-    VIDEO_DECODE_READ = VIDEO_DECODE_READ_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },
+    VIDEO_DECODE_READ = VIDEO_DECODE_READ_KHR
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(khr_video_decode_queue),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(khr_video_decode_queue),
+        ]),
+    ]),
 
     /// Write access to an image or buffer as part of a video decode operation.
-    VIDEO_DECODE_WRITE = VIDEO_DECODE_WRITE_KHR {
-        device_extensions: [khr_video_decode_queue],
-    },
+    VIDEO_DECODE_WRITE = VIDEO_DECODE_WRITE_KHR
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(khr_video_decode_queue),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(khr_video_decode_queue),
+        ]),
+    ]),
 
     /// Read access to an image or buffer as part of a video encode operation.
-    VIDEO_ENCODE_READ = VIDEO_ENCODE_READ_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },
+    VIDEO_ENCODE_READ = VIDEO_ENCODE_READ_KHR
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(khr_video_encode_queue),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(khr_video_encode_queue),
+        ]),
+    ]),
 
     /// Write access to an image or buffer as part of a video encode operation.
-    VIDEO_ENCODE_WRITE = VIDEO_ENCODE_WRITE_KHR {
-        device_extensions: [khr_video_encode_queue],
-    },
+    VIDEO_ENCODE_WRITE = VIDEO_ENCODE_WRITE_KHR
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(khr_video_encode_queue),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(khr_video_encode_queue),
+        ]),
+    ]),
 
     /// Write access to a transform feedback buffer during transform feedback operations.
-    TRANSFORM_FEEDBACK_WRITE = TRANSFORM_FEEDBACK_WRITE_EXT {
-        device_extensions: [ext_transform_feedback],
-    },
+    TRANSFORM_FEEDBACK_WRITE = TRANSFORM_FEEDBACK_WRITE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_transform_feedback)]),
+    ]),
 
     /// Read access to a transform feedback counter buffer during transform feedback operations.
-    TRANSFORM_FEEDBACK_COUNTER_READ = TRANSFORM_FEEDBACK_COUNTER_READ_EXT {
-        device_extensions: [ext_transform_feedback],
-    },
+    TRANSFORM_FEEDBACK_COUNTER_READ = TRANSFORM_FEEDBACK_COUNTER_READ_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_transform_feedback)]),
+    ]),
 
     /// Write access to a transform feedback counter buffer during transform feedback operations.
-    TRANSFORM_FEEDBACK_COUNTER_WRITE = TRANSFORM_FEEDBACK_COUNTER_WRITE_EXT {
-        device_extensions: [ext_transform_feedback],
-    },
+    TRANSFORM_FEEDBACK_COUNTER_WRITE = TRANSFORM_FEEDBACK_COUNTER_WRITE_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_transform_feedback)]),
+    ]),
 
     /// Read access to a predicate during conditional rendering.
-    CONDITIONAL_RENDERING_READ = CONDITIONAL_RENDERING_READ_EXT {
-        device_extensions: [ext_conditional_rendering],
-    },
+    CONDITIONAL_RENDERING_READ = CONDITIONAL_RENDERING_READ_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_conditional_rendering)]),
+    ]),
 
     /// Read access to preprocess buffers input to `preprocess_generated_commands`.
-    COMMAND_PREPROCESS_READ = COMMAND_PREPROCESS_READ_NV {
-        device_extensions: [nv_device_generated_commands],
-    },
+    COMMAND_PREPROCESS_READ = COMMAND_PREPROCESS_READ_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_device_generated_commands)]),
+    ]),
 
     /// Read access to sequences buffers output by `preprocess_generated_commands`.
-    COMMAND_PREPROCESS_WRITE = COMMAND_PREPROCESS_WRITE_NV {
-        device_extensions: [nv_device_generated_commands],
-    },
+    COMMAND_PREPROCESS_WRITE = COMMAND_PREPROCESS_WRITE_NV
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(nv_device_generated_commands)]),
+    ]),
 
     /// Read access to a fragment shading rate attachment during rasterization.
-    FRAGMENT_SHADING_RATE_ATTACHMENT_READ = FRAGMENT_SHADING_RATE_ATTACHMENT_READ_KHR {
-        device_extensions: [khr_fragment_shading_rate],
-    },
+    FRAGMENT_SHADING_RATE_ATTACHMENT_READ = FRAGMENT_SHADING_RATE_ATTACHMENT_READ_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_fragment_shading_rate)]),
+    ]),
 
     /// Read access to an acceleration structure or acceleration structure scratch buffer during
     /// trace, build or copy commands.
-    ACCELERATION_STRUCTURE_READ = ACCELERATION_STRUCTURE_READ_KHR {
-        device_extensions: [khr_acceleration_structure, nv_ray_tracing],
-    },
+    ACCELERATION_STRUCTURE_READ = ACCELERATION_STRUCTURE_READ_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_acceleration_structure)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     /// Write access to an acceleration structure or acceleration structure scratch buffer during
     /// trace, build or copy commands.
-    ACCELERATION_STRUCTURE_WRITE = ACCELERATION_STRUCTURE_WRITE_KHR {
-        device_extensions: [khr_acceleration_structure, nv_ray_tracing],
-    },
+    ACCELERATION_STRUCTURE_WRITE = ACCELERATION_STRUCTURE_WRITE_KHR
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(khr_acceleration_structure)]),
+        RequiresAllOf([DeviceExtension(nv_ray_tracing)]),
+    ]),
 
     /// Read access to a fragment density map attachment during dynamic fragment density map
     /// operations.
-    FRAGMENT_DENSITY_MAP_READ = FRAGMENT_DENSITY_MAP_READ_EXT {
-        device_extensions: [ext_fragment_density_map],
-    },
+    FRAGMENT_DENSITY_MAP_READ = FRAGMENT_DENSITY_MAP_READ_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_fragment_density_map)]),
+    ]),
 
     /// Read access to color attachments when performing advanced blend operations.
-    COLOR_ATTACHMENT_READ_NONCOHERENT = COLOR_ATTACHMENT_READ_NONCOHERENT_EXT {
-        device_extensions: [ext_blend_operation_advanced],
-    },
+    COLOR_ATTACHMENT_READ_NONCOHERENT = COLOR_ATTACHMENT_READ_NONCOHERENT_EXT
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(ext_blend_operation_advanced)]),
+    ]),
 
     /// Read access to an invocation mask image.
-    INVOCATION_MASK_READ = INVOCATION_MASK_READ_HUAWEI {
-        device_extensions: [huawei_invocation_mask],
-    },
+    INVOCATION_MASK_READ = INVOCATION_MASK_READ_HUAWEI
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(huawei_invocation_mask),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(huawei_invocation_mask),
+        ]),
+    ]),
 
     /// Read access to a shader binding table.
-    SHADER_BINDING_TABLE_READ = SHADER_BINDING_TABLE_READ_KHR {
-        device_extensions: [khr_ray_tracing_maintenance1],
-    },
+    SHADER_BINDING_TABLE_READ = SHADER_BINDING_TABLE_READ_KHR
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(khr_ray_tracing_pipeline),
+            DeviceExtension(khr_ray_tracing_maintenance1),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(khr_ray_tracing_pipeline),
+            DeviceExtension(khr_ray_tracing_maintenance1),
+        ]),
+    ]),
 
     /// Read access to a micromap object.
-    MICROMAP_READ = MICROMAP_READ_EXT {
-        device_extensions: [ext_opacity_micromap],
-    },
+    MICROMAP_READ = MICROMAP_READ_EXT
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(ext_opacity_micromap),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(ext_opacity_micromap),
+        ]),
+    ]),
 
     /// Write access to a micromap object.
-    MICROMAP_WRITE = MICROMAP_WRITE_EXT {
-        device_extensions: [ext_opacity_micromap],
-    },
+    MICROMAP_WRITE = MICROMAP_WRITE_EXT
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(ext_opacity_micromap),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(ext_opacity_micromap),
+        ]),
+    ]),
 
     /// Read access to a buffer or image during optical flow operations.
-    OPTICAL_FLOW_READ = OPTICAL_FLOW_READ_NV {
-        device_extensions: [nv_optical_flow],
-    },
+    OPTICAL_FLOW_READ = OPTICAL_FLOW_READ_NV
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(nv_optical_flow),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(nv_optical_flow),
+        ]),
+    ]),
 
     /// Write access to a buffer or image during optical flow operations.
-    OPTICAL_FLOW_WRITE = OPTICAL_FLOW_WRITE_NV {
-        device_extensions: [nv_optical_flow],
-    },
+    OPTICAL_FLOW_WRITE = OPTICAL_FLOW_WRITE_NV
+    RequiresOneOf([
+        RequiresAllOf([
+            APIVersion(V1_3),
+            DeviceExtension(nv_optical_flow),
+        ]),
+        RequiresAllOf([
+            DeviceExtension(khr_synchronization2),
+            DeviceExtension(nv_optical_flow),
+        ]),
+    ]),
 }
 
 impl From<AccessFlags> for ash::vk::AccessFlags {
@@ -1661,10 +1800,11 @@ vulkan_bitflags! {
     /// enabled on the device.
     ///
     /// [`khr_device_group`]: crate::device::DeviceExtensions::khr_device_group
-    DEVICE_GROUP = DEVICE_GROUP {
-        api_version: V1_1,
-        device_extensions: [khr_device_group],
-    },
+    DEVICE_GROUP = DEVICE_GROUP
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_device_group)]),
+    ]),
 
 
     /// For subpass dependencies, and pipeline barriers executing within a render pass instance,
@@ -1676,10 +1816,11 @@ vulkan_bitflags! {
     /// enabled on the device.
     ///
     /// [`khr_multiview`]: crate::device::DeviceExtensions::khr_multiview
-    VIEW_LOCAL = VIEW_LOCAL {
-        api_version: V1_1,
-        device_extensions: [khr_multiview],
-    },
+    VIEW_LOCAL = VIEW_LOCAL
+    RequiresOneOf([
+        RequiresAllOf([APIVersion(V1_1)]),
+        RequiresAllOf([DeviceExtension(khr_multiview)]),
+    ]),
 }
 
 /// A memory barrier that is applied globally.
@@ -1767,10 +1908,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains flags from `VkPipelineStageFlagBits2`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["synchronization2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "synchronization2",
+                    )])]),
                     ..Default::default()
                 });
             }
@@ -1779,10 +1919,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains flags from `VkPipelineStageFlagBits2`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["synchronization2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "synchronization2",
+                    )])]),
                     ..Default::default()
                 });
             }
@@ -1791,10 +1930,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_access".into(),
                     problem: "contains flags from `VkAccessFlagBits2`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["synchronization2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "synchronization2",
+                    )])]),
                     ..Default::default()
                 });
             }
@@ -1803,10 +1941,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_access".into(),
                     problem: "contains flags from `VkAccessFlagBits2`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["synchronization2"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "synchronization2",
+                    )])]),
                     ..Default::default()
                 });
             }
@@ -1817,10 +1954,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::GEOMETRY_SHADER`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["geometry_shader"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "geometry_shader",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-03929"],
                 });
             }
@@ -1829,10 +1965,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::GEOMETRY_SHADER`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["geometry_shader"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "geometry_shader",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-03929"],
                 });
             }
@@ -1848,10 +1983,9 @@ impl MemoryBarrier {
                     problem: "contains `PipelineStages::TESSELLATION_CONTROL_SHADER` or \
                         `PipelineStages::TESSELLATION_EVALUATION_SHADER`"
                         .into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["tessellation_shader"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "tessellation_shader",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-03930"],
                 });
             }
@@ -1865,10 +1999,9 @@ impl MemoryBarrier {
                     problem: "contains `PipelineStages::TESSELLATION_CONTROL_SHADER` or \
                         `PipelineStages::TESSELLATION_EVALUATION_SHADER`"
                         .into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["tessellation_shader"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "tessellation_shader",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-03930"],
                 });
             }
@@ -1879,10 +2012,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::CONDITIONAL_RENDERING`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["conditional_rendering"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "conditional_rendering",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-03931"],
                 });
             }
@@ -1891,10 +2023,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::CONDITIONAL_RENDERING`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["conditional_rendering"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "conditional_rendering",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-03931"],
                 });
             }
@@ -1905,10 +2036,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::FRAGMENT_DENSITY_PROCESS`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["fragment_density_map"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "fragment_density_map",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-03932"],
                 });
             }
@@ -1917,10 +2047,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::FRAGMENT_DENSITY_PROCESS`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["fragment_density_map"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "fragment_density_map",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-03932"],
                 });
             }
@@ -1931,10 +2060,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::TRANSFORM_FEEDBACK`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["transform_feedback"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "transform_feedback",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-03933"],
                 });
             }
@@ -1943,10 +2071,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::TRANSFORM_FEEDBACK`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["transform_feedback"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "transform_feedback",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-03933"],
                 });
             }
@@ -1957,10 +2084,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::MESH_SHADER`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["mesh_shader"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "mesh_shader",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-03934"],
                 });
             }
@@ -1969,10 +2095,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::MESH_SHADER`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["mesh_shader"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "mesh_shader",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-03934"],
                 });
             }
@@ -1983,10 +2108,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::TASK_SHADER`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["task_shader"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "task_shader",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-03935"],
                 });
             }
@@ -1995,10 +2119,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::TASK_SHADER`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["task_shader"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "task_shader",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-03935"],
                 });
             }
@@ -2011,10 +2134,10 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["attachment_fragment_shading_rate", "shading_rate_image"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::Feature("attachment_fragment_shading_rate")]),
+                        RequiresAllOf(&[Requires::Feature("shading_rate_image")]),
+                    ]),
                     vuids: &["VUID-VkMemoryBarrier2-shadingRateImage-07316"],
                 });
             }
@@ -2023,10 +2146,10 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::FRAGMENT_SHADING_RATE_ATTACHMENT`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["attachment_fragment_shading_rate", "shading_rate_image"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::Feature("attachment_fragment_shading_rate")]),
+                        RequiresAllOf(&[Requires::Feature("shading_rate_image")]),
+                    ]),
                     vuids: &["VUID-VkMemoryBarrier2-shadingRateImage-07316"],
                 });
             }
@@ -2037,10 +2160,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::SUBPASS_SHADING`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["subpass_shading"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "subpass_shading",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-04957"],
                 });
             }
@@ -2049,10 +2171,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::SUBPASS_SHADING`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["subpass_shading"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "subpass_shading",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-04957"],
                 });
             }
@@ -2063,10 +2184,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::INVOCATION_MASK`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["invocation_mask"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "invocation_mask",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-04995"],
                 });
             }
@@ -2075,10 +2195,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::INVOCATION_MASK`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["invocation_mask"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "invocation_mask",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-04995"],
                 });
             }
@@ -2091,10 +2210,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "src_stages".into(),
                     problem: "contains `PipelineStages::RAY_TRACING_SHADER`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["ray_tracing_pipeline"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "ray_tracing_pipeline",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-srcStageMask-07946"],
                 });
             }
@@ -2103,10 +2221,9 @@ impl MemoryBarrier {
                 return Err(ValidationError {
                     context: "dst_stages".into(),
                     problem: "contains `PipelineStages::RAY_TRACING_SHADER`".into(),
-                    requires_one_of: RequiresOneOf {
-                        features: &["ray_tracing_pipeline"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                        "ray_tracing_pipeline",
+                    )])]),
                     vuids: &["VUID-VkMemoryBarrier2-dstStageMask-07946"],
                 });
             }

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -13,8 +13,8 @@
 use crate::{
     device::{physical::PhysicalDevice, Device, DeviceOwned, Queue},
     macros::{impl_id_counter, vulkan_bitflags, vulkan_bitflags_enum},
-    OomError, RequirementNotMet, RequiresOneOf, RuntimeError, ValidationError, Version,
-    VulkanObject,
+    OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, RuntimeError,
+    ValidationError, Version, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};
 #[cfg(unix)]
@@ -71,11 +71,10 @@ impl Semaphore {
             {
                 return Err(SemaphoreError::RequirementNotMet {
                     required_for: "`create_info.export_handle_types` is not empty",
-                    requires_one_of: RequiresOneOf {
-                        api_version: Some(Version::V1_1),
-                        device_extensions: &["khr_external_semaphore"],
-                        ..Default::default()
-                    },
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_external_semaphore")]),
+                    ]),
                 });
             }
 
@@ -239,10 +238,9 @@ impl Semaphore {
         if !self.device.enabled_extensions().khr_external_semaphore_fd {
             return Err(SemaphoreError::RequirementNotMet {
                 required_for: "`Semaphore::export_fd`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_external_semaphore_fd"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_external_semaphore_fd",
+                )])]),
             });
         }
 
@@ -374,10 +372,9 @@ impl Semaphore {
         {
             return Err(SemaphoreError::RequirementNotMet {
                 required_for: "`Semaphore::export_win32_handle`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_external_semaphore_win32"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_external_semaphore_win32",
+                )])]),
             });
         }
 
@@ -509,10 +506,9 @@ impl Semaphore {
         if !self.device.enabled_extensions().fuchsia_external_semaphore {
             return Err(SemaphoreError::RequirementNotMet {
                 required_for: "`Semaphore::export_zircon_handle`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["fuchsia_external_semaphore"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "fuchsia_external_semaphore",
+                )])]),
             });
         }
 
@@ -640,10 +636,9 @@ impl Semaphore {
         if !self.device.enabled_extensions().khr_external_semaphore_fd {
             return Err(SemaphoreError::RequirementNotMet {
                 required_for: "`Semaphore::import_fd`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_external_semaphore_fd"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_external_semaphore_fd",
+                )])]),
             });
         }
 
@@ -769,10 +764,9 @@ impl Semaphore {
         {
             return Err(SemaphoreError::RequirementNotMet {
                 required_for: "`Semaphore::import_win32_handle`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["khr_external_semaphore_win32"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "khr_external_semaphore_win32",
+                )])]),
             });
         }
 
@@ -896,10 +890,9 @@ impl Semaphore {
         if !self.device.enabled_extensions().fuchsia_external_semaphore {
             return Err(SemaphoreError::RequirementNotMet {
                 required_for: "`Semaphore::import_zircon_handle`",
-                requires_one_of: RequiresOneOf {
-                    device_extensions: &["fuchsia_external_semaphore"],
-                    ..Default::default()
-                },
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "fuchsia_external_semaphore",
+                )])]),
             });
         }
 
@@ -1231,9 +1224,10 @@ vulkan_bitflags_enum! {
     /// The [`fuchsia_external_semaphore`] extension must be enabled on the device.
     ///
     /// [`fuchsia_external_semaphore`]: crate::device::DeviceExtensions::fuchsia_external_semaphore
-    ZIRCON_EVENT, ZirconEvent = ZIRCON_EVENT_FUCHSIA {
-        device_extensions: [fuchsia_external_semaphore],
-    },
+    ZIRCON_EVENT, ZirconEvent = ZIRCON_EVENT_FUCHSIA
+    RequiresOneOf([
+        RequiresAllOf([DeviceExtension(fuchsia_external_semaphore)]),
+    ]),
 }
 
 vulkan_bitflags! {


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to pipeline construction:
- `ViewportState` is now a standard struct with two fields, `viewports` and `scissors`.
- The `origin` and `dimensions` fields of `Viewport` and `Scissors` are renamed to `offset` and `extent` to match Vulkan.
- `Viewport::depth_range` is now an inclusive range.
- All fields of `AttachmentBlend` are renamed to match Vulkan.

Changes to pipeline caches:
- They are now constructed with the standard combination of a `new` constructor and a `PipelineCacheCreateInfo`.
````

Depends on #2233. This convertes `GraphicsPipeline` and related types to use `ValidationError`.