### PR TITLE
Add missing `_ne` field to pipeline state create infos

### DIFF
--- a/vulkano/src/pipeline/graphics/color_blend.rs
+++ b/vulkano/src/pipeline/graphics/color_blend.rs
@@ -56,6 +56,8 @@ pub struct ColorBlendState {
 
     /// The constant color to use for some of the `BlendFactor` variants.
     pub blend_constants: StateMode<[f32; 4]>,
+
+    pub _ne: crate::NonExhaustive,
 }
 
 impl ColorBlendState {
@@ -75,6 +77,7 @@ impl ColorBlendState {
                 })
                 .collect(),
             blend_constants: StateMode::Fixed([0.0, 0.0, 0.0, 0.0]),
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -148,6 +151,7 @@ impl ColorBlendState {
             logic_op,
             ref attachments,
             blend_constants: _,
+            _ne: _,
         } = self;
 
         flags

--- a/vulkano/src/pipeline/graphics/depth_stencil.rs
+++ b/vulkano/src/pipeline/graphics/depth_stencil.rs
@@ -53,6 +53,8 @@ pub struct DepthStencilState {
     /// If set to `None`, the stencil test is disabled, all fragments will pass and no stencil
     /// writes are performed.
     pub stencil: Option<StencilState>,
+
+    pub _ne: crate::NonExhaustive,
 }
 
 impl DepthStencilState {
@@ -64,6 +66,7 @@ impl DepthStencilState {
             depth: Default::default(),
             depth_bounds: Default::default(),
             stencil: Default::default(),
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -80,6 +83,7 @@ impl DepthStencilState {
             }),
             depth_bounds: Default::default(),
             stencil: Default::default(),
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -89,6 +93,7 @@ impl DepthStencilState {
             ref depth,
             ref depth_bounds,
             ref stencil,
+            _ne: _,
         } = self;
 
         flags

--- a/vulkano/src/pipeline/graphics/discard_rectangle.rs
+++ b/vulkano/src/pipeline/graphics/discard_rectangle.rs
@@ -31,6 +31,8 @@ pub struct DiscardRectangleState {
     /// [`ext_discard_rectangles`](crate::device::DeviceExtensions::ext_discard_rectangles)
     /// extension must be enabled on the device.
     pub rectangles: PartialStateMode<Vec<Scissor>, u32>,
+
+    pub _ne: crate::NonExhaustive,
 }
 
 impl DiscardRectangleState {
@@ -40,6 +42,7 @@ impl DiscardRectangleState {
         Self {
             mode: DiscardRectangleMode::Exclusive,
             rectangles: PartialStateMode::Fixed(Vec::new()),
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -47,6 +50,7 @@ impl DiscardRectangleState {
         let &Self {
             mode,
             ref rectangles,
+            _ne: _,
         } = self;
 
         let properties = device.physical_device().properties();

--- a/vulkano/src/pipeline/graphics/input_assembly.rs
+++ b/vulkano/src/pipeline/graphics/input_assembly.rs
@@ -40,6 +40,8 @@ pub struct InputAssemblyState {
     /// [`extended_dynamic_state2`](crate::device::Features::extended_dynamic_state2) feature must
     /// be enabled on the device.
     pub primitive_restart_enable: StateMode<bool>,
+
+    pub _ne: crate::NonExhaustive,
 }
 
 impl InputAssemblyState {
@@ -50,6 +52,7 @@ impl InputAssemblyState {
         Self {
             topology: PartialStateMode::Fixed(PrimitiveTopology::TriangleList),
             primitive_restart_enable: StateMode::Fixed(false),
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -85,6 +88,7 @@ impl InputAssemblyState {
         let &Self {
             topology,
             primitive_restart_enable,
+            _ne: _,
         } = self;
 
         match topology {

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -299,6 +299,7 @@ impl GraphicsPipeline {
             let VertexInputState {
                 bindings,
                 attributes,
+                _ne: _,
             } = vertex_input_state;
 
             vertex_binding_descriptions_vk.extend(bindings.iter().map(
@@ -366,6 +367,7 @@ impl GraphicsPipeline {
             let &InputAssemblyState {
                 topology,
                 primitive_restart_enable,
+                _ne: _,
             } = input_assembly_state;
 
             let topology = match topology {
@@ -405,6 +407,7 @@ impl GraphicsPipeline {
             let &TessellationState {
                 patch_control_points,
                 domain_origin,
+                _ne: _,
             } = tessellation_state;
 
             let patch_control_points = match patch_control_points {
@@ -519,6 +522,7 @@ impl GraphicsPipeline {
                 line_width,
                 line_rasterization_mode,
                 line_stipple,
+                _ne: _,
             } = rasterization_state;
 
             let rasterizer_discard_enable = match rasterizer_discard_enable {
@@ -649,6 +653,7 @@ impl GraphicsPipeline {
                 ref sample_mask,
                 alpha_to_coverage_enable,
                 alpha_to_one_enable,
+                _ne: _,
             } = multisample_state;
 
             let (sample_shading_enable, min_sample_shading) =
@@ -678,6 +683,7 @@ impl GraphicsPipeline {
                 ref depth,
                 ref depth_bounds,
                 ref stencil,
+                _ne: _,
             } = depth_stencil_state;
 
             let (depth_test_enable, depth_write_enable, depth_compare_op) =
@@ -870,6 +876,7 @@ impl GraphicsPipeline {
                 logic_op,
                 ref attachments,
                 blend_constants,
+                _ne: _,
             } = color_blend_state;
 
             color_blend_attachments_vk.extend(attachments.iter().map(
@@ -1027,7 +1034,11 @@ impl GraphicsPipeline {
         let mut discard_rectangles: SmallVec<[_; 2]> = SmallVec::new();
 
         if let Some(discard_rectangle_state) = discard_rectangle_state {
-            let DiscardRectangleState { mode, rectangles } = discard_rectangle_state;
+            let DiscardRectangleState {
+                mode,
+                rectangles,
+                _ne: _,
+            } = discard_rectangle_state;
 
             let discard_rectangle_count = match rectangles {
                 PartialStateMode::Fixed(rectangles) => {
@@ -1234,6 +1245,7 @@ impl GraphicsPipeline {
             let &InputAssemblyState {
                 topology,
                 primitive_restart_enable,
+                _ne: _,
             } = input_assembly_state;
 
             match topology {
@@ -1259,6 +1271,7 @@ impl GraphicsPipeline {
             let &TessellationState {
                 patch_control_points,
                 domain_origin: _,
+                _ne: _,
             } = tessellation_state;
 
             match patch_control_points {
@@ -1393,6 +1406,7 @@ impl GraphicsPipeline {
                 depth,
                 depth_bounds,
                 stencil,
+                _ne: _,
             } = depth_stencil_state;
 
             if let Some(depth_state) = depth {
@@ -1510,6 +1524,7 @@ impl GraphicsPipeline {
                 logic_op,
                 ref attachments,
                 blend_constants,
+                _ne: _,
             } = color_blend_state;
 
             if let Some(logic_op) = logic_op {

--- a/vulkano/src/pipeline/graphics/multisample.rs
+++ b/vulkano/src/pipeline/graphics/multisample.rs
@@ -57,6 +57,8 @@ pub struct MultisampleState {
     /// If set to `true`, the [`alpha_to_one`](crate::device::Features::alpha_to_one)
     /// feature must be enabled on the device.
     pub alpha_to_one_enable: bool,
+
+    pub _ne: crate::NonExhaustive,
 }
 
 impl MultisampleState {
@@ -69,6 +71,7 @@ impl MultisampleState {
             sample_mask: [0xFFFFFFFF; 2],
             alpha_to_coverage_enable: false,
             alpha_to_one_enable: false,
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -79,6 +82,7 @@ impl MultisampleState {
             sample_mask: _,
             alpha_to_coverage_enable: _,
             alpha_to_one_enable,
+            _ne: _,
         } = self;
 
         rasterization_samples

--- a/vulkano/src/pipeline/graphics/rasterization.rs
+++ b/vulkano/src/pipeline/graphics/rasterization.rs
@@ -81,6 +81,8 @@ pub struct RasterizationState {
     /// [`ext_line_rasterization`](crate::device::DeviceExtensions::ext_line_rasterization)
     /// extension and an additional feature must be enabled on the device.
     pub line_stipple: Option<StateMode<LineStipple>>,
+
+    pub _ne: crate::NonExhaustive,
 }
 
 impl RasterizationState {
@@ -99,6 +101,7 @@ impl RasterizationState {
             line_width: StateMode::Fixed(1.0),
             line_rasterization_mode: Default::default(),
             line_stipple: None,
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -148,6 +151,7 @@ impl RasterizationState {
             line_width,
             line_rasterization_mode,
             ref line_stipple,
+            _ne: _,
         } = self;
 
         let properties = device.physical_device().properties();

--- a/vulkano/src/pipeline/graphics/tessellation.rs
+++ b/vulkano/src/pipeline/graphics/tessellation.rs
@@ -33,6 +33,8 @@ pub struct TessellationState {
     ///
     /// The default value is [`TessellationDomainOrigin::UpperLeft`].
     pub domain_origin: TessellationDomainOrigin,
+
+    pub _ne: crate::NonExhaustive,
 }
 
 impl TessellationState {
@@ -42,6 +44,7 @@ impl TessellationState {
         Self {
             patch_control_points: StateMode::Fixed(3),
             domain_origin: TessellationDomainOrigin::default(),
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -63,6 +66,7 @@ impl TessellationState {
         let &Self {
             patch_control_points,
             domain_origin,
+            _ne: _,
         } = self;
 
         let properties = device.physical_device().properties();

--- a/vulkano/src/pipeline/graphics/vertex_input/mod.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/mod.rs
@@ -120,7 +120,7 @@ mod impl_vertex;
 mod vertex;
 
 /// The state in a graphics pipeline describing how the vertex input stage should behave.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct VertexInputState {
     /// A description of the vertex buffers that the vertex input stage will read from.
     pub bindings: HashMap<u32, VertexInputBindingDescription>,
@@ -128,6 +128,8 @@ pub struct VertexInputState {
     /// Describes, for each shader input location, the mapping between elements in a vertex buffer
     /// and the components of that location in the shader.
     pub attributes: HashMap<u32, VertexInputAttributeDescription>,
+
+    pub _ne: crate::NonExhaustive,
 }
 
 impl VertexInputState {
@@ -137,6 +139,7 @@ impl VertexInputState {
         VertexInputState {
             bindings: Default::default(),
             attributes: Default::default(),
+            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -180,6 +183,7 @@ impl VertexInputState {
         let Self {
             bindings,
             attributes,
+            _ne: _,
         } = self;
 
         let properties = device.physical_device().properties();
@@ -296,6 +300,17 @@ impl VertexInputState {
         }
 
         Ok(())
+    }
+}
+
+impl Default for VertexInputState {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            bindings: HashMap::default(),
+            attributes: HashMap::default(),
+            _ne: crate::NonExhaustive(()),
+        }
     }
 }
 


### PR DESCRIPTION
Changelog:
Remove:
```markdown
### Breaking changes
Changes to pipeline construction:
- Added a `domain_origin` field to `TessellationState`.
```
Add:
```markdown
### Breaking changes
Changes to pipeline construction:
- Added a `_ne` field to all pipeline state create info structs, as they should have had all along.

### Additions
- Added a `domain_origin` field to `TessellationState`.
```
See https://github.com/vulkano-rs/vulkano/pull/2224#issuecomment-1584196752 for context.