### PR TITLE
Update dependencies

### DIFF
--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -2,10 +2,7 @@
 name = "vulkano-shaders"
 version = "0.33.0"
 edition = "2021"
-authors = [
-    "Pierre Krieger <pierre.krieger1708@gmail.com>",
-    "The vulkano contributors",
-]
+authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Shaders rust code generation macro"
 license = "MIT/Apache-2.0"
@@ -23,7 +20,7 @@ heck = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 shaderc = "0.8"
-syn = { version = "1.0", features = ["full", "extra-traits"] }
+syn = { version = "2.0", features = ["full", "extra-traits"] }
 vulkano = { version = "0.33.0", path = "../vulkano", default-features = false }
 
 [features]

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -2,10 +2,7 @@
 name = "vulkano"
 version = "0.33.0"
 edition = "2021"
-authors = [
-    "Pierre Krieger <pierre.krieger1708@gmail.com>",
-    "The vulkano contributors",
-]
+authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>", "The vulkano contributors"]
 repository = "https://github.com/vulkano-rs/vulkano"
 description = "Safe wrapper for the Vulkan graphics API"
 license = "MIT/Apache-2.0"
@@ -20,11 +17,11 @@ build = "build.rs"
 ahash = "0.8"
 # When updating Ash, also update vk.xml to the same Vulkan patch version that Ash uses.
 # All versions of vk.xml can be found at https://github.com/KhronosGroup/Vulkan-Headers/commits/main/registry/vk.xml.
-ash = "^0.37.2"
+ash = "^0.37.3"
 bytemuck = { version = "1.9", features = ["min_const_generics"] }
 crossbeam-queue = "0.3"
 half = { version = "2", features = ["bytemuck"] }
-libloading = "0.7"
+libloading = "0.8"
 once_cell = "1.17"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 raw-window-handle = "0.5"
@@ -40,14 +37,14 @@ core-graphics-types = "0.1"
 [build-dependencies]
 ahash = "0.8"
 heck = "0.4"
-indexmap = "1.8"
+indexmap = "2.0"
 once_cell = "1.16"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-vk-parse = "0.8"
+vk-parse = "0.12"
 
 [dev-dependencies]
 cgmath = "0.18"

--- a/vulkano/autogen/mod.rs
+++ b/vulkano/autogen/mod.rs
@@ -239,7 +239,12 @@ impl<'r> VkRegistryData<'r> {
             .filter_map(|child| {
                 if let RegistryChild::Extensions(ext) = child {
                     return Some(ext.children.iter().filter(|ext| {
-                        if ext.supported.as_deref() == Some("vulkan") && ext.obsoletedby.is_none() {
+                        if ext
+                            .supported
+                            .as_deref()
+                            .map_or(false, |s| s.split(',').any(|s| s == "vulkan"))
+                            && ext.obsoletedby.is_none()
+                        {
                             return true;
                         }
                         false
@@ -271,7 +276,9 @@ impl<'r> VkRegistryData<'r> {
             .iter()
             .filter_map(|child| {
                 if let RegistryChild::Feature(feat) = child {
-                    return Some((feat.name.as_str(), feat));
+                    if feat.api.split(',').any(|s| s == "vulkan") {
+                        return Some((feat.name.as_str(), feat));
+                    }
                 }
 
                 None

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -304,26 +304,6 @@ impl Device {
             })
             .collect();
 
-        // Device layers were deprecated in Vulkan 1.0.13, and device layer requests should be
-        // ignored by the driver. For backwards compatibility, the spec recommends passing the
-        // exact instance layers to the device as well. There's no need to support separate
-        // requests at device creation time for legacy drivers: the spec claims that "[at] the
-        // time of deprecation there were no known device-only layers."
-        //
-        // Because there's no way to query the list of layers enabled for an instance, we need
-        // to save it alongside the instance. (`vkEnumerateDeviceLayerProperties` should get
-        // the right list post-1.0.13, but not pre-1.0.13, so we can't use it here.)
-        let enabled_layers_vk: Vec<CString> = physical_device
-            .instance()
-            .enabled_layers()
-            .iter()
-            .map(|name| CString::new(name.clone()).unwrap())
-            .collect();
-        let enabled_layers_ptrs_vk = enabled_layers_vk
-            .iter()
-            .map(|layer| layer.as_ptr())
-            .collect::<SmallVec<[_; 2]>>();
-
         let enabled_extensions_strings_vk = Vec::<CString>::from(enabled_extensions);
         let enabled_extensions_ptrs_vk = enabled_extensions_strings_vk
             .iter()
@@ -349,8 +329,6 @@ impl Device {
             flags: ash::vk::DeviceCreateFlags::empty(),
             queue_create_info_count: queue_create_infos_vk.len() as u32,
             p_queue_create_infos: queue_create_infos_vk.as_ptr(),
-            enabled_layer_count: enabled_layers_ptrs_vk.len() as u32,
-            pp_enabled_layer_names: enabled_layers_ptrs_vk.as_ptr(),
             enabled_extension_count: enabled_extensions_ptrs_vk.len() as u32,
             pp_enabled_extension_names: enabled_extensions_ptrs_vk.as_ptr(),
             p_enabled_features: ptr::null(),

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -647,6 +647,10 @@ impl Display for RuntimeError {
                 "a surface has changed in such a way that it is no longer compatible with the \
                 swapchain, and further presentation requests using the swapchain will fail"
             }
+            RuntimeError::InvalidVideoStdParameters => {
+                "the provided Video Std parameters do not adhere to the requirements of the used \
+                video compression standard"
+            }
             RuntimeError::ValidationFailed => "validation failed",
             RuntimeError::FullScreenExclusiveModeLost => {
                 "an operation on a swapchain created with application controlled full-screen \

--- a/vulkano/vk.xml
+++ b/vulkano/vk.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <comment>
-Copyright 2015-2022 The Khronos Group Inc.
+Copyright 2015-2023 The Khronos Group Inc.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
     </comment>
@@ -32,6 +32,7 @@ branch of the member gitlab server.
         <platform name="metal" protect="VK_USE_PLATFORM_METAL_EXT" comment="Metal on CoreAnimation on Apple platforms"/>
         <platform name="fuchsia" protect="VK_USE_PLATFORM_FUCHSIA" comment="Fuchsia"/>
         <platform name="ggp" protect="VK_USE_PLATFORM_GGP" comment="Google Games Platform"/>
+        <platform name="sci" protect="VK_USE_PLATFORM_SCI" comment="NVIDIA SCI"/>
         <platform name="provisional" protect="VK_ENABLE_BETA_EXTENSIONS" comment="Enable declarations for beta/provisional extensions"/>
         <platform name="screen" protect="VK_USE_PLATFORM_SCREEN_QNX" comment="QNX Screen Graphics Subsystem"/>
     </platforms>
@@ -66,14 +67,15 @@ branch of the member gitlab server.
         <tag name="KHR"         author="Khronos"                       contact="Tom Olson @tomolson"/>
         <tag name="KHX"         author="Khronos"                       contact="Tom Olson @tomolson"/>
         <tag name="EXT"         author="Multivendor"                   contact="Jon Leech @oddhack"/>
-        <tag name="MESA"        author="Mesa open source project"      contact="Chad Versace @chadversary, Daniel Stone @fooishbar, David Airlie @airlied, Jason Ekstrand @jekstrand"/>
+        <tag name="MESA"        author="Mesa open source project"      contact="Lina Versace @versalinyaa, Daniel Stone @fooishbar, David Airlie @airlied, Faith Ekstrand @gfxstrand"/>
         <tag name="INTEL"       author="Intel Corporation"             contact="Slawek Grajewski @sgrajewski"/>
         <tag name="HUAWEI"      author="Huawei Technologies Co. Ltd."  contact="Pan Gao @PanGao-h, Juntao Li @Lawrenceleehw"/>
         <tag name="VALVE"       author="Valve Corporation"             contact="Pierre-Loup Griffais @plagman, Joshua Ashton @Joshua-Ashton, Hans-Kristian Arntzen @HansKristian-Work"/>
         <tag name="QNX"         author="BlackBerry Limited"            contact="Mike Gorchak @mgorchak-blackberry"/>
         <tag name="JUICE"       author="Juice Technologies, Inc."      contact="David McCloskey @damcclos, Dean Beeler @canadacow"/>
         <tag name="FB"          author="Facebook, Inc"                 contact="Artem Bolgar @artyom17"/>
-        <tag name="RASTERGRID"  author="RasterGrid Kft."               contact="Daniel Rakos @aqnuep1"/>
+        <tag name="RASTERGRID"  author="RasterGrid Kft."               contact="Daniel Rakos @aqnuep"/>
+        <tag name="MSFT"        author="Microsoft Corporation"         contact="Jesse Natalie @jenatali"/>
     </tags>
 
     <types comment="Vulkan type definitions">
@@ -90,6 +92,8 @@ branch of the member gitlab server.
         <type category="include" name="zircon/types.h"/>
         <type category="include" name="ggp_c/vulkan_types.h"/>
         <type category="include" name="screen/screen.h"/>
+        <type category="include" name="nvscisync.h"/>
+        <type category="include" name="nvscibuf.h"/>
             <comment>
                 In the current header structure, each platform's interfaces
                 are confined to a platform-specific header (vulkan_xlib.h,
@@ -130,41 +134,58 @@ branch of the member gitlab server.
         <type requires="ggp_c/vulkan_types.h" name="GgpFrameToken"/>
         <type requires="screen/screen.h" name="_screen_context"/>
         <type requires="screen/screen.h" name="_screen_window"/>
+        <type requires="nvscisync.h" name="NvSciSyncAttrList"/>
+        <type requires="nvscisync.h" name="NvSciSyncObj"/>
+        <type requires="nvscisync.h" name="NvSciSyncFence"/>
+        <type requires="nvscibuf.h" name="NvSciBufAttrList"/>
+        <type requires="nvscibuf.h" name="NvSciBufObj"/>
 
-        <type category="define">// DEPRECATED: This define is deprecated. VK_MAKE_API_VERSION should be used instead.
+        <type category="define" deprecated="true">// DEPRECATED: This define is deprecated. VK_MAKE_API_VERSION should be used instead.
 #define <name>VK_MAKE_VERSION</name>(major, minor, patch) \
-    ((((uint32_t)(major)) &lt;&lt; 22) | (((uint32_t)(minor)) &lt;&lt; 12) | ((uint32_t)(patch)))</type>
-        <type category="define">// DEPRECATED: This define is deprecated. VK_API_VERSION_MAJOR should be used instead.
-#define <name>VK_VERSION_MAJOR</name>(version) ((uint32_t)(version) &gt;&gt; 22)</type>
-        <type category="define">// DEPRECATED: This define is deprecated. VK_API_VERSION_MINOR should be used instead.
-#define <name>VK_VERSION_MINOR</name>(version) (((uint32_t)(version) &gt;&gt; 12) &amp; 0x3FFU)</type>
-        <type category="define">// DEPRECATED: This define is deprecated. VK_API_VERSION_PATCH should be used instead.
+    ((((uint32_t)(major)) &lt;&lt; 22U) | (((uint32_t)(minor)) &lt;&lt; 12U) | ((uint32_t)(patch)))</type>
+        <type category="define" deprecated="true">// DEPRECATED: This define is deprecated. VK_API_VERSION_MAJOR should be used instead.
+#define <name>VK_VERSION_MAJOR</name>(version) ((uint32_t)(version) &gt;&gt; 22U)</type>
+        <type category="define" deprecated="true">// DEPRECATED: This define is deprecated. VK_API_VERSION_MINOR should be used instead.
+#define <name>VK_VERSION_MINOR</name>(version) (((uint32_t)(version) &gt;&gt; 12U) &amp; 0x3FFU)</type>
+        <type category="define" deprecated="true">// DEPRECATED: This define is deprecated. VK_API_VERSION_PATCH should be used instead.
 #define <name>VK_VERSION_PATCH</name>(version) ((uint32_t)(version) &amp; 0xFFFU)</type>
 
         <type category="define">#define <name>VK_MAKE_API_VERSION</name>(variant, major, minor, patch) \
-    ((((uint32_t)(variant)) &lt;&lt; 29) | (((uint32_t)(major)) &lt;&lt; 22) | (((uint32_t)(minor)) &lt;&lt; 12) | ((uint32_t)(patch)))</type>
-        <type category="define">#define <name>VK_API_VERSION_VARIANT</name>(version) ((uint32_t)(version) &gt;&gt; 29)</type>
-        <type category="define">#define <name>VK_API_VERSION_MAJOR</name>(version) (((uint32_t)(version) &gt;&gt; 22) &amp; 0x7FU)</type>
-        <type category="define">#define <name>VK_API_VERSION_MINOR</name>(version) (((uint32_t)(version) &gt;&gt; 12) &amp; 0x3FFU)</type>
+    ((((uint32_t)(variant)) &lt;&lt; 29U) | (((uint32_t)(major)) &lt;&lt; 22U) | (((uint32_t)(minor)) &lt;&lt; 12U) | ((uint32_t)(patch)))</type>
+        <type category="define">#define <name>VK_API_VERSION_VARIANT</name>(version) ((uint32_t)(version) &gt;&gt; 29U)</type>
+        <type category="define">#define <name>VK_API_VERSION_MAJOR</name>(version) (((uint32_t)(version) &gt;&gt; 22U) &amp; 0x7FU)</type>
+        <type category="define">#define <name>VK_API_VERSION_MINOR</name>(version) (((uint32_t)(version) &gt;&gt; 12U) &amp; 0x3FFU)</type>
         <type category="define">#define <name>VK_API_VERSION_PATCH</name>(version) ((uint32_t)(version) &amp; 0xFFFU)</type>
 
+        <type category="define" requires="VK_HEADER_VERSION">// Vulkan SC variant number
+#define <name>VKSC_API_VARIANT</name> 1</type>
+
         <type category="define">// DEPRECATED: This define has been removed. Specific version defines (e.g. VK_API_VERSION_1_0), or the VK_MAKE_VERSION macro, should be used instead.
-//#define <name>VK_API_VERSION</name> <type>VK_MAKE_VERSION</type>(1, 0, 0) // Patch version should always be set to 0</type>
-        <type category="define" requires="VK_MAKE_API_VERSION">// Vulkan 1.0 version number
+//#define <name>VK_API_VERSION</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 0, 0) // Patch version should always be set to 0</type>
+        <type category="define">// Vulkan 1.0 version number
 #define <name>VK_API_VERSION_1_0</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 0, 0)// Patch version should always be set to 0</type>
-        <type category="define" requires="VK_MAKE_API_VERSION">// Vulkan 1.1 version number
+        <type category="define">// Vulkan 1.1 version number
 #define <name>VK_API_VERSION_1_1</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 1, 0)// Patch version should always be set to 0</type>
-        <type category="define" requires="VK_MAKE_API_VERSION">// Vulkan 1.2 version number
+        <type category="define">// Vulkan 1.2 version number
 #define <name>VK_API_VERSION_1_2</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 2, 0)// Patch version should always be set to 0</type>
         <type category="define" requires="VK_MAKE_API_VERSION">// Vulkan 1.3 version number
 #define <name>VK_API_VERSION_1_3</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 3, 0)// Patch version should always be set to 0</type>
-        <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 238</type>
-        <type category="define" requires="VK_HEADER_VERSION">// Complete version of this file
-#define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 3, VK_HEADER_VERSION)</type>
+        <type category="define" requires="VKSC_API_VARIANT">// Vulkan SC 1.0 version number
+#define <name>VKSC_API_VERSION_1_0</name> <type>VK_MAKE_API_VERSION</type>(VKSC_API_VARIANT, 1, 0, 0)// Patch version should always be set to 0</type>
 
-        <type category="define">
+        <type api="vulkan" category="define">// Version of this file
+#define <name>VK_HEADER_VERSION</name> 251</type>
+        <type api="vulkan" category="define" requires="VK_HEADER_VERSION">// Complete version of this file
+#define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 3, VK_HEADER_VERSION)</type>
+        <type api="vulkansc" category="define">// Version of this file
+#define <name>VK_HEADER_VERSION</name> 12</type>
+        <type api="vulkansc" category="define" requires="VKSC_API_VARIANT">// Complete version of this file
+#define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(VKSC_API_VARIANT, 1, 0, VK_HEADER_VERSION)</type>
+
+        <type api="vulkan" category="define">
 #define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* object;</type>
+        <type api="vulkansc" category="define" comment="Extra parenthesis are a MISRA-C requirement that exposes a bug in MSVC">
+#define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* (object);</type>
 
         <type category="define" name="VK_USE_64_BIT_PTR_DEFINES">
 #ifndef VK_USE_64_BIT_PTR_DEFINES
@@ -189,12 +210,20 @@ branch of the member gitlab server.
 #ifndef VK_NULL_HANDLE
     #define VK_NULL_HANDLE 0
 #endif</type>
-        <type category="define" requires="VK_NULL_HANDLE" name="VK_DEFINE_NON_DISPATCHABLE_HANDLE">
+        <type api="vulkan" category="define" requires="VK_NULL_HANDLE" name="VK_DEFINE_NON_DISPATCHABLE_HANDLE">
 #ifndef VK_DEFINE_NON_DISPATCHABLE_HANDLE
     #if (VK_USE_64_BIT_PTR_DEFINES==1)
         #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *object;
     #else
         #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef uint64_t object;
+    #endif
+#endif</type>
+        <type api="vulkansc" category="define" requires="VK_NULL_HANDLE" name="VK_DEFINE_NON_DISPATCHABLE_HANDLE" comment="Extra parenthesis are a MISRA-C requirement that exposes a bug in MSVC">
+#ifndef VK_DEFINE_NON_DISPATCHABLE_HANDLE
+    #if (VK_USE_64_BIT_PTR_DEFINES==1)
+        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *(object);
+    #else
+        #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef uint64_t (object);
     #endif
 #endif</type>
 
@@ -267,9 +296,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkSamplerCreateFlagBits"          category="bitmask">typedef <type>VkFlags</type> <name>VkSamplerCreateFlags</name>;</type>
         <type requires="VkPipelineLayoutCreateFlagBits"   category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineLayoutCreateFlags</name>;</type>
         <type requires="VkPipelineCacheCreateFlagBits"    category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCacheCreateFlags</name>;</type>
-        <type requires="VkPipelineDepthStencilStateCreateFlagBits" category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDepthStencilStateCreateFlags</name>;</type>
+        <type api="vulkan" requires="VkPipelineDepthStencilStateCreateFlagBits" category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDepthStencilStateCreateFlags</name>;</type>
+        <type api="vulkansc" category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDepthStencilStateCreateFlags</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineDynamicStateCreateFlags</name>;</type>
-        <type requires="VkPipelineColorBlendStateCreateFlagBits"   category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineColorBlendStateCreateFlags</name>;</type>
+        <type api="vulkan" requires="VkPipelineColorBlendStateCreateFlagBits"   category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineColorBlendStateCreateFlags</name>;</type>
+        <type api="vulkansc" category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineColorBlendStateCreateFlags</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineMultisampleStateCreateFlags</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineRasterizationStateCreateFlags</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineViewportStateCreateFlags</name>;</type>
@@ -342,6 +373,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkPipelineCompilerControlFlagBitsAMD" category="bitmask">typedef <type>VkFlags</type> <name>VkPipelineCompilerControlFlagsAMD</name>;</type>
         <type requires="VkShaderCorePropertiesFlagBitsAMD" category="bitmask">typedef <type>VkFlags</type> <name>VkShaderCorePropertiesFlagsAMD</name>;</type>
         <type requires="VkDeviceDiagnosticsConfigFlagBitsNV" category="bitmask">typedef <type>VkFlags</type> <name>VkDeviceDiagnosticsConfigFlagsNV</name>;</type>
+        <type requires="VkRefreshObjectFlagBitsKHR"       category="bitmask">typedef <type>VkFlags</type> <name>VkRefreshObjectFlagsKHR</name>;</type>
         <type bitvalues="VkAccessFlagBits2"               category="bitmask">typedef <type>VkFlags64</type> <name>VkAccessFlags2</name>;</type>
         <type                                             category="bitmask" name="VkAccessFlags2KHR" alias="VkAccessFlags2"/>
         <type bitvalues="VkPipelineStageFlagBits2"        category="bitmask">typedef <type>VkFlags64</type> <name>VkPipelineStageFlags2</name>;</type>
@@ -443,6 +475,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkOpticalFlowExecuteFlagBitsNV"         category="bitmask">typedef <type>VkFlags</type>   <name>VkOpticalFlowExecuteFlagsNV</name>;</type>
         <type requires="VkPresentScalingFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkPresentScalingFlagsEXT</name>;</type>
         <type requires="VkPresentGravityFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkPresentGravityFlagsEXT</name>;</type>
+        <type requires="VkShaderCreateFlagBitsEXT"        category="bitmask">typedef <type>VkFlags</type> <name>VkShaderCreateFlagsEXT</name>;</type>
 
             <comment>Video Core extension</comment>
         <type requires="VkVideoCodecOperationFlagBitsKHR"           category="bitmask">typedef <type>VkFlags</type> <name>VkVideoCodecOperationFlagsKHR</name>;</type>
@@ -466,6 +499,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkVideoEncodeUsageFlagBitsKHR"              category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeUsageFlagsKHR</name>;</type>
         <type requires="VkVideoEncodeContentFlagBitsKHR"            category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeContentFlagsKHR</name>;</type>
         <type requires="VkVideoEncodeCapabilityFlagBitsKHR"         category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeCapabilityFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeFeedbackFlagBitsKHR"           category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeFeedbackFlagsKHR</name>;</type>
         <type                                                       category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeRateControlFlagsKHR</name>;</type>
         <type requires="VkVideoEncodeRateControlModeFlagBitsKHR"    category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeRateControlModeFlagsKHR</name>;</type>
         <type requires="VkVideoChromaSubsamplingFlagBitsKHR"        category="bitmask">typedef <type>VkFlags</type> <name>VkVideoChromaSubsamplingFlagsKHR</name>;</type>
@@ -473,15 +507,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
 
             <comment>Video Encode H.264 extension</comment>
         <type requires="VkVideoEncodeH264CapabilityFlagBitsEXT"     category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH264CapabilityFlagsEXT</name>;</type>
-        <type requires="VkVideoEncodeH264InputModeFlagBitsEXT"      category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH264InputModeFlagsEXT</name>;</type>
-        <type requires="VkVideoEncodeH264OutputModeFlagBitsEXT"     category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH264OutputModeFlagsEXT</name>;</type>
 
             <comment>Video Encode H.265 extension</comment>
         <type requires="VkVideoEncodeH265CapabilityFlagBitsEXT"     category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265CapabilityFlagsEXT</name>;</type>
-        <type requires="VkVideoEncodeH265InputModeFlagBitsEXT"      category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265InputModeFlagsEXT</name>;</type>
-        <type requires="VkVideoEncodeH265OutputModeFlagBitsEXT"     category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265OutputModeFlagsEXT</name>;</type>
         <type requires="VkVideoEncodeH265CtbSizeFlagBitsEXT"        category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265CtbSizeFlagsEXT</name>;</type>
         <type requires="VkVideoEncodeH265TransformBlockSizeFlagBitsEXT"        category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265TransformBlockSizeFlagsEXT</name>;</type>
+        <type category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryUnmapFlagsKHR</name>;</type>
 
             <comment>Types which can be void pointers or class pointers, selected at compile time</comment>
         <type category="handle"                           objtypeenum="VK_OBJECT_TYPE_INSTANCE"><type>VK_DEFINE_HANDLE</type>(<name>VkInstance</name>)</type>
@@ -526,6 +557,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="handle" parent="VkDevice"         objtypeenum="VK_OBJECT_TYPE_CU_FUNCTION_NVX"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkCuFunctionNVX</name>)</type>
         <type category="handle" parent="VkDevice"         objtypeenum="VK_OBJECT_TYPE_OPTICAL_FLOW_SESSION_NV"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkOpticalFlowSessionNV</name>)</type>
         <type category="handle" parent="VkDevice"         objtypeenum="VK_OBJECT_TYPE_MICROMAP_EXT"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkMicromapEXT</name>)</type>
+        <type category="handle" parent="VkDevice"         objtypeenum="VK_OBJECT_TYPE_SHADER_EXT"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkShaderEXT</name>)</type>
 
             <comment>WSI extensions</comment>
         <type category="handle" parent="VkPhysicalDevice" objtypeenum="VK_OBJECT_TYPE_DISPLAY_KHR"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayKHR</name>)</type>
@@ -538,6 +570,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <comment>Video extensions</comment>
         <type category="handle" parent="VkDevice"          objtypeenum="VK_OBJECT_TYPE_VIDEO_SESSION_KHR"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkVideoSessionKHR</name>)</type>
         <type category="handle" parent="VkVideoSessionKHR" objtypeenum="VK_OBJECT_TYPE_VIDEO_SESSION_PARAMETERS_KHR"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkVideoSessionParametersKHR</name>)</type>
+
+            <comment>VK_NV_external_sci_sync2</comment>
+        <type category="handle" parent="VkDevice"          objtypeenum="VK_OBJECT_TYPE_SEMAPHORE_SCI_SYNC_POOL_NV"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkSemaphoreSciSyncPoolNV</name>)</type>
 
             <comment>Types generated from corresponding enums tags below</comment>
         <type name="VkAttachmentLoadOp" category="enum"/>
@@ -692,6 +727,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkShaderModuleCreateFlagBits" category="enum"/>
         <type name="VkPipelineCompilerControlFlagBitsAMD" category="enum"/>
         <type name="VkShaderCorePropertiesFlagBitsAMD" category="enum"/>
+        <type name="VkRefreshObjectFlagBitsKHR" category="enum"/>
+        <type name="VkFaultLevel" category="enum"/>
+        <type name="VkFaultType" category="enum"/>
+        <type name="VkFaultQueryBehavior" category="enum"/>
+        <type name="VkPipelineMatchControl" category="enum"/>
+        <type name="VkSciSyncClientTypeNV" category="enum"/>
+        <type name="VkSciSyncPrimitiveTypeNV" category="enum"/>
         <type name="VkToolPurposeFlagBits" category="enum"/>
         <type category="enum" name="VkToolPurposeFlagBitsEXT"                      alias="VkToolPurposeFlagBits"/>
         <type name="VkFragmentShadingRateNV" category="enum"/>
@@ -702,6 +744,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkPipelineStageFlagBits2" category="enum"/>
         <type category="enum" name="VkPipelineStageFlagBits2KHR"                   alias="VkPipelineStageFlagBits2"/>
         <type name="VkProvokingVertexModeEXT" category="enum"/>
+        <type name="VkPipelineCacheValidationVersion" category="enum"/>
         <type name="VkImageFormatConstraintsFlagBitsFUCHSIA" category="enum"/>
         <type name="VkImageConstraintsInfoFlagBitsFUCHSIA" category="enum"/>
         <type name="VkFormatFeatureFlagBits2" category="enum"/>
@@ -727,6 +770,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkDeviceFaultVendorBinaryHeaderVersionEXT" category="enum"/>
         <type name="VkMemoryDecompressionMethodFlagBitsNV" category="enum"/>
         <type name="VkDirectDriverLoadingModeLUNARG" category="enum"/>
+        <type name="VkDisplacementMicromapFormatNV" category="enum"/>
+        <type name="VkShaderCreateFlagBitsEXT" category="enum"/>
+        <type name="VkShaderCodeTypeEXT" category="enum"/>
 
             <comment>WSI extensions</comment>
         <type name="VkColorSpaceKHR" category="enum"/>
@@ -832,18 +878,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkVideoEncodeContentFlagBitsKHR" category="enum"/>
         <type name="VkVideoEncodeTuningModeKHR" category="enum"/>
         <type name="VkVideoEncodeCapabilityFlagBitsKHR" category="enum"/>
+        <type name="VkVideoEncodeFeedbackFlagBitsKHR" category="enum"/>
         <type name="VkVideoEncodeRateControlModeFlagBitsKHR" category="enum"/>
 
            <comment>Video H.264 Encode extensions</comment>
         <type name="VkVideoEncodeH264CapabilityFlagBitsEXT"     category="enum"/>
-        <type name="VkVideoEncodeH264InputModeFlagBitsEXT"      category="enum"/>
-        <type name="VkVideoEncodeH264OutputModeFlagBitsEXT"     category="enum"/>
         <type name="VkVideoEncodeH264RateControlStructureEXT"   category="enum"/>
 
            <comment>Video H.265 Encode extensions</comment>
         <type name="VkVideoEncodeH265CapabilityFlagBitsEXT"     category="enum"/>
-        <type name="VkVideoEncodeH265InputModeFlagBitsEXT"      category="enum"/>
-        <type name="VkVideoEncodeH265OutputModeFlagBitsEXT"     category="enum"/>
         <type name="VkVideoEncodeH265RateControlStructureEXT"   category="enum"/>
         <type name="VkVideoEncodeH265CtbSizeFlagBitsEXT"        category="enum"/>
         <type name="VkVideoEncodeH265TransformBlockSizeFlagBitsEXT"        category="enum"/>
@@ -894,6 +937,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
     <type>VkDebugUtilsMessageTypeFlagsEXT</type>                  messageTypes,
     const <type>VkDebugUtilsMessengerCallbackDataEXT</type>*      pCallbackData,
     <type>void</type>*                                            pUserData);</type>
+
+            <comment>The PFN_vkFaultCallbackFunction type is used by VKSC_VERSION_1_0</comment>
+        <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkFaultCallbackFunction</name>)(
+    <type>VkBool32</type>                                    unrecordedFaults,
+    <type>uint32_t</type>                                    faultCount,
+    const <type>VkFaultData</type>*                          pFaults);</type>
 
             <comment>The PFN_vkDeviceMemoryReportCallbackEXT type is used by the VK_EXT_device_memory_report extension</comment>
         <type category="funcpointer" requires="VkDeviceMemoryReportCallbackDataEXT">typedef void (VKAPI_PTR *<name>PFN_vkDeviceMemoryReportCallbackEXT</name>)(
@@ -1011,8 +1060,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>VkDeviceCreateFlags</type>    <name>flags</name></member>
             <member><type>uint32_t</type>        <name>queueCreateInfoCount</name></member>
             <member len="queueCreateInfoCount">const <type>VkDeviceQueueCreateInfo</type>* <name>pQueueCreateInfos</name></member>
-            <member optional="true"><type>uint32_t</type>               <name>enabledLayerCount</name></member>
-            <member len="enabledLayerCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledLayerNames</name><comment>Ordered list of layer names to be enabled</comment></member>
+            <member optional="true" deprecated="ignored"><type>uint32_t</type>               <name>enabledLayerCount</name></member>
+            <member len="enabledLayerCount,null-terminated" deprecated="ignored">const <type>char</type>* const*      <name>ppEnabledLayerNames</name><comment>Ordered list of layer names to be enabled</comment></member>
             <member optional="true"><type>uint32_t</type>               <name>enabledExtensionCount</name></member>
             <member len="enabledExtensionCount,null-terminated">const <type>char</type>* const*      <name>ppEnabledExtensionNames</name></member>
             <member optional="true">const <type>VkPhysicalDeviceFeatures</type>* <name>pEnabledFeatures</name></member>
@@ -1368,8 +1417,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineShaderStageCreateFlags</type>    <name>flags</name></member>
             <member><type>VkShaderStageFlagBits</type>  <name>stage</name><comment>Shader stage</comment></member>
-            <member optional="true"><type>VkShaderModule</type>         <name>module</name><comment>Module containing entry point</comment></member>
-            <member len="null-terminated">const <type>char</type>*            <name>pName</name><comment>Null-terminated entry point name</comment></member>
+            <member optional="true"><type>VkShaderModule</type> <name>module</name><comment>Module containing entry point</comment></member>
+            <member api="vulkan" len="null-terminated">const <type>char</type>* <name>pName</name><comment>Null-terminated entry point name</comment></member>
+            <member api="vulkansc" optional="true" len="null-terminated">const <type>char</type>* <name>pName</name><comment>Null-terminated entry point name</comment></member>
             <member optional="true">const <type>VkSpecializationInfo</type>* <name>pSpecializationInfo</name></member>
         </type>
         <type category="struct" name="VkComputePipelineCreateInfo">
@@ -1503,8 +1553,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
-            <member noautovalidity="true" optional="true"><type>uint32_t</type>               <name>stageCount</name></member>
-            <member noautovalidity="true" len="stageCount" optional="true">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
+            <member noautovalidity="true" optional="true"><type>uint32_t</type> <name>stageCount</name></member>
+            <member api="vulkan" noautovalidity="true" len="stageCount" optional="true">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
+            <member api="vulkansc" noautovalidity="true" len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
             <member noautovalidity="true" optional="true">const <type>VkPipelineVertexInputStateCreateInfo</type>* <name>pVertexInputState</name></member>
             <member noautovalidity="true" optional="true">const <type>VkPipelineInputAssemblyStateCreateInfo</type>* <name>pInputAssemblyState</name></member>
             <member noautovalidity="true" optional="true">const <type>VkPipelineTessellationStateCreateInfo</type>* <name>pTessellationState</name></member>
@@ -1524,7 +1575,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCacheCreateFlags</type>    <name>flags</name></member>
-            <member optional="true"><type>size_t</type>                 <name>initialDataSize</name><comment>Size of initial data to populate cache, in bytes</comment></member>
+            <member api="vulkan" optional="true"><type>size_t</type>           <name>initialDataSize</name><comment>Size of initial data to populate cache, in bytes</comment></member>
+            <member api="vulkansc"><type>size_t</type>                         <name>initialDataSize</name><comment>Size of initial data to populate cache, in bytes</comment></member>
             <member len="initialDataSize">const <type>void</type>*            <name>pInitialData</name><comment>Initial data to populate cache</comment></member>
         </type>
         <type category="struct" name="VkPipelineCacheHeaderVersionOne">
@@ -1534,6 +1586,30 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>vendorID</name></member>
             <member><type>uint32_t</type>               <name>deviceID</name></member>
             <member><type>uint8_t</type>                <name>pipelineCacheUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
+        </type>
+        <type category="struct" name="VkPipelineCacheStageValidationIndexEntry">
+            <comment>The fields in this structure are non-normative since structure packing is implementation-defined in C. The specification defines the normative layout.</comment>
+            <member><type>uint64_t</type>               <name>codeSize</name></member>
+            <member><type>uint64_t</type>               <name>codeOffset</name></member>
+        </type>
+        <type category="struct" name="VkPipelineCacheSafetyCriticalIndexEntry">
+            <comment>The fields in this structure are non-normative since structure packing is implementation-defined in C. The specification defines the normative layout.</comment>
+            <member><type>uint8_t</type>                <name>pipelineIdentifier</name>[<enum>VK_UUID_SIZE</enum>]</member>
+            <member><type>uint64_t</type>               <name>pipelineMemorySize</name></member>
+            <member><type>uint64_t</type>               <name>jsonSize</name></member>
+            <member><type>uint64_t</type>               <name>jsonOffset</name></member>
+            <member><type>uint32_t</type>               <name>stageIndexCount</name></member>
+            <member><type>uint32_t</type>               <name>stageIndexStride</name></member>
+            <member><type>uint64_t</type>               <name>stageIndexOffset</name></member>
+        </type>
+        <type category="struct" name="VkPipelineCacheHeaderVersionSafetyCriticalOne">
+            <comment>The fields in this structure are non-normative since structure packing is implementation-defined in C. The specification defines the normative layout.</comment>
+            <member><type>VkPipelineCacheHeaderVersionOne</type>        <name>headerVersionOne</name></member>
+            <member><type>VkPipelineCacheValidationVersion</type>       <name>validationVersion</name></member>
+            <member><type>uint32_t</type>                               <name>implementationData</name></member>
+            <member><type>uint32_t</type>                               <name>pipelineIndexCount</name></member>
+            <member><type>uint32_t</type>                               <name>pipelineIndexStride</name></member>
+            <member><type>uint64_t</type>                               <name>pipelineIndexOffset</name></member>
         </type>
         <type category="struct" name="VkPushConstantRange">
             <member><type>VkShaderStageFlags</type>     <name>stageFlags</name><comment>Which stages use the range</comment></member>
@@ -2083,7 +2159,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkCompositeAlphaFlagBitsKHR</type>      <name>compositeAlpha</name><comment>The alpha blending mode used when compositing this surface with other surfaces in the window system</comment></member>
             <member><type>VkPresentModeKHR</type>                 <name>presentMode</name><comment>Which presentation mode to use for presents on this swap chain</comment></member>
             <member><type>VkBool32</type>                         <name>clipped</name><comment>Specifies whether presentable images may be affected by window clip regions</comment></member>
-            <member optional="true"><type>VkSwapchainKHR</type>   <name>oldSwapchain</name><comment>Existing swap chain to replace, if any</comment></member>
+            <member api="vulkan" optional="true"><type>VkSwapchainKHR</type>                         <name>oldSwapchain</name><comment>Existing swap chain to replace, if any</comment></member>
+            <member api="vulkansc" noautovalidity="true" optional="true"><type>VkSwapchainKHR</type> <name>oldSwapchain</name><comment>Existing swap chain to replace, if any</comment></member>
         </type>
         <type category="struct" name="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -2115,6 +2192,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member len="enabledValidationFeatureCount">const <type>VkValidationFeatureEnableEXT</type>* <name>pEnabledValidationFeatures</name><comment>Validation features to enable</comment></member>
             <member optional="true"><type>uint32_t</type>                         <name>disabledValidationFeatureCount</name><comment>Number of validation features to disable</comment></member>
             <member len="disabledValidationFeatureCount">const <type>VkValidationFeatureDisableEXT</type>* <name>pDisabledValidationFeatures</name><comment>Validation features to disable</comment></member>
+        </type>
+        <type category="struct" name="VkApplicationParametersEXT" allowduplicate="true" structextends="VkApplicationInfo,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_APPLICATION_PARAMETERS_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*        <name>pNext</name></member>
+            <member><type>uint32_t</type>                           <name>vendorID</name></member>
+            <member optional="true"><type>uint32_t</type>           <name>deviceID</name></member>
+            <member><type>uint32_t</type>                           <name>key</name></member>
+            <member><type>uint64_t</type>                           <name>value</name></member>
         </type>
         <type category="struct" name="VkPipelineRasterizationStateRasterizationOrderAMD" structextends="VkPipelineRasterizationStateCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD"><type>VkStructureType</type> <name>sType</name></member>
@@ -2187,6 +2272,35 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>SECURITY_ATTRIBUTES</type>*       <name>pAttributes</name></member>
             <member optional="true"><type>DWORD</type>                            <name>dwAccess</name></member>
         </type>
+        <type category="struct" name="VkExportMemorySciBufInfoNV" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_MEMORY_SCI_BUF_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                 <name>pNext</name></member>
+            <member><type>NvSciBufAttrList</type>                            <name>pAttributes</name></member>
+        </type>
+        <type category="struct" name="VkImportMemorySciBufInfoNV" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_SCI_BUF_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagBits</type>     <name>handleType</name></member>
+            <member><type>NvSciBufObj</type>                            <name>handle</name></member>
+        </type>
+        <type category="struct" name="VkMemoryGetSciBufInfoNV">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_GET_SCI_BUF_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkDeviceMemory</type>                         <name>memory</name></member>
+            <member><type>VkExternalMemoryHandleTypeFlagBits</type>     <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkMemorySciBufPropertiesNV">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_SCI_BUF_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>uint32_t</type>                               <name>memoryTypeBits</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalMemorySciBufFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCI_BUF_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                       <name>pNext</name></member>
+            <member><type>VkBool32</type>                                    <name>sciBufImport</name></member>
+            <member><type>VkBool32</type>                                    <name>sciBufExport</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalSciBufFeaturesNV"  alias="VkPhysicalDeviceExternalMemorySciBufFeaturesNV"/>
         <type category="struct" name="VkWin32KeyedMutexAcquireReleaseInfoNV" structextends="VkSubmitInfo,VkSubmitInfo2">
             <member values="VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
@@ -2698,6 +2812,80 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkFence</type>                                <name>fence</name></member>
             <member><type>VkExternalFenceHandleTypeFlagBits</type>   <name>handleType</name></member>
         </type>
+        <type category="struct" name="VkExportFenceSciSyncInfoNV" structextends="VkFenceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_FENCE_SCI_SYNC_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>NvSciSyncAttrList</type>                      <name>pAttributes</name></member>
+        </type>
+        <type category="struct" name="VkImportFenceSciSyncInfoNV">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_FENCE_SCI_SYNC_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member externsync="true"><type>VkFence</type>              <name>fence</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagBits</type>      <name>handleType</name></member>
+            <member><type>void</type>*                                  <name>handle</name></member>
+        </type>
+        <type category="struct" name="VkFenceGetSciSyncInfoNV">
+            <member values="VK_STRUCTURE_TYPE_FENCE_GET_SCI_SYNC_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkFence</type>                                <name>fence</name></member>
+            <member><type>VkExternalFenceHandleTypeFlagBits</type>      <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkExportSemaphoreSciSyncInfoNV" structextends="VkSemaphoreCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_SCI_SYNC_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>NvSciSyncAttrList</type>                      <name>pAttributes</name></member>
+        </type>
+        <type category="struct" name="VkImportSemaphoreSciSyncInfoNV">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_SCI_SYNC_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member externsync="true"><type>VkSemaphore</type>          <name>semaphore</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagBits</type>  <name>handleType</name></member>
+            <member><type>void</type>*                                  <name>handle</name></member>
+        </type>
+        <type category="struct" name="VkSemaphoreGetSciSyncInfoNV">
+            <member values="VK_STRUCTURE_TYPE_SEMAPHORE_GET_SCI_SYNC_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkSemaphore</type>                            <name>semaphore</name></member>
+            <member><type>VkExternalSemaphoreHandleTypeFlagBits</type>  <name>handleType</name></member>
+        </type>
+        <type category="struct" name="VkSciSyncAttributesInfoNV">
+            <member values="VK_STRUCTURE_TYPE_SCI_SYNC_ATTRIBUTES_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkSciSyncClientTypeNV</type>                  <name>clientType</name></member>
+            <member><type>VkSciSyncPrimitiveTypeNV</type>               <name>primitiveType</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalSciSyncFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SCI_SYNC_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkBool32</type>                               <name>sciSyncFence</name></member>
+            <member><type>VkBool32</type>                               <name>sciSyncSemaphore</name></member>
+            <member><type>VkBool32</type>                               <name>sciSyncImport</name></member>
+            <member><type>VkBool32</type>                               <name>sciSyncExport</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalSciSync2FeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SCI_SYNC_2_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkBool32</type>                               <name>sciSyncFence</name></member>
+            <member><type>VkBool32</type>                               <name>sciSyncSemaphore2</name></member>
+            <member><type>VkBool32</type>                               <name>sciSyncImport</name></member>
+            <member><type>VkBool32</type>                               <name>sciSyncExport</name></member>
+        </type>
+        <type category="struct" name="VkSemaphoreSciSyncPoolCreateInfoNV">
+            <member values="VK_STRUCTURE_TYPE_SEMAPHORE_SCI_SYNC_POOL_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>NvSciSyncObj</type>                           <name>handle</name></member>
+        </type>
+        <type category="struct" name="VkSemaphoreSciSyncCreateInfoNV" structextends="VkSemaphoreCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_SEMAPHORE_SCI_SYNC_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkSemaphoreSciSyncPoolNV</type>               <name>semaphorePool</name></member>
+            <member>const <type>NvSciSyncFence</type>*                  <name>pFence</name></member>
+        </type>
+        <type category="struct" name="VkDeviceSemaphoreSciSyncPoolReservationCreateInfoNV" allowduplicate="true" structextends="VkDeviceObjectReservationCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_SEMAPHORE_SCI_SYNC_POOL_RESERVATION_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>uint32_t</type>                               <name>semaphoreSciSyncPoolRequestCount</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceMultiviewFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
@@ -3179,6 +3367,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkImageUsageFlags</type> <name>usage</name></member>
+        </type>
+        <type category="struct" name="VkImageViewSlicedCreateInfoEXT" structextends="VkImageViewCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>uint32_t</type> <name>sliceOffset</name></member>
+            <member><type>uint32_t</type> <name>sliceCount</name></member>
         </type>
         <type category="struct" name="VkImageViewUsageCreateInfoKHR"                           alias="VkImageViewUsageCreateInfo"/>
         <type category="struct" name="VkPipelineTessellationDomainOriginStateCreateInfo" structextends="VkPipelineTessellationStateCreateInfo">
@@ -4834,6 +5028,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*         <name>pNext</name></member>
             <member><type>uint32_t</type>            <name>counterPassIndex</name><comment>Index for which counter pass to submit</comment></member>
         </type>
+        <type category="struct" name="VkPerformanceQueryReservationInfoKHR" allowduplicate="true" structextends="VkDeviceObjectReservationCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_RESERVATION_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*         <name>pNext</name></member>
+            <member><type>uint32_t</type>            <name>maxPerformanceQueriesPerPool</name><comment>Maximum number of VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR queries in a query pool</comment></member>
+        </type>
         <type category="struct" name="VkHeadlessSurfaceCreateInfoEXT">
             <member values="VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
@@ -5045,12 +5244,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member limittype="bitmask"><type>VkShaderStageFlags</type>         <name>requiredSubgroupSizeStages</name><comment>The shader stages that support specifying a subgroup size</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSubgroupSizeControlPropertiesEXT" alias="VkPhysicalDeviceSubgroupSizeControlProperties"/>
-        <type category="struct" name="VkPipelineShaderStageRequiredSubgroupSizeCreateInfo" returnedonly="true" structextends="VkPipelineShaderStageCreateInfo">
+        <type category="struct" name="VkPipelineShaderStageRequiredSubgroupSizeCreateInfo" returnedonly="true" structextends="VkPipelineShaderStageCreateInfo,VkShaderCreateInfoEXT">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*  <name>pNext</name></member>
             <member><type>uint32_t</type>               <name>requiredSubgroupSize</name></member>
         </type>
         <type category="struct" name="VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT" alias="VkPipelineShaderStageRequiredSubgroupSizeCreateInfo"/>
+        <type category="struct" name="VkShaderRequiredSubgroupSizeCreateInfoEXT" alias="VkPipelineShaderStageRequiredSubgroupSizeCreateInfo"/>
         <type category="struct" name="VkSubpassShadingPipelineCreateInfoHUAWEI" returnedonly="true" structextends="VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_SHADING_PIPELINE_CREATE_INFO_HUAWEI"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
@@ -5061,6 +5261,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member limittype="max,pot"><type>uint32_t</type>               <name>maxSubpassShadingWorkgroupSizeAspectRatio</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_PROPERTIES_HUAWEI"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member limittype="max,pot"><type>uint32_t</type>           <name>maxWorkGroupCount</name>[3]</member>
+            <member limittype="max,pot"><type>uint32_t</type>           <name>maxWorkGroupSize</name>[3]</member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxOutputClusterCount</name></member>
+            <member limittype="exact"><type>VkDeviceSize</type>         <name>indirectBufferOffsetAlignment</name></member>
         </type>
         <type category="struct" name="VkMemoryOpaqueCaptureAddressAllocateInfo" structextends="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -5323,6 +5531,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>deviceCoherentMemory</name></member>
         </type>
+        <type category="struct" name="VkFaultData" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_FAULT_DATA"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true" optional="true"><type>void</type>* <name>pNext</name></member>
+            <member><type>VkFaultLevel</type>                    <name>faultLevel</name></member>
+            <member><type>VkFaultType</type>                     <name>faultType</name></member>
+        </type>
+        <type category="struct" name="VkFaultCallbackInfo" structextends="VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_FAULT_CALLBACK_INFO"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>           <name>faultCount</name></member>
+            <member optional="true" len="faultCount"><type>VkFaultData</type>*<name>pFaults</name></member>
+            <member><type>PFN_vkFaultCallbackFunction</type>        <name>pfnFaultCallback</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceToolProperties" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>* <name>pNext</name></member>
@@ -5500,6 +5721,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>uint32_t</type>                               <name>libraryCount</name></member>
             <member len="libraryCount">const <type>VkPipeline</type>*                   <name>pLibraries</name></member>
         </type>
+        <type category="struct" name="VkRefreshObjectKHR">
+            <member><type>VkObjectType</type>                                       <name>objectType</name></member>
+            <member objecttype="objectType" externsync="true"><type>uint64_t</type> <name>objectHandle</name></member>
+            <member optional="true"><type>VkRefreshObjectFlagsKHR</type>            <name>flags</name></member>
+        </type>
+        <type category="struct" name="VkRefreshObjectListKHR">
+            <member values="VK_STRUCTURE_TYPE_REFRESH_OBJECT_LIST_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
+            <member><type>uint32_t</type>                                           <name>objectCount</name></member>
+            <member len="objectCount">const <type>VkRefreshObjectKHR</type>*        <name>pObjects</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceExtendedDynamicStateFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
@@ -5593,6 +5825,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*                                         <name>pNext</name></member>
             <member optional="true"><type>VkDeviceDiagnosticsConfigFlagsNV</type>    <name>flags</name></member>
         </type>
+        <type category="struct" name="VkPipelineOfflineCreateInfo" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo,VkRayTracingPipelineCreateInfoKHR,VkRayTracingPipelineCreateInfoNV">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_OFFLINE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
+            <member><type>uint8_t</type>                                       <name>pipelineIdentifier</name>[<enum>VK_UUID_SIZE</enum>]</member>
+            <member><type>VkPipelineMatchControl</type>                        <name>matchControl</name></member>
+            <member><type>VkDeviceSize</type>                                  <name>poolEntrySize</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*          <name>pNext</name></member>
@@ -5666,6 +5905,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>subpassShading</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI"><type>VkStructureType</type>  <name>sType</name></member>
+            <member optional="true"><type>void</type>*<name>pNext</name></member>
+            <member><type>VkBool32</type> <name>clustercullingShader</name></member>
+            <member><type>VkBool32</type> <name>multiviewClusterCullingShader</name></member>
+       </type>
         <type category="struct" name="VkBufferCopy2">
             <member values="VK_STRUCTURE_TYPE_BUFFER_COPY_2"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*        <name>pNext</name></member>
@@ -5867,6 +6112,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type>                                        <name>image2DViewOf3D</name></member>
             <member><type>VkBool32</type>                                        <name>sampler2DViewOf3D</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*                     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>imageSlicedViewOf3D</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>attachmentFeedbackLoopDynamicState</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true" noautovalidity="true"><type>void</type>*     <name>pNext</name></member>
@@ -6027,6 +6282,97 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type>                           <name>synchronization2</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSynchronization2FeaturesKHR" alias="VkPhysicalDeviceSynchronization2Features"/>
+        <type category="struct" name="VkPhysicalDeviceVulkanSC10Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_SC_1_0_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*          <name>pNext</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>   <name>deviceNoDynamicHostAllocations</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>   <name>deviceDestroyFreesMemory</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>   <name>commandPoolMultipleCommandBuffersRecording</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>   <name>commandPoolResetCommandBuffer</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>   <name>commandBufferSimultaneousUse</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>   <name>secondaryCommandBufferNullOrImagelessFramebuffer</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>   <name>recycleDescriptorSetMemory</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>   <name>recyclePipelineMemory</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxRenderPassSubpasses</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxRenderPassDependencies</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxSubpassInputAttachments</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxSubpassPreserveAttachments</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxFramebufferAttachments</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxDescriptorSetLayoutBindings</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxQueryFaultCount</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxCallbackFaultCount</name></member>
+            <member limittype="max"><type>uint32_t</type>       <name>maxCommandPoolCommandBuffers</name></member>
+            <member limittype="max"><type>VkDeviceSize</type>   <name>maxCommandBufferSize</name></member>
+        </type>
+        <type category="struct" name="VkPipelinePoolSize">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_POOL_SIZE"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
+            <member><type>VkDeviceSize</type>                   <name>poolEntrySize</name></member>
+            <member><type>uint32_t</type>                       <name>poolEntryCount</name></member>
+        </type>
+        <type category="struct" name="VkDeviceObjectReservationCreateInfo" allowduplicate="true" structextends="VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_OBJECT_RESERVATION_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>pipelineCacheCreateInfoCount</name></member>
+            <member len="pipelineCacheCreateInfoCount">const <type>VkPipelineCacheCreateInfo</type>* <name>pPipelineCacheCreateInfos</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>pipelinePoolSizeCount</name></member>
+            <member len="pipelinePoolSizeCount">const <type>VkPipelinePoolSize</type>* <name>pPipelinePoolSizes</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>semaphoreRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>commandBufferRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>fenceRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>deviceMemoryRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>bufferRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>imageRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>eventRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>queryPoolRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>bufferViewRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>imageViewRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>layeredImageViewRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>pipelineCacheRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>pipelineLayoutRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>renderPassRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>graphicsPipelineRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>computePipelineRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>descriptorSetLayoutRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>samplerRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>descriptorPoolRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>descriptorSetRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>framebufferRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>commandPoolRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>samplerYcbcrConversionRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>surfaceRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>swapchainRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>displayModeRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>subpassDescriptionRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>attachmentDescriptionRequestCount</name></member>
+            <member optional="true"><type>uint32_t</type>       <name>descriptorSetLayoutBindingRequestCount</name></member>
+            <member><type>uint32_t</type>                       <name>descriptorSetLayoutBindingLimit</name></member>
+            <member><type>uint32_t</type>                       <name>maxImageViewMipLevels</name></member>
+            <member><type>uint32_t</type>                       <name>maxImageViewArrayLayers</name></member>
+            <member><type>uint32_t</type>                       <name>maxLayeredImageViewMipLevels</name></member>
+            <member><type>uint32_t</type>                       <name>maxOcclusionQueriesPerPool</name></member>
+            <member><type>uint32_t</type>                       <name>maxPipelineStatisticsQueriesPerPool</name></member>
+            <member><type>uint32_t</type>                       <name>maxTimestampQueriesPerPool</name></member>
+            <member><type>uint32_t</type>                       <name>maxImmutableSamplersPerDescriptorSetLayout</name></member>
+        </type>
+        <type category="struct" name="VkCommandPoolMemoryReservationCreateInfo" structextends="VkCommandPoolCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_COMMAND_POOL_MEMORY_RESERVATION_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
+            <member optional="false"><type>VkDeviceSize</type>  <name>commandPoolReservedSize</name></member>
+            <member optional="false"><type>uint32_t</type>      <name>commandPoolMaxCommandBuffers</name></member>
+        </type>
+        <type category="struct" name="VkCommandPoolMemoryConsumption" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_COMMAND_POOL_MEMORY_CONSUMPTION"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*          <name>pNext</name></member>
+            <member><type>VkDeviceSize</type>                   <name>commandPoolAllocated</name></member>
+            <member><type>VkDeviceSize</type>                   <name>commandPoolReservedSize</name></member>
+            <member><type>VkDeviceSize</type>                   <name>commandBufferAllocated</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceVulkanSC10Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_SC_1_0_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*          <name>pNext</name></member>
+            <member><type>VkBool32</type>                       <name>shaderAtomicInstructions</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
@@ -6282,10 +6628,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkVideoDecodeH265PictureInfoKHR" structextends="VkVideoDecodeInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PICTURE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*        <name>pNext</name></member>
-            <member><type>StdVideoDecodeH265PictureInfo</type>*     <name>pStdPictureInfo</name></member>
-            <member><type>uint32_t</type>                           <name>sliceSegmentCount</name></member>
-            <member len="sliceSegmentCount">const <type>uint32_t</type>*   <name>pSliceSegmentOffsets</name></member>
+            <member optional="true">const <type>void</type>*                <name>pNext</name></member>
+            <member>const <type>StdVideoDecodeH265PictureInfo</type>*       <name>pStdPictureInfo</name></member>
+            <member><type>uint32_t</type>                                   <name>sliceSegmentCount</name></member>
+            <member len="sliceSegmentCount">const <type>uint32_t</type>*    <name>pSliceSegmentOffsets</name></member>
         </type>
         <type category="struct" name="VkVideoDecodeH265DpbSlotInfoKHR" structextends="VkVideoReferenceSlotInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_DPB_SLOT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -6348,28 +6694,33 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkVideoEncodeFlagsKHR</type>  <name>flags</name></member>
             <member><type>uint32_t</type>                               <name>qualityLevel</name></member>
-            <member><type>VkBuffer</type>                               <name>dstBitstreamBuffer</name></member>
-            <member><type>VkDeviceSize</type>                           <name>dstBitstreamBufferOffset</name></member>
-            <member><type>VkDeviceSize</type>                           <name>dstBitstreamBufferMaxRange</name></member>
+            <member><type>VkBuffer</type>                               <name>dstBuffer</name></member>
+            <member><type>VkDeviceSize</type>                           <name>dstBufferOffset</name></member>
+            <member><type>VkDeviceSize</type>                           <name>dstBufferRange</name></member>
             <member><type>VkVideoPictureResourceInfoKHR</type>          <name>srcPictureResource</name></member>
             <member optional="true">const <type>VkVideoReferenceSlotInfoKHR</type>* <name>pSetupReferenceSlot</name></member>
             <member optional="true"><type>uint32_t</type>               <name>referenceSlotCount</name></member>
             <member len="referenceSlotCount">const <type>VkVideoReferenceSlotInfoKHR</type>* <name>pReferenceSlots</name></member>
             <member><type>uint32_t</type>                               <name>precedingExternallyEncodedBytes</name></member>
         </type>
+        <type category="struct" name="VkQueryPoolVideoEncodeFeedbackCreateInfoKHR" structextends="VkQueryPoolCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkVideoEncodeFeedbackFlagsKHR</type>          <name>encodeFeedbackFlags</name></member>
+        </type>
         <type category="struct" name="VkVideoEncodeRateControlInfoKHR" structextends="VkVideoCodingControlInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*              <name>pNext</name></member>
             <member optional="true"><type>VkVideoEncodeRateControlFlagsKHR</type> <name>flags</name></member>
-            <member><type>VkVideoEncodeRateControlModeFlagBitsKHR</type>  <name>rateControlMode</name></member>
-            <member><type>uint8_t</type>                                  <name>layerCount</name></member>
-            <member len="layerCount">const <type>VkVideoEncodeRateControlLayerInfoKHR</type>* <name>pLayerConfigs</name></member>
+            <member optional="true"><type>VkVideoEncodeRateControlModeFlagBitsKHR</type>  <name>rateControlMode</name></member>
+            <member optional="true"><type>uint32_t</type>                                 <name>layerCount</name></member>
+            <member len="layerCount">const <type>VkVideoEncodeRateControlLayerInfoKHR</type>* <name>pLayers</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeRateControlLayerInfoKHR" structextends="VkVideoCodingControlInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*              <name>pNext</name></member>
-            <member><type>uint32_t</type>                                 <name>averageBitrate</name></member>
-            <member><type>uint32_t</type>                                 <name>maxBitrate</name></member>
+            <member optional="true">const <type>void</type>*              <name>pNext</name></member>
+            <member><type>uint64_t</type>                                 <name>averageBitrate</name></member>
+            <member><type>uint64_t</type>                                 <name>maxBitrate</name></member>
             <member><type>uint32_t</type>                                 <name>frameRateNumerator</name></member>
             <member><type>uint32_t</type>                                 <name>frameRateDenominator</name></member>
             <member><type>uint32_t</type>                                 <name>virtualBufferSizeInMs</name></member>
@@ -6380,19 +6731,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*                 <name>pNext</name></member>
             <member noautovalidity="true"><type>VkVideoEncodeCapabilityFlagsKHR</type>       <name>flags</name></member>
             <member><type>VkVideoEncodeRateControlModeFlagsKHR</type>  <name>rateControlModes</name></member>
-            <member><type>uint8_t</type>                               <name>rateControlLayerCount</name></member>
-            <member><type>uint8_t</type>                               <name>qualityLevelCount</name></member>
+            <member><type>uint32_t</type>                              <name>maxRateControlLayers</name></member>
+            <member><type>uint32_t</type>                              <name>maxQualityLevels</name></member>
             <member><type>VkExtent2D</type>                            <name>inputImageDataFillAlignment</name></member>
+            <member><type>VkVideoEncodeFeedbackFlagsKHR</type>         <name>supportedEncodeFeedbackFlags</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH264CapabilitiesEXT" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                 <name>pNext</name></member>
             <member noautovalidity="true"><type>VkVideoEncodeH264CapabilityFlagsEXT</type>   <name>flags</name></member>
-            <member><type>VkVideoEncodeH264InputModeFlagsEXT</type>    <name>inputModeFlags</name></member>
-            <member><type>VkVideoEncodeH264OutputModeFlagsEXT</type>   <name>outputModeFlags</name></member>
-            <member><type>uint8_t</type>                               <name>maxPPictureL0ReferenceCount</name></member>
-            <member><type>uint8_t</type>                               <name>maxBPictureL0ReferenceCount</name></member>
-            <member><type>uint8_t</type>                               <name>maxL1ReferenceCount</name></member>
+            <member><type>uint32_t</type>                              <name>maxPPictureL0ReferenceCount</name></member>
+            <member><type>uint32_t</type>                              <name>maxBPictureL0ReferenceCount</name></member>
+            <member><type>uint32_t</type>                              <name>maxL1ReferenceCount</name></member>
             <member><type>VkBool32</type>                              <name>motionVectorsOverPicBoundariesFlag</name></member>
             <member><type>uint32_t</type>                              <name>maxBytesPerPicDenom</name></member>
             <member><type>uint32_t</type>                              <name>maxBitsPerMbDenom</name></member>
@@ -6404,7 +6754,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264PictureInfo"/>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264ReferenceInfo"/>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264SliceHeaderFlags"/>
-        <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefMemMgmtCtrlOperations"/>
+        <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264ReferenceListsInfo"/>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264PictureInfoFlags"/>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264ReferenceInfoFlags"/>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefMgmtFlags"/>
@@ -6420,41 +6770,23 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkVideoEncodeH264SessionParametersCreateInfoEXT" structextends="VkVideoSessionParametersCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                                                         <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*                                         <name>pNext</name></member>
             <member><type>uint32_t</type>                                                            <name>maxStdSPSCount</name></member>
             <member><type>uint32_t</type>                                                            <name>maxStdPPSCount</name></member>
             <member optional="true">const <type>VkVideoEncodeH264SessionParametersAddInfoEXT</type>* <name>pParametersAddInfo</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264DpbSlotInfoEXT">
+        <type category="struct" name="VkVideoEncodeH264DpbSlotInfoEXT" structextends="VkVideoReferenceSlotInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                                                          <name>pNext</name></member>
-            <member><type>int8_t</type>                                                               <name>slotIndex</name></member>
+            <member optional="true">const <type>void</type>*                                          <name>pNext</name></member>
             <member>const <type>StdVideoEncodeH264ReferenceInfo</type>*                               <name>pStdReferenceInfo</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH264VclFrameInfoEXT" structextends="VkVideoEncodeInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_VCL_FRAME_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                        <name>pNext</name></member>
-            <member optional="true">const <type>VkVideoEncodeH264ReferenceListsInfoEXT</type>*      <name>pReferenceFinalLists</name></member>
+            <member optional="true">const <type>StdVideoEncodeH264ReferenceListsInfo</type>*        <name>pStdReferenceFinalLists</name></member>
             <member><type>uint32_t</type>                                                           <name>naluSliceEntryCount</name></member>
             <member len="naluSliceEntryCount">const <type>VkVideoEncodeH264NaluSliceInfoEXT</type>* <name>pNaluSliceEntries</name></member>
-            <member>const <type>StdVideoEncodeH264PictureInfo</type>*                               <name>pCurrentPictureInfo</name></member>
-        </type>
-        <type category="struct" name="VkVideoEncodeH264ReferenceListsInfoEXT">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_REFERENCE_LISTS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
-            <member optional="true"><type>uint8_t</type>                                                <name>referenceList0EntryCount</name></member>
-            <member len="referenceList0EntryCount">const <type>VkVideoEncodeH264DpbSlotInfoEXT</type>*  <name>pReferenceList0Entries</name></member>
-            <member optional="true"><type>uint8_t</type>                                                <name>referenceList1EntryCount</name></member>
-            <member len="referenceList1EntryCount">const <type>VkVideoEncodeH264DpbSlotInfoEXT</type>*  <name>pReferenceList1Entries</name></member>
-            <member>const <type>StdVideoEncodeH264RefMemMgmtCtrlOperations</type>*                      <name>pMemMgmtCtrlOperations</name></member>
-        </type>
-        <type category="struct" name="VkVideoEncodeH264EmitPictureParametersInfoEXT" structextends="VkVideoEncodeInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_EMIT_PICTURE_PARAMETERS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*             <name>pNext</name></member>
-            <member><type>uint8_t</type>                                 <name>spsId</name></member>
-            <member><type>VkBool32</type>                                <name>emitSpsEnable</name></member>
-            <member><type>uint32_t</type>                                <name>ppsIdEntryCount</name></member>
-            <member len="ppsIdEntryCount">const <type>uint8_t</type>*    <name>ppsIdEntries</name></member>
+            <member>const <type>StdVideoEncodeH264PictureInfo</type>*                               <name>pStdPictureInfo</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH264ProfileInfoEXT" structextends="VkVideoProfileInfoKHR,VkQueryPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -6465,8 +6797,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
             <member><type>uint32_t</type>                                        <name>mbCount</name></member>
-            <member optional="true">const <type>VkVideoEncodeH264ReferenceListsInfoEXT</type>* <name>pReferenceFinalLists</name></member>
-            <member>const <type>StdVideoEncodeH264SliceHeader</type>*            <name>pSliceHeaderStd</name></member>
+            <member optional="true">const <type>StdVideoEncodeH264ReferenceListsInfo</type>* <name>pStdReferenceFinalLists</name></member>
+            <member>const <type>StdVideoEncodeH264SliceHeader</type>*            <name>pStdSliceHeader</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH264RateControlInfoEXT" structextends="VkVideoCodingControlInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -6475,7 +6807,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>                                        <name>idrPeriod</name></member>
             <member><type>uint32_t</type>                                        <name>consecutiveBFrameCount</name></member>
             <member><type>VkVideoEncodeH264RateControlStructureEXT</type>        <name>rateControlStructure</name></member>
-            <member><type>uint8_t</type>                                         <name>temporalLayerCount</name></member>
+            <member><type>uint32_t</type>                                        <name>temporalLayerCount</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH264QpEXT">
             <member noautovalidity="true"><type>int32_t</type> <name>qpI</name></member>
@@ -6490,7 +6822,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkVideoEncodeH264RateControlLayerInfoEXT" structextends="VkVideoCodingControlInfoKHR,VkVideoEncodeRateControlLayerInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
-            <member><type>uint8_t</type>                                         <name>temporalLayerId</name></member>
+            <member><type>uint32_t</type>                                        <name>temporalLayerId</name></member>
             <member><type>VkBool32</type>                                        <name>useInitialRcQp</name></member>
             <member><type>VkVideoEncodeH264QpEXT</type>                          <name>initialRcQp</name></member>
             <member><type>VkBool32</type>                                        <name>useMinQp</name></member>
@@ -6504,32 +6836,30 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                 <name>pNext</name></member>
             <member noautovalidity="true"><type>VkVideoEncodeH265CapabilityFlagsEXT</type>   <name>flags</name></member>
-            <member><type>VkVideoEncodeH265InputModeFlagsEXT</type>    <name>inputModeFlags</name></member>
-            <member><type>VkVideoEncodeH265OutputModeFlagsEXT</type>   <name>outputModeFlags</name></member>
             <member><type>VkVideoEncodeH265CtbSizeFlagsEXT</type>      <name>ctbSizes</name></member>
             <member><type>VkVideoEncodeH265TransformBlockSizeFlagsEXT</type>      <name>transformBlockSizes</name></member>
-            <member><type>uint8_t</type>                               <name>maxPPictureL0ReferenceCount</name></member>
-            <member><type>uint8_t</type>                               <name>maxBPictureL0ReferenceCount</name></member>
-            <member><type>uint8_t</type>                               <name>maxL1ReferenceCount</name></member>
-            <member><type>uint8_t</type>                               <name>maxSubLayersCount</name></member>
-            <member><type>uint8_t</type>                               <name>minLog2MinLumaCodingBlockSizeMinus3</name></member>
-            <member><type>uint8_t</type>                               <name>maxLog2MinLumaCodingBlockSizeMinus3</name></member>
-            <member><type>uint8_t</type>                               <name>minLog2MinLumaTransformBlockSizeMinus2</name></member>
-            <member><type>uint8_t</type>                               <name>maxLog2MinLumaTransformBlockSizeMinus2</name></member>
-            <member><type>uint8_t</type>                               <name>minMaxTransformHierarchyDepthInter</name></member>
-            <member><type>uint8_t</type>                               <name>maxMaxTransformHierarchyDepthInter</name></member>
-            <member><type>uint8_t</type>                               <name>minMaxTransformHierarchyDepthIntra</name></member>
-            <member><type>uint8_t</type>                               <name>maxMaxTransformHierarchyDepthIntra</name></member>
-            <member><type>uint8_t</type>                               <name>maxDiffCuQpDeltaDepth</name></member>
-            <member><type>uint8_t</type>                               <name>minMaxNumMergeCand</name></member>
-            <member><type>uint8_t</type>                               <name>maxMaxNumMergeCand</name></member>
+            <member><type>uint32_t</type>                              <name>maxPPictureL0ReferenceCount</name></member>
+            <member><type>uint32_t</type>                              <name>maxBPictureL0ReferenceCount</name></member>
+            <member><type>uint32_t</type>                              <name>maxL1ReferenceCount</name></member>
+            <member><type>uint32_t</type>                              <name>maxSubLayersCount</name></member>
+            <member><type>uint32_t</type>                              <name>minLog2MinLumaCodingBlockSizeMinus3</name></member>
+            <member><type>uint32_t</type>                              <name>maxLog2MinLumaCodingBlockSizeMinus3</name></member>
+            <member><type>uint32_t</type>                              <name>minLog2MinLumaTransformBlockSizeMinus2</name></member>
+            <member><type>uint32_t</type>                              <name>maxLog2MinLumaTransformBlockSizeMinus2</name></member>
+            <member><type>uint32_t</type>                              <name>minMaxTransformHierarchyDepthInter</name></member>
+            <member><type>uint32_t</type>                              <name>maxMaxTransformHierarchyDepthInter</name></member>
+            <member><type>uint32_t</type>                              <name>minMaxTransformHierarchyDepthIntra</name></member>
+            <member><type>uint32_t</type>                              <name>maxMaxTransformHierarchyDepthIntra</name></member>
+            <member><type>uint32_t</type>                              <name>maxDiffCuQpDeltaDepth</name></member>
+            <member><type>uint32_t</type>                              <name>minMaxNumMergeCand</name></member>
+            <member><type>uint32_t</type>                              <name>maxMaxNumMergeCand</name></member>
         </type>
         <type category="include" name="vk_video/vulkan_video_codec_h265std_encode.h">#include "vk_video/vulkan_video_codec_h265std_encode.h"</type>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265PictureInfoFlags"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265PictureInfo"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265SliceSegmentHeader"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceInfo"/>
-        <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceModifications"/>
+        <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceListsInfo"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265SliceSegmentHeaderFlags"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceInfoFlags"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceModificationFlags"/>
@@ -6554,27 +6884,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkVideoEncodeH265VclFrameInfoEXT" structextends="VkVideoEncodeInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_VCL_FRAME_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                       <name>pNext</name></member>
-            <member optional="true">const <type>VkVideoEncodeH265ReferenceListsInfoEXT</type>*     <name>pReferenceFinalLists</name></member>
+            <member optional="true">const <type>StdVideoEncodeH265ReferenceListsInfo</type>*       <name>pStdReferenceFinalLists</name></member>
             <member><type>uint32_t</type>                                                          <name>naluSliceSegmentEntryCount</name></member>
             <member len="naluSliceSegmentEntryCount">const <type>VkVideoEncodeH265NaluSliceSegmentInfoEXT</type>* <name>pNaluSliceSegmentEntries</name></member>
-            <member>const <type>StdVideoEncodeH265PictureInfo</type>*                              <name>pCurrentPictureInfo</name></member>
-        </type>
-        <type category="struct" name="VkVideoEncodeH265EmitPictureParametersInfoEXT" structextends="VkVideoEncodeInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_EMIT_PICTURE_PARAMETERS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*             <name>pNext</name></member>
-            <member><type>uint8_t</type>                                 <name>vpsId</name></member>
-            <member><type>uint8_t</type>                                 <name>spsId</name></member>
-            <member><type>VkBool32</type>                                <name>emitVpsEnable</name></member>
-            <member><type>VkBool32</type>                                <name>emitSpsEnable</name></member>
-            <member optional="true"><type>uint32_t</type>                <name>ppsIdEntryCount</name></member>
-            <member len="ppsIdEntryCount">const <type>uint8_t</type>*    <name>ppsIdEntries</name></member>
+            <member>const <type>StdVideoEncodeH265PictureInfo</type>*                              <name>pStdPictureInfo</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH265NaluSliceSegmentInfoEXT">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                <name>pNext</name></member>
             <member><type>uint32_t</type>                                                   <name>ctbCount</name></member>
-            <member optional="true">const <type>VkVideoEncodeH265ReferenceListsInfoEXT</type>* <name>pReferenceFinalLists</name></member>
-            <member>const <type>StdVideoEncodeH265SliceSegmentHeader</type>*                <name>pSliceSegmentHeaderStd</name></member>
+            <member optional="true">const <type>StdVideoEncodeH265ReferenceListsInfo</type>* <name>pStdReferenceFinalLists</name></member>
+            <member>const <type>StdVideoEncodeH265SliceSegmentHeader</type>*                <name>pStdSliceSegmentHeader</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH265RateControlInfoEXT" structextends="VkVideoCodingControlInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -6583,7 +6903,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>                                        <name>idrPeriod</name></member>
             <member><type>uint32_t</type>                                        <name>consecutiveBFrameCount</name></member>
             <member><type>VkVideoEncodeH265RateControlStructureEXT</type>        <name>rateControlStructure</name></member>
-            <member><type>uint8_t</type>                                         <name>subLayerCount</name></member>
+            <member><type>uint32_t</type>                                        <name>subLayerCount</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeH265QpEXT">
             <member noautovalidity="true"><type>int32_t</type> <name>qpI</name></member>
@@ -6598,7 +6918,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkVideoEncodeH265RateControlLayerInfoEXT" structextends="VkVideoCodingControlInfoKHR,VkVideoEncodeRateControlLayerInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
-            <member><type>uint8_t</type>                                         <name>temporalId</name></member>
+            <member><type>uint32_t</type>                                        <name>temporalId</name></member>
             <member><type>VkBool32</type>                                        <name>useInitialRcQp</name></member>
             <member><type>VkVideoEncodeH265QpEXT</type>                          <name>initialRcQp</name></member>
             <member><type>VkBool32</type>                                        <name>useMinQp</name></member>
@@ -6613,20 +6933,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*    <name>pNext</name></member>
             <member><type>StdVideoH265ProfileIdc</type>         <name>stdProfileIdc</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265DpbSlotInfoEXT">
+        <type category="struct" name="VkVideoEncodeH265DpbSlotInfoEXT" structextends="VkVideoReferenceSlotInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*              <name>pNext</name></member>
-            <member><type>int8_t</type>                                   <name>slotIndex</name></member>
             <member>const <type>StdVideoEncodeH265ReferenceInfo</type>*   <name>pStdReferenceInfo</name></member>
-        </type>
-        <type category="struct" name="VkVideoEncodeH265ReferenceListsInfoEXT">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_REFERENCE_LISTS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
-            <member optional="true"><type>uint8_t</type>                                                <name>referenceList0EntryCount</name></member>
-            <member len="referenceList0EntryCount">const <type>VkVideoEncodeH265DpbSlotInfoEXT</type>*  <name>pReferenceList0Entries</name></member>
-            <member optional="true"><type>uint8_t</type>                                                <name>referenceList1EntryCount</name></member>
-            <member len="referenceList1EntryCount">const <type>VkVideoEncodeH265DpbSlotInfoEXT</type>*  <name>pReferenceList1Entries</name></member>
-            <member>const <type>StdVideoEncodeH265ReferenceModifications</type>*                        <name>pReferenceModifications</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceInheritedViewportScissorFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
@@ -7114,7 +7424,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*                                                <name>pNext</name></member>
             <member optional="true"><type>VkRenderingFlags</type>                                           <name>flags</name></member>
             <member><type>uint32_t</type>                                                                   <name>viewMask</name></member>
-            <member optional="true"><type>uint32_t</type>                                                   <name>colorAttachmentCount</name></member>
+            <member api="vulkan" optional="true"><type>uint32_t</type>                                      <name>colorAttachmentCount</name></member>
+            <member api="vulkansc"><type>uint32_t</type>                                                    <name>colorAttachmentCount</name></member>
             <member len="colorAttachmentCount">const <type>VkFormat</type>*                                 <name>pColorAttachmentFormats</name></member>
             <member><type>VkFormat</type>                                                                   <name>depthAttachmentFormat</name></member>
             <member><type>VkFormat</type>                                                                   <name>stencilAttachmentFormat</name></member>
@@ -7365,7 +7676,42 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>uint32_t</type>                               <name>usageCountsCount</name></member>
             <member len="usageCountsCount" optional="true">const <type>VkMicromapUsageEXT</type>*  <name>pUsageCounts</name></member>
             <member len="usageCountsCount,1" optional="true,false">const <type>VkMicromapUsageEXT</type>* const* <name>ppUsageCounts</name></member>
-            <member><type>VkMicromapEXT</type>                                          <name>micromap</name></member>
+            <member optional="true"><type>VkMicromapEXT</type>                          <name>micromap</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceDisplacementMicromapFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>displacementMicromap</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceDisplacementMicromapPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
+            <member limittype="max"><type>uint32_t</type>                         <name>maxDisplacementMicromapSubdivisionLevel</name></member>
+        </type>
+        <type category="struct" name="VkAccelerationStructureTrianglesDisplacementMicromapNV" structextends="VkAccelerationStructureGeometryTrianglesDataKHR">
+            <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                                  <name>pNext</name></member>
+
+            <member><type>VkFormat</type>                                               <name>displacementBiasAndScaleFormat</name></member>
+            <member><type>VkFormat</type>                                               <name>displacementVectorFormat</name></member>
+
+            <member noautovalidity="true"><type>VkDeviceOrHostAddressConstKHR</type>    <name>displacementBiasAndScaleBuffer</name></member>
+            <member><type>VkDeviceSize</type>                                           <name>displacementBiasAndScaleStride</name></member>
+            <member noautovalidity="true"><type>VkDeviceOrHostAddressConstKHR</type>    <name>displacementVectorBuffer</name></member>
+            <member><type>VkDeviceSize</type>                                           <name>displacementVectorStride</name></member>
+            <member noautovalidity="true"><type>VkDeviceOrHostAddressConstKHR</type>    <name>displacedMicromapPrimitiveFlags</name></member>
+            <member><type>VkDeviceSize</type>                                           <name>displacedMicromapPrimitiveFlagsStride</name></member>
+            <member><type>VkIndexType</type>                                            <name>indexType</name></member>
+            <member noautovalidity="true"><type>VkDeviceOrHostAddressConstKHR</type>    <name>indexBuffer</name></member>
+            <member><type>VkDeviceSize</type>                                           <name>indexStride</name></member>
+
+            <member><type>uint32_t</type>                                               <name>baseTriangle</name></member>
+
+            <member optional="true"><type>uint32_t</type>                                                          <name>usageCountsCount</name></member>
+            <member len="usageCountsCount" optional="true">const <type>VkMicromapUsageEXT</type>*                  <name>pUsageCounts</name></member>
+            <member len="usageCountsCount,1" optional="true,false">const <type>VkMicromapUsageEXT</type>* const*   <name>ppUsageCounts</name></member>
+
+            <member optional="true"><type>VkMicromapEXT</type>                          <name>micromap</name></member>
         </type>
         <type category="struct" name="VkPipelinePropertiesIdentifierEXT">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_PROPERTIES_IDENTIFIER_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -7644,6 +7990,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>applicationNameOffset</name></member>
             <member><type>uint32_t</type>               <name>applicationVersion</name></member>
             <member><type>uint32_t</type>               <name>engineNameOffset</name></member>
+            <member><type>uint32_t</type>               <name>engineVersion</name></member>
+            <member><type>uint32_t</type>               <name>apiVersion</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*                                                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                                                                                               <name>pipelineLibraryGroupHandles</name></member>
         </type>
         <type category="struct" name="VkDecompressMemoryRegionNV">
             <member><type>VkDeviceAddress</type>   <name>srcAddress</name></member>
@@ -7663,6 +8016,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                 <name>shaderCoreBuiltins</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type>                 <name>dynamicRenderingUnusedAttachments</name></member>
         </type>
         <type category="struct" name="VkSurfacePresentModeEXT" structextends="VkPhysicalDeviceSurfaceInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -7691,19 +8049,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkSwapchainPresentFenceInfoEXT" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*               <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*         <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>swapchainCount</name><comment>Copy of VkPresentInfoKHR::swapchainCount</comment></member>
             <member len="swapchainCount">const <type>VkFence</type>* <name>pFences</name><comment>Fence to signal for each swapchain</comment></member>
         </type>
         <type category="struct" name="VkSwapchainPresentModesCreateInfoEXT" structextends="VkSwapchainCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*               <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*         <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>presentModeCount</name></member><comment>Length of the pPresentModes array</comment>
             <member len="presentModeCount">const <type>VkPresentModeKHR</type>* <name>pPresentModes</name></member><comment>Presentation modes which will be usable with this swapchain</comment>
         </type>
         <type category="struct" name="VkSwapchainPresentModeInfoEXT" structextends="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*               <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*         <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>swapchainCount</name><comment>Copy of VkPresentInfoKHR::swapchainCount</comment></member>
             <member len="swapchainCount">const <type>VkPresentModeKHR</type>* <name>pPresentModes</name><comment>Presentation mode for each swapchain</comment></member>
         </type>
@@ -7749,6 +8107,89 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*            <name>pNext</name></member>
             <member><type>VkBool32</type>                         <name>multiviewPerViewViewports</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>VkBool32</type>                     <name>rayTracingPositionFetch</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderCorePropertiesARM" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                          <name>pNext</name></member>
+            <member limittype="exact"><type>uint32_t</type>         <name>pixelRate</name></member>
+            <member limittype="exact"><type>uint32_t</type>         <name>texelRate</name></member>
+            <member limittype="exact"><type>uint32_t</type>         <name>fmaRate</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>multiviewPerViewRenderAreas</name></member>
+        </type>
+        <type category="struct" name="VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM" structextends="VkRenderPassBeginInfo,VkRenderingInfo">
+            <member values="VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_RENDER_AREAS_RENDER_PASS_BEGIN_INFO_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>         <name>perViewRenderAreaCount</name></member>
+            <member len="perViewRenderAreaCount">const <type>VkRect2D</type>*  <name>pPerViewRenderAreas</name></member>
+        </type>
+        <type category="struct" name="VkQueryLowLatencySupportNV" structextends="VkSemaphoreCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_QUERY_LOW_LATENCY_SUPPORT_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>void</type>*                                       <name>pQueriedLowLatencyData</name></member>
+        </type>
+        <type category="struct" name="VkMemoryMapInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_MAP_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*      <name>pNext</name></member>
+            <member optional="true"><type>VkMemoryMapFlags</type> <name>flags</name></member>
+            <member externsync="true"><type>VkDeviceMemory</type> <name>memory</name></member>
+            <member><type>VkDeviceSize</type>                     <name>offset</name></member>
+            <member><type>VkDeviceSize</type>                     <name>size</name></member>
+        </type>
+        <type category="struct" name="VkMemoryUnmapInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_UNMAP_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkMemoryUnmapFlagsKHR</type>  <name>flags</name></member>
+            <member externsync="true"><type>VkDeviceMemory</type>       <name>memory</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderObjectFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*                                           <name>pNext</name></member>
+            <member><type>VkBool32</type>                                                                              <name>shaderObject</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderObjectPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*                                             <name>pNext</name></member>
+            <member limittype="noauto"><type>uint8_t</type>                                                              <name>shaderBinaryUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
+            <member limittype="noauto"><type>uint32_t</type>                                                             <name>shaderBinaryVersion</name></member>
+        </type>
+        <type category="struct" name="VkShaderCreateInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_SHADER_CREATE_INFO_EXT"><type>VkStructureType</type>       <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                             <name>pNext</name></member>
+            <member optional="true"><type>VkShaderCreateFlagsEXT</type>                                  <name>flags</name></member>
+            <member><type>VkShaderStageFlagBits</type>                                                   <name>stage</name></member>
+            <member optional="true"><type>VkShaderStageFlags</type>                                      <name>nextStage</name></member>
+            <member><type>VkShaderCodeTypeEXT</type>                                                     <name>codeType</name></member>
+            <member><type>size_t</type>                                                                  <name>codeSize</name></member>
+            <member len="codeSize">const <type>void</type>*                                              <name>pCode</name></member>
+            <member optional="true" len="null-terminated">const <type>char</type>*                       <name>pName</name></member>
+            <member optional="true"><type>uint32_t</type>                                                <name>setLayoutCount</name></member>
+            <member optional="true" len="setLayoutCount">const <type>VkDescriptorSetLayout</type>*       <name>pSetLayouts</name></member>
+            <member optional="true"><type>uint32_t</type>                                                <name>pushConstantRangeCount</name></member>
+            <member optional="true" len="pushConstantRangeCount">const <type>VkPushConstantRange</type>* <name>pPushConstantRanges</name></member>
+            <member optional="true">const <type>VkSpecializationInfo</type>*                             <name>pSpecializationInfo</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderTileImageFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true"><type>void</type>*        <name>pNext</name></member>
+          <member><type>VkBool32</type>                     <name>shaderTileImageColorReadAccess</name></member>
+          <member><type>VkBool32</type>                     <name>shaderTileImageDepthReadAccess</name></member>
+          <member><type>VkBool32</type>                     <name>shaderTileImageStencilReadAccess</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderTileImagePropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
+          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true"><type>void</type>*        <name>pNext</name></member>
+          <member limittype="noauto"><type>VkBool32</type>  <name>shaderTileImageCoherentReadAccelerated</name></member>
+          <member limittype="noauto"><type>VkBool32</type>  <name>shaderTileImageReadSampleFromPixelRateInvocation</name></member>
+          <member limittype="noauto"><type>VkBool32</type>  <name>shaderTileImageReadFromHelperInvocation</name></member>
+        </type>
     </types>
 
 
@@ -7766,6 +8207,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum type="float"    value="1000.0F"   name="VK_LOD_CLAMP_NONE"/>
         <enum type="uint32_t" value="(~0U)"     name="VK_REMAINING_MIP_LEVELS"/>
         <enum type="uint32_t" value="(~0U)"     name="VK_REMAINING_ARRAY_LAYERS"/>
+        <enum type="uint32_t" value="(~0U)"     name="VK_REMAINING_3D_SLICES_EXT"/>
         <enum type="uint64_t" value="(~0ULL)"   name="VK_WHOLE_SIZE"/>
         <enum type="uint32_t" value="(~0U)"     name="VK_ATTACHMENT_UNUSED"/>
         <enum type="uint32_t" value="1"         name="VK_TRUE"/>
@@ -8548,7 +8990,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="0"    name="VK_STENCIL_FACE_FRONT_BIT"                         comment="Front face"/>
         <enum bitpos="1"    name="VK_STENCIL_FACE_BACK_BIT"                          comment="Back face"/>
         <enum value="0x00000003" name="VK_STENCIL_FACE_FRONT_AND_BACK"               comment="Front and back faces"/>
-        <enum                    name="VK_STENCIL_FRONT_AND_BACK" alias="VK_STENCIL_FACE_FRONT_AND_BACK" comment="Backwards-compatible alias containing a typo"/>
+        <enum api="vulkan"  name="VK_STENCIL_FRONT_AND_BACK" alias="VK_STENCIL_FACE_FRONT_AND_BACK" deprecated="aliased"/>
     </enums>
     <enums name="VkDescriptorPoolCreateFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT" comment="Descriptor sets may be freed individually"/>
@@ -8573,7 +9015,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkColorSpaceKHR" type="enum">
         <enum value="0"     name="VK_COLOR_SPACE_SRGB_NONLINEAR_KHR"/>
-        <enum               name="VK_COLORSPACE_SRGB_NONLINEAR_KHR" alias="VK_COLOR_SPACE_SRGB_NONLINEAR_KHR" comment="Backwards-compatible alias containing a typo"/>
+        <enum api="vulkan"  name="VK_COLORSPACE_SRGB_NONLINEAR_KHR" alias="VK_COLOR_SPACE_SRGB_NONLINEAR_KHR" deprecated="aliased"/>
     </enums>
     <enums name="VkDisplayPlaneAlphaFlagBitsKHR" type="bitmask">
         <enum bitpos="0"    name="VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR"/>
@@ -8644,7 +9086,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="26"    name="VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT"/>
         <enum value="27"    name="VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT"/>
         <enum value="28"    name="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT"/>
-        <enum               name="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT" comment="Backwards-compatible alias containing a typo"/>
+        <enum               name="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT" deprecated="aliased"/>
         <enum value="29"    name="VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT"/>
         <enum value="30"    name="VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT"/>
             <comment>NVX_device_generated_commands formerly used these enum values, but that extension has been removed
@@ -8652,7 +9094,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 value 32 / name VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT
             </comment>
         <enum value="33"    name="VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT"/>
-        <enum               name="VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT" comment="Backwards-compatible alias containing a typo"/>
+        <enum               name="VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT" deprecated="aliased"/>
     </enums>
     <enums name="VkDeviceMemoryReportEventTypeEXT" type="enum">
         <enum value="0"     name="VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_ALLOCATE_EXT"/>
@@ -8773,7 +9215,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkSurfaceCounterFlagBitsEXT" type="bitmask">
         <enum bitpos="0"    name="VK_SURFACE_COUNTER_VBLANK_BIT_EXT"/>
-        <enum               name="VK_SURFACE_COUNTER_VBLANK_EXT" alias="VK_SURFACE_COUNTER_VBLANK_BIT_EXT" comment="Backwards-compatible alias containing a typo"/>
+        <enum               name="VK_SURFACE_COUNTER_VBLANK_EXT" alias="VK_SURFACE_COUNTER_VBLANK_BIT_EXT" deprecated="aliased"/>
     </enums>
     <enums name="VkDisplayPowerStateEXT" type="enum">
         <enum value="0"     name="VK_DISPLAY_POWER_STATE_OFF_EXT"/>
@@ -8912,7 +9354,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="0x10004" name="VK_VENDOR_ID_CODEPLAY" comment="Codeplay Software Ltd. vendor ID"/>
         <enum value="0x10005" name="VK_VENDOR_ID_MESA"  comment="Mesa vendor ID"/>
         <enum value="0x10006" name="VK_VENDOR_ID_POCL"  comment="PoCL vendor ID"/>
-            <unused start="0x10007" comment="This is the next unused available Khronos vendor ID"/>
+        <enum value="0x10007" name="VK_VENDOR_ID_MOBILEYE"  comment="Mobileye vendor ID"/>
+            <unused start="0x10008" comment="This is the next unused available Khronos vendor ID"/>
     </enums>
     <enums name="VkDriverId" type="enum">
         <comment>Driver IDs are now represented as enums instead of the old
@@ -8942,6 +9385,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="22"      name="VK_DRIVER_ID_MESA_VENUS"                    comment="Mesa open source project"/>
         <enum value="23"      name="VK_DRIVER_ID_MESA_DOZEN"                    comment="Mesa open source project"/>
         <enum value="24"      name="VK_DRIVER_ID_MESA_NVK"                      comment="Mesa open source project"/>
+        <enum value="25"      name="VK_DRIVER_ID_IMAGINATION_OPEN_SOURCE_MESA"  comment="Imagination Technologies"/>
     </enums>
     <enums name="VkConditionalRenderingFlagBitsEXT" type="bitmask">
         <enum bitpos="0"    name="VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT"/>
@@ -9089,9 +9533,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="0"     name="VK_PERFORMANCE_COUNTER_SCOPE_COMMAND_BUFFER_KHR"/>
         <enum value="1"     name="VK_PERFORMANCE_COUNTER_SCOPE_RENDER_PASS_KHR"/>
         <enum value="2"     name="VK_PERFORMANCE_COUNTER_SCOPE_COMMAND_KHR"/>
-        <enum               name="VK_QUERY_SCOPE_COMMAND_BUFFER_KHR" alias="VK_PERFORMANCE_COUNTER_SCOPE_COMMAND_BUFFER_KHR" comment="Backwards-compatible alias containing a typo"/>
-        <enum               name="VK_QUERY_SCOPE_RENDER_PASS_KHR" alias="VK_PERFORMANCE_COUNTER_SCOPE_RENDER_PASS_KHR" comment="Backwards-compatible alias containing a typo"/>
-        <enum               name="VK_QUERY_SCOPE_COMMAND_KHR" alias="VK_PERFORMANCE_COUNTER_SCOPE_COMMAND_KHR" comment="Backwards-compatible alias containing a typo"/>
+        <enum               name="VK_QUERY_SCOPE_COMMAND_BUFFER_KHR" alias="VK_PERFORMANCE_COUNTER_SCOPE_COMMAND_BUFFER_KHR" deprecated="aliased"/>
+        <enum               name="VK_QUERY_SCOPE_RENDER_PASS_KHR" alias="VK_PERFORMANCE_COUNTER_SCOPE_RENDER_PASS_KHR" deprecated="aliased"/>
+        <enum               name="VK_QUERY_SCOPE_COMMAND_KHR" alias="VK_PERFORMANCE_COUNTER_SCOPE_COMMAND_KHR" deprecated="aliased"/>
     </enums>
     <enums name="VkMemoryDecompressionMethodFlagBitsNV" type="bitmask" bitwidth="64">
         <enum bitpos="0" name="VK_MEMORY_DECOMPRESSION_METHOD_GDEFLATE_1_0_BIT_NV"/>
@@ -9119,13 +9563,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkPerformanceCounterDescriptionFlagBitsKHR" type="bitmask">
         <enum bitpos="0"    name="VK_PERFORMANCE_COUNTER_DESCRIPTION_PERFORMANCE_IMPACTING_BIT_KHR"/>
-        <enum               name="VK_PERFORMANCE_COUNTER_DESCRIPTION_PERFORMANCE_IMPACTING_KHR" alias="VK_PERFORMANCE_COUNTER_DESCRIPTION_PERFORMANCE_IMPACTING_BIT_KHR" comment="Backwards-compatible alias containing a typo"/>
+        <enum               name="VK_PERFORMANCE_COUNTER_DESCRIPTION_PERFORMANCE_IMPACTING_KHR" alias="VK_PERFORMANCE_COUNTER_DESCRIPTION_PERFORMANCE_IMPACTING_BIT_KHR" deprecated="aliased"/>
         <enum bitpos="1"    name="VK_PERFORMANCE_COUNTER_DESCRIPTION_CONCURRENTLY_IMPACTED_BIT_KHR"/>
-        <enum               name="VK_PERFORMANCE_COUNTER_DESCRIPTION_CONCURRENTLY_IMPACTED_KHR" alias="VK_PERFORMANCE_COUNTER_DESCRIPTION_CONCURRENTLY_IMPACTED_BIT_KHR" comment="Backwards-compatible alias containing a typo"/>
+        <enum               name="VK_PERFORMANCE_COUNTER_DESCRIPTION_CONCURRENTLY_IMPACTED_KHR" alias="VK_PERFORMANCE_COUNTER_DESCRIPTION_CONCURRENTLY_IMPACTED_BIT_KHR" deprecated="aliased"/>
     </enums>
     <enums name="VkAcquireProfilingLockFlagBitsKHR" type="bitmask">
     </enums>
     <enums name="VkShaderCorePropertiesFlagBitsAMD" type="bitmask">
+    </enums>
+    <enums name="VkRefreshObjectFlagBitsKHR" type="bitmask">
     </enums>
     <enums name="VkPerformanceConfigurationTypeINTEL" type="enum">
         <enum value="0"     name="VK_PERFORMANCE_CONFIGURATION_TYPE_COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED_INTEL"/>
@@ -9169,6 +9615,24 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkPipelineCompilerControlFlagBitsAMD" type="bitmask">
     </enums>
+    <enums name="VkFaultLevel" type="enum">
+        <enum value="0"    name="VK_FAULT_LEVEL_UNASSIGNED"/>
+        <enum value="1"    name="VK_FAULT_LEVEL_CRITICAL"/>
+        <enum value="2"    name="VK_FAULT_LEVEL_RECOVERABLE"/>
+        <enum value="3"    name="VK_FAULT_LEVEL_WARNING"/>
+    </enums>
+    <enums name="VkFaultType" type="enum">
+        <enum value="0"    name="VK_FAULT_TYPE_INVALID"/>
+        <enum value="1"    name="VK_FAULT_TYPE_UNASSIGNED"/>
+        <enum value="2"    name="VK_FAULT_TYPE_IMPLEMENTATION"/>
+        <enum value="3"    name="VK_FAULT_TYPE_SYSTEM"/>
+        <enum value="4"    name="VK_FAULT_TYPE_PHYSICAL_DEVICE"/>
+        <enum value="5"    name="VK_FAULT_TYPE_COMMAND_BUFFER_FULL"/>
+        <enum value="6"    name="VK_FAULT_TYPE_INVALID_API_USAGE"/>
+    </enums>
+    <enums name="VkFaultQueryBehavior" type="enum">
+        <enum value="0"    name="VK_FAULT_QUERY_BEHAVIOR_GET_AND_CLEAR_ALL_FAULTS"/>
+    </enums>
     <enums name="VkToolPurposeFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_TOOL_PURPOSE_VALIDATION_BIT"/>
         <enum               name="VK_TOOL_PURPOSE_VALIDATION_BIT_EXT"          alias="VK_TOOL_PURPOSE_VALIDATION_BIT"/>
@@ -9180,6 +9644,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum               name="VK_TOOL_PURPOSE_ADDITIONAL_FEATURES_BIT_EXT" alias="VK_TOOL_PURPOSE_ADDITIONAL_FEATURES_BIT"/>
         <enum bitpos="4"    name="VK_TOOL_PURPOSE_MODIFYING_FEATURES_BIT"/>
         <enum               name="VK_TOOL_PURPOSE_MODIFYING_FEATURES_BIT_EXT"  alias="VK_TOOL_PURPOSE_MODIFYING_FEATURES_BIT"/>
+    </enums>
+    <enums name="VkPipelineMatchControl" type="enum">
+        <enum value="0"     name="VK_PIPELINE_MATCH_CONTROL_APPLICATION_UUID_EXACT_MATCH"/>
     </enums>
     <enums name="VkFragmentShadingRateCombinerOpKHR" type="enum">
         <enum value="0" name="VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR"/>
@@ -9330,9 +9797,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkPipelineLayoutCreateFlagBits" type="bitmask">
     </enums>
+    <enums name="VkSciSyncClientTypeNV" type="enum">
+        <enum value="0"    name="VK_SCI_SYNC_CLIENT_TYPE_SIGNALER_NV"/>
+        <enum value="1"    name="VK_SCI_SYNC_CLIENT_TYPE_WAITER_NV"/>
+        <enum value="2"    name="VK_SCI_SYNC_CLIENT_TYPE_SIGNALER_WAITER_NV"/>
+    </enums>
+    <enums name="VkSciSyncPrimitiveTypeNV" type="enum">
+        <enum value="0"   name="VK_SCI_SYNC_PRIMITIVE_TYPE_FENCE_NV"/>
+        <enum value="1"   name="VK_SCI_SYNC_PRIMITIVE_TYPE_SEMAPHORE_NV"/>
+    </enums>
     <enums name="VkProvokingVertexModeEXT" type="enum">
         <enum value="0"     name="VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT"/>
         <enum value="1"     name="VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT"/>
+    </enums>
+    <enums name="VkPipelineCacheValidationVersion" type="enum">
+        <enum value="1"     name="VK_PIPELINE_CACHE_VALIDATION_VERSION_SAFETY_CRITICAL_ONE"/>
     </enums>
     <enums name="VkAccelerationStructureMotionInstanceTypeNV" type="enum">
         <enum value="0" name="VK_ACCELERATION_STRUCTURE_MOTION_INSTANCE_TYPE_STATIC_NV"/>
@@ -9436,10 +9915,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
     <enums name="VkVideoEncodeCapabilityFlagBitsKHR" type="bitmask">
         <enum bitpos="0"    name="VK_VIDEO_ENCODE_CAPABILITY_PRECEDING_EXTERNALLY_ENCODED_BYTES_BIT_KHR"/>
     </enums>
+    <enums name="VkVideoEncodeFeedbackFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"    name="VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR"/>
+    </enums>
     <enums name="VkVideoEncodeRateControlModeFlagBitsKHR" type="bitmask">
-        <enum value="0"      name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_NONE_BIT_KHR"/>
-        <enum value="1"      name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_CBR_BIT_KHR"/>
-        <enum value="2"      name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR"/>
+        <enum value="0"     name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DEFAULT_KHR"/>
+        <enum bitpos="0"    name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_CBR_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR"/>
     </enums>
     <enums name="VkVideoEncodeH264CapabilityFlagBitsEXT" type="bitmask">
         <enum bitpos="0"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_DIRECT_8X8_INFERENCE_ENABLED_BIT_EXT"/>
@@ -9452,7 +9936,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="7"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_SECOND_CHROMA_QP_OFFSET_BIT_EXT"/>
         <enum bitpos="8"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_PIC_INIT_QP_MINUS26_BIT_EXT"/>
         <enum bitpos="9"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_PRED_BIT_EXT"/>
-        <enum bitpos="10"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_BIPRED_EXPLICIT_BIT_EXT"/>
+        <enum bitpos="10"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_BIPRED_EXPLICIT_BIT_EXT"/>
         <enum bitpos="11"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_BIPRED_IMPLICIT_BIT_EXT"/>
         <enum bitpos="12"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_PRED_NO_TABLE_BIT_EXT"/>
         <enum bitpos="13"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_TRANSFORM_8X8_BIT_EXT"/>
@@ -9467,16 +9951,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="22"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_ROW_UNALIGNED_SLICE_BIT_EXT"/>
         <enum bitpos="23"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DIFFERENT_SLICE_TYPE_BIT_EXT"/>
         <enum bitpos="24"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_B_FRAME_IN_L1_LIST_BIT_EXT"/>
-    </enums>
-    <enums name="VkVideoEncodeH264InputModeFlagBitsEXT" type="bitmask">
-        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H264_INPUT_MODE_FRAME_BIT_EXT"/>
-        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H264_INPUT_MODE_SLICE_BIT_EXT"/>
-        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H264_INPUT_MODE_NON_VCL_BIT_EXT"/>
-    </enums>
-    <enums name="VkVideoEncodeH264OutputModeFlagBitsEXT" type="bitmask">
-        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H264_OUTPUT_MODE_FRAME_BIT_EXT"/>
-        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H264_OUTPUT_MODE_SLICE_BIT_EXT"/>
-        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H264_OUTPUT_MODE_NON_VCL_BIT_EXT"/>
+        <enum bitpos="25"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DIFFERENT_REFERENCE_FINAL_LISTS_BIT_EXT"/>
     </enums>
     <enums name="VkVideoEncodeH264RateControlStructureEXT" type="enum">
         <enum value="0"       name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_STRUCTURE_UNKNOWN_EXT"/>
@@ -9583,16 +10058,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="23"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_DEPENDENT_SLICE_SEGMENT_BIT_EXT"/>
         <enum bitpos="24"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_DIFFERENT_SLICE_TYPE_BIT_EXT"/>
         <enum bitpos="25"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_B_FRAME_IN_L1_LIST_BIT_EXT"/>
-    </enums>
-    <enums name="VkVideoEncodeH265InputModeFlagBitsEXT" type="bitmask">
-        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H265_INPUT_MODE_FRAME_BIT_EXT"/>
-        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H265_INPUT_MODE_SLICE_SEGMENT_BIT_EXT"/>
-        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H265_INPUT_MODE_NON_VCL_BIT_EXT"/>
-    </enums>
-    <enums name="VkVideoEncodeH265OutputModeFlagBitsEXT" type="bitmask">
-        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H265_OUTPUT_MODE_FRAME_BIT_EXT"/>
-        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H265_OUTPUT_MODE_SLICE_SEGMENT_BIT_EXT"/>
-        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H265_OUTPUT_MODE_NON_VCL_BIT_EXT"/>
+        <enum bitpos="26"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_DIFFERENT_REFERENCE_FINAL_LISTS_BIT_EXT"/>
     </enums>
     <enums name="VkVideoEncodeH265RateControlStructureEXT" type="enum">
         <enum value="0"       name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_STRUCTURE_UNKNOWN_EXT"/>
@@ -9749,6 +10215,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
     <enums name="VkDeviceFaultVendorBinaryHeaderVersionEXT" type="enum">
         <enum value="1"     name="VK_DEVICE_FAULT_VENDOR_BINARY_HEADER_VERSION_ONE_EXT"/>
     </enums>
+    <enums name="VkDisplacementMicromapFormatNV" type="enum">
+        <enum value="1" name="VK_DISPLACEMENT_MICROMAP_FORMAT_64_TRIANGLES_64_BYTES_NV"/>
+        <enum value="2" name="VK_DISPLACEMENT_MICROMAP_FORMAT_256_TRIANGLES_128_BYTES_NV"/>
+        <enum value="3" name="VK_DISPLACEMENT_MICROMAP_FORMAT_1024_TRIANGLES_128_BYTES_NV"/>
+    </enums>
+    <enums name="VkShaderCreateFlagBitsEXT" type="bitmask">
+        <enum bitpos="0" name="VK_SHADER_CREATE_LINK_STAGE_BIT_EXT"/>
+    </enums>
+    <enums name="VkShaderCodeTypeEXT" type="enum">
+        <enum value="0" name="VK_SHADER_CODE_TYPE_BINARY_EXT"/>
+        <enum value="1" name="VK_SHADER_CODE_TYPE_SPIRV_EXT"/>
+    </enums>
+
     <commands comment="Vulkan command definitions">
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_LAYER_NOT_PRESENT,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INCOMPATIBLE_DRIVER">
             <proto><type>VkResult</type> <name>vkCreateInstance</name></proto>
@@ -9817,7 +10296,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="true"><type>VkImageCreateFlags</type> <name>flags</name></param>
             <param><type>VkImageFormatProperties</type>* <name>pImageFormatProperties</name></param>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_FEATURE_NOT_PRESENT,VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_DEVICE_LOST">
+        <command api="vulkan" successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_FEATURE_NOT_PRESENT,VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_DEVICE_LOST">
+            <proto><type>VkResult</type> <name>vkCreateDevice</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkDeviceCreateInfo</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkDevice</type>* <name>pDevice</name></param>
+        </command>
+        <command api="vulkansc" successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_FEATURE_NOT_PRESENT,VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_DEVICE_LOST,VK_ERROR_INVALID_PIPELINE_CACHE_DATA">
             <proto><type>VkResult</type> <name>vkCreateDevice</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
             <param>const <type>VkDeviceCreateInfo</type>* <name>pCreateInfo</name></param>
@@ -9847,7 +10333,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
             <param optional="true" len="pPropertyCount"><type>VkExtensionProperties</type>* <name>pProperties</name></param>
         </command>
-        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+        <command api="vulkan" successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkEnumerateDeviceLayerProperties</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
+            <param optional="true" len="pPropertyCount"><type>VkLayerProperties</type>* <name>pProperties</name></param>
+        </command>
+        <command api="vulkansc" successcodes="VK_SUCCESS">
             <proto><type>VkResult</type> <name>vkEnumerateDeviceLayerProperties</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
             <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
@@ -10158,7 +10650,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="true" externsync="true"><type>VkShaderModule</type> <name>shaderModule</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+        <command api="vulkan" successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreatePipelineCache</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkPipelineCacheCreateInfo</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkPipelineCache</type>* <name>pPipelineCache</name></param>
+        </command>
+        <command api="vulkansc" successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_PIPELINE_CACHE_DATA">
             <proto><type>VkResult</type> <name>vkCreatePipelineCache</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkPipelineCacheCreateInfo</type>* <name>pCreateInfo</name></param>
@@ -10185,7 +10684,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>uint32_t</type> <name>srcCacheCount</name></param>
             <param len="srcCacheCount">const <type>VkPipelineCache</type>* <name>pSrcCaches</name></param>
         </command>
-        <command successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV">
+        <command api="vulkan" successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV">
             <proto><type>VkResult</type> <name>vkCreateGraphicsPipelines</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param optional="true"><type>VkPipelineCache</type> <name>pipelineCache</name></param>
@@ -10194,10 +10693,28 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param len="createInfoCount"><type>VkPipeline</type>* <name>pPipelines</name></param>
         </command>
-        <command successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV">
+        <command api="vulkansc" successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NO_PIPELINE_MATCH,VK_ERROR_OUT_OF_POOL_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateGraphicsPipelines</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkPipelineCache</type> <name>pipelineCache</name></param>
+            <param><type>uint32_t</type> <name>createInfoCount</name></param>
+            <param len="createInfoCount">const <type>VkGraphicsPipelineCreateInfo</type>* <name>pCreateInfos</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param len="createInfoCount"><type>VkPipeline</type>* <name>pPipelines</name></param>
+        </command>
+        <command api="vulkan" successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV">
             <proto><type>VkResult</type> <name>vkCreateComputePipelines</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param optional="true"><type>VkPipelineCache</type> <name>pipelineCache</name></param>
+            <param><type>uint32_t</type> <name>createInfoCount</name></param>
+            <param len="createInfoCount">const <type>VkComputePipelineCreateInfo</type>* <name>pCreateInfos</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param len="createInfoCount"><type>VkPipeline</type>* <name>pPipelines</name></param>
+        </command>
+        <command api="vulkansc" successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NO_PIPELINE_MATCH,VK_ERROR_OUT_OF_POOL_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateComputePipelines</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkPipelineCache</type> <name>pipelineCache</name></param>
             <param><type>uint32_t</type> <name>createInfoCount</name></param>
             <param len="createInfoCount">const <type>VkComputePipelineCreateInfo</type>* <name>pCreateInfos</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
@@ -10369,7 +10886,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <param>the sname:VkCommandPool that pname:commandBuffer was allocated from</param>
             </implicitexternsyncparams>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR">
             <proto><type>VkResult</type> <name>vkEndCommandBuffer</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <implicitexternsyncparams>
@@ -10389,6 +10906,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>VkPipelineBindPoint</type> <name>pipelineBindPoint</name></param>
             <param><type>VkPipeline</type> <name>pipeline</name></param>
+        </command>
+        <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdSetAttachmentFeedbackLoopEnableEXT</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param optional="true"><type>VkImageAspectFlags</type> <name>aspectMask</name></param>
         </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
             <proto><type>void</type> <name>vkCmdSetViewport</name></proto>
@@ -10539,6 +11061,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <command queues="graphics" renderpass="inside" cmdbufferlevel="primary,secondary" tasks="action">
             <proto><type>void</type> <name>vkCmdSubpassShadingHUAWEI</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+        </command>
+        <command queues="graphics" renderpass="inside" cmdbufferlevel="primary,secondary" tasks="action">
+            <proto><type>void</type> <name>vkCmdDrawClusterHUAWEI</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>uint32_t</type> <name>groupCountX</name></param>
+            <param><type>uint32_t</type> <name>groupCountY</name></param>
+            <param><type>uint32_t</type> <name>groupCountZ</name></param>
+        </command>
+        <command queues="graphics" renderpass="inside" cmdbufferlevel="primary,secondary" tasks="action">
+            <proto><type>void</type> <name>vkCmdDrawClusterIndirectHUAWEI</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>VkBuffer</type> <name>buffer</name></param>
+            <param><type>VkDeviceSize</type> <name>offset</name></param>
         </command>
         <command queues="transfer,graphics,compute" renderpass="outside" cmdbufferlevel="primary,secondary" tasks="action">
             <proto><type>void</type> <name>vkCmdCopyBuffer</name></proto>
@@ -10831,7 +11366,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <proto><type>VkResult</type> <name>vkCreateSharedSwapchainsKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>uint32_t</type> <name>swapchainCount</name></param>
-            <param len="swapchainCount" externsync="pCreateInfos[].surface,pCreateInfos[].oldSwapchain">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfos</name></param>
+            <param api="vulkan" len="swapchainCount" externsync="pCreateInfos[].surface,pCreateInfos[].oldSwapchain">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfos</name></param>
+            <param api="vulkansc" len="swapchainCount" externsync="pCreateInfos[].surface">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfos</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param len="swapchainCount"><type>VkSwapchainKHR</type>* <name>pSwapchains</name></param>
         </command>
@@ -10871,7 +11407,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_COMPRESSION_EXHAUSTED_EXT">
             <proto><type>VkResult</type> <name>vkCreateSwapchainKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="pCreateInfo-&gt;surface,pCreateInfo-&gt;oldSwapchain">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfo</name></param>
+            <param api="vulkan" externsync="pCreateInfo-&gt;surface,pCreateInfo-&gt;oldSwapchain">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfo</name></param>
+            <param api="vulkansc" externsync="pCreateInfo-&gt;surface">const <type>VkSwapchainCreateInfoKHR</type>* <name>pCreateInfo</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param><type>VkSwapchainKHR</type>* <name>pSwapchain</name></param>
         </command>
@@ -11220,6 +11757,24 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param>const <type>VkMemoryGetRemoteAddressInfoNV</type>* <name>pMemoryGetRemoteAddressInfo</name></param>
             <param><type>VkRemoteAddressNV</type>* <name>pAddress</name></param>
         </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkGetMemorySciBufNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkMemoryGetSciBufInfoNV</type>* <name>pGetSciBufInfo</name></param>
+            <param><type>NvSciBufObj</type>* <name>pHandle</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_INVALID_EXTERNAL_HANDLE">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceExternalMemorySciBufPropertiesNV</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></param>
+            <param><type>NvSciBufObj</type> <name>handle</name></param>
+            <param><type>VkMemorySciBufPropertiesNV</type>* <name>pMemorySciBufProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceSciBufAttributesNV</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param><type>NvSciBufAttrList</type> <name>pAttributes</name></param>
+        </command>
         <command>
             <proto><type>void</type> <name>vkGetPhysicalDeviceExternalSemaphoreProperties</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
@@ -11288,6 +11843,58 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <proto><type>VkResult</type> <name>vkImportFenceFdKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkImportFenceFdInfoKHR</type>* <name>pImportFenceFdInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_NOT_PERMITTED_EXT">
+            <proto><type>VkResult</type> <name>vkGetFenceSciSyncFenceNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkFenceGetSciSyncInfoNV</type>* <name>pGetSciSyncHandleInfo</name></param>
+            <param><type>void</type>* <name>pHandle</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_NOT_PERMITTED_EXT">
+            <proto><type>VkResult</type> <name>vkGetFenceSciSyncObjNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkFenceGetSciSyncInfoNV</type>* <name>pGetSciSyncHandleInfo</name></param>
+            <param><type>void</type>* <name>pHandle</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_NOT_PERMITTED_EXT">
+            <proto><type>VkResult</type> <name>vkImportFenceSciSyncFenceNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImportFenceSciSyncInfoNV</type>* <name>pImportFenceSciSyncInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_NOT_PERMITTED_EXT">
+            <proto><type>VkResult</type> <name>vkImportFenceSciSyncObjNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImportFenceSciSyncInfoNV</type>* <name>pImportFenceSciSyncInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_NOT_PERMITTED_EXT">
+            <proto><type>VkResult</type> <name>vkGetSemaphoreSciSyncObjNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkSemaphoreGetSciSyncInfoNV</type>* <name>pGetSciSyncInfo</name></param>
+            <param><type>void</type>* <name>pHandle</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_NOT_PERMITTED_EXT,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkImportSemaphoreSciSyncObjNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkImportSemaphoreSciSyncInfoNV</type>* <name>pImportSemaphoreSciSyncInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceSciSyncAttributesNV</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkSciSyncAttributesInfoNV</type>* <name>pSciSyncAttributesInfo</name></param>
+            <param><type>NvSciSyncAttrList</type> <name>pAttributes</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateSemaphoreSciSyncPoolNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkSemaphoreSciSyncPoolCreateInfoNV</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkSemaphoreSciSyncPoolNV</type>* <name>pSemaphorePool</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkDestroySemaphoreSciSyncPoolNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param optional="true" externsync="true"><type>VkSemaphoreSciSyncPoolNV</type> <name>semaphorePool</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
         </command>
         <command successcodes="VK_SUCCESS">
             <proto><type>VkResult</type> <name>vkReleaseDisplayEXT</name></proto>
@@ -11513,6 +12120,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>uint32_t</type> <name>firstDiscardRectangle</name></param>
             <param><type>uint32_t</type> <name>discardRectangleCount</name></param>
             <param len="discardRectangleCount">const <type>VkRect2D</type>* <name>pDiscardRectangles</name></param>
+        </command>
+        <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdSetDiscardRectangleEnableEXT</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>VkBool32</type> <name>discardRectangleEnable</name></param>
+        </command>
+        <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdSetDiscardRectangleModeEXT</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>VkDiscardRectangleModeEXT</type> <name>discardRectangleMode</name></param>
         </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
             <proto><type>void</type> <name>vkCmdSetSampleLocationsEXT</name></proto>
@@ -11949,6 +12566,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param len="exclusiveScissorCount">const <type>VkRect2D</type>* <name>pExclusiveScissors</name></param>
         </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdSetExclusiveScissorEnableNV</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>uint32_t</type> <name>firstExclusiveScissor</name></param>
+            <param><type>uint32_t</type> <name>exclusiveScissorCount</name></param>
+            <param len="exclusiveScissorCount">const <type>VkBool32</type>* <name>pExclusiveScissorEnables</name></param>
+        </command>
+        <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
             <proto><type>void</type> <name>vkCmdBindShadingRateImageNV</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param optional="true"><type>VkImageView</type> <name>imageView</name></param>
@@ -12195,7 +12819,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>size_t</type> <name>dataSize</name></param>
             <param len="dataSize"><type>void</type>* <name>pData</name></param>
         </command>
-        <command successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV">
+        <command api="vulkan" successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV">
             <proto><type>VkResult</type> <name>vkCreateRayTracingPipelinesNV</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param optional="true"><type>VkPipelineCache</type> <name>pipelineCache</name></param>
@@ -12204,11 +12828,30 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param len="createInfoCount"><type>VkPipeline</type>* <name>pPipelines</name></param>
         </command>
-        <command successcodes="VK_SUCCESS,VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS">
+        <command api="vulkansc" successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NO_PIPELINE_MATCH,VK_ERROR_OUT_OF_POOL_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateRayTracingPipelinesNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkPipelineCache</type> <name>pipelineCache</name></param>
+            <param><type>uint32_t</type> <name>createInfoCount</name></param>
+            <param len="createInfoCount">const <type>VkRayTracingPipelineCreateInfoNV</type>* <name>pCreateInfos</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param len="createInfoCount"><type>VkPipeline</type>* <name>pPipelines</name></param>
+        </command>
+        <command api="vulkan" successcodes="VK_SUCCESS,VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS">
             <proto><type>VkResult</type> <name>vkCreateRayTracingPipelinesKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param optional="true"><type>VkDeferredOperationKHR</type> <name>deferredOperation</name></param>
             <param optional="true"><type>VkPipelineCache</type> <name>pipelineCache</name></param>
+            <param><type>uint32_t</type> <name>createInfoCount</name></param>
+            <param len="createInfoCount">const <type>VkRayTracingPipelineCreateInfoKHR</type>* <name>pCreateInfos</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param len="createInfoCount"><type>VkPipeline</type>* <name>pPipelines</name></param>
+        </command>
+        <command api="vulkansc" successcodes="VK_SUCCESS,VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS,VK_ERROR_NO_PIPELINE_MATCH,VK_ERROR_OUT_OF_POOL_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateRayTracingPipelinesKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param optional="true"><type>VkDeferredOperationKHR</type> <name>deferredOperation</name></param>
+            <param><type>VkPipelineCache</type> <name>pipelineCache</name></param>
             <param><type>uint32_t</type> <name>createInfoCount</name></param>
             <param len="createInfoCount">const <type>VkRayTracingPipelineCreateInfoKHR</type>* <name>pCreateInfos</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
@@ -12419,6 +13062,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>lineStippleFactor</name></param>
             <param><type>uint16_t</type> <name>lineStipplePattern</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetFaultData</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkFaultQueryBehavior</type> <name>faultQueryBehavior</name></param>
+            <param><type>VkBool32</type>* <name>pUnrecordedFaults</name></param>
+            <param><type>uint32_t</type>* <name>pFaultCount</name></param>
+            <param optional="true" len="pFaultCount"><type>VkFaultData</type>* <name>pFaults</name></param>
         </command>
         <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY">
             <proto><type>VkResult</type> <name>vkGetPhysicalDeviceToolProperties</name></proto>
@@ -12837,6 +13488,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param>const <type>VkResolveImageInfo2</type>* <name>pResolveImageInfo</name></param>
         </command>
         <command name="vkCmdResolveImage2KHR" alias="vkCmdResolveImage2"/>
+        <command queues="graphics,compute,transfer" renderpass="outside" cmdbufferlevel="primary,secondary" tasks="action">
+            <proto><type>void</type> <name>vkCmdRefreshObjectsKHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkRefreshObjectListKHR</type>* <name>pRefreshObjects</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceRefreshableObjectTypesKHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pRefreshableObjectTypeCount</name></param>
+            <param optional="true" len="pRefreshableObjectTypeCount"><type>VkObjectType</type>* <name>pRefreshableObjectTypes</name></param>
+        </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
             <proto><type>void</type> <name>vkCmdSetFragmentShadingRateKHR</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type>           <name>commandBuffer</name></param>
@@ -12935,6 +13597,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="false,true"><type>uint32_t</type>* <name>pCheckpointDataCount</name></param>
             <param optional="true" len="pCheckpointDataCount"><type>VkCheckpointData2NV</type>* <name>pCheckpointData</name></param>
         </command>
+        <command>
+            <proto><type>void</type> <name>vkGetCommandPoolMemoryConsumption</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkCommandPool</type> <name>commandPool</name></param>
+            <param optional="true" externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>VkCommandPoolMemoryConsumption</type>* <name>pConsumption</name></param>
+        </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR">
             <proto><type>VkResult</type> <name>vkGetPhysicalDeviceVideoCapabilitiesKHR</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
@@ -12948,7 +13617,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="false,true"><type>uint32_t</type>* <name>pVideoFormatPropertyCount</name></param>
             <param optional="true" len="pVideoFormatPropertyCount"><type>VkVideoFormatPropertiesKHR</type>* <name>pVideoFormatProperties</name></param>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR">
             <proto><type>VkResult</type> <name>vkCreateVideoSessionKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkVideoSessionCreateInfoKHR</type>* <name>pCreateInfo</name></param>
@@ -12961,14 +13630,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="true" externsync="true"><type>VkVideoSessionKHR</type> <name>videoSession</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR">
             <proto><type>VkResult</type> <name>vkCreateVideoSessionParametersKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkVideoSessionParametersCreateInfoKHR</type>* <name>pCreateInfo</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param><type>VkVideoSessionParametersKHR</type>* <name>pVideoSessionParameters</name></param>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR">
             <proto><type>VkResult</type> <name>vkUpdateVideoSessionParametersKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkVideoSessionParametersKHR</type> <name>videoSessionParameters</name></param>
@@ -13396,9 +14065,48 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkReleaseSwapchainImagesInfoEXT</type>* <name>pReleaseInfo</name></param>
         </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED">
+            <proto><type>VkResult</type> <name>vkMapMemory2KHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkMemoryMapInfoKHR</type>* <name>pMemoryMapInfo</name></param>
+            <param optional="false,true"><type>void</type>** <name>ppData</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS">
+            <proto><type>VkResult</type> <name>vkUnmapMemory2KHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkMemoryUnmapInfoKHR</type>* <name>pMemoryUnmapInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT">
+            <proto><type>VkResult</type> <name>vkCreateShadersEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>uint32_t</type> <name>createInfoCount</name></param>
+            <param len="createInfoCount">const <type>VkShaderCreateInfoEXT</type>* <name>pCreateInfos</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param len="createInfoCount"><type>VkShaderEXT</type>* <name>pShaders</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkDestroyShaderEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkShaderEXT</type> <name>shader</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetShaderBinaryDataEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkShaderEXT</type> <name>shader</name></param>
+            <param optional="false,true"><type>size_t</type>* <name>pDataSize</name></param>
+            <param optional="true" len="pDataSize"><type>void</type>* <name>pData</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdBindShadersEXT</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>uint32_t</type> <name>stageCount</name></param>
+            <param len="stageCount">const <type>VkShaderStageFlagBits</type>* <name>pStages</name></param>
+            <param optional="true,true" len="stageCount">const <type>VkShaderEXT</type>* <name>pShaders</name></param>
+        </command>
     </commands>
 
-    <feature api="vulkan" name="VK_VERSION_1_0" number="1.0" comment="Vulkan core API interface definitions">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_0" number="1.0" comment="Vulkan core API interface definitions">
         <require comment="Header boilerplate">
             <type name="vk_platform"/>
             <type name="VK_DEFINE_HANDLE"/>
@@ -13912,7 +14620,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <command name="vkCmdExecuteCommands"/>
         </require>
     </feature>
-    <feature api="vulkan" name="VK_VERSION_1_1" number="1.1" comment="Vulkan 1.1 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_1" number="1.1" comment="Vulkan 1.1 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_1"/>
         </require>
@@ -14066,7 +14774,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </require>
         <require comment="Promoted from VK_KHR_variable_pointers">
             <enum extends="VkStructureType" extnumber="121" offset="0"          name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES"/>
-            <enum extends="VkStructureType"                                     name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES"/>
+            <enum api="vulkan" extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES"/>
             <type name="VkPhysicalDeviceVariablePointerFeatures"/>
             <type name="VkPhysicalDeviceVariablePointersFeatures"/>
         </require>
@@ -14239,12 +14947,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </require>
         <require comment="Promoted from VK_KHR_shader_draw_parameters, with a feature support query added">
             <enum extends="VkStructureType" extnumber="64"  offset="0"          name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES"/>
-            <enum extends="VkStructureType"                                     name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES"/>
+            <enum api="vulkan" extends="VkStructureType"                                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES"/>
             <type name="VkPhysicalDeviceShaderDrawParameterFeatures"/>
             <type name="VkPhysicalDeviceShaderDrawParametersFeatures"/>
         </require>
     </feature>
-    <feature api="vulkan" name="VK_VERSION_1_2" number="1.2" comment="Vulkan 1.2 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_2" number="1.2" comment="Vulkan 1.2 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_2"/>
         </require>
@@ -14439,7 +15147,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <command name="vkGetDeviceMemoryOpaqueCaptureAddress"/>
         </require>
     </feature>
-    <feature api="vulkan" name="VK_VERSION_1_3" number="1.3" comment="Vulkan 1.3 core API interface definitions.">
+    <feature api="vulkan,vulkansc" name="VK_VERSION_1_3" number="1.3" comment="Vulkan 1.3 core API interface definitions.">
         <require>
             <type name="VK_API_VERSION_1_3"/>
         </require>
@@ -14704,8 +15412,144 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </require>
     </feature>
 
+    <feature api="vulkansc" name="VKSC_VERSION_1_0" number="1.0" comment="Vulkan SC core API interface definitions">
+        <require>
+            <type name="VKSC_API_VARIANT"/>
+            <type name="VKSC_API_VERSION_1_0"/>
+            <type name="VkPhysicalDeviceVulkanSC10Features"/>
+            <type name="VkPhysicalDeviceVulkanSC10Properties"/>
+            <enum offset="0" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_SC_1_0_FEATURES"/>
+            <enum offset="1" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_SC_1_0_PROPERTIES"/>
+            <enum offset="1" extnumber="12" extends="VkResult" dir="-"  name="VK_ERROR_VALIDATION_FAILED"/>
+        </require>
+        <require comment="static memory functionality">
+            <type name="VkDeviceObjectReservationCreateInfo"/>
+            <type name="VkCommandPoolMemoryReservationCreateInfo"/>
+            <type name="VkCommandPoolMemoryConsumption"/>
+            <type name="VkPipelinePoolSize"/>
+            <command name="vkGetCommandPoolMemoryConsumption"/>
+            <enum offset="2" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_DEVICE_OBJECT_RESERVATION_CREATE_INFO"/>
+            <enum offset="3" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_COMMAND_POOL_MEMORY_RESERVATION_CREATE_INFO"/>
+            <enum offset="4" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_COMMAND_POOL_MEMORY_CONSUMPTION"/>
+            <enum offset="5" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_PIPELINE_POOL_SIZE"/>
+        </require>
+        <require comment="fault handling functionality">
+            <enum offset="7" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_FAULT_DATA"/>
+            <enum offset="8" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_FAULT_CALLBACK_INFO"/>
+            <type name="VkFaultData"/>
+            <type name="VkFaultCallbackInfo"/>
+            <type name="VkFaultLevel"/>
+            <type name="VkFaultType"/>
+            <type name="VkFaultQueryBehavior"/>
+            <type name="PFN_vkFaultCallbackFunction"/>
+            <command name="vkGetFaultData"/>
+        </require>
+        <require comment="pipeline offline create info">
+            <enum offset="10" extnumber="299" extends="VkStructureType"  name="VK_STRUCTURE_TYPE_PIPELINE_OFFLINE_CREATE_INFO"/>
+            <type name="VkPipelineOfflineCreateInfo"/>
+            <type name="VkPipelineMatchControl"/>
+        </require>
+        <require comment="pipeline cache functionality">
+            <enum offset="0" extnumber="299" extends="VkResult" dir="-" name="VK_ERROR_INVALID_PIPELINE_CACHE_DATA"/>
+            <enum offset="1" extnumber="299" extends="VkResult" dir="-" name="VK_ERROR_NO_PIPELINE_MATCH"/>
+            <enum bitpos="1" extends="VkPipelineCacheCreateFlagBits"    name="VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT"/>
+            <enum bitpos="2" extends="VkPipelineCacheCreateFlagBits"    name="VK_PIPELINE_CACHE_CREATE_USE_APPLICATION_STORAGE_BIT"/>
+            <type name="VkPipelineCacheCreateFlagBits" comment="This should be picked up from the extends= attributes above"/>
+        </require>
+        <require comment="seu safe memory functionality">
+            <enum bitpos="2" extends="VkMemoryHeapFlagBits"             name="VK_MEMORY_HEAP_SEU_SAFE_BIT"/>
+        </require>
+        <require comment="pipeline cache header - These types are part of the API, though not all directly used in API commands or data structures">
+            <enum offset="1" extnumber="299" extends="VkPipelineCacheHeaderVersion"    name="VK_PIPELINE_CACHE_HEADER_VERSION_SAFETY_CRITICAL_ONE"/>
+            <type name="VkPipelineCacheValidationVersion"/>
+            <type name="VkPipelineCacheStageValidationIndexEntry"/>
+            <type name="VkPipelineCacheSafetyCriticalIndexEntry"/>
+            <type name="VkPipelineCacheHeaderVersionSafetyCriticalOne"/>
+        </require>
+
+        <remove comment="SC 1.0 removes some features from Vulkan 1.0/1.1/1.2">
+            <enum name="VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO"/>
+            <!--enum name="VK_OBJECT_TYPE_SHADER_MODULE" comment="leave this present for compatibility"/-->
+            <enum name="VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT"/>
+            <enum name="VK_PIPELINE_CREATE_DERIVATIVE_BIT"/>
+            <enum name="VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT"/>
+
+            <!-- Remove Vulkan and deprecated macros -->
+            <type name="VK_API_VERSION"/>
+            <type name="VK_MAKE_VERSION"/>
+            <type name="VK_VERSION_MAJOR"/>
+            <type name="VK_VERSION_MINOR"/>
+            <type name="VK_VERSION_PATCH"/>
+
+            <!--type name="VkShaderModule" comment="leave this present for compatibility"/-->
+            <type name="VkShaderModuleCreateFlags"/>
+            <type name="VkShaderModuleCreateFlagBits"/>
+            <type name="VkShaderModuleCreateInfo"/>
+            <type name="VkCommandPoolTrimFlags"/>
+            <type name="VkCommandPoolTrimFlagsKHR"/>
+            <command name="vkCreateShaderModule"/>
+            <command name="vkDestroyShaderModule"/>
+            <command name="vkMergePipelineCaches"/>
+            <command name="vkGetPipelineCacheData"/>
+            <command name="vkTrimCommandPool"/>
+            <command name="vkTrimCommandPoolKHR"/>
+            <command name="vkDestroyCommandPool"/>
+            <command name="vkDestroyDescriptorPool"/>
+            <command name="vkDestroyQueryPool"/>
+            <command name="vkDestroySwapchainKHR"/>
+            <command name="vkFreeMemory"/>
+
+            <!-- Descriptor update templates are unsupported -->
+            <enum name="VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO"/>
+            <enum name="VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE"/>
+            <command name="vkCreateDescriptorUpdateTemplate"/>
+            <command name="vkDestroyDescriptorUpdateTemplate"/>
+            <command name="vkUpdateDescriptorSetWithTemplate"/>
+            <type name="VkDescriptorUpdateTemplate"/>
+            <type name="VkDescriptorUpdateTemplateCreateFlags"/>
+            <type name="VkDescriptorUpdateTemplateType"/>
+            <type name="VkDescriptorUpdateTemplateEntry"/>
+            <type name="VkDescriptorUpdateTemplateCreateInfo"/>
+            <enum name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET"/>
+
+            <!-- Sparse resources are unsupported -->
+            <enum name="VK_QUEUE_SPARSE_BINDING_BIT"/>
+            <!--type name="VkPhysicalDeviceSparseProperties" comment="needed for VkPhysicalDeviceProperties"/-->
+            <type name="VkSparseImageFormatProperties"/>
+            <type name="VkSparseImageFormatFlagBits"/>
+            <type name="VkSparseImageFormatFlags"/>
+            <command name="vkGetPhysicalDeviceSparseImageFormatProperties"/>
+            <command name="vkGetPhysicalDeviceSparseImageFormatProperties2"/>
+            <type name="VkPhysicalDeviceSparseImageFormatInfo2"/>
+            <enum name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2"/>
+            <type name="VkSparseImageFormatProperties2"/>
+            <enum name="VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2"/>
+            <type name="VkSparseImageMemoryRequirements"/>
+            <command name="vkGetImageSparseMemoryRequirements"/>
+            <command name="vkGetImageSparseMemoryRequirements2"/>
+            <type name="VkImageSparseMemoryRequirementsInfo2"/>
+            <enum name="VK_STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2"/>
+            <type name="VkSparseImageMemoryRequirements2"/>
+            <enum name="VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2"/>
+            <type name="VkSparseMemoryBind"/>
+            <type name="VkSparseMemoryBindFlagBits"/>
+            <type name="VkSparseMemoryBindFlags"/>
+            <type name="VkSparseBufferMemoryBindInfo"/>
+            <type name="VkSparseImageOpaqueMemoryBindInfo"/>
+            <type name="VkSparseImageMemoryBindInfo"/>
+            <type name="VkSparseImageMemoryBind"/>
+            <command name="vkQueueBindSparse"/>
+            <type name="VkBindSparseInfo"/>
+            <enum name="VK_STRUCTURE_TYPE_BIND_SPARSE_INFO"/>
+            <type name="VkDeviceGroupBindSparseInfo"/>
+            <enum name="VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO"/>
+
+            <command name="vkDestroySemaphoreSciSyncPoolNV"/>
+        </remove>
+    </feature>
+
     <extensions comment="Vulkan extension interface definitions">
-        <extension name="VK_KHR_surface" number="1" type="instance" author="KHR" contact="James Jones @cubanismo,Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_KHR_surface" number="1" type="instance" author="KHR" contact="James Jones @cubanismo,Ian Elliott @ianelliottus" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="25"                                                name="VK_KHR_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_surface&quot;"                        name="VK_KHR_SURFACE_EXTENSION_NAME"/>
@@ -14727,7 +15571,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceSurfacePresentModesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_swapchain" number="2" type="device" requires="VK_KHR_surface" author="KHR" contact="James Jones @cubanismo,Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_KHR_swapchain" number="2" type="device" depends="VK_KHR_surface" author="KHR" contact="James Jones @cubanismo,Ian Elliott @ianelliottus" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="70"                                                name="VK_KHR_SWAPCHAIN_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_swapchain&quot;"                      name="VK_KHR_SWAPCHAIN_EXTENSION_NAME"/>
@@ -14748,7 +15592,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkAcquireNextImageKHR"/>
                 <command name="vkQueuePresentKHR"/>
             </require>
-            <require feature="VK_VERSION_1_1">
+            <require depends="VK_VERSION_1_1">
                 <comment>This duplicates definitions in VK_KHR_device_group below</comment>
                 <enum extends="VkStructureType" extnumber="61"  offset="7"      name="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR"/>
                 <enum extends="VkStructureType" extnumber="61"  offset="8"      name="VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR"/>
@@ -14772,7 +15616,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="1" extends="VkSwapchainCreateFlagBitsKHR"         name="VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR"     comment="Swapchain is protected"/>
             </require>
         </extension>
-        <extension name="VK_KHR_display" number="3" type="instance" requires="VK_KHR_surface" author="KHR" contact="James Jones @cubanismo,Norbert Nopper @FslNopper" supported="vulkan">
+        <extension name="VK_KHR_display" number="3" type="instance" depends="VK_KHR_surface" author="KHR" contact="James Jones @cubanismo,Norbert Nopper @FslNopper" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="23"                                                name="VK_KHR_DISPLAY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_display&quot;"                        name="VK_KHR_DISPLAY_EXTENSION_NAME"/>
@@ -14803,7 +15647,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateDisplayPlaneSurfaceKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_display_swapchain" number="4" type="device" requires="VK_KHR_swapchain,VK_KHR_display" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_KHR_display_swapchain" number="4" type="device" depends="VK_KHR_swapchain+VK_KHR_display" author="KHR" contact="James Jones @cubanismo" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="10"                                                name="VK_KHR_DISPLAY_SWAPCHAIN_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_display_swapchain&quot;"              name="VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME"/>
@@ -14813,7 +15657,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateSharedSwapchainsKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_xlib_surface" number="5" type="instance" requires="VK_KHR_surface" platform="xlib" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_KHR_xlib_surface" number="5" type="instance" depends="VK_KHR_surface" platform="xlib" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="6"                                                 name="VK_KHR_XLIB_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_xlib_surface&quot;"                   name="VK_KHR_XLIB_SURFACE_EXTENSION_NAME"/>
@@ -14824,7 +15668,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceXlibPresentationSupportKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_xcb_surface" number="6" type="instance" requires="VK_KHR_surface" platform="xcb" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_KHR_xcb_surface" number="6" type="instance" depends="VK_KHR_surface" platform="xcb" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="6"                                                 name="VK_KHR_XCB_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_xcb_surface&quot;"                    name="VK_KHR_XCB_SURFACE_EXTENSION_NAME"/>
@@ -14835,7 +15679,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceXcbPresentationSupportKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_wayland_surface" number="7" type="instance" requires="VK_KHR_surface" platform="wayland" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_KHR_wayland_surface" number="7" type="instance" depends="VK_KHR_surface" platform="wayland" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="6"                                                 name="VK_KHR_WAYLAND_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_wayland_surface&quot;"                name="VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME"/>
@@ -14846,13 +15690,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceWaylandPresentationSupportKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_mir_surface" number="8" type="instance" requires="VK_KHR_surface" author="KHR" supported="disabled" comment="Extension permanently disabled. Extension number should not be reused">
+        <extension name="VK_KHR_mir_surface" number="8" type="instance" depends="VK_KHR_surface" author="KHR" supported="disabled" comment="Extension permanently disabled. Extension number should not be reused" ratified="vulkan">
             <require>
                 <enum value="4"                                                 name="VK_KHR_MIR_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_mir_surface&quot;"                    name="VK_KHR_MIR_SURFACE_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_android_surface" number="9" type="instance" requires="VK_KHR_surface" platform="android" author="KHR" contact="Jesse Hall @critsec" supported="vulkan">
+        <extension name="VK_KHR_android_surface" number="9" type="instance" depends="VK_KHR_surface" platform="android" author="KHR" contact="Jesse Hall @critsec" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="6"                                                 name="VK_KHR_ANDROID_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_android_surface&quot;"                name="VK_KHR_ANDROID_SURFACE_EXTENSION_NAME"/>
@@ -14863,7 +15707,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateAndroidSurfaceKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_win32_surface" number="10" type="instance" requires="VK_KHR_surface" platform="win32" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_KHR_win32_surface" number="10" type="instance" depends="VK_KHR_surface" platform="win32" author="KHR" contact="Jesse Hall @critsec,Ian Elliott @ianelliottus" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="6"                                                 name="VK_KHR_WIN32_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_win32_surface&quot;"                  name="VK_KHR_WIN32_SURFACE_EXTENSION_NAME"/>
@@ -14901,8 +15745,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="10"                                                name="VK_EXT_DEBUG_REPORT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_debug_report&quot;"                   name="VK_EXT_DEBUG_REPORT_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT"/>
-                <enum alias="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT" extends="VkStructureType" name="VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT" comment="Backwards-compatible alias containing a typo"/>
-                <enum offset="1" extends="VkResult" dir="-"                     name="VK_ERROR_VALIDATION_FAILED_EXT"/>
+                <enum alias="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT" extends="VkStructureType" name="VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT" deprecated="aliased"/>
+                <enum api="vulkan" offset="1" extends="VkResult" dir="-"        name="VK_ERROR_VALIDATION_FAILED_EXT"/>
+                <enum api="vulkansc" extends="VkResult"                         name="VK_ERROR_VALIDATION_FAILED_EXT" alias="VK_ERROR_VALIDATION_FAILED"/>
                 <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT"/>
                 <type name="VkDebugReportCallbackEXT"/>
                 <type name="PFN_vkDebugReportCallbackEXT"/>
@@ -14914,7 +15759,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkDestroyDebugReportCallbackEXT"/>
                 <command name="vkDebugReportMessageEXT"/>
             </require>
-            <require feature="VK_VERSION_1_1">
+            <require depends="VK_VERSION_1_1">
                 <comment>This duplicates definitions in other extensions, below</comment>
                 <enum extends="VkDebugReportObjectTypeEXT" extnumber="157" offset="0"  name="VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT"/>
                 <enum extends="VkDebugReportObjectTypeEXT" extnumber="86"  offset="0"  name="VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT"/>
@@ -14927,18 +15772,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0" extends="VkResult" dir="-"                     name="VK_ERROR_INVALID_SHADER_NV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_depth_range_unrestricted" type="device" number="14" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_depth_range_unrestricted" type="device" number="14" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                                 name="VK_EXT_DEPTH_RANGE_UNRESTRICTED_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_depth_range_unrestricted&quot;"       name="VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_sampler_mirror_clamp_to_edge" type="device" number="15" author="KHR" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_sampler_mirror_clamp_to_edge" type="device" number="15" author="KHR" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="3"                                                 name="VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_sampler_mirror_clamp_to_edge&quot;"   name="VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME"/>
                 <enum value="4" extends="VkSamplerAddressMode"                  name="VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE" comment="Note that this defines what was previously a core enum, and so uses the 'value' attribute rather than 'offset', and does not have a suffix. This is a special case, and should not be repeated"/>
-                <enum           extends="VkSamplerAddressMode"                  name="VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE_KHR" alias="VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE" comment="Alias introduced for consistency with extension suffixing rules"/>
+                <enum           extends="VkSamplerAddressMode"                  name="VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE_KHR" alias="VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE"  deprecated="aliased" comment="Introduced for consistency with extension suffixing rules"/>
             </require>
         </extension>
         <extension name="VK_IMG_filter_cubic" number="16" type="device" author="IMG" contact="Tobias Hector @tobski" supported="vulkan">
@@ -14988,7 +15833,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_shader_explicit_vertex_parameter&quot;" name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_debug_marker" number="23" type="device" requires="VK_EXT_debug_report" author="Baldur Karlsson" contact="Baldur Karlsson @baldurk" specialuse="debugging" supported="vulkan" promotedto="VK_EXT_debug_utils">
+        <extension name="VK_EXT_debug_marker" number="23" type="device" depends="VK_EXT_debug_report" author="Baldur Karlsson" contact="Baldur Karlsson @baldurk" specialuse="debugging" supported="vulkan" promotedto="VK_EXT_debug_utils">
             <require>
                 <enum value="4"                                                 name="VK_EXT_DEBUG_MARKER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_debug_marker&quot;"                   name="VK_EXT_DEBUG_MARKER_EXTENSION_NAME"/>
@@ -15006,7 +15851,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdDebugMarkerInsertEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_video_queue" number="24" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_synchronization2" author="KHR" contact="Tony Zlatinski @tzlatinski" supported="vulkan" requiresCore="1.1">
+        <extension name="VK_KHR_video_queue" number="24" type="device" depends="VK_VERSION_1_1+VK_KHR_synchronization2" author="KHR" contact="Tony Zlatinski @tzlatinski" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="8"                                         name="VK_KHR_VIDEO_QUEUE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_queue&quot;"            name="VK_KHR_VIDEO_QUEUE_EXTENSION_NAME"/>
@@ -15095,7 +15940,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdControlVideoCodingKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_video_decode_queue" number="25" type="device" requires="VK_KHR_video_queue,VK_KHR_synchronization2" author="KHR" contact="jake.beju@amd.com" supported="vulkan">
+        <extension name="VK_KHR_video_decode_queue" number="25" type="device" depends="VK_KHR_video_queue+VK_KHR_synchronization2" author="KHR" contact="jake.beju@amd.com" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="7"                                         name="VK_KHR_VIDEO_DECODE_QUEUE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_decode_queue&quot;"     name="VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME"/>
@@ -15131,7 +15976,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoDecodeInfoKHR"/>
                 <command name="vkCmdDecodeVideoKHR"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <enum bitpos="25" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR"/>
                 <enum bitpos="26" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR"/>
             </require>
@@ -15160,7 +16005,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_28&quot;"                   name="VK_EXT_EXTENSION_28_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_transform_feedback" number="29" type="device" author="NV" contact="Piers Daniell @pdaniell-nv" specialuse="glemulation,d3demulation,devtools" supported="vulkan" requires="VK_KHR_get_physical_device_properties2">
+        <extension name="VK_EXT_transform_feedback" number="29" type="device" author="NV" contact="Piers Daniell @pdaniell-nv" specialuse="glemulation,d3demulation,devtools" supported="vulkan" depends="VK_KHR_get_physical_device_properties2">
             <require>
                 <enum value="1"                                                 name="VK_EXT_TRANSFORM_FEEDBACK_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_transform_feedback&quot;"             name="VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME"/>
@@ -15272,9 +16117,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_shader_ballot&quot;"                  name="VK_AMD_SHADER_BALLOT_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_video_encode_h264" number="39" type="device" requires="VK_KHR_video_encode_queue" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan">
+        <extension name="VK_EXT_video_encode_h264" number="39" type="device" depends="VK_KHR_video_encode_queue" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan">
             <require>
-                <enum value="9"                                                 name="VK_EXT_VIDEO_ENCODE_H264_SPEC_VERSION"/>
+                <enum value="10"                                                name="VK_EXT_VIDEO_ENCODE_H264_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_video_encode_h264&quot;"              name="VK_EXT_VIDEO_ENCODE_H264_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="1" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
@@ -15282,25 +16127,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="3" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_VCL_FRAME_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="4" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="5" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="6" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_EMIT_PICTURE_PARAMETERS_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="7" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="8" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="9" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="10" extends="VkStructureType"                     name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_REFERENCE_LISTS_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum bitpos="16" extends="VkVideoCodecOperationFlagBitsKHR"    name="VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
 
                 <type name="VkVideoEncodeH264CapabilityFlagBitsEXT"/>
                 <type name="VkVideoEncodeH264CapabilityFlagsEXT"/>
-                <type name="VkVideoEncodeH264InputModeFlagBitsEXT"/>
-                <type name="VkVideoEncodeH264InputModeFlagsEXT"/>
-                <type name="VkVideoEncodeH264OutputModeFlagBitsEXT"/>
-                <type name="VkVideoEncodeH264OutputModeFlagsEXT"/>
                 <type name="VkVideoEncodeH264CapabilitiesEXT"/>
                 <type name="VkVideoEncodeH264SessionParametersCreateInfoEXT"/>
                 <type name="VkVideoEncodeH264SessionParametersAddInfoEXT"/>
                 <type name="VkVideoEncodeH264VclFrameInfoEXT"/>
-                <type name="VkVideoEncodeH264ReferenceListsInfoEXT"/>
-                <type name="VkVideoEncodeH264EmitPictureParametersInfoEXT"/>
                 <type name="VkVideoEncodeH264DpbSlotInfoEXT"/>
                 <type name="VkVideoEncodeH264NaluSliceInfoEXT"/>
                 <type name="VkVideoEncodeH264ProfileInfoEXT"/>
@@ -15311,9 +16148,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoEncodeH264FrameSizeEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_video_encode_h265" number="40" type="device" requires="VK_KHR_video_encode_queue" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan">
+        <extension name="VK_EXT_video_encode_h265" number="40" type="device" depends="VK_KHR_video_encode_queue" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan">
             <require>
-                <enum value="9"                                              name="VK_EXT_VIDEO_ENCODE_H265_SPEC_VERSION"/>
+                <enum value="10"                                             name="VK_EXT_VIDEO_ENCODE_H265_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_video_encode_h265&quot;"           name="VK_EXT_VIDEO_ENCODE_H265_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="1" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
@@ -15321,19 +16158,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="3" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_VCL_FRAME_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="4" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="5" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="6" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_EMIT_PICTURE_PARAMETERS_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="7" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="8" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_REFERENCE_LISTS_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="9" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="10" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum bitpos="17" extends="VkVideoCodecOperationFlagBitsKHR" name="VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
 
                 <type name="VkVideoEncodeH265CapabilityFlagBitsEXT"/>
                 <type name="VkVideoEncodeH265CapabilityFlagsEXT"/>
-                <type name="VkVideoEncodeH265InputModeFlagBitsEXT"/>
-                <type name="VkVideoEncodeH265InputModeFlagsEXT"/>
-                <type name="VkVideoEncodeH265OutputModeFlagBitsEXT"/>
-                <type name="VkVideoEncodeH265OutputModeFlagsEXT"/>
 
                 <type name="VkVideoEncodeH265CtbSizeFlagBitsEXT"/>
                 <type name="VkVideoEncodeH265CtbSizeFlagsEXT"/>
@@ -15343,11 +16174,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoEncodeH265SessionParametersCreateInfoEXT"/>
                 <type name="VkVideoEncodeH265SessionParametersAddInfoEXT"/>
                 <type name="VkVideoEncodeH265VclFrameInfoEXT"/>
-                <type name="VkVideoEncodeH265EmitPictureParametersInfoEXT"/>
                 <type name="VkVideoEncodeH265DpbSlotInfoEXT"/>
                 <type name="VkVideoEncodeH265NaluSliceSegmentInfoEXT"/>
                 <type name="VkVideoEncodeH265ProfileInfoEXT"/>
-                <type name="VkVideoEncodeH265ReferenceListsInfoEXT"/>
                 <type name="VkVideoEncodeH265RateControlInfoEXT"/>
                 <type name="VkVideoEncodeH265RateControlStructureEXT"/>
                 <type name="VkVideoEncodeH265RateControlLayerInfoEXT"/>
@@ -15355,7 +16184,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoEncodeH265FrameSizeEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_video_decode_h264" number="41" type="device" requires="VK_KHR_video_decode_queue" author="KHR" contact="peter.fang@amd.com" supported="vulkan">
+        <extension name="VK_KHR_video_decode_h264" number="41" type="device" depends="VK_KHR_video_decode_queue" author="KHR" contact="peter.fang@amd.com" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="8"                                              name="VK_KHR_VIDEO_DECODE_H264_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_decode_h264&quot;"           name="VK_KHR_VIDEO_DECODE_H264_EXTENSION_NAME"/>
@@ -15376,7 +16205,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoDecodeH264DpbSlotInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_AMD_texture_gather_bias_lod" number="42" author="AMD" contact="Rex Xu @amdrexu" supported="vulkan" type="device" requires="VK_KHR_get_physical_device_properties2">
+        <extension name="VK_AMD_texture_gather_bias_lod" number="42" author="AMD" contact="Rex Xu @amdrexu" supported="vulkan" type="device" depends="VK_KHR_get_physical_device_properties2">
             <require>
                 <enum value="1"                                                 name="VK_AMD_TEXTURE_GATHER_BIAS_LOD_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_texture_gather_bias_lod&quot;"        name="VK_AMD_TEXTURE_GATHER_BIAS_LOD_EXTENSION_NAME"/>
@@ -15400,7 +16229,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_44&quot;"                   name="VK_AMD_EXTENSION_44_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_dynamic_rendering" number="45" author="KHR" type="device" requires="VK_KHR_depth_stencil_resolve,VK_KHR_get_physical_device_properties2" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_dynamic_rendering" number="45" author="KHR" type="device" depends="VK_KHR_depth_stencil_resolve+VK_KHR_get_physical_device_properties2" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_DYNAMIC_RENDERING_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_dynamic_rendering&quot;"              name="VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME"/>
@@ -15420,27 +16249,27 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkRenderingFlagsKHR"/>
                 <type name="VkRenderingFlagBitsKHR"/>
             </require>
-            <require extension="VK_KHR_fragment_shading_rate">
+            <require depends="VK_KHR_fragment_shading_rate">
                 <enum bitpos="21" extends="VkPipelineCreateFlagBits"                name="VK_PIPELINE_CREATE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
-                <enum alias="VK_PIPELINE_CREATE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR" extends="VkPipelineCreateFlagBits" name="VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR" comment="Backwards-compatible alias containing a typo"/>
+                <enum alias="VK_PIPELINE_CREATE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR" extends="VkPipelineCreateFlagBits" name="VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR" deprecated="aliased"/>
                 <enum offset="6" extends="VkStructureType" extnumber="45"           name="VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR"/>
                 <type name="VkRenderingFragmentShadingRateAttachmentInfoKHR"/>
             </require>
-            <require extension="VK_EXT_fragment_density_map">
+            <require depends="VK_EXT_fragment_density_map">
                 <enum bitpos="22" extends="VkPipelineCreateFlagBits"                name="VK_PIPELINE_CREATE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT"/>
-                <enum alias="VK_PIPELINE_CREATE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT" extends="VkPipelineCreateFlagBits" name="VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT" comment="Backwards-compatible alias containing a typo"/>
+                <enum alias="VK_PIPELINE_CREATE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT" extends="VkPipelineCreateFlagBits" name="VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT" deprecated="aliased"/>
                 <enum offset="7" extends="VkStructureType" extnumber="45"           name="VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT"/>
                 <type name="VkRenderingFragmentDensityMapAttachmentInfoEXT"/>
             </require>
-            <require extension="VK_AMD_mixed_attachment_samples">
+            <require depends="VK_AMD_mixed_attachment_samples">
                 <enum offset="8" extends="VkStructureType" extnumber="45"           name="VK_STRUCTURE_TYPE_ATTACHMENT_SAMPLE_COUNT_INFO_AMD"/>
                 <type name="VkAttachmentSampleCountInfoAMD"/>
             </require>
-            <require extension="VK_NV_framebuffer_mixed_samples">
+            <require depends="VK_NV_framebuffer_mixed_samples">
                 <enum extends="VkStructureType" name="VK_STRUCTURE_TYPE_ATTACHMENT_SAMPLE_COUNT_INFO_NV" alias="VK_STRUCTURE_TYPE_ATTACHMENT_SAMPLE_COUNT_INFO_AMD"/>
                 <type name="VkAttachmentSampleCountInfoNV"/>
             </require>
-            <require extension="VK_NVX_multiview_per_view_attributes">
+            <require depends="VK_NVX_multiview_per_view_attributes">
                 <enum offset="9" extends="VkStructureType" extnumber="45"           name="VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_ATTRIBUTES_INFO_NVX"/>
                 <type name="VkMultiviewPerViewAttributesInfoNVX"/>
             </require>
@@ -15469,7 +16298,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_GOOGLE_extension_49&quot;"                name="VK_GOOGLE_EXTENSION_49_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_GGP_stream_descriptor_surface" number="50" type="instance" requires="VK_KHR_surface" platform="ggp" author="GGP" contact="Jean-Francois Roy @jfroy" supported="vulkan">
+        <extension name="VK_GGP_stream_descriptor_surface" number="50" type="instance" depends="VK_KHR_surface" platform="ggp" author="GGP" contact="Jean-Francois Roy @jfroy" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_GGP_STREAM_DESCRIPTOR_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_GGP_stream_descriptor_surface&quot;"      name="VK_GGP_STREAM_DESCRIPTOR_SURFACE_EXTENSION_NAME"/>
@@ -15479,7 +16308,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateStreamDescriptorSurfaceGGP"/>
             </require>
         </extension>
-        <extension name="VK_NV_corner_sampled_image" number="51" author="NV" type="device" requires="VK_KHR_get_physical_device_properties2" contact="Daniel Koch @dgkoch" supported="vulkan">
+        <extension name="VK_NV_corner_sampled_image" number="51" author="NV" type="device" depends="VK_KHR_get_physical_device_properties2" contact="Daniel Koch @dgkoch" supported="vulkan">
             <require>
                 <enum value="2"                                                 name="VK_NV_CORNER_SAMPLED_IMAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_corner_sampled_image&quot;"            name="VK_NV_CORNER_SAMPLED_IMAGE_EXTENSION_NAME"/>
@@ -15488,10 +16317,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceCornerSampledImageFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_52" number="52" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_NV_private_vendor_info" number="52" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkansc">
             <require>
-                <enum value="0"                                                 name="VK_NV_EXTENSION_52_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_52&quot;"                    name="VK_NV_EXTENSION_52_EXTENSION_NAME"/>
+                <enum value="2"                                                 name="VK_NV_PRIVATE_VENDOR_INFO_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_private_vendor_info&quot;"             name="VK_NV_PRIVATE_VENDOR_INFO_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PRIVATE_VENDOR_INFO_RESERVED_OFFSET_0_NV"/>
             </require>
         </extension>
         <extension name="VK_NV_extension_53" number="53" author="NV" contact="Jeff Bolz @jeffbolznv" supported="disabled">
@@ -15500,7 +16330,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_53&quot;"                    name="VK_NV_EXTENSION_53_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_multiview" number="54" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_multiview" number="54" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_MULTIVIEW_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_multiview&quot;"                      name="VK_KHR_MULTIVIEW_EXTENSION_NAME"/>
@@ -15539,7 +16369,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceExternalImageFormatPropertiesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_external_memory" number="57" type="device" requires="VK_NV_external_memory_capabilities" author="NV" contact="James Jones @cubanismo" supported="vulkan" deprecatedby="VK_KHR_external_memory">
+        <extension name="VK_NV_external_memory" number="57" type="device" depends="VK_NV_external_memory_capabilities" author="NV" contact="James Jones @cubanismo" supported="vulkan" deprecatedby="VK_KHR_external_memory">
             <require>
                 <enum value="1"                                                 name="VK_NV_EXTERNAL_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_external_memory&quot;"                 name="VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME"/>
@@ -15549,7 +16379,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkExportMemoryAllocateInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_external_memory_win32" number="58" type="device" requires="VK_NV_external_memory" author="NV" contact="James Jones @cubanismo" platform="win32" supported="vulkan" deprecatedby="VK_KHR_external_memory_win32">
+        <extension name="VK_NV_external_memory_win32" number="58" type="device" depends="VK_NV_external_memory" author="NV" contact="James Jones @cubanismo" platform="win32" supported="vulkan" deprecatedby="VK_KHR_external_memory_win32">
             <require>
                 <enum value="1"                                                 name="VK_NV_EXTERNAL_MEMORY_WIN32_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_external_memory_win32&quot;"           name="VK_NV_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"/>
@@ -15560,7 +16390,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMemoryWin32HandleNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_win32_keyed_mutex" number="59" type="device" requires="VK_NV_external_memory_win32" author="NV" contact="Carsten Rohde @crohde" platform="win32" supported="vulkan" promotedto="VK_KHR_win32_keyed_mutex">
+        <extension name="VK_NV_win32_keyed_mutex" number="59" type="device" depends="VK_NV_external_memory_win32" author="NV" contact="Carsten Rohde @crohde" platform="win32" supported="vulkan" promotedto="VK_KHR_win32_keyed_mutex">
             <require>
                 <enum value="2"                                                 name="VK_NV_WIN32_KEYED_MUTEX_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_win32_keyed_mutex&quot;"               name="VK_NV_WIN32_KEYED_MUTEX_EXTENSION_NAME"/>
@@ -15568,7 +16398,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkWin32KeyedMutexAcquireReleaseInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_get_physical_device_properties2" number="60" type="instance" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_get_physical_device_properties2" number="60" type="instance" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="2"                                                 name="VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_get_physical_device_properties2&quot;" name="VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME"/>
@@ -15599,7 +16429,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceSparseImageFormatProperties2KHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_device_group" number="61" type="device" author="KHR" requires="VK_KHR_device_group_creation" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_device_group" number="61" type="device" author="KHR" depends="VK_KHR_device_group_creation" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="4"                                                 name="VK_KHR_DEVICE_GROUP_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_device_group&quot;"                   name="VK_KHR_DEVICE_GROUP_EXTENSION_NAME"/>
@@ -15629,14 +16459,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkPipelineCreateFlagBits"                        name="VK_PIPELINE_CREATE_DISPATCH_BASE_KHR" alias="VK_PIPELINE_CREATE_DISPATCH_BASE"/>
                 <enum extends="VkDependencyFlagBits"                            name="VK_DEPENDENCY_DEVICE_GROUP_BIT_KHR" alias="VK_DEPENDENCY_DEVICE_GROUP_BIT"/>
             </require>
-            <require extension="VK_KHR_bind_memory2">
+            <require depends="VK_KHR_bind_memory2">
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO_KHR" alias="VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO"/>
                 <enum extends="VkStructureType"                                 name="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO_KHR" alias="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO"/>
                 <type name="VkBindBufferMemoryDeviceGroupInfoKHR"/>
                 <type name="VkBindImageMemoryDeviceGroupInfoKHR"/>
                 <enum extends="VkImageCreateFlagBits"                           name="VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR" alias="VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT"/>
             </require>
-            <require extension="VK_KHR_surface">
+            <require depends="VK_KHR_surface">
                 <enum offset="7" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR"/>
                 <type name="VkDeviceGroupPresentModeFlagBitsKHR"/>
                 <type name="VkDeviceGroupPresentModeFlagsKHR"/>
@@ -15645,7 +16475,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDeviceGroupSurfacePresentModesKHR"/>
                 <command name="vkGetPhysicalDevicePresentRectanglesKHR"/>
             </require>
-            <require extension="VK_KHR_swapchain">
+            <require depends="VK_KHR_swapchain">
                 <enum offset="8" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR"/>
                 <enum offset="9" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR"/>
                 <enum offset="10" extends="VkStructureType"                     name="VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHR"/>
@@ -15669,7 +16499,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkValidationCheckEXT"/>
             </require>
         </extension>
-        <extension name="VK_NN_vi_surface" number="63" type="instance" author="NN" contact="Mathias Heyer gitlab:@mheyer" requires="VK_KHR_surface" platform="vi" supported="vulkan">
+        <extension name="VK_NN_vi_surface" number="63" type="instance" author="NN" contact="Mathias Heyer gitlab:@mheyer" depends="VK_KHR_surface" platform="vi" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_NN_VI_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NN_vi_surface&quot;"                      name="VK_NN_VI_SURFACE_EXTENSION_NAME"/>
@@ -15679,7 +16509,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateViSurfaceNN"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_draw_parameters" number="64" type="device" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_shader_draw_parameters" number="64" type="device" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_SHADER_DRAW_PARAMETERS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_draw_parameters&quot;"         name="VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME"/>
@@ -15697,7 +16527,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_shader_subgroup_vote&quot;"           name="VK_EXT_SHADER_SUBGROUP_VOTE_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_texture_compression_astc_hdr" number="67" type="device" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" requires="VK_KHR_get_physical_device_properties2" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_texture_compression_astc_hdr" number="67" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                                 name="VK_EXT_TEXTURE_COMPRESSION_ASTC_HDR_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_texture_compression_astc_hdr&quot;"   name="VK_EXT_TEXTURE_COMPRESSION_ASTC_HDR_EXTENSION_NAME"/>
@@ -15719,7 +16549,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkFormat"                                        name="VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT" alias="VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK"/>
             </require>
         </extension>
-        <extension name="VK_EXT_astc_decode_mode" number="68" type="device" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" requires="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_EXT_astc_decode_mode" number="68" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                                 name="VK_EXT_ASTC_DECODE_MODE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_astc_decode_mode&quot;"               name="VK_EXT_ASTC_DECODE_MODE_EXTENSION_NAME"/>
@@ -15729,7 +16559,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceASTCDecodeFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pipeline_robustness" requires="VK_KHR_get_physical_device_properties2" number="69" type="device" author="IMG" contact="Jarred Davies" supported="vulkan">
+        <extension name="VK_EXT_pipeline_robustness" depends="VK_KHR_get_physical_device_properties2" number="69" type="device" author="IMG" contact="Jarred Davies" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_PIPELINE_ROBUSTNESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pipeline_robustness&quot;"            name="VK_EXT_PIPELINE_ROBUSTNESS_EXTENSION_NAME"/>
@@ -15743,12 +16573,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineRobustnessImageBehaviorEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_maintenance1" number="70" type="device" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_maintenance1" number="70" type="device" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="2"                                                 name="VK_KHR_MAINTENANCE_1_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_maintenance1&quot;"                   name="VK_KHR_MAINTENANCE_1_EXTENSION_NAME"/>
-                <enum alias="VK_KHR_MAINTENANCE_1_SPEC_VERSION"                 name="VK_KHR_MAINTENANCE1_SPEC_VERSION" comment="Backwards-compatible alias containing a typo"/>
-                <enum alias="VK_KHR_MAINTENANCE_1_EXTENSION_NAME"               name="VK_KHR_MAINTENANCE1_EXTENSION_NAME" comment="Backwards-compatible alias containing a typo"/>
+                <enum alias="VK_KHR_MAINTENANCE_1_SPEC_VERSION"                 name="VK_KHR_MAINTENANCE1_SPEC_VERSION" deprecated="aliased"/>
+                <enum alias="VK_KHR_MAINTENANCE_1_EXTENSION_NAME"               name="VK_KHR_MAINTENANCE1_EXTENSION_NAME" deprecated="aliased"/>
                 <enum extends="VkResult"                                        name="VK_ERROR_OUT_OF_POOL_MEMORY_KHR" alias="VK_ERROR_OUT_OF_POOL_MEMORY"/>
                 <enum extends="VkFormatFeatureFlagBits"                         name="VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR" alias="VK_FORMAT_FEATURE_TRANSFER_SRC_BIT"/>
                 <enum extends="VkFormatFeatureFlagBits"                         name="VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR" alias="VK_FORMAT_FEATURE_TRANSFER_DST_BIT"/>
@@ -15757,7 +16587,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkTrimCommandPoolKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_device_group_creation" number="71" type="instance" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_device_group_creation" number="71" type="instance" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_DEVICE_GROUP_CREATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_device_group_creation&quot;"          name="VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME"/>
@@ -15770,7 +16600,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkMemoryHeapFlagBits"                            name="VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHR" alias="VK_MEMORY_HEAP_MULTI_INSTANCE_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_memory_capabilities" number="72" type="instance" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_external_memory_capabilities" number="72" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_memory_capabilities&quot;"   name="VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME"/>
@@ -15803,7 +16633,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceExternalBufferPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_memory" number="73" type="device" requires="VK_KHR_external_memory_capabilities" author="KHR" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_external_memory" number="73" type="device" depends="VK_KHR_external_memory_capabilities" author="KHR" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_memory&quot;"                name="VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME"/>
@@ -15817,7 +16647,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkExportMemoryAllocateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_memory_win32" number="74" type="device" requires="VK_KHR_external_memory" author="KHR" contact="James Jones @cubanismo" platform="win32" supported="vulkan">
+        <extension name="VK_KHR_external_memory_win32" number="74" type="device" depends="VK_KHR_external_memory" author="KHR" contact="James Jones @cubanismo" platform="win32" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_MEMORY_WIN32_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_memory_win32&quot;"          name="VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"/>
@@ -15833,7 +16663,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMemoryWin32HandlePropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_memory_fd" number="75" type="device" requires="VK_KHR_external_memory" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_KHR_external_memory_fd" number="75" type="device" depends="VK_KHR_external_memory,VK_VERSION_1_1" author="KHR" contact="James Jones @cubanismo" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_MEMORY_FD_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_memory_fd&quot;"             name="VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME"/>
@@ -15847,7 +16677,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMemoryFdPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_win32_keyed_mutex" number="76" type="device" requires="VK_KHR_external_memory_win32" author="KHR" contact="Carsten Rohde @crohde" platform="win32" supported="vulkan">
+        <extension name="VK_KHR_win32_keyed_mutex" number="76" type="device" depends="VK_KHR_external_memory_win32" author="KHR" contact="Carsten Rohde @crohde" platform="win32" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_WIN32_KEYED_MUTEX_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_win32_keyed_mutex&quot;"              name="VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME"/>
@@ -15855,7 +16685,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkWin32KeyedMutexAcquireReleaseInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_semaphore_capabilities" number="77" type="instance" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_external_semaphore_capabilities" number="77" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_semaphore_capabilities&quot;" name="VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME"/>
@@ -15880,7 +16710,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceExternalSemaphorePropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_semaphore" number="78" type="device" requires="VK_KHR_external_semaphore_capabilities" author="KHR" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_external_semaphore" number="78" type="device" depends="VK_KHR_external_semaphore_capabilities" author="KHR" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_EXTERNAL_SEMAPHORE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_semaphore&quot;"         name="VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME"/>
@@ -15891,7 +16721,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkExportSemaphoreCreateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_semaphore_win32" number="79" type="device" requires="VK_KHR_external_semaphore" author="KHR" contact="James Jones @cubanismo" platform="win32" supported="vulkan">
+        <extension name="VK_KHR_external_semaphore_win32" number="79" type="device" depends="VK_KHR_external_semaphore" author="KHR" contact="James Jones @cubanismo" platform="win32" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_EXTERNAL_SEMAPHORE_WIN32_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_semaphore_win32&quot;"   name="VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME"/>
@@ -15907,7 +16737,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetSemaphoreWin32HandleKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_semaphore_fd" number="80" type="device" requires="VK_KHR_external_semaphore" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_KHR_external_semaphore_fd" number="80" type="device" depends="VK_KHR_external_semaphore,VK_VERSION_1_1" author="KHR" contact="James Jones @cubanismo" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_KHR_EXTERNAL_SEMAPHORE_FD_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_semaphore_fd&quot;"      name="VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME"/>
@@ -15919,7 +16749,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetSemaphoreFdKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_push_descriptor" number="81" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_KHR_push_descriptor" number="81" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="2"                                             name="VK_KHR_PUSH_DESCRIPTOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_push_descriptor&quot;"            name="VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME"/>
@@ -15928,16 +16758,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdPushDescriptorSetKHR"/>
                 <type name="VkPhysicalDevicePushDescriptorPropertiesKHR"/>
             </require>
-            <require feature="VK_VERSION_1_1">
+            <require depends="VK_VERSION_1_1">
                 <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
                 <enum value="1" extends="VkDescriptorUpdateTemplateType"    name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR" comment="Create descriptor update template for pushed descriptor updates"/>
             </require>
-            <require extension="VK_KHR_descriptor_update_template">
+            <require depends="VK_KHR_descriptor_update_template">
                 <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
                 <enum value="1" extends="VkDescriptorUpdateTemplateType"    name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR" comment="Create descriptor update template for pushed descriptor updates"/>
             </require>
         </extension>
-        <extension name="VK_EXT_conditional_rendering" number="82" type="device" author="NV" contact="Vikram Kushwaha @vkushwaha" supported="vulkan">
+        <extension name="VK_EXT_conditional_rendering" number="82" type="device" author="NV" contact="Vikram Kushwaha @vkushwaha" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_CONDITIONAL_RENDERING_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_conditional_rendering&quot;"      name="VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME"/>
@@ -15956,7 +16786,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkCommandBufferInheritanceConditionalRenderingInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_float16_int8" number="83" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_shader_float16_int8" number="83" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SHADER_FLOAT16_INT8_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_float16_int8&quot;"        name="VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME"/>
@@ -15966,7 +16796,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFloat16Int8FeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_16bit_storage" number="84" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_storage_buffer_storage_class" author="KHR" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_16bit_storage" number="84" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class" author="KHR" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_16BIT_STORAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_16bit_storage&quot;"              name="VK_KHR_16BIT_STORAGE_EXTENSION_NAME"/>
@@ -15974,7 +16804,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevice16BitStorageFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_incremental_present" number="85" type="device" author="KHR" requires="VK_KHR_swapchain" contact="Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_KHR_incremental_present" number="85" type="device" author="KHR" depends="VK_KHR_swapchain" contact="Ian Elliott @ianelliottus" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_KHR_INCREMENTAL_PRESENT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_incremental_present&quot;"        name="VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME"/>
@@ -15984,7 +16814,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkRectLayerKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_descriptor_update_template" number="86" type="device" author="KHR" contact="Markus Tavenrath @mtavenrath" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_descriptor_update_template" number="86" type="device" author="KHR" contact="Markus Tavenrath @mtavenrath" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_descriptor_update_template&quot;" name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME"/>
@@ -16000,11 +16830,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkDescriptorUpdateTemplateCreateInfoKHR"/>
                 <enum extends="VkDescriptorUpdateTemplateType"              name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR" alias="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET"/>
             </require>
-            <require extension="VK_KHR_push_descriptor">
+            <require depends="VK_KHR_push_descriptor">
                 <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
                 <enum value="1" extends="VkDescriptorUpdateTemplateType"    name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR" comment="Create descriptor update template for pushed descriptor updates"/>
             </require>
-            <require extension="VK_EXT_debug_report">
+            <require depends="VK_EXT_debug_report">
                 <enum extends="VkDebugReportObjectTypeEXT"                  name="VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT"/>
             </require>
         </extension>
@@ -16025,14 +16855,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetViewportWScalingNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_direct_mode_display" number="89" type="instance" requires="VK_KHR_display" author="NV" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_EXT_direct_mode_display" number="89" type="instance" depends="VK_KHR_display" author="NV" contact="James Jones @cubanismo" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_DIRECT_MODE_DISPLAY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_direct_mode_display&quot;"        name="VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME"/>
                 <command name="vkReleaseDisplayEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_acquire_xlib_display" number="90" type="instance" requires="VK_EXT_direct_mode_display" author="NV" contact="James Jones @cubanismo" platform="xlib_xrandr" supported="vulkan">
+        <extension name="VK_EXT_acquire_xlib_display" number="90" type="instance" depends="VK_EXT_direct_mode_display" author="NV" contact="James Jones @cubanismo" platform="xlib_xrandr" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_ACQUIRE_XLIB_DISPLAY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_acquire_xlib_display&quot;"       name="VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME"/>
@@ -16040,19 +16870,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetRandROutputDisplayEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_display_surface_counter" number="91" type="instance" requires="VK_KHR_display" author="NV" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_EXT_display_surface_counter" number="91" type="instance" depends="VK_KHR_display" author="NV" contact="James Jones @cubanismo" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_DISPLAY_SURFACE_COUNTER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_display_surface_counter&quot;"    name="VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME"/>
                 <enum offset="0"                                           extends="VkStructureType" name="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT"/>
-                <enum alias="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT" extends="VkStructureType" name="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES2_EXT" comment="Backwards-compatible alias containing a typo"/>
+                <enum api="vulkan" extends="VkStructureType" name="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES2_EXT" alias="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT" deprecated="aliased"/>
                 <type name="VkSurfaceCounterFlagsEXT"/>
                 <type name="VkSurfaceCounterFlagBitsEXT"/>
                 <type name="VkSurfaceCapabilities2EXT"/>
                 <command name="vkGetPhysicalDeviceSurfaceCapabilities2EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_display_control" number="92" type="device" requires="VK_EXT_display_surface_counter,VK_KHR_swapchain" author="NV" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_EXT_display_control" number="92" type="device" depends="VK_EXT_display_surface_counter+VK_KHR_swapchain" author="NV" contact="James Jones @cubanismo" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_DISPLAY_CONTROL_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_display_control&quot;"            name="VK_EXT_DISPLAY_CONTROL_EXTENSION_NAME"/>
@@ -16073,7 +16903,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetSwapchainCounterEXT"/>
             </require>
         </extension>
-        <extension name="VK_GOOGLE_display_timing" number="93" type="device" author="GOOGLE" requires="VK_KHR_swapchain" contact="Ian Elliott @ianelliottus" supported="vulkan">
+        <extension name="VK_GOOGLE_display_timing" number="93" type="device" author="GOOGLE" depends="VK_KHR_swapchain" contact="Ian Elliott @ianelliottus" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_GOOGLE_DISPLAY_TIMING_SPEC_VERSION"/>
                 <enum value="&quot;VK_GOOGLE_display_timing&quot;"          name="VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME"/>
@@ -16113,11 +16943,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="1"                                             name="VK_NV_VIEWPORT_ARRAY_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_viewport_array2&quot;"             name="VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME"/>
-                <enum alias="VK_NV_VIEWPORT_ARRAY_2_SPEC_VERSION"           name="VK_NV_VIEWPORT_ARRAY2_SPEC_VERSION" comment="Backwards-compatible alias containing a typo"/>
-                <enum alias="VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME"         name="VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME" comment="Backwards-compatible alias containing a typo"/>
+                <enum alias="VK_NV_VIEWPORT_ARRAY_2_SPEC_VERSION"           name="VK_NV_VIEWPORT_ARRAY2_SPEC_VERSION" deprecated="aliased"/>
+                <enum alias="VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME"         name="VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME" deprecated="aliased"/>
             </require>
         </extension>
-        <extension name="VK_NVX_multiview_per_view_attributes" number="98" type="device" requires="VK_KHR_multiview" author="NVX" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_NVX_multiview_per_view_attributes" number="98" type="device" depends="VK_KHR_multiview" author="NVX" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_SPEC_VERSION"/>
                 <enum value="&quot;VK_NVX_multiview_per_view_attributes&quot;" name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_EXTENSION_NAME"/>
@@ -16138,18 +16968,22 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineViewportSwizzleStateCreateFlagsNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_discard_rectangles" number="100" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_discard_rectangles" number="100" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
             <require>
-                <enum value="1"                                             name="VK_EXT_DISCARD_RECTANGLES_SPEC_VERSION"/>
+                <enum value="2"                                             name="VK_EXT_DISCARD_RECTANGLES_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_discard_rectangles&quot;"         name="VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT"/>
                 <enum offset="0" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT"/>
+                <enum offset="1" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT"/>
+                <enum offset="2" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_DISCARD_RECTANGLE_MODE_EXT"/>
                 <type name="VkPhysicalDeviceDiscardRectanglePropertiesEXT"/>
                 <type name="VkPipelineDiscardRectangleStateCreateInfoEXT"/>
                 <type name="VkPipelineDiscardRectangleStateCreateFlagsEXT"/>
                 <type name="VkDiscardRectangleModeEXT"/>
                 <command name="vkCmdSetDiscardRectangleEXT"/>
+                <command name="vkCmdSetDiscardRectangleEnableEXT"/>
+                <command name="vkCmdSetDiscardRectangleModeEXT"/>
             </require>
         </extension>
         <extension name="VK_NV_extension_101" number="101" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
@@ -16158,7 +16992,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_101&quot;"               name="VK_NV_EXTENSION_101_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_conservative_rasterization" number="102" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_conservative_rasterization" number="102" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_CONSERVATIVE_RASTERIZATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_conservative_rasterization&quot;" name="VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME"/>
@@ -16170,7 +17004,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkConservativeRasterizationModeEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_depth_clip_enable" number="103" type="device" author="EXT" contact="Piers Daniell @pdaniell-nv" specialuse="d3demulation" supported="vulkan">
+        <extension name="VK_EXT_depth_clip_enable" number="103" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Piers Daniell @pdaniell-nv" specialuse="d3demulation" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_DEPTH_CLIP_ENABLE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_depth_clip_enable&quot;"          name="VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME"/>
@@ -16185,9 +17019,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                             name="VK_NV_EXTENSION_104_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_extension_104&quot;"               name="VK_NV_EXTENSION_104_EXTENSION_NAME"/>
+                <enum bitpos="0"  extends="VkPrivateDataSlotCreateFlagBits" name="VK_PRIVATE_DATA_SLOT_CREATE_RESERVED_0_BIT_NV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_swapchain_colorspace" number="105" type="instance" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" requires="VK_KHR_surface" supported="vulkan">
+        <extension name="VK_EXT_swapchain_colorspace" number="105" type="instance" depends="VK_KHR_surface" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" supported="vulkan,vulkansc">
             <require>
                 <enum value="4"                                             name="VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_swapchain_colorspace&quot;"       name="VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME"/>
@@ -16205,10 +17040,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="12" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT"/>
                 <enum offset="13" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_PASS_THROUGH_EXT"/>
                 <enum offset="14" extends="VkColorSpaceKHR"                 name="VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT"/>
-                <enum extends="VkColorSpaceKHR"                             name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT" alias="VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT" comment="Backwards-compatible alias containing a typo"/>
+                <enum api="vulkan" extends="VkColorSpaceKHR"                name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT" alias="VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT" deprecated="aliased"/>
             </require>
         </extension>
-        <extension name="VK_EXT_hdr_metadata" number="106" type="device" requires="VK_KHR_swapchain" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" supported="vulkan">
+        <extension name="VK_EXT_hdr_metadata" number="106" type="device" depends="VK_KHR_swapchain" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_EXT_HDR_METADATA_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_hdr_metadata&quot;"               name="VK_EXT_HDR_METADATA_EXTENSION_NAME"/>
@@ -16230,7 +17065,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_IMG_extension_108&quot;"              name="VK_IMG_EXTENSION_108_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_imageless_framebuffer" requires="VK_KHR_maintenance2,VK_KHR_image_format_list" number="109" author="KHR" contact="Tobias Hector @tobias" type="device" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_imageless_framebuffer" depends="VK_KHR_maintenance2+VK_KHR_image_format_list+VK_KHR_get_physical_device_properties2" number="109" author="KHR" contact="Tobias Hector @tobias" type="device" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_IMAGELESS_FRAMEBUFFER_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_imageless_framebuffer&quot;"      name="VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME"/>
@@ -16245,7 +17080,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkFramebufferCreateFlagBits"                 name="VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR" alias="VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_create_renderpass2" requires="VK_KHR_multiview,VK_KHR_maintenance2" number="110" author="KHR" contact="Tobias Hector @tobias" type="device" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_create_renderpass2" depends="VK_KHR_multiview+VK_KHR_maintenance2" number="110" author="KHR" contact="Tobias Hector @tobias" type="device" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_CREATE_RENDERPASS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_create_renderpass2&quot;"         name="VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME"/>
@@ -16275,7 +17110,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_IMG_extension_111&quot;"              name="VK_IMG_EXTENSION_111_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shared_presentable_image" number="112" type="device" requires="VK_KHR_swapchain,VK_KHR_get_physical_device_properties2,VK_KHR_get_surface_capabilities2" author="KHR" contact="Alon Or-bach @alonorbach" supported="vulkan">
+        <extension name="VK_KHR_shared_presentable_image" number="112" type="device" depends="VK_KHR_swapchain+VK_KHR_get_surface_capabilities2+(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)" author="KHR" contact="Alon Or-bach @alonorbach" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_KHR_SHARED_PRESENTABLE_IMAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shared_presentable_image&quot;"   name="VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME"/>
@@ -16287,7 +17122,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetSwapchainStatusKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_fence_capabilities" number="113" type="instance" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_external_fence_capabilities" number="113" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_EXTERNAL_FENCE_CAPABILITIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_fence_capabilities&quot;" name="VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME"/>
@@ -16311,7 +17146,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceExternalFencePropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_fence" number="114" type="device" requires="VK_KHR_external_fence_capabilities" author="KHR" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_external_fence" number="114" type="device" depends="VK_KHR_external_fence_capabilities" author="KHR" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_EXTERNAL_FENCE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_fence&quot;"             name="VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME"/>
@@ -16322,7 +17157,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkExportFenceCreateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_fence_win32" number="115" type="device" requires="VK_KHR_external_fence" author="KHR" contact="Jesse Hall @critsec" platform="win32" supported="vulkan">
+        <extension name="VK_KHR_external_fence_win32" number="115" type="device" depends="VK_KHR_external_fence" author="KHR" contact="Jesse Hall @critsec" platform="win32" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_EXTERNAL_FENCE_WIN32_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_fence_win32&quot;"       name="VK_KHR_EXTERNAL_FENCE_WIN32_EXTENSION_NAME"/>
@@ -16336,7 +17171,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetFenceWin32HandleKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_fence_fd" number="116" type="device" requires="VK_KHR_external_fence" author="KHR" contact="Jesse Hall @critsec" supported="vulkan">
+        <extension name="VK_KHR_external_fence_fd" number="116" type="device" depends="VK_KHR_external_fence,VK_VERSION_1_1" author="KHR" contact="Jesse Hall @critsec" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_KHR_EXTERNAL_FENCE_FD_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_fence_fd&quot;"          name="VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME"/>
@@ -16348,7 +17183,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetFenceFdKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_performance_query" number="117" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alon Or-bach @alonorbach" specialuse="devtools" supported="vulkan">
+        <extension name="VK_KHR_performance_query" number="117" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Alon Or-bach @alonorbach" specialuse="devtools" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                    name="VK_KHR_PERFORMANCE_QUERY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_performance_query&quot;" name="VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME"/>
@@ -16380,13 +17215,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkAcquireProfilingLockKHR"/>
                 <command name="vkReleaseProfilingLockKHR"/>
             </require>
+            <require depends="VKSC_VERSION_1_0" api="vulkansc">
+                <enum offset="7" extends="VkStructureType"         name="VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_RESERVATION_INFO_KHR"/>
+                <type name="VkPerformanceQueryReservationInfoKHR"/>
+            </require>
         </extension>
-        <extension name="VK_KHR_maintenance2" number="118" type="device" author="KHR" contact="Michael Worcester @michaelworcester" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_maintenance2" number="118" type="device" author="KHR" contact="Michael Worcester @michaelworcester" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_MAINTENANCE_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_maintenance2&quot;"               name="VK_KHR_MAINTENANCE_2_EXTENSION_NAME"/>
-                <enum alias="VK_KHR_MAINTENANCE_2_SPEC_VERSION"             name="VK_KHR_MAINTENANCE2_SPEC_VERSION" comment="Backwards-compatible alias containing a typo"/>
-                <enum alias="VK_KHR_MAINTENANCE_2_EXTENSION_NAME"           name="VK_KHR_MAINTENANCE2_EXTENSION_NAME" comment="Backwards-compatible alias containing a typo"/>
+                <enum alias="VK_KHR_MAINTENANCE_2_SPEC_VERSION"             name="VK_KHR_MAINTENANCE2_SPEC_VERSION" deprecated="aliased"/>
+                <enum alias="VK_KHR_MAINTENANCE_2_EXTENSION_NAME"           name="VK_KHR_MAINTENANCE2_EXTENSION_NAME" deprecated="aliased"/>
                 <enum extends="VkImageCreateFlagBits"                       name="VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT_KHR" alias="VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT"/>
                 <enum extends="VkImageCreateFlagBits"                       name="VK_IMAGE_CREATE_EXTENDED_USAGE_BIT_KHR" alias="VK_IMAGE_CREATE_EXTENDED_USAGE_BIT"/>
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES"/>
@@ -16414,7 +17253,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_119&quot;"              name="VK_KHR_EXTENSION_119_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_get_surface_capabilities2" number="120" type="instance" requires="VK_KHR_surface" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_KHR_get_surface_capabilities2" number="120" type="instance" depends="VK_KHR_surface" author="KHR" contact="James Jones @cubanismo" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_KHR_GET_SURFACE_CAPABILITIES_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_get_surface_capabilities2&quot;"  name="VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME"/>
@@ -16428,7 +17267,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceSurfaceFormats2KHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_variable_pointers" number="121" type="device" author="KHR" contact="Jesse Hall @critsec" requires="VK_KHR_get_physical_device_properties2,VK_KHR_storage_buffer_storage_class" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_variable_pointers" number="121" type="device" author="KHR" contact="Jesse Hall @critsec" depends="VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_VARIABLE_POINTERS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_variable_pointers&quot;"          name="VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME"/>
@@ -16438,7 +17277,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceVariablePointersFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_get_display_properties2" number="122" type="instance" requires="VK_KHR_display" author="KHR" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_KHR_get_display_properties2" number="122" type="instance" depends="VK_KHR_display" author="KHR" contact="James Jones @cubanismo" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_KHR_GET_DISPLAY_PROPERTIES_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_get_display_properties2&quot;"    name="VK_KHR_GET_DISPLAY_PROPERTIES_2_EXTENSION_NAME"/>
@@ -16458,7 +17297,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDisplayPlaneCapabilities2KHR"/>
             </require>
         </extension>
-        <extension name="VK_MVK_ios_surface" number="123" type="instance" requires="VK_KHR_surface" platform="ios" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings" deprecatedby="VK_EXT_metal_surface">
+        <extension name="VK_MVK_ios_surface" number="123" type="instance" depends="VK_KHR_surface" platform="ios" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings" deprecatedby="VK_EXT_metal_surface">
             <require>
                 <enum value="3"                                             name="VK_MVK_IOS_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_MVK_ios_surface&quot;"                name="VK_MVK_IOS_SURFACE_EXTENSION_NAME"/>
@@ -16468,7 +17307,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateIOSSurfaceMVK"/>
             </require>
         </extension>
-        <extension name="VK_MVK_macos_surface" number="124" type="instance" requires="VK_KHR_surface" platform="macos" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings" deprecatedby="VK_EXT_metal_surface">
+        <extension name="VK_MVK_macos_surface" number="124" type="instance" depends="VK_KHR_surface" platform="macos" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings" deprecatedby="VK_EXT_metal_surface">
             <require>
                 <enum value="3"                                             name="VK_MVK_MACOS_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_MVK_macos_surface&quot;"              name="VK_MVK_MACOS_SURFACE_EXTENSION_NAME"/>
@@ -16484,21 +17323,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_MVK_moltenvk&quot;"                   name="VK_MVK_MOLTENVK_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_external_memory_dma_buf" number="126" type="device" requires="VK_KHR_external_memory_fd" author="EXT" contact="Chad Versace @chadversary" supported="vulkan">
+        <extension name="VK_EXT_external_memory_dma_buf" number="126" type="device" depends="VK_KHR_external_memory_fd" author="EXT" contact="Lina Versace @versalinyaa" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_EXTERNAL_MEMORY_DMA_BUF_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_external_memory_dma_buf&quot;"    name="VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME"/>
                 <enum bitpos="9" extends="VkExternalMemoryHandleTypeFlagBits" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_queue_family_foreign" number="127" type="device" author="EXT" requires="VK_KHR_external_memory" contact="Chad Versace @chadversary" supported="vulkan">
+        <extension name="VK_EXT_queue_family_foreign" number="127" type="device" author="EXT" depends="VK_KHR_external_memory,VK_VERSION_1_1" contact="Lina Versace @versalinyaa" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_QUEUE_FAMILY_FOREIGN_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_queue_family_foreign&quot;"       name="VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME"/>
                 <enum                                                       name="VK_QUEUE_FAMILY_FOREIGN_EXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_dedicated_allocation" number="128" type="device" author="KHR" requires="VK_KHR_get_memory_requirements2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_dedicated_allocation" number="128" type="device" author="KHR" depends="VK_KHR_get_memory_requirements2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="3"                                             name="VK_KHR_DEDICATED_ALLOCATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_dedicated_allocation&quot;"       name="VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME"/>
@@ -16508,7 +17347,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkMemoryDedicatedAllocateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_debug_utils" number="129" type="instance" author="EXT" contact="Mark Young @marky-lunarg" specialuse="debugging" supported="vulkan">
+        <extension name="VK_EXT_debug_utils" number="129" type="instance" author="EXT" contact="Mark Young @marky-lunarg" specialuse="debugging" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_EXT_DEBUG_UTILS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_debug_utils&quot;"                name="VK_EXT_DEBUG_UTILS_EXTENSION_NAME"/>
@@ -16544,7 +17383,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkSubmitDebugUtilsMessageEXT"/>
             </require>
         </extension>
-        <extension name="VK_ANDROID_external_memory_android_hardware_buffer" number="130" type="device" author="ANDROID" requires="VK_KHR_sampler_ycbcr_conversion,VK_KHR_external_memory,VK_EXT_queue_family_foreign,VK_KHR_dedicated_allocation" platform="android" contact="Jesse Hall @critsec" supported="vulkan">
+        <extension name="VK_ANDROID_external_memory_android_hardware_buffer" number="130" type="device" author="ANDROID" depends="VK_KHR_sampler_ycbcr_conversion+VK_KHR_external_memory+VK_EXT_queue_family_foreign+VK_KHR_dedicated_allocation" platform="android" contact="Jesse Hall @critsec" supported="vulkan">
             <require>
                 <enum value="5"                                             name="VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_SPEC_VERSION"/>
                 <enum value="&quot;VK_ANDROID_external_memory_android_hardware_buffer&quot;" name="VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME"/>
@@ -16565,12 +17404,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMemoryAndroidHardwareBufferANDROID"/>
                 <type name="AHardwareBuffer"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <type name="VkAndroidHardwareBufferFormatProperties2ANDROID"/>
                 <enum offset="6" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID"/>
             </require>
         </extension>
-        <extension name="VK_EXT_sampler_filter_minmax" number="131" type="device" author="NV" requires="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_EXT_sampler_filter_minmax" number="131" type="device" author="NV" depends="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
             <require>
                 <enum value="2"                                             name="VK_EXT_SAMPLER_FILTER_MINMAX_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_sampler_filter_minmax&quot;"      name="VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME"/>
@@ -16585,7 +17424,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_storage_buffer_storage_class" number="132" type="device" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_storage_buffer_storage_class" number="132" type="device" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_storage_buffer_storage_class&quot;" name="VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME"/>
@@ -16628,7 +17467,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_shader_fragment_mask&quot;"       name="VK_AMD_SHADER_FRAGMENT_MASK_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_inline_uniform_block" number="139" type="device" author="EXT" requires="VK_KHR_get_physical_device_properties2,VK_KHR_maintenance1" contact="Daniel Rakos @aqnuep" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_inline_uniform_block" number="139" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2+VK_KHR_maintenance1" contact="Daniel Rakos @aqnuep" supported="vulkan" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_INLINE_UNIFORM_BLOCK_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_inline_uniform_block&quot;"       name="VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME"/>
@@ -16649,7 +17488,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_140&quot;"              name="VK_AMD_EXTENSION_140_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_shader_stencil_export" number="141" type="device" author="EXT" contact="Dominik Witczak @dominikwitczakamd" supported="vulkan">
+        <extension name="VK_EXT_shader_stencil_export" number="141" type="device" author="EXT" contact="Dominik Witczak @dominikwitczakamd" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_SHADER_STENCIL_EXPORT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_shader_stencil_export&quot;"      name="VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME"/>
@@ -16667,7 +17506,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_143&quot;"              name="VK_AMD_EXTENSION_143_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_sample_locations" number="144" type="device" author="AMD" contact="Daniel Rakos @drakos-amd" supported="vulkan" requires="VK_KHR_get_physical_device_properties2">
+        <extension name="VK_EXT_sample_locations" number="144" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="AMD" contact="Daniel Rakos @drakos-amd" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_SAMPLE_LOCATIONS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_sample_locations&quot;"           name="VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME"/>
@@ -16690,7 +17529,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceMultisamplePropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_relaxed_block_layout" number="145" type="device" author="KHR" contact="John Kessenich @johnkslang" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_relaxed_block_layout" number="145" type="device" author="KHR" contact="John Kessenich @johnkslang" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_RELAXED_BLOCK_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_relaxed_block_layout&quot;"       name="VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME"/>
@@ -16702,7 +17541,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_RESERVED_do_not_use_146&quot;"        name="VK_RESERVED_DO_NOT_USE_146_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_get_memory_requirements2" number="147" type="device" author="KHR" contact="Jason Ekstrand @jekstrand" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_get_memory_requirements2" number="147" type="device" author="KHR" contact="Faith Ekstrand @gfxstrand" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1" name="VK_KHR_GET_MEMORY_REQUIREMENTS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_get_memory_requirements2&quot;"   name="VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME"/>
@@ -16721,7 +17560,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetImageSparseMemoryRequirements2KHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_image_format_list" number="148" type="device" author="KHR" contact="Jason Ekstrand @jekstrand" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_image_format_list" number="148" type="device" author="KHR" contact="Faith Ekstrand @gfxstrand" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_IMAGE_FORMAT_LIST_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_image_format_list&quot;"          name="VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME"/>
@@ -16729,7 +17568,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkImageFormatListCreateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_blend_operation_advanced" number="149" type="device" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan" requires="VK_KHR_get_physical_device_properties2">
+        <extension name="VK_EXT_blend_operation_advanced" number="149" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_EXT_BLEND_OPERATION_ADVANCED_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_blend_operation_advanced&quot;"   name="VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME"/>
@@ -16798,7 +17637,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineCoverageToColorStateCreateInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_acceleration_structure" number="151" type="device" requiresCore="1.1" requires="VK_EXT_descriptor_indexing,VK_KHR_buffer_device_address,VK_KHR_deferred_host_operations" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1">
+        <extension name="VK_KHR_acceleration_structure" number="151" type="device" depends="VK_VERSION_1_1+VK_EXT_descriptor_indexing+VK_KHR_buffer_device_address+VK_KHR_deferred_host_operations" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1" ratified="vulkan">
             <require>
                 <enum value="13"                                            name="VK_KHR_ACCELERATION_STRUCTURE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_acceleration_structure&quot;"     name="VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME"/>
@@ -16883,11 +17722,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDeviceAccelerationStructureCompatibilityKHR"/>
                 <command name="vkGetAccelerationStructureBuildSizesKHR"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <enum bitpos="29" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_ray_tracing_pipeline" number="348" type="device" requiresCore="1.1" requires="VK_KHR_spirv_1_4,VK_KHR_acceleration_structure" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1">
+        <extension name="VK_KHR_ray_tracing_pipeline" number="348" type="device" depends="VK_KHR_spirv_1_4+VK_KHR_acceleration_structure" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_RAY_TRACING_PIPELINE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_ray_tracing_pipeline&quot;"       name="VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME"/>
@@ -16932,7 +17771,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetRayTracingPipelineStackSizeKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_ray_query" number="349" type="device" requiresCore="1.1" requires="VK_KHR_spirv_1_4,VK_KHR_acceleration_structure" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1">
+        <extension name="VK_KHR_ray_query" number="349" type="device" depends="VK_KHR_spirv_1_4+VK_KHR_acceleration_structure" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_RAY_QUERY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_ray_query&quot;"                  name="VK_KHR_RAY_QUERY_EXTENSION_NAME"/>
@@ -16963,7 +17802,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0" extends="VkPolygonMode"                    name="VK_POLYGON_MODE_FILL_RECTANGLE_NV"/>
             </require>
         </extension>
-        <extension name="VK_NV_shader_sm_builtins" number="155" type="device" requiresCore="1.1" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
+        <extension name="VK_NV_shader_sm_builtins" number="155" type="device" depends="VK_VERSION_1_1" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_SHADER_SM_BUILTINS_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_shader_sm_builtins&quot;"          name="VK_NV_SHADER_SM_BUILTINS_EXTENSION_NAME"/>
@@ -16973,13 +17812,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderSMBuiltinsFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_post_depth_coverage" number="156" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan">
+        <extension name="VK_EXT_post_depth_coverage" number="156" type="device" author="NV" contact="Daniel Koch @dgkoch" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_POST_DEPTH_COVERAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_post_depth_coverage&quot;"        name="VK_EXT_POST_DEPTH_COVERAGE_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_sampler_ycbcr_conversion" number="157" type="device" requires="VK_KHR_maintenance1,VK_KHR_bind_memory2,VK_KHR_get_memory_requirements2,VK_KHR_get_physical_device_properties2" author="KHR" contact="Andrew Garrard @fluppeteer" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_sampler_ycbcr_conversion" number="157" type="device" depends="VK_KHR_maintenance1+VK_KHR_bind_memory2+VK_KHR_get_memory_requirements2+VK_KHR_get_physical_device_properties2" author="KHR" contact="Andrew Garrard @fluppeteer" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="14"                                            name="VK_KHR_SAMPLER_YCBCR_CONVERSION_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_sampler_ycbcr_conversion&quot;"   name="VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME"/>
@@ -17058,11 +17897,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkChromaLocation"                            name="VK_CHROMA_LOCATION_COSITED_EVEN_KHR" alias="VK_CHROMA_LOCATION_COSITED_EVEN"/>
                 <enum extends="VkChromaLocation"                            name="VK_CHROMA_LOCATION_MIDPOINT_KHR" alias="VK_CHROMA_LOCATION_MIDPOINT"/>
             </require>
-            <require extension="VK_EXT_debug_report">
+            <require depends="VK_EXT_debug_report">
                 <enum extends="VkDebugReportObjectTypeEXT" offset="0"       name="VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_bind_memory2" number="158" type="device" author="KHR" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_bind_memory2" number="158" type="device" author="KHR" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_BIND_MEMORY_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_bind_memory2&quot;"               name="VK_KHR_BIND_MEMORY_2_EXTENSION_NAME"/>
@@ -17075,7 +17914,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkBindImageMemoryInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_drm_format_modifier" number="159" type="device" requires="VK_KHR_bind_memory2,VK_KHR_get_physical_device_properties2,VK_KHR_image_format_list,VK_KHR_sampler_ycbcr_conversion" author="EXT" contact="Chad Versace @chadversary" supported="vulkan">
+        <extension name="VK_EXT_image_drm_format_modifier" number="159" type="device" depends="((VK_KHR_bind_memory2+VK_KHR_get_physical_device_properties2+VK_KHR_sampler_ycbcr_conversion),VK_VERSION_1_1)+(VK_KHR_image_format_list,VK_VERSION_1_2)" author="EXT" contact="Lina Versace @versalinyaa" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_drm_format_modifier&quot;"  name="VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME"/>
@@ -17098,7 +17937,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkImageDrmFormatModifierPropertiesEXT"/>
                 <command name="vkGetImageDrmFormatModifierPropertiesEXT"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <type name="VkDrmFormatModifierPropertiesList2EXT"/>
                 <type name="VkDrmFormatModifierProperties2EXT"/>
                 <enum offset="6" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_2_EXT"/>
@@ -17128,7 +17967,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetValidationCacheDataEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_descriptor_indexing" number="162" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_maintenance3" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_EXT_descriptor_indexing" number="162" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_maintenance3" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
             <require>
                 <enum value="2"                                             name="VK_EXT_DESCRIPTOR_INDEXING_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_descriptor_indexing&quot;"        name="VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME"/>
@@ -17159,7 +17998,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_shader_viewport_index_layer&quot;" name="VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_portability_subset" number="164" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Bill Hollings @billhollings" platform="provisional" supported="vulkan" provisional="true">
+        <extension name="VK_KHR_portability_subset" number="164" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Bill Hollings @billhollings" platform="provisional" supported="vulkan" provisional="true" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_PORTABILITY_SUBSET_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_portability_subset&quot;"         name="VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME"/>
@@ -17169,7 +18008,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePortabilitySubsetPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_shading_rate_image" number="165" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_shading_rate_image" number="165" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
                 <enum value="3"                                             name="VK_NV_SHADING_RATE_IMAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_shading_rate_image&quot;"          name="VK_NV_SHADING_RATE_IMAGE_EXTENSION_NAME"/>
@@ -17197,7 +18036,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetCoarseSampleOrderNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_ray_tracing" number="166" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_get_memory_requirements2" author="NV" contact="Eric Werness @ewerness-nv" supported="vulkan">
+        <extension name="VK_NV_ray_tracing" number="166" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_get_memory_requirements2" author="NV" contact="Eric Werness @ewerness-nv" supported="vulkan">
             <require>
                 <enum value="3"                               name="VK_NV_RAY_TRACING_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_ray_tracing&quot;"   name="VK_NV_RAY_TRACING_EXTENSION_NAME"/>
@@ -17293,7 +18132,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCompileDeferredNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_representative_fragment_test" number="167" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
+        <extension name="VK_NV_representative_fragment_test" number="167" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_NV_REPRESENTATIVE_FRAGMENT_TEST_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_representative_fragment_test&quot;" name="VK_NV_REPRESENTATIVE_FRAGMENT_TEST_EXTENSION_NAME"/>
@@ -17309,12 +18148,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_168&quot;"               name="VK_NV_EXTENSION_168_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_maintenance3" number="169" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1">
+        <extension name="VK_KHR_maintenance3" number="169" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_MAINTENANCE_3_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_maintenance3&quot;"               name="VK_KHR_MAINTENANCE_3_EXTENSION_NAME"/>
-                <enum alias="VK_KHR_MAINTENANCE_3_SPEC_VERSION"             name="VK_KHR_MAINTENANCE3_SPEC_VERSION" comment="Backwards-compatible alias containing a typo"/>
-                <enum alias="VK_KHR_MAINTENANCE_3_EXTENSION_NAME"           name="VK_KHR_MAINTENANCE3_EXTENSION_NAME" comment="Backwards-compatible alias containing a typo"/>
+                <enum alias="VK_KHR_MAINTENANCE_3_SPEC_VERSION"             name="VK_KHR_MAINTENANCE3_SPEC_VERSION" deprecated="aliased"/>
+                <enum alias="VK_KHR_MAINTENANCE_3_EXTENSION_NAME"           name="VK_KHR_MAINTENANCE3_EXTENSION_NAME" deprecated="aliased"/>
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES"/>
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT_KHR" alias="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT"/>
                 <type name="VkPhysicalDeviceMaintenance3PropertiesKHR"/>
@@ -17322,7 +18161,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDescriptorSetLayoutSupportKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_draw_indirect_count" number="170" type="device" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_draw_indirect_count" number="170" type="device" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_DRAW_INDIRECT_COUNT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_draw_indirect_count&quot;"        name="VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME"/>
@@ -17330,7 +18169,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdDrawIndexedIndirectCountKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_filter_cubic" number="171" type="device" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="vulkan">
+        <extension name="VK_EXT_filter_cubic" number="171" type="device" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="vulkan,vulkansc">
             <require>
                 <enum value="3"                                             name="VK_EXT_FILTER_CUBIC_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_filter_cubic&quot;"               name="VK_EXT_FILTER_CUBIC_EXTENSION_NAME"/>
@@ -17365,17 +18204,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_QCOM_extension_174&quot;"             name="VK_QCOM_EXTENSION_174_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_global_priority" number="175" type="device" author="EXT" contact="Andres Rodriguez @lostgoat" supported="vulkan" promotedto="VK_KHR_global_priority">
+        <extension name="VK_EXT_global_priority" number="175" type="device" author="EXT" contact="Andres Rodriguez @lostgoat" supported="vulkan,vulkansc" promotedto="VK_KHR_global_priority">
             <require>
                 <enum value="2"                                             name="VK_EXT_GLOBAL_PRIORITY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_global_priority&quot;"            name="VK_EXT_GLOBAL_PRIORITY_EXTENSION_NAME"/>
-                <enum extends="VkStructureType" alias="VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR" name="VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT"/>
-                <enum extends="VkResult" alias="VK_ERROR_NOT_PERMITTED_KHR" name="VK_ERROR_NOT_PERMITTED_EXT"/>
+                <enum extends="VkStructureType" name="VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT" alias="VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR"/>
+                <enum extends="VkResult" name="VK_ERROR_NOT_PERMITTED_EXT" alias="VK_ERROR_NOT_PERMITTED_KHR"/>
                 <type name="VkDeviceQueueGlobalPriorityCreateInfoEXT"/>
                 <type name="VkQueueGlobalPriorityEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_subgroup_extended_types" number="176" type="device" requiresCore="1.1" author="KHR" contact="Neil Henning @sheredom" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_shader_subgroup_extended_types" number="176" type="device" depends="VK_VERSION_1_1" author="KHR" contact="Neil Henning @sheredom" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_subgroup_extended_types&quot;" name="VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME"/>
@@ -17389,7 +18228,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_177&quot;"              name="VK_EXT_EXTENSION_177_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_8bit_storage" number="178" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_storage_buffer_storage_class" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_8bit_storage" number="178" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_8BIT_STORAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_8bit_storage&quot;"               name="VK_KHR_8BIT_STORAGE_EXTENSION_NAME"/>
@@ -17397,7 +18236,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevice8BitStorageFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_external_memory_host" number="179" type="device" author="EXT" requires="VK_KHR_external_memory" contact="Daniel Rakos @drakos-amd" supported="vulkan">
+        <extension name="VK_EXT_external_memory_host" number="179" type="device" author="EXT" depends="VK_KHR_external_memory,VK_VERSION_1_1" contact="Daniel Rakos @drakos-amd" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_EXTERNAL_MEMORY_HOST_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_external_memory_host&quot;"       name="VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME"/>
@@ -17419,7 +18258,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdWriteBufferMarkerAMD"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_atomic_int64" number="181" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Aaron Hagan @ahagan" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_shader_atomic_int64" number="181" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Aaron Hagan @ahagan" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SHADER_ATOMIC_INT64_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_atomic_int64&quot;"        name="VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME"/>
@@ -17427,7 +18266,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderAtomicInt64FeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_clock" number="182" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Aaron Hagan @ahagan" supported="vulkan">
+        <extension name="VK_KHR_shader_clock" number="182" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Aaron Hagan @ahagan" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                          name="VK_KHR_SHADER_CLOCK_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_clock&quot;"            name="VK_KHR_SHADER_CLOCK_EXTENSION_NAME"/>
@@ -17451,7 +18290,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineCompilerControlCreateInfoAMD"/>
             </require>
         </extension>
-        <extension name="VK_EXT_calibrated_timestamps" number="185" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Daniel Rakos @drakos-amd" supported="vulkan">
+        <extension name="VK_EXT_calibrated_timestamps" number="185" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Daniel Rakos @drakos-amd" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_EXT_CALIBRATED_TIMESTAMPS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_calibrated_timestamps&quot;"      name="VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME"/>
@@ -17462,7 +18301,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetCalibratedTimestampsEXT"/>
             </require>
         </extension>
-        <extension name="VK_AMD_shader_core_properties" number="186" type="device" author="AMD" requires="VK_KHR_get_physical_device_properties2" contact="Martin Dinkov @mdinkov" supported="vulkan">
+        <extension name="VK_AMD_shader_core_properties" number="186" type="device" author="AMD" depends="VK_KHR_get_physical_device_properties2" contact="Martin Dinkov @mdinkov" supported="vulkan">
             <require>
                 <enum value="2"                                          name="VK_AMD_SHADER_CORE_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_core_properties&quot;"  name="VK_AMD_SHADER_CORE_PROPERTIES_EXTENSION_NAME"/>
@@ -17476,7 +18315,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_187&quot;"              name="VK_AMD_EXTENSION_187_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_video_decode_h265" number="188" type="device" requires="VK_KHR_video_decode_queue" author="KHR" contact="peter.fang@amd.com" supported="vulkan">
+        <extension name="VK_KHR_video_decode_h265" number="188" type="device" depends="VK_KHR_video_decode_queue" author="KHR" contact="peter.fang@amd.com" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="7"                                             name="VK_KHR_VIDEO_DECODE_H265_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_decode_h265&quot;"          name="VK_KHR_VIDEO_DECODE_H265_EXTENSION_NAME"/>
@@ -17497,7 +18336,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoDecodeH265DpbSlotInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_global_priority" number="189" type="device" author="KHR" contact="Tobias Hector @tobski" supported="vulkan">
+        <extension name="VK_KHR_global_priority" number="189" type="device" author="KHR" contact="Tobias Hector @tobski" depends="VK_KHR_get_physical_device_properties2" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_GLOBAL_PRIORITY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_global_priority&quot;"            name="VK_KHR_GLOBAL_PRIORITY_EXTENSION_NAME"/>
@@ -17521,7 +18360,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkDeviceMemoryOverallocationCreateInfoAMD"/>
             </require>
         </extension>
-        <extension name="VK_EXT_vertex_attribute_divisor" number="191" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Vikram Kushwaha @vkushwaha" supported="vulkan">
+        <extension name="VK_EXT_vertex_attribute_divisor" number="191" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Vikram Kushwaha @vkushwaha" supported="vulkan,vulkansc">
             <require>
                 <enum value="3"                                         name="VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_vertex_attribute_divisor&quot;"   name="VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME"/>
@@ -17534,7 +18373,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_GGP_frame_token" number="192" type="device" requires="VK_KHR_swapchain,VK_GGP_stream_descriptor_surface" platform="ggp" author="GGP" contact="Jean-Francois Roy @jfroy" supported="vulkan">
+        <extension name="VK_GGP_frame_token" number="192" type="device" depends="VK_KHR_swapchain+VK_GGP_stream_descriptor_surface" platform="ggp" author="GGP" contact="Jean-Francois Roy @jfroy" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_GGP_FRAME_TOKEN_SPEC_VERSION"/>
                 <enum value="&quot;VK_GGP_frame_token&quot;"                    name="VK_GGP_FRAME_TOKEN_EXTENSION_NAME"/>
@@ -17569,11 +18408,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                         name="VK_GOOGLE_EXTENSION_196_SPEC_VERSION"/>
                 <enum value="&quot;VK_GOOGLE_extension_196&quot;"       name="VK_GOOGLE_EXTENSION_196_EXTENSION_NAME"/>
-                <enum bitpos="1"  extends="VkPipelineCacheCreateFlagBits"
-                    name="VK_PIPELINE_CACHE_CREATE_RESERVED_1_BIT_EXT"/>
+                <enum extends="VkPipelineCacheCreateFlagBits"           name="VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT_EXT" alias="VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_driver_properties" number="197" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Daniel Rakos @drakos-amd" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_driver_properties" number="197" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Daniel Rakos @drakos-amd" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_DRIVER_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_driver_properties&quot;"          name="VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME"/>
@@ -17597,7 +18435,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceDriverPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_float_controls" number="198" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_shader_float_controls" number="198" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="4"                                             name="VK_KHR_SHADER_FLOAT_CONTROLS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_float_controls&quot;"      name="VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME"/>
@@ -17609,14 +18447,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkShaderFloatControlsIndependence"           name="VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE_KHR"        alias="VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE"/>
             </require>
         </extension>
-        <extension name="VK_NV_shader_subgroup_partitioned" number="199" type="device" requiresCore="1.1" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_NV_shader_subgroup_partitioned" number="199" type="device" depends="VK_VERSION_1_1" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_SHADER_SUBGROUP_PARTITIONED_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_shader_subgroup_partitioned&quot;" name="VK_NV_SHADER_SUBGROUP_PARTITIONED_EXTENSION_NAME"/>
                 <enum bitpos="8" extends="VkSubgroupFeatureFlagBits"        name="VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_depth_stencil_resolve" number="200" type="device" requires="VK_KHR_create_renderpass2" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_depth_stencil_resolve" number="200" type="device" depends="VK_KHR_create_renderpass2" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_DEPTH_STENCIL_RESOLVE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_depth_stencil_resolve&quot;"      name="VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME"/>
@@ -17633,14 +18471,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkResolveModeFlagBits"                       name="VK_RESOLVE_MODE_MAX_BIT_KHR" alias="VK_RESOLVE_MODE_MAX_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_swapchain_mutable_format" number="201" type="device" author="KHR" requires="VK_KHR_swapchain,VK_KHR_maintenance2,VK_KHR_image_format_list" contact="Daniel Rakos @drakos-arm" supported="vulkan">
+        <extension name="VK_KHR_swapchain_mutable_format" number="201" type="device" author="KHR" depends="VK_KHR_swapchain+(VK_KHR_maintenance2,VK_VERSION_1_1)+(VK_KHR_image_format_list,VK_VERSION_1_2)" contact="Daniel Rakos @drakos-amd" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                         name="VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_swapchain_mutable_format&quot;" name="VK_KHR_SWAPCHAIN_MUTABLE_FORMAT_EXTENSION_NAME"/>
                 <enum bitpos="2" extends="VkSwapchainCreateFlagBitsKHR" name="VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_compute_shader_derivatives" number="202" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_compute_shader_derivatives" number="202" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_COMPUTE_SHADER_DERIVATIVES_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_compute_shader_derivatives&quot;" name="VK_NV_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME"/>
@@ -17648,7 +18486,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_mesh_shader" number="203" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
+        <extension name="VK_NV_mesh_shader" number="203" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_MESH_SHADER_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_mesh_shader&quot;"             name="VK_NV_MESH_SHADER_EXTENSION_NAME"/>
@@ -17666,7 +18504,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkDrawMeshTasksIndirectCommandNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_fragment_shader_barycentric" number="204" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan" promotedto="VK_KHR_fragment_shader_barycentric">
+        <extension name="VK_NV_fragment_shader_barycentric" number="204" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan" promotedto="VK_KHR_fragment_shader_barycentric">
             <require>
                 <enum value="1"                                         name="VK_NV_FRAGMENT_SHADER_BARYCENTRIC_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_fragment_shader_barycentric&quot;" name="VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME"/>
@@ -17674,7 +18512,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_shader_image_footprint" number="205" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_shader_image_footprint" number="205" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_NV_SHADER_IMAGE_FOOTPRINT_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_shader_image_footprint&quot;"  name="VK_NV_SHADER_IMAGE_FOOTPRINT_EXTENSION_NAME"/>
@@ -17682,19 +18520,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderImageFootprintFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_scissor_exclusive" number="206" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_scissor_exclusive" number="206" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
-                <enum value="1"                                         name="VK_NV_SCISSOR_EXCLUSIVE_SPEC_VERSION"/>
+                <enum value="2"                                         name="VK_NV_SCISSOR_EXCLUSIVE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_scissor_exclusive&quot;"       name="VK_NV_SCISSOR_EXCLUSIVE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV"/>
-                <enum offset="1" extends="VkDynamicState" name="VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV"/>
                 <enum offset="2" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV"/>
+                <enum offset="0" extends="VkDynamicState" name="VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_ENABLE_NV"/>
+                <enum offset="1" extends="VkDynamicState" name="VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV"/>
                 <type name="VkPipelineViewportExclusiveScissorStateCreateInfoNV"/>
                 <type name="VkPhysicalDeviceExclusiveScissorFeaturesNV"/>
+                <command name="vkCmdSetExclusiveScissorEnableNV"/>
                 <command name="vkCmdSetExclusiveScissorNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_device_diagnostic_checkpoints" type="device" number="207" requires="VK_KHR_get_physical_device_properties2" author="NVIDIA" contact="Nuno Subtil @nsubtil" supported="vulkan">
+        <extension name="VK_NV_device_diagnostic_checkpoints" type="device" number="207" depends="VK_KHR_get_physical_device_properties2" author="NVIDIA" contact="Nuno Subtil @nsubtil" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_device_diagnostic_checkpoints&quot;" name="VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME"/>
@@ -17706,7 +18546,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetQueueCheckpointDataNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_timeline_semaphore" number="208" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Jason Ekstrand @jekstrand" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_timeline_semaphore" number="208" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Faith Ekstrand @gfxstrand" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="2"                                         name="VK_KHR_TIMELINE_SEMAPHORE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_timeline_semaphore&quot;"     name="VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME"/>
@@ -17739,7 +18579,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_209&quot;"          name="VK_KHR_EXTENSION_209_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_INTEL_shader_integer_functions2" number="210" type="device" requires="VK_KHR_get_physical_device_properties2" author="INTEL" contact="Ian Romanick @ianromanick" supported="vulkan">
+        <extension name="VK_INTEL_shader_integer_functions2" number="210" type="device" depends="VK_KHR_get_physical_device_properties2" author="INTEL" contact="Ian Romanick @ianromanick" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_INTEL_SHADER_INTEGER_FUNCTIONS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_INTEL_shader_integer_functions2&quot;" name="VK_INTEL_SHADER_INTEGER_FUNCTIONS_2_EXTENSION_NAME"/>
@@ -17752,7 +18592,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="2"                                         name="VK_INTEL_PERFORMANCE_QUERY_SPEC_VERSION"/>
                 <enum value="&quot;VK_INTEL_performance_query&quot;"    name="VK_INTEL_PERFORMANCE_QUERY_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL"/>
-                <enum extends="VkStructureType" name="VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO_INTEL" alias="VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL" comment="Backwards-compatible alias containing a typo"/>
+                <enum extends="VkStructureType" name="VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO_INTEL" alias="VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL" deprecated="aliased"/>
                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_INITIALIZE_PERFORMANCE_API_INFO_INTEL"/>
                 <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PERFORMANCE_MARKER_INFO_INTEL"/>
                 <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PERFORMANCE_STREAM_MARKER_INFO_INTEL"/>
@@ -17786,7 +18626,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPerformanceParameterINTEL"/>
             </require>
         </extension>
-        <extension name="VK_KHR_vulkan_memory_model" number="212" type="device" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_vulkan_memory_model" number="212" type="device" author="KHR" contact="Jeff Bolz @jeffbolznv" depends="VK_KHR_get_physical_device_properties2" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="3"                                         name="VK_KHR_VULKAN_MEMORY_MODEL_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_vulkan_memory_model&quot;"    name="VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME"/>
@@ -17794,7 +18634,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceVulkanMemoryModelFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pci_bus_info" number="213" type="device" author="EXT" requires="VK_KHR_get_physical_device_properties2" contact="Matthaeus G. Chajdas @anteru" supported="vulkan">
+        <extension name="VK_EXT_pci_bus_info" number="213" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Matthaeus G. Chajdas @anteru" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                         name="VK_EXT_PCI_BUS_INFO_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pci_bus_info&quot;"           name="VK_EXT_PCI_BUS_INFO_EXTENSION_NAME"/>
@@ -17802,7 +18642,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePCIBusInfoPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_AMD_display_native_hdr" number="214" type="device" author="AMD" requires="VK_KHR_get_physical_device_properties2,VK_KHR_get_surface_capabilities2,VK_KHR_swapchain" contact="Matthaeus G. Chajdas @anteru" supported="vulkan">
+        <extension name="VK_AMD_display_native_hdr" number="214" type="device" author="AMD" depends="VK_KHR_get_physical_device_properties2+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" contact="Matthaeus G. Chajdas @anteru" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_AMD_DISPLAY_NATIVE_HDR_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_display_native_hdr&quot;"     name="VK_AMD_DISPLAY_NATIVE_HDR_EXTENSION_NAME"/>
@@ -17814,7 +18654,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkSetLocalDimmingAMD"/>
             </require>
         </extension>
-        <extension name="VK_FUCHSIA_imagepipe_surface" number="215" type="instance" author="FUCHSIA" requires="VK_KHR_surface" platform="fuchsia" contact="Craig Stout @cdotstout" supported="vulkan">
+        <extension name="VK_FUCHSIA_imagepipe_surface" number="215" type="instance" author="FUCHSIA" depends="VK_KHR_surface" platform="fuchsia" contact="Craig Stout @cdotstout" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_FUCHSIA_IMAGEPIPE_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_FUCHSIA_imagepipe_surface&quot;"  name="VK_FUCHSIA_IMAGEPIPE_SURFACE_EXTENSION_NAME"/>
@@ -17824,7 +18664,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateImagePipeSurfaceFUCHSIA"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_terminate_invocation" number="216" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_shader_terminate_invocation" number="216" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Jesse Hall @critsec" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                                 name="VK_KHR_SHADER_TERMINATE_INVOCATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_terminate_invocation&quot;"    name="VK_KHR_SHADER_TERMINATE_INVOCATION_EXTENSION_NAME"/>
@@ -17838,7 +18678,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_GOOGLE_extension_217&quot;"           name="VK_GOOGLE_EXTENSION_217_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_metal_surface" number="218" type="instance" requires="VK_KHR_surface" platform="metal" supported="vulkan" author="EXT" contact="Dzmitry Malyshau @kvark">
+        <extension name="VK_EXT_metal_surface" number="218" type="instance" depends="VK_KHR_surface" platform="metal" supported="vulkan" author="EXT" contact="Dzmitry Malyshau @kvark">
             <require>
                 <enum value="1"                                             name="VK_EXT_METAL_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_metal_surface&quot;"              name="VK_EXT_METAL_SURFACE_EXTENSION_NAME"/>
@@ -17849,7 +18689,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="CAMetalLayer"/>
             </require>
         </extension>
-        <extension name="VK_EXT_fragment_density_map" number="219" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Matthew Netsch @mnetsch" supported="vulkan">
+        <extension name="VK_EXT_fragment_density_map" number="219" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_FRAGMENT_DENSITY_MAP_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_fragment_density_map&quot;"       name="VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME"/>
@@ -17869,7 +18709,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFragmentDensityMapPropertiesEXT"/>
                 <type name="VkRenderPassFragmentDensityMapCreateInfoEXT"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <enum bitpos="24" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT"/>
             </require>
         </extension>
@@ -17886,7 +18726,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="0" extends="VkRenderPassCreateFlagBits"        name="VK_RENDER_PASS_CREATE_RESERVED_0_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_scalar_block_layout" number="222" requires="VK_KHR_get_physical_device_properties2" type="device" author="EXT" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_EXT_scalar_block_layout" number="222" depends="VK_KHR_get_physical_device_properties2" type="device" author="EXT" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_2">
             <require>
                 <enum value="1"                                             name="VK_EXT_SCALAR_BLOCK_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_scalar_block_layout&quot;"        name="VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME"/>
@@ -17904,8 +18744,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="1"                                             name="VK_GOOGLE_HLSL_FUNCTIONALITY_1_SPEC_VERSION"/>
                 <enum value="&quot;VK_GOOGLE_hlsl_functionality1&quot;"     name="VK_GOOGLE_HLSL_FUNCTIONALITY_1_EXTENSION_NAME"/>
-                <enum alias="VK_GOOGLE_HLSL_FUNCTIONALITY_1_SPEC_VERSION"   name="VK_GOOGLE_HLSL_FUNCTIONALITY1_SPEC_VERSION" comment="Backwards-compatible alias containing a typo"/>
-                <enum alias="VK_GOOGLE_HLSL_FUNCTIONALITY_1_EXTENSION_NAME" name="VK_GOOGLE_HLSL_FUNCTIONALITY1_EXTENSION_NAME" comment="Backwards-compatible alias containing a typo"/>
+                <enum alias="VK_GOOGLE_HLSL_FUNCTIONALITY_1_SPEC_VERSION"   name="VK_GOOGLE_HLSL_FUNCTIONALITY1_SPEC_VERSION" deprecated="aliased"/>
+                <enum alias="VK_GOOGLE_HLSL_FUNCTIONALITY_1_EXTENSION_NAME" name="VK_GOOGLE_HLSL_FUNCTIONALITY1_EXTENSION_NAME" deprecated="aliased"/>
             </require>
         </extension>
         <extension name="VK_GOOGLE_decorate_string" number="225" type="device" author="GOOGLE" contact="Hai Nguyen @chaoticbob" supported="vulkan">
@@ -17914,7 +18754,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_GOOGLE_decorate_string&quot;"         name="VK_GOOGLE_DECORATE_STRING_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_subgroup_size_control" number="226" type="device" requiresCore="1.1" author="EXT" contact="Neil Henning @sheredom" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_subgroup_size_control" number="226" type="device" depends="VK_VERSION_1_1" author="EXT" contact="Neil Henning @sheredom" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="2"                                             name="VK_EXT_SUBGROUP_SIZE_CONTROL_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_subgroup_size_control&quot;"      name="VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME"/>
@@ -17928,7 +18768,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkPipelineShaderStageCreateFlagBits"         name="VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT" alias="VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_fragment_shading_rate" number="227" type="device" requires="VK_KHR_create_renderpass2,VK_KHR_get_physical_device_properties2" author="KHR" contact="Tobias Hector @tobski" supported="vulkan">
+        <extension name="VK_KHR_fragment_shading_rate" number="227" type="device" depends="(VK_KHR_create_renderpass2,VK_VERSION_1_2)+(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)" author="KHR" contact="Tobias Hector @tobski" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="2"                                                 name="VK_KHR_FRAGMENT_SHADING_RATE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_fragment_shading_rate&quot;" name="VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME"/>
@@ -17952,11 +18792,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="22" extends="VkPipelineStageFlagBits"             name="VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
                 <enum bitpos="30" extends="VkFormatFeatureFlagBits"             name="VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <enum bitpos="30" extends="VkFormatFeatureFlagBits2"            name="VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_AMD_shader_core_properties2" number="228" type="device" author="AMD" contact="Matthaeus G. Chajdas @anteru" supported="vulkan" requires="VK_AMD_shader_core_properties">
+        <extension name="VK_AMD_shader_core_properties2" number="228" type="device" author="AMD" contact="Matthaeus G. Chajdas @anteru" supported="vulkan" depends="VK_AMD_shader_core_properties">
             <require>
                 <enum value="1"                                             name="VK_AMD_SHADER_CORE_PROPERTIES_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_core_properties2&quot;"    name="VK_AMD_SHADER_CORE_PROPERTIES_2_EXTENSION_NAME"/>
@@ -17972,7 +18812,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_229&quot;"              name="VK_AMD_EXTENSION_229_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_device_coherent_memory" number="230" type="device" author="AMD" contact="Tobias Hector @tobski" supported="vulkan">
+        <extension name="VK_AMD_device_coherent_memory" number="230" type="device" author="AMD" contact="Tobias Hector @tobski" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_AMD_DEVICE_COHERENT_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_device_coherent_memory&quot;"     name="VK_AMD_DEVICE_COHERENT_MEMORY_EXTENSION_NAME"/>
@@ -18006,7 +18846,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_234&quot;"              name="VK_AMD_EXTENSION_234_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_shader_image_atomic_int64" number="235" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Tobias Hector @tobski" supported="vulkan">
+        <extension name="VK_EXT_shader_image_atomic_int64" number="235" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Tobias Hector @tobski" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_SHADER_IMAGE_ATOMIC_INT64_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_shader_image_atomic_int64&quot;"  name="VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME"/>
@@ -18020,13 +18860,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_236&quot;"              name="VK_AMD_EXTENSION_236_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_spirv_1_4" number="237" type="device" requiresCore="1.1" requires="VK_KHR_shader_float_controls" author="KHR" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_spirv_1_4" number="237" type="device" depends="VK_VERSION_1_1+VK_KHR_shader_float_controls" author="KHR" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SPIRV_1_4_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_spirv_1_4&quot;"                  name="VK_KHR_SPIRV_1_4_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_memory_budget" number="238" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_EXT_memory_budget" number="238" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_MEMORY_BUDGET_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_memory_budget&quot;"              name="VK_EXT_MEMORY_BUDGET_EXTENSION_NAME"/>
@@ -18034,7 +18874,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceMemoryBudgetPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_memory_priority" number="239" type="device" requires="VK_KHR_get_physical_device_properties2"  author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_EXT_memory_priority" number="239" type="device" depends="VK_KHR_get_physical_device_properties2"  author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_MEMORY_PRIORITY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_memory_priority&quot;"            name="VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME"/>
@@ -18044,7 +18884,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkMemoryPriorityAllocateInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_surface_protected_capabilities" number="240" type="instance" requiresCore="1.1" requires="VK_KHR_get_surface_capabilities2" author="KHR" contact="Sandeep Shinde @sashinde" supported="vulkan">
+        <extension name="VK_KHR_surface_protected_capabilities" number="240" type="instance" depends="VK_VERSION_1_1+VK_KHR_get_surface_capabilities2" author="KHR" contact="Sandeep Shinde @sashinde" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SURFACE_PROTECTED_CAPABILITIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_surface_protected_capabilities&quot;"   name="VK_KHR_SURFACE_PROTECTED_CAPABILITIES_EXTENSION_NAME"/>
@@ -18052,7 +18892,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSurfaceProtectedCapabilitiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_dedicated_allocation_image_aliasing" number="241" type="device" requires="VK_KHR_dedicated_allocation" author="NVIDIA" contact="Nuno Subtil @nsubtil" supported="vulkan">
+        <extension name="VK_NV_dedicated_allocation_image_aliasing" number="241" type="device" depends="VK_KHR_dedicated_allocation+VK_KHR_get_physical_device_properties2" author="NVIDIA" contact="Nuno Subtil @nsubtil" supported="vulkan">
             <require>
                 <enum value="1"                                                         name="VK_NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_dedicated_allocation_image_aliasing&quot;"     name="VK_NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_EXTENSION_NAME"/>
@@ -18060,7 +18900,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_separate_depth_stencil_layouts" number="242" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_create_renderpass2" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_separate_depth_stencil_layouts" number="242" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_create_renderpass2" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                                   name="VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_separate_depth_stencil_layouts&quot;"   name="VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME"/>
@@ -18089,7 +18929,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_MESA_extension_244&quot;"              name="VK_MESA_EXTENSION_244_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_buffer_device_address" number="245" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Jeff Bolz @jeffbolznv"  deprecatedby="VK_KHR_buffer_device_address" supported="vulkan">
+        <extension name="VK_EXT_buffer_device_address" number="245" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Jeff Bolz @jeffbolznv"  deprecatedby="VK_KHR_buffer_device_address" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_BUFFER_DEVICE_ADDRESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_buffer_device_address&quot;"      name="VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME"/>
@@ -18117,13 +18957,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type                                                       name="VkPhysicalDeviceToolPropertiesEXT"/>
                 <command                                                    name="vkGetPhysicalDeviceToolPropertiesEXT"/>
             </require>
-            <require extension="VK_EXT_debug_report">
+            <require depends="VK_EXT_debug_report">
                 <enum bitpos="5" extends="VkToolPurposeFlagBits"            name="VK_TOOL_PURPOSE_DEBUG_REPORTING_BIT_EXT"/>
             </require>
-            <require extension="VK_EXT_debug_marker">
+            <require depends="VK_EXT_debug_marker">
                 <enum bitpos="6" extends="VkToolPurposeFlagBits"            name="VK_TOOL_PURPOSE_DEBUG_MARKERS_BIT_EXT"/>
             </require>
-            <require extension="VK_EXT_debug_utils">
+            <require depends="VK_EXT_debug_utils">
                 <enum bitpos="5" extends="VkToolPurposeFlagBits"            name="VK_TOOL_PURPOSE_DEBUG_REPORTING_BIT_EXT"/>
                 <enum bitpos="6" extends="VkToolPurposeFlagBits"            name="VK_TOOL_PURPOSE_DEBUG_MARKERS_BIT_EXT"/>
             </require>
@@ -18136,7 +18976,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkImageStencilUsageCreateInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_validation_features" number="248" type="instance" author="LUNARG" contact="Karl Schultz @karl-lunarg" specialuse="debugging" supported="vulkan">
+        <extension name="VK_EXT_validation_features" number="248" type="instance" author="LUNARG" contact="Karl Schultz @karl-lunarg" specialuse="debugging" supported="vulkan,vulkansc">
             <require>
                 <enum value="5"                                             name="VK_EXT_VALIDATION_FEATURES_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_validation_features&quot;"        name="VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME"/>
@@ -18146,7 +18986,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkValidationFeatureDisableEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_present_wait" number="249" type="device" requires="VK_KHR_swapchain,VK_KHR_present_id" author="KHR" contact="Keith Packard @keithp" supported="vulkan">
+        <extension name="VK_KHR_present_wait" number="249" type="device" depends="VK_KHR_swapchain+VK_KHR_present_id" author="KHR" contact="Keith Packard @keithp" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                         name="VK_KHR_PRESENT_WAIT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_present_wait&quot;"           name="VK_KHR_PRESENT_WAIT_EXTENSION_NAME"/>
@@ -18155,7 +18995,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePresentWaitFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_cooperative_matrix" number="250" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_NV_cooperative_matrix" number="250" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
             <require>
                 <enum value="1"                                              name="VK_NV_COOPERATIVE_MATRIX_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_cooperative_matrix&quot;"           name="VK_NV_COOPERATIVE_MATRIX_EXTENSION_NAME"/>
@@ -18170,7 +19010,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceCooperativeMatrixPropertiesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_coverage_reduction_mode" number="251" requires="VK_NV_framebuffer_mixed_samples" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
+        <extension name="VK_NV_coverage_reduction_mode" number="251" depends="VK_NV_framebuffer_mixed_samples+VK_KHR_get_physical_device_properties2" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_COVERAGE_REDUCTION_MODE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_coverage_reduction_mode&quot;"     name="VK_NV_COVERAGE_REDUCTION_MODE_EXTENSION_NAME"/>
@@ -18185,7 +19025,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_fragment_shader_interlock" number="252" author="EXT" type="device" requires="VK_KHR_get_physical_device_properties2" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_fragment_shader_interlock" number="252" author="EXT" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                                 name="VK_EXT_FRAGMENT_SHADER_INTERLOCK_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_fragment_shader_interlock&quot;"      name="VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME"/>
@@ -18193,7 +19033,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_ycbcr_image_arrays" number="253" type="device" requires="VK_KHR_sampler_ycbcr_conversion" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_ycbcr_image_arrays" number="253" type="device" depends="VK_KHR_sampler_ycbcr_conversion,VK_VERSION_1_1" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_YCBCR_IMAGE_ARRAYS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_ycbcr_image_arrays&quot;"         name="VK_EXT_YCBCR_IMAGE_ARRAYS_EXTENSION_NAME"/>
@@ -18201,7 +19041,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_uniform_buffer_standard_layout" number="254" requires="VK_KHR_get_physical_device_properties2" type="device" author="KHR" contact="Graeme Leese @gnl21" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_uniform_buffer_standard_layout" number="254" depends="VK_KHR_get_physical_device_properties2" type="device" author="KHR" contact="Graeme Leese @gnl21" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_uniform_buffer_standard_layout&quot;" name="VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME"/>
@@ -18209,7 +19049,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES"/>
             </require>
         </extension>
-        <extension name="VK_EXT_provoking_vertex" number="255" type="device" author="EXT" requires="VK_KHR_get_physical_device_properties2" contact="Jesse Hall @jessehall" specialuse="glemulation" supported="vulkan">
+        <extension name="VK_EXT_provoking_vertex" number="255" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2" contact="Jesse Hall @jessehall" specialuse="glemulation" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_PROVOKING_VERTEX_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_provoking_vertex&quot;"           name="VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME"/>
@@ -18222,7 +19062,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkProvokingVertexModeEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_full_screen_exclusive" number="256" type="device" author="EXT" requires="VK_KHR_get_physical_device_properties2,VK_KHR_surface,VK_KHR_get_surface_capabilities2,VK_KHR_swapchain" platform="win32" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_EXT_full_screen_exclusive" number="256" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2+VK_KHR_surface+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" platform="win32" contact="James Jones @cubanismo" supported="vulkan">
             <require>
                 <enum value="4"                                             name="VK_EXT_FULL_SCREEN_EXCLUSIVE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_full_screen_exclusive&quot;"      name="VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME"/>
@@ -18236,18 +19076,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkAcquireFullScreenExclusiveModeEXT"/>
                 <command name="vkReleaseFullScreenExclusiveModeEXT"/>
             </require>
-            <require extension="VK_KHR_win32_surface">
+            <require depends="VK_KHR_win32_surface">
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT"/>
                 <type name="VkSurfaceFullScreenExclusiveWin32InfoEXT"/>
             </require>
-            <require extension="VK_KHR_device_group">
+            <require depends="VK_KHR_device_group">
                 <command name="vkGetDeviceGroupSurfacePresentModes2EXT"/>
             </require>
-            <require feature="VK_VERSION_1_1">
+            <require depends="VK_VERSION_1_1">
                 <command name="vkGetDeviceGroupSurfacePresentModes2EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_headless_surface" number="257" type="instance" requires="VK_KHR_surface" author="EXT" contact="Lisa Wu @chengtianww" supported="vulkan">
+        <extension name="VK_EXT_headless_surface" number="257" type="instance" depends="VK_KHR_surface" author="EXT" contact="Lisa Wu @chengtianww" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                                 name="VK_EXT_HEADLESS_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_headless_surface&quot;"               name="VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME"/>
@@ -18257,7 +19097,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateHeadlessSurfaceEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_buffer_device_address" number="258" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_KHR_buffer_device_address" number="258" type="device" depends="(VK_KHR_get_physical_device_properties2+VK_KHR_device_group),VK_VERSION_1_1" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_BUFFER_DEVICE_ADDRESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_buffer_device_address&quot;"      name="VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME"/>
@@ -18291,7 +19131,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="19" extends="VkImageCreateFlagBits"           name="VK_IMAGE_CREATE_RESERVED_19_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_line_rasterization" number="260" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Jeff Bolz @jeffbolznv" specialuse="cadsupport" supported="vulkan">
+        <extension name="VK_EXT_line_rasterization" number="260" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Jeff Bolz @jeffbolznv" specialuse="cadsupport" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_LINE_RASTERIZATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_line_rasterization&quot;"         name="VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME"/>
@@ -18306,7 +19146,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetLineStippleEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_shader_atomic_float" number="261" type="device" author="NV" requires="VK_KHR_get_physical_device_properties2" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
+        <extension name="VK_EXT_shader_atomic_float" number="261" type="device" author="NV" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_SHADER_ATOMIC_FLOAT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_shader_atomic_float&quot;"        name="VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME"/>
@@ -18314,7 +19154,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_host_query_reset" number="262" author="EXT" contact="Bas Nieuwenhuizen @BNieuwenhuizen" supported="vulkan" type="device" requires="VK_KHR_get_physical_device_properties2" promotedto="VK_VERSION_1_2">
+        <extension name="VK_EXT_host_query_reset" number="262" author="EXT" contact="Bas Nieuwenhuizen @BNieuwenhuizen" supported="vulkan" type="device" depends="VK_KHR_get_physical_device_properties2" promotedto="VK_VERSION_1_2">
             <require>
                 <enum value="1"                                             name="VK_EXT_HOST_QUERY_RESET_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_host_query_reset&quot;"           name="VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME"/>
@@ -18341,7 +19181,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_BRCM_extension_265&quot;"             name="VK_BRCM_EXTENSION_265_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_index_type_uint8" number="266" type="device" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_index_type_uint8" number="266" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_EXT_INDEX_TYPE_UINT8_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_index_type_uint8&quot;"           name="VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME"/>
@@ -18356,7 +19196,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_267&quot;"              name="VK_EXT_EXTENSION_267_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extended_dynamic_state" number="268" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_extended_dynamic_state" number="268" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_EXTENDED_DYNAMIC_STATE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extended_dynamic_state&quot;"     name="VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME"/>
@@ -18388,7 +19228,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetStencilOpEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_deferred_host_operations" number="269" type="device" author="KHR" contact="Josh Barczak @jbarczak" supported="vulkan">
+        <extension name="VK_KHR_deferred_host_operations" number="269" type="device" author="KHR" contact="Josh Barczak @jbarczak" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="4"                                             name="VK_KHR_DEFERRED_HOST_OPERATIONS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_deferred_host_operations&quot;"   name="VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME"/>
@@ -18405,7 +19245,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkResult"       offset="3"       name="VK_OPERATION_NOT_DEFERRED_KHR" />
             </require>
         </extension>
-        <extension name="VK_KHR_pipeline_executable_properties" number="270" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Jason Ekstrand @jekstrand" specialuse="devtools" supported="vulkan">
+        <extension name="VK_KHR_pipeline_executable_properties" number="270" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Faith Ekstrand @gfxstrand" specialuse="devtools" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                         name="VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_pipeline_executable_properties&quot;"   name="VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME"/>
@@ -18430,26 +19270,34 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPipelineExecutableInternalRepresentationsKHR"/>
             </require>
         </extension>
-        <extension name="VK_INTEL_extension_271" number="271" type="device" author="INTEL" contact="Jason Ekstrand @jekstrand" supported="disabled">
+        <extension name="VK_INTEL_extension_271" number="271" type="device" author="INTEL" contact="Faith Ekstrand @gfxstrand" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_INTEL_EXTENSION_271_SPEC_VERSION"/>
                 <enum value="&quot;VK_INTEL_extension_271&quot;"            name="VK_INTEL_EXTENSION_271_EXTENSION_NAME"/>
                 <enum bitpos="22" extends="VkImageUsageFlagBits"            name="VK_IMAGE_USAGE_RESERVED_22_BIT_EXT"/>
+                <enum bitpos="46" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_RESERVED_46_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_INTEL_extension_272" number="272" type="device" author="INTEL" contact="Jason Ekstrand @jekstrand" supported="disabled">
+        <extension name="VK_KHR_map_memory2" number="272" type="device" author="KHR" contact="Faith Ekstrand @gfxstrand" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_INTEL_EXTENSION_272_SPEC_VERSION"/>
-                <enum value="&quot;VK_INTEL_extension_272&quot;"            name="VK_INTEL_EXTENSION_272_EXTENSION_NAME"/>
+                <enum value="1"                               name="VK_KHR_MAP_MEMORY_2_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_map_memory2&quot;"  name="VK_KHR_MAP_MEMORY_2_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"    name="VK_STRUCTURE_TYPE_MEMORY_MAP_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"    name="VK_STRUCTURE_TYPE_MEMORY_UNMAP_INFO_KHR"/>
+                <type name="VkMemoryMapInfoKHR"/>
+                <type name="VkMemoryUnmapInfoKHR"/>
+                <type name="VkMemoryUnmapFlagsKHR"/>
+                <command name="vkMapMemory2KHR"/>
+                <command name="vkUnmapMemory2KHR"/>
             </require>
         </extension>
-        <extension name="VK_INTEL_extension_273" number="273" type="device" author="INTEL" contact="Jason Ekstrand @jekstrand" supported="disabled">
+        <extension name="VK_INTEL_extension_273" number="273" type="device" author="INTEL" contact="Faith Ekstrand @gfxstrand" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_INTEL_EXTENSION_273_SPEC_VERSION"/>
                 <enum value="&quot;VK_INTEL_extension_273&quot;"            name="VK_INTEL_EXTENSION_273_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_shader_atomic_float2" number="274" type="device" requires="VK_EXT_shader_atomic_float" author="EXT" contact="Jason Ekstrand @jekstrand" supported="vulkan">
+        <extension name="VK_EXT_shader_atomic_float2" number="274" type="device" depends="VK_EXT_shader_atomic_float" author="EXT" contact="Faith Ekstrand @gfxstrand" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_SHADER_ATOMIC_FLOAT_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_shader_atomic_float2&quot;"       name="VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME"/>
@@ -18457,7 +19305,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_surface_maintenance1" number="275" type="instance" requires="VK_KHR_surface,VK_KHR_get_surface_capabilities2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
+        <extension name="VK_EXT_surface_maintenance1" number="275" type="instance" depends="VK_KHR_surface+VK_KHR_get_surface_capabilities2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_SURFACE_MAINTENANCE_1_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_surface_maintenance1&quot;"       name="VK_EXT_SURFACE_MAINTENANCE_1_EXTENSION_NAME"/>
@@ -18473,7 +19321,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSurfacePresentModeCompatibilityEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_swapchain_maintenance1" number="276" type="device" requires="VK_KHR_swapchain,VK_EXT_surface_maintenance1,VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
+        <extension name="VK_EXT_swapchain_maintenance1" number="276" type="device" depends="VK_KHR_swapchain+VK_EXT_surface_maintenance1+VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_SWAPCHAIN_MAINTENANCE_1_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_swapchain_maintenance1&quot;"     name="VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME"/>
@@ -18493,7 +19341,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkReleaseSwapchainImagesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_shader_demote_to_helper_invocation" number="277" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_shader_demote_to_helper_invocation" number="277" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_shader_demote_to_helper_invocation&quot;" name="VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME"/>
@@ -18501,7 +19349,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_device_generated_commands" number="278" type="device" requiresCore="1.1" requires="VK_KHR_buffer_device_address" author="NV" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
+        <extension name="VK_NV_device_generated_commands" number="278" type="device" depends="VK_VERSION_1_1+VK_KHR_buffer_device_address" author="NV" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
             <require>
                 <comment>
                     This extension requires buffer_device_address functionality.
@@ -18549,7 +19397,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkDestroyIndirectCommandsLayoutNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_inherited_viewport_scissor" number="279" type="device" author="NV" contact="David Zhao Akeley @akeley98" supported="vulkan">
+        <extension name="VK_NV_inherited_viewport_scissor" number="279" type="device" author="NV" contact="David Zhao Akeley @akeley98" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_INHERITED_VIEWPORT_SCISSOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_inherited_viewport_scissor&quot;"  name="VK_NV_INHERITED_VIEWPORT_SCISSOR_EXTENSION_NAME"/>
@@ -18565,7 +19413,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_280&quot;"              name="VK_KHR_EXTENSION_280_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_integer_dot_product" number="281" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Kevin Petit @kevinpetit" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_shader_integer_dot_product" number="281" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Kevin Petit @kevinpetit" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SHADER_INTEGER_DOT_PRODUCT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_integer_dot_product&quot;" name="VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME"/>
@@ -18575,7 +19423,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_texel_buffer_alignment" number="282" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_texel_buffer_alignment" number="282" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_TEXEL_BUFFER_ALIGNMENT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_texel_buffer_alignment&quot;"     name="VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME"/>
@@ -18585,7 +19433,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_render_pass_transform" number="283" type="device" requires="VK_KHR_swapchain,VK_KHR_surface" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_render_pass_transform" number="283" type="device" depends="VK_KHR_swapchain+VK_KHR_surface" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
             <require>
                 <enum value="3"                                             name="VK_QCOM_RENDER_PASS_TRANSFORM_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_render_pass_transform&quot;"     name="VK_QCOM_RENDER_PASS_TRANSFORM_EXTENSION_NAME"/>
@@ -18602,7 +19450,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_284&quot;"              name="VK_EXT_EXTENSION_284_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_device_memory_report" number="285" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Yiwei Zhang @zhangyiwei" specialuse="devtools" supported="vulkan">
+        <extension name="VK_EXT_device_memory_report" number="285" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Yiwei Zhang @zhangyiwei" specialuse="devtools" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_DEVICE_MEMORY_REPORT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_device_memory_report&quot;"       name="VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME"/>
@@ -18617,7 +19465,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="PFN_vkDeviceMemoryReportCallbackEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_acquire_drm_display" number="286" type="instance" requires="VK_EXT_direct_mode_display" author="EXT" contact="Drew DeVault sir@cmpwn.com" supported="vulkan">
+        <extension name="VK_EXT_acquire_drm_display" number="286" type="instance" depends="VK_EXT_direct_mode_display" author="EXT" contact="Drew DeVault sir@cmpwn.com" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_ACQUIRE_DRM_DISPLAY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_acquire_drm_display&quot;"        name="VK_EXT_ACQUIRE_DRM_DISPLAY_EXTENSION_NAME"/>
@@ -18625,7 +19473,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDrmDisplayEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_robustness2" number="287"  type="device" author="EXT" contact="Liam Middlebrook @liam-middlebrook" supported="vulkan">
+        <extension name="VK_EXT_robustness2" number="287"  type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Liam Middlebrook @liam-middlebrook" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                                 name="VK_EXT_ROBUSTNESS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_robustness2&quot;"                    name="VK_EXT_ROBUSTNESS_2_EXTENSION_NAME"/>
@@ -18635,7 +19483,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceRobustness2PropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_custom_border_color" number="288" type="device" author="EXT" contact="Liam Middlebrook @liam-middlebrook" specialuse="glemulation,d3demulation" supported="vulkan">
+        <extension name="VK_EXT_custom_border_color" number="288" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Liam Middlebrook @liam-middlebrook" specialuse="glemulation,d3demulation" supported="vulkan,vulkansc">
             <require>
                 <enum value="12"                                            name="VK_EXT_CUSTOM_BORDER_COLOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_custom_border_color&quot;"        name="VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME"/>
@@ -18696,7 +19544,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_GOOGLE_user_type&quot;"               name="VK_GOOGLE_USER_TYPE_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_pipeline_library" number="291" type="device" author="KHR" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
+        <extension name="VK_KHR_pipeline_library" number="291" type="device" author="KHR" contact="Christoph Kubisch @pixeljetstream" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_PIPELINE_LIBRARY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_pipeline_library&quot;"           name="VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME"/>
@@ -18711,7 +19559,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_292&quot;"               name="VK_NV_EXTENSION_292_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_present_barrier" number="293" type="device" author="NV" requires="VK_KHR_get_physical_device_properties2,VK_KHR_surface,VK_KHR_get_surface_capabilities2,VK_KHR_swapchain" contact="Liya Li @liyli" supported="vulkan">
+        <extension name="VK_NV_present_barrier" number="293" type="device" author="NV" depends="VK_KHR_get_physical_device_properties2+VK_KHR_surface+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" contact="Liya Li @liyli" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_PRESENT_BARRIER_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_present_barrier&quot;"             name="VK_NV_PRESENT_BARRIER_EXTENSION_NAME"/>
@@ -18723,13 +19571,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSwapchainPresentBarrierCreateInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_non_semantic_info" number="294" type="device" author="KHR" contact="Baldur Karlsson @baldurk" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_shader_non_semantic_info" number="294" type="device" author="KHR" contact="Baldur Karlsson @baldurk" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SHADER_NON_SEMANTIC_INFO_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_non_semantic_info&quot;"   name="VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_present_id" number="295" type="device" requires="VK_KHR_swapchain" author="KHR" contact="Keith Packard @keithp" supported="vulkan">
+        <extension name="VK_KHR_present_id" number="295" type="device" depends="VK_KHR_swapchain+VK_KHR_get_physical_device_properties2" author="KHR" contact="Keith Packard @keithp" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                         name="VK_KHR_PRESENT_ID_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_present_id&quot;"             name="VK_KHR_PRESENT_ID_EXTENSION_NAME"/>
@@ -18739,7 +19587,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePresentIdFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_private_data" number="296" type="device" author="NV" contact="Matthew Rusch @mattruschnv" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_private_data" number="296" type="device" author="NV" contact="Matthew Rusch @mattruschnv" supported="vulkan" depends="VK_KHR_get_physical_device_properties2" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_PRIVATE_DATA_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_private_data&quot;"               name="VK_EXT_PRIVATE_DATA_EXTENSION_NAME"/>
@@ -18765,7 +19613,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="3" extends="VkPipelineShaderStageCreateFlagBits"  name="VK_PIPELINE_SHADER_STAGE_CREATE_RESERVED_3_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pipeline_creation_cache_control" number="298" type="device" author="AMD" contact="Gregory Grebe @grgrebe_amd" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_pipeline_creation_cache_control" number="298" type="device" author="AMD" contact="Gregory Grebe @grgrebe_amd" depends="VK_KHR_get_physical_device_properties2" supported="vulkan" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="3"                                             name="VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pipeline_creation_cache_control&quot;"    name="VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME"/>
@@ -18779,18 +19627,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineCacheCreateFlagBits" comment="This is a temporary workaround for processors not recognizing that VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT above also requires this type"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_299" number="299" author="KHR" contact="Mark Bellamy @mark.bellamy_arm" supported="disabled">
-            <require>
-                <enum value="0"                                             name="VK_KHR_EXTENSION_299_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_299&quot;"              name="VK_KHR_EXTENSION_299_EXTENSION_NAME"/>
-                <enum bitpos="2"  extends="VkMemoryHeapFlagBits"            name="VK_MEMORY_HEAP_RESERVED_2_BIT_KHR"/>
-                <enum             extends="VkPipelineCacheCreateFlagBits"   name="VK_PIPELINE_CACHE_CREATE_RESERVED_1_BIT_KHR" alias="VK_PIPELINE_CACHE_CREATE_RESERVED_1_BIT_EXT"/>
-                <enum bitpos="2"  extends="VkPipelineCacheCreateFlagBits"   name="VK_PIPELINE_CACHE_CREATE_RESERVED_2_BIT_KHR"/>
+        <extension name="VK_KHR_extension_299" number="299" type="device" author="KHR" contact="Mark Bellamy @mark.bellamy_arm" supported="disabled">
+            <require comment="used for Vulkan SC 1.0 namespace">
+                <enum value="0"                                         name="VK_KHR_EXTENSION_299_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_299&quot;"          name="VK_KHR_EXTENSION_299_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_video_encode_queue" number="300"  type="device" requires="VK_KHR_video_queue,VK_KHR_synchronization2" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan">
+        <extension name="VK_KHR_video_encode_queue" number="300"  type="device" depends="VK_KHR_video_queue+VK_KHR_synchronization2" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="7"                                         name="VK_KHR_VIDEO_ENCODE_QUEUE_SPEC_VERSION"/>
+                <enum value="8"                                         name="VK_KHR_VIDEO_ENCODE_QUEUE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_encode_queue&quot;"     name="VK_KHR_VIDEO_ENCODE_QUEUE_EXTENSION_NAME"/>
                 <!-- VkPipelineStageFlagBits bitpos="27" is reserved by this extension, but not used -->
                 <enum bitpos="27" extends="VkPipelineStageFlagBits2"    name="VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS" />
@@ -18801,6 +19646,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum bitpos="6" extends="VkQueueFlagBits"              name="VK_QUEUE_VIDEO_ENCODE_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum bitpos="1" extends="VkVideoCodingControlFlagBitsKHR" name="VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum bitpos="2" extends="VkVideoCodingControlFlagBitsKHR" name="VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_LAYER_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
@@ -18814,7 +19660,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_DST_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="1" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="2" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_DPB_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="0" extends="VkQueryType"                  name="VK_QUERY_TYPE_VIDEO_ENCODE_BITSTREAM_BUFFER_RANGE_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="0" extends="VkQueryType"                  name="VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+
+                <enum offset="0" extends="VkResult" dir="-"             name="VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
 
                 <type name="VkVideoEncodeFlagsKHR"/>
                 <type name="VkVideoEncodeInfoKHR"/>
@@ -18822,6 +19670,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoEncodeCapabilityFlagBitsKHR"/>
                 <type name="VkVideoEncodeCapabilityFlagsKHR"/>
                 <type name="VkVideoEncodeCapabilitiesKHR"/>
+
+                <type name="VkQueryPoolVideoEncodeFeedbackCreateInfoKHR"/>
+                <type name="VkVideoEncodeFeedbackFlagBitsKHR"/>
+                <type name="VkVideoEncodeFeedbackFlagsKHR"/>
 
                 <type name="VkVideoEncodeUsageFlagBitsKHR"/>
                 <type name="VkVideoEncodeUsageFlagsKHR"/>
@@ -18838,12 +19690,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
 
                 <command name="vkCmdEncodeVideoKHR"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <enum bitpos="27" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum bitpos="28" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
             </require>
         </extension>
-        <extension name="VK_NV_device_diagnostics_config" number="301" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
+        <extension name="VK_NV_device_diagnostics_config" number="301" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_NV_DEVICE_DIAGNOSTICS_CONFIG_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_device_diagnostics_config&quot;"   name="VK_NV_DEVICE_DIAGNOSTICS_CONFIG_EXTENSION_NAME"/>
@@ -18898,10 +19750,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_308&quot;"               name="VK_NV_EXTENSION_308_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_309" number="309" author="KHR" contact="Aidan Fabius @afabius" supported="disabled">
+        <extension name="VK_KHR_object_refresh" number="309" type="device" author="KHR" contact="Aidan Fabius @afabius" supported="vulkansc" ratified="vulkansc">
             <require>
-                <enum value="0"                                             name="VK_KHR_EXTENSION_309_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_309&quot;"              name="VK_KHR_EXTENSION_309_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_KHR_OBJECT_REFRESH_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_object_refresh&quot;"             name="VK_KHR_OBJECT_REFRESH_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_REFRESH_OBJECT_LIST_KHR"/>
+                <type name="VkRefreshObjectListKHR"/>
+                <type name="VkRefreshObjectKHR"/>
+                <type name="VkRefreshObjectFlagBitsKHR"/>
+                <type name="VkRefreshObjectFlagsKHR"/>
+                <command name="vkCmdRefreshObjectsKHR"/>
+                <command name="vkGetPhysicalDeviceRefreshableObjectTypesKHR"/>
             </require>
         </extension>
         <extension name="VK_QCOM_extension_310" number="310" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
@@ -18911,10 +19770,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_RESERVED_QCOM"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_311" number="311" author="NV" contact="Charles Hansen @cshansen" supported="disabled">
+        <extension name="VK_NV_low_latency" number="311" author="NV" type="device" supported="vulkan" contact="Charles Hansen @cshansen" >
             <require>
-                <enum value="0"                                             name="VK_NV_EXTENSION_311_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_311&quot;"               name="VK_NV_EXTENSION_311_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_NV_LOW_LATENCY_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_low_latency&quot;"                 name="VK_NV_LOW_LATENCY_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_QUERY_LOW_LATENCY_SUPPORT_NV"/>
+                <type name="VkQueryLowLatencySupportNV"/>
             </require>
         </extension>
         <extension name="VK_EXT_metal_objects" number="312" type="device" platform="metal" supported="vulkan" author="EXT" contact="Bill Hollings @billhollings">
@@ -18968,7 +19829,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_314&quot;"              name="VK_AMD_EXTENSION_314_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_synchronization2" number="315" type="device" author="KHR" requires="VK_KHR_get_physical_device_properties2" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_synchronization2" number="315" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Tobias Hector @tobski" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_KHR_SYNCHRONIZATION_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_synchronization2&quot;"           name="VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME"/>
@@ -19007,65 +19868,65 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdWriteTimestamp2KHR"/>
                 <command name="vkQueueSubmit2KHR"/>
             </require>
-            <require extension="VK_EXT_transform_feedback">
+            <require depends="VK_EXT_transform_feedback">
                 <enum bitpos="24" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT"/>
                 <enum bitpos="25" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT"/>
                 <enum bitpos="26" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT"/>
                 <enum bitpos="27" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT"/>
             </require>
-            <require extension="VK_EXT_conditional_rendering">
+            <require depends="VK_EXT_conditional_rendering">
                 <enum bitpos="18" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT" comment="A pipeline stage for conditional rendering predicate fetch"/>
                 <enum bitpos="20" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_CONDITIONAL_RENDERING_READ_BIT_EXT"  comment="read access flag for reading conditional rendering predicate"/>
             </require>
-            <require extension="VK_NV_device_generated_commands">
+            <require depends="VK_NV_device_generated_commands">
                 <enum bitpos="17" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV"/>
                 <enum bitpos="17" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV"/>
                 <enum bitpos="18" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_COMMAND_PREPROCESS_WRITE_BIT_NV"/>
             </require>
-            <require extension="VK_KHR_fragment_shading_rate">
+            <require depends="VK_KHR_fragment_shading_rate">
                 <enum bitpos="22" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
                 <enum bitpos="23" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR"/>
             </require>
-            <require extension="VK_NV_shading_rate_image">
+            <require depends="VK_NV_shading_rate_image">
                 <enum extends="VkPipelineStageFlagBits2"                    name="VK_PIPELINE_STAGE_2_SHADING_RATE_IMAGE_BIT_NV" alias="VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
                 <enum extends="VkAccessFlagBits2"                           name="VK_ACCESS_2_SHADING_RATE_IMAGE_READ_BIT_NV"    alias="VK_ACCESS_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR"/>
             </require>
-            <require extension="VK_KHR_acceleration_structure">
+            <require depends="VK_KHR_acceleration_structure">
                 <enum bitpos="25" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR"/>
                 <enum bitpos="21" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR"/>
                 <enum bitpos="22" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR"/>
             </require>
-            <require extension="VK_KHR_ray_tracing_pipeline">
+            <require depends="VK_KHR_ray_tracing_pipeline">
                 <enum bitpos="21" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR"/>
             </require>
-            <require extension="VK_NV_ray_tracing">
+            <require depends="VK_NV_ray_tracing">
                 <enum extends="VkPipelineStageFlagBits2"                    name="VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_NV" alias="VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR"/>
                 <enum extends="VkPipelineStageFlagBits2"                    name="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_NV" alias="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR"/>
                 <enum extends="VkAccessFlagBits2"                           name="VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_NV" alias="VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR"/>
                 <enum extends="VkAccessFlagBits2"                           name="VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_NV" alias="VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR"/>
             </require>
-            <require extension="VK_EXT_fragment_density_map">
+            <require depends="VK_EXT_fragment_density_map">
                 <enum bitpos="23" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT"/>
                 <enum bitpos="24" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_FRAGMENT_DENSITY_MAP_READ_BIT_EXT"/>
             </require>
-            <require extension="VK_EXT_blend_operation_advanced">
+            <require depends="VK_EXT_blend_operation_advanced">
                 <enum bitpos="19" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT"/>
             </require>
-            <require extension="VK_NV_mesh_shader">
+            <require depends="VK_NV_mesh_shader">
                 <enum extends="VkPipelineStageFlagBits2"                    name="VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_NV" alias="VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT"/>
                 <enum extends="VkPipelineStageFlagBits2"                    name="VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_NV" alias="VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT"/>
             </require>
-            <require extension="VK_AMD_buffer_marker">
+            <require depends="VK_AMD_buffer_marker">
                 <command name="vkCmdWriteBufferMarker2AMD"/>
             </require>
-            <require extension="VK_NV_device_diagnostic_checkpoints">
+            <require depends="VK_NV_device_diagnostic_checkpoints">
                 <type name="VkQueueFamilyCheckpointProperties2NV"/>
                 <type name="VkCheckpointData2NV"/>
                 <command name="vkGetQueueCheckpointData2NV"/>
                 <enum offset="8" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV"/>
                 <enum offset="9" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_CHECKPOINT_DATA_2_NV"/>
             </require>
-            <require extension="VK_EXT_mesh_shader">
+            <require depends="VK_EXT_mesh_shader">
                 <enum bitpos="19" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT"/>
                 <enum bitpos="20" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT"/>
             </require>
@@ -19076,7 +19937,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_316&quot;"              name="VK_AMD_EXTENSION_316_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_descriptor_buffer" number="317" type="device" author="EXT" requires="VK_KHR_get_physical_device_properties2,VK_KHR_buffer_device_address,VK_KHR_synchronization2,VK_EXT_descriptor_indexing" contact="Tobias Hector @tobski" supported="vulkan">
+        <extension name="VK_EXT_descriptor_buffer" number="317" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2+VK_KHR_buffer_device_address+VK_KHR_synchronization2+VK_EXT_descriptor_indexing" contact="Tobias Hector @tobski" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_DESCRIPTOR_BUFFER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_descriptor_buffer&quot;"              name="VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME"/>
@@ -19128,7 +19989,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetImageViewOpaqueCaptureDescriptorDataEXT"/>
                 <command name="vkGetSamplerOpaqueCaptureDescriptorDataEXT"/>
             </require>
-            <require extension="VK_KHR_acceleration_structure,VK_NV_ray_tracing">
+            <require depends="VK_KHR_acceleration_structure,VK_NV_ray_tracing">
                 <enum offset="9" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT"/>
                 <type name="VkAccelerationStructureCaptureDescriptorDataInfoEXT"/>
                 <command name="vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT"/>
@@ -19154,7 +20015,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_320&quot;"              name="VK_AMD_EXTENSION_320_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_graphics_pipeline_library" number="321" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_pipeline_library" author="AMD" contact="Tobias Hector @tobski" supported="vulkan">
+        <extension name="VK_EXT_graphics_pipeline_library" number="321" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_pipeline_library" author="AMD" contact="Tobias Hector @tobski" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_GRAPHICS_PIPELINE_LIBRARY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_graphics_pipeline_library&quot;"  name="VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME"/>
@@ -19172,7 +20033,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="1" extends="VkPipelineLayoutCreateFlagBits" name="VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_AMD_shader_early_and_late_fragment_tests" number="322" author="EXT" contact="Tobias Hector @tobski" type="device" supported="vulkan">
+        <extension name="VK_AMD_shader_early_and_late_fragment_tests" number="322" author="EXT" contact="Tobias Hector @tobski" type="device" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_early_and_late_fragment_tests&quot;" name="VK_AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_EXTENSION_NAME"/>
@@ -19180,7 +20041,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD"/>
             </require>
         </extension>
-        <extension name="VK_KHR_fragment_shader_barycentric" number="323" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Stu Smith" supported="vulkan">
+        <extension name="VK_KHR_fragment_shader_barycentric" number="323" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Stu Smith" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                              name="VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_fragment_shader_barycentric&quot;" name="VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME"/>
@@ -19190,7 +20051,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_subgroup_uniform_control_flow" number="324" type="device" requiresCore="1.1" author="KHR" contact="Alan Baker @alan-baker" supported="vulkan">
+        <extension name="VK_KHR_shader_subgroup_uniform_control_flow" number="324" type="device" depends="VK_VERSION_1_1" author="KHR" contact="Alan Baker @alan-baker" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1" name="VK_KHR_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_subgroup_uniform_control_flow&quot;" name="VK_KHR_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_EXTENSION_NAME"/>
@@ -19204,7 +20065,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_325&quot;"              name="VK_KHR_EXTENSION_325_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_zero_initialize_workgroup_memory" number="326" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alan Baker @alan-baker" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_zero_initialize_workgroup_memory" number="326" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alan Baker @alan-baker" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="1"                                                   name="VK_KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_zero_initialize_workgroup_memory&quot;" name="VK_KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_EXTENSION_NAME"/>
@@ -19212,7 +20073,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_fragment_shading_rate_enums" number="327" type="device" requires="VK_KHR_fragment_shading_rate" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_fragment_shading_rate_enums" number="327" type="device" depends="VK_KHR_fragment_shading_rate" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_NV_FRAGMENT_SHADING_RATE_ENUMS_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_fragment_shading_rate_enums&quot;" name="VK_NV_FRAGMENT_SHADING_RATE_ENUMS_EXTENSION_NAME"/>
@@ -19227,7 +20088,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetFragmentShadingRateEnumNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_ray_tracing_motion_blur" number="328" type="device" requires="VK_KHR_ray_tracing_pipeline" author="NV" contact="Eric Werness" supported="vulkan">
+        <extension name="VK_NV_ray_tracing_motion_blur" number="328" type="device" depends="VK_KHR_ray_tracing_pipeline" author="NV" contact="Eric Werness" supported="vulkan">
             <require>
                 <enum value="1"                                                    name="VK_NV_RAY_TRACING_MOTION_BLUR_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_ray_tracing_motion_blur&quot;"            name="VK_NV_RAY_TRACING_MOTION_BLUR_EXTENSION_NAME"/>
@@ -19250,7 +20111,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkAccelerationStructureMotionInstanceFlagsNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_mesh_shader" number="329" type="device" requiresCore="1.1" requires="VK_KHR_get_physical_device_properties2,VK_KHR_spirv_1_4" author="EXT" sortorder="1" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
+        <extension name="VK_EXT_mesh_shader" number="329" type="device" depends="VK_KHR_spirv_1_4" author="EXT" sortorder="1" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_EXT_MESH_SHADER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_mesh_shader&quot;"            name="VK_EXT_MESH_SHADER_EXTENSION_NAME"/>
@@ -19270,7 +20131,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceMeshShaderPropertiesEXT"/>
                 <type name="VkDrawMeshTasksIndirectCommandEXT"/>
             </require>
-            <require extension="VK_NV_device_generated_commands">
+            <require depends="VK_NV_device_generated_commands">
                 <enum offset="0" extends="VkIndirectCommandsTokenTypeNV" name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_MESH_TASKS_NV"/>
             </require>
         </extension>
@@ -19280,7 +20141,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_330&quot;"               name="VK_NV_EXTENSION_330_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_ycbcr_2plane_444_formats" number="331" type="device" requires="VK_KHR_sampler_ycbcr_conversion" author="EXT" contact="Tony Zlatinski @tzlatinski" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_ycbcr_2plane_444_formats" number="331" type="device" depends="VK_KHR_sampler_ycbcr_conversion,VK_VERSION_1_1" author="EXT" contact="Tony Zlatinski @tzlatinski" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <comment>
                     VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT and
@@ -19303,7 +20164,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_332&quot;"               name="VK_NV_EXTENSION_332_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_fragment_density_map2" number="333" type="device" requires="VK_EXT_fragment_density_map" author="EXT" contact="Matthew Netsch @mnetsch" supported="vulkan">
+        <extension name="VK_EXT_fragment_density_map2" number="333" type="device" depends="VK_EXT_fragment_density_map" author="EXT" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_FRAGMENT_DENSITY_MAP_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_fragment_density_map2&quot;"      name="VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME"/>
@@ -19314,7 +20175,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_rotated_copy_commands" number="334" type="device" requires="VK_KHR_swapchain,VK_KHR_copy_commands2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_rotated_copy_commands" number="334" type="device" depends="VK_KHR_swapchain+VK_KHR_copy_commands2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_QCOM_ROTATED_COPY_COMMANDS_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_rotated_copy_commands&quot;"     name="VK_QCOM_ROTATED_COPY_COMMANDS_EXTENSION_NAME"/>
@@ -19322,13 +20183,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkCopyCommandTransformInfoQCOM"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_335" number="335" author="KHR" contact="Mark Bellamy @mark.bellamy_arm" supported="disabled">
+        <extension name="VK_KHR_extension_335" number="335" type="device" author="KHR" contact="Mark Bellamy @mark.bellamy_arm" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_KHR_EXTENSION_335_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_extension_335&quot;"              name="VK_KHR_EXTENSION_335_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_robustness" number="336" type="device" author="EXT" contact="Graeme Leese @gnl21" supported="vulkan" requires="VK_KHR_get_physical_device_properties2" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_image_robustness" number="336" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Graeme Leese @gnl21" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_ROBUSTNESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_robustness&quot;"           name="VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME"/>
@@ -19336,7 +20197,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceImageRobustnessFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_workgroup_memory_explicit_layout" number="337" type="device" requires="VK_KHR_get_physical_device_properties2" author="KHR" contact="Caio Marcelo de Oliveira Filho @cmarcelo" supported="vulkan">
+        <extension name="VK_KHR_workgroup_memory_explicit_layout" number="337" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Caio Marcelo de Oliveira Filho @cmarcelo" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                                      name="VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_workgroup_memory_explicit_layout&quot;"    name="VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_EXTENSION_NAME"/>
@@ -19344,7 +20205,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_copy_commands2" number="338" author="KHR" type="device" contact="Jeff Leger @jackohound" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_copy_commands2" number="338" author="KHR" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Jeff Leger @jackohound" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3" ratified="vulkan,vulkansc">
             <require>
                 <enum value="1"                                             name="VK_KHR_COPY_COMMANDS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_copy_commands2&quot;"             name="VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME"/>
@@ -19378,7 +20239,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdResolveImage2KHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_compression_control" number="339" type="device" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
+        <extension name="VK_EXT_image_compression_control" number="339" type="device" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_COMPRESSION_CONTROL_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_compression_control&quot;"  name="VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME"/>
@@ -19400,7 +20261,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetImageSubresourceLayout2EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_attachment_feedback_loop_layout" number="340" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan">
+        <extension name="VK_EXT_attachment_feedback_loop_layout" number="340" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan">
             <require>
                 <enum value="2"                                                    name="VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_attachment_feedback_loop_layout&quot;"   name="VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME"/>
@@ -19413,7 +20274,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_4444_formats" number="341" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_4444_formats" number="341" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <comment>
                     VkPhysicalDevice4444FormatsFeaturesEXT and
@@ -19428,9 +20289,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevice4444FormatsFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_device_fault" number="342" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Ralph Potter gitlab:@r_potter" supported="vulkan">
+        <extension name="VK_EXT_device_fault" number="342" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Ralph Potter gitlab:@r_potter" supported="vulkan">
             <require>
-                <enum value="1"                                             name="VK_EXT_DEVICE_FAULT_SPEC_VERSION"/>
+                <enum value="2"                                             name="VK_EXT_DEVICE_FAULT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_device_fault&quot;"               name="VK_EXT_DEVICE_FAULT_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEVICE_FAULT_COUNTS_EXT"/>
@@ -19446,7 +20307,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDeviceFaultInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_ARM_rasterization_order_attachment_access" number="343" type="device" requires="VK_KHR_get_physical_device_properties2" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" promotedto="VK_EXT_rasterization_order_attachment_access">
+        <extension name="VK_ARM_rasterization_order_attachment_access" number="343" type="device" depends="VK_KHR_get_physical_device_properties2" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" promotedto="VK_EXT_rasterization_order_attachment_access">
             <require>
                 <enum value="1"                                                        name="VK_ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_ARM_rasterization_order_attachment_access&quot;" name="VK_ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXTENSION_NAME"/>
@@ -19466,7 +20327,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_ARM_extension_344&quot;"              name="VK_ARM_EXTENSION_344_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_rgba10x6_formats" number="345" type="device" requires="VK_KHR_sampler_ycbcr_conversion" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
+        <extension name="VK_EXT_rgba10x6_formats" number="345" type="device" depends="VK_KHR_sampler_ycbcr_conversion" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
              <require>
                     <enum value="1"                                                name="VK_EXT_RGBA10X6_FORMATS_SPEC_VERSION"/>
                     <enum value="&quot;VK_EXT_rgba10x6_formats&quot;"              name="VK_EXT_RGBA10X6_FORMATS_EXTENSION_NAME"/>
@@ -19474,7 +20335,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                     <type name="VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_acquire_winrt_display" number="346" type="device" requires="VK_EXT_direct_mode_display" author="NV" contact="Jeff Juliano @jjuliano" platform="win32" supported="vulkan">
+        <extension name="VK_NV_acquire_winrt_display" number="346" type="device" depends="VK_EXT_direct_mode_display" author="NV" contact="Jeff Juliano @jjuliano" platform="win32" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_ACQUIRE_WINRT_DISPLAY_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_acquire_winrt_display&quot;"       name="VK_NV_ACQUIRE_WINRT_DISPLAY_EXTENSION_NAME"/>
@@ -19482,7 +20343,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetWinrtDisplayNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_directfb_surface" number="347" type="instance" requires="VK_KHR_surface" platform="directfb" supported="vulkan" author="EXT" contact="Nicolas Caramelli @caramelli">
+        <extension name="VK_EXT_directfb_surface" number="347" type="instance" depends="VK_KHR_surface" platform="directfb" supported="vulkan" author="EXT" contact="Nicolas Caramelli @caramelli">
             <require>
                 <enum value="1"                                             name="VK_EXT_DIRECTFB_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_directfb_surface&quot;"           name="VK_EXT_DIRECTFB_SURFACE_EXTENSION_NAME"/>
@@ -19493,7 +20354,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceDirectFBPresentationSupportEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_350" number="350" author="KHR" contact="Mark Bellamy @mark.bellamy_arm" supported="disabled">
+        <extension name="VK_KHR_extension_350" number="350" type="device" author="KHR" contact="Mark Bellamy @mark.bellamy_arm" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_KHR_EXTENSION_350_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_extension_350&quot;"              name="VK_KHR_EXTENSION_350_EXTENSION_NAME"/>
@@ -19505,7 +20366,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_351&quot;"               name="VK_NV_EXTENSION_351_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_VALVE_mutable_descriptor_type" number="352" type="device" supported="vulkan" author="VALVE" contact="Joshua Ashton @Joshua-Ashton,Hans-Kristian Arntzen @HansKristian-Work" specialuse="d3demulation" requires="VK_KHR_maintenance3" promotedto="VK_EXT_mutable_descriptor_type">
+        <extension name="VK_VALVE_mutable_descriptor_type" number="352" type="device" supported="vulkan" author="VALVE" contact="Joshua Ashton @Joshua-Ashton,Hans-Kristian Arntzen @HansKristian-Work" specialuse="d3demulation" depends="VK_KHR_maintenance3" promotedto="VK_EXT_mutable_descriptor_type">
             <require>
                 <enum value="1"                                                name="VK_VALVE_MUTABLE_DESCRIPTOR_TYPE_SPEC_VERSION"/>
                 <enum value="&quot;VK_VALVE_mutable_descriptor_type&quot;"     name="VK_VALVE_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME"/>
@@ -19519,7 +20380,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkMutableDescriptorTypeCreateInfoVALVE"/>
             </require>
         </extension>
-        <extension name="VK_EXT_vertex_input_dynamic_state" number="353" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_vertex_input_dynamic_state" number="353" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_vertex_input_dynamic_state&quot;" name="VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME"/>
@@ -19533,7 +20394,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetVertexInputEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_physical_device_drm" number="354" author="EXT" type="device" contact="Simon Ser @emersion" supported="vulkan" requires="VK_KHR_get_physical_device_properties2">
+        <extension name="VK_EXT_physical_device_drm" number="354" author="EXT" type="device" contact="Simon Ser @emersion" supported="vulkan" depends="VK_KHR_get_physical_device_properties2">
             <require>
                 <enum value="1"                                             name="VK_EXT_PHYSICAL_DEVICE_DRM_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_physical_device_drm&quot;"        name="VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME"/>
@@ -19543,7 +20404,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceDrmPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_device_address_binding_report" number="355" type="device" requires="VK_KHR_get_physical_device_properties2,VK_EXT_debug_utils" author="EXT" contact="Ralph Potter gitlab:@r_potter" specialuse="debugging,devtools" supported="vulkan">
+        <extension name="VK_EXT_device_address_binding_report" number="355" type="device" depends="VK_KHR_get_physical_device_properties2+VK_EXT_debug_utils" author="EXT" contact="Ralph Potter gitlab:@r_potter" specialuse="debugging,devtools" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_DEVICE_ADDRESS_BINDING_REPORT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_device_address_binding_report&quot;"  name="VK_EXT_DEVICE_ADDRESS_BINDING_REPORT_EXTENSION_NAME"/>
@@ -19557,7 +20418,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkDeviceAddressBindingTypeEXT" />
             </require>
         </extension>
-        <extension name="VK_EXT_depth_clip_control" number="356" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
+        <extension name="VK_EXT_depth_clip_control" number="356" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
             <require>
                 <enum value="1"                                             name="VK_EXT_DEPTH_CLIP_CONTROL_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_depth_clip_control&quot;"         name="VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME"/>
@@ -19567,7 +20428,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineViewportDepthClipControlCreateInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_primitive_topology_list_restart" number="357" type="device" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
+        <extension name="VK_EXT_primitive_topology_list_restart" number="357" type="device" author="EXT" contact="Shahbaz Youssefi @syoussefi" depends="VK_KHR_get_physical_device_properties2" supported="vulkan" specialuse="glemulation">
             <require>
                 <enum value="1"                                             name="VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_primitive_topology_list_restart&quot;"           name="VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME"/>
@@ -19593,7 +20454,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_360&quot;"              name="VK_EXT_EXTENSION_360_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_format_feature_flags2" number="361" author="KHR" type="device" requires="VK_KHR_get_physical_device_properties2" contact="Lionel Landwerlin @llandwerlin" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_format_feature_flags2" number="361" author="KHR" type="device" depends="VK_KHR_get_physical_device_properties2" contact="Lionel Landwerlin @llandwerlin" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="2"                                             name="VK_KHR_FORMAT_FEATURE_FLAGS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_format_feature_flags2&quot;"      name="VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME"/>
@@ -19621,7 +20482,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_FUCHSIA_extension_364&quot;"          name="VK_FUCHSIA_EXTENSION_364_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_FUCHSIA_external_memory" number="365" type="device" requires="VK_KHR_external_memory_capabilities,VK_KHR_external_memory" author="FUCHSIA" contact="John Rosasco @rosasco" platform="fuchsia" supported="vulkan">
+        <extension name="VK_FUCHSIA_external_memory" number="365" type="device" depends="VK_KHR_external_memory_capabilities+VK_KHR_external_memory" author="FUCHSIA" contact="John Rosasco @rosasco" platform="fuchsia" supported="vulkan">
             <require>
                 <enum value="1"                                                name="VK_FUCHSIA_EXTERNAL_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_FUCHSIA_external_memory&quot;"           name="VK_FUCHSIA_EXTERNAL_MEMORY_EXTENSION_NAME"/>
@@ -19636,7 +20497,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMemoryZirconHandlePropertiesFUCHSIA"/>
             </require>
         </extension>
-        <extension name="VK_FUCHSIA_external_semaphore" number="366" type="device" requires="VK_KHR_external_semaphore_capabilities,VK_KHR_external_semaphore" author="FUCHSIA" contact="John Rosasco @rosasco" platform="fuchsia" supported="vulkan">
+        <extension name="VK_FUCHSIA_external_semaphore" number="366" type="device" depends="VK_KHR_external_semaphore_capabilities+VK_KHR_external_semaphore" author="FUCHSIA" contact="John Rosasco @rosasco" platform="fuchsia" supported="vulkan">
             <require>
                 <enum value="1"                                                name="VK_FUCHSIA_EXTERNAL_SEMAPHORE_SPEC_VERSION"/>
                 <enum value="&quot;VK_FUCHSIA_external_semaphore&quot;"        name="VK_FUCHSIA_EXTERNAL_SEMAPHORE_EXTENSION_NAME"/>
@@ -19649,7 +20510,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetSemaphoreZirconHandleFUCHSIA"/>
             </require>
         </extension>
-        <extension name="VK_FUCHSIA_buffer_collection" number="367" type="device" requires="VK_FUCHSIA_external_memory,VK_KHR_sampler_ycbcr_conversion" author="FUCHSIA" contact="John Rosasco @rosasco" supported="vulkan" platform="fuchsia">
+        <extension name="VK_FUCHSIA_buffer_collection" number="367" type="device" depends="VK_FUCHSIA_external_memory+VK_KHR_sampler_ycbcr_conversion" author="FUCHSIA" contact="John Rosasco @rosasco" supported="vulkan" platform="fuchsia">
             <require>
                 <enum value="2"                                         name="VK_FUCHSIA_BUFFER_COLLECTION_SPEC_VERSION"/>
                 <enum value="&quot;VK_FUCHSIA_buffer_collection&quot;"  name="VK_FUCHSIA_BUFFER_COLLECTION_EXTENSION_NAME"/>
@@ -19699,7 +20560,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="4" extends="VkDescriptorBindingFlagBits"  name="VK_DESCRIPTOR_BINDING_RESERVED_4_BIT_QCOM"/>
             </require>
         </extension>
-        <extension name="VK_HUAWEI_subpass_shading" number="370" type="device" author="HUAWEI" contact="Pan Gao @PanGao-h" requires="VK_KHR_create_renderpass2,VK_KHR_synchronization2" supported="vulkan">
+        <extension name="VK_HUAWEI_subpass_shading" number="370" type="device" author="HUAWEI" contact="Pan Gao @PanGao-h" depends="VK_KHR_create_renderpass2+VK_KHR_synchronization2" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_HUAWEI_SUBPASS_SHADING_SPEC_VERSION"/>
                 <enum value="&quot;VK_HUAWEI_subpass_shading&quot;"         name="VK_HUAWEI_SUBPASS_SHADING_EXTENSION_NAME"/>
@@ -19716,7 +20577,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSubpassShadingHUAWEI"/>
             </require>
         </extension>
-        <extension name="VK_HUAWEI_invocation_mask" number="371" type="device" requires="VK_KHR_ray_tracing_pipeline,VK_KHR_synchronization2" author="Huawei" contact="Pan Gao @PanGao-h" supported="vulkan">
+        <extension name="VK_HUAWEI_invocation_mask" number="371" type="device" depends="VK_KHR_ray_tracing_pipeline+VK_KHR_synchronization2" author="Huawei" contact="Pan Gao @PanGao-h" supported="vulkan">
             <require>
                 <enum value="1"                                              name="VK_HUAWEI_INVOCATION_MASK_SPEC_VERSION"/>
                 <enum value="&quot;VK_HUAWEI_invocation_mask&quot;"        name="VK_HUAWEI_INVOCATION_MASK_EXTENSION_NAME"/>
@@ -19728,7 +20589,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdBindInvocationMaskHUAWEI"/>
             </require>
         </extension>
-        <extension name="VK_NV_external_memory_rdma" number="372" type="device" requires="VK_KHR_external_memory" author="NV" contact="Carsten Rohde @crohde" supported="vulkan">
+        <extension name="VK_NV_external_memory_rdma" number="372" type="device" depends="VK_KHR_external_memory" author="NV" contact="Carsten Rohde @crohde" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_NV_EXTERNAL_MEMORY_RDMA_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_external_memory_rdma&quot;"            name="VK_NV_EXTERNAL_MEMORY_RDMA_EXTENSION_NAME"/>
@@ -19742,7 +20603,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMemoryRemoteAddressNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pipeline_properties" number="373" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Mukund Keshava @mkeshavanv" supported="vulkan">
+        <extension name="VK_EXT_pipeline_properties" number="373" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Mukund Keshava @mkeshavanv" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_PIPELINE_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pipeline_properties&quot;"        name="VK_EXT_PIPELINE_PROPERTIES_EXTENSION_NAME"/>
@@ -19755,20 +20616,60 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPipelinePropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_374" number="374" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_NV_external_sci_sync" number="374" depends="VK_VERSION_1_1" platform="sci" type="device" author="NV" contact="Kai Zhang @kazhang" supported="vulkansc" deprecatedby="VK_NV_external_sci_sync2">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_374_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_374&quot;"           name="VK_NV_EXTENSION_374_EXTENSION_NAME"/>
-                <enum bitpos="4" extends="VkExternalFenceHandleTypeFlagBits" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_RESERVED_4_BIT_NV"/>
-                <enum bitpos="5" extends="VkExternalFenceHandleTypeFlagBits" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_RESERVED_5_BIT_NV"/>
-                <enum bitpos="5" extends="VkExternalSemaphoreHandleTypeFlagBits" name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_RESERVED_5_BIT_NV"/>
+                <enum value="2"                                         name="VK_NV_EXTERNAL_SCI_SYNC_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_external_sci_sync&quot;"       name="VK_NV_EXTERNAL_SCI_SYNC_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_FENCE_SCI_SYNC_INFO_NV"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_FENCE_SCI_SYNC_INFO_NV"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_FENCE_GET_SCI_SYNC_INFO_NV"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SCI_SYNC_ATTRIBUTES_INFO_NV"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_SCI_SYNC_INFO_NV"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_SCI_SYNC_INFO_NV"/>
+                <enum offset="6" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SEMAPHORE_GET_SCI_SYNC_INFO_NV"/>
+                <enum offset="7" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SCI_SYNC_FEATURES_NV"/>
+                <enum bitpos="4" extends="VkExternalFenceHandleTypeFlagBits" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_SCI_SYNC_OBJ_BIT_NV"/>
+                <enum bitpos="5" extends="VkExternalFenceHandleTypeFlagBits" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_SCI_SYNC_FENCE_BIT_NV"/>
+                <enum bitpos="5" extends="VkExternalSemaphoreHandleTypeFlagBits" name="VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SCI_SYNC_OBJ_BIT_NV"/>
+                <type name="VkSciSyncClientTypeNV"/>
+                <type name="VkSciSyncPrimitiveTypeNV"/>
+                <type name="VkExportFenceSciSyncInfoNV"/>
+                <type name="VkImportFenceSciSyncInfoNV"/>
+                <type name="VkFenceGetSciSyncInfoNV"/>
+                <type name="VkSciSyncAttributesInfoNV"/>
+                <type name="VkExportSemaphoreSciSyncInfoNV"/>
+                <type name="VkImportSemaphoreSciSyncInfoNV"/>
+                <type name="VkSemaphoreGetSciSyncInfoNV"/>
+                <type name="VkPhysicalDeviceExternalSciSyncFeaturesNV"/>
+                <command name="vkGetFenceSciSyncFenceNV"/>
+                <command name="vkGetFenceSciSyncObjNV"/>
+                <command name="vkImportFenceSciSyncFenceNV"/>
+                <command name="vkImportFenceSciSyncObjNV"/>
+                <command name="vkGetPhysicalDeviceSciSyncAttributesNV"/>
+                <command name="vkGetSemaphoreSciSyncObjNV"/>
+                <command name="vkImportSemaphoreSciSyncObjNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_375" number="375" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_NV_external_memory_sci_buf" number="375" depends="VK_VERSION_1_1" platform="sci" type="device" author="NV" contact="Kai Zhang @kazhang" supported="vulkansc">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_375_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_375&quot;"           name="VK_NV_EXTENSION_375_EXTENSION_NAME"/>
-                <enum bitpos="13" extends="VkExternalMemoryHandleTypeFlagBits"  name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_RESERVED_13_BIT_NV"/>
+                <enum value="2"                                         name="VK_NV_EXTERNAL_MEMORY_SCI_BUF_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_external_memory_sci_buf&quot;" name="VK_NV_EXTERNAL_MEMORY_SCI_BUF_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_MEMORY_SCI_BUF_INFO_NV"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXPORT_MEMORY_SCI_BUF_INFO_NV"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_GET_SCI_BUF_INFO_NV"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_SCI_BUF_PROPERTIES_NV"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCI_BUF_FEATURES_NV"/>
+                <enum extends="VkStructureType"                         name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SCI_BUF_FEATURES_NV" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCI_BUF_FEATURES_NV"/>
+                <enum bitpos="13" extends="VkExternalMemoryHandleTypeFlagBits"  name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_SCI_BUF_BIT_NV"/>
+                <type name="VkExportMemorySciBufInfoNV"/>
+                <type name="VkImportMemorySciBufInfoNV"/>
+                <type name="VkMemoryGetSciBufInfoNV"/>
+                <type name="VkMemorySciBufPropertiesNV"/>
+                <type name="VkPhysicalDeviceExternalMemorySciBufFeaturesNV"/>
+                <type name="VkPhysicalDeviceExternalSciBufFeaturesNV"/>
+                <command name="vkGetMemorySciBufNV"/>
+                <command name="vkGetPhysicalDeviceExternalMemorySciBufPropertiesNV"/>
+                <command name="vkGetPhysicalDeviceSciBufAttributesNV"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_376" number="376" author="EXT" contact="Melih Yasin Yalcin @yalcinmelihyasin" supported="disabled">
@@ -19777,7 +20678,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_376&quot;"          name="VK_EXT_EXTENSION_376_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_multisampled_render_to_single_sampled" number="377" type="device" requires="VK_KHR_create_renderpass2,VK_KHR_depth_stencil_resolve" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
+        <extension name="VK_EXT_multisampled_render_to_single_sampled" number="377" type="device" depends="VK_KHR_create_renderpass2+VK_KHR_depth_stencil_resolve" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_multisampled_render_to_single_sampled&quot;"   name="VK_EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_EXTENSION_NAME"/>
@@ -19790,7 +20691,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkMultisampledRenderToSingleSampledInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extended_dynamic_state2" number="378" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_extended_dynamic_state2" number="378" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan,vulkansc" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_EXTENDED_DYNAMIC_STATE_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extended_dynamic_state2&quot;"    name="VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME"/>
@@ -19808,7 +20709,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetPrimitiveRestartEnableEXT"/>
             </require>
         </extension>
-        <extension name="VK_QNX_screen_surface" number="379" type="instance" requires="VK_KHR_surface" platform="screen" author="QNX" contact="Mike Gorchak @mgorchak-blackberry" supported="vulkan">
+        <extension name="VK_QNX_screen_surface" number="379" type="instance" depends="VK_KHR_surface" platform="screen" author="QNX" contact="Mike Gorchak @mgorchak-blackberry" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_QNX_SCREEN_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_QNX_screen_surface&quot;"         name="VK_QNX_SCREEN_SURFACE_EXTENSION_NAME"/>
@@ -19831,7 +20732,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_381&quot;"          name="VK_KHR_EXTENSION_381_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_color_write_enable" number="382" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Sharif Elcott @selcott" supported="vulkan">
+        <extension name="VK_EXT_color_write_enable" number="382" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Sharif Elcott @selcott" supported="vulkan,vulkansc">
             <require>
                 <enum value="1"                                         name="VK_EXT_COLOR_WRITE_ENABLE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_color_write_enable&quot;"     name="VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME"/>
@@ -19843,7 +20744,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetColorWriteEnableEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_primitives_generated_query" number="383" type="device" requires="VK_EXT_transform_feedback" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
+        <extension name="VK_EXT_primitives_generated_query" number="383" type="device" depends="VK_EXT_transform_feedback" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
             <require>
                 <enum value="1"                                                 name="VK_EXT_PRIMITIVES_GENERATED_QUERY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_primitives_generated_query&quot;"     name="VK_EXT_PRIMITIVES_GENERATED_QUERY_EXTENSION_NAME"/>
@@ -19870,7 +20771,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_GOOGLE_extension_386&quot;"       name="VK_GOOGLE_EXTENSION_386_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_ray_tracing_maintenance1" number="387" type="device" requiresCore="1.1" requires="VK_KHR_acceleration_structure" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan">
+        <extension name="VK_KHR_ray_tracing_maintenance1" number="387" type="device" depends="VK_KHR_acceleration_structure" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_RAY_TRACING_MAINTENANCE_1_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_ray_tracing_maintenance1&quot;"   name="VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME"/>
@@ -19879,14 +20780,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="1" extends="VkQueryType"                      name="VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SIZE_KHR"/>
                 <type name="VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"/>
             </require>
-            <require extension="VK_KHR_synchronization2">
+            <require depends="VK_KHR_synchronization2">
                 <!-- VkPipelineStageFlagBits bitpos="28" is reserved by this extension, but not used -->
                 <enum bitpos="28" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR"/>
             </require>
-            <require extension="VK_KHR_synchronization2+VK_KHR_ray_tracing_pipeline">
+            <require depends="VK_KHR_synchronization2+VK_KHR_ray_tracing_pipeline">
                 <enum bitpos="40" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR"/>
             </require>
-            <require extension="VK_KHR_ray_tracing_pipeline">
+            <require depends="VK_KHR_ray_tracing_pipeline">
                 <type name="VkTraceRaysIndirectCommand2KHR"/>
                 <command name="vkCmdTraceRaysIndirect2KHR"/>
             </require>
@@ -19897,12 +20798,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_388&quot;"              name="VK_EXT_EXTENSION_388_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_global_priority_query" number="389" type="device" requires="VK_EXT_global_priority,VK_KHR_get_physical_device_properties2" author="EXT" contact="Yiwei Zhang @zhangyiwei" supported="vulkan" promotedto="VK_KHR_global_priority">
+        <extension name="VK_EXT_global_priority_query" number="389" type="device" depends="VK_EXT_global_priority+VK_KHR_get_physical_device_properties2" author="EXT" contact="Yiwei Zhang @zhangyiwei" supported="vulkan" promotedto="VK_KHR_global_priority">
             <require>
                 <enum value="1"                                         name="VK_EXT_GLOBAL_PRIORITY_QUERY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_global_priority_query&quot;"  name="VK_EXT_GLOBAL_PRIORITY_QUERY_EXTENSION_NAME"/>
-                <enum extends="VkStructureType" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_EXT"/>
-                <enum extends="VkStructureType" alias="VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR" name="VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_EXT"/>
+                <enum extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_EXT" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR"/>
+                <enum extends="VkStructureType" name="VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_EXT" alias="VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR"/>
                 <enum                                                   name="VK_MAX_GLOBAL_PRIORITY_SIZE_EXT"/>
                 <type                                                   name="VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT"/>
                 <type                                                   name="VkQueueFamilyGlobalPriorityPropertiesEXT"/>
@@ -19920,7 +20821,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_391&quot;"              name="VK_EXT_EXTENSION_391_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_view_min_lod" number="392" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan">
+        <extension name="VK_EXT_image_view_min_lod" number="392" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_VIEW_MIN_LOD_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_view_min_lod&quot;"         name="VK_EXT_IMAGE_VIEW_MIN_LOD_EXTENSION_NAME"/>
@@ -19930,7 +20831,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type                                                       name="VkImageViewMinLodCreateInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_multi_draw" number="393" author="EXT" contact="Mike Blumenkrantz @zmike" type="device" supported="vulkan">
+        <extension name="VK_EXT_multi_draw" number="393" author="EXT" contact="Mike Blumenkrantz @zmike" type="device" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_EXT_MULTI_DRAW_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_multi_draw&quot;"             name="VK_EXT_MULTI_DRAW_EXTENSION_NAME"/>
@@ -19944,7 +20845,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkMultiDrawIndexedInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_2d_view_of_3d" number="394" requires="VK_KHR_maintenance1,VK_KHR_get_physical_device_properties2" author="EXT" contact="Mike Blumenkrantz @zmike" specialuse="glemulation" type="device" supported="vulkan">
+        <extension name="VK_EXT_image_2d_view_of_3d" number="394" depends="VK_KHR_maintenance1+VK_KHR_get_physical_device_properties2" author="EXT" contact="Mike Blumenkrantz @zmike" specialuse="glemulation" type="device" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_2D_VIEW_OF_3D_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_2d_view_of_3d&quot;"              name="VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME"/>
@@ -19953,20 +20854,24 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkImageCreateFlagBits" bitpos="17"  name="VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT" comment="Image is created with a layout where individual slices are capable of being used as 2D images"/>
             </require>
         </extension>
-        <extension name="VK_KHR_portability_enumeration" number="395" author="KHR" contact="Charles Giessen @charles-lunarg" type="instance" supported="vulkan">
+        <extension name="VK_KHR_portability_enumeration" number="395" author="KHR" contact="Charles Giessen @charles-lunarg" type="instance" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_PORTABILITY_ENUMERATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_portability_enumeration&quot;"    name="VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME"/>
                 <enum bitpos="0" extends="VkInstanceCreateFlagBits"         name="VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_396" number="396" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="disabled">
+        <extension name="VK_EXT_shader_tile_image" number="396" type="device" author="EXT" depends="VK_VERSION_1_3" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_KHR_EXTENSION_396_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_396&quot;"              name="VK_KHR_EXTENSION_396_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_EXT_SHADER_TILE_IMAGE_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_shader_tile_image&quot;"          name="VK_EXT_SHADER_TILE_IMAGE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT"/>
+                <type name="VkPhysicalDeviceShaderTileImageFeaturesEXT"/>
+                <type name="VkPhysicalDeviceShaderTileImagePropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_opacity_micromap" number="397" type="device"  requires="VK_KHR_acceleration_structure,VK_KHR_synchronization2" author="EXT" contact="Christoph Kubisch @pixeljetstream, Eric Werness" supported="vulkan">
+        <extension name="VK_EXT_opacity_micromap" number="397" type="device"  depends="VK_KHR_acceleration_structure+VK_KHR_synchronization2" author="EXT" contact="Christoph Kubisch @pixeljetstream, Eric Werness" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_OPACITY_MICROMAP_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_opacity_micromap&quot;"           name="VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME"/>
@@ -20032,13 +20937,20 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMicromapBuildSizesEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_398" number="398" author="NV" contact="Christoph Kubisch @pixeljetstream, Eric Werness @ewerness-nv" supported="disabled">
+        <extension name="VK_NV_displacement_micromap" number="398" type="device" depends="VK_EXT_opacity_micromap" author="NV" contact="Christoph Kubisch @pixeljetstream, Eric Werness" supported="vulkan" provisional="true" platform="provisional">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_398_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_398&quot;"           name="VK_NV_EXTENSION_398_EXTENSION_NAME"/>
-                <enum bitpos="28" extends="VkPipelineCreateFlagBits"    name="VK_PIPELINE_CREATE_RESERVED_BIT_28_NV"/>
-                <enum bitpos="9"  extends="VkBuildAccelerationStructureFlagBitsKHR" name="VK_BUILD_ACCELERATION_STRUCTURE_RESERVED_BIT_9_NV"/>
-                <enum bitpos="10" extends="VkBuildAccelerationStructureFlagBitsKHR" name="VK_BUILD_ACCELERATION_STRUCTURE_RESERVED_BIT_10_NV"/>
+                <enum value="1"                                        name="VK_NV_DISPLACEMENT_MICROMAP_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_displacement_micromap&quot;"  name="VK_NV_DISPLACEMENT_MICROMAP_EXTENSION_NAME"/>
+                <enum offset="0"  extends="VkStructureType"            name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="1"  extends="VkStructureType"            name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="2"  extends="VkStructureType"            name="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum bitpos="28" extends="VkPipelineCreateFlagBits"   name="VK_PIPELINE_CREATE_RAY_TRACING_DISPLACEMENT_MICROMAP_BIT_NV" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum bitpos="9"  extends="VkBuildAccelerationStructureFlagBitsKHR" name="VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_DISPLACEMENT_MICROMAP_UPDATE_NV" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="0"  extends="VkMicromapTypeEXT"          name="VK_MICROMAP_TYPE_DISPLACEMENT_MICROMAP_NV" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <type name="VkPhysicalDeviceDisplacementMicromapFeaturesNV"/>
+                <type name="VkPhysicalDeviceDisplacementMicromapPropertiesNV"/>
+                <type name="VkAccelerationStructureTrianglesDisplacementMicromapNV"/>
+                <type name="VkDisplacementMicromapFormatNV"/>
             </require>
         </extension>
         <extension name="VK_JUICE_extension_399" number="399" author="JUICE" contact="Dean Beeler @canadacow" supported="disabled">
@@ -20079,12 +20991,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_FB_extension_404&quot;"           name="VK_FB_EXTENSION_404_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_HUAWEI_extension_405" number="405" author="HUAWEI" contact="Hueilong Wang @wyvernathuawei" supported="disabled">
+        <extension name="VK_HUAWEI_cluster_culling_shader" number="405" type="device" depends="VK_KHR_get_physical_device_properties2" author="HUAWEI" contact="Yuchang Wang @richard_Wang2" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_HUAWEI_EXTENSION_405_SPEC_VERSION"/>
-                <enum value="&quot;VK_HUAWEI_extension_405&quot;"       name="VK_HUAWEI_EXTENSION_405_EXTENSION_NAME"/>
-                <enum bitpos="41" extends="VkPipelineStageFlagBits2"    name="VK_PIPELINE_STAGE_2_RESEVED_41_BIT_HUAWEI"/>
-                <enum bitpos="19" extends="VkShaderStageFlagBits"       name="VK_SHADER_STAGE_RESERVED_19_BIT_HUAWEI"/>
+                <enum value="2"                                              name="VK_HUAWEI_CLUSTER_CULLING_SHADER_SPEC_VERSION"/>
+                <enum value="&quot;VK_HUAWEI_cluster_culling_shader&quot;"   name="VK_HUAWEI_CLUSTER_CULLING_SHADER_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI"/>
+                <enum offset="1" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_PROPERTIES_HUAWEI"/>
+                <enum bitpos="41" extends="VkPipelineStageFlagBits2"         name="VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+                <enum bitpos="19" extends="VkShaderStageFlagBits"            name="VK_SHADER_STAGE_CLUSTER_CULLING_BIT_HUAWEI"/>
+                <enum bitpos="13" extends="VkQueryPipelineStatisticFlagBits" name="VK_QUERY_PIPELINE_STATISTIC_CLUSTER_CULLING_SHADER_INVOCATIONS_BIT_HUAWEI"/>
+                <command name="vkCmdDrawClusterHUAWEI"/>
+                <command name="vkCmdDrawClusterIndirectHUAWEI"/>
+                <type name="VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI"/>
+                <type name="VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI"/>
             </require>
         </extension>
         <extension name="VK_HUAWEI_extension_406" number="406" author="HUAWEI" contact="Hueilong Wang @wyvernathuawei" supported="disabled">
@@ -20123,7 +21042,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_GGP_extension_411&quot;"          name="VK_GGP_EXTENSION_411_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_border_color_swizzle" number="412" type="device" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan" requires="VK_EXT_custom_border_color" specialuse="glemulation,d3demulation">
+        <extension name="VK_EXT_border_color_swizzle" number="412" type="device" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan" depends="VK_EXT_custom_border_color" specialuse="glemulation,d3demulation">
             <require>
                 <enum value="1"                                         name="VK_EXT_BORDER_COLOR_SWIZZLE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_border_color_swizzle&quot;"   name="VK_EXT_BORDER_COLOR_SWIZZLE_EXTENSION_NAME"/>
@@ -20133,7 +21052,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSamplerBorderColorComponentMappingCreateInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pageable_device_local_memory" number="413" author="EXT" contact="Piers Daniell @pdaniell-nv" type="device" requires="VK_EXT_memory_priority" supported="vulkan">
+        <extension name="VK_EXT_pageable_device_local_memory" number="413" author="EXT" contact="Piers Daniell @pdaniell-nv" type="device" depends="VK_EXT_memory_priority" supported="vulkan">
             <require>
                 <enum value="1"                                                  name="VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pageable_device_local_memory&quot;"    name="VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME"/>
@@ -20142,7 +21061,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command                                                         name="vkSetDeviceMemoryPriorityEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_maintenance4" number="414" type="device" requiresCore="1.1" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_KHR_maintenance4" number="414" type="device" depends="VK_VERSION_1_1" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="2"                                             name="VK_KHR_MAINTENANCE_4_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_maintenance4&quot;"               name="VK_KHR_MAINTENANCE_4_EXTENSION_NAME"/>
@@ -20166,10 +21085,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_HUAWEI_extension_415&quot;"         name="VK_HUAWEI_EXTENSION_415_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_ARM_extension_416" number="416" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="disabled">
+        <extension name="VK_ARM_shader_core_properties" number="416" type="device" depends="VK_VERSION_1_1" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_ARM_EXTENSION_416_SPEC_VERSION"/>
-                <enum value="&quot;VK_ARM_extension_416&quot;"          name="VK_ARM_EXTENSION_416_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_ARM_SHADER_CORE_PROPERTIES_SPEC_VERSION"/>
+                <enum value="&quot;VK_ARM_shader_core_properties&quot;" name="VK_ARM_SHADER_CORE_PROPERTIES_EXTENSION_NAME"/>
+                <enum offset="0"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_ARM"/>
+                <type name="VkPhysicalDeviceShaderCorePropertiesARM"/>
             </require>
         </extension>
         <extension name="VK_KHR_extension_417" number="417" author="KHR" contact="Kevin Petit @kevinpetit" supported="disabled">
@@ -20184,11 +21105,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_ARM_extension_418&quot;"          name="VK_ARM_EXTENSION_418_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_419" number="419" author="EXT" contact="Mike Blumenkrantz @zmike" type="device" supported="disabled">
+        <extension name="VK_EXT_image_sliced_view_of_3d" number="419" depends="VK_KHR_maintenance1+VK_KHR_get_physical_device_properties2" author="EXT" contact="Mike Blumenkrantz @zmike" specialuse="d3demulation" type="device" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_419_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_419&quot;"              name="VK_EXT_EXTENSION_419_EXTENSION_NAME"/>
-                <enum bitpos="3" extends="VkImageViewCreateFlagBits"        name="VK_IMAGE_VIEW_CREATE_RESERVED_3_BIT_EXT"/>
+                <enum value="1"                                             name="VK_EXT_IMAGE_SLICED_VIEW_OF_3D_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_image_sliced_view_of_3d&quot;"    name="VK_EXT_IMAGE_SLICED_VIEW_OF_3D_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT"/>
+                <enum name="VK_REMAINING_3D_SLICES_EXT"/>
+                <type name="VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT"/>
+                <type name="VkImageViewSlicedCreateInfoEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_420" number="420" author="EXT" contact="Mike Blumenkrantz @zmike" type="device" supported="disabled">
@@ -20198,7 +21123,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="4" extends="VkSwapchainCreateFlagBitsKHR" name="VK_SWAPCHAIN_CREATE_RESERVED_4_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_VALVE_descriptor_set_host_mapping" number="421" type="device" author="VALVE" contact="Hans-Kristian Arntzen @HansKristian-Work" specialuse="d3demulation" supported="vulkan">
+        <extension name="VK_VALVE_descriptor_set_host_mapping" number="421" type="device" author="VALVE" contact="Hans-Kristian Arntzen @HansKristian-Work" specialuse="d3demulation" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_VALVE_DESCRIPTOR_SET_HOST_MAPPING_SPEC_VERSION"/>
                 <enum value="&quot;VK_VALVE_descriptor_set_host_mapping&quot;"  name="VK_VALVE_DESCRIPTOR_SET_HOST_MAPPING_EXTENSION_NAME"/>
@@ -20212,7 +21137,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDescriptorSetHostMappingVALVE"/>
             </require>
         </extension>
-        <extension name="VK_EXT_depth_clamp_zero_one" number="422" author="EXT" type="device" contact="Graeme Leese @gnl21" supported="vulkan">
+        <extension name="VK_EXT_depth_clamp_zero_one" number="422" author="EXT" type="device" contact="Graeme Leese @gnl21" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_DEPTH_CLAMP_ZERO_ONE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_depth_clamp_zero_one&quot;"       name="VK_EXT_DEPTH_CLAMP_ZERO_ONE_EXTENSION_NAME"/>
@@ -20220,7 +21145,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceDepthClampZeroOneFeaturesEXT" />
             </require>
         </extension>
-        <extension name="VK_EXT_non_seamless_cube_map" number="423" author="EXT" type="device" contact="Georg Lehmann @DadSchoorse" specialuse="d3demulation,glemulation" supported="vulkan">
+        <extension name="VK_EXT_non_seamless_cube_map" number="423" author="EXT" type="device" contact="Georg Lehmann @DadSchoorse" specialuse="d3demulation,glemulation" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_NON_SEAMLESS_CUBE_MAP_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_non_seamless_cube_map&quot;"      name="VK_EXT_NON_SEAMLESS_CUBE_MAP_EXTENSION_NAME"/>
@@ -20241,7 +21166,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_ARM_extension_425&quot;"          name="VK_ARM_EXTENSION_425_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_fragment_density_map_offset" number="426" type="device" requires="VK_KHR_get_physical_device_properties2,VK_EXT_fragment_density_map" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
+        <extension name="VK_QCOM_fragment_density_map_offset" number="426" type="device" depends="VK_KHR_get_physical_device_properties2+VK_EXT_fragment_density_map" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="1"                                               name="VK_QCOM_FRAGMENT_DENSITY_MAP_OFFSET_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_fragment_density_map_offset&quot;" name="VK_QCOM_FRAGMENT_DENSITY_MAP_OFFSET_EXTENSION_NAME"/>
@@ -20254,7 +21179,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSubpassFragmentDensityMapOffsetEndInfoQCOM"/>
             </require>
         </extension>
-        <extension name="VK_NV_copy_memory_indirect" number="427" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_buffer_device_address" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
+        <extension name="VK_NV_copy_memory_indirect" number="427" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_buffer_device_address" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_COPY_MEMORY_INDIRECT_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_copy_memory_indirect&quot;"    name="VK_NV_COPY_MEMORY_INDIRECT_EXTENSION_NAME"/>
@@ -20268,7 +21193,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdCopyMemoryToImageIndirectNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_memory_decompression" number="428" type="device" requires="VK_KHR_get_physical_device_properties2,VK_KHR_buffer_device_address" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
+        <extension name="VK_NV_memory_decompression" number="428" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_buffer_device_address" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_MEMORY_DECOMPRESSION_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_memory_decompression&quot;"       name="VK_NV_MEMORY_DECOMPRESSION_EXTENSION_NAME"/>
@@ -20295,14 +21220,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_430&quot;"           name="VK_NV_EXTENSION_430_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_linear_color_attachment" number="431" type="device" author="NVIDIA" contact="sourav parmar @souravpNV" supported="vulkan">
+        <extension name="VK_NV_linear_color_attachment" number="431" type="device" author="NVIDIA" contact="sourav parmar @souravpNV" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_LINEAR_COLOR_ATTACHMENT_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_linear_color_attachment&quot;" name="VK_NV_LINEAR_COLOR_ATTACHMENT_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV"/>
                 <type                                                   name="VkPhysicalDeviceLinearColorAttachmentFeaturesNV"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <enum bitpos="38" extends="VkFormatFeatureFlagBits2"    name="VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV" comment="Format support linear image as render target, it cannot be mixed with non linear attachment"/>
             </require>
         </extension>
@@ -20318,7 +21243,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_433&quot;"           name="VK_NV_EXTENSION_433_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_GOOGLE_surfaceless_query" number="434" type="instance" requires="VK_KHR_surface" author="GOOGLE" contact="Shahbaz Youssefi @syoussefi" specialuse="glemulation" supported="vulkan">
+        <extension name="VK_GOOGLE_surfaceless_query" number="434" type="instance" depends="VK_KHR_surface" author="GOOGLE" contact="Shahbaz Youssefi @syoussefi" specialuse="glemulation" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_GOOGLE_SURFACELESS_QUERY_SPEC_VERSION"/>
                 <enum value="&quot;VK_GOOGLE_surfaceless_query&quot;"   name="VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME"/>
@@ -20330,10 +21255,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_435&quot;"          name="VK_KHR_EXTENSION_435_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_436" number="436" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_EXT_application_parameters" number="436" type="instance" author="EXT" contact="Daniel Koch @dgkoch" supported="vulkansc">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_436_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_436&quot;"           name="VK_NV_EXTENSION_436_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_EXT_APPLICATION_PARAMETERS_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_application_parameters&quot;" name="VK_EXT_APPLICATION_PARAMETERS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_APPLICATION_PARAMETERS_EXT"/>
+                <type name="VkApplicationParametersEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_437" number="437" author="EXT" contact="Jonathan Weinstein @Jonathan-Weinstein" supported="disabled">
@@ -20342,7 +21269,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_437&quot;"          name="VK_EXT_EXTENSION_437_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_compression_control_swapchain" number="438" type="device" requires="VK_EXT_image_compression_control" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
+        <extension name="VK_EXT_image_compression_control_swapchain" number="438" type="device" depends="VK_EXT_image_compression_control" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_compression_control_swapchain&quot;"  name="VK_EXT_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_EXTENSION_NAME"/>
@@ -20364,7 +21291,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="1" extends="VkDeviceQueueCreateFlagBits"  name="VK_DEVICE_QUEUE_CREATE_RESERVED_1_BIT_QCOM"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_image_processing" number="441" type="device" requires="VK_KHR_format_feature_flags2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_image_processing" number="441" type="device" depends="VK_KHR_format_feature_flags2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_QCOM_IMAGE_PROCESSING_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_image_processing&quot;"      name="VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME"/>
@@ -20380,7 +21307,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceImageProcessingFeaturesQCOM"/>
                 <type name="VkPhysicalDeviceImageProcessingPropertiesQCOM"/>
             </require>
-            <require extension="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2">
                 <enum bitpos="34" extends="VkFormatFeatureFlagBits2" name="VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM"/>
                 <enum bitpos="35" extends="VkFormatFeatureFlagBits2" name="VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"/>
                 <enum bitpos="36" extends="VkFormatFeatureFlagBits2" name="VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM"/>
@@ -20458,21 +21385,25 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                         name="VK_ARM_EXTENSION_453_SPEC_VERSION"/>
                 <enum value="&quot;VK_ARM_extension_453&quot;"          name="VK_ARM_EXTENSION_453_EXTENSION_NAME"/>
+                <enum bitpos="11" extends="VkQueueFlagBits"             name="VK_QUEUE_RESERVED_11_BIT_ARM"/>
+                <enum bitpos="43" extends="VkPipelineStageFlagBits2"    name="VK_PIPELINE_STAGE_2_RESERVED_43_BIT_ARM"/>
+                <enum bitpos="49" extends="VkAccessFlagBits2"           name="VK_ACCESS_2_RESERVED_49_BIT_ARM"/>
+                <enum bitpos="50" extends="VkAccessFlagBits2"           name="VK_ACCESS_2_RESERVED_50_BIT_ARM"/>
             </require>
         </extension>
-        <extension name="VK_GOOGLE_extension_454" number="454" author="GOOGLE" contact="Chad Versace @chadversary" supported="disabled">
+        <extension name="VK_GOOGLE_extension_454" number="454" author="GOOGLE" contact="Lina Versace @versalinyaa" supported="disabled">
             <require>
-                <enum value="0"                                         name="VK_GOOGLE_EXTENSION_454_SPEC_VERSION"/>
+                <enum value="0"                                                         name="VK_GOOGLE_EXTENSION_454_SPEC_VERSION"/>
                 <enum value="&quot;VK_GOOGLE_extension_454&quot;"       name="VK_GOOGLE_EXTENSION_454_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_GOOGLE_extension_455" number="455" author="GOOGLE" contact="Chad Versace @chadversary" supported="disabled">
+        <extension name="VK_GOOGLE_extension_455" number="455" author="GOOGLE" contact="Lina Versace @versalinyaa" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_GOOGLE_EXTENSION_455_SPEC_VERSION"/>
                 <enum value="&quot;VK_GOOGLE_extension_455&quot;"       name="VK_GOOGLE_EXTENSION_455_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extended_dynamic_state3" number="456" type="device" requires="VK_KHR_get_physical_device_properties2" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_extended_dynamic_state3" number="456" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
             <require>
                 <enum value="2"                                              name="VK_EXT_EXTENDED_DYNAMIC_STATE_3_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extended_dynamic_state3&quot;"     name="VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME"/>
@@ -20546,19 +21477,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetCoverageReductionModeNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_457" number="457" author="RASTERGRID" contact="Daniel Rakos @aqnuep1" supported="disabled">
+        <extension name="VK_EXT_extension_457" number="457" author="RASTERGRID" contact="Daniel Rakos @aqnuep" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_EXT_EXTENSION_457_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_457&quot;"          name="VK_EXT_EXTENSION_457_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_458" number="458" author="RASTERGRID" contact="Daniel Rakos @aqnuep1" supported="disabled">
+        <extension name="VK_EXT_extension_458" number="458" author="RASTERGRID" contact="Daniel Rakos @aqnuep" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_EXT_EXTENSION_458_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_458&quot;"          name="VK_EXT_EXTENSION_458_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_subpass_merge_feedback" number="459" type="device" author="EXT" contact="Ting Wei @catweiting" supported="vulkan">
+        <extension name="VK_EXT_subpass_merge_feedback" number="459" type="device" author="EXT" contact="Ting Wei @catweiting" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="2"                                              name="VK_EXT_SUBPASS_MERGE_FEEDBACK_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_subpass_merge_feedback&quot;"      name="VK_EXT_SUBPASS_MERGE_FEEDBACK_EXTENSION_NAME"/>
@@ -20593,6 +21524,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="0"                                         name="VK_EXT_EXTENSION_461_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_461&quot;"          name="VK_EXT_EXTENSION_461_EXTENSION_NAME"/>
                 <enum bitpos="39" extends="VkFormatFeatureFlagBits2"    name="VK_FORMAT_FEATURE_2_RESERVED_39_BIT_EXT"/>
+                <enum bitpos="23" extends="VkImageUsageFlagBits"        name="VK_IMAGE_USAGE_RESERVED_23_BIT_EXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_462" number="462" author="EXT" contact="Joshua Ashton @Joshua-Ashton,Liam Middlebrook @liam-middlebrook" supported="disabled">
@@ -20601,7 +21533,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_462&quot;"          name="VK_EXT_EXTENSION_462_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_shader_module_identifier" number="463" type="device" requires="VK_KHR_get_physical_device_properties2,VK_EXT_pipeline_creation_cache_control" author="EXT" contact="Hans-Kristian Arntzen @HansKristian-Work" supported="vulkan">
+        <extension name="VK_EXT_shader_module_identifier" number="463" type="device" depends="VK_KHR_get_physical_device_properties2+VK_EXT_pipeline_creation_cache_control" author="EXT" contact="Hans-Kristian Arntzen @HansKristian-Work" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_SHADER_MODULE_IDENTIFIER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_shader_module_identifier&quot;"   name="VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME"/>
@@ -20618,7 +21550,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetShaderModuleCreateInfoIdentifierEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_rasterization_order_attachment_access" number="464" type="device" requires="VK_KHR_get_physical_device_properties2" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
+        <extension name="VK_EXT_rasterization_order_attachment_access" number="464" type="device" depends="VK_KHR_get_physical_device_properties2" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
             <require>
                 <enum value="1"                                                        name="VK_EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_rasterization_order_attachment_access&quot;" name="VK_EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXTENSION_NAME"/>
@@ -20634,7 +21566,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="6" extends="VkSubpassDescriptionFlagBits"              name="VK_SUBPASS_DESCRIPTION_RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_optical_flow" number="465" requires="VK_KHR_get_physical_device_properties2,VK_KHR_format_feature_flags2,VK_KHR_synchronization2" type="device" author="NV" contact="Carsten Rohde @crohde" supported="vulkan">
+        <extension name="VK_NV_optical_flow" number="465" depends="VK_KHR_get_physical_device_properties2+VK_KHR_format_feature_flags2+VK_KHR_synchronization2" type="device" author="NV" contact="Carsten Rohde @crohde" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_OPTICAL_FLOW_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_optical_flow&quot;"                name="VK_NV_OPTICAL_FLOW_EXTENSION_NAME"/>
@@ -20679,7 +21611,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdOpticalFlowExecuteNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_legacy_dithering" number="466" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
+        <extension name="VK_EXT_legacy_dithering" number="466" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
             <require>
                 <enum value="1"                                         name="VK_EXT_LEGACY_DITHERING_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_legacy_dithering&quot;"       name="VK_EXT_LEGACY_DITHERING_EXTENSION_NAME"/>
@@ -20687,14 +21619,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="7" extends="VkSubpassDescriptionFlagBits" name="VK_SUBPASS_DESCRIPTION_ENABLE_LEGACY_DITHERING_BIT_EXT"/>
                 <type name="VkPhysicalDeviceLegacyDitheringFeaturesEXT"/>
             </require>
-            <require feature="VK_VERSION_1_3">
+            <require depends="VK_VERSION_1_3">
                 <enum bitpos="3" extends="VkRenderingFlagBits"          name="VK_RENDERING_ENABLE_LEGACY_DITHERING_BIT_EXT"/>
             </require>
-            <require extension="VK_KHR_dynamic_rendering">
+            <require depends="VK_KHR_dynamic_rendering">
                 <enum bitpos="3" extends="VkRenderingFlagBits"          name="VK_RENDERING_ENABLE_LEGACY_DITHERING_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pipeline_protected_access" number="467" type="device" requires="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
+        <extension name="VK_EXT_pipeline_protected_access" number="467" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_PIPELINE_PROTECTED_ACCESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pipeline_protected_access&quot;"  name="VK_EXT_PIPELINE_PROTECTED_ACCESS_EXTENSION_NAME"/>
@@ -20714,6 +21646,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                         name="VK_ANDROID_EXTENSION_469_SPEC_VERSION"/>
                 <enum value="&quot;VK_ANDROID_extension_469&quot;"      name="VK_ANDROID_EXTENSION_469_EXTENSION_NAME"/>
+                <enum bitpos="4" extends="VkResolveModeFlagBits"        name="VK_RESOLVE_MODE_EXTENSION_469_FLAG_0_BIT"/>
             </require>
         </extension>
         <extension name="VK_AMD_extension_470" number="470" author="AMD" contact="Stu Smith" supported="disabled">
@@ -20788,19 +21721,108 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_481&quot;"          name="VK_EXT_EXTENSION_481_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_482" number="482" author="KHR" contact="Eric Werness" supported="disabled">
+        <extension name="VK_KHR_ray_tracing_position_fetch" number="482" type="device" depends="VK_KHR_acceleration_structure" author="KHR" contact="Eric Werness" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_EXT_EXTENSION_482_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_482&quot;"          name="VK_EXT_EXTENSION_482_EXTENSION_NAME"/>
+                <enum value="1"                                                     name="VK_KHR_RAY_TRACING_POSITION_FETCH_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_ray_tracing_position_fetch&quot;"         name="VK_KHR_RAY_TRACING_POSITION_FETCH_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                          name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR"/>
+                <enum bitpos="11" extends="VkBuildAccelerationStructureFlagBitsKHR" name="VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_DATA_ACCESS_KHR"/>
+                <type name="VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_483" number="483" author="EXT" contact="Piers Daniell" supported="disabled">
+        <extension name="VK_EXT_shader_object" number="483" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+(VK_KHR_dynamic_rendering,VK_VERSION_1_3)" type="device" author="EXT" contact="Daniel Story @daniel-story" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_EXT_EXTENSION_483_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_483&quot;"          name="VK_EXT_EXTENSION_483_EXTENSION_NAME"/>
-                <enum bitpos="15" extends="VkShaderStageFlagBits"       name="VK_SHADER_STAGE_EXT_483_RESERVE_15"/>
-                <enum bitpos="16" extends="VkShaderStageFlagBits"       name="VK_SHADER_STAGE_EXT_483_RESERVE_16"/>
-                <enum bitpos="17" extends="VkShaderStageFlagBits"       name="VK_SHADER_STAGE_EXT_483_RESERVE_17"/>
+                <enum value="1"                                            name="VK_EXT_SHADER_OBJECT_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_shader_object&quot;"             name="VK_EXT_SHADER_OBJECT_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT"/>
+                <enum offset="1" extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_PROPERTIES_EXT"/>
+                <enum offset="2" extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_SHADER_CREATE_INFO_EXT"/>
+                <enum extnumber="353" offset="1" extends="VkStructureType" name="VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT"/>
+                <enum extnumber="353" offset="2" extends="VkStructureType" name="VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT"/>
+                <enum extends="VkStructureType"                            name="VK_STRUCTURE_TYPE_SHADER_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT" alias="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"/>
+                <enum offset="0" extends="VkObjectType"                    name="VK_OBJECT_TYPE_SHADER_EXT"/>
+                <enum offset="0" extends="VkResult"                        name="VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT"/>
+                <type name="VkShaderEXT"/>
+                <type name="VkShaderCreateFlagBitsEXT"/>
+                <type name="VkShaderCreateFlagsEXT"/>
+                <type name="VkShaderCodeTypeEXT"/>
+                <type name="VkPhysicalDeviceShaderObjectFeaturesEXT"/>
+                <type name="VkPhysicalDeviceShaderObjectPropertiesEXT"/>
+                <type name="VkShaderCreateInfoEXT"/>
+                <type name="VkShaderRequiredSubgroupSizeCreateInfoEXT"/>
+                <type name="VkVertexInputBindingDescription2EXT"/>
+                <type name="VkVertexInputAttributeDescription2EXT"/>
+                <type name="VkColorBlendEquationEXT"/>
+                <type name="VkColorBlendAdvancedEXT"/>
+                <command name="vkCreateShadersEXT"/>
+                <command name="vkDestroyShaderEXT"/>
+                <command name="vkGetShaderBinaryDataEXT"/>
+                <command name="vkCmdBindShadersEXT"/>
+                <command name="vkCmdSetCullModeEXT"/>
+                <command name="vkCmdSetFrontFaceEXT"/>
+                <command name="vkCmdSetPrimitiveTopologyEXT"/>
+                <command name="vkCmdSetViewportWithCountEXT"/>
+                <command name="vkCmdSetScissorWithCountEXT"/>
+                <command name="vkCmdBindVertexBuffers2EXT"/>
+                <command name="vkCmdSetDepthTestEnableEXT"/>
+                <command name="vkCmdSetDepthWriteEnableEXT"/>
+                <command name="vkCmdSetDepthCompareOpEXT"/>
+                <command name="vkCmdSetDepthBoundsTestEnableEXT"/>
+                <command name="vkCmdSetStencilTestEnableEXT"/>
+                <command name="vkCmdSetStencilOpEXT"/>
+                <command name="vkCmdSetVertexInputEXT"/>
+                <command name="vkCmdSetPatchControlPointsEXT"/>
+                <command name="vkCmdSetRasterizerDiscardEnableEXT"/>
+                <command name="vkCmdSetDepthBiasEnableEXT"/>
+                <command name="vkCmdSetLogicOpEXT"/>
+                <command name="vkCmdSetPrimitiveRestartEnableEXT"/>
+                <command name="vkCmdSetTessellationDomainOriginEXT"/>
+                <command name="vkCmdSetDepthClampEnableEXT"/>
+                <command name="vkCmdSetPolygonModeEXT"/>
+                <command name="vkCmdSetRasterizationSamplesEXT"/>
+                <command name="vkCmdSetSampleMaskEXT"/>
+                <command name="vkCmdSetAlphaToCoverageEnableEXT"/>
+                <command name="vkCmdSetAlphaToOneEnableEXT"/>
+                <command name="vkCmdSetLogicOpEnableEXT"/>
+                <command name="vkCmdSetColorBlendEnableEXT"/>
+                <command name="vkCmdSetColorBlendEquationEXT"/>
+                <command name="vkCmdSetColorWriteMaskEXT"/>
+                <command name="vkCmdSetRasterizationStreamEXT"/>
+                <command name="vkCmdSetConservativeRasterizationModeEXT"/>
+                <command name="vkCmdSetExtraPrimitiveOverestimationSizeEXT"/>
+                <command name="vkCmdSetDepthClipEnableEXT"/>
+                <command name="vkCmdSetSampleLocationsEnableEXT"/>
+                <command name="vkCmdSetColorBlendAdvancedEXT"/>
+                <command name="vkCmdSetProvokingVertexModeEXT"/>
+                <command name="vkCmdSetLineRasterizationModeEXT"/>
+                <command name="vkCmdSetLineStippleEnableEXT"/>
+                <command name="vkCmdSetDepthClipNegativeOneToOneEXT"/>
+                <command name="vkCmdSetViewportWScalingEnableNV"/>
+                <command name="vkCmdSetViewportSwizzleNV"/>
+                <command name="vkCmdSetCoverageToColorEnableNV"/>
+                <command name="vkCmdSetCoverageToColorLocationNV"/>
+                <command name="vkCmdSetCoverageModulationModeNV"/>
+                <command name="vkCmdSetCoverageModulationTableEnableNV"/>
+                <command name="vkCmdSetCoverageModulationTableNV"/>
+                <command name="vkCmdSetShadingRateImageEnableNV"/>
+                <command name="vkCmdSetRepresentativeFragmentTestEnableNV"/>
+                <command name="vkCmdSetCoverageReductionModeNV"/>
+            </require>
+            <require depends="VK_EXT_subgroup_size_control,VK_VERSION_1_3">
+                <enum bitpos="1" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT"/>
+                <enum bitpos="2" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT"/>
+            </require>
+            <require depends="VK_EXT_mesh_shader,VK_NV_mesh_shader">
+                <enum bitpos="3" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT"/>
+            </require>
+            <require depends="VK_KHR_device_group,VK_VERSION_1_1">
+                <enum bitpos="4" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_DISPATCH_BASE_BIT_EXT"/>
+            </require>
+            <require depends="VK_KHR_fragment_shading_rate">
+                <enum bitpos="5" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_EXT"/>
+            </require>
+            <require depends="VK_EXT_fragment_density_map">
+                <enum bitpos="6" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_484" number="484" author="KHR" contact="Chris Glover @cdglove" supported="disabled">
@@ -20809,7 +21831,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_484&quot;"          name="VK_EXT_EXTENSION_484_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_tile_properties" number="485" type="device" requires="VK_KHR_get_physical_device_properties2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_tile_properties" number="485" type="device" depends="VK_KHR_get_physical_device_properties2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
             <require>
                 <enum value="1"                                               name="VK_QCOM_TILE_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_tile_properties&quot;"             name="VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME"/>
@@ -20822,7 +21844,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkRenderingInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_SEC_amigo_profiling" number="486" type="device" requires="VK_KHR_get_physical_device_properties2" author="SEC" contact="Ralph Potter gitlab:@r_potter" supported="vulkan">
+        <extension name="VK_SEC_amigo_profiling" number="486" type="device" depends="VK_KHR_get_physical_device_properties2" author="SEC" contact="Ralph Potter gitlab:@r_potter" supported="vulkan">
             <require>
                 <enum value="1"                                               name="VK_SEC_AMIGO_PROFILING_SPEC_VERSION"/>
                 <enum value="&quot;VK_SEC_amigo_profiling&quot;"              name="VK_SEC_AMIGO_PROFILING_EXTENSION_NAME"/>
@@ -20844,7 +21866,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_488&quot;"          name="VK_EXT_EXTENSION_488_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_multiview_per_view_viewports" number="489" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_multiview_per_view_viewports" number="489" type="device" author="QCOM" contact="Jeff Leger @jackohound" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="1"                                                name="VK_QCOM_MULTIVIEW_PER_VIEW_VIEWPORTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_multiview_per_view_viewports&quot;" name="VK_QCOM_MULTIVIEW_PER_VIEW_VIEWPORTS_EXTENSION_NAME"/>
@@ -20852,13 +21874,46 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_490" number="490" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_NV_external_sci_sync2" number="490" author="NV" depends="VK_VERSION_1_1" platform="sci" type="device" contact="Kai Zhang @kazhang" supported="vulkansc">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_490_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_490&quot;"           name="VK_NV_EXTENSION_490_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_NV_EXTERNAL_SCI_SYNC_2_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_external_sci_sync2&quot;"      name="VK_NV_EXTERNAL_SCI_SYNC_2_EXTENSION_NAME"/>
+                <enum offset="0"  extends="VkObjectType"                name="VK_OBJECT_TYPE_SEMAPHORE_SCI_SYNC_POOL_NV"   comment="VkSemaphoreSciSyncPoolNV"/>
+                <enum offset="0"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_SEMAPHORE_SCI_SYNC_POOL_CREATE_INFO_NV"/>
+                <enum offset="1"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_SEMAPHORE_SCI_SYNC_CREATE_INFO_NV"/>
+                <enum offset="2"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SCI_SYNC_2_FEATURES_NV"/>
+                <type name="VkSemaphoreSciSyncPoolNV"/>
+                <type name="VkPhysicalDeviceExternalSciSync2FeaturesNV"/>
+                <type name="VkSemaphoreSciSyncPoolCreateInfoNV"/>
+                <type name="VkSemaphoreSciSyncCreateInfoNV"/>
+                <command name="vkCreateSemaphoreSciSyncPoolNV"/>
+                <command name="vkDestroySemaphoreSciSyncPoolNV"/>
+            </require>
+            <require comment="functionality re-used unmodified from VK_NV_external_sci_sync">
+                <enum extnumber="374" offset="0" extends="VkStructureType"   name="VK_STRUCTURE_TYPE_IMPORT_FENCE_SCI_SYNC_INFO_NV"/>
+                <enum extnumber="374" offset="1" extends="VkStructureType"   name="VK_STRUCTURE_TYPE_EXPORT_FENCE_SCI_SYNC_INFO_NV"/>
+                <enum extnumber="374" offset="2" extends="VkStructureType"   name="VK_STRUCTURE_TYPE_FENCE_GET_SCI_SYNC_INFO_NV"/>
+                <enum extnumber="374" offset="3" extends="VkStructureType"   name="VK_STRUCTURE_TYPE_SCI_SYNC_ATTRIBUTES_INFO_NV"/>
+                <enum bitpos="4" extends="VkExternalFenceHandleTypeFlagBits" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_SCI_SYNC_OBJ_BIT_NV"/>
+                <enum bitpos="5" extends="VkExternalFenceHandleTypeFlagBits" name="VK_EXTERNAL_FENCE_HANDLE_TYPE_SCI_SYNC_FENCE_BIT_NV"/>
+                <type name="VkSciSyncClientTypeNV"/>
+                <type name="VkSciSyncPrimitiveTypeNV"/>
+                <type name="VkExportFenceSciSyncInfoNV"/>
+                <type name="VkImportFenceSciSyncInfoNV"/>
+                <type name="VkFenceGetSciSyncInfoNV"/>
+                <type name="VkSciSyncAttributesInfoNV"/>
+                <command name="vkGetFenceSciSyncFenceNV"/>
+                <command name="vkGetFenceSciSyncObjNV"/>
+                <command name="vkImportFenceSciSyncFenceNV"/>
+                <command name="vkImportFenceSciSyncObjNV"/>
+                <command name="vkGetPhysicalDeviceSciSyncAttributesNV"/>
+            </require>
+            <require depends="VKSC_VERSION_1_0" api="vulkansc">
+                <enum offset="3" extends="VkStructureType"         name="VK_STRUCTURE_TYPE_DEVICE_SEMAPHORE_SCI_SYNC_POOL_RESERVATION_CREATE_INFO_NV"/>
+                <type name="VkDeviceSemaphoreSciSyncPoolReservationCreateInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_ray_tracing_invocation_reorder" number="491" type="device" requires="VK_KHR_ray_tracing_pipeline" author="NV" contact="Eric Werness @ewerness-nv" supported="vulkan">
+        <extension name="VK_NV_ray_tracing_invocation_reorder" number="491" type="device" depends="VK_KHR_ray_tracing_pipeline" author="NV" contact="Eric Werness @ewerness-nv" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_NV_RAY_TRACING_INVOCATION_REORDER_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_ray_tracing_invocation_reorder&quot;"  name="VK_NV_RAY_TRACING_INVOCATION_REORDER_EXTENSION_NAME"/>
@@ -20887,7 +21942,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_494&quot;"           name="VK_NV_EXTENSION_494_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_mutable_descriptor_type" number="495" type="device" supported="vulkan" author="EXT" contact="Joshua Ashton @Joshua-Ashton,Hans-Kristian Arntzen @HansKristian-Work" specialuse="d3demulation" requires="VK_KHR_maintenance3">
+        <extension name="VK_EXT_mutable_descriptor_type" number="495" type="device" supported="vulkan" author="EXT" contact="Joshua Ashton @Joshua-Ashton,Hans-Kristian Arntzen @HansKristian-Work" specialuse="d3demulation" depends="VK_KHR_maintenance3">
             <require>
                 <enum value="1"                                                name="VK_EXT_MUTABLE_DESCRIPTOR_TYPE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_mutable_descriptor_type&quot;"       name="VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME"/>
@@ -20913,7 +21968,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_497&quot;"              name="VK_EXT_EXTENSION_497_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_ARM_shader_core_builtins" number="498" author="ARM" contact="Kevin Petit @kevinpetit" type="device" supported="vulkan">
+        <extension name="VK_ARM_shader_core_builtins" number="498" author="ARM" contact="Kevin Petit @kevinpetit" type="device" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_ARM_SHADER_CORE_BUILTINS_SPEC_VERSION"/>
                 <enum value="&quot;VK_ARM_shader_core_builtins&quot;"   name="VK_ARM_SHADER_CORE_BUILTINS_EXTENSION_NAME"/>
@@ -20923,16 +21978,20 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_499" number="499" author="EXT" contact="Hans-Kristian Arntzen @HansKristian-Work" type="device" supported="disabled">
+        <extension name="VK_EXT_pipeline_library_group_handles" number="499" type="device" depends="VK_KHR_ray_tracing_pipeline+VK_KHR_pipeline_library" author="EXT" contact="Hans-Kristian Arntzen @HansKristian-Work" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_499_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_499&quot;"              name="VK_EXT_EXTENSION_499_EXTENSION_NAME"/>
+                <enum value="1"                                                  name="VK_EXT_PIPELINE_LIBRARY_GROUP_HANDLES_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_pipeline_library_group_handles&quot;"  name="VK_EXT_PIPELINE_LIBRARY_GROUP_HANDLES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                       name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT"/>
+                <type name="VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_500" number="500" author="EXT" contact="Piers Daniell @pdaniell-nv" type="device" supported="disabled">
+        <extension name="VK_EXT_dynamic_rendering_unused_attachments" number="500" author="EXT" contact="Piers Daniell @pdaniell-nv" type="device" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+(VK_KHR_dynamic_rendering,VK_VERSION_1_3)" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_500_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_500&quot;"              name="VK_EXT_EXTENSION_500_EXTENSION_NAME"/>
+                <enum value="1"                                                        name="VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_dynamic_rendering_unused_attachments&quot;"  name="VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME"/>
+                <enum offset="0"  extends="VkStructureType"                            name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT"/>
+                <type name="VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_501" number="501" author="SEC" contact="Chris Hambacher @chambacher" type="device" supported="disabled">
@@ -20969,6 +22028,178 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                             name="VK_NV_EXTENSION_506_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_extension_506&quot;"               name="VK_NV_EXTENSION_506_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_507" number="507" author="KHR" contact="Kevin Petit @kevinpetit" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_507_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_507&quot;"              name="VK_KHR_EXTENSION_507_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_508" number="508" author="EXT" contact="Kevin Petit @kevinpetit" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_508_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_508&quot;"              name="VK_EXT_EXTENSION_508_EXTENSION_NAME"/>
+                <enum bitpos="10" extends="VkQueueFlagBits"                 name="VK_QUEUE_RESERVED_10_BIT_EXT" />
+                <enum bitpos="42" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_RESERVED_42_BIT_EXT" />
+                <enum bitpos="47" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_RESERVED_47_BIT_EXT" />
+                <enum bitpos="48" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_RESERVED_48_BIT_EXT" />
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_509" number="509" author="EXT" contact="Kevin Petit @kevinpetit" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_509_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_509&quot;"              name="VK_EXT_EXTENSION_509_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_MESA_extension_510" number="510" author="MESA" contact="Dave Airlie @airlied" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_MESA_EXTENSION_510_SPEC_VERSION"/>
+                <enum value="&quot;VK_MESA_extension_510&quot;"             name="VK_MESA_EXTENSION_510_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_QCOM_multiview_per_view_render_areas" number="511" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+            <require>
+                <enum value="1"                                                   name="VK_QCOM_MULTIVIEW_PER_VIEW_RENDER_AREAS_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_multiview_per_view_render_areas&quot;" name="VK_QCOM_MULTIVIEW_PER_VIEW_RENDER_AREAS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                        name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM"/>
+                <enum offset="1" extends="VkStructureType"                        name="VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_RENDER_AREAS_RENDER_PASS_BEGIN_INFO_QCOM"/>
+                <type name="VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM"/>
+               <type name="VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_512" number="512" author="EXT" contact="Jean-Noe Morissette @MagicPoncho" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_512_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_512&quot;"              name="VK_EXT_EXTENSION_512_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_513" number="513" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_513_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_513&quot;"              name="VK_KHR_EXTENSION_513_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_514" number="514" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_514_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_514&quot;"              name="VK_KHR_EXTENSION_514_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_515" number="515" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_515_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_515&quot;"              name="VK_KHR_EXTENSION_515_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_516" number="516" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_516_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_516&quot;"              name="VK_KHR_EXTENSION_516_EXTENSION_NAME"/>
+                <enum bitpos="20" extends="VkImageCreateFlagBits"           name="VK_IMAGE_CREATE_RESERVED_20_BIT_KHR"/>
+                <enum bitpos="6" extends="VkBufferCreateFlagBits"           name="VK_BUFFER_CREATE_RESERVED_6_BIT_KHR"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_517" number="517" author="EXT" contact="Daniel Story" supported="disabled">
+            <require>
+                <enum value="0"                                                name="VK_EXT_EXTENSION_517_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_517&quot;"                 name="VK_EXT_EXTENSION_517_EXTENSION_NAME"/>
+                <enum bitpos="6" extends="VkDescriptorSetLayoutCreateFlagBits" name="VK_DESCRIPTOR_SET_LAYOUT_CREATE_RESERVED_6_BIT_EXT"/>
+            </require>
+        </extension>
+        <extension name="VK_MESA_extension_518" number="518" author="MESA" contact="Dave Airlie @airlied" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_MESA_EXTENSION_518_SPEC_VERSION"/>
+                <enum value="&quot;VK_MESA_extension_518&quot;"             name="VK_MESA_EXTENSION_518_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_QCOM_extension_519" number="519" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+            <require>
+                <enum value="0"                                                   name="VK_QCOM_EXTENSION_519_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_extension_519&quot;"                   name="VK_QCOM_EXTENSION_519_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_QCOM_extension_520" number="520" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+            <require>
+                <enum value="0"                                                   name="VK_QCOM_EXTENSION_520_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_extension_520&quot;"                   name="VK_QCOM_EXTENSION_520_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_QCOM_extension_521" number="521" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+            <require>
+                <enum value="0"                                                   name="VK_QCOM_EXTENSION_521_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_extension_521&quot;"                   name="VK_QCOM_EXTENSION_521_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_QCOM_extension_522" number="522" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+            <require>
+                <enum value="0"                                                   name="VK_QCOM_EXTENSION_522_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_extension_522&quot;"                   name="VK_QCOM_EXTENSION_522_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_523" number="523" author="EXT" contact="Kevin Petit @kevinpetit" supported="disabled">
+            <require>
+                <enum value="0"                                                name="VK_EXT_EXTENSION_523_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_523&quot;"                 name="VK_EXT_EXTENSION_523_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_524" number="524" author="EXT" contact="Tony Zlatinski @tzlatinski" supported="disabled">
+            <require>
+                <enum value="0"                                                name="VK_EXT_EXTENSION_524_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_524&quot;"                 name="VK_EXT_EXTENSION_524_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_attachment_feedback_loop_dynamic_state" number="525" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2+VK_EXT_attachment_feedback_loop_layout" contact="Mike Blumenkrantz @zmike" supported="vulkan">
+            <require>
+                <enum value="1"                                                                name="VK_EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_attachment_feedback_loop_dynamic_state&quot;" name="VK_EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                                     name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT"/>
+                <enum offset="0" extends="VkDynamicState"                                      name="VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT"/>
+                <type name="VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT"/>
+                <command name="vkCmdSetAttachmentFeedbackLoopEnableEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_526" number="526" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_526_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_526&quot;"          name="VK_EXT_EXTENSION_526_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_527" number="527" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_527_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_527&quot;"          name="VK_EXT_EXTENSION_527_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_528" number="528" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_528_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_528&quot;"          name="VK_EXT_EXTENSION_528_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_529" number="529" author="KHR" contact="Graeme Leese @gnl21" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_529_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_529&quot;"          name="VK_KHR_EXTENSION_529_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_QNX_extension_530" number="530" author="QNX" contact="Mike Gorchak @mgorchak-blackberry" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_QNX_EXTENSION_530_SPEC_VERSION"/>
+                <enum value="&quot;VK_QNX_extension_530&quot;"          name="VK_QNX_EXTENSION_530_EXTENSION_NAME"/>
+                <enum bitpos="14" extends="VkExternalMemoryHandleTypeFlagBits" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_530_BIT_QNX"/>
+            </require>
+        </extension>
+        <extension name="VK_MSFT_extension_531" number="531" author="MSFT" contact="Jesse Natalie @jenatali" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_MSFT_EXTENSION_531_SPEC_VERSION"/>
+                <enum value="&quot;VK_MSFT_extension_531&quot;"         name="VK_MSFT_EXTENSION_531_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_532" number="532" author="KHR" contact="Tobias Hector @tobias" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_532_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_532&quot;"         name="VK_KHR_EXTENSION_532_EXTENSION_NAME"/>
             </require>
         </extension>
     </extensions>
@@ -22540,11 +23771,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <spirvextension name="SPV_EXT_shader_atomic_float16_add">
             <enable extension="VK_EXT_shader_atomic_float2"/>
         </spirvextension>
+        <spirvextension name="SPV_EXT_fragment_fully_covered">
+            <enable extension="VK_EXT_conservative_rasterization"/>
+        </spirvextension>
         <spirvextension name="SPV_KHR_integer_dot_product">
             <enable version="VK_API_VERSION_1_3"/>
             <enable extension="VK_KHR_shader_integer_dot_product"/>
         </spirvextension>
-        <spirvextension name="SPV_INTEL_shader_integer_functions">
+        <spirvextension name="SPV_INTEL_shader_integer_functions2">
             <enable extension="VK_INTEL_shader_integer_functions2"/>
         </spirvextension>
         <spirvextension name="SPV_KHR_device_group">
@@ -22556,6 +23790,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </spirvextension>
         <spirvextension name="SPV_EXT_mesh_shader">
             <enable extension="VK_EXT_mesh_shader"/>
+        </spirvextension>
+        <spirvextension name="SPV_KHR_ray_tracing_position_fetch">
+            <enable extension="VK_KHR_ray_tracing_position_fetch"/>
+        </spirvextension>
+        <spirvextension name="SPV_EXT_shader_tile_image">
+            <enable extension="VK_EXT_shader_tile_image"/>
+        </spirvextension>
+        <spirvextension name="SPV_EXT_opacity_micromap">
+            <enable extension="VK_EXT_opacity_micromap"/>
         </spirvextension>
     </spirvextensions>
     <spirvcapabilities comment="SPIR-V Capabilities allowed in Vulkan and what is required to use it">
@@ -22930,7 +24173,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <enable struct="VkPhysicalDeviceRayQueryFeaturesKHR" feature="rayQuery" requires="VK_KHR_ray_query"/>
         </spirvcapability>
         <spirvcapability name="RayCullMaskKHR">
-             <enable struct="VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR" feature="rayTracingMaintenance1" requires="VK_KHR_ray_tracing_maintenance1"/>
+            <enable struct="VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR" feature="rayTracingMaintenance1" requires="VK_KHR_ray_tracing_maintenance1"/>
         </spirvcapability>
         <spirvcapability name="RayTracingNV">
             <enable extension="VK_NV_ray_tracing"/>
@@ -23027,6 +24270,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </spirvcapability>
         <spirvcapability name="ShaderInvocationReorderNV">
             <enable extension="VK_NV_ray_tracing_invocation_reorder"/>
+        </spirvcapability>
+        <spirvcapability name="ClusterCullingShadingHUAWEI">
+            <enable struct="VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI" feature="clustercullingShader" requires="VK_HUAWEI_cluster_culling_shader"/>
+        </spirvcapability>
+        <spirvcapability name="RayTracingPositionFetchKHR">
+            <enable struct="VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR" feature="rayTracingPositionFetch" requires="VK_KHR_ray_tracing_position_fetch"/>
+        </spirvcapability>
+        <spirvcapability name="TileImageColorReadAccessEXT">
+            <enable struct="VkPhysicalDeviceShaderTileImageFeaturesEXT" feature="shaderTileImageColorReadAccess" requires="VK_EXT_shader_tile_image"/>
+        </spirvcapability>
+        <spirvcapability name="TileImageDepthReadAccessEXT">
+            <enable struct="VkPhysicalDeviceShaderTileImageFeaturesEXT" feature="shaderTileImageDepthReadAccess" requires="VK_EXT_shader_tile_image"/>
+        </spirvcapability>
+        <spirvcapability name="TileImageStencilReadAccessEXT">
+            <enable struct="VkPhysicalDeviceShaderTileImageFeaturesEXT" feature="shaderTileImageStencilReadAccess" requires="VK_EXT_shader_tile_image"/>
         </spirvcapability>
     </spirvcapabilities>
 </registry>


### PR DESCRIPTION
Changelog:
```markdown
### Public dependency updates
- [ash](https://crates.io/crates/ash) 0.37.3 (Vulkan 1.3.251)
- [libloading](https://crates.io/crates/libloading) 0.8
````

The newer vk.xml file uses a new, more complicated format for expressing dependencies of extensions. I wrote a "simple" parser to extract the information from it.

Syn 2.0 is used in the vulkano-macros crate, and it has some breaking changes that I haven't been able to fix, so I've left it at 1.0 for now.