### PR TITLE
Fix use-after-free in debug utils names setup

### DIFF
--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -1042,7 +1042,9 @@ impl Device {
         let info = ash::vk::DebugUtilsObjectNameInfoEXT {
             object_type: T::Handle::TYPE,
             object_handle: object.handle().as_raw(),
-            p_object_name: object_name_vk.map_or(ptr::null(), |object_name| object_name.as_ptr()),
+            p_object_name: object_name_vk
+                .as_ref()
+                .map_or(ptr::null(), |object_name| object_name.as_ptr()),
             ..Default::default()
         };
 


### PR DESCRIPTION
This fixes the use-after-free but that I discovered while playing around with debug utils names (first reported in #2242).

1. [x] Update documentation to reflect any user-facing changes - in this repository. => No docs change

2. [x] Make sure that the changes are covered by unit-tests. => UB cannot be covered by unit tests I think?

3. [x] Run `cargo fmt` on the changes.

4. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.
   
   Please remove any items from the template below that are not applicable.

5. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects. => See above.

Changelog:
```markdown
### Bugs fixed
- `Device::set_debug_utils_object_name` no longer exhibits use-after-free UB.
````
