### PR TITLE
ValidationError-ify command buffers and command pools

### DIFF
--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -65,9 +65,7 @@
 //! queue. If not possible, the queue will be entirely flushed and the command added to a fresh new
 //! queue with a fresh new barrier prototype.
 
-pub use self::builder::{
-    AutoCommandBufferBuilder, CommandBufferBeginError, CommandBufferBuildError,
-};
+pub use self::builder::*;
 pub(in crate::command_buffer) use self::builder::{
     BeginRenderPassState, BeginRenderingState, QueryState, RenderPassState,
     RenderPassStateAttachments, RenderPassStateType, SetOrPush,

--- a/vulkano/src/pipeline/graphics/subpass.rs
+++ b/vulkano/src/pipeline/graphics/subpass.rs
@@ -179,8 +179,8 @@ impl PipelineRenderingCreateInfo {
                 problem: "the number of views exceeds the \
                     `max_multiview_view_count` limit"
                     .into(),
-                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature("multiview")])]),
                 vuids: &["VUID-VkGraphicsPipelineCreateInfo-renderPass-06578"],
+                ..Default::default()
             }));
         }
 


### PR DESCRIPTION
Changelog:
```markdown
Changes to command buffers:
- `CommandPoolResetError` is renamed to `ResetCommandPoolError`.
- Command pool creation and resetting now take `CommandPoolCreateFlags` and `CommandPoolResetFlags` respectively.
```

Just the usual. The renaming of the error type follows the guidelines here: https://rust-lang.github.io/api-guidelines/naming.html#names-use-a-consistent-word-order-c-word-order
