### PR TITLE
Fix allocation type validation in `RawImage::bind_memory`

### DIFF
--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -1300,7 +1300,7 @@ vulkan_enum! {
 /// ```
 #[inline]
 pub fn max_mip_levels(extent: [u32; 3]) -> u32 {
-    // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#resources-image-miplevel-sizing
+    // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#resources-image-mip-level-sizing
     //
     // This calculates `floor(log2(max(width, height, depth))) + 1` using fast integer operations.
     32 - (extent[0] | extent[1] | extent[2]).leading_zeros()

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -780,7 +780,7 @@ impl RawImage {
                     if self.tiling() != ImageTiling::Linear {
                         return Err(Box::new(ValidationError {
                             problem: format!(
-                                "`allocations[{}].allocation_type()` is `AllocationType::Linear` \
+                                "`allocations[{}].allocation_type()` is `AllocationType::Linear`, \
                                 but `self.tiling()` is not `ImageTiling::Linear`",
                                 index
                             )
@@ -794,7 +794,7 @@ impl RawImage {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`allocations[{}].allocation_type()` is \
-                                `AllocationType::NonLinear` but `self.tiling()` is not \
+                                `AllocationType::NonLinear`, but `self.tiling()` is not \
                                 `ImageTiling::Optimal`",
                                 index
                             )

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -773,7 +773,7 @@ impl From<ImageTiling> for AllocationType {
         match tiling {
             ImageTiling::Optimal => AllocationType::NonLinear,
             ImageTiling::Linear => AllocationType::Linear,
-            ImageTiling::DrmFormatModifier => AllocationType::Linear, // TODO: improve
+            ImageTiling::DrmFormatModifier => AllocationType::Unknown,
         }
     }
 }


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- Fixed validation for the `AllocationType` of allocations in `RawImage::bind_memory`, where the image tiling wasn't taken into consideration.
```