### PR TITLE
Add validation for `VkExportMemoryAllocateInfo`

### DIFF
--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -896,18 +896,19 @@ vulkan_bitflags! {
     },*/
 }
 
-/// The buffer configuration to query in
-/// [`PhysicalDevice::external_buffer_properties`](crate::device::physical::PhysicalDevice::external_buffer_properties).
+/// The buffer configuration to query in [`PhysicalDevice::external_buffer_properties`].
+///
+/// [`PhysicalDevice::external_buffer_properties`]: crate::device::physical::PhysicalDevice::external_buffer_properties
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ExternalBufferInfo {
-    /// The external handle type that will be used with the buffer.
-    pub handle_type: ExternalMemoryHandleType,
+    /// The flags that will be used.
+    pub flags: BufferCreateFlags,
 
     /// The usage that the buffer will have.
     pub usage: BufferUsage,
 
-    /// The sparse binding parameters that will be used.
-    pub sparse: Option<BufferCreateFlags>,
+    /// The external handle type that will be used with the buffer.
+    pub handle_type: ExternalMemoryHandleType,
 
     pub _ne: crate::NonExhaustive,
 }
@@ -917,9 +918,9 @@ impl ExternalBufferInfo {
     #[inline]
     pub fn handle_type(handle_type: ExternalMemoryHandleType) -> Self {
         Self {
-            handle_type,
+            flags: BufferCreateFlags::empty(),
             usage: BufferUsage::empty(),
-            sparse: None,
+            handle_type,
             _ne: crate::NonExhaustive(()),
         }
     }
@@ -929,11 +930,19 @@ impl ExternalBufferInfo {
         physical_device: &PhysicalDevice,
     ) -> Result<(), Box<ValidationError>> {
         let &Self {
-            handle_type,
+            flags,
             usage,
-            sparse: _,
+            handle_type,
             _ne: _,
         } = self;
+
+        flags
+            .validate_physical_device(physical_device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkPhysicalDeviceExternalBufferInfo-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
 
         usage
             .validate_physical_device(physical_device)

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -538,14 +538,14 @@ impl PhysicalDevice {
             /* Input */
 
             let &ExternalBufferInfo {
-                handle_type,
+                flags,
                 usage,
-                sparse,
+                handle_type,
                 _ne: _,
             } = info;
 
             let external_buffer_info = ash::vk::PhysicalDeviceExternalBufferInfo {
-                flags: sparse.map(Into::into).unwrap_or_default(),
+                flags: flags.into(),
                 usage: usage.into(),
                 handle_type: handle_type.into(),
                 ..Default::default()

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -959,7 +959,7 @@ impl RawImage {
                             problem: format!(
                                 "`allocations[{}].device_memory().export_handle_types()` has the \
                                 `{:?}` flag set, which requires a dedicated allocation as returned \
-                                by `PhysicalDevice::external_buffer_properties`, but \
+                                by `PhysicalDevice::image_format_properties`, but \
                                 `allocations[{}].device_memory()` is not a dedicated allocation",
                                 index, handle_type, index,
                             )

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -743,9 +743,8 @@ impl<'d> MemoryAllocateInfo<'d> {
 
             // VUID-VkMemoryAllocateInfo-pNext-00639
             // VUID-VkExportMemoryAllocateInfo-handleTypes-00656
-            // TODO: how do you fullfill this when you don't know the image or buffer parameters?
-            // Does exporting memory require specifying these parameters up front, and does it tie
-            // the allocation to only images or buffers of that type?
+            // Impossible to validate here, instead this is validated in `RawBuffer::bind_memory`
+            // and `RawImage::bind_memory`.
         }
 
         if !flags.is_empty() {


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
- `ExternalBufferInfo::sparse` was replaced by a `flags` field.

### Bugs fixed
- Added missing validation for `MemoryAllocateInfo::export_handle_types`.
```
I'm unsure whether this belongs in `Bugs fixed` or `Additions`, since we knew this validation wasn't present.