### PR TITLE
Add `Format::UNDEFINED`

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -226,13 +226,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -316,7 +314,7 @@ fn main() {
             &memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::R8G8B8A8_UNORM),
+                format: Format::R8G8B8A8_UNORM,
                 extent: [TRANSFER_GRANULARITY * 2, TRANSFER_GRANULARITY * 2, 1],
                 usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
                 ..Default::default()

--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -128,13 +128,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -107,13 +107,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -158,7 +158,7 @@ impl FrameSystem {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::A2B10G10R10_UNORM_PACK32),
+                    format: Format::A2B10G10R10_UNORM_PACK32,
                     extent: [1, 1, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT
                         | ImageUsage::TRANSIENT_ATTACHMENT
@@ -175,7 +175,7 @@ impl FrameSystem {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R16G16B16A16_SFLOAT),
+                    format: Format::R16G16B16A16_SFLOAT,
                     extent: [1, 1, 1],
                     usage: ImageUsage::TRANSIENT_ATTACHMENT | ImageUsage::INPUT_ATTACHMENT,
                     ..Default::default()
@@ -190,7 +190,7 @@ impl FrameSystem {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::D16_UNORM),
+                    format: Format::D16_UNORM,
                     extent: [1, 1, 1],
                     usage: ImageUsage::TRANSIENT_ATTACHMENT | ImageUsage::INPUT_ATTACHMENT,
                     ..Default::default()
@@ -284,7 +284,7 @@ impl FrameSystem {
                     &self.memory_allocator,
                     ImageCreateInfo {
                         extent,
-                        format: Some(Format::A2B10G10R10_UNORM_PACK32),
+                        format: Format::A2B10G10R10_UNORM_PACK32,
                         usage: ImageUsage::COLOR_ATTACHMENT
                             | ImageUsage::TRANSIENT_ATTACHMENT
                             | ImageUsage::INPUT_ATTACHMENT,
@@ -300,7 +300,7 @@ impl FrameSystem {
                     &self.memory_allocator,
                     ImageCreateInfo {
                         extent,
-                        format: Some(Format::R16G16B16A16_SFLOAT),
+                        format: Format::R16G16B16A16_SFLOAT,
                         usage: ImageUsage::COLOR_ATTACHMENT
                             | ImageUsage::TRANSIENT_ATTACHMENT
                             | ImageUsage::INPUT_ATTACHMENT,
@@ -316,7 +316,7 @@ impl FrameSystem {
                     &self.memory_allocator,
                     ImageCreateInfo {
                         extent,
-                        format: Some(Format::D16_UNORM),
+                        format: Format::D16_UNORM,
                         usage: ImageUsage::DEPTH_STENCIL_ATTACHMENT
                             | ImageUsage::TRANSIENT_ATTACHMENT
                             | ImageUsage::INPUT_ATTACHMENT,

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -129,13 +129,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         let (swapchain, images) = Swapchain::new(
             device.clone(),

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -218,7 +218,7 @@ fn main() {
         &memory_allocator,
         ImageCreateInfo {
             image_type: ImageType::Dim2d,
-            format: Some(Format::R8G8B8A8_UNORM),
+            format: Format::R8G8B8A8_UNORM,
             extent: [1024, 1024, 1],
             usage: ImageUsage::TRANSFER_SRC | ImageUsage::STORAGE,
             ..Default::default()

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -121,7 +121,7 @@ mod linux {
             ImageCreateInfo {
                 flags: ImageCreateFlags::MUTABLE_FORMAT,
                 image_type: ImageType::Dim2d,
-                format: Some(Format::R16G16B16A16_UNORM),
+                format: Format::R16G16B16A16_UNORM,
                 extent: [200, 200, 1],
                 usage: ImageUsage::TRANSFER_SRC | ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
                 external_memory_handle_types: ExternalMemoryHandleTypes::OPAQUE_FD,
@@ -562,13 +562,11 @@ mod linux {
                 .physical_device()
                 .surface_capabilities(&surface, Default::default())
                 .unwrap();
-            let image_format = Some(
-                device
-                    .physical_device()
-                    .surface_formats(&surface, Default::default())
-                    .unwrap()[0]
-                    .0,
-            );
+            let image_format = device
+                .physical_device()
+                .surface_formats(&surface, Default::default())
+                .unwrap()[0]
+                .0;
 
             Swapchain::new(
                 device.clone(),

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -133,13 +133,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -252,7 +250,7 @@ fn main() {
         let image = Image::new(
             &memory_allocator,
             ImageCreateInfo {
-                format: Some(Format::R8G8B8A8_UNORM),
+                format: Format::R8G8B8A8_UNORM,
                 extent,
                 usage: ImageUsage::TRANSFER_SRC | ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
                 ..Default::default()

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -131,13 +131,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -251,7 +249,7 @@ fn main() {
             &memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::R8G8B8A8_SRGB),
+                format: Format::R8G8B8A8_SRGB,
                 extent,
                 usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
                 ..Default::default()

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -137,13 +137,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -257,7 +255,7 @@ fn main() {
             &memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::R8G8B8A8_SRGB),
+                format: Format::R8G8B8A8_SRGB,
                 extent,
                 usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
                 ..Default::default()

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -146,13 +146,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -144,13 +144,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -161,7 +161,7 @@ fn main() {
             &memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::R8G8B8A8_UNORM),
+                format: Format::R8G8B8A8_UNORM,
                 extent: [1024, 1024, 1],
                 usage: ImageUsage::COLOR_ATTACHMENT | ImageUsage::TRANSIENT_ATTACHMENT,
                 samples: SampleCount::Sample4,
@@ -178,7 +178,7 @@ fn main() {
         &memory_allocator,
         ImageCreateInfo {
             image_type: ImageType::Dim2d,
-            format: Some(Format::R8G8B8A8_UNORM),
+            format: Format::R8G8B8A8_UNORM,
             extent: [1024, 1024, 1],
             usage: ImageUsage::TRANSFER_SRC
                 | ImageUsage::TRANSFER_DST

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -152,13 +152,11 @@ fn main() {
 
     // The swapchain and framebuffer images for this particular window.
     let (swapchain, images) = {
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
         let window = surface.object().unwrap().downcast_ref::<Window>().unwrap();
 
         Swapchain::new(
@@ -362,13 +360,11 @@ fn main() {
                     .into_iter()
                     .next()
                     .unwrap();
-                let image_format = Some(
-                    device
-                        .physical_device()
-                        .surface_formats(&surface, Default::default())
-                        .unwrap()[0]
-                        .0,
-                );
+                let image_format = device
+                    .physical_device()
+                    .surface_formats(&surface, Default::default())
+                    .unwrap()[0]
+                    .0;
 
                 Swapchain::new(
                     device.clone(),

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -96,7 +96,7 @@ impl GameOfLifeComputePipeline {
                 memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [size[0], size[1], 1],
                     usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED | ImageUsage::STORAGE,
                     ..Default::default()

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -140,7 +140,7 @@ fn main() {
         &memory_allocator,
         ImageCreateInfo {
             image_type: ImageType::Dim2d,
-            format: Some(Format::B8G8R8A8_SRGB),
+            format: Format::B8G8R8A8_SRGB,
             extent: [512, 512, 1],
             array_layers: 2,
             usage: ImageUsage::TRANSFER_SRC | ImageUsage::COLOR_ATTACHMENT,

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -126,13 +126,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -574,7 +572,7 @@ fn window_size_dependent_setup(
             memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::D16_UNORM),
+                format: Format::D16_UNORM,
                 extent: images[0].extent(),
                 usage: ImageUsage::DEPTH_STENCIL_ATTACHMENT | ImageUsage::TRANSIENT_ATTACHMENT,
                 ..Default::default()

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -127,13 +127,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -246,7 +244,7 @@ fn main() {
             &memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::R8G8B8A8_SRGB),
+                format: Format::R8G8B8A8_SRGB,
                 extent,
                 usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
                 ..Default::default()

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -134,13 +134,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -139,13 +139,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -312,7 +310,7 @@ fn main() {
             &memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::R8G8B8A8_SRGB),
+                format: Format::R8G8B8A8_SRGB,
                 extent,
                 usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
                 ..Default::default()
@@ -360,7 +358,7 @@ fn main() {
             &memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::R8G8B8A8_SRGB),
+                format: Format::R8G8B8A8_SRGB,
                 extent,
                 usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
                 ..Default::default()

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -145,13 +145,11 @@ fn main() {
             .surface_capabilities(&surface, Default::default())
             .unwrap();
 
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -135,13 +135,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -443,7 +441,7 @@ fn window_size_dependent_setup(
             memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(Format::D16_UNORM),
+                format: Format::D16_UNORM,
                 extent: images[0].extent(),
                 usage: ImageUsage::DEPTH_STENCIL_ATTACHMENT | ImageUsage::TRANSIENT_ATTACHMENT,
                 ..Default::default()

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -238,13 +238,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -133,13 +133,11 @@ fn main() {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         Swapchain::new(
             device.clone(),
@@ -230,7 +228,7 @@ fn main() {
         let extent: [u32; 3] = [128, 128, 1];
         let array_layers = 3u32;
 
-        let buffer_size = format.block_size().unwrap()
+        let buffer_size = format.block_size()
             * extent
                 .into_iter()
                 .map(|e| e as DeviceSize)
@@ -270,7 +268,7 @@ fn main() {
             &memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
-                format: Some(format),
+                format,
                 extent,
                 array_layers,
                 usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -239,13 +239,11 @@ fn main() {
             .unwrap();
 
         // Choosing the internal format that the images will have.
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         // Please take a look at the docs for the meaning of the parameters we didn't mention.
         Swapchain::new(

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -208,13 +208,11 @@ fn main() {
             .unwrap();
 
         // Choosing the internal format that the images will have.
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
 
         // Please take a look at the docs for the meaning of the parameters we didn't mention.
         Swapchain::new(

--- a/vulkano-macros/src/derive_vertex.rs
+++ b/vulkano-macros/src/derive_vertex.rs
@@ -72,9 +72,7 @@ pub fn derive_vertex(ast: syn::DeriveInput) -> Result<TokenStream> {
 
                     let field_size = ::std::mem::size_of::<#field_ty>();
                     let format = #format;
-                    let format_size = format
-                        .block_size()
-                        .expect("no block size for format") as usize;
+                    let format_size = format.block_size() as usize;
                     let num_elements = field_size / format_size;
                     let remainder = field_size % format_size;
                     ::std::assert!(

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -99,13 +99,11 @@ impl VulkanoWindowRenderer {
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = Some(
-            device
-                .physical_device()
-                .surface_formats(&surface, Default::default())
-                .unwrap()[0]
-                .0,
-        );
+        let image_format = device
+            .physical_device()
+            .surface_formats(&surface, Default::default())
+            .unwrap()[0]
+            .0;
         let (swapchain, images) = Swapchain::new(device, surface, {
             let mut create_info = SwapchainCreateInfo {
                 min_image_count: surface_capabilities.min_image_count.max(2),
@@ -145,9 +143,7 @@ impl VulkanoWindowRenderer {
     /// Return swapchain image format.
     #[inline]
     pub fn swapchain_format(&self) -> Format {
-        self.final_views[self.image_index as usize]
-            .format()
-            .unwrap()
+        self.final_views[self.image_index as usize].format()
     }
 
     /// Returns the index of last swapchain image that is the next render target.
@@ -234,7 +230,7 @@ impl VulkanoWindowRenderer {
                 &self.memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(format),
+                    format,
                     extent: final_view_image.extent(),
                     usage,
                     ..Default::default()
@@ -368,7 +364,7 @@ impl VulkanoWindowRenderer {
             .map(|c| *c.0)
             .collect::<Vec<usize>>();
         for i in resizable_views {
-            let format = self.get_additional_image_view(i).format().unwrap();
+            let format = self.get_additional_image_view(i).format();
             let usage = self.get_additional_image_view(i).usage();
             self.remove_additional_image_view(i);
             self.add_additional_image_view(i, format, usage);

--- a/vulkano/autogen/formats.rs
+++ b/vulkano/autogen/formats.rs
@@ -13,6 +13,7 @@ use once_cell::sync::Lazy;
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::{format_ident, quote};
 use regex::Regex;
+use std::iter::once;
 use vk_parse::{
     Enum, EnumSpec, Extension, ExtensionChild, Feature, Format, FormatChild, InterfaceItem,
 };
@@ -46,7 +47,7 @@ struct FormatMember {
     aspect_plane2: bool,
 
     block_extent: [u32; 3],
-    block_size: Option<u64>,
+    block_size: u64,
     compatibility: Ident,
     components: [u8; 4],
     compression: Option<Ident>,
@@ -64,11 +65,12 @@ struct FormatMember {
 
 fn formats_output(members: &[FormatMember]) -> TokenStream {
     let enum_items = members.iter().map(|FormatMember { name, ffi_name, .. }| {
-        quote! { #name = ash::vk::Format::#ffi_name.as_raw(), }
+        let default = (ffi_name == "UNDEFINED").then(|| quote! { #[default] });
+        quote! { #default #name = ash::vk::Format::#ffi_name.as_raw(), }
     });
     let aspects_items = members.iter().map(
-        |FormatMember {
-             name,
+        |&FormatMember {
+             ref name,
              aspect_color,
              aspect_depth,
              aspect_stencil,
@@ -77,19 +79,31 @@ fn formats_output(members: &[FormatMember]) -> TokenStream {
              aspect_plane2,
              ..
          }| {
-            let aspect_items = [
-                aspect_color.then(|| quote! { crate::image::ImageAspects::COLOR }),
-                aspect_depth.then(|| quote! { crate::image::ImageAspects::DEPTH }),
-                aspect_stencil.then(|| quote! { crate::image::ImageAspects::STENCIL }),
-                aspect_plane0.then(|| quote! { crate::image::ImageAspects::PLANE_0 }),
-                aspect_plane1.then(|| quote! { crate::image::ImageAspects::PLANE_1 }),
-                aspect_plane2.then(|| quote! { crate::image::ImageAspects::PLANE_2 }),
-            ]
-            .into_iter()
-            .flatten();
+            if aspect_color
+                || aspect_depth
+                || aspect_stencil
+                || aspect_plane0
+                || aspect_plane1
+                || aspect_plane2
+            {
+                let aspect_items = [
+                    aspect_color.then(|| quote! { crate::image::ImageAspects::COLOR }),
+                    aspect_depth.then(|| quote! { crate::image::ImageAspects::DEPTH }),
+                    aspect_stencil.then(|| quote! { crate::image::ImageAspects::STENCIL }),
+                    aspect_plane0.then(|| quote! { crate::image::ImageAspects::PLANE_0 }),
+                    aspect_plane1.then(|| quote! { crate::image::ImageAspects::PLANE_1 }),
+                    aspect_plane2.then(|| quote! { crate::image::ImageAspects::PLANE_2 }),
+                ]
+                .into_iter()
+                .flatten();
 
-            quote! {
-                Self::#name => #(#aspect_items)|*,
+                quote! {
+                    Self::#name => #(#aspect_items)|*,
+                }
+            } else {
+                quote! {
+                    Self::#name => crate::image::ImageAspects::empty(),
+                }
             }
         },
     );
@@ -109,14 +123,12 @@ fn formats_output(members: &[FormatMember]) -> TokenStream {
             }
         },
     );
-    let block_size_items = members.iter().filter_map(
+    let block_size_items = members.iter().map(
         |FormatMember {
              name, block_size, ..
          }| {
-            block_size.as_ref().map(|size| {
-                let size = Literal::u64_unsuffixed(*size);
-                quote! { Self::#name => Some(#size), }
-            })
+            let block_size = Literal::u64_unsuffixed(*block_size);
+            quote! { Self::#name => #block_size, }
         },
     );
     let compatibility_items = members.iter().map(
@@ -319,7 +331,7 @@ fn formats_output(members: &[FormatMember]) -> TokenStream {
 
     quote! {
         /// An enumeration of all the possible formats.
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
         #[repr(i32)]
         #[allow(non_camel_case_types)]
         #[non_exhaustive]
@@ -358,14 +370,12 @@ fn formats_output(members: &[FormatMember]) -> TokenStream {
             /// For regular formats, this is the size of a single texel, but for more specialized
             /// formats this may be the size of multiple texels.
             ///
-            /// Depth/stencil formats are considered to have an opaque memory representation, and do
-            /// not have a well-defined size. Multi-planar formats store the color components
-            /// disjointly in memory, and therefore do not have a well-defined size for all
-            /// components as a whole. The individual planes do have a well-defined size.
-            pub fn block_size(self) -> Option<DeviceSize> {
+            /// Multi-planar formats store the color components disjointly in memory, and therefore
+            /// the texels do not form a single texel block. The block size for such formats
+            /// indicates the sum of the block size of each plane.
+            pub fn block_size(self) -> DeviceSize {
                 match self {
                     #(#block_size_items)*
-                    _ => None,
                 }
             }
 
@@ -576,6 +586,36 @@ fn formats_members(
     static BLOCK_EXTENT_REGEX: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"^(\d+),(\d+),(\d+)$").unwrap());
 
+    once(
+        FormatMember {
+            name: format_ident!("UNDEFINED"),
+            ffi_name: format_ident!("UNDEFINED"),
+            requires_all_of: Vec::new(),
+
+            aspect_color: false,
+            aspect_depth: false,
+            aspect_stencil: false,
+            aspect_plane0: false,
+            aspect_plane1: false,
+            aspect_plane2: false,
+
+            block_extent: [0; 3],
+            block_size: 0,
+            compatibility: format_ident!("Undefined"),
+            components: [0u8; 4],
+            compression: None,
+            planes: vec![],
+            texels_per_block: 0,
+            type_color: None,
+            type_depth: None,
+            type_stencil: None,
+            ycbcr_chroma_sampling: None,
+
+            type_std_array: None,
+            type_cgmath: None,
+            type_nalgebra: None,
+        }
+    ).chain(
     formats
         .iter()
         .map(|format| {
@@ -603,7 +643,7 @@ fn formats_members(
                 aspect_plane2: false,
 
                 block_extent: [1, 1, 1],
-                block_size: None,
+                block_size: format.blockSize as u64,
                 compatibility: format_ident!(
                     "Class_{}",
                     format.class.replace('-', "").replace(' ', "_")
@@ -712,10 +752,7 @@ fn formats_members(
                 }
             };
 
-            // Depth-stencil and multi-planar formats don't have well-defined block sizes.
             if let (Some(numeric_type), true) = (&member.type_color, member.planes.is_empty()) {
-                member.block_size = Some(format.blockSize as u64);
-
                 if format.compressed.is_some() {
                     member.type_std_array = Some({
                         let block_size = Literal::usize_unsuffixed(format.blockSize as usize);
@@ -868,6 +905,6 @@ fn formats_members(
             }
 
             member
-        })
+        }))
         .collect()
 }

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -1028,7 +1028,6 @@ impl AutoSyncState {
             .separate_depth_stencil_layouts
             && image
                 .format()
-                .unwrap()
                 .aspects()
                 .contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
         {
@@ -1604,11 +1603,9 @@ impl RenderPassStateAttachments {
                 .collect(),
             depth_attachment: (subpass_desc.depth_stencil_attachment.as_ref())
                 .filter(|depth_stencil_attachment| {
-                    (rp_attachments[depth_stencil_attachment.attachment as usize]
-                        .format
-                        .unwrap())
-                    .aspects()
-                    .intersects(ImageAspects::DEPTH)
+                    (rp_attachments[depth_stencil_attachment.attachment as usize].format)
+                        .aspects()
+                        .intersects(ImageAspects::DEPTH)
                 })
                 .map(|depth_stencil_attachment| RenderPassStateAttachmentInfo {
                     image_view: fb_attachments[depth_stencil_attachment.attachment as usize]
@@ -1625,11 +1622,9 @@ impl RenderPassStateAttachments {
                 }),
             stencil_attachment: (subpass_desc.depth_stencil_attachment.as_ref())
                 .filter(|depth_stencil_attachment| {
-                    (rp_attachments[depth_stencil_attachment.attachment as usize]
-                        .format
-                        .unwrap())
-                    .aspects()
-                    .intersects(ImageAspects::STENCIL)
+                    (rp_attachments[depth_stencil_attachment.attachment as usize].format)
+                        .aspects()
+                        .intersects(ImageAspects::STENCIL)
                 })
                 .map(|depth_stencil_attachment| RenderPassStateAttachmentInfo {
                     image_view: fb_attachments[depth_stencil_attachment.attachment as usize]

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -101,26 +101,26 @@ where
             }
         }
 
-        let image_aspects = image.format().unwrap().aspects();
+        let image_aspects = image.format().aspects();
 
         // VUID-vkCmdClearColorImage-image-00007
         if image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
             return Err(ClearError::FormatNotSupported {
-                format: image.format().unwrap(),
+                format: image.format(),
             });
         }
 
         // VUID-vkCmdClearColorImage-image-00007
-        if image.format().unwrap().compression().is_some() {
+        if image.format().compression().is_some() {
             return Err(ClearError::FormatNotSupported {
-                format: image.format().unwrap(),
+                format: image.format(),
             });
         }
 
         // VUID-vkCmdClearColorImage-image-01545
-        if image.format().unwrap().ycbcr_chroma_sampling().is_some() {
+        if image.format().ycbcr_chroma_sampling().is_some() {
             return Err(ClearError::FormatNotSupported {
-                format: image.format().unwrap(),
+                format: image.format(),
             });
         }
 
@@ -278,12 +278,12 @@ where
             }
         }
 
-        let image_aspects = image.format().unwrap().aspects();
+        let image_aspects = image.format().aspects();
 
         // VUID-vkCmdClearDepthStencilImage-image-00014
         if !image_aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
             return Err(ClearError::FormatNotSupported {
-                format: image.format().unwrap(),
+                format: image.format(),
             });
         }
 

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -300,8 +300,8 @@ where
 
         let copy_2d_3d_supported =
             device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1;
-        let mut src_image_aspects = src_image.format().unwrap().aspects();
-        let mut dst_image_aspects = dst_image.format().unwrap().aspects();
+        let mut src_image_aspects = src_image.format().aspects();
+        let mut dst_image_aspects = dst_image.format().aspects();
 
         if device.api_version() >= Version::V1_1 || device.enabled_extensions().khr_maintenance1 {
             // VUID-VkCopyImageInfo2-srcImage-01995
@@ -341,8 +341,8 @@ where
             // VUID-VkCopyImageInfo2-srcImage-01548
             if src_image.format() != dst_image.format() {
                 return Err(CopyError::FormatsMismatch {
-                    src_format: src_image.format().unwrap(),
-                    dst_format: dst_image.format().unwrap(),
+                    src_format: src_image.format(),
+                    dst_format: dst_image.format(),
                 });
             }
         }
@@ -390,11 +390,11 @@ where
 
                 Some((
                     granularity(
-                        src_image.format().unwrap().block_extent(),
+                        src_image.format().block_extent(),
                         src_image_aspects.intersects(ImageAspects::PLANE_0),
                     ),
                     granularity(
-                        dst_image.format().unwrap().block_extent(),
+                        dst_image.format().block_extent(),
                         dst_image_aspects.intersects(ImageAspects::PLANE_0),
                     ),
                 ))
@@ -493,23 +493,21 @@ where
                         }
 
                         if subresource.aspects.intersects(ImageAspects::PLANE_0) {
-                            (image.format().unwrap().planes()[0], image.extent())
+                            (image.format().planes()[0], image.extent())
                         } else if subresource.aspects.intersects(ImageAspects::PLANE_1) {
                             (
-                                image.format().unwrap().planes()[1],
+                                image.format().planes()[1],
                                 image
                                     .format()
-                                    .unwrap()
                                     .ycbcr_chroma_sampling()
                                     .unwrap()
                                     .subsampled_extent(image.extent()),
                             )
                         } else {
                             (
-                                image.format().unwrap().planes()[2],
+                                image.format().planes()[2],
                                 image
                                     .format()
-                                    .unwrap()
                                     .ycbcr_chroma_sampling()
                                     .unwrap()
                                     .subsampled_extent(image.extent()),
@@ -517,7 +515,7 @@ where
                         }
                     } else {
                         (
-                            image.format().unwrap(),
+                            image.format(),
                             mip_level_extent(image.extent(), subresource.mip_level).unwrap(),
                         )
                     };
@@ -1031,7 +1029,7 @@ where
         assert_eq!(device, src_buffer.device());
         assert_eq!(device, dst_image.device());
 
-        let mut image_aspects = dst_image.format().unwrap().aspects();
+        let mut image_aspects = dst_image.format().aspects();
 
         // VUID-VkCopyBufferToImageInfo2-commandBuffer-04477
         if !queue_family_properties
@@ -1115,7 +1113,7 @@ where
                 };
 
                 Some(granularity(
-                    dst_image.format().unwrap().block_extent(),
+                    dst_image.format().block_extent(),
                     image_aspects.intersects(ImageAspects::PLANE_0),
                 ))
             }
@@ -1188,23 +1186,21 @@ where
             let (image_subresource_format, image_subresource_extent) =
                 if image_aspects.intersects(ImageAspects::PLANE_0) {
                     if image_subresource.aspects.intersects(ImageAspects::PLANE_0) {
-                        (dst_image.format().unwrap().planes()[0], dst_image.extent())
+                        (dst_image.format().planes()[0], dst_image.extent())
                     } else if image_subresource.aspects.intersects(ImageAspects::PLANE_1) {
                         (
-                            dst_image.format().unwrap().planes()[1],
+                            dst_image.format().planes()[1],
                             dst_image
                                 .format()
-                                .unwrap()
                                 .ycbcr_chroma_sampling()
                                 .unwrap()
                                 .subsampled_extent(dst_image.extent()),
                         )
                     } else {
                         (
-                            dst_image.format().unwrap().planes()[2],
+                            dst_image.format().planes()[2],
                             dst_image
                                 .format()
-                                .unwrap()
                                 .ycbcr_chroma_sampling()
                                 .unwrap()
                                 .subsampled_extent(dst_image.extent()),
@@ -1212,7 +1208,7 @@ where
                     }
                 } else {
                     (
-                        dst_image.format().unwrap(),
+                        dst_image.format(),
                         mip_level_extent(dst_image.extent(), image_subresource.mip_level).unwrap(),
                     )
                 };
@@ -1346,7 +1342,7 @@ where
                         _ => unreachable!(),
                     }
                 } else {
-                    image_subresource_format.block_size().unwrap()
+                    image_subresource_format.block_size()
                 };
 
             // VUID-VkCopyBufferToImageInfo2-pRegions-04725
@@ -1452,8 +1448,7 @@ where
                             Resource::Buffer {
                                 buffer: src_buffer.clone(),
                                 range: buffer_offset
-                                    ..buffer_offset
-                                        + region.buffer_copy_size(dst_image.format().unwrap()),
+                                    ..buffer_offset + region.buffer_copy_size(dst_image.format()),
                                 memory_access: PipelineStageAccessFlags::Copy_TransferRead,
                             },
                         ),
@@ -1528,7 +1523,7 @@ where
         assert_eq!(device, dst_buffer.device());
         assert_eq!(device, src_image.device());
 
-        let mut image_aspects = src_image.format().unwrap().aspects();
+        let mut image_aspects = src_image.format().aspects();
 
         // VUID-VkCopyImageToBufferInfo2-srcImage-00186
         if !src_image.usage().intersects(ImageUsage::TRANSFER_SRC) {
@@ -1603,7 +1598,7 @@ where
                 };
 
                 Some(granularity(
-                    src_image.format().unwrap().block_extent(),
+                    src_image.format().block_extent(),
                     image_aspects.intersects(ImageAspects::PLANE_0),
                 ))
             }
@@ -1674,23 +1669,21 @@ where
             let (image_subresource_format, image_subresource_extent) =
                 if image_aspects.intersects(ImageAspects::PLANE_0) {
                     if image_subresource.aspects.intersects(ImageAspects::PLANE_0) {
-                        (src_image.format().unwrap().planes()[0], src_image.extent())
+                        (src_image.format().planes()[0], src_image.extent())
                     } else if image_subresource.aspects.intersects(ImageAspects::PLANE_1) {
                         (
-                            src_image.format().unwrap().planes()[1],
+                            src_image.format().planes()[1],
                             src_image
                                 .format()
-                                .unwrap()
                                 .ycbcr_chroma_sampling()
                                 .unwrap()
                                 .subsampled_extent(src_image.extent()),
                         )
                     } else {
                         (
-                            src_image.format().unwrap().planes()[2],
+                            src_image.format().planes()[2],
                             src_image
                                 .format()
-                                .unwrap()
                                 .ycbcr_chroma_sampling()
                                 .unwrap()
                                 .subsampled_extent(src_image.extent()),
@@ -1698,7 +1691,7 @@ where
                     }
                 } else {
                     (
-                        src_image.format().unwrap(),
+                        src_image.format(),
                         mip_level_extent(src_image.extent(), image_subresource.mip_level).unwrap(),
                     )
                 };
@@ -1832,7 +1825,7 @@ where
                         _ => unreachable!(),
                     }
                 } else {
-                    image_subresource_format.block_size().unwrap()
+                    image_subresource_format.block_size()
                 };
 
             // VUID-VkCopyImageToBufferInfo2-pRegions-04725
@@ -1948,8 +1941,7 @@ where
                             Resource::Buffer {
                                 buffer: dst_buffer.clone(),
                                 range: buffer_offset
-                                    ..buffer_offset
-                                        + region.buffer_copy_size(src_image.format().unwrap()),
+                                    ..buffer_offset + region.buffer_copy_size(src_image.format()),
                                 memory_access: PipelineStageAccessFlags::Copy_TransferWrite,
                             },
                         ),
@@ -2045,8 +2037,8 @@ where
         assert_eq!(device, src_image.device());
         assert_eq!(device, dst_image.device());
 
-        let src_image_aspects = src_image.format().unwrap().aspects();
-        let dst_image_aspects = dst_image.format().unwrap().aspects();
+        let src_image_aspects = src_image.format().aspects();
+        let dst_image_aspects = dst_image.format().aspects();
         let src_image_type = src_image.image_type();
         let dst_image_type = dst_image.image_type();
 
@@ -2089,28 +2081,18 @@ where
         }
 
         // VUID-VkBlitImageInfo2-srcImage-06421
-        if src_image
-            .format()
-            .unwrap()
-            .ycbcr_chroma_sampling()
-            .is_some()
-        {
+        if src_image.format().ycbcr_chroma_sampling().is_some() {
             return Err(CopyError::FormatNotSupported {
                 resource: CopyErrorResource::Source,
-                format: src_image.format().unwrap(),
+                format: src_image.format(),
             });
         }
 
         // VUID-VkBlitImageInfo2-dstImage-06422
-        if dst_image
-            .format()
-            .unwrap()
-            .ycbcr_chroma_sampling()
-            .is_some()
-        {
+        if dst_image.format().ycbcr_chroma_sampling().is_some() {
             return Err(CopyError::FormatNotSupported {
                 resource: CopyErrorResource::Destination,
-                format: src_image.format().unwrap(),
+                format: src_image.format(),
             });
         }
 
@@ -2120,8 +2102,8 @@ where
             // VUID-VkBlitImageInfo2-srcImage-00231
             if src_image.format() != dst_image.format() {
                 return Err(CopyError::FormatsMismatch {
-                    src_format: src_image.format().unwrap(),
-                    dst_format: dst_image.format().unwrap(),
+                    src_format: src_image.format(),
+                    dst_format: dst_image.format(),
                 });
             }
         } else {
@@ -2129,8 +2111,8 @@ where
             // VUID-VkBlitImageInfo2-srcImage-00230
             if !matches!(
                 (
-                    src_image.format().unwrap().type_color().unwrap(),
-                    dst_image.format().unwrap().type_color().unwrap(),
+                    src_image.format().type_color().unwrap(),
+                    dst_image.format().type_color().unwrap(),
                 ),
                 (
                     NumericType::SFLOAT
@@ -2151,8 +2133,8 @@ where
                     | (NumericType::UINT, NumericType::UINT)
             ) {
                 return Err(CopyError::FormatsNotCompatible {
-                    src_format: src_image.format().unwrap(),
-                    dst_format: dst_image.format().unwrap(),
+                    src_format: src_image.format(),
+                    dst_format: dst_image.format(),
                 });
             }
         }
@@ -2655,8 +2637,8 @@ where
         // VUID-VkResolveImageInfo2-srcImage-01386
         if src_image.format() != dst_image.format() {
             return Err(CopyError::FormatsMismatch {
-                src_format: src_image.format().unwrap(),
-                dst_format: dst_image.format().unwrap(),
+                src_format: src_image.format(),
+                dst_format: dst_image.format(),
             });
         }
 
@@ -2685,16 +2667,8 @@ where
         // Should be guaranteed by the requirement that formats match, and that the destination
         // image format features support color attachments.
         debug_assert!(
-            src_image
-                .format()
-                .unwrap()
-                .aspects()
-                .intersects(ImageAspects::COLOR)
-                && dst_image
-                    .format()
-                    .unwrap()
-                    .aspects()
-                    .intersects(ImageAspects::COLOR)
+            src_image.format().aspects().intersects(ImageAspects::COLOR)
+                && dst_image.format().aspects().intersects(ImageAspects::COLOR)
         );
 
         for (region_index, region) in regions.iter().enumerate() {
@@ -4113,7 +4087,7 @@ impl BufferImageCopy {
                 _ => unreachable!(),
             }
         } else {
-            format.block_size().unwrap()
+            format.block_size()
         };
 
         num_blocks * block_size
@@ -4957,10 +4931,7 @@ mod tests {
             })
             .product::<DeviceSize>()
             * layer_count as DeviceSize;
-        let block_size = format
-            .block_size()
-            .expect("this format cannot accept pixels");
-        num_blocks * block_size
+        num_blocks * format.block_size()
     }
 
     #[test]

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -912,7 +912,7 @@ where
 
                 // The SPIR-V Image Format is not compatible with the image view’s format.
                 if let Some(format) = binding_reqs.image_format {
-                    if image_view.format() != Some(format) {
+                    if image_view.format() != format {
                         return Err(DescriptorResourceInvalidError::ImageViewFormatMismatch {
                             required: format,
                             provided: image_view.format(),
@@ -959,11 +959,11 @@ where
                                 | ImageAspects::PLANE_1
                                 | ImageAspects::PLANE_2,
                         ) {
-                            image_view.format().unwrap().type_color().unwrap()
+                            image_view.format().type_color().unwrap()
                         } else if aspects.intersects(ImageAspects::DEPTH) {
-                            image_view.format().unwrap().type_depth().unwrap()
+                            image_view.format().type_depth().unwrap()
                         } else if aspects.intersects(ImageAspects::STENCIL) {
-                            image_view.format().unwrap().type_stencil().unwrap()
+                            image_view.format().type_stencil().unwrap()
                         } else {
                             // Per `ImageViewBuilder::aspects` and
                             // VUID-VkDescriptorImageInfo-imageView-01976
@@ -2652,7 +2652,7 @@ impl Display for PipelineExecutionError {
 pub enum DescriptorResourceInvalidError {
     ImageViewFormatMismatch {
         required: Format,
-        provided: Option<Format>,
+        provided: Format,
     },
     ImageViewMultisampledMismatch {
         required: bool,

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -313,7 +313,7 @@ where
             .enumerate()
         {
             let attachment_index = attachment_index as u32;
-            let attachment_format = attachment_desc.format.unwrap();
+            let attachment_format = attachment_desc.format;
 
             if attachment_desc.load_op == AttachmentLoadOp::Clear
                 || attachment_desc
@@ -877,7 +877,7 @@ where
 
                 let resolve_image = resolve_image_view.image();
 
-                match image_view.format().unwrap().type_color().unwrap() {
+                match image_view.format().type_color().unwrap() {
                     NumericType::SFLOAT
                     | NumericType::UFLOAT
                     | NumericType::SNORM
@@ -987,7 +987,7 @@ where
             // VUID-VkRenderingAttachmentInfo-storeOp-parameter
             store_op.validate_device(device)?;
 
-            let image_aspects = image_view.format().unwrap().aspects();
+            let image_aspects = image_view.format().aspects();
 
             // VUID-VkRenderingInfo-pDepthAttachment-06547
             if !image_aspects.intersects(ImageAspects::DEPTH) {
@@ -1127,7 +1127,7 @@ where
             // VUID-VkRenderingAttachmentInfo-storeOp-parameter
             store_op.validate_device(device)?;
 
-            let image_aspects = image_view.format().unwrap().aspects();
+            let image_aspects = image_view.format().aspects();
 
             // VUID-VkRenderingInfo-pStencilAttachment-06548
             if !image_aspects.intersects(ImageAspects::STENCIL) {
@@ -2380,7 +2380,7 @@ impl RenderingAttachmentInfo {
     /// Returns a `RenderingAttachmentInfo` with the specified `image_view`.
     #[inline]
     pub fn image_view(image_view: Arc<ImageView>) -> Self {
-        let aspects = image_view.format().unwrap().aspects();
+        let aspects = image_view.format().aspects();
         let image_layout = if aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
             ImageLayout::DepthStencilAttachmentOptimal
         } else {
@@ -2424,7 +2424,7 @@ impl RenderingAttachmentResolveInfo {
     /// Returns a `RenderingAttachmentResolveInfo` with the specified `image_view`.
     #[inline]
     pub fn image_view(image_view: Arc<ImageView>) -> Self {
-        let aspects = image_view.format().unwrap().aspects();
+        let aspects = image_view.format().aspects();
         let image_layout = if aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
             ImageLayout::DepthStencilAttachmentOptimal
         } else {

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -183,7 +183,7 @@ where
                         .enumerate()
                         .filter_map(|(i, (a, f))| a.as_ref().map(|a| (i as u32, &a.image_view, f)))
                     {
-                        let required_format = image_view.format().unwrap();
+                        let required_format = image_view.format();
 
                         // VUID-vkCmdExecuteCommands-imageView-06028
                         if Some(required_format) != inherited_format {
@@ -216,11 +216,11 @@ where
                         .map(|a| (&a.image_view, inheritance_info.depth_attachment_format))
                     {
                         // VUID-vkCmdExecuteCommands-pDepthAttachment-06029
-                        if Some(image_view.format().unwrap()) != format {
+                        if Some(image_view.format()) != format {
                             return Err(
                                 ExecuteCommandsError::RenderPassDepthAttachmentFormatMismatch {
                                     command_buffer_index,
-                                    required_format: image_view.format().unwrap(),
+                                    required_format: image_view.format(),
                                     inherited_format: format,
                                 },
                             );
@@ -244,11 +244,11 @@ where
                         .map(|a| (&a.image_view, inheritance_info.stencil_attachment_format))
                     {
                         // VUID-vkCmdExecuteCommands-pStencilAttachment-06030
-                        if Some(image_view.format().unwrap()) != format {
+                        if Some(image_view.format()) != format {
                             return Err(
                                 ExecuteCommandsError::RenderPassStencilAttachmentFormatMismatch {
                                     command_buffer_index,
-                                    required_format: image_view.format().unwrap(),
+                                    required_format: image_view.format(),
                                     inherited_format: format,
                                 },
                             );

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -551,6 +551,14 @@ impl CommandBufferInheritanceRenderingInfo {
                 ..ValidationError::from_requirement(err)
             })?;
 
+            if format == Format::UNDEFINED {
+                return Err(Box::new(ValidationError {
+                    context: format!("color_attachment_formats[{}]", index).into(),
+                    problem: "is `Format::UNDEFINED`".into(),
+                    ..Default::default()
+                }));
+            }
+
             let potential_format_features = unsafe {
                 device
                     .physical_device()
@@ -575,6 +583,14 @@ impl CommandBufferInheritanceRenderingInfo {
                 vuids: &["VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-parameter"],
                 ..ValidationError::from_requirement(err)
             })?;
+
+            if format == Format::UNDEFINED {
+                return Err(Box::new(ValidationError {
+                    context: "depth_attachment_format".into(),
+                    problem: "is `Format::UNDEFINED`".into(),
+                    ..Default::default()
+                }));
+            }
 
             if !format.aspects().intersects(ImageAspects::DEPTH) {
                 return Err(Box::new(ValidationError {
@@ -614,6 +630,14 @@ impl CommandBufferInheritanceRenderingInfo {
                 vuids: &["VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-parameter"],
                 ..ValidationError::from_requirement(err)
             })?;
+
+            if format == Format::UNDEFINED {
+                return Err(Box::new(ValidationError {
+                    context: "stencil_attachment_format".into(),
+                    problem: "is `Format::UNDEFINED`".into(),
+                    ..Default::default()
+                }));
+            }
 
             if !format.aspects().intersects(ImageAspects::STENCIL) {
                 return Err(Box::new(ValidationError {

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -1027,7 +1027,7 @@ impl PhysicalDevice {
                 ..
             } = &mut image_format_info;
 
-            let aspects = format.unwrap().aspects();
+            let aspects = format.aspects();
 
             if stencil_usage.is_empty()
                 || !aspects.contains(ImageAspects::DEPTH | ImageAspects::STENCIL)
@@ -1055,7 +1055,7 @@ impl PhysicalDevice {
                 let has_separate_stencil_usage = stencil_usage != usage;
 
                 let mut info2_vk = ash::vk::PhysicalDeviceImageFormatInfo2 {
-                    format: format.unwrap().into(),
+                    format: format.into(),
                     ty: image_type.into(),
                     tiling: tiling.into(),
                     usage: usage.into(),
@@ -1330,7 +1330,7 @@ impl PhysicalDevice {
                 } = format_info;
 
                 let format_info2 = ash::vk::PhysicalDeviceSparseImageFormatInfo2 {
-                    format: format.unwrap().into(),
+                    format: format.into(),
                     ty: image_type.into(),
                     samples: samples.into(),
                     usage: usage.into(),

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -310,6 +310,7 @@ pub struct FormatCompatibility(pub(crate) &'static FormatCompatibilityInner);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(non_camel_case_types)]
 pub(crate) enum FormatCompatibilityInner {
+    Undefined,
     Class_8bit,
     Class_16bit,
     Class_24bit,

--- a/vulkano/src/image/sampler/mod.rs
+++ b/vulkano/src/image/sampler/mod.rs
@@ -402,11 +402,11 @@ impl Sampler {
                         | ImageAspects::PLANE_1
                         | ImageAspects::PLANE_2,
                 ) {
-                    image_view.format().unwrap().type_color().unwrap()
+                    image_view.format().type_color().unwrap()
                 } else if aspects.intersects(ImageAspects::DEPTH) {
-                    image_view.format().unwrap().type_depth().unwrap()
+                    image_view.format().type_depth().unwrap()
                 } else if aspects.intersects(ImageAspects::STENCIL) {
-                    image_view.format().unwrap().type_stencil().unwrap()
+                    image_view.format().type_stencil().unwrap()
                 } else {
                     // Per `ImageViewBuilder::aspects` and
                     // VUID-VkDescriptorImageInfo-imageView-01976
@@ -1077,7 +1077,7 @@ impl SamplerCreateInfo {
             let potential_format_features = unsafe {
                 device
                     .physical_device()
-                    .format_properties_unchecked(sampler_ycbcr_conversion.format().unwrap())
+                    .format_properties_unchecked(sampler_ycbcr_conversion.format())
                     .potential_format_features()
             };
 

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -52,7 +52,7 @@
 //! # let descriptor_set_allocator: vulkano::descriptor_set::allocator::StandardDescriptorSetAllocator = return;
 //! #
 //! let conversion = SamplerYcbcrConversion::new(device.clone(), SamplerYcbcrConversionCreateInfo {
-//!     format: Some(Format::G8_B8_R8_3PLANE_420_UNORM),
+//!     format: Format::G8_B8_R8_3PLANE_420_UNORM,
 //!     ycbcr_model: SamplerYcbcrModelConversion::YcbcrIdentity,
 //!     ..Default::default()
 //! })
@@ -85,7 +85,7 @@
 //!     &memory_allocator,
 //!     ImageCreateInfo {
 //!         image_type: ImageType::Dim2d,
-//!         format: Some(Format::G8_B8_R8_3PLANE_420_UNORM),
+//!         format: Format::G8_B8_R8_3PLANE_420_UNORM,
 //!         extent: [1920, 1080, 1],
 //!         usage: ImageUsage::SAMPLED,
 //!         ..Default::default()
@@ -127,7 +127,7 @@ pub struct SamplerYcbcrConversion {
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
     id: NonZeroU64,
 
-    format: Option<Format>,
+    format: Format,
     ycbcr_model: SamplerYcbcrModelConversion,
     ycbcr_range: SamplerYcbcrRange,
     component_mapping: ComponentMapping,
@@ -189,7 +189,7 @@ impl SamplerYcbcrConversion {
         } = &create_info;
 
         let create_info_vk = ash::vk::SamplerYcbcrConversionCreateInfo {
-            format: format.unwrap().into(),
+            format: format.into(),
             ycbcr_model: ycbcr_model.into(),
             ycbcr_range: ycbcr_range.into(),
             components: component_mapping.into(),
@@ -287,7 +287,7 @@ impl SamplerYcbcrConversion {
 
     /// Returns the format that the conversion was created for.
     #[inline]
-    pub fn format(&self) -> Option<Format> {
+    pub fn format(&self) -> Format {
         self.format
     }
 
@@ -384,8 +384,8 @@ pub struct SamplerYcbcrConversionCreateInfo {
     /// Compatibility notice: currently, this value must be `Some`, but future additions may allow
     /// `None` as a valid value as well.
     ///
-    /// The default value is `None`.
-    pub format: Option<Format>,
+    /// The default value is `Format::UNDEFINED`.
+    pub format: Format,
 
     /// The conversion between the input color model and the output RGB color model.
     ///
@@ -443,7 +443,7 @@ impl Default for SamplerYcbcrConversionCreateInfo {
     #[inline]
     fn default() -> Self {
         Self {
-            format: None,
+            format: Format::UNDEFINED,
             ycbcr_model: SamplerYcbcrModelConversion::RgbIdentity,
             ycbcr_range: SamplerYcbcrRange::ItuFull,
             component_mapping: ComponentMapping::identity(),
@@ -467,12 +467,6 @@ impl SamplerYcbcrConversionCreateInfo {
             force_explicit_reconstruction,
             _ne: _,
         } = self;
-
-        let format = format.ok_or(ValidationError {
-            context: "format".into(),
-            problem: "is `None`".into(),
-            ..Default::default()
-        })?;
 
         format
             .validate_device(device)

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -883,7 +883,7 @@ impl Display for SuballocatorError {
 ///         &memory_allocator,
 ///         ImageCreateInfo {
 ///             image_type: ImageType::Dim2d,
-///             format: Some(Format::R8G8B8A8_UNORM),
+///             format: Format::R8G8B8A8_UNORM,
 ///             extent: [1024, 1024, 1],
 ///             usage: ImageUsage::SAMPLED,
 ///             ..Default::default()

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -924,7 +924,7 @@ impl GraphicsPipeline {
                 }
             };
 
-            let mut color_blend_state_vk =
+            let color_blend_state_vk =
                 color_blend_state_vk.insert(ash::vk::PipelineColorBlendStateCreateInfo {
                     flags: flags.into(),
                     logic_op_enable,
@@ -2888,7 +2888,6 @@ impl GraphicsPipelineCreateInfo {
                             subpass.render_pass().attachments()
                                 [depth_stencil_attachment.attachment as usize]
                                 .format
-                                .unwrap()
                                 .aspects()
                                 .intersects(ImageAspects::DEPTH)
                         }),
@@ -2923,7 +2922,6 @@ impl GraphicsPipelineCreateInfo {
                                     subpass.render_pass().attachments()
                                         [depth_stencil_attachment.attachment as usize]
                                         .format
-                                        .unwrap()
                                         .aspects()
                                         .intersects(ImageAspects::DEPTH)
                                 })
@@ -2955,7 +2953,6 @@ impl GraphicsPipelineCreateInfo {
                             subpass.render_pass().attachments()
                                 [depth_stencil_attachment.attachment as usize]
                                 .format
-                                .unwrap()
                                 .aspects()
                                 .intersects(ImageAspects::STENCIL)
                         }),
@@ -3006,7 +3003,7 @@ impl GraphicsPipelineCreateInfo {
                         PipelineSubpassType::BeginRenderPass(subpass) => {
                             subpass.subpass_desc().color_attachments[attachment_index]
                                 .as_ref()
-                                .and_then(|color_attachment| {
+                                .map(|color_attachment| {
                                     subpass.render_pass().attachments()
                                         [color_attachment.attachment as usize]
                                         .format

--- a/vulkano/src/pipeline/graphics/vertex_input/definition.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/definition.rs
@@ -84,7 +84,7 @@ unsafe impl VertexDefinition for &[VertexBufferDescription] {
             }
 
             let mut offset = infos.offset as DeviceSize;
-            let block_size = infos.format.block_size().unwrap();
+            let block_size = infos.format.block_size();
             // Double precision formats can exceed a single location.
             // R64B64G64A64_SFLOAT requires two locations, so we need to adapt how we bind
             let location_range = if block_size > 16 {

--- a/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
@@ -57,7 +57,7 @@ macro_rules! impl_vertex {
                             }
                             size_of_raw(p)
                         } as u32;
-                        let format_size = format.block_size().expect("no block size for format") as u32;
+                        let format_size = format.block_size() as u32;
                         let num_elements = field_size / format_size;
                         let remainder = field_size % format_size;
                         assert!(remainder == 0, "struct field `{}` size does not fit multiple of format size", stringify!($member));

--- a/vulkano/src/pipeline/graphics/vertex_input/mod.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/mod.rs
@@ -257,8 +257,7 @@ impl VertexInputState {
                 && !device
                     .enabled_features()
                     .vertex_attribute_access_beyond_stride
-                && offset as DeviceSize + format.block_size().unwrap()
-                    > binding_desc.stride as DeviceSize
+                && offset as DeviceSize + format.block_size() > binding_desc.stride as DeviceSize
             {
                 return Err(Box::new(ValidationError {
                     problem: format!(
@@ -281,7 +280,7 @@ impl VertexInputState {
         // the location following it needs to be empty.
         let unassigned_locations = attributes
             .iter()
-            .filter(|&(_, attribute_desc)| attribute_desc.format.block_size().unwrap() > 16)
+            .filter(|&(_, attribute_desc)| attribute_desc.format.block_size() > 16)
             .map(|(location, _)| location + 1);
 
         for location in unassigned_locations {

--- a/vulkano/src/render_pass/create.rs
+++ b/vulkano/src/render_pass/create.rs
@@ -56,7 +56,7 @@ impl RenderPass {
                     (
                         ash::vk::AttachmentDescription2 {
                             flags: flags.into(),
-                            format: format.map_or(ash::vk::Format::UNDEFINED, |f| f.into()),
+                            format: format.into(),
                             samples: samples.into(),
                             load_op: load_op.into(),
                             store_op: store_op.into(),
@@ -561,7 +561,7 @@ impl RenderPass {
 
                 ash::vk::AttachmentDescription {
                     flags: flags.into(),
-                    format: format.map_or(ash::vk::Format::UNDEFINED, |f| f.into()),
+                    format: format.into(),
                     samples: samples.into(),
                     load_op: load_op.into(),
                     store_op: store_op.into(),

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -558,7 +558,7 @@ impl FramebufferCreateInfo {
             match image_view.view_type() {
                 ImageViewType::Dim2d | ImageViewType::Dim2dArray => {
                     if image_view.image().image_type() == ImageType::Dim3d
-                        && (image_view.format().unwrap().aspects())
+                        && (image_view.format().aspects())
                             .intersects(ImageAspects::DEPTH | ImageAspects::STENCIL)
                     {
                         return Err(Box::new(ValidationError {
@@ -696,7 +696,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [1024, 768, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()
@@ -777,7 +777,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8_UNORM),
+                    format: Format::R8_UNORM,
                     extent: [1024, 768, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()
@@ -827,7 +827,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [600, 600, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()
@@ -877,7 +877,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [512, 700, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()
@@ -933,7 +933,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [256, 512, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()
@@ -948,7 +948,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [512, 128, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()
@@ -1007,7 +1007,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [256, 512, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()
@@ -1055,7 +1055,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [256, 512, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()
@@ -1070,7 +1070,7 @@ mod tests {
                 &memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
-                    format: Some(Format::R8G8B8A8_UNORM),
+                    format: Format::R8G8B8A8_UNORM,
                     extent: [256, 512, 1],
                     usage: ImageUsage::COLOR_ATTACHMENT,
                     ..Default::default()

--- a/vulkano/src/render_pass/macros.rs
+++ b/vulkano/src/render_pass/macros.rs
@@ -225,7 +225,7 @@ macro_rules! ordered_passes_renderpass {
                     $(layouts.final_layout = Some($final_layout);)*
 
                     $crate::render_pass::AttachmentDescription {
-                        format: Some($format),
+                        format: $format,
                         samples: $crate::image::SampleCount::try_from($samples).unwrap(),
                         load_op: $crate::render_pass::AttachmentLoadOp::$load_op,
                         store_op: $crate::render_pass::AttachmentStoreOp::$store_op,


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to `Format`:
- The following objects now use `Format` instead of `Option<Format>`: `BufferView`, `Image`, `ImageView`, `SamplerYcbcrConversion`.
- The `block_size` method no longer returns an `Option`.

### Additions
- Added `Format::UNDEFINED`, and implemented `Default` which returns this value.
````

Following https://github.com/KhronosGroup/Vulkan-Docs/issues/2165, it seems that the Vulkan definition of a "valid VkFormat value" includes `UNDEFINED`. So this makes that a valid enum value for Vulkano as well, and removes `Option` APIs where appropriate.

I haven't done it for attachment formats for dynamic rendering. In this case, `None` doesn't just mean "undefined format", but "no attachment". It matches with the fields of `RenderingInfo` where the attachments that are absent are also represented as `None`.