### PR TITLE
Switch to a more expressive way to specify memory usage

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -68,7 +68,9 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -283,7 +285,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -301,7 +303,7 @@ fn main() {
                     ..Default::default()
                 },
                 AllocationCreateInfo {
-                    usage: MemoryUsage::Upload,
+                    host_access: HostAccessType::SequentialWrite,
                     ..Default::default()
                 },
             )
@@ -717,7 +719,8 @@ fn run_worker(
                     ..Default::default()
                 },
                 AllocationCreateInfo {
-                    usage: MemoryUsage::Upload,
+                    location_preference: MemoryLocationPreference::Host,
+                    host_access: HostAccessType::SequentialWrite,
                     ..Default::default()
                 },
                 (0..TRANSFER_GRANULARITY * TRANSFER_GRANULARITY).map(|_| [0u8; 4]),

--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -68,9 +68,7 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -285,7 +283,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -303,7 +302,8 @@ fn main() {
                     ..Default::default()
                 },
                 AllocationCreateInfo {
-                    host_access: HostAccessType::SequentialWrite,
+                    memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                        | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                     ..Default::default()
                 },
             )
@@ -719,8 +719,8 @@ fn run_worker(
                     ..Default::default()
                 },
                 AllocationCreateInfo {
-                    location_preference: MemoryLocationPreference::Host,
-                    host_access: HostAccessType::SequentialWrite,
+                    memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                        | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                     ..Default::default()
                 },
                 (0..TRANSFER_GRANULARITY * TRANSFER_GRANULARITY).map(|_| [0u8; 4]),

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -26,7 +26,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -171,7 +171,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_RANDOM_ACCESS,
             ..Default::default()
         },
         // Iterator that produces the data.

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -26,7 +26,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -171,7 +171,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         // Iterator that produces the data.

--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -28,7 +28,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{MemoryLocationPreference, StandardMemoryAllocator},
+    memory::allocator::{MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -171,7 +171,8 @@ fn main() {
         SubbufferAllocatorCreateInfo {
             // We want to use the allocated subbuffers as vertex buffers.
             buffer_usage: BufferUsage::VERTEX_BUFFER,
-            location_preference: MemoryLocationPreference::Device,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
     );

--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -28,7 +28,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{MemoryLocationPreference, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -171,6 +171,7 @@ fn main() {
         SubbufferAllocatorCreateInfo {
             // We want to use the allocated subbuffers as vertex buffers.
             buffer_usage: BufferUsage::VERTEX_BUFFER,
+            location_preference: MemoryLocationPreference::Device,
             ..Default::default()
         },
     );

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -19,7 +19,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -78,7 +78,7 @@ impl AmbientLightingSystem {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -19,7 +19,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -78,7 +78,8 @@ impl AmbientLightingSystem {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -20,7 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -72,21 +72,19 @@ impl DirectionalLightingSystem {
                 position: [3.0, -1.0],
             },
         ];
-        let vertex_buffer = {
-            Buffer::from_iter(
-                memory_allocator,
-                BufferCreateInfo {
-                    usage: BufferUsage::VERTEX_BUFFER,
-                    ..Default::default()
-                },
-                AllocationCreateInfo {
-                    usage: MemoryUsage::Upload,
-                    ..Default::default()
-                },
-                vertices,
-            )
-            .expect("failed to create buffer")
-        };
+        let vertex_buffer = Buffer::from_iter(
+            memory_allocator,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                host_access: HostAccessType::SequentialWrite,
+                ..Default::default()
+            },
+            vertices,
+        )
+        .expect("failed to create buffer");
 
         let pipeline = {
             let device = gfx_queue.device();

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -20,7 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -79,7 +79,8 @@ impl DirectionalLightingSystem {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -20,7 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -78,7 +78,7 @@ impl PointLightingSystem {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -20,7 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -78,7 +78,8 @@ impl PointLightingSystem {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -15,7 +15,7 @@ use vulkano::{
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
     },
     device::Queue,
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -67,7 +67,8 @@ impl TriangleDrawSystem {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -15,7 +15,7 @@ use vulkano::{
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
     },
     device::Queue,
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -67,7 +67,7 @@ impl TriangleDrawSystem {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -28,7 +28,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -194,7 +194,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         aligned_data,
@@ -208,7 +209,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::RandomAccess,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_RANDOM_ACCESS,
             ..Default::default()
         },
         (0..12).map(|_| 0u32),

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -28,7 +28,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -194,7 +194,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         aligned_data,
@@ -208,7 +208,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::RandomAccess,
             ..Default::default()
         },
         (0..12).map(|_| 0u32),

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -30,7 +30,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo, InstanceExtensions},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -244,7 +244,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Download,
+            host_access: HostAccessType::RandomAccess,
             ..Default::default()
         },
         (0..1024 * 1024 * 4).map(|_| 0u8),

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -30,7 +30,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo, InstanceExtensions},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -244,7 +244,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::RandomAccess,
+            memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                | MemoryTypeFilter::HOST_RANDOM_ACCESS,
             ..Default::default()
         },
         (0..1024 * 1024 * 4).map(|_| 0u8),

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -40,11 +40,11 @@ mod linux {
         },
         memory::{
             allocator::{
-                AllocationCreateInfo, HostAccessType, MemoryAlloc, MemoryAllocator,
-                MemoryTypeFilter, StandardMemoryAllocator,
+                AllocationCreateInfo, MemoryAlloc, MemoryAllocator, MemoryTypeFilter,
+                StandardMemoryAllocator,
             },
             DedicatedAllocation, DeviceMemory, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
-            MemoryAllocateInfo, MemoryPropertyFlags,
+            MemoryAllocateInfo,
         },
         pipeline::{
             graphics::{
@@ -139,10 +139,7 @@ mod linux {
                 memory_type_index: memory_allocator
                     .find_memory_type_index(
                         image_requirements.memory_type_bits,
-                        MemoryTypeFilter {
-                            preferred_flags: MemoryPropertyFlags::DEVICE_LOCAL,
-                            ..Default::default()
-                        },
+                        MemoryTypeFilter::PREFER_DEVICE,
                     )
                     .unwrap(),
                 dedicated_allocation: Some(DedicatedAllocation::Image(&raw_image)),
@@ -615,7 +612,8 @@ mod linux {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -40,11 +40,11 @@ mod linux {
         },
         memory::{
             allocator::{
-                AllocationCreateInfo, MemoryAlloc, MemoryAllocator, MemoryUsage,
-                StandardMemoryAllocator,
+                AllocationCreateInfo, HostAccessType, MemoryAlloc, MemoryAllocator,
+                MemoryTypeFilter, StandardMemoryAllocator,
             },
             DedicatedAllocation, DeviceMemory, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
-            MemoryAllocateInfo,
+            MemoryAllocateInfo, MemoryPropertyFlags,
         },
         pipeline::{
             graphics::{
@@ -139,7 +139,10 @@ mod linux {
                 memory_type_index: memory_allocator
                     .find_memory_type_index(
                         image_requirements.memory_type_bits,
-                        MemoryUsage::DeviceOnly.into(),
+                        MemoryTypeFilter {
+                            preferred_flags: MemoryPropertyFlags::DEVICE_LOCAL,
+                            ..Default::default()
+                        },
                     )
                     .unwrap(),
                 dedicated_allocation: Some(DedicatedAllocation::Image(&raw_image)),
@@ -612,7 +615,7 @@ mod linux {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             vertices,

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -30,9 +30,7 @@ use vulkano::{
         Image, ImageCreateInfo, ImageLayout, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -192,7 +190,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -240,8 +239,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -30,7 +30,9 @@ use vulkano::{
         Image, ImageCreateInfo, ImageLayout, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -190,7 +192,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -238,7 +240,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -28,9 +28,7 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -190,7 +188,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -238,8 +237,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -28,7 +28,9 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -188,7 +190,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -236,7 +238,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -37,7 +37,9 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -194,7 +196,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -242,7 +244,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -37,9 +37,7 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -196,7 +194,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -244,8 +243,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -42,7 +42,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::StandardMemoryAllocator,
+    memory::allocator::{MemoryLocationPreference, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo,
         graphics::{
@@ -255,6 +255,7 @@ fn main() {
         memory_allocator.clone(),
         SubbufferAllocatorCreateInfo {
             buffer_usage: BufferUsage::INDIRECT_BUFFER | BufferUsage::STORAGE_BUFFER,
+            location_preference: MemoryLocationPreference::Device,
             ..Default::default()
         },
     );
@@ -262,6 +263,7 @@ fn main() {
         memory_allocator,
         SubbufferAllocatorCreateInfo {
             buffer_usage: BufferUsage::STORAGE_BUFFER | BufferUsage::VERTEX_BUFFER,
+            location_preference: MemoryLocationPreference::Device,
             ..Default::default()
         },
     );

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -42,7 +42,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{MemoryLocationPreference, StandardMemoryAllocator},
+    memory::allocator::{MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo,
         graphics::{
@@ -255,7 +255,8 @@ fn main() {
         memory_allocator.clone(),
         SubbufferAllocatorCreateInfo {
             buffer_usage: BufferUsage::INDIRECT_BUFFER | BufferUsage::STORAGE_BUFFER,
-            location_preference: MemoryLocationPreference::Device,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
     );
@@ -263,7 +264,8 @@ fn main() {
         memory_allocator,
         SubbufferAllocatorCreateInfo {
             buffer_usage: BufferUsage::STORAGE_BUFFER | BufferUsage::VERTEX_BUFFER,
-            location_preference: MemoryLocationPreference::Device,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
     );

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -25,7 +25,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -193,7 +193,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -230,7 +231,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         instances,

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -25,7 +25,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -186,21 +186,19 @@ fn main() {
             position: [0.25, -0.1],
         },
     ];
-    let vertex_buffer = {
-        Buffer::from_iter(
-            &memory_allocator,
-            BufferCreateInfo {
-                usage: BufferUsage::VERTEX_BUFFER,
-                ..Default::default()
-            },
-            AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
-                ..Default::default()
-            },
-            vertices,
-        )
-        .unwrap()
-    };
+    let vertex_buffer = Buffer::from_iter(
+        &memory_allocator,
+        BufferCreateInfo {
+            usage: BufferUsage::VERTEX_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            host_access: HostAccessType::SequentialWrite,
+            ..Default::default()
+        },
+        vertices,
+    )
+    .unwrap();
 
     // Now we create another buffer that will store the unique data per instance. For this example,
     // we'll have the instances form a 10x10 grid that slowly gets larger.
@@ -232,7 +230,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         instances,

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -21,7 +21,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -65,7 +65,7 @@ impl FractalComputePipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             colors,
@@ -124,7 +124,7 @@ impl FractalComputePipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             colors,

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -21,7 +21,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -65,7 +65,8 @@ impl FractalComputePipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             colors,
@@ -124,7 +125,8 @@ impl FractalComputePipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             colors,

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -22,7 +22,7 @@ use vulkano::{
         sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode},
         view::ImageView,
     },
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -101,7 +101,7 @@ impl PixelsDrawPipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             vertices,
@@ -114,7 +114,7 @@ impl PixelsDrawPipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             indices,

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -22,7 +22,7 @@ use vulkano::{
         sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode},
         view::ImageView,
     },
-    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -101,7 +101,8 @@ impl PixelsDrawPipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             vertices,
@@ -114,7 +115,8 @@ impl PixelsDrawPipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             indices,

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -76,7 +76,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage, SampleCount},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -305,7 +305,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -373,7 +373,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Download,
+            host_access: HostAccessType::RandomAccess,
             ..Default::default()
         },
         (0..1024 * 1024 * 4).map(|_| 0u8),

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -76,7 +76,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage, SampleCount},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -305,7 +305,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -373,7 +374,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::RandomAccess,
+            memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                | MemoryTypeFilter::HOST_RANDOM_ACCESS,
             ..Default::default()
         },
         (0..1024 * 1024 * 4).map(|_| 0u8),

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -29,7 +29,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -207,7 +207,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -29,7 +29,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -207,7 +207,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -23,7 +23,7 @@ use vulkano::{
     device::Queue,
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -54,7 +54,8 @@ fn rand_grid(memory_allocator: &impl MemoryAllocator, size: [u32; 2]) -> Subbuff
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         (0..(size[0] * size[1])).map(|_| rand::thread_rng().gen_range(0u32..=1)),

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -23,7 +23,7 @@ use vulkano::{
     device::Queue,
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryUsage},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -54,7 +54,7 @@ fn rand_grid(memory_allocator: &impl MemoryAllocator, size: [u32; 2]) -> Subbuff
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         (0..(size[0] * size[1])).map(|_| rand::thread_rng().gen_range(0u32..=1)),

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -23,7 +23,7 @@ use vulkano::{
         sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode},
         view::ImageView,
     },
-    memory::allocator::{AllocationCreateInfo, HostAccessType},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -97,7 +97,8 @@ impl PixelsDrawPipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             vertices,
@@ -110,7 +111,8 @@ impl PixelsDrawPipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             indices,

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -23,7 +23,7 @@ use vulkano::{
         sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode},
         view::ImageView,
     },
-    memory::allocator::{AllocationCreateInfo, MemoryUsage},
+    memory::allocator::{AllocationCreateInfo, HostAccessType},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -97,7 +97,7 @@ impl PixelsDrawPipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             vertices,
@@ -110,7 +110,7 @@ impl PixelsDrawPipeline {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             indices,

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -29,7 +29,7 @@ use vulkano::{
         ImageUsage, SampleCount,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo, InstanceExtensions},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -177,7 +177,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -318,7 +318,7 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Download,
+                host_access: HostAccessType::RandomAccess,
                 ..Default::default()
             },
             (0..image.extent()[0] * image.extent()[1] * 4).map(|_| 0u8),

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -29,7 +29,7 @@ use vulkano::{
         ImageUsage, SampleCount,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo, InstanceExtensions},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -177,7 +177,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -318,7 +319,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::RandomAccess,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_RANDOM_ACCESS,
                 ..Default::default()
             },
             (0..image.extent()[0] * image.extent()[1] * 4).map(|_| 0u8),

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -25,7 +25,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -215,7 +215,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -25,7 +25,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -215,7 +215,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -25,7 +25,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -152,7 +152,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         0..65536u32,

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -25,7 +25,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -145,22 +145,19 @@ fn main() {
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
-    let data_buffer = {
-        let data_iter = 0..65536u32;
-        Buffer::from_iter(
-            &memory_allocator,
-            BufferCreateInfo {
-                usage: BufferUsage::STORAGE_BUFFER,
-                ..Default::default()
-            },
-            AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
-                ..Default::default()
-            },
-            data_iter,
-        )
-        .unwrap()
-    };
+    let data_buffer = Buffer::from_iter(
+        &memory_allocator,
+        BufferCreateInfo {
+            usage: BufferUsage::STORAGE_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            host_access: HostAccessType::SequentialWrite,
+            ..Default::default()
+        },
+        0..65536u32,
+    )
+    .unwrap();
 
     let layout = pipeline.layout().set_layouts().get(0).unwrap();
     let set = PersistentDescriptorSet::new(

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -26,7 +26,9 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -184,7 +186,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -231,7 +233,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -26,9 +26,7 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -186,7 +184,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -233,8 +232,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -275,7 +275,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -275,7 +275,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -29,9 +29,7 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -250,7 +248,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -299,8 +298,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,
@@ -348,8 +347,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -29,7 +29,9 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -248,7 +250,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -297,7 +299,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,
@@ -345,7 +348,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             (info.width * info.height * 4) as DeviceSize,

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -25,7 +25,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -146,7 +146,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::RandomAccess,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_RANDOM_ACCESS,
             ..Default::default()
         },
         // We intitialize half of the array and leave the other half at 0, we will use the copy

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -25,7 +25,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -146,7 +146,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::RandomAccess,
             ..Default::default()
         },
         // We intitialize half of the array and leave the other half at 0, we will use the copy

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -24,7 +24,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -152,7 +152,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_RANDOM_ACCESS,
             ..Default::default()
         },
         0..65536u32,

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -24,7 +24,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -145,22 +145,19 @@ fn main() {
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
-    let data_buffer = {
-        let data_iter = 0..65536u32;
-        Buffer::from_iter(
-            &memory_allocator,
-            BufferCreateInfo {
-                usage: BufferUsage::STORAGE_BUFFER,
-                ..Default::default()
-            },
-            AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
-                ..Default::default()
-            },
-            data_iter,
-        )
-        .unwrap()
-    };
+    let data_buffer = Buffer::from_iter(
+        &memory_allocator,
+        BufferCreateInfo {
+            usage: BufferUsage::STORAGE_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            host_access: HostAccessType::SequentialWrite,
+            ..Default::default()
+        },
+        0..65536u32,
+    )
+    .unwrap();
 
     let layout = pipeline.layout().set_layouts().get(0).unwrap();
     let set = PersistentDescriptorSet::new(

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -39,7 +39,7 @@ use vulkano::{
         QueueCreateInfo, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -242,7 +242,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::RandomAccess,
             ..Default::default()
         },
         0..65536u32,

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -39,7 +39,7 @@ use vulkano::{
         QueueCreateInfo, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -242,7 +242,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::RandomAccess,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_RANDOM_ACCESS,
             ..Default::default()
         },
         0..65536u32,

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -28,7 +28,9 @@ use vulkano::{
     },
     image::{view::ImageView, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         compute::ComputePipelineCreateInfo,
         graphics::{
@@ -363,7 +365,8 @@ fn main() {
             },
             AllocationCreateInfo {
                 // Specify this buffer will be used for uploading to the GPU.
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             vertices,
@@ -383,7 +386,8 @@ fn main() {
             },
             AllocationCreateInfo {
                 // Specify this buffer will only be used by the device.
-                usage: MemoryUsage::DeviceOnly,
+                location_preference: MemoryLocationPreference::Device,
+                host_access: HostAccessType::DontCare,
                 ..Default::default()
             },
             PARTICLE_COUNT as vulkano::DeviceSize,

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -28,9 +28,7 @@ use vulkano::{
     },
     image::{view::ImageView, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo,
         graphics::{
@@ -365,8 +363,8 @@ fn main() {
             },
             AllocationCreateInfo {
                 // Specify this buffer will be used for uploading to the GPU.
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             vertices,
@@ -386,8 +384,7 @@ fn main() {
             },
             AllocationCreateInfo {
                 // Specify this buffer will only be used by the device.
-                location_preference: MemoryLocationPreference::Device,
-                host_access: HostAccessType::DontCare,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE,
                 ..Default::default()
             },
             PARTICLE_COUNT as vulkano::DeviceSize,

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -22,7 +22,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -145,22 +145,19 @@ fn main() {
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
-    let data_buffer = {
-        let data_iter = 0..65536u32;
-        Buffer::from_iter(
-            &memory_allocator,
-            BufferCreateInfo {
-                usage: BufferUsage::STORAGE_BUFFER,
-                ..Default::default()
-            },
-            AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
-                ..Default::default()
-            },
-            data_iter,
-        )
-        .unwrap()
-    };
+    let data_buffer = Buffer::from_iter(
+        &memory_allocator,
+        BufferCreateInfo {
+            usage: BufferUsage::STORAGE_BUFFER,
+            ..Default::default()
+        },
+        AllocationCreateInfo {
+            host_access: HostAccessType::RandomAccess,
+            ..Default::default()
+        },
+        0..65536u32,
+    )
+    .unwrap();
 
     let layout = pipeline.layout().set_layouts().get(0).unwrap();
     let set = PersistentDescriptorSet::new(

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -22,7 +22,7 @@ use vulkano::{
         QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -152,7 +152,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::RandomAccess,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_RANDOM_ACCESS,
             ..Default::default()
         },
         0..65536u32,

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -29,9 +29,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -173,7 +171,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         POSITIONS,
@@ -186,7 +185,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         NORMALS,
@@ -199,7 +199,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         INDICES,
@@ -210,7 +211,8 @@ fn main() {
         memory_allocator.clone(),
         SubbufferAllocatorCreateInfo {
             buffer_usage: BufferUsage::UNIFORM_BUFFER,
-            location_preference: MemoryLocationPreference::Device,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
     );

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -209,8 +209,8 @@ fn main() {
     let uniform_buffer = SubbufferAllocator::new(
         memory_allocator.clone(),
         SubbufferAllocatorCreateInfo {
-            location_preference: MemoryLocationPreference::Device,
             buffer_usage: BufferUsage::UNIFORM_BUFFER,
+            location_preference: MemoryLocationPreference::Device,
             ..Default::default()
         },
     );

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -29,7 +29,7 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -171,7 +171,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         POSITIONS,
@@ -184,7 +184,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         NORMALS,
@@ -197,7 +197,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         INDICES,

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -29,7 +29,9 @@ use vulkano::{
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -207,6 +209,7 @@ fn main() {
     let uniform_buffer = SubbufferAllocator::new(
         memory_allocator.clone(),
         SubbufferAllocatorCreateInfo {
+            location_preference: MemoryLocationPreference::Device,
             buffer_usage: BufferUsage::UNIFORM_BUFFER,
             ..Default::default()
         },

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -310,7 +310,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -310,7 +310,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -28,9 +28,7 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{
-        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-    },
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -192,7 +190,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,
@@ -245,8 +244,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             buffer_size,

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -28,7 +28,9 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{
+        AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+    },
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -190,7 +192,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,
@@ -243,7 +245,8 @@ fn main() {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             buffer_size,

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -320,7 +320,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -34,7 +34,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -320,7 +320,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -29,7 +29,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -289,7 +289,7 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            usage: MemoryUsage::Upload,
+            host_access: HostAccessType::SequentialWrite,
             ..Default::default()
         },
         vertices,

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -29,7 +29,7 @@ use vulkano::{
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -289,7 +289,8 @@ fn main() {
             ..Default::default()
         },
         AllocationCreateInfo {
-            host_access: HostAccessType::SequentialWrite,
+            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
             ..Default::default()
         },
         vertices,

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -76,9 +76,6 @@
 //!
 //! [`RawBuffer`]: self::sys::RawBuffer
 //! [`SubbufferAllocator`]: self::allocator::SubbufferAllocator
-//! [`HostAccessType::DontCare`]: crate::memory::allocator::HostAccessType::DontCare
-//! [`HostAccessType::SequentialWrite`]: crate::memory::allocator::HostAccessType::SequentialWrite
-//! [`HostAccessType::RandomAccess`]: crate::memory::allocator::HostAccessType::RandomAccess
 //! [the `view` module]: self::view
 //! [the `shader` module documentation]: crate::shader
 

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -157,7 +157,7 @@ pub mod view;
 ///         AutoCommandBufferBuilder, CommandBufferUsage, CopyBufferInfo,
 ///         PrimaryCommandBufferAbstract,
 ///     },
-///     memory::allocator::{AllocationCreateInfo, MemoryUsage},
+///     memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryLocationPreference},
 ///     sync::GpuFuture,
 ///     DeviceSize,
 /// };
@@ -179,14 +179,15 @@ pub mod view;
 ///     },
 ///     AllocationCreateInfo {
 ///         // Specify use for upload to the device.
-///         usage: MemoryUsage::Upload,
+///         location_preference: MemoryLocationPreference::Host,
+///         host_access: HostAccessType::SequentialWrite,
 ///         ..Default::default()
 ///     },
 ///     data,
 /// )
 /// .unwrap();
 ///
-/// // Create a buffer in device-local with enough space for a slice of `10_000` floats.
+/// // Create a buffer in device-local memory with enough space for a slice of `10_000` floats.
 /// let device_local_buffer = Buffer::new_slice::<f32>(
 ///     &memory_allocator,
 ///     BufferCreateInfo {
@@ -196,7 +197,8 @@ pub mod view;
 ///     },
 ///     AllocationCreateInfo {
 ///         // Specify use by the device only.
-///         usage: MemoryUsage::DeviceOnly,
+///         location_preference: MemoryLocationPreference::Device,
+///         host_access: HostAccessType::DontCare,
 ///         ..Default::default()
 ///     },
 ///     10_000 as DeviceSize,

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -46,25 +46,6 @@
 //! once, or you can keep reusing the same buffer (because its size is unchanging) it's best to
 //! use a dedicated `Buffer` for that.
 //!
-//! # Memory usage
-//!
-//! When allocating memory for a buffer, you have to specify a *memory usage*. This tells the
-//! memory allocator what memory type it should pick for the allocation.
-//!
-//! - [`HostAccessType::DontCare`] will allocate a buffer that's usually located in device-local
-//!   memory and whose content can't be directly accessed by your application. Accessing this
-//!   buffer from the device is generally faster compared to accessing a buffer that's located in
-//!   host-visible memory.
-//! - [`HostAccessType::SequentialWrite`] and [`HostAccessType::RandomAccess`] both allocate from a
-//!   host-visible memory type, which means the buffer can be accessed directly from the host.
-//!   Buffers allocated with these memory usages are needed to get data to and from the device.
-//!
-//! Take for example a buffer that is under constant access by the device but you need to read its
-//! content on the host from time to time, it may be a good idea to use a device-local buffer as
-//! the main buffer and a host-visible buffer for when you need to read it. Then whenever you need
-//! to read the main buffer, ask the device to copy from the device-local buffer to the
-//! host-visible buffer, and read the host-visible buffer instead.
-//!
 //! # Buffer usage
 //!
 //! When you create a buffer, you have to specify its *usage*. In other words, you have to
@@ -157,7 +138,7 @@ pub mod view;
 ///         AutoCommandBufferBuilder, CommandBufferUsage, CopyBufferInfo,
 ///         PrimaryCommandBufferAbstract,
 ///     },
-///     memory::allocator::{AllocationCreateInfo, HostAccessType, MemoryLocationPreference},
+///     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter},
 ///     sync::GpuFuture,
 ///     DeviceSize,
 /// };
@@ -166,6 +147,7 @@ pub mod view;
 /// # let queue: std::sync::Arc<vulkano::device::Queue> = return;
 /// # let memory_allocator: vulkano::memory::allocator::StandardMemoryAllocator = return;
 /// # let command_buffer_allocator: vulkano::command_buffer::allocator::StandardCommandBufferAllocator = return;
+/// #
 /// // Simple iterator to construct test data.
 /// let data = (0..10_000).map(|i| i as f32);
 ///
@@ -179,8 +161,8 @@ pub mod view;
 ///     },
 ///     AllocationCreateInfo {
 ///         // Specify use for upload to the device.
-///         location_preference: MemoryLocationPreference::Host,
-///         host_access: HostAccessType::SequentialWrite,
+///         memory_type_filter: MemoryTypeFilter::PREFER_HOST
+///             | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
 ///         ..Default::default()
 ///     },
 ///     data,
@@ -197,8 +179,7 @@ pub mod view;
 ///     },
 ///     AllocationCreateInfo {
 ///         // Specify use by the device only.
-///         location_preference: MemoryLocationPreference::Device,
-///         host_access: HostAccessType::DontCare,
+///         memory_type_filter: MemoryTypeFilter::PREFER_DEVICE,
 ///         ..Default::default()
 ///     },
 ///     10_000 as DeviceSize,

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -51,13 +51,13 @@
 //! When allocating memory for a buffer, you have to specify a *memory usage*. This tells the
 //! memory allocator what memory type it should pick for the allocation.
 //!
-//! - [`MemoryUsage::DeviceOnly`] will allocate a buffer that's usually located in device-local
+//! - [`HostAccessType::DontCare`] will allocate a buffer that's usually located in device-local
 //!   memory and whose content can't be directly accessed by your application. Accessing this
 //!   buffer from the device is generally faster compared to accessing a buffer that's located in
 //!   host-visible memory.
-//! - [`MemoryUsage::Upload`] and [`MemoryUsage::Download`] both allocate from a host-visible
-//!   memory type, which means the buffer can be accessed directly from the host. Buffers allocated
-//!   with these memory usages are needed to get data to and from the device.
+//! - [`HostAccessType::SequentialWrite`] and [`HostAccessType::RandomAccess`] both allocate from a
+//!   host-visible memory type, which means the buffer can be accessed directly from the host.
+//!   Buffers allocated with these memory usages are needed to get data to and from the device.
 //!
 //! Take for example a buffer that is under constant access by the device but you need to read its
 //! content on the host from time to time, it may be a good idea to use a device-local buffer as
@@ -95,9 +95,9 @@
 //!
 //! [`RawBuffer`]: self::sys::RawBuffer
 //! [`SubbufferAllocator`]: self::allocator::SubbufferAllocator
-//! [`MemoryUsage::DeviceOnly`]: crate::memory::allocator::MemoryUsage::DeviceOnly
-//! [`MemoryUsage::Upload`]: crate::memory::allocator::MemoryUsage::Upload
-//! [`MemoryUsage::Download`]: crate::memory::allocator::MemoryUsage::Download
+//! [`HostAccessType::DontCare`]: crate::memory::allocator::HostAccessType::DontCare
+//! [`HostAccessType::SequentialWrite`]: crate::memory::allocator::HostAccessType::SequentialWrite
+//! [`HostAccessType::RandomAccess`]: crate::memory::allocator::HostAccessType::RandomAccess
 //! [the `view` module]: self::view
 //! [the `shader` module documentation]: crate::shader
 

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -1119,7 +1119,7 @@ mod tests {
         },
         memory::{
             allocator::{
-                AllocationCreateInfo, AllocationType, DeviceLayout, MemoryAllocator, MemoryUsage,
+                AllocationCreateInfo, AllocationType, DeviceLayout, MemoryAllocator,
                 StandardMemoryAllocator,
             },
             MemoryRequirements,
@@ -1199,10 +1199,7 @@ mod tests {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
             },
-            AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
-                ..Default::default()
-            },
+            AllocationCreateInfo::default(),
             6,
         )
         .unwrap();

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -465,7 +465,7 @@ mod tests {
     use crate::{
         buffer::{Buffer, BufferCreateInfo, BufferUsage},
         format::Format,
-        memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+        memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator},
     };
 
     #[test]
@@ -480,13 +480,11 @@ mod tests {
                 usage: BufferUsage::UNIFORM_TEXEL_BUFFER,
                 ..Default::default()
             },
-            AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
-                ..Default::default()
-            },
+            AllocationCreateInfo::default(),
             128,
         )
         .unwrap();
+
         BufferView::new(
             buffer,
             BufferViewCreateInfo {

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -321,9 +321,7 @@ mod tests {
         },
         device::{Device, DeviceCreateInfo, QueueCreateInfo},
         image::sampler::{Sampler, SamplerCreateInfo},
-        memory::allocator::{
-            AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
-        },
+        memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
         pipeline::{layout::PipelineLayoutCreateInfo, PipelineBindPoint, PipelineLayout},
         shader::ShaderStages,
         sync::GpuFuture,
@@ -374,8 +372,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::SequentialWrite,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                 ..Default::default()
             },
             [1_u32, 2].iter().copied(),
@@ -389,8 +387,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::RandomAccess,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_RANDOM_ACCESS,
                 ..Default::default()
             },
             [0_u32, 10, 20, 3, 4].iter().copied(),
@@ -513,8 +511,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::RandomAccess,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_RANDOM_ACCESS,
                 ..Default::default()
             },
             [0_u32, 1, 2, 3].iter().copied(),
@@ -568,8 +566,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                location_preference: MemoryLocationPreference::Host,
-                host_access: HostAccessType::RandomAccess,
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_RANDOM_ACCESS,
                 ..Default::default()
             },
             [0_u32, 1, 2, 3].iter().copied(),
@@ -625,7 +623,8 @@ mod tests {
                     ..Default::default()
                 },
                 AllocationCreateInfo {
-                    host_access: HostAccessType::SequentialWrite,
+                    memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                        | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                     ..Default::default()
                 },
                 0u32,
@@ -722,7 +721,8 @@ mod tests {
                     ..Default::default()
                 },
                 AllocationCreateInfo {
-                    host_access: HostAccessType::SequentialWrite,
+                    memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                        | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                     ..Default::default()
                 },
                 0u32,

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -321,7 +321,9 @@ mod tests {
         },
         device::{Device, DeviceCreateInfo, QueueCreateInfo},
         image::sampler::{Sampler, SamplerCreateInfo},
-        memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+        memory::allocator::{
+            AllocationCreateInfo, HostAccessType, MemoryLocationPreference, StandardMemoryAllocator,
+        },
         pipeline::{layout::PipelineLayoutCreateInfo, PipelineBindPoint, PipelineLayout},
         shader::ShaderStages,
         sync::GpuFuture,
@@ -372,7 +374,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::SequentialWrite,
                 ..Default::default()
             },
             [1_u32, 2].iter().copied(),
@@ -386,7 +389,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::RandomAccess,
                 ..Default::default()
             },
             [0_u32, 10, 20, 3, 4].iter().copied(),
@@ -509,7 +513,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::RandomAccess,
                 ..Default::default()
             },
             [0_u32, 1, 2, 3].iter().copied(),
@@ -563,7 +568,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                location_preference: MemoryLocationPreference::Host,
+                host_access: HostAccessType::RandomAccess,
                 ..Default::default()
             },
             [0_u32, 1, 2, 3].iter().copied(),
@@ -619,7 +625,7 @@ mod tests {
                     ..Default::default()
                 },
                 AllocationCreateInfo {
-                    usage: MemoryUsage::Upload,
+                    host_access: HostAccessType::SequentialWrite,
                     ..Default::default()
                 },
                 0u32,
@@ -716,7 +722,7 @@ mod tests {
                     ..Default::default()
                 },
                 AllocationCreateInfo {
-                    usage: MemoryUsage::Upload,
+                    host_access: HostAccessType::SequentialWrite,
                     ..Default::default()
                 },
                 0u32,

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -868,14 +868,18 @@ impl Display for SuballocatorError {
 /// Basic usage as a global allocator for long-lived resources:
 ///
 /// ```
-/// use vulkano::format::Format;
-/// use vulkano::image::{Image, ImageCreateInfo, ImageType, ImageUsage};
-/// use vulkano::memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator};
-/// # let device: std::sync::Arc<vulkano::device::Device> = return;
+/// use vulkano::{
+///     format::Format,
+///     image::{Image, ImageCreateInfo, ImageType, ImageUsage},
+///     memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator},
+/// };
 ///
+/// # let device: std::sync::Arc<vulkano::device::Device> = return;
+/// #
 /// let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
 ///
 /// # fn read_textures() -> Vec<Vec<u8>> { Vec::new() }
+/// #
 /// // Allocate some resources.
 /// let textures_data: Vec<Vec<u8>> = read_textures();
 /// let textures = textures_data.into_iter().map(|data| {
@@ -902,13 +906,27 @@ impl Display for SuballocatorError {
 ///
 /// ```
 /// use std::sync::Arc;
-/// use vulkano::buffer::allocator::SubbufferAllocator;
-/// use vulkano::memory::allocator::StandardMemoryAllocator;
-/// # let device: std::sync::Arc<vulkano::device::Device> = return;
+/// use vulkano::{
+///     buffer::{
+///         allocator::{SubbufferAllocator, SubbufferAllocatorCreateInfo},
+///         BufferUsage,
+///     },
+///     memory::allocator::{MemoryTypeFilter, StandardMemoryAllocator},
+/// };
 ///
+/// # let device: std::sync::Arc<vulkano::device::Device> = return;
+/// #
 /// // We need to wrap the allocator in an `Arc` so that we can share ownership of it.
 /// let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
-/// let buffer_allocator = SubbufferAllocator::new(memory_allocator.clone(), Default::default());
+/// let buffer_allocator = SubbufferAllocator::new(
+///     memory_allocator.clone(),
+///     SubbufferAllocatorCreateInfo {
+///         buffer_usage: BufferUsage::TRANSFER_SRC,
+///         memory_type_filter: MemoryTypeFilter::PREFER_HOST
+///             | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
+///         ..Default::default()
+///     },
+/// );
 ///
 /// // You can continue using `memory_allocator` for other things.
 /// ```

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -388,7 +388,7 @@ mod tests {
         descriptor_set::{
             allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,
         },
-        memory::allocator::{AllocationCreateInfo, MemoryUsage, StandardMemoryAllocator},
+        memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
         pipeline::{
             compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
             ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -467,7 +467,7 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                usage: MemoryUsage::Upload,
+                host_access: HostAccessType::RandomAccess,
                 ..Default::default()
             },
             0,

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -388,7 +388,7 @@ mod tests {
         descriptor_set::{
             allocator::StandardDescriptorSetAllocator, PersistentDescriptorSet, WriteDescriptorSet,
         },
-        memory::allocator::{AllocationCreateInfo, HostAccessType, StandardMemoryAllocator},
+        memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
         pipeline::{
             compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
             ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -467,7 +467,8 @@ mod tests {
                 ..Default::default()
             },
             AllocationCreateInfo {
-                host_access: HostAccessType::RandomAccess,
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_RANDOM_ACCESS,
                 ..Default::default()
             },
             0,


### PR DESCRIPTION
Previously there were these memory usages:
`MemoryUsage` | Ideal memory type
-|-
`DeviceOnly` | `DEVICE_LOCAL`
`Upload` | `DEVICE_LOCAL \| HOST_VISIBLE \| HOST_COHERENT`
`Download` | `HOST_VISIBLE \| HOST_CACHED`

However, almost all PC and laptop implementations also have a memory type that is `HOST_VISIBLE | HOST_COHERENT`, which was not possible to request using those, which is the biggest reason for this change. However, some other implementations have more quirky memory types as well, such a `DEVICE_LOCAL | HOST_VISIBLE | HOST_CACHED` memory type on MacOS and mobile devices. It was also not possible to distinguish between that and the non-device-local host-cached one.

Here's all the combinations possible now, using the presets available as associated constants of `MemoryTypeFilter`:
`MemoryTypeFilter` | Ideal memory type
-|-
`PREFER_DEVICE` | `DEVICE_LOCAL`
`PREFER_DEVICE \| HOST_SEQUENTIAL_WRITE` | `DEVICE_LOCAL \| HOST_VISIBLE \| HOST_COHERENT`
`PREFER_DEVICE \| HOST_RANDOM_ACCESS` | `DEVICE_LOCAL \| HOST_VISIBLE \| HOST_CACHED`
`PREFER_HOST` |
`PREFER_HOST \| HOST_SEQUENTIAL_WRITE` | `HOST_VISIBLE \| HOST_COHERENT`
`PREFER_HOST \| HOST_RANDOM_ACCESS` | `HOST_VISIBLE \| HOST_CACHED`

There are of course still some memory types that can't be differentiated, such as in the case of `HostAccessType::RandomAccess`, there might be both `HOST_VISIBLE | HOST_CACHED` and `HOST_VISIBLE | HOST_COHERENT | HOST_CACHED` around. If the user truly needs something that specialized, then they should specify the memory type filter manually.

Changelog:
```markdown
### Breaking changes
Changes to memory allocation:
- `AllocationCreateInfo::usage` and `SubbufferAllocatorCreateInfo::memory_usage` were replaced by a `memory_type_filter` field, to allow for a more flexible selection of the memory type. Additionally, `SubbufferAllocatorCreateInfo::memory_type_filter` defaults to `MemoryTypeFilter::PREFER_DEVICE` for consistency with `AllocationCreateInfo`, unlike the previous default of `MemoryUsage::Upload`.
- `SubbufferAllocatorCreateInfo::buffer_usage` is now empty by default for consistency with `BufferCreateInfo`.
```