### PR TITLE
ValidationError-ify futures

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -85,11 +85,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
@@ -570,9 +569,9 @@ fn main() {
                 }
 
                 let (image_index, suboptimal, acquire_future) =
-                    match acquire_next_image(swapchain.clone(), None) {
+                    match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                         Ok(r) => r,
-                        Err(AcquireError::OutOfDate) => {
+                        Err(VulkanError::OutOfDate) => {
                             recreate_swapchain = true;
                             return;
                         }
@@ -662,11 +661,11 @@ fn main() {
                     )
                     .then_signal_fence_and_flush();
 
-                match future {
+                match future.map_err(Validated::unwrap) {
                     Ok(future) => {
                         previous_frame_end = Some(future.boxed());
                     }
-                    Err(FlushError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }

--- a/examples/src/bin/buffer-allocator.rs
+++ b/examples/src/bin/buffer-allocator.rs
@@ -44,11 +44,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -318,9 +317,9 @@ fn main() {
                 }
 
                 let (image_index, suboptimal, acquire_future) =
-                    match acquire_next_image(swapchain.clone(), None) {
+                    match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                         Ok(r) => r,
-                        Err(AcquireError::OutOfDate) => {
+                        Err(VulkanError::OutOfDate) => {
                             recreate_swapchain = true;
                             return;
                         }
@@ -406,11 +405,11 @@ fn main() {
                     )
                     .then_signal_fence_and_flush();
 
-                match future {
+                match future.map_err(Validated::unwrap) {
                     Ok(future) => {
                         previous_frame_end = Some(Box::new(future) as Box<_>);
                     }
-                    Err(FlushError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         previous_frame_end = Some(Box::new(sync::now(device.clone())) as Box<_>);
                     }

--- a/examples/src/bin/clear_attachments.rs
+++ b/examples/src/bin/clear_attachments.rs
@@ -21,11 +21,10 @@ use vulkano::{
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -196,9 +195,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -276,11 +275,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -41,11 +41,10 @@ use vulkano::{
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     memory::allocator::StandardMemoryAllocator,
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -222,9 +221,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -269,11 +268,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -47,11 +47,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    DeviceSize, VulkanLibrary,
+    sync::{self, GpuFuture},
+    DeviceSize, Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -444,9 +443,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -501,11 +500,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -54,11 +54,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    DeviceSize, VulkanLibrary,
+    sync::{self, GpuFuture},
+    DeviceSize, Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -412,9 +411,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -469,11 +468,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/indirect.rs
+++ b/examples/src/bin/indirect.rs
@@ -61,11 +61,10 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     single_pass_renderpass,
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -412,9 +411,9 @@ fn main() {
                 }
 
                 let (image_index, suboptimal, acquire_future) =
-                    match acquire_next_image(swapchain.clone(), None) {
+                    match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                         Ok(r) => r,
-                        Err(AcquireError::OutOfDate) => {
+                        Err(VulkanError::OutOfDate) => {
                             recreate_swapchain = true;
                             return;
                         }
@@ -515,11 +514,11 @@ fn main() {
                     )
                     .then_signal_fence_and_flush();
 
-                match future {
+                match future.map_err(Validated::unwrap) {
                     Ok(future) => {
                         previous_frame_end = Some(future.boxed());
                     }
-                    Err(FlushError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -42,11 +42,10 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     single_pass_renderpass,
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -388,9 +387,9 @@ fn main() {
                 }
 
                 let (image_index, suboptimal, acquire_future) =
-                    match acquire_next_image(swapchain.clone(), None) {
+                    match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                         Ok(r) => r,
-                        Err(AcquireError::OutOfDate) => {
+                        Err(VulkanError::OutOfDate) => {
                             recreate_swapchain = true;
                             return;
                         }
@@ -445,11 +444,11 @@ fn main() {
                     )
                     .then_signal_fence_and_flush();
 
-                match future {
+                match future.map_err(Validated::unwrap) {
                     Ok(future) => {
                         previous_frame_end = Some(future.boxed());
                     }
-                    Err(FlushError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -45,11 +45,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{ElementState, Event, KeyboardInput, WindowEvent},
@@ -434,9 +433,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         *recreate_swapchain = true;
                         return;
                     }
@@ -486,11 +485,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     *previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     *recreate_swapchain = true;
                     *previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -43,11 +43,10 @@ use vulkano::{
     query::{QueryControlFlags, QueryPool, QueryPoolCreateInfo, QueryResultFlags, QueryType},
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -408,9 +407,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -497,11 +496,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -43,11 +43,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    DeviceSize, VulkanLibrary,
+    sync::{self, GpuFuture},
+    DeviceSize, Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -385,9 +384,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -444,11 +443,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -51,11 +51,10 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     shader::ShaderModule,
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -334,9 +333,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -385,11 +384,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -46,11 +46,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    DeviceSize, VulkanLibrary,
+    sync::{self, GpuFuture},
+    DeviceSize, Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -520,9 +519,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -577,11 +576,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -50,7 +50,7 @@ use vulkano::{
         SwapchainPresentInfo,
     },
     sync::{self, future::FenceSignalFuture, GpuFuture},
-    VulkanLibrary,
+    Validated, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -622,7 +622,7 @@ fn main() {
                     .then_signal_fence_and_flush();
 
                 // Update this frame's future with current fence.
-                fences[image_index as usize] = match future {
+                fences[image_index as usize] = match future.map_err(Validated::unwrap) {
                     // Success, store result into vector.
                     Ok(future) => Some(Arc::new(future)),
 

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -48,11 +48,10 @@ use vulkano::{
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     shader::EntryPoint,
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -352,9 +351,9 @@ fn main() {
                 .unwrap();
 
                 let (image_index, suboptimal, acquire_future) =
-                    match acquire_next_image(swapchain.clone(), None) {
+                    match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                         Ok(r) => r,
-                        Err(AcquireError::OutOfDate) => {
+                        Err(VulkanError::OutOfDate) => {
                             recreate_swapchain = true;
                             return;
                         }
@@ -412,11 +411,11 @@ fn main() {
                     )
                     .then_signal_fence_and_flush();
 
-                match future {
+                match future.map_err(Validated::unwrap) {
                     Ok(future) => {
                         previous_frame_end = Some(future.boxed());
                     }
-                    Err(FlushError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -51,11 +51,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -446,9 +445,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -497,11 +496,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -45,11 +45,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    DeviceSize, VulkanLibrary,
+    sync::{self, GpuFuture},
+    DeviceSize, Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -402,9 +401,9 @@ fn main() {
             }
 
             let (image_index, suboptimal, acquire_future) =
-                match acquire_next_image(swapchain.clone(), None) {
+                match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                     Ok(r) => r,
-                    Err(AcquireError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         return;
                     }
@@ -459,11 +458,11 @@ fn main() {
                 )
                 .then_signal_fence_and_flush();
 
-            match future {
+            match future.map_err(Validated::unwrap) {
                 Ok(future) => {
                     previous_frame_end = Some(future.boxed());
                 }
-                Err(FlushError::OutOfDate) => {
+                Err(VulkanError::OutOfDate) => {
                     recreate_swapchain = true;
                     previous_frame_end = Some(sync::now(device.clone()).boxed());
                 }

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -51,11 +51,10 @@ use vulkano::{
     },
     render_pass::{AttachmentLoadOp, AttachmentStoreOp},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    Version, VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, Version, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -569,9 +568,9 @@ fn main() {
                 // This function can block if no image is available. The parameter is an optional
                 // timeout after which the function call will return an error.
                 let (image_index, suboptimal, acquire_future) =
-                    match acquire_next_image(swapchain.clone(), None) {
+                    match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                         Ok(r) => r,
-                        Err(AcquireError::OutOfDate) => {
+                        Err(VulkanError::OutOfDate) => {
                             recreate_swapchain = true;
                             return;
                         }
@@ -667,11 +666,11 @@ fn main() {
                     )
                     .then_signal_fence_and_flush();
 
-                match future {
+                match future.map_err(Validated::unwrap) {
                     Ok(future) => {
                         previous_frame_end = Some(future.boxed());
                     }
-                    Err(FlushError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -45,11 +45,10 @@ use vulkano::{
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{
-        acquire_next_image, AcquireError, Surface, Swapchain, SwapchainCreateInfo,
-        SwapchainPresentInfo,
+        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
     },
-    sync::{self, FlushError, GpuFuture},
-    VulkanLibrary,
+    sync::{self, GpuFuture},
+    Validated, VulkanError, VulkanLibrary,
 };
 use winit::{
     event::{Event, WindowEvent},
@@ -569,9 +568,9 @@ fn main() {
                 // This function can block if no image is available. The parameter is an optional
                 // timeout after which the function call will return an error.
                 let (image_index, suboptimal, acquire_future) =
-                    match acquire_next_image(swapchain.clone(), None) {
+                    match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
                         Ok(r) => r,
-                        Err(AcquireError::OutOfDate) => {
+                        Err(VulkanError::OutOfDate) => {
                             recreate_swapchain = true;
                             return;
                         }
@@ -661,11 +660,11 @@ fn main() {
                     )
                     .then_signal_fence_and_flush();
 
-                match future {
+                match future.map_err(Validated::unwrap) {
                     Ok(future) => {
                         previous_frame_end = Some(future.boxed());
                     }
-                    Err(FlushError::OutOfDate) => {
+                    Err(VulkanError::OutOfDate) => {
                         recreate_swapchain = true;
                         previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }

--- a/vulkano/autogen/errors.rs
+++ b/vulkano/autogen/errors.rs
@@ -66,8 +66,9 @@ fn errors_members(errors: &[&str]) -> Vec<ErrorsMember> {
 
             let mut parts = ffi_name.split('_').collect::<Vec<_>>();
 
-            assert!(parts[0] == "ERROR");
-            parts.remove(0);
+            if parts[0] == "ERROR" {
+                parts.remove(0);
+            }
 
             if ["EXT", "KHR", "NV"].contains(parts.last().unwrap()) {
                 parts.pop();

--- a/vulkano/autogen/mod.rs
+++ b/vulkano/autogen/mod.rs
@@ -191,7 +191,10 @@ impl<'r> VkRegistryData<'r> {
                 }) if name == "VkResult" => Some(children.iter().filter_map(|en| {
                     if let EnumsChild::Enum(en) = en {
                         if let EnumSpec::Value { value, .. } = &en.spec {
-                            if value.starts_with('-') {
+                            // Treat NotReady and Timeout as error conditions
+                            if value.starts_with('-')
+                                || matches!(en.name.as_str(), "VK_NOT_READY" | "VK_TIMEOUT")
+                            {
                                 return Some(en.name.as_str());
                             }
                         }

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -17,12 +17,10 @@ use crate::{
     image::{Image, ImageLayout},
     swapchain::Swapchain,
     sync::{
-        future::{
-            now, AccessCheckError, AccessError, FlushError, GpuFuture, NowFuture, SubmitAnyBuilder,
-        },
+        future::{now, AccessCheckError, AccessError, GpuFuture, NowFuture, SubmitAnyBuilder},
         PipelineStages,
     },
-    DeviceSize, SafeDeref, VulkanObject,
+    DeviceSize, SafeDeref, Validated, VulkanError, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};
 use std::{
@@ -235,7 +233,7 @@ where
 {
     // Implementation of `build_submission`. Doesn't check whenever the future was already flushed.
     // You must make sure to not submit same command buffer multiple times.
-    unsafe fn build_submission_impl(&self) -> Result<SubmitAnyBuilder, FlushError> {
+    unsafe fn build_submission_impl(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         Ok(match self.previous.build_submission()? {
             SubmitAnyBuilder::Empty => SubmitAnyBuilder::CommandBuffer(
                 SubmitInfo {
@@ -289,7 +287,7 @@ where
         self.previous.cleanup_finished();
     }
 
-    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, FlushError> {
+    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         if *self.submitted.lock() {
             return Ok(SubmitAnyBuilder::Empty);
         }
@@ -297,7 +295,7 @@ where
         self.build_submission_impl()
     }
 
-    fn flush(&self) -> Result<(), FlushError> {
+    fn flush(&self) -> Result<(), Validated<VulkanError>> {
         unsafe {
             let mut submitted = self.submitted.lock();
             if *submitted {

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -23,11 +23,11 @@ use crate::{
     swapchain::{PresentInfo, SwapchainPresentInfo},
     sync::{
         fence::{Fence, FenceState},
-        future::{AccessCheckError, FlushError, GpuFuture},
+        future::{AccessCheckError, GpuFuture},
         semaphore::SemaphoreState,
     },
-    OomError, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanError,
-    VulkanObject,
+    OomError, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version,
+    VulkanError, VulkanObject,
 };
 use ahash::HashMap;
 use parking_lot::{Mutex, MutexGuard};
@@ -694,7 +694,7 @@ impl<'a> QueueGuard<'a> {
         fence: Option<Arc<Fence>>,
         future: &dyn GpuFuture,
         queue: &Queue,
-    ) -> Result<(), FlushError> {
+    ) -> Result<(), Validated<VulkanError>> {
         let submit_infos: SmallVec<[_; 4]> = smallvec![submit_info];
         let mut states = States::from_submit_infos(&submit_infos);
 
@@ -707,15 +707,31 @@ impl<'a> QueueGuard<'a> {
 
                 match command_buffer.usage() {
                     CommandBufferUsage::OneTimeSubmit => {
-                        // VUID-vkQueueSubmit2-commandBuffer-03874
                         if state.has_been_submitted() {
-                            return Err(FlushError::OneTimeSubmitAlreadySubmitted);
+                            return Err(Box::new(ValidationError {
+                                problem: "a command buffer, or one of the secondary \
+                                    command buffers it executes, was created with the \
+                                    `CommandBufferUsage::OneTimeSubmit` usage, but \
+                                    it has already been submitted in the past"
+                                    .into(),
+                                vuids: &["VUID-vkQueueSubmit2-commandBuffer-03874"],
+                                ..Default::default()
+                            })
+                            .into());
                         }
                     }
                     CommandBufferUsage::MultipleSubmit => {
-                        // VUID-vkQueueSubmit2-commandBuffer-03875
                         if state.is_submit_pending() {
-                            return Err(FlushError::ExclusiveAlreadyInUse);
+                            return Err(Box::new(ValidationError {
+                                problem: "a command buffer, or one of the secondary \
+                                    command buffers it executes, was not created with the \
+                                    `CommandBufferUsage::SimultaneousUse` usage, but \
+                                    it is already in use by the device"
+                                    .into(),
+                                vuids: &["VUID-vkQueueSubmit2-commandBuffer-03875"],
+                                ..Default::default()
+                            })
+                            .into());
                         }
                     }
                     CommandBufferUsage::SimultaneousUse => (),
@@ -739,10 +755,17 @@ impl<'a> QueueGuard<'a> {
                             queue,
                         ) {
                             Err(AccessCheckError::Denied(error)) => {
-                                return Err(FlushError::ResourceAccessError {
-                                    error,
-                                    use_ref: range_usage.first_use,
-                                });
+                                return Err(Box::new(ValidationError {
+                                    problem: format!(
+                                        "access to a resource has been denied\n\
+                                        resource use: {:?}\n\
+                                        error: {}",
+                                        range_usage.first_use, error
+                                    )
+                                    .into(),
+                                    ..Default::default()
+                                })
+                                .into());
                             }
                             Err(AccessCheckError::Unknown) => {
                                 let result = if range_usage.mutable {
@@ -752,10 +775,17 @@ impl<'a> QueueGuard<'a> {
                                 };
 
                                 if let Err(error) = result {
-                                    return Err(FlushError::ResourceAccessError {
-                                        error,
-                                        use_ref: range_usage.first_use,
-                                    });
+                                    return Err(Box::new(ValidationError {
+                                        problem: format!(
+                                            "access to a resource has been denied\n\
+                                            resource use: {:?}\n\
+                                            error: {}",
+                                            range_usage.first_use, error
+                                        )
+                                        .into(),
+                                        ..Default::default()
+                                    })
+                                    .into());
                                 }
                             }
                             _ => (),
@@ -775,10 +805,17 @@ impl<'a> QueueGuard<'a> {
                             queue,
                         ) {
                             Err(AccessCheckError::Denied(error)) => {
-                                return Err(FlushError::ResourceAccessError {
-                                    error,
-                                    use_ref: range_usage.first_use,
-                                });
+                                return Err(Box::new(ValidationError {
+                                    problem: format!(
+                                        "access to a resource has been denied\n\
+                                        resource use: {:?}\n\
+                                        error: {}",
+                                        range_usage.first_use, error
+                                    )
+                                    .into(),
+                                    ..Default::default()
+                                })
+                                .into());
                             }
                             Err(AccessCheckError::Unknown) => {
                                 let result = if range_usage.mutable {
@@ -789,10 +826,17 @@ impl<'a> QueueGuard<'a> {
                                 };
 
                                 if let Err(error) = result {
-                                    return Err(FlushError::ResourceAccessError {
-                                        error,
-                                        use_ref: range_usage.first_use,
-                                    });
+                                    return Err(Box::new(ValidationError {
+                                        problem: format!(
+                                            "access to a resource has been denied\n\
+                                            resource use: {:?}\n\
+                                            error: {}",
+                                            range_usage.first_use, error
+                                        )
+                                        .into(),
+                                        ..Default::default()
+                                    })
+                                    .into());
                                 }
                             }
                             _ => (),

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -298,6 +298,8 @@ impl Error for VulkanError {}
 impl Display for VulkanError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         let msg = match self {
+            VulkanError::NotReady => "a resource is not yet ready",
+            VulkanError::Timeout => "an operation has not completed in the specified time",
             VulkanError::OutOfHostMemory => "a host memory allocation has failed",
             VulkanError::OutOfDeviceMemory => "a device memory allocation has failed",
             VulkanError::InitializationFailed => {

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -13,9 +13,9 @@ use crate::{
     device::{Device, DeviceOwned, Queue},
     image::{Image, ImageLayout},
     sync::{
-        fence::{Fence, FenceError},
+        fence::Fence,
         future::{AccessCheckError, AccessError, FlushError, GpuFuture, SubmitAnyBuilder},
-        semaphore::{Semaphore, SemaphoreError},
+        semaphore::Semaphore,
     },
     DeviceSize, OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, VulkanError,
     VulkanObject,
@@ -186,10 +186,10 @@ impl SwapchainAcquireFuture {
     /// If timeout is `None`, will potentially block forever
     ///
     /// You still need to join with this future for present to work
-    pub fn wait(&self, timeout: Option<Duration>) -> Result<(), FenceError> {
+    pub fn wait(&self, timeout: Option<Duration>) -> Result<bool, VulkanError> {
         match &self.fence {
             Some(fence) => fence.wait(timeout),
-            None => Ok(()),
+            None => Ok(true),
         }
     }
 }
@@ -330,12 +330,6 @@ pub enum AcquireError {
     /// The surface has changed in a way that makes the swapchain unusable. You must query the
     /// surface's new properties and recreate a new swapchain if you want to continue drawing.
     OutOfDate,
-
-    /// Error during fence creation.
-    FenceError(FenceError),
-
-    /// Error during semaphore creation.
-    SemaphoreError(SemaphoreError),
 }
 
 impl Error for AcquireError {
@@ -361,22 +355,8 @@ impl Display for AcquireError {
                 AcquireError::FullScreenExclusiveModeLost => {
                     "the swapchain no longer has full-screen exclusivity"
                 }
-                AcquireError::FenceError(_) => "error creating fence",
-                AcquireError::SemaphoreError(_) => "error creating semaphore",
             }
         )
-    }
-}
-
-impl From<FenceError> for AcquireError {
-    fn from(err: FenceError) -> Self {
-        AcquireError::FenceError(err)
-    }
-}
-
-impl From<SemaphoreError> for AcquireError {
-    fn from(err: SemaphoreError) -> Self {
-        AcquireError::SemaphoreError(err)
     }
 }
 

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -186,10 +186,10 @@ impl SwapchainAcquireFuture {
     /// If timeout is `None`, will potentially block forever
     ///
     /// You still need to join with this future for present to work
-    pub fn wait(&self, timeout: Option<Duration>) -> Result<bool, VulkanError> {
+    pub fn wait(&self, timeout: Option<Duration>) -> Result<(), VulkanError> {
         match &self.fence {
             Some(fence) => fence.wait(timeout),
-            None => Ok(true),
+            None => Ok(()),
         }
     }
 }

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -276,9 +276,10 @@
 //! as last parameter the old swapchain.
 //!
 //! ```
-//! use vulkano::swapchain;
-//! use vulkano::swapchain::{AcquireError, SwapchainCreateInfo, SwapchainPresentInfo};
-//! use vulkano::sync::GpuFuture;
+//! use vulkano::{
+//!     swapchain::{self, SwapchainCreateInfo, SwapchainPresentInfo},
+//!     sync::GpuFuture, Validated, VulkanError,
+//! };
 //!
 //! // let (swapchain, images) = Swapchain::new(...);
 //! # let mut swapchain: ::std::sync::Arc<::vulkano::swapchain::Swapchain> = return;
@@ -298,11 +299,12 @@
 //!         recreate_swapchain = false;
 //!     }
 //!
-//!     let (image_index, suboptimal, acq_future) = match swapchain::acquire_next_image(swapchain.clone(), None) {
-//!         Ok(r) => r,
-//!         Err(AcquireError::OutOfDate) => { recreate_swapchain = true; continue; },
-//!         Err(err) => panic!("{:?}", err),
-//!     };
+//!     let (image_index, suboptimal, acq_future) =
+//!         match swapchain::acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
+//!             Ok(r) => r,
+//!             Err(VulkanError::OutOfDate) => { recreate_swapchain = true; continue; },
+//!             Err(err) => panic!("{:?}", err),
+//!         };
 //!
 //!     // ...
 //!

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -994,6 +994,7 @@ impl Fence {
                 requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
                     "khr_external_fence_win32",
                 )])]),
+                ..Default::default()
             }));
         }
 

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -14,16 +14,14 @@ use crate::{
     device::{physical::PhysicalDevice, Device, DeviceOwned, Queue},
     instance::InstanceOwnedDebugWrapper,
     macros::{impl_id_counter, vulkan_bitflags, vulkan_bitflags_enum},
-    OomError, RequirementNotMet, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version,
-    VulkanError, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,
+    VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
 #[cfg(unix)]
 use std::fs::File;
 use std::{
-    error::Error,
-    fmt::{Display, Error as FmtError, Formatter},
     future::Future,
     mem::MaybeUninit,
     num::NonZeroU64,
@@ -38,7 +36,7 @@ use std::{
 ///
 /// # Queue-to-host synchronization
 ///
-/// The primary use of a fence is to know when execution of a queue has reached a particular point.
+/// The primary use of a fence is to know when a queue operation has completed executing.
 /// When adding a command to a queue, a fence can be provided with the command, to be signaled
 /// when the operation finishes. You can check for a fence's current status by calling
 /// `is_signaled`, `wait` or `await` on it. If the fence is found to be signaled, that means that
@@ -54,9 +52,7 @@ use std::{
 /// Because of this, it is highly recommended to call `is_signaled`, `wait` or `await` on your fences.
 /// Otherwise, the queue will hold onto resources indefinitely (using up memory)
 /// and resource locks will not be released, which may cause errors when submitting future
-/// queue operations. It is not strictly necessary to wait for *every* fence, as a fence
-/// that was signaled later in the queue will automatically clean up resources associated with
-/// earlier fences too.
+/// queue operations.
 #[derive(Debug)]
 pub struct Fence {
     handle: ash::vk::Fence,
@@ -64,6 +60,7 @@ pub struct Fence {
     id: NonZeroU64,
     must_put_in_pool: bool,
 
+    flags: FenceCreateFlags,
     export_handle_types: ExternalFenceHandleTypes,
 
     state: Mutex<FenceState>,
@@ -72,81 +69,39 @@ pub struct Fence {
 impl Fence {
     /// Creates a new `Fence`.
     #[inline]
-    pub fn new(device: Arc<Device>, create_info: FenceCreateInfo) -> Result<Fence, FenceError> {
+    pub fn new(
+        device: Arc<Device>,
+        create_info: FenceCreateInfo,
+    ) -> Result<Fence, Validated<VulkanError>> {
         Self::validate_new(&device, &create_info)?;
 
         unsafe { Ok(Self::new_unchecked(device, create_info)?) }
     }
 
-    fn validate_new(device: &Device, create_info: &FenceCreateInfo) -> Result<(), FenceError> {
-        let &FenceCreateInfo {
-            signaled: _,
-            export_handle_types,
-            _ne: _,
-        } = create_info;
-
-        if !export_handle_types.is_empty() {
-            if !(device.api_version() >= Version::V1_1
-                || device.enabled_extensions().khr_external_fence)
-            {
-                return Err(FenceError::RequirementNotMet {
-                    required_for: "`create_info.export_handle_types` is not empty",
-                    requires_one_of: RequiresOneOf(&[
-                        RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
-                        RequiresAllOf(&[Requires::DeviceExtension("khr_external_fence")]),
-                    ]),
-                });
-            }
-
-            // VUID-VkExportFenceCreateInfo-handleTypes-01446
-            export_handle_types.validate_device(device)?;
-
-            // VUID-VkExportFenceCreateInfo-handleTypes-01446
-            for handle_type in export_handle_types.into_iter() {
-                let external_fence_properties = unsafe {
-                    device
-                        .physical_device()
-                        .external_fence_properties_unchecked(ExternalFenceInfo::handle_type(
-                            handle_type,
-                        ))
-                };
-
-                if !external_fence_properties.exportable {
-                    return Err(FenceError::HandleTypeNotExportable { handle_type });
-                }
-
-                if !external_fence_properties
-                    .compatible_handle_types
-                    .contains(export_handle_types)
-                {
-                    return Err(FenceError::ExportHandleTypesNotCompatible);
-                }
-            }
-        }
+    fn validate_new(
+        device: &Device,
+        create_info: &FenceCreateInfo,
+    ) -> Result<(), Box<ValidationError>> {
+        create_info
+            .validate(device)
+            .map_err(|err| err.add_context("create_info"))?;
 
         Ok(())
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    #[inline]
     pub unsafe fn new_unchecked(
         device: Arc<Device>,
         create_info: FenceCreateInfo,
     ) -> Result<Fence, VulkanError> {
         let FenceCreateInfo {
-            signaled,
+            flags,
             export_handle_types,
             _ne: _,
         } = create_info;
 
-        let mut flags = ash::vk::FenceCreateFlags::empty();
-
-        if signaled {
-            flags |= ash::vk::FenceCreateFlags::SIGNALED;
-        }
-
         let mut create_info_vk = ash::vk::FenceCreateInfo {
-            flags,
+            flags: flags.into(),
             ..Default::default()
         };
         let mut export_fence_create_info_vk = None;
@@ -183,9 +138,12 @@ impl Fence {
             device: InstanceOwnedDebugWrapper(device),
             id: Self::next_id(),
             must_put_in_pool: false,
+
+            flags,
             export_handle_types,
+
             state: Mutex::new(FenceState {
-                is_signaled: signaled,
+                is_signaled: flags.intersects(FenceCreateFlags::SIGNALED),
                 ..Default::default()
             }),
         })
@@ -198,7 +156,7 @@ impl Fence {
     /// For most applications, using the fence pool should be preferred,
     /// in order to avoid creating new fences every frame.
     #[inline]
-    pub fn from_pool(device: Arc<Device>) -> Result<Fence, FenceError> {
+    pub fn from_pool(device: Arc<Device>) -> Result<Fence, VulkanError> {
         let handle = device.fence_pool().lock().pop();
         let fence = match handle {
             Some(handle) => {
@@ -215,13 +173,17 @@ impl Fence {
                     device: InstanceOwnedDebugWrapper(device),
                     id: Self::next_id(),
                     must_put_in_pool: true,
+
+                    flags: FenceCreateFlags::empty(),
                     export_handle_types: ExternalFenceHandleTypes::empty(),
+
                     state: Mutex::new(Default::default()),
                 }
             }
             None => {
                 // Pool is empty, alloc new fence
-                let mut fence = Fence::new(device, FenceCreateInfo::default())?;
+                let mut fence =
+                    unsafe { Fence::new_unchecked(device, FenceCreateInfo::default())? };
                 fence.must_put_in_pool = true;
                 fence
             }
@@ -243,7 +205,7 @@ impl Fence {
         create_info: FenceCreateInfo,
     ) -> Fence {
         let FenceCreateInfo {
-            signaled,
+            flags,
             export_handle_types,
             _ne: _,
         } = create_info;
@@ -253,17 +215,26 @@ impl Fence {
             device: InstanceOwnedDebugWrapper(device),
             id: Self::next_id(),
             must_put_in_pool: false,
+
+            flags,
             export_handle_types,
+
             state: Mutex::new(FenceState {
-                is_signaled: signaled,
+                is_signaled: flags.intersects(FenceCreateFlags::SIGNALED),
                 ..Default::default()
             }),
         }
     }
 
+    /// Returns the flags that the fence was created with.
+    #[inline]
+    pub fn flags(&self) -> FenceCreateFlags {
+        self.flags
+    }
+
     /// Returns true if the fence is signaled.
     #[inline]
-    pub fn is_signaled(&self) -> Result<bool, OomError> {
+    pub fn is_signaled(&self) -> Result<bool, VulkanError> {
         let queue_to_signal = {
             let mut state = self.state();
 
@@ -282,7 +253,7 @@ impl Fence {
             match result {
                 ash::vk::Result::SUCCESS => unsafe { state.set_signaled() },
                 ash::vk::Result::NOT_READY => return Ok(false),
-                err => return Err(VulkanError::from(err).into()),
+                err => return Err(VulkanError::from(err)),
             }
         };
 
@@ -299,16 +270,16 @@ impl Fence {
 
     /// Waits until the fence is signaled, or at least until the timeout duration has elapsed.
     ///
-    /// Returns `Ok` if the fence is now signaled. Returns `Err` if the timeout was reached instead.
+    /// Returns `true` if the fence is now signaled, `false` if the timeout was reached instead.
     ///
     /// If you pass a duration of 0, then the function will return without blocking.
-    pub fn wait(&self, timeout: Option<Duration>) -> Result<(), FenceError> {
+    pub fn wait(&self, timeout: Option<Duration>) -> Result<bool, VulkanError> {
         let queue_to_signal = {
             let mut state = self.state.lock();
 
             // If the fence is already signaled, we don't need to wait.
             if state.is_signaled().unwrap_or(false) {
-                return Ok(());
+                return Ok(true);
             }
 
             let timeout_ns = timeout.map_or(u64::MAX, |timeout| {
@@ -331,8 +302,8 @@ impl Fence {
 
             match result {
                 ash::vk::Result::SUCCESS => unsafe { state.set_signaled() },
-                ash::vk::Result::TIMEOUT => return Err(FenceError::Timeout),
-                err => return Err(VulkanError::from(err).into()),
+                ash::vk::Result::TIMEOUT => return Ok(false),
+                err => return Err(VulkanError::from(err)),
             }
         };
 
@@ -344,7 +315,7 @@ impl Fence {
             }
         }
 
-        Ok(())
+        Ok(true)
     }
 
     /// Waits for multiple fences at once.
@@ -355,17 +326,17 @@ impl Fence {
     pub fn multi_wait<'a>(
         fences: impl IntoIterator<Item = &'a Fence>,
         timeout: Option<Duration>,
-    ) -> Result<(), FenceError> {
+    ) -> Result<bool, Validated<VulkanError>> {
         let fences: SmallVec<[_; 8]> = fences.into_iter().collect();
         Self::validate_multi_wait(&fences, timeout)?;
 
-        unsafe { Self::multi_wait_unchecked(fences, timeout) }
+        unsafe { Ok(Self::multi_wait_unchecked(fences, timeout)?) }
     }
 
     fn validate_multi_wait(
         fences: &[&Fence],
         _timeout: Option<Duration>,
-    ) -> Result<(), FenceError> {
+    ) -> Result<(), Box<ValidationError>> {
         if fences.is_empty() {
             return Ok(());
         }
@@ -384,7 +355,7 @@ impl Fence {
     pub unsafe fn multi_wait_unchecked<'a>(
         fences: impl IntoIterator<Item = &'a Fence>,
         timeout: Option<Duration>,
-    ) -> Result<(), FenceError> {
+    ) -> Result<bool, VulkanError> {
         let queues_to_signal: SmallVec<[_; 8]> = {
             let iter = fences.into_iter();
             let mut fences_vk: SmallVec<[_; 8]> = SmallVec::new();
@@ -405,7 +376,7 @@ impl Fence {
             // VUID-vkWaitForFences-fenceCount-arraylength
             // If there are no fences, or all the fences are signaled, we don't need to wait.
             if fences_vk.is_empty() {
-                return Ok(());
+                return Ok(true);
             }
 
             let device = &fences[0].device;
@@ -433,8 +404,8 @@ impl Fence {
                     .zip(&mut states)
                     .filter_map(|(fence, state)| state.set_signaled().map(|state| (state, fence)))
                     .collect(),
-                ash::vk::Result::TIMEOUT => return Err(FenceError::Timeout),
-                err => return Err(VulkanError::from(err).into()),
+                ash::vk::Result::TIMEOUT => return Ok(false),
+                err => return Err(VulkanError::from(err)),
             }
         };
 
@@ -444,24 +415,27 @@ impl Fence {
             queue.with(|mut q| q.fence_signaled(fence));
         }
 
-        Ok(())
+        Ok(true)
     }
 
     /// Resets the fence.
     ///
     /// The fence must not be in use by a queue operation.
     #[inline]
-    pub fn reset(&self) -> Result<(), FenceError> {
+    pub fn reset(&self) -> Result<(), Validated<VulkanError>> {
         let mut state = self.state.lock();
         self.validate_reset(&state)?;
 
         unsafe { Ok(self.reset_unchecked_locked(&mut state)?) }
     }
 
-    fn validate_reset(&self, state: &FenceState) -> Result<(), FenceError> {
-        // VUID-vkResetFences-pFences-01123
+    fn validate_reset(&self, state: &FenceState) -> Result<(), Box<ValidationError>> {
         if state.is_in_queue() {
-            return Err(FenceError::InQueue);
+            return Err(Box::new(ValidationError {
+                problem: "the fence is in use".into(),
+                vuids: &["VUID-vkResetFences-pFences-01123"],
+                ..Default::default()
+            }));
         }
 
         Ok(())
@@ -493,7 +467,9 @@ impl Fence {
     /// # Panics
     ///
     /// - Panics if not all fences belong to the same device.
-    pub fn multi_reset<'a>(fences: impl IntoIterator<Item = &'a Fence>) -> Result<(), FenceError> {
+    pub fn multi_reset<'a>(
+        fences: impl IntoIterator<Item = &'a Fence>,
+    ) -> Result<(), Validated<VulkanError>> {
         let (fences, mut states): (SmallVec<[_; 8]>, SmallVec<[_; 8]>) = fences
             .into_iter()
             .map(|fence| {
@@ -509,20 +485,24 @@ impl Fence {
     fn validate_multi_reset(
         fences: &[&Fence],
         states: &[MutexGuard<'_, FenceState>],
-    ) -> Result<(), FenceError> {
+    ) -> Result<(), Box<ValidationError>> {
         if fences.is_empty() {
             return Ok(());
         }
 
         let device = &fences[0].device;
 
-        for (fence, state) in fences.iter().zip(states) {
+        for (fence_index, (fence, state)) in fences.iter().zip(states).enumerate() {
             // VUID-vkResetFences-pFences-parent
             assert_eq!(device, &fence.device);
 
-            // VUID-vkResetFences-pFences-01123
             if state.is_in_queue() {
-                return Err(FenceError::InQueue);
+                return Err(Box::new(ValidationError {
+                    context: format!("fences[{}]", fence_index).into(),
+                    problem: "the fence is in use".into(),
+                    vuids: &["VUID-vkResetFences-pFences-01123"],
+                    ..Default::default()
+                }));
             }
         }
 
@@ -573,7 +553,10 @@ impl Fence {
     /// extension must be enabled on the device.
     #[cfg(unix)]
     #[inline]
-    pub fn export_fd(&self, handle_type: ExternalFenceHandleType) -> Result<File, FenceError> {
+    pub fn export_fd(
+        &self,
+        handle_type: ExternalFenceHandleType,
+    ) -> Result<File, Validated<VulkanError>> {
         let mut state = self.state.lock();
         self.validate_export_fd(handle_type, &state)?;
 
@@ -585,36 +568,69 @@ impl Fence {
         &self,
         handle_type: ExternalFenceHandleType,
         state: &FenceState,
-    ) -> Result<(), FenceError> {
+    ) -> Result<(), Box<ValidationError>> {
         if !self.device.enabled_extensions().khr_external_fence_fd {
-            return Err(FenceError::RequirementNotMet {
-                required_for: "`Fence::export_fd`",
+            return Err(Box::new(ValidationError {
                 requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
                     "khr_external_fence_fd",
                 )])]),
-            });
+                ..Default::default()
+            }));
         }
 
-        // VUID-VkFenceGetFdInfoKHR-handleType-parameter
-        handle_type.validate_device(&self.device)?;
+        handle_type
+            .validate_device(&self.device)
+            .map_err(|err| ValidationError {
+                context: "handle_type".into(),
+                vuids: &["VUID-VkFenceGetFdInfoKHR-handleType-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
 
-        // VUID-VkFenceGetFdInfoKHR-handleType-01453
+        if !matches!(
+            handle_type,
+            ExternalFenceHandleType::OpaqueFd | ExternalFenceHandleType::SyncFd
+        ) {
+            return Err(Box::new(ValidationError {
+                context: "handle_type".into(),
+                problem: "is not `ExternalFenceHandleType::OpaqueFd` or \
+                    `ExternalFenceHandleType::SyncFd`"
+                    .into(),
+                vuids: &["VUID-VkFenceGetFdInfoKHR-handleType-01456"],
+                ..Default::default()
+            }));
+        }
+
         if !self.export_handle_types.intersects(handle_type.into()) {
-            return Err(FenceError::HandleTypeNotEnabled);
+            return Err(Box::new(ValidationError {
+                problem: "`self.export_handle_types()` does not contain `handle_type`".into(),
+                vuids: &["VUID-VkFenceGetFdInfoKHR-handleType-01453"],
+                ..Default::default()
+            }));
         }
 
-        // VUID-VkFenceGetFdInfoKHR-handleType-01454
         if handle_type.has_copy_transference()
             && !(state.is_signaled().unwrap_or(false) || state.is_in_queue())
         {
-            return Err(FenceError::HandleTypeCopyNotSignaled);
+            return Err(Box::new(ValidationError {
+                problem: "`handle_type` has copy transference, but \
+                    the fence is not signaled, and \
+                    a signal operation on the fence is not pending"
+                    .into(),
+                vuids: &["VUID-VkFenceGetFdInfoKHR-handleType-01454"],
+                ..Default::default()
+            }));
         }
 
-        // VUID-VkFenceGetFdInfoKHR-fence-01455
         if let Some(imported_handle_type) = state.current_import {
             match imported_handle_type {
                 ImportType::SwapchainAcquire => {
-                    return Err(FenceError::ImportedForSwapchainAcquire)
+                    return Err(Box::new(ValidationError {
+                        problem: "the fence currently has an imported payload from a \
+                            swapchain acquire operation"
+                            .into(),
+                        vuids: &["VUID-VkFenceGetFdInfoKHR-fence-01455"],
+                        ..Default::default()
+                    }));
                 }
                 ImportType::ExternalFence(imported_handle_type) => {
                     let external_fence_properties = unsafe {
@@ -629,20 +645,17 @@ impl Fence {
                         .export_from_imported_handle_types
                         .intersects(imported_handle_type.into())
                     {
-                        return Err(FenceError::ExportFromImportedNotSupported {
-                            imported_handle_type,
-                        });
+                        return Err(Box::new(ValidationError {
+                            problem: "the fence currently has an imported payload, whose type \
+                                does not allow re-exporting as `handle_type`, as \
+                                returned by `PhysicalDevice::external_fence_properties`"
+                                .into(),
+                            vuids: &["VUID-VkFenceGetFdInfoKHR-fence-01455"],
+                            ..Default::default()
+                        }));
                     }
                 }
             }
-        }
-
-        // VUID-VkFenceGetFdInfoKHR-handleType-01456
-        if !matches!(
-            handle_type,
-            ExternalFenceHandleType::OpaqueFd | ExternalFenceHandleType::SyncFd
-        ) {
-            return Err(FenceError::HandleTypeNotFd);
         }
 
         Ok(())
@@ -697,7 +710,7 @@ impl Fence {
     pub fn export_win32_handle(
         &self,
         handle_type: ExternalFenceHandleType,
-    ) -> Result<*mut std::ffi::c_void, FenceError> {
+    ) -> Result<*mut std::ffi::c_void, Validated<VulkanError>> {
         let mut state = self.state.lock();
         self.validate_export_win32_handle(handle_type, &state)?;
 
@@ -709,43 +722,81 @@ impl Fence {
         &self,
         handle_type: ExternalFenceHandleType,
         state: &FenceState,
-    ) -> Result<(), FenceError> {
+    ) -> Result<(), Box<ValidationError>> {
         if !self.device.enabled_extensions().khr_external_fence_win32 {
-            return Err(FenceError::RequirementNotMet {
-                required_for: "`Fence::export_win32_handle`",
+            return Err(Box::new(ValidationError {
                 requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
                     "khr_external_fence_win32",
                 )])]),
-            });
+                ..Default::default()
+            }));
         }
 
-        // VUID-VkFenceGetWin32HandleInfoKHR-handleType-parameter
-        handle_type.validate_device(&self.device)?;
+        handle_type
+            .validate_device(&self.device)
+            .map_err(|err| ValidationError {
+                context: "handle_type".into(),
+                vuids: &["VUID-VkFenceGetWin32HandleInfoKHR-handleType-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
 
-        // VUID-VkFenceGetWin32HandleInfoKHR-handleType-01448
+        if !matches!(
+            handle_type,
+            ExternalFenceHandleType::OpaqueWin32 | ExternalFenceHandleType::OpaqueWin32Kmt
+        ) {
+            return Err(Box::new(ValidationError {
+                context: "handle_type".into(),
+                problem: "is not `ExternalFenceHandleType::OpaqueWin32` or \
+                    `ExternalFenceHandleType::OpaqueWin32Kmt`"
+                    .into(),
+                vuids: &["VUID-VkFenceGetWin32HandleInfoKHR-handleType-01452"],
+                ..Default::default()
+            }));
+        }
+
         if !self.export_handle_types.intersects(handle_type.into()) {
-            return Err(FenceError::HandleTypeNotEnabled);
+            return Err(Box::new(ValidationError {
+                problem: "`self.export_handle_types()` does not contain `handle_type`".into(),
+                vuids: &["VUID-VkFenceGetWin32HandleInfoKHR-handleType-01448"],
+                ..Default::default()
+            }));
         }
 
-        // VUID-VkFenceGetWin32HandleInfoKHR-handleType-01449
         if matches!(handle_type, ExternalFenceHandleType::OpaqueWin32)
             && state.is_exported(handle_type)
         {
-            return Err(FenceError::AlreadyExported);
+            return Err(Box::new(ValidationError {
+                problem: "`handle_type` is `ExternalFenceHandleType::OpaqueWin32`, but \
+                    a handle of this type has already been exported from this fence"
+                    .into(),
+                vuids: &["VUID-VkFenceGetWin32HandleInfoKHR-handleType-01449"],
+                ..Default::default()
+            }));
         }
 
-        // VUID-VkFenceGetWin32HandleInfoKHR-handleType-01451
         if handle_type.has_copy_transference()
             && !(state.is_signaled().unwrap_or(false) || state.is_in_queue())
         {
-            return Err(FenceError::HandleTypeCopyNotSignaled);
+            return Err(Box::new(ValidationError {
+                problem: "`handle_type` has copy transference, but \
+                    the fence is not signaled, and \
+                    a signal operation on the fence is not pending"
+                    .into(),
+                vuids: &["VUID-VkFenceGetWin32HandleInfoKHR-handleType-01451"],
+                ..Default::default()
+            }));
         }
 
-        // VUID-VkFenceGetWin32HandleInfoKHR-fence-01450
         if let Some(imported_handle_type) = state.current_import {
             match imported_handle_type {
                 ImportType::SwapchainAcquire => {
-                    return Err(FenceError::ImportedForSwapchainAcquire)
+                    return Err(Box::new(ValidationError {
+                        problem: "the fence currently has an imported payload from a \
+                            swapchain acquire operation"
+                            .into(),
+                        vuids: &["VUID-VkFenceGetWin32HandleInfoKHR-fence-01450"],
+                        ..Default::default()
+                    }));
                 }
                 ImportType::ExternalFence(imported_handle_type) => {
                     let external_fence_properties = unsafe {
@@ -760,20 +811,17 @@ impl Fence {
                         .export_from_imported_handle_types
                         .intersects(imported_handle_type.into())
                     {
-                        return Err(FenceError::ExportFromImportedNotSupported {
-                            imported_handle_type,
-                        });
+                        return Err(Box::new(ValidationError {
+                            problem: "the fence currently has an imported payload, whose type \
+                                does not allow re-exporting as `handle_type`, as \
+                                returned by `PhysicalDevice::external_fence_properties`"
+                                .into(),
+                            vuids: &["VUID-VkFenceGetWin32HandleInfoKHR-fence-01450"],
+                            ..Default::default()
+                        }));
                     }
                 }
             }
-        }
-
-        // VUID-VkFenceGetWin32HandleInfoKHR-handleType-01452
-        if !matches!(
-            handle_type,
-            ExternalFenceHandleType::OpaqueWin32 | ExternalFenceHandleType::OpaqueWin32Kmt
-        ) {
-            return Err(FenceError::HandleTypeNotWin32);
         }
 
         Ok(())
@@ -832,7 +880,7 @@ impl Fence {
     pub unsafe fn import_fd(
         &self,
         import_fence_fd_info: ImportFenceFdInfo,
-    ) -> Result<(), FenceError> {
+    ) -> Result<(), Validated<VulkanError>> {
         let mut state = self.state.lock();
         self.validate_import_fd(&import_fence_fd_info, &state)?;
 
@@ -844,49 +892,27 @@ impl Fence {
         &self,
         import_fence_fd_info: &ImportFenceFdInfo,
         state: &FenceState,
-    ) -> Result<(), FenceError> {
+    ) -> Result<(), Box<ValidationError>> {
         if !self.device.enabled_extensions().khr_external_fence_fd {
-            return Err(FenceError::RequirementNotMet {
-                required_for: "`Fence::import_fd`",
+            return Err(Box::new(ValidationError {
                 requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
                     "khr_external_fence_fd",
                 )])]),
-            });
+                ..Default::default()
+            }));
         }
 
-        // VUID-vkImportFenceFdKHR-fence-01463
         if state.is_in_queue() {
-            return Err(FenceError::InQueue);
+            return Err(Box::new(ValidationError {
+                problem: "the fence is in use".into(),
+                vuids: &["VUID-vkImportFenceFdKHR-fence-01463"],
+                ..Default::default()
+            }));
         }
 
-        let &ImportFenceFdInfo {
-            flags,
-            handle_type,
-            file: _,
-            _ne: _,
-        } = import_fence_fd_info;
-
-        // VUID-VkImportFenceFdInfoKHR-flags-parameter
-        flags.validate_device(&self.device)?;
-
-        // VUID-VkImportFenceFdInfoKHR-handleType-parameter
-        handle_type.validate_device(&self.device)?;
-
-        // VUID-VkImportFenceFdInfoKHR-handleType-01464
-        if !matches!(
-            handle_type,
-            ExternalFenceHandleType::OpaqueFd | ExternalFenceHandleType::SyncFd
-        ) {
-            return Err(FenceError::HandleTypeNotFd);
-        }
-
-        // VUID-VkImportFenceFdInfoKHR-fd-01541
-        // Can't validate, therefore unsafe
-
-        // VUID-VkImportFenceFdInfoKHR-handleType-07306
-        if handle_type.has_copy_transference() && !flags.intersects(FenceImportFlags::TEMPORARY) {
-            return Err(FenceError::HandletypeCopyNotTemporary);
-        }
+        import_fence_fd_info
+            .validate(&self.device)
+            .map_err(|err| err.add_context("import_fence_fd_info"))?;
 
         Ok(())
     }
@@ -950,7 +976,7 @@ impl Fence {
     pub unsafe fn import_win32_handle(
         &self,
         import_fence_win32_handle_info: ImportFenceWin32HandleInfo,
-    ) -> Result<(), FenceError> {
+    ) -> Result<(), Validated<VulkanError>> {
         let mut state = self.state.lock();
         self.validate_import_win32_handle(&import_fence_win32_handle_info, &state)?;
 
@@ -962,48 +988,21 @@ impl Fence {
         &self,
         import_fence_win32_handle_info: &ImportFenceWin32HandleInfo,
         state: &FenceState,
-    ) -> Result<(), FenceError> {
+    ) -> Result<(), Box<ValidationError>> {
         if !self.device.enabled_extensions().khr_external_fence_win32 {
-            return Err(FenceError::RequirementNotMet {
-                required_for: "`Fence::import_win32_handle`",
+            return Err(Box::new(ValidationError {
                 requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
                     "khr_external_fence_win32",
                 )])]),
-            });
+            }));
         }
 
-        // VUID-vkImportFenceWin32HandleKHR-fence-04448
         if state.is_in_queue() {
-            return Err(FenceError::InQueue);
-        }
-
-        let &ImportFenceWin32HandleInfo {
-            flags,
-            handle_type,
-            handle: _,
-            _ne: _,
-        } = import_fence_win32_handle_info;
-
-        // VUID-VkImportFenceWin32HandleInfoKHR-flags-parameter
-        flags.validate_device(&self.device)?;
-
-        // VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457
-        handle_type.validate_device(&self.device)?;
-
-        // VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457
-        if !matches!(
-            handle_type,
-            ExternalFenceHandleType::OpaqueWin32 | ExternalFenceHandleType::OpaqueWin32Kmt
-        ) {
-            return Err(FenceError::HandleTypeNotWin32);
-        }
-
-        // VUID-VkImportFenceWin32HandleInfoKHR-handle-01539
-        // Can't validate, therefore unsafe
-
-        // VUID?
-        if handle_type.has_copy_transference() && !flags.intersects(FenceImportFlags::TEMPORARY) {
-            return Err(FenceError::HandletypeCopyNotTemporary);
+            return Err(Box::new(ValidationError {
+                problem: "the fence is in use".into(),
+                vuids: &["VUID-vkImportFenceWin32HandleKHR-fence-04448"],
+                ..Default::default()
+            }));
         }
 
         Ok(())
@@ -1060,7 +1059,7 @@ impl Fence {
     }
 
     // Shared by Fence and FenceSignalFuture
-    pub(crate) fn poll_impl(&self, cx: &mut Context<'_>) -> Poll<Result<(), OomError>> {
+    pub(crate) fn poll_impl(&self, cx: &mut Context<'_>) -> Poll<Result<(), VulkanError>> {
         // Vulkan only allows polling of the fence status, so we have to use a spin future.
         // This is still better than blocking in async applications, since a smart-enough async engine
         // can choose to run some other tasks between probing this one.
@@ -1097,7 +1096,7 @@ impl Drop for Fence {
 }
 
 impl Future for Fence {
-    type Output = Result<(), OomError>;
+    type Output = Result<(), VulkanError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.poll_impl(cx)
@@ -1121,6 +1120,433 @@ unsafe impl DeviceOwned for Fence {
 }
 
 impl_id_counter!(Fence);
+
+/// Parameters to create a new `Fence`.
+#[derive(Clone, Debug)]
+pub struct FenceCreateInfo {
+    /// Additional properties of the fence.
+    ///
+    /// The default value is empty.
+    pub flags: FenceCreateFlags,
+
+    /// The handle types that can be exported from the fence.
+    pub export_handle_types: ExternalFenceHandleTypes,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl Default for FenceCreateInfo {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            flags: FenceCreateFlags::empty(),
+            export_handle_types: ExternalFenceHandleTypes::empty(),
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+}
+
+impl FenceCreateInfo {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
+        let &Self {
+            flags,
+            export_handle_types,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkFenceCreateInfo-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if !export_handle_types.is_empty() {
+            if !(device.api_version() >= Version::V1_1
+                || device.enabled_extensions().khr_external_fence)
+            {
+                return Err(Box::new(ValidationError {
+                    context: "export_handle_types".into(),
+                    problem: "is not empty".into(),
+                    requires_one_of: RequiresOneOf(&[
+                        RequiresAllOf(&[Requires::APIVersion(Version::V1_1)]),
+                        RequiresAllOf(&[Requires::DeviceExtension("khr_external_fence")]),
+                    ]),
+                    ..Default::default()
+                }));
+            }
+
+            export_handle_types
+                .validate_device(device)
+                .map_err(|err| ValidationError {
+                    context: "export_handle_types".into(),
+                    vuids: &["VUID-VkExportFenceCreateInfo-handleTypes-parameter"],
+                    ..ValidationError::from_requirement(err)
+                })?;
+
+            for handle_type in export_handle_types.into_iter() {
+                let external_fence_properties = unsafe {
+                    device
+                        .physical_device()
+                        .external_fence_properties_unchecked(ExternalFenceInfo::handle_type(
+                            handle_type,
+                        ))
+                };
+
+                if !external_fence_properties.exportable {
+                    return Err(Box::new(ValidationError {
+                        context: "export_handle_types".into(),
+                        problem: format!(
+                            "the handle type `ExternalFenceHandleTypes::{:?}` is not exportable, \
+                            as returned by `PhysicalDevice::external_fence_properties`",
+                            ExternalFenceHandleTypes::from(handle_type)
+                        )
+                        .into(),
+                        vuids: &["VUID-VkExportFenceCreateInfo-handleTypes-01446"],
+                        ..Default::default()
+                    }));
+                }
+
+                if !external_fence_properties
+                    .compatible_handle_types
+                    .contains(export_handle_types)
+                {
+                    return Err(Box::new(ValidationError {
+                        context: "export_handle_types".into(),
+                        problem: format!(
+                            "the handle type `ExternalFenceHandleTypes::{:?}` is not compatible \
+                            with the other specified handle types, as returned by \
+                            `PhysicalDevice::external_fence_properties`",
+                            ExternalFenceHandleTypes::from(handle_type)
+                        )
+                        .into(),
+                        vuids: &["VUID-VkExportFenceCreateInfo-handleTypes-01446"],
+                        ..Default::default()
+                    }));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Flags specifying additional properties of a fence.
+    FenceCreateFlags = FenceCreateFlags(u32);
+
+    /// Creates the fence in the signaled state.
+    SIGNALED = SIGNALED,
+}
+
+vulkan_bitflags_enum! {
+    #[non_exhaustive]
+    /// A set of [`ExternalFenceHandleType`] values.
+    ExternalFenceHandleTypes,
+
+    /// The handle type used to export or import fences to/from an external source.
+    ExternalFenceHandleType impl {
+        /// Returns whether the given handle type has *copy transference* rather than *reference
+        /// transference*.
+        ///
+        /// Imports of handles with copy transference must always be temporary. Exports of such
+        /// handles must only occur if the fence is already signaled, or if there is a fence signal
+        /// operation pending in a queue.
+        #[inline]
+        pub fn has_copy_transference(self) -> bool {
+            // As defined by
+            // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap7.html#synchronization-fence-handletypes-win32
+            // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap7.html#synchronization-fence-handletypes-fd
+            matches!(self, Self::SyncFd)
+        }
+    },
+
+    = ExternalFenceHandleTypeFlags(u32);
+
+    /// A POSIX file descriptor handle that is only usable with Vulkan and compatible APIs.
+    ///
+    /// This handle type has *reference transference*.
+    OPAQUE_FD, OpaqueFd = OPAQUE_FD,
+
+    /// A Windows NT handle that is only usable with Vulkan and compatible APIs.
+    ///
+    /// This handle type has *reference transference*.
+    OPAQUE_WIN32, OpaqueWin32 = OPAQUE_WIN32,
+
+    /// A Windows global share handle that is only usable with Vulkan and compatible APIs.
+    ///
+    /// This handle type has *reference transference*.
+    OPAQUE_WIN32_KMT, OpaqueWin32Kmt = OPAQUE_WIN32_KMT,
+
+    /// A POSIX file descriptor handle to a Linux Sync File or Android Fence object.
+    ///
+    /// This handle type has *copy transference*.
+    SYNC_FD, SyncFd = SYNC_FD,
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Additional parameters for a fence payload import.
+    FenceImportFlags = FenceImportFlags(u32);
+
+    /// The fence payload will be imported only temporarily, regardless of the permanence of the
+    /// imported handle type.
+    TEMPORARY = TEMPORARY,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct ImportFenceFdInfo {
+    /// Additional parameters for the import operation.
+    ///
+    /// If `handle_type` has *copy transference*, this must include the `temporary` flag.
+    ///
+    /// The default value is [`FenceImportFlags::empty()`].
+    pub flags: FenceImportFlags,
+
+    /// The handle type of `file`.
+    ///
+    /// There is no default value.
+    pub handle_type: ExternalFenceHandleType,
+
+    /// The file to import the fence from.
+    ///
+    /// If `handle_type` is `ExternalFenceHandleType::SyncFd`, then `file` can be `None`.
+    /// Instead of an imported file descriptor, a dummy file descriptor `-1` is used,
+    /// which represents a fence that is always signaled.
+    ///
+    /// The default value is `None`, which must be overridden if `handle_type` is not
+    /// `ExternalFenceHandleType::SyncFd`.
+    pub file: Option<File>,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+#[cfg(unix)]
+impl ImportFenceFdInfo {
+    /// Returns an `ImportFenceFdInfo` with the specified `handle_type`.
+    #[inline]
+    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+        Self {
+            flags: FenceImportFlags::empty(),
+            handle_type,
+            file: None,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
+        let &Self {
+            flags,
+            handle_type,
+            file: _,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkImportFenceFdInfoKHR-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        handle_type
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "handle_type".into(),
+                vuids: &["VUID-VkImportFenceFdInfoKHR-handleType-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if !matches!(
+            handle_type,
+            ExternalFenceHandleType::OpaqueFd | ExternalFenceHandleType::SyncFd
+        ) {
+            return Err(Box::new(ValidationError {
+                context: "handle_type".into(),
+                problem: "is not `ExternalFenceHandleType::OpaqueFd` or \
+                    `ExternalFenceHandleType::SyncFd`"
+                    .into(),
+                vuids: &["VUID-VkImportFenceFdInfoKHR-handleType-01464"],
+                ..Default::default()
+            }));
+        }
+
+        // VUID-VkImportFenceFdInfoKHR-fd-01541
+        // Can't validate, therefore unsafe
+
+        if handle_type.has_copy_transference() && !flags.intersects(FenceImportFlags::TEMPORARY) {
+            return Err(Box::new(ValidationError {
+                problem: "`handle_type` has copy transference, but \
+                    `flags` does not contain `FenceImportFlags::TEMPORARY`"
+                    .into(),
+                vuids: &["VUID-VkImportFenceFdInfoKHR-handleType-07306"],
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+#[derive(Debug)]
+pub struct ImportFenceWin32HandleInfo {
+    /// Additional parameters for the import operation.
+    ///
+    /// If `handle_type` has *copy transference*, this must include the `temporary` flag.
+    ///
+    /// The default value is [`FenceImportFlags::empty()`].
+    pub flags: FenceImportFlags,
+
+    /// The handle type of `handle`.
+    ///
+    /// There is no default value.
+    pub handle_type: ExternalFenceHandleType,
+
+    /// The file to import the fence from.
+    ///
+    /// The default value is `null`, which must be overridden.
+    pub handle: *mut std::ffi::c_void,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+#[cfg(windows)]
+impl ImportFenceWin32HandleInfo {
+    /// Returns an `ImportFenceWin32HandleInfo` with the specified `handle_type`.
+    #[inline]
+    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+        Self {
+            flags: FenceImportFlags::empty(),
+            handle_type,
+            handle: ptr::null_mut(),
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
+        let &Self {
+            flags,
+            handle_type,
+            handle: _,
+            _ne: _,
+        } = self;
+
+        flags
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "flags".into(),
+                vuids: &["VUID-VkImportFenceWin32HandleInfoKHR-flags-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        handle_type
+            .validate_device(device)
+            .map_err(|err| ValidationError {
+                context: "handle_type".into(),
+                vuids: &["VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        if !matches!(
+            handle_type,
+            ExternalFenceHandleType::OpaqueWin32 | ExternalFenceHandleType::OpaqueWin32Kmt
+        ) {
+            return Err(Box::new(ValidationError {
+                context: "handle_type".into(),
+                problem: "is not `ExternalFenceHandleType::OpaqueWin32` or \
+                    `ExternalFenceHandleType::OpaqueWin32Kmt`"
+                    .into(),
+                vuids: &["VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457"],
+                ..Default::default()
+            }));
+        }
+
+        // VUID-VkImportFenceWin32HandleInfoKHR-handle-01539
+        // Can't validate, therefore unsafe
+
+        if handle_type.has_copy_transference() && !flags.intersects(FenceImportFlags::TEMPORARY) {
+            return Err(Box::new(ValidationError {
+                problem: "`handle_type` has copy transference, but \
+                    `flags` does not contain `FenceImportFlags::TEMPORARY`"
+                    .into(),
+                // vuids?
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+}
+
+/// The fence configuration to query in
+/// [`PhysicalDevice::external_fence_properties`](crate::device::physical::PhysicalDevice::external_fence_properties).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ExternalFenceInfo {
+    /// The external handle type that will be used with the fence.
+    pub handle_type: ExternalFenceHandleType,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl ExternalFenceInfo {
+    /// Returns an `ExternalFenceInfo` with the specified `handle_type`.
+    #[inline]
+    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+        Self {
+            handle_type,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(
+        &self,
+        physical_device: &PhysicalDevice,
+    ) -> Result<(), Box<ValidationError>> {
+        let &Self {
+            handle_type,
+            _ne: _,
+        } = self;
+
+        handle_type
+            .validate_physical_device(physical_device)
+            .map_err(|err| ValidationError {
+                context: "handle_type".into(),
+                vuids: &["VUID-VkPhysicalDeviceExternalFenceInfo-handleType-parameter"],
+                ..ValidationError::from_requirement(err)
+            })?;
+
+        Ok(())
+    }
+}
+
+/// The properties for exporting or importing external handles, when a fence is created
+/// with a specific configuration.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct ExternalFenceProperties {
+    /// Whether a handle can be exported to an external source with the queried
+    /// external handle type.
+    pub exportable: bool,
+
+    /// Whether a handle can be imported from an external source with the queried
+    /// external handle type.
+    pub importable: bool,
+
+    /// Which external handle types can be re-exported after the queried external handle type has
+    /// been imported.
+    pub export_from_imported_handle_types: ExternalFenceHandleTypes,
+
+    /// Which external handle types can be enabled along with the queried external handle type
+    /// when creating the fence.
+    pub compatible_handle_types: ExternalFenceHandleTypes,
+}
 
 #[derive(Debug, Default)]
 pub(crate) struct FenceState {
@@ -1240,395 +1666,10 @@ impl From<ExternalFenceHandleType> for ImportType {
     }
 }
 
-/// Parameters to create a new `Fence`.
-#[derive(Clone, Debug)]
-pub struct FenceCreateInfo {
-    /// Whether the fence should be created in the signaled state.
-    ///
-    /// The default value is `false`.
-    pub signaled: bool,
-
-    /// The handle types that can be exported from the fence.
-    pub export_handle_types: ExternalFenceHandleTypes,
-
-    pub _ne: crate::NonExhaustive,
-}
-
-impl Default for FenceCreateInfo {
-    #[inline]
-    fn default() -> Self {
-        Self {
-            signaled: false,
-            export_handle_types: ExternalFenceHandleTypes::empty(),
-            _ne: crate::NonExhaustive(()),
-        }
-    }
-}
-
-vulkan_bitflags_enum! {
-    #[non_exhaustive]
-    /// A set of [`ExternalFenceHandleType`] values.
-    ExternalFenceHandleTypes,
-
-    /// The handle type used to export or import fences to/from an external source.
-    ExternalFenceHandleType impl {
-        /// Returns whether the given handle type has *copy transference* rather than *reference
-        /// transference*.
-        ///
-        /// Imports of handles with copy transference must always be temporary. Exports of such
-        /// handles must only occur if the fence is already signaled, or if there is a fence signal
-        /// operation pending in a queue.
-        #[inline]
-        pub fn has_copy_transference(self) -> bool {
-            // As defined by
-            // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap7.html#synchronization-fence-handletypes-win32
-            // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap7.html#synchronization-fence-handletypes-fd
-            matches!(self, Self::SyncFd)
-        }
-    },
-
-    = ExternalFenceHandleTypeFlags(u32);
-
-    /// A POSIX file descriptor handle that is only usable with Vulkan and compatible APIs.
-    ///
-    /// This handle type has *reference transference*.
-    OPAQUE_FD, OpaqueFd = OPAQUE_FD,
-
-    /// A Windows NT handle that is only usable with Vulkan and compatible APIs.
-    ///
-    /// This handle type has *reference transference*.
-    OPAQUE_WIN32, OpaqueWin32 = OPAQUE_WIN32,
-
-    /// A Windows global share handle that is only usable with Vulkan and compatible APIs.
-    ///
-    /// This handle type has *reference transference*.
-    OPAQUE_WIN32_KMT, OpaqueWin32Kmt = OPAQUE_WIN32_KMT,
-
-    /// A POSIX file descriptor handle to a Linux Sync File or Android Fence object.
-    ///
-    /// This handle type has *copy transference*.
-    SYNC_FD, SyncFd = SYNC_FD,
-}
-
-vulkan_bitflags! {
-    #[non_exhaustive]
-
-    /// Additional parameters for a fence payload import.
-    FenceImportFlags = FenceImportFlags(u32);
-
-    /// The fence payload will be imported only temporarily, regardless of the permanence of the
-    /// imported handle type.
-    TEMPORARY = TEMPORARY,
-}
-
-#[cfg(unix)]
-#[derive(Debug)]
-pub struct ImportFenceFdInfo {
-    /// Additional parameters for the import operation.
-    ///
-    /// If `handle_type` has *copy transference*, this must include the `temporary` flag.
-    ///
-    /// The default value is [`FenceImportFlags::empty()`].
-    pub flags: FenceImportFlags,
-
-    /// The handle type of `file`.
-    ///
-    /// There is no default value.
-    pub handle_type: ExternalFenceHandleType,
-
-    /// The file to import the fence from.
-    ///
-    /// If `handle_type` is `ExternalFenceHandleType::SyncFd`, then `file` can be `None`.
-    /// Instead of an imported file descriptor, a dummy file descriptor `-1` is used,
-    /// which represents a fence that is always signaled.
-    ///
-    /// The default value is `None`, which must be overridden if `handle_type` is not
-    /// `ExternalFenceHandleType::SyncFd`.
-    pub file: Option<File>,
-
-    pub _ne: crate::NonExhaustive,
-}
-
-#[cfg(unix)]
-impl ImportFenceFdInfo {
-    /// Returns an `ImportFenceFdInfo` with the specified `handle_type`.
-    #[inline]
-    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
-        Self {
-            flags: FenceImportFlags::empty(),
-            handle_type,
-            file: None,
-            _ne: crate::NonExhaustive(()),
-        }
-    }
-}
-
-#[cfg(windows)]
-#[derive(Debug)]
-pub struct ImportFenceWin32HandleInfo {
-    /// Additional parameters for the import operation.
-    ///
-    /// If `handle_type` has *copy transference*, this must include the `temporary` flag.
-    ///
-    /// The default value is [`FenceImportFlags::empty()`].
-    pub flags: FenceImportFlags,
-
-    /// The handle type of `handle`.
-    ///
-    /// There is no default value.
-    pub handle_type: ExternalFenceHandleType,
-
-    /// The file to import the fence from.
-    ///
-    /// The default value is `null`, which must be overridden.
-    pub handle: *mut std::ffi::c_void,
-
-    pub _ne: crate::NonExhaustive,
-}
-
-#[cfg(windows)]
-impl ImportFenceWin32HandleInfo {
-    /// Returns an `ImportFenceWin32HandleInfo` with the specified `handle_type`.
-    #[inline]
-    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
-        Self {
-            flags: FenceImportFlags::empty(),
-            handle_type,
-            handle: ptr::null_mut(),
-            _ne: crate::NonExhaustive(()),
-        }
-    }
-}
-
-/// The fence configuration to query in
-/// [`PhysicalDevice::external_fence_properties`](crate::device::physical::PhysicalDevice::external_fence_properties).
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ExternalFenceInfo {
-    /// The external handle type that will be used with the fence.
-    pub handle_type: ExternalFenceHandleType,
-
-    pub _ne: crate::NonExhaustive,
-}
-
-impl ExternalFenceInfo {
-    /// Returns an `ExternalFenceInfo` with the specified `handle_type`.
-    #[inline]
-    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
-        Self {
-            handle_type,
-            _ne: crate::NonExhaustive(()),
-        }
-    }
-
-    pub(crate) fn validate(
-        &self,
-        physical_device: &PhysicalDevice,
-    ) -> Result<(), Box<ValidationError>> {
-        let &Self {
-            handle_type,
-            _ne: _,
-        } = self;
-
-        handle_type
-            .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkPhysicalDeviceExternalFenceInfo-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
-
-        Ok(())
-    }
-}
-
-/// The properties for exporting or importing external handles, when a fence is created
-/// with a specific configuration.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub struct ExternalFenceProperties {
-    /// Whether a handle can be exported to an external source with the queried
-    /// external handle type.
-    pub exportable: bool,
-
-    /// Whether a handle can be imported from an external source with the queried
-    /// external handle type.
-    pub importable: bool,
-
-    /// Which external handle types can be re-exported after the queried external handle type has
-    /// been imported.
-    pub export_from_imported_handle_types: ExternalFenceHandleTypes,
-
-    /// Which external handle types can be enabled along with the queried external handle type
-    /// when creating the fence.
-    pub compatible_handle_types: ExternalFenceHandleTypes,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum FenceError {
-    /// Not enough memory available.
-    OomError(OomError),
-
-    /// The device has been lost.
-    DeviceLost,
-
-    /// The specified timeout wasn't long enough.
-    Timeout,
-
-    RequirementNotMet {
-        required_for: &'static str,
-        requires_one_of: RequiresOneOf,
-    },
-
-    /// The provided handle type does not permit more than one export,
-    /// and a handle of this type was already exported previously.
-    AlreadyExported,
-
-    /// The provided handle type cannot be exported from the current import handle type.
-    ExportFromImportedNotSupported {
-        imported_handle_type: ExternalFenceHandleType,
-    },
-
-    /// One of the export handle types is not compatible with the other provided handles.
-    ExportHandleTypesNotCompatible,
-
-    /// A handle type with copy transference was provided, but the fence is not signaled and there
-    /// is no pending queue operation that will signal it.
-    HandleTypeCopyNotSignaled,
-
-    /// A handle type with copy transference was provided,
-    /// but the `temporary` import flag was not set.
-    HandletypeCopyNotTemporary,
-
-    /// The provided export handle type was not set in `export_handle_types` when creating the
-    /// fence.
-    HandleTypeNotEnabled,
-
-    /// Exporting is not supported for the provided handle type.
-    HandleTypeNotExportable {
-        handle_type: ExternalFenceHandleType,
-    },
-
-    /// The provided handle type is not a POSIX file descriptor handle.
-    HandleTypeNotFd,
-
-    /// The provided handle type is not a Win32 handle.
-    HandleTypeNotWin32,
-
-    /// The fence currently has a temporary import for a swapchain acquire operation.
-    ImportedForSwapchainAcquire,
-
-    /// The fence is currently in use by a queue.
-    InQueue,
-}
-
-impl Error for FenceError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::OomError(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl Display for FenceError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        match self {
-            Self::OomError(_) => write!(f, "not enough memory available"),
-            Self::DeviceLost => write!(f, "the device was lost"),
-            Self::Timeout => write!(f, "the timeout has been reached"),
-            Self::RequirementNotMet {
-                required_for,
-                requires_one_of,
-            } => write!(
-                f,
-                "a requirement was not met for: {}; requires one of: {}",
-                required_for, requires_one_of,
-            ),
-
-            Self::AlreadyExported => write!(
-                f,
-                "the provided handle type does not permit more than one export, and a handle of \
-                this type was already exported previously",
-            ),
-            Self::ExportFromImportedNotSupported {
-                imported_handle_type,
-            } => write!(
-                f,
-                "the provided handle type cannot be exported from the current imported handle type \
-                {:?}",
-                imported_handle_type,
-            ),
-            Self::ExportHandleTypesNotCompatible => write!(
-                f,
-                "one of the export handle types is not compatible with the other provided handles",
-            ),
-            Self::HandleTypeCopyNotSignaled => write!(
-                f,
-                "a handle type with copy transference was provided, but the fence is not signaled \
-                and there is no pending queue operation that will signal it",
-            ),
-            Self::HandletypeCopyNotTemporary => write!(
-                f,
-                "a handle type with copy transference was provided, but the `temporary` \
-                import flag was not set",
-            ),
-            Self::HandleTypeNotEnabled => write!(
-                f,
-                "the provided export handle type was not set in `export_handle_types` when \
-                creating the fence",
-            ),
-            Self::HandleTypeNotExportable { handle_type } => write!(
-                f,
-                "exporting is not supported for handles of type {:?}",
-                handle_type,
-            ),
-            Self::HandleTypeNotFd => write!(
-                f,
-                "the provided handle type is not a POSIX file descriptor handle",
-            ),
-            Self::HandleTypeNotWin32 => {
-                write!(f, "the provided handle type is not a Win32 handle")
-            }
-            Self::ImportedForSwapchainAcquire => write!(
-                f,
-                "the fence currently has a temporary import for a swapchain acquire operation",
-            ),
-            Self::InQueue => write!(f, "the fence is currently in use by a queue"),
-        }
-    }
-}
-
-impl From<VulkanError> for FenceError {
-    fn from(err: VulkanError) -> Self {
-        match err {
-            e @ VulkanError::OutOfHostMemory | e @ VulkanError::OutOfDeviceMemory => {
-                Self::OomError(e.into())
-            }
-            VulkanError::DeviceLost => Self::DeviceLost,
-            _ => panic!("unexpected error: {:?}", err),
-        }
-    }
-}
-
-impl From<OomError> for FenceError {
-    fn from(err: OomError) -> Self {
-        Self::OomError(err)
-    }
-}
-
-impl From<RequirementNotMet> for FenceError {
-    fn from(err: RequirementNotMet) -> Self {
-        Self::RequirementNotMet {
-            required_for: err.required_for,
-            requires_one_of: err.requires_one_of,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{
-        sync::fence::{Fence, FenceCreateInfo},
+        sync::fence::{Fence, FenceCreateFlags, FenceCreateInfo},
         VulkanObject,
     };
     use std::time::Duration;
@@ -1648,7 +1689,7 @@ mod tests {
         let fence = Fence::new(
             device,
             FenceCreateInfo {
-                signaled: true,
+                flags: FenceCreateFlags::SIGNALED,
                 ..Default::default()
             },
         )
@@ -1663,7 +1704,7 @@ mod tests {
         let fence = Fence::new(
             device,
             FenceCreateInfo {
-                signaled: true,
+                flags: FenceCreateFlags::SIGNALED,
                 ..Default::default()
             },
         )
@@ -1678,7 +1719,7 @@ mod tests {
         let fence = Fence::new(
             device,
             FenceCreateInfo {
-                signaled: true,
+                flags: FenceCreateFlags::SIGNALED,
                 ..Default::default()
             },
         )
@@ -1696,7 +1737,7 @@ mod tests {
             let fence1 = Fence::new(
                 device1.clone(),
                 FenceCreateInfo {
-                    signaled: true,
+                    flags: FenceCreateFlags::SIGNALED,
                     ..Default::default()
                 },
             )
@@ -1704,7 +1745,7 @@ mod tests {
             let fence2 = Fence::new(
                 device2.clone(),
                 FenceCreateInfo {
-                    signaled: true,
+                    flags: FenceCreateFlags::SIGNALED,
                     ..Default::default()
                 },
             )
@@ -1726,7 +1767,7 @@ mod tests {
             let fence1 = Fence::new(
                 device1.clone(),
                 FenceCreateInfo {
-                    signaled: true,
+                    flags: FenceCreateFlags::SIGNALED,
                     ..Default::default()
                 },
             )
@@ -1734,7 +1775,7 @@ mod tests {
             let fence2 = Fence::new(
                 device2.clone(),
                 FenceCreateInfo {
-                    signaled: true,
+                    flags: FenceCreateFlags::SIGNALED,
                     ..Default::default()
                 },
             )

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -300,7 +300,6 @@ impl Fence {
 
             match result {
                 ash::vk::Result::SUCCESS => unsafe { state.set_signaled() },
-                ash::vk::Result::TIMEOUT => return Err(VulkanError::Timeout),
                 err => return Err(VulkanError::from(err)),
             }
         };
@@ -402,7 +401,6 @@ impl Fence {
                     .zip(&mut states)
                     .filter_map(|(fence, state)| state.set_signaled().map(|state| (state, fence)))
                     .collect(),
-                ash::vk::Result::TIMEOUT => return Err(VulkanError::Timeout),
                 err => return Err(VulkanError::from(err)),
             }
         };

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -19,7 +19,7 @@ use crate::{
         future::{AccessError, SubmitAnyBuilder},
         PipelineStages,
     },
-    DeviceSize, OomError,
+    DeviceSize, VulkanError,
 };
 use parking_lot::{Mutex, MutexGuard};
 use std::{
@@ -140,7 +140,7 @@ where
     F: GpuFuture,
 {
     /// Returns true if the fence is signaled by the GPU.
-    pub fn is_signaled(&self) -> Result<bool, OomError> {
+    pub fn is_signaled(&self) -> Result<bool, VulkanError> {
         let state = self.state.lock();
 
         match &*state {
@@ -190,14 +190,11 @@ where
 
         match *state {
             FenceSignalFutureState::Flushed(ref mut prev, ref fence) => {
-                match fence.wait(Some(Duration::from_secs(0))) {
-                    Ok(()) => {
-                        unsafe { prev.signal_finished() }
-                        *state = FenceSignalFutureState::Cleaned;
-                    }
-                    Err(_) => {
-                        prev.cleanup_finished();
-                    }
+                if fence.wait(Some(Duration::from_secs(0))) == Ok(true) {
+                    unsafe { prev.signal_finished() }
+                    *state = FenceSignalFutureState::Cleaned;
+                } else {
+                    prev.cleanup_finished();
                 }
             }
             FenceSignalFutureState::Pending(ref mut prev, _) => {
@@ -381,7 +378,7 @@ impl<F> Future for FenceSignalFuture<F>
 where
     F: GpuFuture,
 {
-    type Output = Result<(), OomError>;
+    type Output = Result<(), VulkanError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // Implement through fence

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::{AccessCheckError, FlushError, GpuFuture};
+use super::{AccessCheckError, GpuFuture};
 use crate::{
     buffer::Buffer,
     command_buffer::{SemaphoreSubmitInfo, SubmitInfo},
@@ -19,7 +19,7 @@ use crate::{
         future::{AccessError, SubmitAnyBuilder},
         PipelineStages,
     },
-    DeviceSize, VulkanError,
+    DeviceSize, Validated, ValidationError, VulkanError,
 };
 use parking_lot::{Mutex, MutexGuard};
 use std::{
@@ -160,7 +160,7 @@ where
     ///
     /// If the wait is successful, this function also cleans any resource locked by previous
     /// submissions.
-    pub fn wait(&self, timeout: Option<Duration>) -> Result<(), FlushError> {
+    pub fn wait(&self, timeout: Option<Duration>) -> Result<(), Validated<VulkanError>> {
         let mut state = self.state.lock();
 
         self.flush_impl(&mut state)?;
@@ -211,7 +211,7 @@ where
     fn flush_impl(
         &self,
         state: &mut MutexGuard<'_, FenceSignalFutureState<F>>,
-    ) -> Result<(), FlushError> {
+    ) -> Result<(), Validated<VulkanError>> {
         unsafe {
             // In this function we temporarily replace the current state with `Poisoned` at the
             // beginning, and we take care to always put back a value into `state` before
@@ -314,12 +314,18 @@ where
                             })
                             .map_err(|err| OutcomeErr::Partial(err.into()))
                     } else {
-                        // VUID-VkPresentIdKHR-presentIds-04999
                         for swapchain_info in &present_info.swapchain_infos {
                             if swapchain_info.present_id.map_or(false, |present_id| {
                                 !swapchain_info.swapchain.try_claim_present_id(present_id)
                             }) {
-                                return Err(FlushError::PresentIdLessThanOrEqual);
+                                return Err(Box::new(ValidationError {
+                                    problem: "the provided `present_id` was not greater than any \
+                                        `present`_id passed previously for the same swapchain"
+                                        .into(),
+                                    vuids: &["VUID-VkPresentIdKHR-presentIds-04999"],
+                                    ..Default::default()
+                                })
+                                .into());
                             }
 
                             match previous.check_swapchain_image_acquired(
@@ -329,9 +335,21 @@ where
                             ) {
                                 Ok(_) => (),
                                 Err(AccessCheckError::Unknown) => {
-                                    return Err(AccessError::SwapchainImageNotAcquired.into())
+                                    return Err(Box::new(ValidationError {
+                                        problem: AccessError::SwapchainImageNotAcquired
+                                            .to_string()
+                                            .into(),
+                                        ..Default::default()
+                                    })
+                                    .into());
                                 }
-                                Err(AccessCheckError::Denied(e)) => return Err(e.into()),
+                                Err(AccessCheckError::Denied(err)) => {
+                                    return Err(Box::new(ValidationError {
+                                        problem: err.to_string().into(),
+                                        ..Default::default()
+                                    })
+                                    .into());
+                                }
                             }
                         }
 
@@ -414,7 +432,7 @@ where
         self.cleanup_finished_impl()
     }
 
-    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, FlushError> {
+    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         let mut state = self.state.lock();
         self.flush_impl(&mut state)?;
 
@@ -433,7 +451,7 @@ where
         Ok(SubmitAnyBuilder::Empty)
     }
 
-    fn flush(&self) -> Result<(), FlushError> {
+    fn flush(&self) -> Result<(), Validated<VulkanError>> {
         let mut state = self.state.lock();
         self.flush_impl(&mut state)
     }
@@ -569,13 +587,13 @@ where
         self.cleanup_finished_impl()
     }
 
-    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, FlushError> {
+    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         // Note that this is sound because we always return `SubmitAnyBuilder::Empty`. See the
         // documentation of `build_submission`.
         (**self).build_submission()
     }
 
-    fn flush(&self) -> Result<(), FlushError> {
+    fn flush(&self) -> Result<(), Validated<VulkanError>> {
         (**self).flush()
     }
 

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -190,7 +190,7 @@ where
 
         match *state {
             FenceSignalFutureState::Flushed(ref mut prev, ref fence) => {
-                if fence.wait(Some(Duration::from_secs(0))) == Ok(true) {
+                if fence.wait(Some(Duration::from_secs(0))).is_ok() {
                     unsafe { prev.signal_finished() }
                     *state = FenceSignalFutureState::Cleaned;
                 } else {

--- a/vulkano/src/sync/future/join.rs
+++ b/vulkano/src/sync/future/join.rs
@@ -7,13 +7,13 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::{AccessCheckError, FlushError, GpuFuture, SubmitAnyBuilder};
+use super::{AccessCheckError, GpuFuture, SubmitAnyBuilder};
 use crate::{
     buffer::Buffer,
     device::{Device, DeviceOwned, Queue},
     image::{Image, ImageLayout},
     swapchain::Swapchain,
-    DeviceSize, VulkanObject,
+    DeviceSize, Validated, VulkanError, VulkanObject,
 };
 use std::{ops::Range, sync::Arc};
 
@@ -62,7 +62,7 @@ where
         self.second.cleanup_finished();
     }
 
-    fn flush(&self) -> Result<(), FlushError> {
+    fn flush(&self) -> Result<(), Validated<VulkanError>> {
         // Since each future remembers whether it has been flushed, there's no safety issue here
         // if we call this function multiple times.
         self.first.flush()?;
@@ -71,7 +71,7 @@ where
         Ok(())
     }
 
-    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, FlushError> {
+    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         // TODO: review this function
         let first = self.first.build_submission()?;
         let second = self.second.build_submission()?;

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -96,10 +96,7 @@ pub use self::{
     now::{now, NowFuture},
     semaphore_signal::SemaphoreSignalFuture,
 };
-use super::{
-    fence::{Fence, FenceError},
-    semaphore::Semaphore,
-};
+use super::{fence::Fence, semaphore::Semaphore};
 use crate::{
     buffer::Buffer,
     command_buffer::{
@@ -683,17 +680,6 @@ impl From<VulkanError> for FlushError {
             VulkanError::OutOfDate => Self::OutOfDate,
             VulkanError::FullScreenExclusiveModeLost => Self::FullScreenExclusiveModeLost,
             _ => panic!("unexpected error: {:?}", err),
-        }
-    }
-}
-
-impl From<FenceError> for FlushError {
-    fn from(err: FenceError) -> FlushError {
-        match err {
-            FenceError::OomError(err) => Self::OomError(err),
-            FenceError::Timeout => Self::Timeout,
-            FenceError::DeviceLost => Self::DeviceLost,
-            _ => unreachable!(),
         }
     }
 }

--- a/vulkano/src/sync/future/now.rs
+++ b/vulkano/src/sync/future/now.rs
@@ -7,13 +7,13 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::{AccessCheckError, FlushError, GpuFuture, SubmitAnyBuilder};
+use super::{AccessCheckError, GpuFuture, SubmitAnyBuilder};
 use crate::{
     buffer::Buffer,
     device::{Device, DeviceOwned, Queue},
     image::{Image, ImageLayout},
     swapchain::Swapchain,
-    DeviceSize,
+    DeviceSize, Validated, VulkanError,
 };
 use std::{ops::Range, sync::Arc};
 
@@ -33,12 +33,12 @@ unsafe impl GpuFuture for NowFuture {
     fn cleanup_finished(&mut self) {}
 
     #[inline]
-    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, FlushError> {
+    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         Ok(SubmitAnyBuilder::Empty)
     }
 
     #[inline]
-    fn flush(&self) -> Result<(), FlushError> {
+    fn flush(&self) -> Result<(), Validated<VulkanError>> {
         Ok(())
     }
 

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -7,7 +7,7 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use super::{AccessCheckError, FlushError, GpuFuture, SubmitAnyBuilder};
+use super::{AccessCheckError, GpuFuture, SubmitAnyBuilder};
 use crate::{
     buffer::Buffer,
     command_buffer::{SemaphoreSubmitInfo, SubmitInfo},
@@ -15,7 +15,7 @@ use crate::{
     image::{Image, ImageLayout},
     swapchain::Swapchain,
     sync::{future::AccessError, semaphore::Semaphore, PipelineStages},
-    DeviceSize,
+    DeviceSize, Validated, ValidationError, VulkanError,
 };
 use parking_lot::Mutex;
 use smallvec::smallvec;
@@ -69,7 +69,7 @@ where
         self.previous.cleanup_finished();
     }
 
-    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, FlushError> {
+    unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         // Flushing the signaling part, since it must always be submitted before the waiting part.
         self.flush()?;
         let sem = smallvec![self.semaphore.clone()];
@@ -77,7 +77,7 @@ where
         Ok(SubmitAnyBuilder::SemaphoresWait(sem))
     }
 
-    fn flush(&self) -> Result<(), FlushError> {
+    fn flush(&self) -> Result<(), Validated<VulkanError>> {
         unsafe {
             let mut wait_submitted = self.wait_submitted.lock();
 
@@ -142,12 +142,18 @@ where
                                      builder.submit(&queue)?;*/
                 }
                 SubmitAnyBuilder::QueuePresent(present_info) => {
-                    // VUID-VkPresentIdKHR-presentIds-04999
                     for swapchain_info in &present_info.swapchain_infos {
                         if swapchain_info.present_id.map_or(false, |present_id| {
                             !swapchain_info.swapchain.try_claim_present_id(present_id)
                         }) {
-                            return Err(FlushError::PresentIdLessThanOrEqual);
+                            return Err(Box::new(ValidationError {
+                                problem: "the provided `present_id` was not greater than any \
+                                    `present`_id passed previously for the same swapchain"
+                                    .into(),
+                                vuids: &["VUID-VkPresentIdKHR-presentIds-04999"],
+                                ..Default::default()
+                            })
+                            .into());
                         }
 
                         match self.previous.check_swapchain_image_acquired(
@@ -157,9 +163,21 @@ where
                         ) {
                             Ok(_) => (),
                             Err(AccessCheckError::Unknown) => {
-                                return Err(AccessError::SwapchainImageNotAcquired.into())
+                                return Err(Box::new(ValidationError {
+                                    problem: AccessError::SwapchainImageNotAcquired
+                                        .to_string()
+                                        .into(),
+                                    ..Default::default()
+                                })
+                                .into());
                             }
-                            Err(AccessCheckError::Denied(e)) => return Err(e.into()),
+                            Err(AccessCheckError::Denied(err)) => {
+                                return Err(Box::new(ValidationError {
+                                    problem: err.to_string().into(),
+                                    ..Default::default()
+                                })
+                                .into());
+                            }
                         }
                     }
 
@@ -177,7 +195,7 @@ where
                             }],
                             None,
                         )?;
-                        Ok::<_, FlushError>(())
+                        Ok::<_, Validated<VulkanError>>(())
                     })?;
                 }
             };

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -19,7 +19,7 @@
 #[allow(unused)]
 pub(crate) use self::pipeline::{PipelineStageAccess, PipelineStageAccessFlags};
 pub use self::{
-    future::{now, FlushError, GpuFuture},
+    future::{now, GpuFuture},
     pipeline::{
         AccessFlags, BufferMemoryBarrier, DependencyFlags, DependencyInfo, ImageMemoryBarrier,
         MemoryBarrier, PipelineStage, PipelineStages, QueueFamilyOwnershipTransfer,


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to `Swapchain`:
- `acquire_next_image` and `wait_for_present` now return `Validated<VulkanError>`.

Changes to futures:
- `FlushError` is replaced with `Validated<VulkanError>`.
````

Depends on #2267.

Since futures are planned to be removed anyway, I didn't give these too much thought.