### PR TITLE
Allow to be built without cargo

### DIFF
--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -1059,11 +1059,20 @@ impl InstanceCreateInfo {
     #[inline]
     pub fn application_from_cargo_toml() -> Self {
         Self {
-            application_name: Some(env!("CARGO_PKG_NAME").to_owned()),
+            application_name: Some(option_env!("CARGO_PKG_NAME").unwrap().to_owned()),
             application_version: Version {
-                major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
-                minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
-                patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
+                major: option_env!("CARGO_PKG_VERSION_MAJOR")
+                    .unwrap()
+                    .parse()
+                    .unwrap(),
+                minor: option_env!("CARGO_PKG_VERSION_MINOR")
+                    .unwrap()
+                    .parse()
+                    .unwrap(),
+                patch: option_env!("CARGO_PKG_VERSION_PATCH")
+                    .unwrap()
+                    .parse()
+                    .unwrap(),
             },
             ..Default::default()
         }


### PR DESCRIPTION
aosp has introduced this project as a dependency, and aosp doesn't use cargo to build. `env!` will fail the compilation if the envs are not set. Replace with `option_env` to delay the panic to runtime.

1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [x] Make sure that the changes are covered by unit-tests: this change will be built by the aosp build infrastructure.

4. [x] Run `cargo fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.
   
   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Bugs fixed
- Allow compile without cargo
````
