### PR TITLE
Some shader fixes and improvements

### DIFF
--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -440,17 +440,7 @@ fn read_spirv_words_from_file(path: impl AsRef<Path>) -> Vec<u32> {
     });
     file.read_to_end(&mut bytes).unwrap();
 
-    // Convert the bytes to words.
-    // SPIR-V is defined to be always little-endian, so this may need an endianness conversion.
-    assert!(
-        bytes.len() % 4 == 0,
-        "file `{}` does not contain a whole number of SPIR-V words",
-        path.display(),
-    );
-
-    // TODO: Use `slice::array_chunks` once it's stable.
-    bytes
-        .chunks_exact(4)
-        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
-        .collect()
+    vulkano::shader::spirv::bytes_to_words(&bytes)
+        .unwrap_or_else(|err| panic!("file `{}`: {}", path.display(), err))
+        .into_owned()
 }

--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -667,12 +667,7 @@ impl TypeStruct {
                 Instruction::Name { name, .. } => Some(Ident::new(name, Span::call_site())),
                 _ => None,
             })
-            .ok_or_else(|| {
-                Error::new_spanned(
-                    &shader.source,
-                    "expected struct in shader interface to have an associated `Name` instruction",
-                )
-            })?;
+            .unwrap_or_else(|| format_ident!("Unnamed{}", struct_id.as_raw()));
 
         let mut members = Vec::<Member>::with_capacity(member_type_ids.len());
 
@@ -822,7 +817,10 @@ impl TypeStruct {
             members.push(Member { ident, ty, offset });
         }
 
-        Ok(TypeStruct { ident, members })
+        Ok(TypeStruct {
+            ident,
+            members,
+        })
     }
 
     fn size(&self) -> Option<usize> {


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- vulkano-shaders: Use a placeholder name instead of erroring out, when the shader doesn't contain a name for a struct.
````

Aside from fixing the bug, this also adds a convenience function to convert bytes to words.