### PR TITLE
Remove remaining old error types, other cleanup

### DIFF
--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -817,10 +817,7 @@ impl TypeStruct {
             members.push(Member { ident, ty, offset });
         }
 
-        Ok(TypeStruct {
-            ident,
-            members,
-        })
+        Ok(TypeStruct { ident, members })
     }
 
     fn size(&self) -> Option<usize> {

--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -378,18 +378,14 @@ impl AccelerationStructureCreateInfo {
             _ne: _,
         } = self;
 
-        create_flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "create_flags".into(),
-                vuids: &["VUID-VkAccelerationStructureCreateInfoKHR-createFlags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        create_flags.validate_device(device).map_err(|err| {
+            err.add_context("create_flags")
+                .set_vuids(&["VUID-VkAccelerationStructureCreateInfoKHR-createFlags-parameter"])
+        })?;
 
-        ty.validate_device(device).map_err(|err| ValidationError {
-            context: "ty".into(),
-            vuids: &["VUID-VkAccelerationStructureCreateInfoKHR-type-parameter"],
-            ..ValidationError::from_requirement(err)
+        ty.validate_device(device).map_err(|err| {
+            err.add_context("ty")
+                .set_vuids(&["VUID-VkAccelerationStructureCreateInfoKHR-type-parameter"])
         })?;
 
         if !buffer
@@ -513,13 +509,10 @@ impl AccelerationStructureBuildGeometryInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter"])
+        })?;
 
         let max_geometry_count = device
             .physical_device()
@@ -1009,23 +1002,16 @@ impl AccelerationStructureGeometryTrianglesData {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"])
+        })?;
 
-        vertex_format
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "vertex_format".into(),
-                vuids: &[
-                    "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-parameter",
-                ],
-                ..ValidationError::from_requirement(err)
-            })?;
+        vertex_format.validate_device(device).map_err(|err| {
+            err.add_context("vertex_format").set_vuids(&[
+                "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-parameter",
+            ])
+        })?;
 
         if unsafe {
             !device
@@ -1127,13 +1113,10 @@ impl AccelerationStructureGeometryAabbsData {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"])
+        })?;
 
         if stride % 8 != 0 {
             return Err(Box::new(ValidationError {
@@ -1199,13 +1182,10 @@ impl AccelerationStructureGeometryInstancesData {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkAccelerationStructureGeometryKHR-flags-parameter"])
+        })?;
 
         Ok(())
     }
@@ -1402,12 +1382,10 @@ impl CopyAccelerationStructureInfo {
         assert_eq!(device, src.device().as_ref());
         assert_eq!(device, dst.device().as_ref());
 
-        mode.validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "mode".into(),
-                vuids: &["VUID-VkCopyAccelerationStructureInfoKHR-mode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        mode.validate_device(device).map_err(|err| {
+            err.add_context("mode")
+                .set_vuids(&["VUID-VkCopyAccelerationStructureInfoKHR-mode-parameter"])
+        })?;
 
         if !matches!(
             mode,
@@ -1485,12 +1463,10 @@ impl CopyAccelerationStructureToMemoryInfo {
         assert_eq!(device, src.device().as_ref());
         assert_eq!(device, dst.device().as_ref());
 
-        mode.validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "mode".into(),
-                vuids: &["VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        mode.validate_device(device).map_err(|err| {
+            err.add_context("mode")
+                .set_vuids(&["VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-parameter"])
+        })?;
 
         if !matches!(mode, CopyAccelerationStructureMode::Serialize) {
             return Err(Box::new(ValidationError {
@@ -1555,12 +1531,10 @@ impl CopyMemoryToAccelerationStructureInfo {
         assert_eq!(device, src.device().as_ref());
         assert_eq!(device, dst.device().as_ref());
 
-        mode.validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "mode".into(),
-                vuids: &["VUID-VkCopyMemoryToAccelerationStructureInfoKHR-mode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        mode.validate_device(device).map_err(|err| {
+            err.add_context("mode")
+                .set_vuids(&["VUID-VkCopyMemoryToAccelerationStructureInfoKHR-mode-parameter"])
+        })?;
 
         if !matches!(mode, CopyAccelerationStructureMode::Deserialize) {
             return Err(Box::new(ValidationError {

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -912,18 +912,16 @@ impl ExternalBufferInfo {
 
         flags
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkPhysicalDeviceExternalBufferInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("flags")
+                    .set_vuids(&["VUID-VkPhysicalDeviceExternalBufferInfo-flags-parameter"])
             })?;
 
         usage
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "usage".into(),
-                vuids: &["VUID-VkPhysicalDeviceExternalBufferInfo-usage-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("usage")
+                    .set_vuids(&["VUID-VkPhysicalDeviceExternalBufferInfo-usage-parameter"])
             })?;
 
         if usage.is_empty() {
@@ -937,10 +935,9 @@ impl ExternalBufferInfo {
 
         handle_type
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkPhysicalDeviceExternalBufferInfo-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("handle_type")
+                    .set_vuids(&["VUID-VkPhysicalDeviceExternalBufferInfo-handleType-parameter"])
             })?;
 
         Ok(())

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -340,12 +340,12 @@ where
             };
         }
 
-        let mapped_ptr =
-            self.mapped_ptr()
-                .ok_or(HostAccessError::ValidationError(ValidationError {
-                    problem: "the memory of this subbuffer is not host-visible".into(),
-                    ..Default::default()
-                }))?;
+        let mapped_ptr = self.mapped_ptr().ok_or_else(|| {
+            HostAccessError::ValidationError(Box::new(ValidationError {
+                problem: "the memory of this subbuffer is not host-visible".into(),
+                ..Default::default()
+            }))
+        })?;
         // SAFETY: `Subbuffer` guarantees that its contents are laid out correctly for `T`.
         let data = unsafe { &*T::from_ffi(mapped_ptr.as_ptr(), self.size as usize) };
 
@@ -415,12 +415,12 @@ where
             };
         }
 
-        let mapped_ptr =
-            self.mapped_ptr()
-                .ok_or(HostAccessError::ValidationError(ValidationError {
-                    problem: "the memory of this subbuffer is not host-visible".into(),
-                    ..Default::default()
-                }))?;
+        let mapped_ptr = self.mapped_ptr().ok_or_else(|| {
+            HostAccessError::ValidationError(Box::new(ValidationError {
+                problem: "the memory of this subbuffer is not host-visible".into(),
+                ..Default::default()
+            }))
+        })?;
         // SAFETY: `Subbuffer` guarantees that its contents are laid out correctly for `T`.
         let data = unsafe { &mut *T::from_ffi(mapped_ptr.as_ptr(), self.size as usize) };
 

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -674,21 +674,15 @@ impl BufferCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkBufferCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkBufferCreateInfo-flags-parameter"])
+        })?;
 
-        usage
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "usage".into(),
-                vuids: &["VUID-VkBufferCreateInfo-usage-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        usage.validate_device(device).map_err(|err| {
+            err.add_context("usage")
+                .set_vuids(&["VUID-VkBufferCreateInfo-usage-parameter"])
+        })?;
 
         if usage.is_empty() {
             return Err(Box::new(ValidationError {
@@ -819,10 +813,9 @@ impl BufferCreateInfo {
 
             external_memory_handle_types
                 .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "external_memory_handle_types".into(),
-                    vuids: &["VUID-VkExternalMemoryBufferCreateInfo-handleTypes-parameter"],
-                    ..ValidationError::from_requirement(err)
+                .map_err(|err| {
+                    err.add_context("external_memory_handle_types")
+                        .set_vuids(&["VUID-VkExternalMemoryBufferCreateInfo-handleTypes-parameter"])
                 })?;
 
             // TODO:

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -439,13 +439,10 @@ impl BufferViewCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let Self { format, _ne: _ } = self;
 
-        format
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "format".into(),
-                vuids: &["VUID-VkBufferViewCreateInfo-format-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        format.validate_device(device).map_err(|err| {
+            err.add_context("format")
+                .set_vuids(&["VUID-VkBufferViewCreateInfo-format-parameter"])
+        })?;
 
         Ok(())
     }

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -482,10 +482,9 @@ where
     ) -> Result<(), Box<ValidationError>> {
         pipeline_bind_point
             .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "pipeline_bind_point".into(),
-                vuids: &["VUID-vkCmdBindDescriptorSets-pipelineBindPoint-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("pipeline_bind_point")
+                    .set_vuids(&["VUID-vkCmdBindDescriptorSets-pipelineBindPoint-parameter"])
             })?;
 
         let queue_family_properties = self.queue_family_properties();
@@ -1185,10 +1184,9 @@ where
 
         pipeline_bind_point
             .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "pipeline_bind_point".into(),
-                vuids: &["VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("pipeline_bind_point")
+                    .set_vuids(&["VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-parameter"])
             })?;
 
         let queue_family_properties = self.queue_family_properties();

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -703,13 +703,10 @@ impl ClearColorImageInfo {
             _ne: _,
         } = self;
 
-        image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "image_layout".into(),
-                vuids: &["VUID-vkCmdClearColorImage-imageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        image_layout.validate_device(device).map_err(|err| {
+            err.add_context("image_layout")
+                .set_vuids(&["VUID-vkCmdClearColorImage-imageLayout-parameter"])
+        })?;
 
         // VUID-vkCmdClearColorImage-commonparent
         assert_eq!(device, image.device().as_ref());
@@ -885,13 +882,10 @@ impl ClearDepthStencilImageInfo {
             _ne: _,
         } = self;
 
-        image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "image_layout".into(),
-                vuids: &["VUID-vkCmdClearDepthStencilImage-imageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        image_layout.validate_device(device).map_err(|err| {
+            err.add_context("image_layout")
+                .set_vuids(&["VUID-vkCmdClearDepthStencilImage-imageLayout-parameter"])
+        })?;
 
         // VUID-vkCmdClearDepthStencilImage-commonparent
         assert_eq!(device, image.device().as_ref());

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -2514,21 +2514,15 @@ impl CopyImageInfo {
             _ne: _,
         } = self;
 
-        src_image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_image_layout".into(),
-                vuids: &["VUID-VkCopyImageInfo2-srcImageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_image_layout.validate_device(device).map_err(|err| {
+            err.add_context("src_image_layout")
+                .set_vuids(&["VUID-VkCopyImageInfo2-srcImageLayout-parameter"])
+        })?;
 
-        dst_image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_image_layout".into(),
-                vuids: &["VUID-VkCopyImageInfo2-dstImageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_image_layout.validate_device(device).map_err(|err| {
+            err.add_context("dst_image_layout")
+                .set_vuids(&["VUID-VkCopyImageInfo2-dstImageLayout-parameter"])
+        })?;
 
         // VUID-VkCopyImageInfo2-commonparent
         assert_eq!(device, src_image.device().as_ref());
@@ -3876,13 +3870,10 @@ impl CopyBufferToImageInfo {
             _ne: _,
         } = self;
 
-        dst_image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_image_layout".into(),
-                vuids: &["VUID-VkCopyBufferToImageInfo2-dstImageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_image_layout.validate_device(device).map_err(|err| {
+            err.add_context("dst_image_layout")
+                .set_vuids(&["VUID-VkCopyBufferToImageInfo2-dstImageLayout-parameter"])
+        })?;
 
         // VUID-VkCopyBufferToImageInfo2-commonparent
         assert_eq!(device, src_buffer.device().as_ref());
@@ -4488,13 +4479,10 @@ impl CopyImageToBufferInfo {
             _ne: _,
         } = self;
 
-        src_image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_image_layout".into(),
-                vuids: &["VUID-VkCopyImageToBufferInfo2-srcImageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_image_layout.validate_device(device).map_err(|err| {
+            err.add_context("src_image_layout")
+                .set_vuids(&["VUID-VkCopyImageToBufferInfo2-srcImageLayout-parameter"])
+        })?;
 
         // VUID-VkCopyImageToBufferInfo2-commonparent
         assert_eq!(device, src_image.device().as_ref());
@@ -5306,29 +5294,20 @@ impl BlitImageInfo {
             _ne: _,
         } = self;
 
-        src_image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_image_layout".into(),
-                vuids: &["VUID-VkBlitImageInfo2-srcImageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_image_layout.validate_device(device).map_err(|err| {
+            err.add_context("src_image_layout")
+                .set_vuids(&["VUID-VkBlitImageInfo2-srcImageLayout-parameter"])
+        })?;
 
-        dst_image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_image_layout".into(),
-                vuids: &["VUID-VkBlitImageInfo2-dstImageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_image_layout.validate_device(device).map_err(|err| {
+            err.add_context("dst_image_layout")
+                .set_vuids(&["VUID-VkBlitImageInfo2-dstImageLayout-parameter"])
+        })?;
 
-        filter
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "filter".into(),
-                vuids: &["VUID-VkBlitImageInfo2-filter-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        filter.validate_device(device).map_err(|err| {
+            err.add_context("filter")
+                .set_vuids(&["VUID-VkBlitImageInfo2-filter-parameter"])
+        })?;
 
         // VUID-VkBlitImageInfo2-commonparent
         assert_eq!(device, src_image.device().as_ref());
@@ -6219,21 +6198,15 @@ impl ResolveImageInfo {
             _ne: _,
         } = self;
 
-        src_image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_image_layout".into(),
-                vuids: &["VUID-VkResolveImageInfo2-srcImageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_image_layout.validate_device(device).map_err(|err| {
+            err.add_context("src_image_layout")
+                .set_vuids(&["VUID-VkResolveImageInfo2-srcImageLayout-parameter"])
+        })?;
 
-        dst_image_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_image_layout".into(),
-                vuids: &["VUID-VkResolveImageInfo2-dstImageLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_image_layout.validate_device(device).map_err(|err| {
+            err.add_context("dst_image_layout")
+                .set_vuids(&["VUID-VkResolveImageInfo2-dstImageLayout-parameter"])
+        })?;
 
         // VUID-VkResolveImageInfo2-commonparent
         assert_eq!(device, src_image.device().as_ref());

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -1312,13 +1312,10 @@ where
             }));
         }
 
-        cull_mode
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "cull_mode".into(),
-                vuids: &["VUID-vkCmdSetCullMode-cullMode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        cull_mode.validate_device(self.device()).map_err(|err| {
+            err.add_context("cull_mode")
+                .set_vuids(&["VUID-vkCmdSetCullMode-cullMode-parameter"])
+        })?;
 
         Ok(())
     }
@@ -1611,13 +1608,10 @@ where
             }));
         }
 
-        compare_op
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "compare_op".into(),
-                vuids: &["VUID-vkCmdSetDepthCompareOp-depthCompareOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        compare_op.validate_device(self.device()).map_err(|err| {
+            err.add_context("compare_op")
+                .set_vuids(&["VUID-vkCmdSetDepthCompareOp-depthCompareOp-parameter"])
+        })?;
 
         Ok(())
     }
@@ -1863,12 +1857,10 @@ where
             }));
         }
 
-        face.validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "face".into(),
-                vuids: &["VUID-vkCmdSetFrontFace-frontFace-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        face.validate_device(self.device()).map_err(|err| {
+            err.add_context("face")
+                .set_vuids(&["VUID-vkCmdSetFrontFace-frontFace-parameter"])
+        })?;
 
         Ok(())
     }
@@ -2028,13 +2020,10 @@ where
             }));
         }
 
-        logic_op
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "logic_op".into(),
-                vuids: &["VUID-vkCmdSetLogicOpEXT-logicOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        logic_op.validate_device(self.device()).map_err(|err| {
+            err.add_context("logic_op")
+                .set_vuids(&["VUID-vkCmdSetLogicOpEXT-logicOp-parameter"])
+        })?;
 
         Ok(())
     }
@@ -2214,13 +2203,10 @@ where
             }));
         }
 
-        topology
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "topology".into(),
-                vuids: &["VUID-vkCmdSetPrimitiveTopology-primitiveTopology-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        topology.validate_device(self.device()).map_err(|err| {
+            err.add_context("topology")
+                .set_vuids(&["VUID-vkCmdSetPrimitiveTopology-primitiveTopology-parameter"])
+        })?;
 
         // VUID?
         // Since these requirements exist for fixed state when creating the pipeline,
@@ -2561,13 +2547,10 @@ where
             }));
         }
 
-        faces
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "faces".into(),
-                vuids: &["VUID-vkCmdSetStencilCompareMask-faceMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        faces.validate_device(self.device()).map_err(|err| {
+            err.add_context("faces")
+                .set_vuids(&["VUID-vkCmdSetStencilCompareMask-faceMask-parameter"])
+        })?;
 
         Ok(())
     }
@@ -2632,45 +2615,32 @@ where
             }));
         }
 
-        faces
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "faces".into(),
-                vuids: &["VUID-vkCmdSetStencilOp-faceMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        faces.validate_device(self.device()).map_err(|err| {
+            err.add_context("faces")
+                .set_vuids(&["VUID-vkCmdSetStencilOp-faceMask-parameter"])
+        })?;
 
-        fail_op
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "fail_op".into(),
-                vuids: &["VUID-vkCmdSetStencilOp-failOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        fail_op.validate_device(self.device()).map_err(|err| {
+            err.add_context("fail_op")
+                .set_vuids(&["VUID-vkCmdSetStencilOp-failOp-parameter"])
+        })?;
 
-        pass_op
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "pass_op".into(),
-                vuids: &["VUID-vkCmdSetStencilOp-passOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        pass_op.validate_device(self.device()).map_err(|err| {
+            err.add_context("pass_op")
+                .set_vuids(&["VUID-vkCmdSetStencilOp-passOp-parameter"])
+        })?;
 
         depth_fail_op
             .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "depth_fail_op".into(),
-                vuids: &["VUID-vkCmdSetStencilOp-depthFailOp-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("depth_fail_op")
+                    .set_vuids(&["VUID-vkCmdSetStencilOp-depthFailOp-parameter"])
             })?;
 
-        compare_op
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "compare_op".into(),
-                vuids: &["VUID-vkCmdSetStencilOp-compareOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        compare_op.validate_device(self.device()).map_err(|err| {
+            err.add_context("compare_op")
+                .set_vuids(&["VUID-vkCmdSetStencilOp-compareOp-parameter"])
+        })?;
 
         Ok(())
     }
@@ -2738,13 +2708,10 @@ where
             }));
         }
 
-        faces
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "faces".into(),
-                vuids: &["VUID-vkCmdSetStencilReference-faceMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        faces.validate_device(self.device()).map_err(|err| {
+            err.add_context("faces")
+                .set_vuids(&["VUID-vkCmdSetStencilReference-faceMask-parameter"])
+        })?;
 
         Ok(())
     }
@@ -2844,13 +2811,10 @@ where
             }));
         }
 
-        faces
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "faces".into(),
-                vuids: &["VUID-vkCmdSetStencilWriteMask-faceMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        faces.validate_device(self.device()).map_err(|err| {
+            err.add_context("faces")
+                .set_vuids(&["VUID-vkCmdSetStencilWriteMask-faceMask-parameter"])
+        })?;
 
         Ok(())
     }

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -83,11 +83,13 @@ where
             .builder_state
             .pipeline_compute
             .as_ref()
-            .ok_or(Box::new(ValidationError {
-                problem: "no compute pipeline is currently bound".into(),
-                vuids: &["VUID-vkCmdDispatch-None-08606"],
-                ..Default::default()
-            }))?
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    problem: "no compute pipeline is currently bound".into(),
+                    vuids: &["VUID-vkCmdDispatch-None-08606"],
+                    ..Default::default()
+                })
+            })?
             .as_ref();
 
         const VUID_TYPE: VUIDType = VUIDType::Dispatch;
@@ -153,11 +155,13 @@ where
             .builder_state
             .pipeline_compute
             .as_ref()
-            .ok_or(Box::new(ValidationError {
-                problem: "no compute pipeline is currently bound".into(),
-                vuids: &["VUID-vkCmdDispatchIndirect-None-08606"],
-                ..Default::default()
-            }))?
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    problem: "no compute pipeline is currently bound".into(),
+                    vuids: &["VUID-vkCmdDispatchIndirect-None-08606"],
+                    ..Default::default()
+                })
+            })?
             .as_ref();
 
         const VUID_TYPE: VUIDType = VUIDType::DispatchIndirect;
@@ -229,25 +233,25 @@ where
         self.inner
             .validate_draw(vertex_count, instance_count, first_vertex, first_instance)?;
 
-        let render_pass_state =
-            self.builder_state
-                .render_pass
-                .as_ref()
-                .ok_or(Box::new(ValidationError {
-                    problem: "a render pass instance is not active".into(),
-                    vuids: &["VUID-vkCmdDraw-renderpass"],
-                    ..Default::default()
-                }))?;
+        let render_pass_state = self.builder_state.render_pass.as_ref().ok_or_else(|| {
+            Box::new(ValidationError {
+                problem: "a render pass instance is not active".into(),
+                vuids: &["VUID-vkCmdDraw-renderpass"],
+                ..Default::default()
+            })
+        })?;
 
         let pipeline = self
             .builder_state
             .pipeline_graphics
             .as_ref()
-            .ok_or(Box::new(ValidationError {
-                problem: "no graphics pipeline is currently bound".into(),
-                vuids: &["VUID-vkCmdDraw-None-08606"],
-                ..Default::default()
-            }))?
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    problem: "no graphics pipeline is currently bound".into(),
+                    vuids: &["VUID-vkCmdDraw-None-08606"],
+                    ..Default::default()
+                })
+            })?
             .as_ref();
 
         const VUID_TYPE: VUIDType = VUIDType::Draw;
@@ -406,25 +410,25 @@ where
         self.inner
             .validate_draw_indirect(indirect_buffer, draw_count, stride)?;
 
-        let render_pass_state =
-            self.builder_state
-                .render_pass
-                .as_ref()
-                .ok_or(Box::new(ValidationError {
-                    problem: "a render pass instance is not active".into(),
-                    vuids: &["VUID-vkCmdDrawIndirect-renderpass"],
-                    ..Default::default()
-                }))?;
+        let render_pass_state = self.builder_state.render_pass.as_ref().ok_or_else(|| {
+            Box::new(ValidationError {
+                problem: "a render pass instance is not active".into(),
+                vuids: &["VUID-vkCmdDrawIndirect-renderpass"],
+                ..Default::default()
+            })
+        })?;
 
         let pipeline = self
             .builder_state
             .pipeline_graphics
             .as_ref()
-            .ok_or(Box::new(ValidationError {
-                problem: "no graphics pipeline is currently bound".into(),
-                vuids: &["VUID-vkCmdDrawIndirect-None-08606"],
-                ..Default::default()
-            }))?
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    problem: "no graphics pipeline is currently bound".into(),
+                    vuids: &["VUID-vkCmdDrawIndirect-None-08606"],
+                    ..Default::default()
+                })
+            })?
             .as_ref();
 
         const VUID_TYPE: VUIDType = VUIDType::DrawIndirect;
@@ -534,25 +538,25 @@ where
             first_instance,
         )?;
 
-        let render_pass_state =
-            self.builder_state
-                .render_pass
-                .as_ref()
-                .ok_or(Box::new(ValidationError {
-                    problem: "a render pass instance is not active".into(),
-                    vuids: &["VUID-vkCmdDrawIndexed-renderpass"],
-                    ..Default::default()
-                }))?;
+        let render_pass_state = self.builder_state.render_pass.as_ref().ok_or_else(|| {
+            Box::new(ValidationError {
+                problem: "a render pass instance is not active".into(),
+                vuids: &["VUID-vkCmdDrawIndexed-renderpass"],
+                ..Default::default()
+            })
+        })?;
 
         let pipeline = self
             .builder_state
             .pipeline_graphics
             .as_ref()
-            .ok_or(Box::new(ValidationError {
-                problem: "no graphics pipeline is currently bound".into(),
-                vuids: &["VUID-vkCmdDrawIndexed-None-08606"],
-                ..Default::default()
-            }))?
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    problem: "no graphics pipeline is currently bound".into(),
+                    vuids: &["VUID-vkCmdDrawIndexed-None-08606"],
+                    ..Default::default()
+                })
+            })?
             .as_ref();
 
         const VUID_TYPE: VUIDType = VUIDType::DrawIndexed;
@@ -562,15 +566,13 @@ where
         self.validate_pipeline_graphics_render_pass(VUID_TYPE, pipeline, render_pass_state)?;
         self.validate_pipeline_graphics_vertex_buffers(VUID_TYPE, pipeline)?;
 
-        let index_buffer =
-            self.builder_state
-                .index_buffer
-                .as_ref()
-                .ok_or(Box::new(ValidationError {
-                    problem: "no index buffer is currently bound".into(),
-                    vuids: &["VUID-vkCmdDrawIndexed-None-07312"],
-                    ..Default::default()
-                }))?;
+        let index_buffer = self.builder_state.index_buffer.as_ref().ok_or_else(|| {
+            Box::new(ValidationError {
+                problem: "no index buffer is currently bound".into(),
+                vuids: &["VUID-vkCmdDrawIndexed-None-07312"],
+                ..Default::default()
+            })
+        })?;
 
         let index_buffer_bytes = index_buffer.as_bytes();
 
@@ -736,25 +738,25 @@ where
         self.inner
             .validate_draw_indexed_indirect(indirect_buffer, draw_count, stride)?;
 
-        let render_pass_state =
-            self.builder_state
-                .render_pass
-                .as_ref()
-                .ok_or(Box::new(ValidationError {
-                    problem: "a render pass instance is not active".into(),
-                    vuids: &["VUID-vkCmdDrawIndexedIndirect-renderpass"],
-                    ..Default::default()
-                }))?;
+        let render_pass_state = self.builder_state.render_pass.as_ref().ok_or_else(|| {
+            Box::new(ValidationError {
+                problem: "a render pass instance is not active".into(),
+                vuids: &["VUID-vkCmdDrawIndexedIndirect-renderpass"],
+                ..Default::default()
+            })
+        })?;
 
         let pipeline = self
             .builder_state
             .pipeline_graphics
             .as_ref()
-            .ok_or(Box::new(ValidationError {
-                problem: "no graphics pipeline is currently bound".into(),
-                vuids: &["VUID-vkCmdDrawIndexedIndirect-None-08606"],
-                ..Default::default()
-            }))?
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    problem: "no graphics pipeline is currently bound".into(),
+                    vuids: &["VUID-vkCmdDrawIndexedIndirect-None-08606"],
+                    ..Default::default()
+                })
+            })?
             .as_ref();
 
         const VUID_TYPE: VUIDType = VUIDType::DrawIndexedIndirect;
@@ -764,15 +766,13 @@ where
         self.validate_pipeline_graphics_render_pass(VUID_TYPE, pipeline, render_pass_state)?;
         self.validate_pipeline_graphics_vertex_buffers(VUID_TYPE, pipeline)?;
 
-        let _index_buffer =
-            self.builder_state
-                .index_buffer
-                .as_ref()
-                .ok_or(Box::new(ValidationError {
-                    problem: "no index buffer is currently bound".into(),
-                    vuids: &["VUID-vkCmdDrawIndexedIndirect-None-07312"],
-                    ..Default::default()
-                }))?;
+        let _index_buffer = self.builder_state.index_buffer.as_ref().ok_or_else(|| {
+            Box::new(ValidationError {
+                problem: "no index buffer is currently bound".into(),
+                vuids: &["VUID-vkCmdDrawIndexedIndirect-None-07312"],
+                ..Default::default()
+            })
+        })?;
 
         Ok(())
     }
@@ -830,7 +830,7 @@ where
             let elements_to_check = if let Some(descriptor_count) = binding_reqs.descriptor_count {
                 // The shader has a fixed-sized array, so it will never access more than
                 // the first `descriptor_count` elements.
-                elements.get(..descriptor_count as usize).ok_or({
+                elements.get(..descriptor_count as usize).ok_or_else(|| {
                     // There are less than `descriptor_count` elements in `elements`
                     Box::new(ValidationError {
                         problem: format!(
@@ -885,13 +885,15 @@ where
             .builder_state
             .descriptor_sets
             .get(&pipeline.bind_point())
-            .ok_or(Box::new(ValidationError {
-                problem: "the currently bound pipeline accesses descriptor sets, but no \
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    problem: "the currently bound pipeline accesses descriptor sets, but no \
                     descriptor sets were previously bound"
-                    .into(),
-                vuids: vuids!(vuid_type, "None-02697"),
-                ..Default::default()
-            }))?;
+                        .into(),
+                    vuids: vuids!(vuid_type, "None-02697"),
+                    ..Default::default()
+                })
+            })?;
 
         if !pipeline.layout().is_compatible_with(
             &descriptor_set_state.pipeline_layout,
@@ -1352,15 +1354,17 @@ where
             let set_resources = descriptor_set_state
                 .descriptor_sets
                 .get(&set_num)
-                .ok_or(Box::new(ValidationError {
-                    problem: format!(
-                        "the currently bound pipeline accesses descriptor set {set_num}, but \
+                .ok_or_else(|| {
+                    Box::new(ValidationError {
+                        problem: format!(
+                            "the currently bound pipeline accesses descriptor set {set_num}, but \
                         no descriptor set was previously bound"
-                    )
-                    .into(),
-                    // vuids?
-                    ..Default::default()
-                }))?
+                        )
+                        .into(),
+                        // vuids?
+                        ..Default::default()
+                    })
+                })?
                 .resources();
 
             let binding_resources = set_resources.binding(binding_num).unwrap();
@@ -1464,13 +1468,15 @@ where
             .builder_state
             .push_constants_pipeline_layout
             .as_ref()
-            .ok_or(Box::new(ValidationError {
-                problem: "the currently bound pipeline accesses push constants, but no \
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    problem: "the currently bound pipeline accesses push constants, but no \
                     push constants were previously set"
-                    .into(),
-                vuids: vuids!(vuid_type, "maintenance4-06425"),
-                ..Default::default()
-            }))?;
+                        .into(),
+                    vuids: vuids!(vuid_type, "maintenance4-06425"),
+                    ..Default::default()
+                })
+            })?;
 
         if pipeline_layout.handle() != constants_pipeline_layout.handle()
             && pipeline_layout.push_constant_ranges()

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -453,13 +453,10 @@ where
 
         let device = self.device();
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-vkCmdBeginQuery-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-vkCmdBeginQuery-flags-parameter"])
+        })?;
 
         // VUID-vkCmdBeginQuery-commonparent
         assert_eq!(device, query_pool.device());
@@ -673,13 +670,10 @@ where
 
         let device = self.device();
 
-        stage
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "stage".into(),
-                vuids: &["VUID-vkCmdWriteTimestamp2-stage-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        stage.validate_device(device).map_err(|err| {
+            err.add_context("stage")
+                .set_vuids(&["VUID-vkCmdWriteTimestamp2-stage-parameter"])
+        })?;
 
         if !device.enabled_features().synchronization2
             && PipelineStages::from(stage).contains_flags2()

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -107,16 +107,18 @@ where
                     .inheritance_info()
                     .render_pass
                     .as_ref()
-                    .ok_or(Box::new(ValidationError {
-                        problem: format!(
-                            "a render pass instance is active, but \
+                    .ok_or_else(|| {
+                        Box::new(ValidationError {
+                            problem: format!(
+                                "a render pass instance is active, but \
                             `command_buffers[{}].inheritance_info().render_pass` is `None`",
-                            command_buffer_index
-                        )
-                        .into(),
-                        vuids: &["VUID-vkCmdExecuteCommands-pCommandBuffers-00096"],
-                        ..Default::default()
-                    }))?;
+                                command_buffer_index
+                            )
+                            .into(),
+                            vuids: &["VUID-vkCmdExecuteCommands-pCommandBuffers-00096"],
+                            ..Default::default()
+                        })
+                    })?;
 
                 match (&render_pass_state.render_pass, inheritance_render_pass) {
                     (
@@ -406,17 +408,20 @@ where
                         let inherited_flags = command_buffer
                             .inheritance_info()
                             .occlusion_query
-                            .ok_or(Box::new(ValidationError {
-                                context: format!(
-                                    "command_buffers[{}].inheritance_info().occlusion_query",
-                                    command_buffer_index
-                                )
-                                .into(),
-                                problem: "is `None`, but an occlusion query is currently active"
+                            .ok_or_else(|| {
+                                Box::new(ValidationError {
+                                    context: format!(
+                                        "command_buffers[{}].inheritance_info().occlusion_query",
+                                        command_buffer_index
+                                    )
                                     .into(),
-                                vuids: &["VUID-vkCmdExecuteCommands-commandBuffer-00102"],
-                                ..Default::default()
-                            }))?;
+                                    problem:
+                                        "is `None`, but an occlusion query is currently active"
+                                            .into(),
+                                    vuids: &["VUID-vkCmdExecuteCommands-commandBuffer-00102"],
+                                    ..Default::default()
+                                })
+                            })?;
 
                         if !inherited_flags.contains(state.flags) {
                             return Err(Box::new(ValidationError {

--- a/vulkano/src/command_buffer/commands/sync.rs
+++ b/vulkano/src/command_buffer/commands/sync.rs
@@ -1359,13 +1359,10 @@ where
         // VUID-vkCmdResetEvent2-commonparent
         assert_eq!(device, event.device());
 
-        stages
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "stages".into(),
-                vuids: &["VUID-vkCmdResetEvent2-stageMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        stages.validate_device(device).map_err(|err| {
+            err.add_context("stages")
+                .set_vuids(&["VUID-vkCmdResetEvent2-stageMask-parameter"])
+        })?;
 
         if !device.enabled_features().synchronization2 {
             if stages.contains_flags2() {

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -283,13 +283,10 @@ impl CommandBufferInheritanceInfo {
         }
 
         if let Some(control_flags) = occlusion_query {
-            control_flags
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "occlusion_query".into(),
-                    vuids: &["VUID-VkCommandBufferInheritanceInfo-queryFlags-00057"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            control_flags.validate_device(device).map_err(|err| {
+                err.add_context("occlusion_query")
+                    .set_vuids(&["VUID-VkCommandBufferInheritanceInfo-queryFlags-00057"])
+            })?;
 
             if !device.enabled_features().inherited_queries {
                 return Err(Box::new(ValidationError {
@@ -318,10 +315,9 @@ impl CommandBufferInheritanceInfo {
 
         query_statistics_flags
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "query_statistics_flags".into(),
-                vuids: &["VUID-VkCommandBufferInheritanceInfo-pipelineStatistics-02789"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("query_statistics_flags")
+                    .set_vuids(&["VUID-VkCommandBufferInheritanceInfo-pipelineStatistics-02789"])
             })?;
 
         if query_statistics_flags.count() > 0
@@ -534,10 +530,10 @@ impl CommandBufferInheritanceRenderingInfo {
             .enumerate()
             .flat_map(|(i, f)| f.map(|f| (i, f)))
         {
-            format.validate_device(device).map_err(|err| ValidationError {
-                context: format!("color_attachment_formats[{}]", index).into(),
-                vuids: &["VUID-VkCommandBufferInheritanceRenderingInfo-pColorAttachmentFormats-parameter"],
-                ..ValidationError::from_requirement(err)
+            format.validate_device(device).map_err(|err| {
+                err.add_context(format!("color_attachment_formats[{}]", index)).set_vuids(
+                    &["VUID-VkCommandBufferInheritanceRenderingInfo-pColorAttachmentFormats-parameter"],
+                )
             })?;
 
             if format == Format::UNDEFINED {
@@ -567,10 +563,10 @@ impl CommandBufferInheritanceRenderingInfo {
         }
 
         if let Some(format) = depth_attachment_format {
-            format.validate_device(device).map_err(|err| ValidationError {
-                context: "depth_attachment_format".into(),
-                vuids: &["VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-parameter"],
-                ..ValidationError::from_requirement(err)
+            format.validate_device(device).map_err(|err| {
+                err.add_context("depth_attachment_format").set_vuids(&[
+                    "VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-parameter",
+                ])
             })?;
 
             if format == Format::UNDEFINED {
@@ -614,10 +610,8 @@ impl CommandBufferInheritanceRenderingInfo {
         }
 
         if let Some(format) = stencil_attachment_format {
-            format.validate_device(device).map_err(|err| ValidationError {
-                context: "stencil_attachment_format".into(),
-                vuids: &["VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-parameter"],
-                ..ValidationError::from_requirement(err)
+            format.validate_device(device).map_err(|err| {
+                err.add_context("stencil_attachment_format").set_vuids(&["VUID-VkCommandBufferInheritanceRenderingInfo-stencilAttachmentFormat-parameter"])
             })?;
 
             if format == Format::UNDEFINED {
@@ -678,12 +672,10 @@ impl CommandBufferInheritanceRenderingInfo {
 
         rasterization_samples
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "rasterization_samples".into(),
-                vuids: &[
+            .map_err(|err| {
+                err.add_context("rasterization_samples").set_vuids(&[
                     "VUID-VkCommandBufferInheritanceRenderingInfo-rasterizationSamples-parameter",
-                ],
-                ..ValidationError::from_requirement(err)
+                ])
             })?;
 
         Ok(())

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -157,13 +157,10 @@ impl CommandPool {
     }
 
     fn validate_reset(&self, flags: CommandPoolResetFlags) -> Result<(), Box<ValidationError>> {
-        flags
-            .validate_device(self.device())
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-vkResetCommandPool-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(self.device()).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-vkResetCommandPool-flags-parameter"])
+        })?;
 
         Ok(())
     }
@@ -389,13 +386,10 @@ impl CommandPoolCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkCommandPoolCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkCommandPoolCreateInfo-flags-parameter"])
+        })?;
 
         if queue_family_index >= device.physical_device().queue_family_properties().len() as u32 {
             return Err(Box::new(ValidationError {

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -329,13 +329,10 @@ impl DescriptorSetLayoutCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkDescriptorSetLayoutCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkDescriptorSetLayoutCreateInfo-flags-parameter"])
+        })?;
 
         // VUID-VkDescriptorSetLayoutCreateInfo-binding-00279
         // Ensured because it is a map
@@ -620,23 +617,16 @@ impl DescriptorSetLayoutBinding {
             _ne: _,
         } = self;
 
-        binding_flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "binding_flags".into(),
-                vuids: &[
-                    "VUID-VkDescriptorSetLayoutBindingFlagsCreateInfo-pBindingFlags-parameter",
-                ],
-                ..ValidationError::from_requirement(err)
-            })?;
+        binding_flags.validate_device(device).map_err(|err| {
+            err.add_context("binding_flags").set_vuids(&[
+                "VUID-VkDescriptorSetLayoutBindingFlagsCreateInfo-pBindingFlags-parameter",
+            ])
+        })?;
 
-        descriptor_type
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "descriptor_type".into(),
-                vuids: &["VUID-VkDescriptorSetLayoutBinding-descriptorType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        descriptor_type.validate_device(device).map_err(|err| {
+            err.add_context("descriptor_type")
+                .set_vuids(&["VUID-VkDescriptorSetLayoutBinding-descriptorType-parameter"])
+        })?;
 
         if descriptor_type == DescriptorType::InlineUniformBlock {
             if !device.enabled_features().inline_uniform_block {
@@ -679,13 +669,10 @@ impl DescriptorSetLayoutBinding {
         }
 
         if descriptor_count != 0 {
-            stages
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "stages".into(),
-                    vuids: &["VUID-VkDescriptorSetLayoutBinding-descriptorCount-00283"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            stages.validate_device(device).map_err(|err| {
+                err.add_context("stages")
+                    .set_vuids(&["VUID-VkDescriptorSetLayoutBinding-descriptorCount-00283"])
+            })?;
 
             if descriptor_type == DescriptorType::InputAttachment
                 && !(stages.is_empty() || stages == ShaderStages::FRAGMENT)

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -408,13 +408,10 @@ impl DescriptorPoolCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkDescriptorPoolCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkDescriptorPoolCreateInfo-flags-parameter"])
+        })?;
 
         if max_sets == 0 {
             return Err(Box::new(ValidationError {
@@ -436,13 +433,10 @@ impl DescriptorPoolCreateInfo {
 
         // VUID-VkDescriptorPoolCreateInfo-pPoolSizes-parameter
         for (&descriptor_type, &pool_size) in pool_sizes.iter() {
-            flags
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "pool_sizes".into(),
-                    vuids: &["VUID-VkDescriptorPoolSize-type-parameter"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            flags.validate_device(device).map_err(|err| {
+                err.add_context("pool_sizes")
+                    .set_vuids(&["VUID-VkDescriptorPoolSize-type-parameter"])
+            })?;
 
             if pool_size == 0 {
                 return Err(Box::new(ValidationError {

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -119,8 +119,8 @@ use crate::{
     instance::{Instance, InstanceOwned, InstanceOwnedDebugWrapper},
     macros::{impl_id_counter, vulkan_bitflags},
     memory::ExternalMemoryHandleType,
-    OomError, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version,
-    VulkanError, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,
+    VulkanObject,
 };
 use ash::vk::Handle;
 use parking_lot::Mutex;
@@ -618,13 +618,10 @@ impl Device {
             }));
         }
 
-        build_type
-            .validate_device(self)
-            .map_err(|err| ValidationError {
-                context: "build_type".into(),
-                vuids: &["VUID-vkGetAccelerationStructureBuildSizesKHR-buildType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        build_type.validate_device(self).map_err(|err| {
+            err.add_context("build_type")
+                .set_vuids(&["VUID-vkGetAccelerationStructureBuildSizesKHR-buildType-parameter"])
+        })?;
 
         // VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-parameter
         build_info
@@ -978,13 +975,10 @@ impl Device {
             }));
         }
 
-        handle_type
-            .validate_device(self)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-vkGetMemoryFdPropertiesKHR-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(self).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-vkGetMemoryFdPropertiesKHR-handleType-parameter"])
+        })?;
 
         if handle_type == ExternalMemoryHandleType::OpaqueFd {
             return Err(Box::new(ValidationError {
@@ -1040,7 +1034,7 @@ impl Device {
         &self,
         object: &T,
         object_name: Option<&str>,
-    ) -> Result<(), OomError> {
+    ) -> Result<(), VulkanError> {
         assert!(object.device().handle() == self.handle());
 
         let object_name_vk = object_name.map(|object_name| CString::new(object_name).unwrap());
@@ -1074,7 +1068,7 @@ impl Device {
     /// of the device (either explicitly or implicitly, for example with a future's destructor)
     /// while this function is waiting.
     #[inline]
-    pub unsafe fn wait_idle(&self) -> Result<(), OomError> {
+    pub unsafe fn wait_idle(&self) -> Result<(), VulkanError> {
         let fns = self.fns();
         (fns.v1_0.device_wait_idle)(self.handle)
             .result()
@@ -1289,19 +1283,21 @@ impl DeviceCreateInfo {
                 physical_device.api_version(),
                 physical_device.instance().enabled_extensions(),
             )
-            .map_err(|err| ValidationError {
-                context: "enabled_extensions".into(),
-                problem: err.to_string().into(),
-                vuids: &["VUID-vkCreateDevice-ppEnabledExtensionNames-01387"],
-                ..Default::default()
+            .map_err(|err| {
+                Box::new(ValidationError {
+                    context: "enabled_extensions".into(),
+                    vuids: &["VUID-vkCreateDevice-ppEnabledExtensionNames-01387"],
+                    ..ValidationError::from_error(err)
+                })
             })?;
 
         enabled_features
             .check_requirements(physical_device.supported_features())
-            .map_err(|err| ValidationError {
-                context: "enabled_features".into(),
-                problem: err.to_string().into(),
-                ..Default::default()
+            .map_err(|err| {
+                Box::new(ValidationError {
+                    context: "enabled_features".into(),
+                    ..ValidationError::from_error(err)
+                })
             })?;
 
         let mut dependency_extensions = *enabled_extensions;
@@ -1592,21 +1588,22 @@ impl QueueCreateInfo {
                 device_extensions,
                 physical_device.instance().enabled_extensions(),
             )
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkDeviceQueueCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("flags")
+                    .set_vuids(&["VUID-VkDeviceQueueCreateInfo-flags-parameter"])
             })?;
 
         let queue_family_properties = physical_device
             .queue_family_properties()
             .get(queue_family_index as usize)
-            .ok_or(ValidationError {
-                context: "queue_family_index".into(),
-                problem: "is not less than the number of queue families in the physical device"
-                    .into(),
-                vuids: &["VUID-VkDeviceQueueCreateInfo-queueFamilyIndex-00381"],
-                ..Default::default()
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    context: "queue_family_index".into(),
+                    problem: "is not less than the number of queue families in the physical device"
+                        .into(),
+                    vuids: &["VUID-VkDeviceQueueCreateInfo-queueFamilyIndex-00381"],
+                    ..Default::default()
+                })
             })?;
 
         if queues.is_empty() {

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -807,13 +807,10 @@ impl PhysicalDevice {
     }
 
     fn validate_format_properties(&self, format: Format) -> Result<(), Box<ValidationError>> {
-        format
-            .validate_physical_device(self)
-            .map_err(|err| ValidationError {
-                context: "format".into(),
-                vuids: &["VUID-vkGetPhysicalDeviceFormatProperties2-format-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        format.validate_physical_device(self).map_err(|err| {
+            err.add_context("format")
+                .set_vuids(&["VUID-vkGetPhysicalDeviceFormatProperties2-format-parameter"])
+        })?;
 
         Ok(())
     }
@@ -1528,10 +1525,12 @@ impl PhysicalDevice {
         if let Some(present_mode) = present_mode {
             let mut present_modes = unsafe {
                 self.surface_present_modes_unchecked(surface)
-                    .map_err(|_err| ValidationError {
-                        context: "PhysicalDevice::surface_present_modes".into(),
-                        problem: "returned an error".into(),
-                        ..Default::default()
+                    .map_err(|_err| {
+                        Box::new(ValidationError {
+                            context: "PhysicalDevice::surface_present_modes".into(),
+                            problem: "returned an error".into(),
+                            ..Default::default()
+                        })
                     })?
             };
 
@@ -1893,10 +1892,12 @@ impl PhysicalDevice {
         if let Some(present_mode) = present_mode {
             let mut present_modes = unsafe {
                 self.surface_present_modes_unchecked(surface)
-                    .map_err(|_err| ValidationError {
-                        context: "PhysicalDevice::surface_present_modes".into(),
-                        problem: "returned an error".into(),
-                        ..Default::default()
+                    .map_err(|_err| {
+                        Box::new(ValidationError {
+                            context: "PhysicalDevice::surface_present_modes".into(),
+                            problem: "returned an error".into(),
+                            ..Default::default()
+                        })
                     })?
             };
 

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -26,8 +26,8 @@ use crate::{
         future::{AccessCheckError, GpuFuture},
         semaphore::SemaphoreState,
     },
-    OomError, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version,
-    VulkanError, VulkanObject,
+    Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,
+    VulkanObject,
 };
 use ahash::HashMap;
 use parking_lot::{Mutex, MutexGuard};
@@ -193,7 +193,7 @@ impl<'a> QueueGuard<'a> {
     /// Just like [`Device::wait_idle`], you shouldn't have to call this function in a typical
     /// program.
     #[inline]
-    pub fn wait_idle(&mut self) -> Result<(), OomError> {
+    pub fn wait_idle(&mut self) -> Result<(), VulkanError> {
         self.state.wait_idle(&self.queue.device, self.queue.handle)
     }
 
@@ -1358,7 +1358,7 @@ struct QueueState {
 }
 
 impl QueueState {
-    fn wait_idle(&mut self, device: &Device, handle: ash::vk::Queue) -> Result<(), OomError> {
+    fn wait_idle(&mut self, device: &Device, handle: ash::vk::Queue) -> Result<(), VulkanError> {
         unsafe {
             let fns = device.fns();
             (fns.v1_0.queue_wait_idle)(handle)

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -1386,13 +1386,10 @@ impl ImageSubresourceLayers {
             ref array_layers,
         } = self;
 
-        aspects
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "aspects".into(),
-                vuids: &["VUID-VkImageSubresourceLayers-aspectMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        aspects.validate_device(device).map_err(|err| {
+            err.add_context("aspects")
+                .set_vuids(&["VUID-VkImageSubresourceLayers-aspectMask-parameter"])
+        })?;
 
         if aspects.is_empty() {
             return Err(Box::new(ValidationError {
@@ -1519,13 +1516,10 @@ impl ImageSubresourceRange {
             ref array_layers,
         } = self;
 
-        aspects
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "aspects".into(),
-                vuids: &["VUID-VkImageSubresourceRange-aspectMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        aspects.validate_device(device).map_err(|err| {
+            err.add_context("aspects")
+                .set_vuids(&["VUID-VkImageSubresourceRange-aspectMask-parameter"])
+        })?;
 
         if aspects.is_empty() {
             return Err(Box::new(ValidationError {
@@ -1753,42 +1747,37 @@ impl ImageFormatInfo {
 
         flags
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkPhysicalDeviceImageFormatInfo2-flags-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("flags")
+                    .set_vuids(&["VUID-VkPhysicalDeviceImageFormatInfo2-flags-parameter"])
             })?;
 
         format
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "format".into(),
-                vuids: &["VUID-VkPhysicalDeviceImageFormatInfo2-format-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("format")
+                    .set_vuids(&["VUID-VkPhysicalDeviceImageFormatInfo2-format-parameter"])
             })?;
 
         image_type
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "image_type".into(),
-                vuids: &["VUID-VkPhysicalDeviceImageFormatInfo2-imageType-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("image_type")
+                    .set_vuids(&["VUID-VkPhysicalDeviceImageFormatInfo2-imageType-parameter"])
             })?;
 
         tiling
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "tiling".into(),
-                vuids: &["VUID-VkPhysicalDeviceImageFormatInfo2-tiling-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("tiling")
+                    .set_vuids(&["VUID-VkPhysicalDeviceImageFormatInfo2-tiling-parameter"])
             })?;
 
         usage
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "usage".into(),
-                vuids: &["VUID-VkPhysicalDeviceImageFormatInfo2-usage-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("usage")
+                    .set_vuids(&["VUID-VkPhysicalDeviceImageFormatInfo2-usage-parameter"])
             })?;
 
         if usage.is_empty() {
@@ -1832,10 +1821,9 @@ impl ImageFormatInfo {
 
             stencil_usage
                 .validate_physical_device(physical_device)
-                .map_err(|err| ValidationError {
-                    context: "stencil_usage".into(),
-                    vuids: &["VUID-VkImageStencilUsageCreateInfo-stencilUsage-parameter"],
-                    ..ValidationError::from_requirement(err)
+                .map_err(|err| {
+                    err.add_context("stencil_usage")
+                        .set_vuids(&["VUID-VkImageStencilUsageCreateInfo-stencilUsage-parameter"])
                 })?;
 
             if stencil_usage.is_empty() {
@@ -1869,10 +1857,10 @@ impl ImageFormatInfo {
 
             handle_type
                 .validate_physical_device(physical_device)
-                .map_err(|err| ValidationError {
-                    context: "handle_type".into(),
-                    vuids: &["VUID-VkPhysicalDeviceExternalImageFormatInfo-handleType-parameter"],
-                    ..ValidationError::from_requirement(err)
+                .map_err(|err| {
+                    err.add_context("handle_type").set_vuids(&[
+                        "VUID-VkPhysicalDeviceExternalImageFormatInfo-handleType-parameter",
+                    ])
                 })?;
         }
 
@@ -1889,12 +1877,10 @@ impl ImageFormatInfo {
 
             image_view_type
                 .validate_physical_device(physical_device)
-                .map_err(|err| ValidationError {
-                    context: "image_view_type".into(),
-                    vuids: &[
+                .map_err(|err| {
+                    err.add_context("image_view_type").set_vuids(&[
                         "VUID-VkPhysicalDeviceImageViewImageFormatInfoEXT-imageViewType-parameter",
-                    ],
-                    ..ValidationError::from_requirement(err)
+                    ])
                 })?;
         }
 
@@ -2155,34 +2141,30 @@ impl SparseImageFormatInfo {
 
         format
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "format".into(),
-                vuids: &["VUID-VkPhysicalDeviceSparseImageFormatInfo2-format-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("format")
+                    .set_vuids(&["VUID-VkPhysicalDeviceSparseImageFormatInfo2-format-parameter"])
             })?;
 
         image_type
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "image_type".into(),
-                vuids: &["VUID-VkPhysicalDeviceSparseImageFormatInfo2-type-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("image_type")
+                    .set_vuids(&["VUID-VkPhysicalDeviceSparseImageFormatInfo2-type-parameter"])
             })?;
 
         samples
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "samples".into(),
-                vuids: &["VUID-VkPhysicalDeviceSparseImageFormatInfo2-samples-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("samples")
+                    .set_vuids(&["VUID-VkPhysicalDeviceSparseImageFormatInfo2-samples-parameter"])
             })?;
 
         usage
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "usage".into(),
-                vuids: &["VUID-VkPhysicalDeviceSparseImageFormatInfo2-usage-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("usage")
+                    .set_vuids(&["VUID-VkPhysicalDeviceSparseImageFormatInfo2-usage-parameter"])
             })?;
 
         if usage.is_empty() {
@@ -2196,10 +2178,9 @@ impl SparseImageFormatInfo {
 
         tiling
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "tiling".into(),
-                vuids: &["VUID-VkPhysicalDeviceSparseImageFormatInfo2-tiling-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("tiling")
+                    .set_vuids(&["VUID-VkPhysicalDeviceSparseImageFormatInfo2-tiling-parameter"])
             })?;
 
         // VUID-VkPhysicalDeviceSparseImageFormatInfo2-samples-01095

--- a/vulkano/src/image/sampler/mod.rs
+++ b/vulkano/src/image/sampler/mod.rs
@@ -814,60 +814,43 @@ impl SamplerCreateInfo {
 
         let properties = device.physical_device().properties();
 
-        mag_filter
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "mag_filter".into(),
-                vuids: &["VUID-VkSamplerCreateInfo-magFilter-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        mag_filter.validate_device(device).map_err(|err| {
+            err.add_context("mag_filter")
+                .set_vuids(&["VUID-VkSamplerCreateInfo-magFilter-parameter"])
+        })?;
 
-        min_filter
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "min_filter".into(),
-                vuids: &["VUID-VkSamplerCreateInfo-minFilter-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        min_filter.validate_device(device).map_err(|err| {
+            err.add_context("min_filter")
+                .set_vuids(&["VUID-VkSamplerCreateInfo-minFilter-parameter"])
+        })?;
 
-        mipmap_mode
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "mipmap_mode".into(),
-                vuids: &["VUID-VkSamplerCreateInfo-mipmapMode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        mipmap_mode.validate_device(device).map_err(|err| {
+            err.add_context("mipmap_mode")
+                .set_vuids(&["VUID-VkSamplerCreateInfo-mipmapMode-parameter"])
+        })?;
 
         for (index, mode) in address_mode.into_iter().enumerate() {
-            mode.validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: format!("address_mode[{}]", index).into(),
-                    vuids: &[
+            mode.validate_device(device).map_err(|err| {
+                err.add_context(format!("address_mode[{}]", index))
+                    .set_vuids(&[
                         "VUID-VkSamplerCreateInfo-addressModeU-parameter",
                         "VUID-VkSamplerCreateInfo-addressModeV-parameter",
                         "VUID-VkSamplerCreateInfo-addressModeW-parameter",
-                    ],
-                    ..ValidationError::from_requirement(err)
-                })?;
+                    ])
+            })?;
         }
 
         if address_mode.contains(&SamplerAddressMode::ClampToBorder) {
-            border_color
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "border_color".into(),
-                    vuids: &["VUID-VkSamplerCreateInfo-addressModeU-01078"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            border_color.validate_device(device).map_err(|err| {
+                err.add_context("border_color")
+                    .set_vuids(&["VUID-VkSamplerCreateInfo-addressModeU-01078"])
+            })?;
         }
 
-        reduction_mode
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "reduction_mode".into(),
-                vuids: &["VUID-VkSamplerReductionModeCreateInfo-reductionMode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        reduction_mode.validate_device(device).map_err(|err| {
+            err.add_context("reduction_mode")
+                .set_vuids(&["VUID-VkSamplerReductionModeCreateInfo-reductionMode-parameter"])
+        })?;
 
         if address_mode.contains(&SamplerAddressMode::MirrorClampToEdge) {
             if !(device.enabled_features().sampler_mirror_clamp_to_edge
@@ -964,13 +947,10 @@ impl SamplerCreateInfo {
         }
 
         if let Some(compare_op) = compare {
-            compare_op
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "compare".into(),
-                    vuids: &["VUID-VkSamplerCreateInfo-compareEnable-01080"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            compare_op.validate_device(device).map_err(|err| {
+                err.add_context("compare")
+                    .set_vuids(&["VUID-VkSamplerCreateInfo-compareEnable-01080"])
+            })?;
 
             if reduction_mode != SamplerReductionMode::WeightedAverage {
                 return Err(Box::new(ValidationError {
@@ -1249,28 +1229,24 @@ impl ComponentMapping {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self { r, g, b, a } = self;
 
-        r.validate_device(device).map_err(|err| ValidationError {
-            context: "r".into(),
-            vuids: &["VUID-VkComponentMapping-r-parameter"],
-            ..ValidationError::from_requirement(err)
+        r.validate_device(device).map_err(|err| {
+            err.add_context("r")
+                .set_vuids(&["VUID-VkComponentMapping-r-parameter"])
         })?;
 
-        g.validate_device(device).map_err(|err| ValidationError {
-            context: "g".into(),
-            vuids: &["VUID-VkComponentMapping-g-parameter"],
-            ..ValidationError::from_requirement(err)
+        g.validate_device(device).map_err(|err| {
+            err.add_context("g")
+                .set_vuids(&["VUID-VkComponentMapping-g-parameter"])
         })?;
 
-        b.validate_device(device).map_err(|err| ValidationError {
-            context: "b".into(),
-            vuids: &["VUID-VkComponentMapping-b-parameter"],
-            ..ValidationError::from_requirement(err)
+        b.validate_device(device).map_err(|err| {
+            err.add_context("b")
+                .set_vuids(&["VUID-VkComponentMapping-b-parameter"])
         })?;
 
-        a.validate_device(device).map_err(|err| ValidationError {
-            context: "a".into(),
-            vuids: &["VUID-VkComponentMapping-a-parameter"],
-            ..ValidationError::from_requirement(err)
+        a.validate_device(device).map_err(|err| {
+            err.add_context("a")
+                .set_vuids(&["VUID-VkComponentMapping-a-parameter"])
         })?;
 
         Ok(())

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -468,54 +468,39 @@ impl SamplerYcbcrConversionCreateInfo {
             _ne: _,
         } = self;
 
-        format
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "format".into(),
-                vuids: &["VUID-VkSamplerYcbcrConversionCreateInfo-format-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        format.validate_device(device).map_err(|err| {
+            err.add_context("format")
+                .set_vuids(&["VUID-VkSamplerYcbcrConversionCreateInfo-format-parameter"])
+        })?;
 
-        ycbcr_model
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "ycbcr_model".into(),
-                vuids: &["VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        ycbcr_model.validate_device(device).map_err(|err| {
+            err.add_context("ycbcr_model")
+                .set_vuids(&["VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-parameter"])
+        })?;
 
-        ycbcr_range
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "ycbcr_range".into(),
-                vuids: &["VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrRange-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        ycbcr_range.validate_device(device).map_err(|err| {
+            err.add_context("ycbcr_range")
+                .set_vuids(&["VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrRange-parameter"])
+        })?;
 
         component_mapping
             .validate(device)
             .map_err(|err| err.add_context("component_mapping"))?;
 
         for (index, offset) in chroma_offset.into_iter().enumerate() {
-            offset
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: format!("chroma_offset[{}]", index).into(),
-                    vuids: &[
+            offset.validate_device(device).map_err(|err| {
+                err.add_context(format!("chroma_offset[{}]", index))
+                    .set_vuids(&[
                         "VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-parameter",
                         "VUID-VkSamplerYcbcrConversionCreateInfo-yChromaOffset-parameter",
-                    ],
-                    ..ValidationError::from_requirement(err)
-                })?;
+                    ])
+            })?;
         }
 
-        chroma_filter
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "chroma_filter".into(),
-                vuids: &["VUID-VkSamplerYcbcrConversionCreateInfo-chromaFilter-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        chroma_filter.validate_device(device).map_err(|err| {
+            err.add_context("chroma_filter")
+                .set_vuids(&["VUID-VkSamplerYcbcrConversionCreateInfo-chromaFilter-parameter"])
+        })?;
 
         if !format
             .numeric_format_color()

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -931,21 +931,15 @@ impl ImageViewCreateInfo {
             _ne: _,
         } = self;
 
-        view_type
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "view_type".into(),
-                vuids: &["VUID-VkImageViewCreateInfo-viewType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        view_type.validate_device(device).map_err(|err| {
+            err.add_context("view_type")
+                .set_vuids(&["VUID-VkImageViewCreateInfo-viewType-parameter"])
+        })?;
 
-        format
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "format".into(),
-                vuids: &["VUID-VkImageViewCreateInfo-format-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        format.validate_device(device).map_err(|err| {
+            err.add_context("format")
+                .set_vuids(&["VUID-VkImageViewCreateInfo-format-parameter"])
+        })?;
 
         component_mapping
             .validate(device)
@@ -955,13 +949,10 @@ impl ImageViewCreateInfo {
             .validate(device)
             .map_err(|err| err.add_context("subresource_range"))?;
 
-        usage
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "usage".into(),
-                vuids: &["VUID-VkImageViewUsageCreateInfo-usage-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        usage.validate_device(device).map_err(|err| {
+            err.add_context("usage")
+                .set_vuids(&["VUID-VkImageViewUsageCreateInfo-usage-parameter"])
+        })?;
 
         match view_type {
             ImageViewType::Dim1d | ImageViewType::Dim2d | ImageViewType::Dim3d => {

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -229,10 +229,10 @@ impl DebugUtilsMessengerCreateInfo {
 
         message_severity
             .validate_instance_raw(instance_api_version, instance_extensions)
-            .map_err(|err| ValidationError {
-                context: "message_severity".into(),
-                vuids: &["VUID-VkDebugUtilsMessengerCreateInfoEXT-messageSeverity-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("message_severity").set_vuids(&[
+                    "VUID-VkDebugUtilsMessengerCreateInfoEXT-messageSeverity-parameter",
+                ])
             })?;
 
         if message_severity.is_empty() {
@@ -246,10 +246,9 @@ impl DebugUtilsMessengerCreateInfo {
 
         message_type
             .validate_instance_raw(instance_api_version, instance_extensions)
-            .map_err(|err| ValidationError {
-                context: "message_type".into(),
-                vuids: &["VUID-VkDebugUtilsMessengerCreateInfoEXT-messageType-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("message_type")
+                    .set_vuids(&["VUID-VkDebugUtilsMessengerCreateInfoEXT-messageType-parameter"])
             })?;
 
         if message_type.is_empty() {

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -338,11 +338,12 @@ impl Instance {
 
         enabled_extensions
             .check_requirements(&supported_extensions, api_version)
-            .map_err(|err| ValidationError {
-                context: "create_info.enabled_extensions".into(),
-                problem: err.to_string().into(),
-                vuids: &["VUID-vkCreateInstance-ppEnabledExtensionNames-01388"],
-                ..Default::default()
+            .map_err(|err| {
+                Box::new(ValidationError {
+                    context: "create_info.enabled_extensions".into(),
+                    vuids: &["VUID-vkCreateInstance-ppEnabledExtensionNames-01388"],
+                    ..ValidationError::from_error(err)
+                })
             })?;
 
         Ok(())
@@ -1051,10 +1052,9 @@ impl InstanceCreateInfo {
 
         flags
             .validate_instance_raw(api_version, enabled_extensions)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkInstanceCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("flags")
+                    .set_vuids(&["VUID-VkInstanceCreateInfo-flags-parameter"])
             })?;
 
         if !debug_utils_messengers.is_empty() {
@@ -1091,12 +1091,11 @@ impl InstanceCreateInfo {
             for (index, enabled) in enabled_validation_features.iter().enumerate() {
                 enabled
                     .validate_instance_raw(api_version, enabled_extensions)
-                    .map_err(|err| ValidationError {
-                        context: format!("enabled_validation_features[{}]", index).into(),
-                        vuids: &[
-                            "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter",
-                        ],
-                        ..ValidationError::from_requirement(err)
+                    .map_err(|err| {
+                        err.add_context(format!("enabled_validation_features[{}]", index))
+                            .set_vuids(&[
+                                "VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-parameter",
+                            ])
                     })?;
             }
 
@@ -1144,12 +1143,12 @@ impl InstanceCreateInfo {
             for (index, disabled) in disabled_validation_features.iter().enumerate() {
                 disabled
                     .validate_instance_raw(api_version, enabled_extensions)
-                    .map_err(|err| ValidationError {
-                        context: format!("disabled_validation_features[{}]", index).into(),
-                        vuids: &[
+                    .map_err(|err| {
+                        err.add_context(format!("disabled_validation_features[{}]", index)).set_vuids(
+                        &[
                             "VUID-VkValidationFeaturesEXT-pDisabledValidationFeatures-parameter",
                         ],
-                        ..ValidationError::from_requirement(err)
+                    )
                     })?;
             }
         }

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -501,15 +501,6 @@ pub struct ValidationError {
 }
 
 impl ValidationError {
-    fn from_requirement(err: RequirementNotMet) -> Self {
-        Self {
-            context: "".into(),
-            problem: err.required_for.into(),
-            vuids: &[],
-            requires_one_of: err.requires_one_of,
-        }
-    }
-
     fn from_error<E: Error>(err: E) -> Self {
         Self {
             context: "".into(),
@@ -526,6 +517,11 @@ impl ValidationError {
             self.context = format!("{}.{}", context.into(), self.context).into();
         }
 
+        self
+    }
+
+    fn set_vuids(mut self: Box<Self>, vuids: &'static [&'static str]) -> Box<Self> {
+        self.vuids = vuids;
         self
     }
 }
@@ -684,44 +680,6 @@ impl Display for Requires {
             Requires::InstanceExtension(instance_extension) => {
                 write!(f, "instance extension `{}`", instance_extension)
             }
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct RequirementNotMet {
-    pub(crate) required_for: &'static str,
-    pub(crate) requires_one_of: RequiresOneOf,
-}
-
-/// Error type returned by most Vulkan functions.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum OomError {
-    /// There is no memory available on the host (ie. the CPU, RAM, etc.).
-    OutOfHostMemory,
-    /// There is no memory available on the device (ie. video memory).
-    OutOfDeviceMemory,
-}
-
-impl Error for OomError {}
-
-impl Display for OomError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        let msg = match self {
-            OomError::OutOfHostMemory => "no memory available on the host",
-            OomError::OutOfDeviceMemory => "no memory available on the graphical device",
-        };
-
-        write!(f, "{msg}")
-    }
-}
-
-impl From<VulkanError> for OomError {
-    fn from(err: VulkanError) -> OomError {
-        match err {
-            VulkanError::OutOfHostMemory => OomError::OutOfHostMemory,
-            VulkanError::OutOfDeviceMemory => OomError::OutOfDeviceMemory,
-            _ => panic!("unexpected error: {:?}", err),
         }
     }
 }

--- a/vulkano/src/library.rs
+++ b/vulkano/src/library.rs
@@ -21,7 +21,7 @@
 pub use crate::fns::EntryFunctions;
 use crate::{
     instance::{InstanceExtensions, LayerProperties},
-    ExtensionProperties, OomError, SafeDeref, Version, VulkanError,
+    ExtensionProperties, SafeDeref, Version, VulkanError,
 };
 use libloading::{Error as LibloadingError, Library};
 use std::{
@@ -233,7 +233,7 @@ impl VulkanLibrary {
     /// ```
     pub fn layer_properties(
         &self,
-    ) -> Result<impl ExactSizeIterator<Item = LayerProperties>, OomError> {
+    ) -> Result<impl ExactSizeIterator<Item = LayerProperties>, VulkanError> {
         let fns = self.fns();
 
         let layer_properties = unsafe {
@@ -255,7 +255,7 @@ impl VulkanLibrary {
                         break properties;
                     }
                     ash::vk::Result::INCOMPLETE => (),
-                    err => return Err(VulkanError::from(err).into()),
+                    err => return Err(VulkanError::from(err)),
                 }
             }
         };

--- a/vulkano/src/macros.rs
+++ b/vulkano/src/macros.rs
@@ -330,7 +330,7 @@ macro_rules! vulkan_bitflags {
             pub(crate) fn validate_device(
                 self,
                 device: &crate::device::Device,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 self.validate_device_raw(
                     device.api_version(),
                     device.enabled_features(),
@@ -344,7 +344,7 @@ macro_rules! vulkan_bitflags {
             pub(crate) fn validate_physical_device(
                 self,
                 physical_device: &crate::device::physical::PhysicalDevice,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 self.validate_device_raw(
                     physical_device.api_version(),
                     physical_device.supported_features(),
@@ -360,7 +360,7 @@ macro_rules! vulkan_bitflags {
                 #[allow(unused_variables)] device_features: &crate::device::Features,
                 #[allow(unused_variables)] device_extensions: &crate::device::DeviceExtensions,
                 #[allow(unused_variables)] instance_extensions: &crate::instance::InstanceExtensions,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 $(
                     $(
                         if self.intersects(Self::$flag_name) && ![
@@ -379,8 +379,8 @@ macro_rules! vulkan_bitflags {
                                 )+)?
                             ].into_iter().all(|x| x)),*
                         ].into_iter().any(|x| x) {
-                            return Err(crate::RequirementNotMet {
-                                required_for: concat!("`", stringify!($ty), "::", stringify!($flag_name), "`"),
+                            return Err(Box::new(crate::ValidationError {
+                                problem: concat!("is `", stringify!($ty), "::", stringify!($flag_name), "`").into(),
                                 requires_one_of: crate::RequiresOneOf(&[
                                     $(crate::RequiresAllOf(&[
                                         $(
@@ -397,7 +397,8 @@ macro_rules! vulkan_bitflags {
                                         )+)?
                                     ])),*
                                 ]),
-                            });
+                                ..Default::default()
+                            }));
                         }
                     )?
                 )*
@@ -410,7 +411,7 @@ macro_rules! vulkan_bitflags {
             pub(crate) fn validate_instance(
                 self,
                 instance: &crate::instance::Instance,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 self.validate_instance_raw(
                     instance.api_version(),
                     instance.enabled_extensions(),
@@ -422,7 +423,7 @@ macro_rules! vulkan_bitflags {
                 self,
                 #[allow(unused_variables)] instance_api_version: crate::Version,
                 #[allow(unused_variables)] instance_extensions: &crate::instance::InstanceExtensions,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 $(
                     $(
                         if self.intersects(Self::$flag_name) && ![
@@ -435,8 +436,8 @@ macro_rules! vulkan_bitflags {
                                 )+)?
                             ].into_iter().all(|x| x)),*
                         ].into_iter().any(|x| x) {
-                            return Err(crate::RequirementNotMet {
-                                required_for: concat!("`", stringify!($ty), "::", stringify!($flag_name), "`"),
+                            return Err(Box::new(crate::ValidationError {
+                                problem: concat!("is `", stringify!($ty), "::", stringify!($flag_name), "`").into(),
                                 requires_one_of: crate::RequiresOneOf(&[
                                     $(crate::RequiresAllOf(&[
                                         $(
@@ -447,7 +448,8 @@ macro_rules! vulkan_bitflags {
                                         )+)?
                                     ])),*
                                 ]),
-                            });
+                                ..Default::default()
+                            }));
                         }
                     )?
                 )*
@@ -668,7 +670,7 @@ macro_rules! vulkan_enum {
             pub(crate) fn validate_device(
                 self,
                 device: &crate::device::Device,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 self.validate_device_raw(
                     device.api_version(),
                     device.enabled_features(),
@@ -682,7 +684,7 @@ macro_rules! vulkan_enum {
             pub(crate) fn validate_physical_device(
                 self,
                 physical_device: &crate::device::physical::PhysicalDevice,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 self.validate_device_raw(
                     physical_device.api_version(),
                     physical_device.supported_features(),
@@ -698,7 +700,7 @@ macro_rules! vulkan_enum {
                 #[allow(unused_variables)] device_features: &crate::device::Features,
                 #[allow(unused_variables)] device_extensions: &crate::device::DeviceExtensions,
                 #[allow(unused_variables)] instance_extensions: &crate::instance::InstanceExtensions,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 match self {
                     $(
                         $(
@@ -719,8 +721,8 @@ macro_rules! vulkan_enum {
                                         )+)?
                                     ].into_iter().all(|x| x)),*
                                  ].into_iter().any(|x| x) {
-                                    return Err(crate::RequirementNotMet {
-                                        required_for: concat!("`", stringify!($ty), "::", stringify!($flag_name), "`"),
+                                    return Err(Box::new(crate::ValidationError {
+                                        problem: concat!("is `", stringify!($ty), "::", stringify!($flag_name), "`").into(),
                                         requires_one_of: crate::RequiresOneOf(&[
                                             $(crate::RequiresAllOf(&[
                                                 $(
@@ -737,7 +739,8 @@ macro_rules! vulkan_enum {
                                                 )+)?
                                             ])),*
                                         ]),
-                                    });
+                                        ..Default::default()
+                                    }));
                                 }
                             },
                         )?
@@ -753,7 +756,7 @@ macro_rules! vulkan_enum {
             pub(crate) fn validate_instance(
                 self,
                 instance: &crate::instance::Instance,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 self.validate_instance_raw(
                     instance.api_version(),
                     instance.enabled_extensions(),
@@ -765,7 +768,7 @@ macro_rules! vulkan_enum {
                 self,
                 #[allow(unused_variables)] instance_api_version: crate::Version,
                 #[allow(unused_variables)] instance_extensions: &crate::instance::InstanceExtensions,
-            ) -> Result<(), crate::RequirementNotMet> {
+            ) -> Result<(), Box<crate::ValidationError>> {
                 match self {
                     $(
                         $(
@@ -780,8 +783,8 @@ macro_rules! vulkan_enum {
                                         )+)?
                                     ].into_iter().all(|x| x)),*
                                  ].into_iter().any(|x| x) {
-                                    return Err(crate::RequirementNotMet {
-                                        required_for: concat!("`", stringify!($ty), "::", stringify!($flag_name), "`"),
+                                    return Err(Box::new(crate::ValidationError {
+                                        problem: concat!("is `", stringify!($ty), "::", stringify!($flag_name), "`").into(),
                                         requires_one_of: crate::RequiresOneOf(&[
                                             $(crate::RequiresAllOf(&[
                                                 $(
@@ -792,7 +795,8 @@ macro_rules! vulkan_enum {
                                                 )+)?
                                             ])),*
                                         ]),
-                                    });
+                                        ..Default::default()
+                                    }));
                                 }
                             },
                         )?

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -939,10 +939,7 @@ impl<S: Suballocator> GenericMemoryAllocator<S> {
             for (index, export_handle_types) in export_handle_types.iter().enumerate() {
                 export_handle_types
                     .validate_device(device)
-                    .map_err(|err| ValidationError {
-                        context: format!("export_handle_types[{}]", index).into(),
-                        ..ValidationError::from_requirement(err)
-                    })?;
+                    .map_err(|err| err.add_context(format!("export_handle_types[{}]", index)))?;
             }
         }
 

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -440,13 +440,10 @@ impl DeviceMemory {
         &self,
         handle_type: ExternalMemoryHandleType,
     ) -> Result<(), Box<ValidationError>> {
-        handle_type
-            .validate_device(&self.device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkMemoryGetFdInfoKHR-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(&self.device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkMemoryGetFdInfoKHR-handleType-parameter"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -621,11 +618,13 @@ impl<'d> MemoryAllocateInfo<'d> {
         let memory_type = memory_properties
             .memory_types
             .get(memory_type_index as usize)
-            .ok_or(ValidationError {
-                context: "memory_type_index".into(),
-                problem: "is not less than the number of memory types in the device".into(),
-                vuids: &["VUID-vkAllocateMemory-pAllocateInfo-01714"],
-                ..Default::default()
+            .ok_or_else(|| {
+                Box::new(ValidationError {
+                    context: "memory_type_index".into(),
+                    problem: "is not less than the number of memory types in the device".into(),
+                    vuids: &["VUID-vkAllocateMemory-pAllocateInfo-01714"],
+                    ..Default::default()
+                })
             })?;
         let memory_heap = &memory_properties.memory_heaps[memory_type.heap_index as usize];
 
@@ -733,13 +732,10 @@ impl<'d> MemoryAllocateInfo<'d> {
                 }));
             }
 
-            export_handle_types
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "export_handle_types".into(),
-                    vuids: &["VUID-VkExportMemoryAllocateInfo-handleTypes-parameter"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            export_handle_types.validate_device(device).map_err(|err| {
+                err.add_context("export_handle_types")
+                    .set_vuids(&["VUID-VkExportMemoryAllocateInfo-handleTypes-parameter"])
+            })?;
 
             // VUID-VkMemoryAllocateInfo-pNext-00639
             // VUID-VkExportMemoryAllocateInfo-handleTypes-00656
@@ -869,13 +865,10 @@ impl MemoryImportInfo {
 
                 #[cfg(unix)]
                 {
-                    handle_type
-                        .validate_device(device)
-                        .map_err(|err| ValidationError {
-                            context: "handle_type".into(),
-                            vuids: &["VUID-VkImportMemoryFdInfoKHR-handleType-parameter"],
-                            ..ValidationError::from_requirement(err)
-                        })?;
+                    handle_type.validate_device(device).map_err(|err| {
+                        err.add_context("handle_type")
+                            .set_vuids(&["VUID-VkImportMemoryFdInfoKHR-handleType-parameter"])
+                    })?;
 
                     match handle_type {
                         ExternalMemoryHandleType::OpaqueFd => {
@@ -929,13 +922,11 @@ impl MemoryImportInfo {
 
                 #[cfg(windows)]
                 {
-                    handle_type
-                        .validate_device(device)
-                        .map_err(|err| ValidationError {
-                            context: "handle_type".into(),
-                            vuids: &["VUID-VkImportMemoryWin32HandleInfoKHR-handleType-parameter"],
-                            ..ValidationError::from_requirement(err)
-                        })?;
+                    handle_type.validate_device(device).map_err(|err| {
+                        err.add_context("handle_type").set_vuids(&[
+                            "VUID-VkImportMemoryWin32HandleInfoKHR-handleType-parameter",
+                        ])
+                    })?;
 
                     match handle_type {
                         ExternalMemoryHandleType::OpaqueWin32

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -365,13 +365,10 @@ impl PipelineCacheCreateInfo {
             _ne,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkPipelineCacheCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkPipelineCacheCreateInfo-flags-parameter"])
+        })?;
 
         Ok(())
     }

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -320,13 +320,10 @@ impl ComputePipelineCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkComputePipelineCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkComputePipelineCreateInfo-flags-parameter"])
+        })?;
 
         stage
             .validate(device)
@@ -359,15 +356,17 @@ impl ComputePipelineCreateInfo {
                     .map(|(k, v)| (*k, v)),
                 entry_point_info.push_constant_requirements.as_ref(),
             )
-            .map_err(|err| ValidationError {
-                context: "stage.entry_point".into(),
-                vuids: &[
-                    "VUID-VkComputePipelineCreateInfo-layout-07987",
-                    "VUID-VkComputePipelineCreateInfo-layout-07988",
-                    "VUID-VkComputePipelineCreateInfo-layout-07990",
-                    "VUID-VkComputePipelineCreateInfo-layout-07991",
-                ],
-                ..ValidationError::from_error(err)
+            .map_err(|err| {
+                Box::new(ValidationError {
+                    context: "stage.entry_point".into(),
+                    vuids: &[
+                        "VUID-VkComputePipelineCreateInfo-layout-07987",
+                        "VUID-VkComputePipelineCreateInfo-layout-07988",
+                        "VUID-VkComputePipelineCreateInfo-layout-07990",
+                        "VUID-VkComputePipelineCreateInfo-layout-07991",
+                    ],
+                    ..ValidationError::from_error(err)
+                })
             })?;
 
         // TODO:

--- a/vulkano/src/pipeline/graphics/color_blend.rs
+++ b/vulkano/src/pipeline/graphics/color_blend.rs
@@ -154,13 +154,10 @@ impl ColorBlendState {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkPipelineColorBlendStateCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkPipelineColorBlendStateCreateInfo-flags-parameter"])
+        })?;
 
         if let Some(logic_op) = logic_op {
             if !device.enabled_features().logic_op {
@@ -175,17 +172,11 @@ impl ColorBlendState {
             }
 
             match logic_op {
-                StateMode::Fixed(logic_op) => {
-                    logic_op
-                        .validate_device(device)
-                        .map_err(|err| ValidationError {
-                            context: "logic_op".into(),
-                            vuids: &[
-                                "VUID-VkPipelineColorBlendStateCreateInfo-logicOpEnable-00607",
-                            ],
-                            ..ValidationError::from_requirement(err)
-                        })?
-                }
+                StateMode::Fixed(logic_op) => logic_op.validate_device(device).map_err(|err| {
+                    err.add_context("logic_op").set_vuids(&[
+                        "VUID-VkPipelineColorBlendStateCreateInfo-logicOpEnable-00607",
+                    ])
+                })?,
                 StateMode::Dynamic => {
                     if !device.enabled_features().extended_dynamic_state2_logic_op {
                         return Err(Box::new(ValidationError {
@@ -471,51 +462,45 @@ impl AttachmentBlend {
 
         src_color_blend_factor
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_color_blend_factor".into(),
-                vuids: &["VUID-VkPipelineColorBlendAttachmentState-srcColorBlendFactor-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("src_color_blend_factor").set_vuids(&[
+                    "VUID-VkPipelineColorBlendAttachmentState-srcColorBlendFactor-parameter",
+                ])
             })?;
 
         dst_color_blend_factor
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_color_blend_factor".into(),
-                vuids: &["VUID-VkPipelineColorBlendAttachmentState-dstColorBlendFactor-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("dst_color_blend_factor").set_vuids(&[
+                    "VUID-VkPipelineColorBlendAttachmentState-dstColorBlendFactor-parameter",
+                ])
             })?;
 
-        color_blend_op
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "color_blend_op".into(),
-                vuids: &["VUID-VkPipelineColorBlendAttachmentState-colorBlendOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        color_blend_op.validate_device(device).map_err(|err| {
+            err.add_context("color_blend_op")
+                .set_vuids(&["VUID-VkPipelineColorBlendAttachmentState-colorBlendOp-parameter"])
+        })?;
 
         src_alpha_blend_factor
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_alpha_blend_factor".into(),
-                vuids: &["VUID-VkPipelineColorBlendAttachmentState-srcAlphaBlendFactor-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("src_alpha_blend_factor").set_vuids(&[
+                    "VUID-VkPipelineColorBlendAttachmentState-srcAlphaBlendFactor-parameter",
+                ])
             })?;
 
         dst_alpha_blend_factor
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_alpha_blend_factor".into(),
-                vuids: &["VUID-VkPipelineColorBlendAttachmentState-dstAlphaBlendFactor-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("dst_alpha_blend_factor").set_vuids(&[
+                    "VUID-VkPipelineColorBlendAttachmentState-dstAlphaBlendFactor-parameter",
+                ])
             })?;
 
-        alpha_blend_op
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "alpha_blend_op".into(),
-                vuids: &["VUID-VkPipelineColorBlendAttachmentState-alphaBlendOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        alpha_blend_op.validate_device(device).map_err(|err| {
+            err.add_context("alpha_blend_op")
+                .set_vuids(&["VUID-VkPipelineColorBlendAttachmentState-alphaBlendOp-parameter"])
+        })?;
 
         if !device.enabled_features().dual_src_blend {
             if matches!(

--- a/vulkano/src/pipeline/graphics/depth_stencil.rs
+++ b/vulkano/src/pipeline/graphics/depth_stencil.rs
@@ -96,13 +96,10 @@ impl DepthStencilState {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkPipelineDepthStencilStateCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkPipelineDepthStencilStateCreateInfo-flags-parameter"])
+        })?;
 
         if let Some(depth_state) = depth {
             depth_state
@@ -243,15 +240,11 @@ impl DepthState {
 
         match compare_op {
             StateMode::Fixed(compare_op) => {
-                compare_op
-                    .validate_device(device)
-                    .map_err(|err| ValidationError {
-                        context: "compare_op".into(),
-                        vuids: &[
-                            "VUID-VkPipelineDepthStencilStateCreateInfo-depthCompareOp-parameter",
-                        ],
-                        ..ValidationError::from_requirement(err)
-                    })?;
+                compare_op.validate_device(device).map_err(|err| {
+                    err.add_context("compare_op").set_vuids(&[
+                        "VUID-VkPipelineDepthStencilStateCreateInfo-depthCompareOp-parameter",
+                    ])
+                })?;
             }
             StateMode::Dynamic => {
                 if !(device.api_version() >= Version::V1_3
@@ -568,37 +561,25 @@ impl StencilOps {
             compare_op,
         } = self;
 
-        fail_op
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "fail_op".into(),
-                vuids: &["VUID-VkStencilOpState-failOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        fail_op.validate_device(device).map_err(|err| {
+            err.add_context("fail_op")
+                .set_vuids(&["VUID-VkStencilOpState-failOp-parameter"])
+        })?;
 
-        pass_op
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "pass_op".into(),
-                vuids: &["VUID-VkStencilOpState-passOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        pass_op.validate_device(device).map_err(|err| {
+            err.add_context("pass_op")
+                .set_vuids(&["VUID-VkStencilOpState-passOp-parameter"])
+        })?;
 
-        depth_fail_op
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "depth_fail_op".into(),
-                vuids: &["VUID-VkStencilOpState-depthFailOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        depth_fail_op.validate_device(device).map_err(|err| {
+            err.add_context("depth_fail_op")
+                .set_vuids(&["VUID-VkStencilOpState-depthFailOp-parameter"])
+        })?;
 
-        compare_op
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "compare_op".into(),
-                vuids: &["VUID-VkStencilOpState-compareOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        compare_op.validate_device(device).map_err(|err| {
+            err.add_context("compare_op")
+                .set_vuids(&["VUID-VkStencilOpState-compareOp-parameter"])
+        })?;
 
         Ok(())
     }

--- a/vulkano/src/pipeline/graphics/discard_rectangle.rs
+++ b/vulkano/src/pipeline/graphics/discard_rectangle.rs
@@ -55,10 +55,10 @@ impl DiscardRectangleState {
 
         let properties = device.physical_device().properties();
 
-        mode.validate_device(device).map_err(|err| ValidationError {
-            context: "mode".into(),
-            vuids: &["VUID-VkPipelineDiscardRectangleStateCreateInfoEXT-discardRectangleMode-parameter"],
-            ..ValidationError::from_requirement(err)
+        mode.validate_device(device).map_err(|err| {
+            err.add_context("mode").set_vuids(&[
+                "VUID-VkPipelineDiscardRectangleStateCreateInfoEXT-discardRectangleMode-parameter",
+            ])
         })?;
 
         let discard_rectangle_count = match rectangles {

--- a/vulkano/src/pipeline/graphics/input_assembly.rs
+++ b/vulkano/src/pipeline/graphics/input_assembly.rs
@@ -93,13 +93,11 @@ impl InputAssemblyState {
 
         match topology {
             PartialStateMode::Fixed(topology) => {
-                topology
-                    .validate_device(device)
-                    .map_err(|err| ValidationError {
-                        context: "topology".into(),
-                        vuids: &["VUID-VkPipelineInputAssemblyStateCreateInfo-topology-parameter"],
-                        ..ValidationError::from_requirement(err)
-                    })?;
+                topology.validate_device(device).map_err(|err| {
+                    err.add_context("topology").set_vuids(&[
+                        "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-parameter",
+                    ])
+                })?;
 
                 match topology {
                     PrimitiveTopology::TriangleFan => {
@@ -156,10 +154,10 @@ impl InputAssemblyState {
                 topology_class
                     .example()
                     .validate_device(device)
-                    .map_err(|err| ValidationError {
-                        context: "topology".into(),
-                        vuids: &["VUID-VkPipelineInputAssemblyStateCreateInfo-topology-parameter"],
-                        ..ValidationError::from_requirement(err)
+                    .map_err(|err| {
+                        err.add_context("topology").set_vuids(&[
+                            "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-parameter",
+                        ])
                     })?;
 
                 if !(device.api_version() >= Version::V1_3

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -1900,13 +1900,10 @@ impl GraphicsPipelineCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkGraphicsPipelineCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkGraphicsPipelineCreateInfo-flags-parameter"])
+        })?;
 
         /*
             Gather shader stages
@@ -2436,10 +2433,12 @@ impl GraphicsPipelineCreateInfo {
                         .map(|(k, v)| (*k, v)),
                     entry_point_info.push_constant_requirements.as_ref(),
                 )
-                .map_err(|err| ValidationError {
-                    context: format!("stages[{}].entry_point", stage_index).into(),
-                    vuids: &["VUID-VkGraphicsPipelineCreateInfo-layout-00756"],
-                    ..ValidationError::from_error(err)
+                .map_err(|err| {
+                    Box::new(ValidationError {
+                        context: format!("stages[{}].entry_point", stage_index).into(),
+                        vuids: &["VUID-VkGraphicsPipelineCreateInfo-layout-00756"],
+                        ..ValidationError::from_error(err)
+                    })
                 })?;
         }
 

--- a/vulkano/src/pipeline/graphics/multisample.rs
+++ b/vulkano/src/pipeline/graphics/multisample.rs
@@ -87,12 +87,10 @@ impl MultisampleState {
 
         rasterization_samples
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "rasterization_samples".into(),
-                vuids: &[
+            .map_err(|err| {
+                err.add_context("rasterization_samples").set_vuids(&[
                     "VUID-VkPipelineMultisampleStateCreateInfo-rasterizationSamples-parameter",
-                ],
-                ..ValidationError::from_requirement(err)
+                ])
             })?;
 
         if let Some(min_sample_shading) = sample_shading {

--- a/vulkano/src/pipeline/graphics/rasterization.rs
+++ b/vulkano/src/pipeline/graphics/rasterization.rs
@@ -156,21 +156,14 @@ impl RasterizationState {
 
         let properties = device.physical_device().properties();
 
-        polygon_mode
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "polygon_mode".into(),
-                vuids: &["VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        polygon_mode.validate_device(device).map_err(|err| {
+            err.add_context("polygon_mode")
+                .set_vuids(&["VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-parameter"])
+        })?;
 
         line_rasterization_mode
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "line_rasterization_mode".into(),
-                vuids: &["VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+            .map_err(|err| err.add_context("line_rasterization_mode").set_vuids(&["VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-parameter"]))?;
 
         if depth_clamp_enable && !device.enabled_features().depth_clamp {
             return Err(Box::new(ValidationError {
@@ -234,13 +227,11 @@ impl RasterizationState {
 
         match cull_mode {
             StateMode::Fixed(cull_mode) => {
-                cull_mode
-                    .validate_device(device)
-                    .map_err(|err| ValidationError {
-                        context: "cull_mode".into(),
-                        vuids: &["VUID-VkPipelineRasterizationStateCreateInfo-cullMode-parameter"],
-                        ..ValidationError::from_requirement(err)
-                    })?;
+                cull_mode.validate_device(device).map_err(|err| {
+                    err.add_context("cull_mode").set_vuids(&[
+                        "VUID-VkPipelineRasterizationStateCreateInfo-cullMode-parameter",
+                    ])
+                })?;
             }
             StateMode::Dynamic => {
                 if !(device.api_version() >= Version::V1_3
@@ -262,13 +253,11 @@ impl RasterizationState {
 
         match front_face {
             StateMode::Fixed(front_face) => {
-                front_face
-                    .validate_device(device)
-                    .map_err(|err| ValidationError {
-                        context: "front_face".into(),
-                        vuids: &["VUID-VkPipelineRasterizationStateCreateInfo-frontFace-parameter"],
-                        ..ValidationError::from_requirement(err)
-                    })?;
+                front_face.validate_device(device).map_err(|err| {
+                    err.add_context("front_face").set_vuids(&[
+                        "VUID-VkPipelineRasterizationStateCreateInfo-frontFace-parameter",
+                    ])
+                })?;
             }
             StateMode::Dynamic => {
                 if !(device.api_version() >= Version::V1_3

--- a/vulkano/src/pipeline/graphics/subpass.rs
+++ b/vulkano/src/pipeline/graphics/subpass.rs
@@ -185,13 +185,10 @@ impl PipelineRenderingCreateInfo {
         {
             let attachment_index = attachment_index as u32;
 
-            format
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: format!("color_attachment_formats[{}]", attachment_index).into(),
-                    vuids: &["VUID-VkGraphicsPipelineCreateInfo-renderPass-06580"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            format.validate_device(device).map_err(|err| {
+                err.add_context(format!("color_attachment_formats[{}]", attachment_index))
+                    .set_vuids(&["VUID-VkGraphicsPipelineCreateInfo-renderPass-06580"])
+            })?;
 
             if format == Format::UNDEFINED {
                 return Err(Box::new(ValidationError {
@@ -217,13 +214,10 @@ impl PipelineRenderingCreateInfo {
         }
 
         if let Some(format) = depth_attachment_format {
-            format
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "depth_attachment_format".into(),
-                    vuids: &["VUID-VkGraphicsPipelineCreateInfo-renderPass-06583"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            format.validate_device(device).map_err(|err| {
+                err.add_context("depth_attachment_format")
+                    .set_vuids(&["VUID-VkGraphicsPipelineCreateInfo-renderPass-06583"])
+            })?;
 
             if format == Format::UNDEFINED {
                 return Err(Box::new(ValidationError {
@@ -258,13 +252,10 @@ impl PipelineRenderingCreateInfo {
         }
 
         if let Some(format) = stencil_attachment_format {
-            format
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "stencil_attachment_format".into(),
-                    vuids: &["VUID-VkGraphicsPipelineCreateInfo-renderPass-06584"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            format.validate_device(device).map_err(|err| {
+                err.add_context("stencil_attachment_format")
+                    .set_vuids(&["VUID-VkGraphicsPipelineCreateInfo-renderPass-06584"])
+            })?;
 
             if format == Format::UNDEFINED {
                 return Err(Box::new(ValidationError {

--- a/vulkano/src/pipeline/graphics/tessellation.rs
+++ b/vulkano/src/pipeline/graphics/tessellation.rs
@@ -112,15 +112,11 @@ impl TessellationState {
             }
         };
 
-        domain_origin
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "domain_origin".into(),
-                vuids: &[
-                    "VUID-VkPipelineTessellationDomainOriginStateCreateInfo-domainOrigin-parameter",
-                ],
-                ..ValidationError::from_requirement(err)
-            })?;
+        domain_origin.validate_device(device).map_err(|err| {
+            err.add_context("domain_origin").set_vuids(&[
+                "VUID-VkPipelineTessellationDomainOriginStateCreateInfo-domainOrigin-parameter",
+            ])
+        })?;
 
         if domain_origin != TessellationDomainOrigin::UpperLeft
             && !(device.api_version() >= Version::V1_1

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -457,13 +457,10 @@ impl PipelineLayoutCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkPipelineLayoutCreateInfo-flags-parameter"])
+        })?;
 
         if set_layouts.len() > properties.max_bound_descriptor_sets as usize {
             return Err(Box::new(ValidationError {
@@ -819,13 +816,10 @@ impl PushConstantRange {
             size,
         } = self;
 
-        stages
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "stages".into(),
-                vuids: &["VUID-VkPushConstantRange-stageFlags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        stages.validate_device(device).map_err(|err| {
+            err.add_context("stages")
+                .set_vuids(&["VUID-VkPushConstantRange-stageFlags-parameter"])
+        })?;
 
         if stages.is_empty() {
             return Err(Box::new(ValidationError {

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -344,24 +344,18 @@ impl PipelineShaderStageCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkPipelineShaderStageCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkPipelineShaderStageCreateInfo-flags-parameter"])
+        })?;
 
         let entry_point_info = entry_point.info();
         let stage_enum = ShaderStage::from(&entry_point_info.execution);
 
-        stage_enum
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "entry_point.info().execution".into(),
-                vuids: &["VUID-VkPipelineShaderStageCreateInfo-stage-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        stage_enum.validate_device(device).map_err(|err| {
+            err.add_context("entry_point.info().execution")
+                .set_vuids(&["VUID-VkPipelineShaderStageCreateInfo-stage-parameter"])
+        })?;
 
         // VUID-VkPipelineShaderStageCreateInfo-pName-00707
         // Guaranteed by definition of `EntryPoint`.

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -523,13 +523,10 @@ impl FramebufferCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkFramebufferCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkFramebufferCreateInfo-flags-parameter"])
+        })?;
 
         for (index, image_view) in attachments.iter().enumerate() {
             assert_eq!(device, image_view.device().as_ref());

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -834,13 +834,10 @@ impl RenderPassCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkRenderPassCreateInfo2-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkRenderPassCreateInfo2-flags-parameter"])
+        })?;
 
         let mut attachment_potential_format_features =
             vec![FormatFeatures::empty(); attachments.len()];
@@ -934,19 +931,18 @@ impl RenderPassCreateInfo {
                     _ne: _,
                 } = color_attachment;
 
-                let attachment_desc =
-                    attachments
-                        .get(attachment as usize)
-                        .ok_or_else(|| ValidationError {
-                            problem: format!(
-                                "`subpasses[{0}].color_attachments[{1}].attachment` \
+                let attachment_desc = attachments.get(attachment as usize).ok_or_else(|| {
+                    Box::new(ValidationError {
+                        problem: format!(
+                            "`subpasses[{0}].color_attachments[{1}].attachment` \
                                 is not less than the length of `attachments`",
-                                subpass_index, ref_index
-                            )
-                            .into(),
-                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
-                            ..Default::default()
-                        })?;
+                            subpass_index, ref_index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                        ..Default::default()
+                    })
+                })?;
 
                 let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
 
@@ -1023,15 +1019,17 @@ impl RenderPassCreateInfo {
 
                     let resolve_attachment_desc = attachments
                         .get(resolve_attachment as usize)
-                        .ok_or_else(|| ValidationError {
-                            problem: format!(
+                        .ok_or_else(|| {
+                            Box::new(ValidationError {
+                                problem: format!(
                                 "`subpasses[{0}].color_resolve_attachments[{1}].attachment` is \
                                 not less than the length of `attachments`",
                                 subpass_index, ref_index
                             )
-                            .into(),
-                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
-                            ..Default::default()
+                                .into(),
+                                vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                                ..Default::default()
+                            })
                         })?;
 
                     let is_first_use =
@@ -1135,19 +1133,18 @@ impl RenderPassCreateInfo {
                     _ne: _,
                 } = depth_stencil_attachment;
 
-                let attachment_desc =
-                    attachments
-                        .get(attachment as usize)
-                        .ok_or_else(|| ValidationError {
-                            problem: format!(
-                                "`subpasses[{}].depth_stencil_attachment.attachment` \
+                let attachment_desc = attachments.get(attachment as usize).ok_or_else(|| {
+                    Box::new(ValidationError {
+                        problem: format!(
+                            "`subpasses[{}].depth_stencil_attachment.attachment` \
                                 is not less than the length of `attachments`",
-                                subpass_index,
-                            )
-                            .into(),
-                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
-                            ..Default::default()
-                        })?;
+                            subpass_index,
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                        ..Default::default()
+                    })
+                })?;
 
                 let format = attachment_desc.format;
 
@@ -1247,15 +1244,17 @@ impl RenderPassCreateInfo {
 
                     let resolve_attachment_desc = attachments
                         .get(resolve_attachment as usize)
-                        .ok_or_else(|| ValidationError {
-                            problem: format!(
+                        .ok_or_else(|| {
+                            Box::new(ValidationError {
+                                problem: format!(
                                 "`subpasses[{}].depth_stencil_resolve_attachment.attachment` is \
                                 not less than the length of `attachments`",
                                 subpass_index,
                             )
-                            .into(),
-                            vuids: &["VUID-VkRenderPassCreateInfo2-pSubpasses-06473"],
-                            ..Default::default()
+                                .into(),
+                                vuids: &["VUID-VkRenderPassCreateInfo2-pSubpasses-06473"],
+                                ..Default::default()
+                            })
                         })?;
 
                     let resolve_format = resolve_attachment_desc.format;
@@ -1391,19 +1390,18 @@ impl RenderPassCreateInfo {
                     _ne: _,
                 } = input_attachment;
 
-                let attachment_desc =
-                    attachments
-                        .get(attachment as usize)
-                        .ok_or_else(|| ValidationError {
-                            problem: format!(
-                                "`subpasses[{}].input_attachments[{}].attachment` \
+                let attachment_desc = attachments.get(attachment as usize).ok_or_else(|| {
+                    Box::new(ValidationError {
+                        problem: format!(
+                            "`subpasses[{}].input_attachments[{}].attachment` \
                                 is not less than the length of `attachments`",
-                                subpass_index, ref_index
-                            )
-                            .into(),
-                            vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
-                            ..Default::default()
-                        })?;
+                            subpass_index, ref_index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkRenderPassCreateInfo2-attachment-03051"],
+                        ..Default::default()
+                    })
+                })?;
 
                 let format_aspects = attachment_desc.format.aspects();
                 let is_first_use = !replace(&mut attachment_is_used[attachment as usize], true);
@@ -1614,12 +1612,12 @@ impl RenderPassCreateInfo {
 
             correlated_view_masks.iter().try_fold(0, |total, &mask| {
                 if total & mask != 0 {
-                    Err(ValidationError {
+                    Err(Box::new(ValidationError {
                         context: "correlated_view_masks".into(),
                         problem: "the bit masks overlap with each other".into(),
                         vuids: &["VUID-VkRenderPassCreateInfo2-pCorrelatedViewMasks-03056"],
                         ..Default::default()
-                    })
+                    }))
                 } else {
                     Ok(total | mask)
                 }
@@ -1757,61 +1755,40 @@ impl AttachmentDescription {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkAttachmentDescription2-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkAttachmentDescription2-flags-parameter"])
+        })?;
 
-        format
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "format".into(),
-                vuids: &["VUID-VkAttachmentDescription2-format-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        format.validate_device(device).map_err(|err| {
+            err.add_context("format")
+                .set_vuids(&["VUID-VkAttachmentDescription2-format-parameter"])
+        })?;
 
-        samples
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "samples".into(),
-                vuids: &["VUID-VkAttachmentDescription2-samples-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        samples.validate_device(device).map_err(|err| {
+            err.add_context("samples")
+                .set_vuids(&["VUID-VkAttachmentDescription2-samples-parameter"])
+        })?;
 
-        load_op
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "load_op".into(),
-                vuids: &["VUID-VkAttachmentDescription2-loadOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        load_op.validate_device(device).map_err(|err| {
+            err.add_context("load_op")
+                .set_vuids(&["VUID-VkAttachmentDescription2-loadOp-parameter"])
+        })?;
 
-        store_op
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "store_op".into(),
-                vuids: &["VUID-VkAttachmentDescription2-storeOp-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        store_op.validate_device(device).map_err(|err| {
+            err.add_context("store_op")
+                .set_vuids(&["VUID-VkAttachmentDescription2-storeOp-parameter"])
+        })?;
 
-        initial_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "initial_layout".into(),
-                vuids: &["VUID-VkAttachmentDescription2-initialLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        initial_layout.validate_device(device).map_err(|err| {
+            err.add_context("initial_layout")
+                .set_vuids(&["VUID-VkAttachmentDescription2-initialLayout-parameter"])
+        })?;
 
-        final_layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "final_layout".into(),
-                vuids: &["VUID-VkAttachmentDescription2-finalLayout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        final_layout.validate_device(device).map_err(|err| {
+            err.add_context("final_layout")
+                .set_vuids(&["VUID-VkAttachmentDescription2-finalLayout-parameter"])
+        })?;
 
         if matches!(
             final_layout,
@@ -1866,23 +1843,17 @@ impl AttachmentDescription {
         }
 
         if let Some(stencil_load_op) = stencil_load_op {
-            stencil_load_op
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "stencil_load_op".into(),
-                    vuids: &["VUID-VkAttachmentDescription2-stencilLoadOp-parameter"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            stencil_load_op.validate_device(device).map_err(|err| {
+                err.add_context("stencil_load_op")
+                    .set_vuids(&["VUID-VkAttachmentDescription2-stencilLoadOp-parameter"])
+            })?;
         }
 
         if let Some(stencil_store_op) = stencil_store_op {
-            stencil_store_op
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "stencil_store_op".into(),
-                    vuids: &["VUID-VkAttachmentDescription2-stencilStoreOp-parameter"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            stencil_store_op.validate_device(device).map_err(|err| {
+                err.add_context("stencil_store_op")
+                    .set_vuids(&["VUID-VkAttachmentDescription2-stencilStoreOp-parameter"])
+            })?;
         }
 
         if stencil_initial_layout.is_some() != stencil_final_layout.is_some() {
@@ -1908,12 +1879,10 @@ impl AttachmentDescription {
 
             stencil_initial_layout
                 .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "stencil_initial_layout".into(),
-                    vuids: &[
+                .map_err(|err| {
+                    err.add_context("stencil_initial_layout").set_vuids(&[
                         "VUID-VkAttachmentDescriptionStencilLayout-stencilInitialLayout-parameter",
-                    ],
-                    ..ValidationError::from_requirement(err)
+                    ])
                 })?;
 
             if matches!(
@@ -1951,12 +1920,10 @@ impl AttachmentDescription {
 
             stencil_final_layout
                 .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "stencil_final_layout".into(),
-                    vuids: &[
+                .map_err(|err| {
+                    err.add_context("stencil_final_layout").set_vuids(&[
                         "VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-parameter",
-                    ],
-                    ..ValidationError::from_requirement(err)
+                    ])
                 })?;
 
             if matches!(
@@ -2375,13 +2342,10 @@ impl SubpassDescription {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkSubpassDescription2-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkSubpassDescription2-flags-parameter"])
+        })?;
 
         if color_attachments.len() as u32 > properties.max_color_attachments {
             return Err(Box::new(ValidationError {
@@ -2859,11 +2823,7 @@ impl SubpassDescription {
 
             depth_resolve_mode
                 .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "depth_resolve_mode".into(),
-                    // vuids?
-                    ..ValidationError::from_requirement(err)
-                })?;
+                .map_err(|err| err.add_context("depth_resolve_mode"))?;
 
             if !properties
                 .supported_depth_resolve_modes
@@ -2892,11 +2852,7 @@ impl SubpassDescription {
 
             stencil_resolve_mode
                 .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "stencil_resolve_mode".into(),
-                    // vuids?
-                    ..ValidationError::from_requirement(err)
-                })?;
+                .map_err(|err| err.add_context("stencil_resolve_mode"))?;
 
             if !properties
                 .supported_stencil_resolve_modes
@@ -3176,13 +3132,10 @@ impl AttachmentReference {
             _ne,
         } = self;
 
-        layout
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "layout".into(),
-                vuids: &["VUID-VkAttachmentReference2-layout-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        layout.validate_device(device).map_err(|err| {
+            err.add_context("layout")
+                .set_vuids(&["VUID-VkAttachmentReference2-layout-parameter"])
+        })?;
 
         if matches!(
             layout,
@@ -3229,13 +3182,10 @@ impl AttachmentReference {
                 }));
             }
 
-            stencil_layout
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "stencil_layout".into(),
-                    vuids: &["VUID-VkAttachmentReferenceStencilLayout-stencilLayout-parameter"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            stencil_layout.validate_device(device).map_err(|err| {
+                err.add_context("stencil_layout")
+                    .set_vuids(&["VUID-VkAttachmentReferenceStencilLayout-stencilLayout-parameter"])
+            })?;
 
             if matches!(
                 stencil_layout,
@@ -3283,11 +3233,7 @@ impl AttachmentReference {
 
         aspects
             .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "aspects".into(),
-                // vuids?
-                ..ValidationError::from_requirement(err)
-            })?;
+            .map_err(|err| err.add_context("aspects"))?;
 
         Ok(())
     }

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -672,18 +672,13 @@ where
                     ) {
                         Ok(_) => (),
                         Err(AccessCheckError::Unknown) => {
-                            return Err(Box::new(ValidationError {
-                                problem: AccessError::SwapchainImageNotAcquired.to_string().into(),
-                                ..Default::default()
-                            })
+                            return Err(Box::new(ValidationError::from_error(
+                                AccessError::SwapchainImageNotAcquired,
+                            ))
                             .into());
                         }
                         Err(AccessCheckError::Denied(err)) => {
-                            return Err(Box::new(ValidationError {
-                                problem: err.to_string().into(),
-                                ..Default::default()
-                            })
-                            .into());
+                            return Err(Box::new(ValidationError::from_error(err)).into());
                         }
                     }
 

--- a/vulkano/src/swapchain/display.rs
+++ b/vulkano/src/swapchain/display.rs
@@ -29,8 +29,7 @@
 #![allow(unused_variables)] // TODO: this module isn't finished
 
 use crate::{
-    device::physical::PhysicalDevice, swapchain::SurfaceTransforms, OomError, VulkanError,
-    VulkanObject,
+    device::physical::PhysicalDevice, swapchain::SurfaceTransforms, VulkanError, VulkanObject,
 };
 use std::{
     ffi::CStr,
@@ -56,7 +55,7 @@ impl DisplayPlane {
     /// See the docs of enumerate().
     pub fn enumerate_raw(
         physical_device: Arc<PhysicalDevice>,
-    ) -> Result<IntoIter<DisplayPlane>, OomError> {
+    ) -> Result<IntoIter<DisplayPlane>, VulkanError> {
         let fns = physical_device.instance().fns();
 
         assert!(physical_device.instance().enabled_extensions().khr_display); // TODO: return error instead
@@ -88,7 +87,7 @@ impl DisplayPlane {
                         break properties;
                     }
                     ash::vk::Result::INCOMPLETE => (),
-                    err => return Err(VulkanError::from(err).into()),
+                    err => return Err(VulkanError::from(err)),
                 }
             }
         };
@@ -189,7 +188,7 @@ impl Display {
     /// See the docs of enumerate().
     pub fn enumerate_raw(
         physical_device: Arc<PhysicalDevice>,
-    ) -> Result<IntoIter<Display>, OomError> {
+    ) -> Result<IntoIter<Display>, VulkanError> {
         let fns = physical_device.instance().fns();
         assert!(physical_device.instance().enabled_extensions().khr_display); // TODO: return error instead
 
@@ -217,7 +216,7 @@ impl Display {
                         break properties;
                     }
                     ash::vk::Result::INCOMPLETE => (),
-                    err => return Err(VulkanError::from(err).into()),
+                    err => return Err(VulkanError::from(err)),
                 }
             }
         };
@@ -295,7 +294,7 @@ impl Display {
     }
 
     /// See the docs of display_modes().
-    pub fn display_modes_raw(&self) -> Result<IntoIter<DisplayMode>, OomError> {
+    pub fn display_modes_raw(&self) -> Result<IntoIter<DisplayMode>, VulkanError> {
         let fns = self.physical_device.instance().fns();
 
         let mode_properties = unsafe {
@@ -324,7 +323,7 @@ impl Display {
                         break properties;
                     }
                     ash::vk::Result::INCOMPLETE => (),
-                    err => return Err(VulkanError::from(err).into()),
+                    err => return Err(VulkanError::from(err)),
                 }
             }
         };
@@ -371,7 +370,7 @@ pub struct DisplayMode {
 }
 
 impl DisplayMode {
-    /*pub fn new(display: &Display) -> Result<Arc<DisplayMode>, OomError> {
+    /*pub fn new(display: &Display) -> Result<Arc<DisplayMode>, VulkanError> {
         let fns = instance.fns();
         assert!(device.instance().enabled_extensions().khr_display);     // TODO: return error instead
 

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -589,10 +589,12 @@ impl Swapchain {
                         ..Default::default()
                     },
                 )
-                .map_err(|_err| ValidationError {
-                    context: "PhysicalDevice::surface_capabilities".into(),
-                    problem: "returned an error".into(),
-                    ..Default::default()
+                .map_err(|_err| {
+                    Box::new(ValidationError {
+                        context: "PhysicalDevice::surface_capabilities".into(),
+                        problem: "returned an error".into(),
+                        ..Default::default()
+                    })
                 })?
         };
         let surface_formats = unsafe {
@@ -608,20 +610,24 @@ impl Swapchain {
                         ..Default::default()
                     },
                 )
-                .map_err(|_err| ValidationError {
-                    context: "PhysicalDevice::surface_formats".into(),
-                    problem: "returned an error".into(),
-                    ..Default::default()
+                .map_err(|_err| {
+                    Box::new(ValidationError {
+                        context: "PhysicalDevice::surface_formats".into(),
+                        problem: "returned an error".into(),
+                        ..Default::default()
+                    })
                 })?
         };
         let surface_present_modes: SmallVec<[_; PresentMode::COUNT]> = unsafe {
             device
                 .physical_device()
                 .surface_present_modes_unchecked(surface)
-                .map_err(|_err| ValidationError {
-                    context: "PhysicalDevice::surface_present_modes".into(),
-                    problem: "returned an error".into(),
-                    ..Default::default()
+                .map_err(|_err| {
+                    Box::new(ValidationError {
+                        context: "PhysicalDevice::surface_present_modes".into(),
+                        problem: "returned an error".into(),
+                        ..Default::default()
+                    })
                 })?
                 .collect()
         };
@@ -814,10 +820,12 @@ impl Swapchain {
                                     ..Default::default()
                                 },
                             )
-                            .map_err(|_err| ValidationError {
-                                context: "PhysicalDevice::surface_capabilities".into(),
-                                problem: "returned an error".into(),
-                                ..Default::default()
+                            .map_err(|_err| {
+                                Box::new(ValidationError {
+                                    context: "PhysicalDevice::surface_capabilities".into(),
+                                    problem: "returned an error".into(),
+                                    ..Default::default()
+                                })
                             })?
                     };
 
@@ -1729,37 +1737,25 @@ impl SwapchainCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkSwapchainCreateInfoKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkSwapchainCreateInfoKHR-flags-parameter"])
+        })?;
 
-        image_format
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "image_format".into(),
-                vuids: &["VUID-VkSwapchainCreateInfoKHR-imageFormat-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        image_format.validate_device(device).map_err(|err| {
+            err.add_context("image_format")
+                .set_vuids(&["VUID-VkSwapchainCreateInfoKHR-imageFormat-parameter"])
+        })?;
 
-        image_color_space
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "image_color_space".into(),
-                vuids: &["VUID-VkSwapchainCreateInfoKHR-imageColorSpace-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        image_color_space.validate_device(device).map_err(|err| {
+            err.add_context("image_color_space")
+                .set_vuids(&["VUID-VkSwapchainCreateInfoKHR-imageColorSpace-parameter"])
+        })?;
 
-        image_usage
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "image_usage".into(),
-                vuids: &["VUID-VkSwapchainCreateInfoKHR-imageUsage-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        image_usage.validate_device(device).map_err(|err| {
+            err.add_context("image_usage")
+                .set_vuids(&["VUID-VkSwapchainCreateInfoKHR-imageUsage-parameter"])
+        })?;
 
         if image_usage.is_empty() {
             return Err(Box::new(ValidationError {
@@ -1770,29 +1766,20 @@ impl SwapchainCreateInfo {
             }));
         }
 
-        pre_transform
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "pre_transform".into(),
-                vuids: &["VUID-VkSwapchainCreateInfoKHR-preTransform-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        pre_transform.validate_device(device).map_err(|err| {
+            err.add_context("pre_transform")
+                .set_vuids(&["VUID-VkSwapchainCreateInfoKHR-preTransform-parameter"])
+        })?;
 
-        composite_alpha
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "composite_alpha".into(),
-                vuids: &["VUID-VkSwapchainCreateInfoKHR-compositeAlpha-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        composite_alpha.validate_device(device).map_err(|err| {
+            err.add_context("composite_alpha")
+                .set_vuids(&["VUID-VkSwapchainCreateInfoKHR-compositeAlpha-parameter"])
+        })?;
 
-        present_mode
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "present_mode".into(),
-                vuids: &["VUID-VkSwapchainCreateInfoKHR-presentMode-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        present_mode.validate_device(device).map_err(|err| {
+            err.add_context("present_mode")
+                .set_vuids(&["VUID-VkSwapchainCreateInfoKHR-presentMode-parameter"])
+        })?;
 
         if image_extent.contains(&0) {
             return Err(Box::new(ValidationError {
@@ -1868,10 +1855,12 @@ impl SwapchainCreateInfo {
                     usage: image_usage,
                     ..Default::default()
                 })
-                .map_err(|_err| ValidationError {
-                    context: "PhysicalDevice::image_format_properties".into(),
-                    problem: "returned an error".into(),
-                    ..Default::default()
+                .map_err(|_err| {
+                    Box::new(ValidationError {
+                        context: "PhysicalDevice::image_format_properties".into(),
+                        problem: "returned an error".into(),
+                        ..Default::default()
+                    })
                 })?
         };
 
@@ -1898,15 +1887,12 @@ impl SwapchainCreateInfo {
             }
 
             for (index, &present_mode) in present_modes.iter().enumerate() {
-                present_mode
-                    .validate_device(device)
-                    .map_err(|err| ValidationError {
-                        context: format!("present_modes[{}]", index).into(),
-                        vuids: &[
+                present_mode.validate_device(device).map_err(|err| {
+                    err.add_context(format!("present_modes[{}]", index))
+                        .set_vuids(&[
                             "VUID-VkSwapchainPresentModesCreateInfoEXT-pPresentModes-parameter",
-                        ],
-                        ..ValidationError::from_requirement(err)
-                    })?;
+                        ])
+                })?;
             }
 
             if !present_modes.contains(&present_mode) {
@@ -1931,15 +1917,11 @@ impl SwapchainCreateInfo {
                 }));
             }
 
-            scaling_behavior
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "scaling_behavior".into(),
-                    vuids: &[
-                        "VUID-VkSwapchainPresentScalingCreateInfoEXT-scalingBehavior-parameter",
-                    ],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            scaling_behavior.validate_device(device).map_err(|err| {
+                err.add_context("scaling_behavior").set_vuids(&[
+                    "VUID-VkSwapchainPresentScalingCreateInfoEXT-scalingBehavior-parameter",
+                ])
+            })?;
 
             // VUID-VkSwapchainPresentScalingCreateInfoEXT-scalingBehavior-07767
             // Ensured by the use of an enum.
@@ -1958,16 +1940,13 @@ impl SwapchainCreateInfo {
             }
 
             for (axis_index, present_gravity) in present_gravity.into_iter().enumerate() {
-                present_gravity
-                    .validate_device(device)
-                    .map_err(|err| ValidationError {
-                        context: format!("present_gravity[{}]", axis_index).into(),
-                        vuids: &[
+                present_gravity.validate_device(device).map_err(|err| {
+                    err.add_context(format!("present_gravity[{}]", axis_index))
+                        .set_vuids(&[
                             "VUID-VkSwapchainPresentScalingCreateInfoEXT-presentGravityX-parameter",
                             "VUID-VkSwapchainPresentScalingCreateInfoEXT-presentGravityY-parameter",
-                        ],
-                        ..ValidationError::from_requirement(err)
-                    })?;
+                        ])
+                })?;
             }
 
             // VUID-VkSwapchainPresentScalingCreateInfoEXT-presentGravityX-07765
@@ -1993,12 +1972,10 @@ impl SwapchainCreateInfo {
 
             full_screen_exclusive
                 .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "full_screen_exclusive".into(),
-                    vuids: &[
+                .map_err(|err| {
+                    err.add_context("full_screen_exclusive").set_vuids(&[
                         "VUID-VkSurfaceFullScreenExclusiveInfoEXT-fullScreenExclusive-parameter",
-                    ],
-                    ..ValidationError::from_requirement(err)
+                    ])
                 })?;
         }
 

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -1882,10 +1882,9 @@ impl SurfaceInfo {
 
             present_mode
                 .validate_physical_device(physical_device)
-                .map_err(|err| ValidationError {
-                    context: "present_mode".into(),
-                    vuids: &["VUID-VkSurfacePresentModeEXT-presentMode-parameter"],
-                    ..ValidationError::from_requirement(err)
+                .map_err(|err| {
+                    err.add_context("present_mode")
+                        .set_vuids(&["VUID-VkSurfacePresentModeEXT-presentMode-parameter"])
                 })?;
         }
 

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -326,13 +326,10 @@ impl EventCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self { flags, _ne: _ } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkEventCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkEventCreateInfo-flags-parameter"])
+        })?;
 
         Ok(())
     }

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -574,13 +574,10 @@ impl Fence {
             }));
         }
 
-        handle_type
-            .validate_device(&self.device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkFenceGetFdInfoKHR-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(&self.device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkFenceGetFdInfoKHR-handleType-parameter"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -728,13 +725,10 @@ impl Fence {
             }));
         }
 
-        handle_type
-            .validate_device(&self.device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkFenceGetWin32HandleInfoKHR-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(&self.device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkFenceGetWin32HandleInfoKHR-handleType-parameter"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -1151,13 +1145,10 @@ impl FenceCreateInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkFenceCreateInfo-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkFenceCreateInfo-flags-parameter"])
+        })?;
 
         if !export_handle_types.is_empty() {
             if !(device.api_version() >= Version::V1_1
@@ -1174,13 +1165,10 @@ impl FenceCreateInfo {
                 }));
             }
 
-            export_handle_types
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "export_handle_types".into(),
-                    vuids: &["VUID-VkExportFenceCreateInfo-handleTypes-parameter"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            export_handle_types.validate_device(device).map_err(|err| {
+                err.add_context("export_handle_types")
+                    .set_vuids(&["VUID-VkExportFenceCreateInfo-handleTypes-parameter"])
+            })?;
 
             for handle_type in export_handle_types.into_iter() {
                 let external_fence_properties = unsafe {
@@ -1344,21 +1332,15 @@ impl ImportFenceFdInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkImportFenceFdInfoKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkImportFenceFdInfoKHR-flags-parameter"])
+        })?;
 
-        handle_type
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkImportFenceFdInfoKHR-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkImportFenceFdInfoKHR-handleType-parameter"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -1435,21 +1417,15 @@ impl ImportFenceWin32HandleInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkImportFenceWin32HandleInfoKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkImportFenceWin32HandleInfoKHR-flags-parameter"])
+        })?;
 
-        handle_type
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -1513,10 +1489,9 @@ impl ExternalFenceInfo {
 
         handle_type
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkPhysicalDeviceExternalFenceInfo-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("handle_type")
+                    .set_vuids(&["VUID-VkPhysicalDeviceExternalFenceInfo-handleType-parameter"])
             })?;
 
         Ok(())

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -335,20 +335,13 @@ where
                             ) {
                                 Ok(_) => (),
                                 Err(AccessCheckError::Unknown) => {
-                                    return Err(Box::new(ValidationError {
-                                        problem: AccessError::SwapchainImageNotAcquired
-                                            .to_string()
-                                            .into(),
-                                        ..Default::default()
-                                    })
+                                    return Err(Box::new(ValidationError::from_error(
+                                        AccessError::SwapchainImageNotAcquired,
+                                    ))
                                     .into());
                                 }
                                 Err(AccessCheckError::Denied(err)) => {
-                                    return Err(Box::new(ValidationError {
-                                        problem: err.to_string().into(),
-                                        ..Default::default()
-                                    })
-                                    .into());
+                                    return Err(Box::new(ValidationError::from_error(err)).into());
                                 }
                             }
                         }

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -163,20 +163,13 @@ where
                         ) {
                             Ok(_) => (),
                             Err(AccessCheckError::Unknown) => {
-                                return Err(Box::new(ValidationError {
-                                    problem: AccessError::SwapchainImageNotAcquired
-                                        .to_string()
-                                        .into(),
-                                    ..Default::default()
-                                })
+                                return Err(Box::new(ValidationError::from_error(
+                                    AccessError::SwapchainImageNotAcquired,
+                                ))
                                 .into());
                             }
                             Err(AccessCheckError::Denied(err)) => {
-                                return Err(Box::new(ValidationError {
-                                    problem: err.to_string().into(),
-                                    ..Default::default()
-                                })
-                                .into());
+                                return Err(Box::new(ValidationError::from_error(err)).into());
                             }
                         }
                     }

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -104,7 +104,7 @@ pub(crate) enum CurrentAccess {
 pub enum HostAccessError {
     AccessConflict(AccessConflict),
     Invalidate(VulkanError),
-    ValidationError(ValidationError),
+    ValidationError(Box<ValidationError>),
 }
 
 impl Error for HostAccessError {

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -1774,13 +1774,10 @@ impl DependencyInfo {
             _ne: _,
         } = self;
 
-        dependency_flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dependency_flags".into(),
-                vuids: &["VUID-VkDependencyInfo-dependencyFlags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dependency_flags.validate_device(device).map_err(|err| {
+            err.add_context("dependency_flags")
+                .set_vuids(&["VUID-VkDependencyInfo-dependencyFlags-parameter"])
+        })?;
 
         for (barrier_index, memory_barrier) in memory_barriers.iter().enumerate() {
             memory_barrier
@@ -1911,37 +1908,25 @@ impl MemoryBarrier {
             _ne: _,
         } = self;
 
-        src_stages
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_stages".into(),
-                vuids: &["VUID-VkMemoryBarrier2-srcStageMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_stages.validate_device(device).map_err(|err| {
+            err.add_context("src_stages")
+                .set_vuids(&["VUID-VkMemoryBarrier2-srcStageMask-parameter"])
+        })?;
 
-        dst_stages
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_stages".into(),
-                vuids: &["VUID-VkMemoryBarrier2-dstStageMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_stages.validate_device(device).map_err(|err| {
+            err.add_context("dst_stages")
+                .set_vuids(&["VUID-VkMemoryBarrier2-dstStageMask-parameter"])
+        })?;
 
-        src_access
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_access".into(),
-                vuids: &["VUID-VkMemoryBarrier2-srcAccessMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_access.validate_device(device).map_err(|err| {
+            err.add_context("src_access")
+                .set_vuids(&["VUID-VkMemoryBarrier2-srcAccessMask-parameter"])
+        })?;
 
-        dst_access
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_access".into(),
-                vuids: &["VUID-VkMemoryBarrier2-dstAccessMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_access.validate_device(device).map_err(|err| {
+            err.add_context("dst_access")
+                .set_vuids(&["VUID-VkMemoryBarrier2-dstAccessMask-parameter"])
+        })?;
 
         if !device.enabled_features().synchronization2 {
             if src_stages.contains_flags2() {
@@ -2439,37 +2424,25 @@ impl BufferMemoryBarrier {
             _ne,
         } = self;
 
-        src_stages
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_stages".into(),
-                vuids: &["VUID-VkBufferMemoryBarrier2-srcStageMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_stages.validate_device(device).map_err(|err| {
+            err.add_context("src_stages")
+                .set_vuids(&["VUID-VkBufferMemoryBarrier2-srcStageMask-parameter"])
+        })?;
 
-        dst_stages
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_stages".into(),
-                vuids: &["VUID-VkBufferMemoryBarrier2-dstStageMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_stages.validate_device(device).map_err(|err| {
+            err.add_context("dst_stages")
+                .set_vuids(&["VUID-VkBufferMemoryBarrier2-dstStageMask-parameter"])
+        })?;
 
-        src_access
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_access".into(),
-                vuids: &["VUID-VkBufferMemoryBarrier2-srcAccessMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_access.validate_device(device).map_err(|err| {
+            err.add_context("src_access")
+                .set_vuids(&["VUID-VkBufferMemoryBarrier2-srcAccessMask-parameter"])
+        })?;
 
-        dst_access
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_access".into(),
-                vuids: &["VUID-VkBufferMemoryBarrier2-dstAccessMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_access.validate_device(device).map_err(|err| {
+            err.add_context("dst_access")
+                .set_vuids(&["VUID-VkBufferMemoryBarrier2-dstAccessMask-parameter"])
+        })?;
 
         if !device.enabled_features().synchronization2 {
             if src_stages.contains_flags2() {
@@ -3124,37 +3097,25 @@ impl ImageMemoryBarrier {
             _ne,
         } = self;
 
-        src_stages
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_stages".into(),
-                vuids: &["VUID-VkImageMemoryBarrier2-srcStageMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_stages.validate_device(device).map_err(|err| {
+            err.add_context("src_stages")
+                .set_vuids(&["VUID-VkImageMemoryBarrier2-srcStageMask-parameter"])
+        })?;
 
-        dst_stages
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_stages".into(),
-                vuids: &["VUID-VkImageMemoryBarrier2-dstStageMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_stages.validate_device(device).map_err(|err| {
+            err.add_context("dst_stages")
+                .set_vuids(&["VUID-VkImageMemoryBarrier2-dstStageMask-parameter"])
+        })?;
 
-        src_access
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "src_access".into(),
-                vuids: &["VUID-VkImageMemoryBarrier2-srcAccessMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        src_access.validate_device(device).map_err(|err| {
+            err.add_context("src_access")
+                .set_vuids(&["VUID-VkImageMemoryBarrier2-srcAccessMask-parameter"])
+        })?;
 
-        dst_access
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "dst_access".into(),
-                vuids: &["VUID-VkImageMemoryBarrier2-dstAccessMask-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        dst_access.validate_device(device).map_err(|err| {
+            err.add_context("dst_access")
+                .set_vuids(&["VUID-VkImageMemoryBarrier2-dstAccessMask-parameter"])
+        })?;
 
         if !device.enabled_features().synchronization2 {
             if src_stages.contains_flags2() {

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -196,13 +196,10 @@ impl Semaphore {
             }));
         }
 
-        handle_type
-            .validate_device(&self.device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkSemaphoreGetFdInfoKHR-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(&self.device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkSemaphoreGetFdInfoKHR-handleType-parameter"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -367,13 +364,10 @@ impl Semaphore {
             }));
         }
 
-        handle_type
-            .validate_device(&self.device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(&self.device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-parameter"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -543,13 +537,10 @@ impl Semaphore {
             }));
         }
 
-        handle_type
-            .validate_device(&self.device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkSemaphoreGetZirconHandleInfoFUCHSIA-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(&self.device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkSemaphoreGetZirconHandleInfoFUCHSIA-handleType-parameter"])
+        })?;
 
         if !matches!(handle_type, ExternalSemaphoreHandleType::ZirconEvent) {
             return Err(Box::new(ValidationError {
@@ -1183,13 +1174,10 @@ impl SemaphoreCreateInfo {
                 }));
             }
 
-            export_handle_types
-                .validate_device(device)
-                .map_err(|err| ValidationError {
-                    context: "export_handle_types".into(),
-                    vuids: &["VUID-VkExportSemaphoreCreateInfo-handleTypes-parameter"],
-                    ..ValidationError::from_requirement(err)
-                })?;
+            export_handle_types.validate_device(device).map_err(|err| {
+                err.add_context("export_handle_types")
+                    .set_vuids(&["VUID-VkExportSemaphoreCreateInfo-handleTypes-parameter"])
+            })?;
 
             for handle_type in export_handle_types.into_iter() {
                 let external_semaphore_properties = unsafe {
@@ -1363,21 +1351,15 @@ impl ImportSemaphoreFdInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkImportSemaphoreFdInfoKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkImportSemaphoreFdInfoKHR-flags-parameter"])
+        })?;
 
-        handle_type
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkImportSemaphoreFdInfoKHR-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkImportSemaphoreFdInfoKHR-handleType-parameter"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -1456,21 +1438,15 @@ impl ImportSemaphoreWin32HandleInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkImportSemaphoreWin32HandleInfoKHR-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkImportSemaphoreWin32HandleInfoKHR-flags-parameter"])
+        })?;
 
-        handle_type
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01140"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01140"])
+        })?;
 
         if !matches!(
             handle_type,
@@ -1551,21 +1527,15 @@ impl ImportSemaphoreZirconHandleInfo {
             _ne: _,
         } = self;
 
-        flags
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "flags".into(),
-                vuids: &["VUID-VkImportSemaphoreZirconHandleInfoFUCHSIA-flags-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        flags.validate_device(device).map_err(|err| {
+            err.add_context("flags")
+                .set_vuids(&["VUID-VkImportSemaphoreZirconHandleInfoFUCHSIA-flags-parameter"])
+        })?;
 
-        handle_type
-            .validate_device(device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkImportSemaphoreZirconHandleInfoFUCHSIA-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
-            })?;
+        handle_type.validate_device(device).map_err(|err| {
+            err.add_context("handle_type")
+                .set_vuids(&["VUID-VkImportSemaphoreZirconHandleInfoFUCHSIA-handleType-parameter"])
+        })?;
 
         if !matches!(handle_type, ExternalSemaphoreHandleType::ZirconEvent) {
             return Err(Box::new(ValidationError {
@@ -1626,10 +1596,9 @@ impl ExternalSemaphoreInfo {
 
         handle_type
             .validate_physical_device(physical_device)
-            .map_err(|err| ValidationError {
-                context: "handle_type".into(),
-                vuids: &["VUID-VkPhysicalDeviceExternalSemaphoreInfo-handleType-parameter"],
-                ..ValidationError::from_requirement(err)
+            .map_err(|err| {
+                err.add_context("handle_type")
+                    .set_vuids(&["VUID-VkPhysicalDeviceExternalSemaphoreInfo-handleType-parameter"])
             })?;
 
         Ok(())


### PR DESCRIPTION
Removes the `OomError` and `RequirementNotMet` error types, replacing them with `VulkanError` and `ValidationError` respectively.