### PR TITLE
Fix #2203 and another bug

### DIFF
--- a/vulkano-shaders/src/entry_point.rs
+++ b/vulkano-shaders/src/entry_point.rs
@@ -299,6 +299,11 @@ fn write_interface(interface: &ShaderInterface) -> TokenStream {
              name,
          }| {
             let base_type = format_ident!("{}", format!("{:?}", base_type));
+            let name = if let Some(name) = name {
+                quote! { ::std::option::Option::Some(::std::borrow::Cow::Borrowed(#name)) }
+            } else {
+                quote! { ::std::option::Option::None }
+            };
 
             quote! {
                 ::vulkano::shader::ShaderInterfaceEntry {
@@ -310,7 +315,7 @@ fn write_interface(interface: &ShaderInterface) -> TokenStream {
                         num_elements: #num_elements,
                         is_64bit: #is_64bit,
                     },
-                    name: ::std::option::Option::Some(::std::borrow::Cow::Borrowed(#name)),
+                    name: #name,
                 }
             }
         },


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- [#2203](https://github.com/vulkano-rs/vulkano/issues/2203) Shader reflection fails to find descriptor set variables if multiple `OpAccessChain` instructions are themselves chained.
- vulkano-shaders: Fix invalid emitted code for shader input/output interfaces if the shader is missing a name decoration.
````

Fixes #2203.