### PR TITLE
Memory allocator impl

### DIFF
--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -276,12 +276,12 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
     }
 }
 
-unsafe impl CommandBufferAllocator for Arc<StandardCommandBufferAllocator> {
-    type Iter = IntoIter<[StandardCommandBufferBuilderAlloc; 1]>;
+unsafe impl<T: CommandBufferAllocator> CommandBufferAllocator for Arc<T> {
+    type Iter = T::Iter;
 
-    type Builder = StandardCommandBufferBuilderAlloc;
+    type Builder = T::Builder;
 
-    type Alloc = StandardCommandBufferAlloc;
+    type Alloc = T::Alloc;
 
     #[inline]
     fn allocate(

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1566,7 +1566,7 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
     }
 }
 
-unsafe impl<S: Suballocator> MemoryAllocator for Arc<GenericMemoryAllocator<S>> {
+unsafe impl<T: MemoryAllocator> MemoryAllocator for Arc<T> {
     fn find_memory_type_index(
         &self,
         memory_type_bits: u32,


### PR DESCRIPTION
This aims to fix some problems with usability when creating a custom memory allocator. Simple scenario is creating a struct wrapping a `MemoryAllocator`
```rust
pub struct FooAllocator(StandardMemoryAllocator);

unsafe impl MemoryAllocator for FooAllocator { /* ... */ }
```
When trying to create a `SubbufferAllocator` using an `Arc<FooAllocator>` it will not compile, because `MemoryAllocator` is only implemented for `Arc<GenericMemoryAllocator<S>>`. With these changes `MemoryAllocator` will be implemented for any `Arc<T> where T: MemoryAllocator`, making custom allocators easier to use.

While I was at it I also added the same blanket implementation for the `CommandBufferAllocator`.