### PR TITLE
Merge `MappedDeviceMemory` into `DeviceMemory`, make `MemoryAlloc` reuse the logic

### DIFF
--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -159,7 +159,7 @@ mod linux {
 
         let image = Arc::new(
             raw_image
-                .bind_memory([MemoryAlloc::new(image_memory).unwrap()])
+                .bind_memory([MemoryAlloc::new(image_memory)])
                 .map_err(|(err, _, _)| err)
                 .unwrap(),
         );

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -125,8 +125,8 @@ impl<T: ?Sized> Subbuffer<T> {
     ///
     /// See [`MappingState::slice`] for the safety invariants of the returned pointer.
     ///
-    /// [`DeviceMemory::map`]: crate::memory::device_memory::DeviceMemory::map
-    /// [`MappingState::slice`]: crate::memory::device_memory::MappingState::slice
+    /// [`DeviceMemory::map`]: crate::memory::DeviceMemory::map
+    /// [`MappingState::slice`]: crate::memory::MappingState::slice
     pub fn mapped_slice(&self) -> Result<NonNull<[u8]>, HostAccessError> {
         match self.buffer().memory() {
             BufferMemory::Normal(a) => {

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -16,7 +16,7 @@ use crate::{
     memory::{
         self,
         allocator::{align_down, align_up, DeviceLayout},
-        is_aligned, DeviceAlignment,
+        is_aligned, DeviceAlignment, MappedMemoryRange,
     },
     sync::HostAccessError,
     DeviceSize, NonZeroDeviceSize, ValidationError,
@@ -25,7 +25,6 @@ use bytemuck::AnyBitPattern;
 use std::{
     alloc::Layout,
     cmp,
-    ffi::c_void,
     hash::{Hash, Hasher},
     marker::PhantomData,
     mem::{self, align_of, size_of},
@@ -119,16 +118,23 @@ impl<T: ?Sized> Subbuffer<T> {
         }
     }
 
-    /// Returns the mapped pointer to the start of the subbuffer if the memory is host-visible,
-    /// otherwise returns [`None`].
-    pub fn mapped_ptr(&self) -> Option<NonNull<c_void>> {
+    /// Returns the mapped pointer to the range of memory of `self`.
+    ///
+    /// The subbuffer must fall within the range of the memory mapping given to
+    /// [`DeviceMemory::map`].
+    ///
+    /// See [`MappingState::slice`] for the safety invariants of the returned pointer.
+    ///
+    /// [`DeviceMemory::map`]: crate::memory::device_memory::DeviceMemory::map
+    /// [`MappingState::slice`]: crate::memory::device_memory::MappingState::slice
+    pub fn mapped_slice(&self) -> Result<NonNull<[u8]>, HostAccessError> {
         match self.buffer().memory() {
-            BufferMemory::Normal(a) => a.mapped_ptr().map(|ptr| {
-                // SAFETY: The original address came from the Vulkan implementation, and allocation
-                // sizes are guaranteed to not exceed `isize::MAX` when there's a mapped pointer,
-                // so the offset better be in range.
-                unsafe { NonNull::new_unchecked(ptr.as_ptr().add(self.offset as usize)) }
-            }),
+            BufferMemory::Normal(a) => {
+                let opt = a.mapped_slice(self.range());
+
+                // SAFETY: `self.range()` is in bounds of the allocation.
+                unsafe { opt.unwrap_unchecked() }
+            }
             BufferMemory::Sparse => unreachable!(),
         }
     }
@@ -327,27 +333,33 @@ where
             .map_err(HostAccessError::AccessConflict)?;
         unsafe { state.cpu_read_lock(range.clone()) };
 
+        let mapped_slice = self.mapped_slice()?;
+
         if allocation.atom_size().is_some() {
-            // If there are other read locks being held at this point, they also called
-            // `invalidate_range` when locking. The GPU can't write data while the CPU holds a read
-            // lock, so there will be no new data and this call will do nothing.
-            // TODO: probably still more efficient to call it only if we're the first to acquire a
-            // read lock, but the number of CPU locks isn't currently tracked anywhere.
-            unsafe {
-                allocation
-                    .invalidate_range(range.clone())
-                    .map_err(HostAccessError::Invalidate)?
+            let memory_range = MappedMemoryRange {
+                offset: range.start,
+                size: range.end - range.start,
+                _ne: crate::NonExhaustive(()),
             };
+
+            // If there are other read locks being held at this point, they also called
+            // `invalidate_range_unchecked` when locking. The device can't write data while the
+            // host holds a read lock, so there will be no new data and this call will do nothing.
+            // TODO: probably still more efficient to call it only if we're the first to acquire a
+            // read lock, but the number of host locks isn't currently tracked anywhere.
+            //
+            // SAFETY:
+            // - `self.mapped_slice()` didn't return an error, which means that the subbuffer falls
+            //   within the mapped range of the memory.
+            // - We ensure that memory mappings are always aligned to the non-coherent atom size
+            //   for non-host-coherent memory, therefore the subbuffer's range aligned to the
+            //   non-coherent atom size must fall within the mapped range of the memory.
+            unsafe { allocation.invalidate_range_unchecked(memory_range) }
+                .map_err(HostAccessError::Invalidate)?;
         }
 
-        let mapped_ptr = self.mapped_ptr().ok_or_else(|| {
-            HostAccessError::ValidationError(Box::new(ValidationError {
-                problem: "the memory of this subbuffer is not host-visible".into(),
-                ..Default::default()
-            }))
-        })?;
         // SAFETY: `Subbuffer` guarantees that its contents are laid out correctly for `T`.
-        let data = unsafe { &*T::from_ffi(mapped_ptr.as_ptr(), self.size as usize) };
+        let data = unsafe { &*T::ptr_from_slice(mapped_slice) };
 
         Ok(BufferReadGuard {
             subbuffer: self,
@@ -407,22 +419,27 @@ where
             .map_err(HostAccessError::AccessConflict)?;
         unsafe { state.cpu_write_lock(range.clone()) };
 
+        let mapped_slice = self.mapped_slice()?;
+
         if allocation.atom_size().is_some() {
-            unsafe {
-                allocation
-                    .invalidate_range(range.clone())
-                    .map_err(HostAccessError::Invalidate)?
+            let memory_range = MappedMemoryRange {
+                offset: range.start,
+                size: range.end - range.start,
+                _ne: crate::NonExhaustive(()),
             };
+
+            // SAFETY:
+            // - `self.mapped_slice()` didn't return an error, which means that the subbuffer falls
+            //   within the mapped range of the memory.
+            // - We ensure that memory mappings are always aligned to the non-coherent atom size
+            //   for non-host-coherent memory, therefore the subbuffer's range aligned to the
+            //   non-coherent atom size must fall within the mapped range of the memory.
+            unsafe { allocation.invalidate_range_unchecked(memory_range) }
+                .map_err(HostAccessError::Invalidate)?;
         }
 
-        let mapped_ptr = self.mapped_ptr().ok_or_else(|| {
-            HostAccessError::ValidationError(Box::new(ValidationError {
-                problem: "the memory of this subbuffer is not host-visible".into(),
-                ..Default::default()
-            }))
-        })?;
         // SAFETY: `Subbuffer` guarantees that its contents are laid out correctly for `T`.
-        let data = unsafe { &mut *T::from_ffi(mapped_ptr.as_ptr(), self.size as usize) };
+        let data = unsafe { &mut *T::ptr_from_slice(mapped_slice) };
 
         Ok(BufferWriteGuard {
             subbuffer: self,
@@ -661,7 +678,13 @@ impl<T: ?Sized> Drop for BufferWriteGuard<'_, T> {
         };
 
         if allocation.atom_size().is_some() && !thread::panicking() {
-            unsafe { allocation.flush_range(self.range.clone()).unwrap() };
+            let memory_range = MappedMemoryRange {
+                offset: self.range.start,
+                size: self.range.end - self.range.start,
+                _ne: crate::NonExhaustive(()),
+            };
+
+            unsafe { allocation.flush_range_unchecked(memory_range).unwrap() };
         }
 
         let mut state = self.subbuffer.buffer().state();
@@ -777,24 +800,24 @@ impl<T: ?Sized> DerefMut for BufferWriteGuard<'_, T> {
 // - `LAYOUT` must be the correct layout for the type, which also means the type must either be
 //   sized or if it's unsized then its metadata must be the same as that of a slice. Implementing
 //   `BufferContents` for any other kind of DST is instantaneous horrifically undefined behavior.
-// - `from_ffi` must create a pointer with the same address as the `data` parameter that is passed
-//   in. The pointer is expected to be aligned properly already.
-// - `from_ffi` must create a pointer that is expected to be valid for reads (and potentially
-//   writes) for exactly `range` bytes. The `data` and `range` are expected to be valid for the
+// - `ptr_from_slice` must create a pointer with the same address as the `slice` parameter that is
+//   passed in. The pointer is expected to be aligned properly already.
+// - `ptr_from_slice` must create a pointer that is expected to be valid for reads (and potentially
+//   writes) for exactly `slice.len()` bytes. The `slice.len()` is expected to be valid for the
 //   `LAYOUT`.
 pub unsafe trait BufferContents: Send + Sync + 'static {
     /// The layout of the contents.
     const LAYOUT: BufferContentsLayout;
 
-    /// Creates a pointer to `Self` from a pointer to the start of the data and a range in bytes.
+    /// Creates a pointer to `Self` from a pointer to a range of mapped memory.
     ///
     /// # Safety
     ///
-    /// - If `Self` is sized, then `range` must match the size exactly.
-    /// - If `Self` is unsized, then the `range` minus the size of the head (sized part) of the DST
-    ///   must be evenly divisible by the size of the element type.
+    /// - If `Self` is sized, then `slice.len()` must match the size exactly.
+    /// - If `Self` is unsized, then `slice.len()` minus the size of the head (sized part) of the
+    ///   DST must be evenly divisible by the size of the element type.
     #[doc(hidden)]
-    unsafe fn from_ffi(data: *mut c_void, range: usize) -> *mut Self;
+    unsafe fn ptr_from_slice(slice: NonNull<[u8]>) -> *mut Self;
 }
 
 unsafe impl<T> BufferContents for T
@@ -809,11 +832,10 @@ where
         };
 
     #[inline(always)]
-    unsafe fn from_ffi(data: *mut c_void, range: usize) -> *mut Self {
-        debug_assert!(range == size_of::<T>());
-        debug_assert!(data as usize % align_of::<T>() == 0);
+    unsafe fn ptr_from_slice(slice: NonNull<[u8]>) -> *mut Self {
+        debug_assert!(slice.len() == size_of::<T>());
 
-        data.cast()
+        <*mut [u8]>::cast::<T>(slice.as_ptr())
     }
 }
 
@@ -827,12 +849,12 @@ where
     });
 
     #[inline(always)]
-    unsafe fn from_ffi(data: *mut c_void, range: usize) -> *mut Self {
-        debug_assert!(range % size_of::<T>() == 0);
-        debug_assert!(data as usize % align_of::<T>() == 0);
-        let len = range / size_of::<T>();
+    unsafe fn ptr_from_slice(slice: NonNull<[u8]>) -> *mut Self {
+        let data = <*mut [u8]>::cast::<T>(slice.as_ptr());
+        let len = slice.len() / size_of::<T>();
+        debug_assert!(slice.len() % size_of::<T>() == 0);
 
-        ptr::slice_from_raw_parts_mut(data.cast(), len)
+        ptr::slice_from_raw_parts_mut(data, len)
     }
 }
 

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -816,7 +816,7 @@ impl StandardMemoryAllocator {
 ///
 /// Every time a new `DeviceMemory` block is allocated, it is mapped in full automatically as long
 /// as it resides in host-visible memory. It remains mapped until it is dropped, which only happens
-/// if the allocator is dropped. In other words, all eligeble blocks are persistently mapped, so
+/// if the allocator is dropped. In other words, all eligible blocks are persistently mapped, so
 /// you don't need to worry about whether or not your host-visible allocations are host-accessible.
 ///
 /// # `DeviceMemory` allocation

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -812,6 +812,13 @@ impl StandardMemoryAllocator {
 ///
 /// See also [the `MemoryAllocator` implementation].
 ///
+/// # Mapping behavior
+///
+/// Every time a new `DeviceMemory` block is allocated, it is mapped in full automatically as long
+/// as it resides in host-visible memory. It remains mapped until it is dropped, which only happens
+/// if the allocator is dropped. In other words, all eligeble blocks are persistently mapped, so
+/// you don't need to worry about whether or not your host-visible allocations are host-accessible.
+///
 /// # `DeviceMemory` allocation
 ///
 /// If an allocation is created with the [`MemoryAllocatePreference::Unknown`] option, and the

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1584,7 +1584,6 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
             // - The memory can't be mapped already, because we just allocated it.
             // - Mapping the whole range is always valid.
             memory.map_unchecked(MemoryMapInfo {
-                flags: Default::default(),
                 offset: 0,
                 size: memory.allocation_size(),
                 _ne: crate::NonExhaustive(()),

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -229,7 +229,7 @@ pub use self::{
 };
 use super::{
     DedicatedAllocation, DeviceAlignment, DeviceMemory, ExternalMemoryHandleTypes,
-    MemoryAllocateFlags, MemoryAllocateInfo, MemoryProperties, MemoryPropertyFlags,
+    MemoryAllocateFlags, MemoryAllocateInfo, MemoryMapInfo, MemoryProperties, MemoryPropertyFlags,
     MemoryRequirements, MemoryType,
 };
 use crate::{
@@ -381,7 +381,7 @@ pub unsafe trait MemoryAllocator: DeviceOwned {
         allocation_size: DeviceSize,
         dedicated_allocation: Option<DedicatedAllocation<'_>>,
         export_handle_types: ExternalMemoryHandleTypes,
-    ) -> Result<MemoryAlloc, MemoryAllocatorError>;
+    ) -> Result<MemoryAlloc, VulkanError>;
 }
 
 /// Describes what memory property flags are required, preferred and not preferred when picking a
@@ -1176,7 +1176,7 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
             .property_flags
             .contains(ash::vk::MemoryPropertyFlags::LAZILY_ALLOCATED)
         {
-            return unsafe {
+            let allocation = unsafe {
                 self.allocate_dedicated_unchecked(
                     memory_type_index,
                     create_info.layout.size(),
@@ -1187,7 +1187,9 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
                         ExternalMemoryHandleTypes::empty()
                     },
                 )
-            };
+            }?;
+
+            return Ok(allocation);
         }
 
         unsafe { self.allocate_from_type_unchecked(memory_type_index, create_info, false) }
@@ -1305,17 +1307,16 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
             let mut i = 0;
 
             loop {
-                let allocate_info = MemoryAllocateInfo {
-                    allocation_size: block_size >> i,
+                let allocation_size = block_size >> i;
+
+                match self.allocate_dedicated_unchecked(
                     memory_type_index,
+                    allocation_size,
+                    None,
                     export_handle_types,
-                    dedicated_allocation: None,
-                    flags: self.flags,
-                    ..Default::default()
-                };
-                match DeviceMemory::allocate_unchecked(self.device.clone(), allocate_info, None) {
-                    Ok(device_memory) => {
-                        break S::new(MemoryAlloc::new(device_memory)?);
+                ) {
+                    Ok(allocation) => {
+                        break S::new(allocation);
                     }
                     // Retry up to 3 times, halving the allocation size each time.
                     Err(VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory) if i < 3 => {
@@ -1459,6 +1460,7 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
                             dedicated_allocation,
                             export_handle_types,
                         )
+                        .map_err(MemoryAllocatorError::VulkanError)
                     } else {
                         if size > block_size / 2 {
                             prefers_dedicated_allocation = true;
@@ -1476,6 +1478,7 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
                                 dedicated_allocation,
                                 export_handle_types,
                             )
+                            .map_err(MemoryAllocatorError::VulkanError)
                             // Fall back to suballocation.
                             .or_else(|err| {
                                 if size <= block_size {
@@ -1504,6 +1507,7 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
                                     dedicated_allocation,
                                     export_handle_types,
                                 )
+                                .map_err(MemoryAllocatorError::VulkanError)
                             })
                         }
                     }
@@ -1515,12 +1519,14 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
 
                     self.allocate_from_type_unchecked(memory_type_index, create_info.clone(), true)
                 }
-                MemoryAllocatePreference::AlwaysAllocate => self.allocate_dedicated_unchecked(
-                    memory_type_index,
-                    size,
-                    dedicated_allocation,
-                    export_handle_types,
-                ),
+                MemoryAllocatePreference::AlwaysAllocate => self
+                    .allocate_dedicated_unchecked(
+                        memory_type_index,
+                        size,
+                        dedicated_allocation,
+                        export_handle_types,
+                    )
+                    .map_err(MemoryAllocatorError::VulkanError),
             };
 
             match res {
@@ -1546,20 +1552,41 @@ unsafe impl<S: Suballocator> MemoryAllocator for GenericMemoryAllocator<S> {
         allocation_size: DeviceSize,
         dedicated_allocation: Option<DedicatedAllocation<'_>>,
         export_handle_types: ExternalMemoryHandleTypes,
-    ) -> Result<MemoryAlloc, MemoryAllocatorError> {
-        let allocate_info = MemoryAllocateInfo {
-            allocation_size,
-            memory_type_index,
-            dedicated_allocation,
-            export_handle_types,
-            flags: self.flags,
-            ..Default::default()
-        };
-        let mut allocation = MemoryAlloc::new(DeviceMemory::allocate_unchecked(
+    ) -> Result<MemoryAlloc, VulkanError> {
+        // SAFETY: The caller must uphold the safety contract.
+        let mut memory = DeviceMemory::allocate_unchecked(
             self.device.clone(),
-            allocate_info,
+            MemoryAllocateInfo {
+                allocation_size,
+                memory_type_index,
+                dedicated_allocation,
+                export_handle_types,
+                flags: self.flags,
+                ..Default::default()
+            },
             None,
-        )?)?;
+        )?;
+
+        if self.pools[memory_type_index as usize]
+            .memory_type
+            .property_flags
+            .intersects(ash::vk::MemoryPropertyFlags::HOST_VISIBLE)
+        {
+            // SAFETY:
+            // - We checked that the memory is host-visible.
+            // - The memory can't be mapped already, because we just allocated it.
+            // - Mapping the whole range is always valid.
+            memory.map_unchecked(MemoryMapInfo {
+                flags: Default::default(),
+                offset: 0,
+                size: memory.allocation_size(),
+                _ne: crate::NonExhaustive(()),
+            })?;
+        }
+
+        let mut allocation = MemoryAlloc::new(memory);
+
+        // SAFETY: The memory is freshly allocated.
         allocation.set_allocation_type(self.allocation_type);
 
         Ok(allocation)
@@ -1628,7 +1655,7 @@ unsafe impl<T: MemoryAllocator> MemoryAllocator for Arc<T> {
         allocation_size: DeviceSize,
         dedicated_allocation: Option<DedicatedAllocation<'_>>,
         export_handle_types: ExternalMemoryHandleTypes,
-    ) -> Result<MemoryAlloc, MemoryAllocatorError> {
+    ) -> Result<MemoryAlloc, VulkanError> {
         (**self).allocate_dedicated_unchecked(
             memory_type_index,
             allocation_size,

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -81,11 +81,6 @@ enum AllocParent {
     Dedicated(DeviceMemory),
 }
 
-// It is safe to share `mapped_ptr` between threads because the user would have to use unsafe code
-// themself to get UB in the first place.
-unsafe impl Send for MemoryAlloc {}
-unsafe impl Sync for MemoryAlloc {}
-
 impl MemoryAlloc {
     /// Creates a new `MemoryAlloc`.
     #[inline]

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -1318,7 +1318,7 @@ vulkan_bitflags_enum! {
 vulkan_bitflags! {
     #[non_exhaustive]
 
-    /// Flags specifying additional properties for device memory allocation.
+    /// Flags specifying additional properties of a device memory allocation.
     MemoryAllocateFlags = MemoryAllocateFlags(u32);
 
     /* TODO: enable

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -22,7 +22,8 @@ use std::{
     mem::MaybeUninit,
     num::NonZeroU64,
     ops::Range,
-    ptr, slice,
+    ptr::{self, NonNull},
+    slice,
     sync::{atomic::Ordering, Arc},
 };
 
@@ -61,7 +62,16 @@ pub struct DeviceMemory {
     export_handle_types: ExternalMemoryHandleTypes,
     imported_handle_type: Option<ExternalMemoryHandleType>,
     flags: MemoryAllocateFlags,
+
+    mapping_state: Option<MappingState>,
+    atom_size: DeviceAlignment,
+    is_coherent: bool,
 }
+
+// It is safe to share `MappingState::ptr` between threads because the user would have to use
+// unsafe code themself to get UB in the first place.
+unsafe impl Send for DeviceMemory {}
+unsafe impl Sync for DeviceMemory {}
 
 impl DeviceMemory {
     /// Allocates a block of memory from the device.
@@ -71,7 +81,6 @@ impl DeviceMemory {
     ///
     /// # Panics
     ///
-    /// - Panics if `allocate_info.allocation_size` is 0.
     /// - Panics if `allocate_info.dedicated_allocation` is `Some` and the contained buffer or
     ///   image does not belong to `device`.
     #[inline]
@@ -82,7 +91,7 @@ impl DeviceMemory {
         if !(device.api_version() >= Version::V1_1
             || device.enabled_extensions().khr_dedicated_allocation)
         {
-            // Fall back instead of erroring out
+            // Fall back instead of erroring out.
             allocate_info.dedicated_allocation = None;
         }
 
@@ -99,7 +108,6 @@ impl DeviceMemory {
     ///
     /// # Panics
     ///
-    /// - Panics if `allocate_info.allocation_size` is 0.
     /// - Panics if `allocate_info.dedicated_allocation` is `Some` and the contained buffer or
     ///   image does not belong to `device`.
     #[inline]
@@ -111,7 +119,7 @@ impl DeviceMemory {
         if !(device.api_version() >= Version::V1_1
             || device.enabled_extensions().khr_dedicated_allocation)
         {
-            // Fall back instead of erroring out
+            // Fall back instead of erroring out.
             allocate_info.dedicated_allocation = None;
         }
 
@@ -281,16 +289,28 @@ impl DeviceMemory {
             output.assume_init()
         };
 
+        let atom_size = device.physical_device().properties().non_coherent_atom_size;
+
+        let is_coherent = device.physical_device().memory_properties().memory_types
+            [memory_type_index as usize]
+            .property_flags
+            .intersects(MemoryPropertyFlags::HOST_COHERENT);
+
         Ok(DeviceMemory {
             handle,
             device: InstanceOwnedDebugWrapper(device),
             id: Self::next_id(),
+
             allocation_size,
             memory_type_index,
             dedicated_to: dedicated_allocation.map(Into::into),
             export_handle_types,
             imported_handle_type,
             flags,
+
+            mapping_state: None,
+            atom_size,
+            is_coherent,
         })
     }
 
@@ -315,16 +335,28 @@ impl DeviceMemory {
             _ne: _,
         } = allocate_info;
 
+        let atom_size = device.physical_device().properties().non_coherent_atom_size;
+
+        let is_coherent = device.physical_device().memory_properties().memory_types
+            [memory_type_index as usize]
+            .property_flags
+            .intersects(MemoryPropertyFlags::HOST_COHERENT);
+
         DeviceMemory {
             handle,
             device: InstanceOwnedDebugWrapper(device),
             id: Self::next_id(),
+
             allocation_size,
             memory_type_index,
             dedicated_to: dedicated_allocation.map(Into::into),
             export_handle_types,
             imported_handle_type: None,
             flags,
+
+            mapping_state: None,
+            atom_size,
+            is_coherent,
         }
     }
 
@@ -368,6 +400,248 @@ impl DeviceMemory {
     #[inline]
     pub fn flags(&self) -> MemoryAllocateFlags {
         self.flags
+    }
+
+    /// Returns the current mapping state, or [`None`] if the memory is not currently host-mapped.
+    #[inline]
+    pub fn mapping_state(&self) -> Option<&MappingState> {
+        self.mapping_state.as_ref()
+    }
+
+    /// Maps a range of memory to be accessed by the host.
+    ///
+    /// `self` must not be host-mapped already and must be allocated from host-visible memory.
+    pub fn map(&mut self, map_info: MemoryMapInfo) -> Result<(), Validated<VulkanError>> {
+        self.validate_map(&map_info)?;
+
+        unsafe { Ok(self.map_unchecked(map_info)?) }
+    }
+
+    fn validate_map(&self, map_info: &MemoryMapInfo) -> Result<(), Box<ValidationError>> {
+        if self.mapping_state.is_some() {
+            return Err(Box::new(ValidationError {
+                problem: "this device memory is already host-mapped".into(),
+                vuids: &["VUID-vkMapMemory-memory-00678"],
+                ..Default::default()
+            }));
+        }
+
+        map_info
+            .validate(self)
+            .map_err(|err| err.add_context("map_info"))?;
+
+        let memory_type = &self
+            .device()
+            .physical_device()
+            .memory_properties()
+            .memory_types[self.memory_type_index() as usize];
+
+        if !memory_type
+            .property_flags
+            .intersects(MemoryPropertyFlags::HOST_VISIBLE)
+        {
+            return Err(Box::new(ValidationError {
+                problem: "`self.memory_type_index()` refers to a memory type whose \
+                    `property_flags` does not contain `MemoryPropertyFlags::HOST_VISIBLE`"
+                    .into(),
+                vuids: &["VUID-vkMapMemory-memory-00682"],
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn map_unchecked(&mut self, map_info: MemoryMapInfo) -> Result<(), VulkanError> {
+        let device = self.device();
+
+        let MemoryMapInfo {
+            flags,
+            offset,
+            size,
+            _ne: _,
+        } = map_info;
+
+        let ptr = {
+            let fns = device.fns();
+            let mut output = MaybeUninit::uninit();
+            (fns.v1_0.map_memory)(
+                device.handle(),
+                self.handle,
+                offset,
+                size,
+                flags.into(),
+                output.as_mut_ptr(),
+            )
+            .result()
+            .map_err(VulkanError::from)?;
+
+            output.assume_init()
+        };
+
+        let ptr = NonNull::new(ptr).unwrap();
+        let range = offset..offset + size;
+        self.mapping_state = Some(MappingState { ptr, range });
+
+        Ok(())
+    }
+
+    /// Unmaps the memory. It will no longer be accessible from the host.
+    ///
+    /// `self` must be currently host-mapped.
+    //
+    // NOTE(Marc): The `&mut` here is more than just because we need to mutate the struct.
+    // `vkMapMemory` and `vkUnmapMemory` must be externally synchronized, but more importantly, if
+    // we allowed unmapping through a shared reference, it would be possible to unmap a resource
+    // that's currently being read or written by the host elsewhere, requiring even more locking on
+    // each host access.
+    pub fn unmap(&mut self) -> Result<(), Box<ValidationError>> {
+        if self.mapping_state.is_none() {
+            return Err(Box::new(ValidationError {
+                problem: "this device memory is not currently host-mapped".into(),
+                vuids: &["VUID-vkUnmapMemory-memory-00689"],
+                ..Default::default()
+            }));
+        }
+
+        unsafe { self.unmap_unchecked() };
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn unmap_unchecked(&mut self) {
+        let device = self.device();
+        let fns = device.fns();
+        (fns.v1_0.unmap_memory)(device.handle(), self.handle);
+
+        self.mapping_state = None;
+    }
+
+    /// Invalidates the host cache for a range of mapped memory.
+    ///
+    /// If the device memory is not [host-coherent], you must call this function before the memory
+    /// is read by the host, if the device previously wrote to the memory. It has no effect if the
+    /// memory is host-coherent.
+    ///
+    /// # Safety
+    ///
+    /// - If there are memory writes by the device that have not been propagated into the host
+    ///   cache, then there must not be any references in Rust code to any portion of the specified
+    ///   `memory_range`.
+    ///
+    /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
+    /// [`map`]: Self::map
+    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
+    #[inline]
+    pub unsafe fn invalidate_range(
+        &self,
+        memory_range: MappedMemoryRange,
+    ) -> Result<(), Validated<VulkanError>> {
+        self.validate_memory_range(&memory_range)?;
+
+        Ok(self.invalidate_range_unchecked(memory_range)?)
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    #[inline]
+    pub unsafe fn invalidate_range_unchecked(
+        &self,
+        memory_range: MappedMemoryRange,
+    ) -> Result<(), VulkanError> {
+        if self.is_coherent {
+            return Ok(());
+        }
+
+        let MappedMemoryRange {
+            offset,
+            size,
+            _ne: _,
+        } = memory_range;
+
+        let memory_range_vk = ash::vk::MappedMemoryRange {
+            memory: self.handle(),
+            offset,
+            size,
+            ..Default::default()
+        };
+
+        let fns = self.device().fns();
+        (fns.v1_0.invalidate_mapped_memory_ranges)(self.device().handle(), 1, &memory_range_vk)
+            .result()
+            .map_err(VulkanError::from)?;
+
+        Ok(())
+    }
+
+    /// Flushes the host cache for a range of mapped memory.
+    ///
+    /// If the device memory is not [host-coherent], you must call this function after writing to
+    /// the memory, if the device is going to read the memory. It has no effect if the memory is
+    /// host-coherent.
+    ///
+    /// # Safety
+    ///
+    /// - There must be no operations pending or executing in a device queue, that access the
+    ///   specified `memory_range`.
+    ///
+    /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
+    /// [`map`]: Self::map
+    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
+    #[inline]
+    pub unsafe fn flush_range(
+        &self,
+        memory_range: MappedMemoryRange,
+    ) -> Result<(), Validated<VulkanError>> {
+        self.validate_memory_range(&memory_range)?;
+
+        Ok(self.flush_range_unchecked(memory_range)?)
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    #[inline]
+    pub unsafe fn flush_range_unchecked(
+        &self,
+        memory_range: MappedMemoryRange,
+    ) -> Result<(), VulkanError> {
+        if self.is_coherent {
+            return Ok(());
+        }
+
+        let MappedMemoryRange {
+            offset,
+            size,
+            _ne: _,
+        } = memory_range;
+
+        let memory_range_vk = ash::vk::MappedMemoryRange {
+            memory: self.handle(),
+            offset,
+            size,
+            ..Default::default()
+        };
+
+        let fns = self.device().fns();
+        (fns.v1_0.flush_mapped_memory_ranges)(self.device().handle(), 1, &memory_range_vk)
+            .result()
+            .map_err(VulkanError::from)?;
+
+        Ok(())
+    }
+
+    // NOTE(Marc): We are validating the parameters regardless of whether the memory is
+    // non-coherent on purpose, to catch potential bugs arising because the code isn't tested on
+    // such hardware.
+    fn validate_memory_range(
+        &self,
+        memory_range: &MappedMemoryRange,
+    ) -> Result<(), Box<ValidationError>> {
+        memory_range
+            .validate(self)
+            .map_err(|err| err.add_context("memory_range"))?;
+
+        Ok(())
     }
 
     /// Retrieves the amount of lazily-allocated memory that is currently commited to this
@@ -1034,7 +1308,7 @@ vulkan_bitflags_enum! {
 vulkan_bitflags! {
     #[non_exhaustive]
 
-    /// A mask specifying flags for device memory allocation.
+    /// Flags specifying additional properties for device memory allocation.
     MemoryAllocateFlags = MemoryAllocateFlags(u32);
 
     /* TODO: enable
@@ -1052,6 +1326,262 @@ vulkan_bitflags! {
 
     /* TODO: enable
     DEVICE_ADDRESS_CAPTURE_REPLAY = DEVICE_ADDRESS_CAPTURE_REPLAY,*/
+}
+
+/// Parameters of a memory map operation.
+#[derive(Debug)]
+pub struct MemoryMapInfo {
+    /// Additional properties of the mapping.
+    ///
+    /// The default value is empty.
+    pub flags: MemoryMapFlags,
+
+    /// The offset (in bytes) from the beginning of the `DeviceMemory`, where the mapping starts.
+    ///
+    /// Must be less than the size of the `DeviceMemory`.
+    ///
+    /// The default value is `0`.
+    pub offset: DeviceSize,
+
+    /// The size (in bytes) of the mapping.
+    ///
+    /// Must be less than or equal to the [`allocation_size`] of the device memory minus `offset`.
+    ///
+    /// The default value is `0`, which must be overridden.
+    ///
+    /// [`allocation_size`]: DeviceMemory::allocation_size
+    pub size: DeviceSize,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl MemoryMapInfo {
+    pub(crate) fn validate(&self, memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
+        let &Self {
+            flags: _,
+            offset,
+            size,
+            _ne: _,
+        } = self;
+
+        if !(offset < memory.allocation_size()) {
+            return Err(Box::new(ValidationError {
+                context: "offset".into(),
+                problem: "is not less than `self.allocation_size()`".into(),
+                vuids: &["VUID-vkMapMemory-offset-00679"],
+                ..Default::default()
+            }));
+        }
+
+        if size == 0 {
+            return Err(Box::new(ValidationError {
+                context: "size".into(),
+                problem: "is zero".into(),
+                vuids: &["VUID-vkMapMemory-size-00680"],
+                ..Default::default()
+            }));
+        }
+
+        if !(size <= memory.allocation_size() - offset) {
+            return Err(Box::new(ValidationError {
+                context: "size".into(),
+                problem: "is not less than or equal to `self.allocation_size()` minus \
+                    `map_info.offset`"
+                    .into(),
+                vuids: &["VUID-vkMapMemory-size-00681"],
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for MemoryMapInfo {
+    #[inline]
+    fn default() -> Self {
+        MemoryMapInfo {
+            flags: MemoryMapFlags::empty(),
+            offset: 0,
+            size: 0,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+}
+
+vulkan_bitflags! {
+    #[non_exhaustive]
+
+    /// Flags specifying additional properties of a memory mapping.
+    MemoryMapFlags = MemoryMapFlags(u32);
+}
+
+/// Represents the currently host-mapped region of a [`DeviceMemory`] block.
+#[derive(Debug)]
+pub struct MappingState {
+    ptr: NonNull<c_void>,
+    range: Range<DeviceSize>,
+}
+
+impl MappingState {
+    /// Returns the pointer to the start of the mapped memory. Meaning that the pointer is already
+    /// offset by the [`offset`].
+    ///
+    /// [`offset`]: Self::offset
+    #[inline]
+    pub fn ptr(&self) -> NonNull<c_void> {
+        self.ptr
+    }
+
+    /// Returns the offset given to [`DeviceMemory::map`].
+    #[inline]
+    pub fn offset(&self) -> DeviceSize {
+        self.range.start
+    }
+
+    /// Returns the size given to [`DeviceMemory::map`].
+    #[inline]
+    pub fn size(&self) -> DeviceSize {
+        self.range.end - self.range.start
+    }
+
+    /// Returns a pointer to a slice of the mapped memory. Returns `None` if out of bounds.
+    ///
+    /// `range` is specified in bytes relative to the start of the memory allocation, and must fall
+    /// within the range of the memory mapping given to [`DeviceMemory::map`].
+    ///
+    /// This function is safe in the sense that the returned pointer is guaranteed to be within
+    /// bounds of the mapped memory, however dereferencing the pointer isn't:
+    ///
+    /// - Normal Rust aliasing rules apply: if you create a mutable reference out of the pointer,
+    ///   you must ensure that no other references exist in Rust to any portion of the same memory.
+    /// - While a reference created from the pointer exists, there must be no operations pending or
+    ///   executing in any queue on the device, that write to any portion of the same memory.
+    /// - While a mutable reference created from the pointer exists, there must be no operations
+    ///   pending or executing in any queue on the device, that read from any portion of the same
+    ///   memory.
+    #[inline]
+    pub fn slice(&self, range: Range<DeviceSize>) -> Option<NonNull<[u8]>> {
+        if self.range.start <= range.start
+            && range.start <= range.end
+            && range.end <= self.range.end
+        {
+            // SAFETY: We checked that the range is within the currently mapped range.
+            Some(unsafe { self.slice_unchecked(range) })
+        } else {
+            None
+        }
+    }
+
+    /// # Safety
+    ///
+    /// - `range` must be within the currently mapped range.
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    #[inline]
+    pub unsafe fn slice_unchecked(&self, range: Range<DeviceSize>) -> NonNull<[u8]> {
+        let ptr = self.ptr.as_ptr();
+
+        // SAFETY: TODO
+        let ptr = ptr.add((range.start - self.range.start) as usize);
+
+        let len = (range.end - range.start) as usize;
+
+        // SAFETY: TODO
+        let ptr = ptr::slice_from_raw_parts_mut(<*mut c_void>::cast::<u8>(ptr), len);
+
+        // SAFETY: TODO
+        NonNull::new_unchecked(ptr)
+    }
+}
+
+/// Represents a range of host-mapped [`DeviceMemory`] to be invalidated or flushed.
+///
+/// Must be contained within the currently mapped range of the device memory.
+#[derive(Debug)]
+pub struct MappedMemoryRange {
+    /// The offset (in bytes) from the beginning of the device memory, where the range starts.
+    ///
+    /// Must be a multiple of the [`non_coherent_atom_size`] device property.
+    ///
+    /// The default value is `0`.
+    ///
+    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
+    pub offset: DeviceSize,
+
+    /// The size (in bytes) of the range.
+    ///
+    /// Must be a multiple of the [`non_coherent_atom_size`] device property, or be equal to the
+    /// [`allocation_size`] of the device memory minus `offset`.
+    ///
+    /// The default value is `0`.
+    ///
+    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
+    /// [`allocation_size`]: DeviceMemory::allocation_size
+    pub size: DeviceSize,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl MappedMemoryRange {
+    pub(crate) fn validate(&self, memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
+        let &Self {
+            offset,
+            size,
+            _ne: _,
+        } = self;
+
+        let end = offset + size;
+
+        if let Some(state) = &memory.mapping_state {
+            if !(state.range.start <= offset && end <= state.range.end) {
+                return Err(Box::new(ValidationError {
+                    problem: "is not contained within the mapped range of this device memory"
+                        .into(),
+                    vuids: &["VUID-VkMappedMemoryRange-size-00685"],
+                    ..Default::default()
+                }));
+            }
+        } else {
+            return Err(Box::new(ValidationError {
+                problem: "this device memory is not currently host-mapped".into(),
+                vuids: &["VUID-VkMappedMemoryRange-memory-00684"],
+                ..Default::default()
+            }));
+        }
+
+        if !is_aligned(offset, memory.atom_size) {
+            return Err(Box::new(ValidationError {
+                context: "offset".into(),
+                problem: "is not aligned to the `non_coherent_atom_size` device property".into(),
+                vuids: &["VUID-VkMappedMemoryRange-offset-00687"],
+                ..Default::default()
+            }));
+        }
+
+        if !(is_aligned(size, memory.atom_size) || end == memory.allocation_size()) {
+            return Err(Box::new(ValidationError {
+                context: "size".into(),
+                problem: "is not aligned to the `non_coherent_atom_size` device property nor \
+                    equal to `self.allocation_size()` minus `memory_range.offset`"
+                    .into(),
+                vuids: &["VUID-VkMappedMemoryRange-size-01390"],
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for MappedMemoryRange {
+    #[inline]
+    fn default() -> Self {
+        MappedMemoryRange {
+            offset: 0,
+            size: 0,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
 }
 
 /// Represents device memory that has been mapped in a CPU-accessible space.
@@ -1095,6 +1625,10 @@ vulkan_bitflags! {
 /// }
 /// ```
 #[derive(Debug)]
+#[deprecated(
+    since = "0.34.0",
+    note = "use the methods provided directly on `DeviceMemory` instead"
+)]
 pub struct MappedDeviceMemory {
     memory: DeviceMemory,
     pointer: *mut c_void, // points to `range.start`
@@ -1110,6 +1644,7 @@ pub struct MappedDeviceMemory {
 // Vulkan specs, documentation of `vkFreeMemory`:
 // > If a memory object is mapped at the time it is freed, it is implicitly unmapped.
 
+#[allow(deprecated)]
 impl MappedDeviceMemory {
     /// Maps a range of memory to be accessed by the CPU.
     ///
@@ -1165,8 +1700,14 @@ impl MappedDeviceMemory {
             }));
         }
 
-        // VUID-vkMapMemory-memory-00678
-        // Guaranteed because we take ownership of `memory`, no other mapping can exist.
+        if memory.mapping_state().is_some() {
+            return Err(Box::new(ValidationError {
+                context: "memory".into(),
+                problem: "is already host-mapped".into(),
+                vuids: &["VUID-vkMapMemory-memory-00678"],
+                ..Default::default()
+            }));
+        }
 
         if range.end > memory.allocation_size {
             return Err(Box::new(ValidationError {
@@ -1480,6 +2021,7 @@ impl MappedDeviceMemory {
     }
 }
 
+#[allow(deprecated)]
 impl AsRef<DeviceMemory> for MappedDeviceMemory {
     #[inline]
     fn as_ref(&self) -> &DeviceMemory {
@@ -1487,6 +2029,7 @@ impl AsRef<DeviceMemory> for MappedDeviceMemory {
     }
 }
 
+#[allow(deprecated)]
 impl AsMut<DeviceMemory> for MappedDeviceMemory {
     #[inline]
     fn as_mut(&mut self) -> &mut DeviceMemory {
@@ -1494,6 +2037,7 @@ impl AsMut<DeviceMemory> for MappedDeviceMemory {
     }
 }
 
+#[allow(deprecated)]
 unsafe impl DeviceOwned for MappedDeviceMemory {
     #[inline]
     fn device(&self) -> &Arc<Device> {
@@ -1501,7 +2045,9 @@ unsafe impl DeviceOwned for MappedDeviceMemory {
     }
 }
 
+#[allow(deprecated)]
 unsafe impl Send for MappedDeviceMemory {}
+#[allow(deprecated)]
 unsafe impl Sync for MappedDeviceMemory {}
 
 #[cfg(test)]

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -528,8 +528,6 @@ impl DeviceMemory {
     }
 
     fn validate_unmap(&self, unmap_info: &MemoryUnmapInfo) -> Result<(), Box<ValidationError>> {
-        let &MemoryUnmapInfo { flags: _, _ne: _ } = unmap_info;
-
         if self.mapping_state.is_none() {
             return Err(Box::new(ValidationError {
                 problem: "this device memory is not currently host-mapped".into(),
@@ -537,6 +535,10 @@ impl DeviceMemory {
                 ..Default::default()
             }));
         }
+
+        unmap_info
+            .validate(self)
+            .map_err(|err| err.add_context("unmap_info"))?;
 
         Ok(())
     }
@@ -1505,6 +1507,14 @@ pub struct MemoryUnmapInfo {
     pub flags: MemoryUnmapFlags,
 
     pub _ne: crate::NonExhaustive,
+}
+
+impl MemoryUnmapInfo {
+    pub(crate) fn validate(&self, _memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
+        let &Self { flags: _, _ne: _ } = self;
+
+        Ok(())
+    }
 }
 
 impl Default for MemoryUnmapInfo {

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -68,11 +68,6 @@ pub struct DeviceMemory {
     is_coherent: bool,
 }
 
-// It is safe to share `MappingState::ptr` between threads because the user would have to use
-// unsafe code themself to get UB in the first place.
-unsafe impl Send for DeviceMemory {}
-unsafe impl Sync for DeviceMemory {}
-
 impl DeviceMemory {
     /// Allocates a block of memory from the device.
     ///
@@ -1462,6 +1457,11 @@ pub struct MappingState {
     ptr: NonNull<c_void>,
     range: Range<DeviceSize>,
 }
+
+// It is safe to share `ptr` between threads because the user would have to use unsafe code
+// themself to get UB in the first place.
+unsafe impl Send for MappingState {}
+unsafe impl Sync for MappingState {}
 
 impl MappingState {
     /// Returns the pointer to the start of the mapped memory. Meaning that the pointer is already

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -1383,8 +1383,6 @@ impl MemoryMapInfo {
             _ne: _,
         } = self;
 
-        let end = offset + size;
-
         if !(offset < memory.allocation_size()) {
             return Err(Box::new(ValidationError {
                 context: "offset".into(),
@@ -1403,7 +1401,7 @@ impl MemoryMapInfo {
             }));
         }
 
-        if !(end <= memory.allocation_size()) {
+        if !(size <= memory.allocation_size() - offset) {
             return Err(Box::new(ValidationError {
                 context: "size".into(),
                 problem: "is not less than or equal to `self.allocation_size()` minus `offset`"
@@ -1424,7 +1422,7 @@ impl MemoryMapInfo {
         // mapped memory after being aligned to the non-coherent atom size.
         if !memory.is_coherent
             && (!is_aligned(offset, atom_size)
-                || (!is_aligned(size, atom_size) && end != memory.allocation_size()))
+                || (!is_aligned(size, atom_size) && offset + size != memory.allocation_size()))
         {
             return Err(Box::new(ValidationError {
                 problem: "`self.memory_type_index()` refers to a memory type whose \

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -1510,8 +1510,10 @@ pub struct MemoryUnmapInfo {
 }
 
 impl MemoryUnmapInfo {
-    pub(crate) fn validate(&self, _memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
-        let &Self { flags: _, _ne: _ } = self;
+    pub(crate) fn validate(&self, memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
+        let &Self { flags, _ne: _ } = self;
+
+        flags.validate_device(memory.device())?;
 
         Ok(())
     }

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -1492,7 +1492,7 @@ pub struct MemoryUnmapInfo {
 }
 
 impl MemoryUnmapInfo {
-    pub(crate) fn validate(&self, memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
+    pub(crate) fn validate(&self, _memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
         let &Self { _ne: _ } = self;
 
         Ok(())

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -1499,11 +1499,22 @@ vulkan_bitflags! {
 }
 
 /// Parameters of a memory unmap operation.
+#[derive(Debug)]
 pub struct MemoryUnmapInfo {
     /// Additional properties of the unmapping.
     pub flags: MemoryUnmapFlags,
 
     pub _ne: crate::NonExhaustive,
+}
+
+impl Default for MemoryUnmapInfo {
+    #[inline]
+    fn default() -> Self {
+        MemoryUnmapInfo {
+            flags: MemoryUnmapFlags::empty(),
+            _ne: crate::NonExhaustive(()),
+        }
+    }
 }
 
 vulkan_bitflags! {

--- a/vulkano/src/padded.rs
+++ b/vulkano/src/padded.rs
@@ -15,11 +15,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     alloc::Layout,
     cmp::Ordering,
-    ffi::c_void,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
-    mem::{align_of, size_of, MaybeUninit},
+    mem::{size_of, MaybeUninit},
     ops::{Deref, DerefMut},
+    ptr::NonNull,
 };
 
 /// A newtype wrapper around `T`, with `N` bytes of trailing padding.
@@ -303,11 +303,10 @@ where
             panic!("zero-sized types are not valid buffer contents");
         };
 
-    unsafe fn from_ffi(data: *mut c_void, range: usize) -> *mut Self {
-        debug_assert!(range == size_of::<Self>());
-        debug_assert!(data as usize % align_of::<Self>() == 0);
+    unsafe fn ptr_from_slice(slice: NonNull<[u8]>) -> *mut Self {
+        debug_assert!(slice.len() == size_of::<Padded<T, N>>());
 
-        data.cast()
+        <*mut [u8]>::cast::<Padded<T, N>>(slice.as_ptr())
     }
 }
 


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
- `Subbuffer::mapped_ptr` was replaced by `Subbuffer::mapped_slice`.
- `MemoryAlloc::new` no longer returns a `Result`, and doesn't map the `DeviceMemory` automatically anymore.
- `MemoryAlloc::mapped_ptr` and `MemoryAlloc::mapped_slice[_mut]` were replaced by `MemoryAlloc::mapped_slice`, which returns a pointer.
- `MemoryAlloc::{invalidate, flush}_range` now take a `MappedMemoryRange` as argument.

### Additions
- Added `DeviceMemory::{map, unmap, mapping_state, invalidate_range, flush_range}`, `MappedDeviceMemory` has been deprecated.
- Added `MemoryMapInfo`, `MemoryUnmapInfo`, `MappingState` and `MappedMemoryRange`.

### Bugs fixed
- Fixed potential UB when using `MemoryAlloc::try_unwrap`, where the allocation was mapped on contruction of the `MemoryAlloc` but not unmapped on unwrapping, allowing double-mapping.
- Fixed a bug in `GenericMemoryAllocator::allocate`, where the root allocations weren't created with the configured `AllocationType`.