### PR TITLE
Fix erroneous used range for buffers in descriptor sets

### DIFF
--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -680,6 +680,9 @@ impl AutoSyncState {
                     ref range,
                     memory_access,
                 } => {
+                    debug_assert!(range.start <= range.end);
+                    debug_assert!(range.end <= buffer.size());
+
                     if let Some(previous_use_ref) = self.find_buffer_conflict(
                         self.command_index,
                         buffer,
@@ -704,6 +707,16 @@ impl AutoSyncState {
                     start_layout,
                     end_layout,
                 } => {
+                    debug_assert!(image.format().aspects().contains(subresource_range.aspects));
+                    debug_assert!(
+                        subresource_range.mip_levels.start <= subresource_range.mip_levels.end
+                    );
+                    debug_assert!(subresource_range.mip_levels.end <= image.mip_levels());
+                    debug_assert!(
+                        subresource_range.array_layers.start <= subresource_range.array_layers.end
+                    );
+                    debug_assert!(subresource_range.array_layers.end <= image.array_layers());
+
                     debug_assert!(memory_access.contains_write() || start_layout == end_layout);
                     debug_assert!(end_layout != ImageLayout::Undefined);
                     debug_assert!(end_layout != ImageLayout::Preinitialized);
@@ -1267,7 +1280,7 @@ struct UnsolvableResourceConflict {
 }
 
 // State of a resource during the building of the command buffer.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct BufferState {
     // Lists every use of the resource.
     resource_uses: Vec<ResourceUseRef>,
@@ -1281,7 +1294,7 @@ struct BufferState {
 }
 
 // State of a resource during the building of the command buffer.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct ImageState {
     // Lists every use of the resource.
     resource_uses: Vec<ResourceUseRef>,

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -281,7 +281,7 @@ impl From<ResourceInCommand> for ResourceUseRef2 {
 }
 
 /// Type of resource whose state is to be tracked.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(super) enum Resource {
     Buffer {
         buffer: Subbuffer<[u8]>,

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -2503,14 +2503,14 @@ where
                                 let (use_ref, memory_access) = use_iter(index as u32);
 
                                 let mut range = range.clone();
-                                range.start += buffer.offset() + dynamic_offset;
-                                range.end += buffer.offset() + dynamic_offset;
+                                range.start += dynamic_offset;
+                                range.end += dynamic_offset;
 
                                 used_resources.push((
                                     use_ref,
                                     Resource::Buffer {
                                         buffer: buffer.clone(),
-                                        range: range.clone(),
+                                        range,
                                         memory_access,
                                     },
                                 ));
@@ -2522,10 +2522,6 @@ where
                                 let DescriptorBufferInfo { buffer, range } = buffer_info;
 
                                 let (use_ref, memory_access) = use_iter(index as u32);
-
-                                let mut range = range.clone();
-                                range.start += buffer.offset();
-                                range.end += buffer.offset();
 
                                 used_resources.push((
                                     use_ref,
@@ -2545,15 +2541,11 @@ where
                             let buffer = buffer_view.buffer();
                             let (use_ref, memory_access) = use_iter(index as u32);
 
-                            let mut range = buffer_view.range();
-                            range.start += buffer.offset();
-                            range.end += buffer.offset();
-
                             used_resources.push((
                                 use_ref,
                                 Resource::Buffer {
                                     buffer: buffer.clone(),
-                                    range: range.clone(),
+                                    range: buffer_view.range().clone(),
                                     memory_access,
                                 },
                             ));


### PR DESCRIPTION
`buffer.offset()` was being added to the range of buffers when it shouldn't have been, effectively resulting it being added twice. I've added some debug sanity checks so that it doesn't happen again.