### PR TITLE
Improved display of some error and remove `unimplemented!` for `UnexpectedImageLayout` display

### DIFF
--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -482,22 +482,28 @@ impl Error for CommandBufferExecError {
 
 impl Display for CommandBufferExecError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        write!(
-            f,
-            "{}",
-            match self {
-                CommandBufferExecError::AccessError { .. } =>
-                    "access to a resource has been denied",
-                CommandBufferExecError::OneTimeSubmitAlreadySubmitted => {
-                    "the command buffer or one of the secondary command buffers it executes was \
-                    created with the \"one time submit\" flag, but has already been submitted in \
-                    the past"
-                }
-                CommandBufferExecError::ExclusiveAlreadyInUse => {
-                    "the command buffer or one of the secondary command buffers it executes is \
-                    already in use was not created with the \"concurrent\" flag"
-                }
+        let value = match self {
+            CommandBufferExecError::AccessError {
+                error,
+                command_name,
+                command_offset,
+                command_param,
+            } => return write!(
+                f,
+                "access to a resource has been denied on command {} (offset: {}, param: {}): {}",
+                command_name, command_offset, command_param, error
+            ),
+            CommandBufferExecError::OneTimeSubmitAlreadySubmitted => {
+                "the command buffer or one of the secondary command buffers it executes was \
+                created with the \"one time submit\" flag, but has already been submitted in \
+                the past"
             }
-        )
+            CommandBufferExecError::ExclusiveAlreadyInUse => {
+                "the command buffer or one of the secondary command buffers it executes is \
+                already in use was not created with the \"concurrent\" flag"
+            }
+        };
+
+        write!(f, "{}", value)
     }
 }

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -502,26 +502,28 @@ impl Error for AccessError {}
 
 impl Display for AccessError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        write!(
-            f,
-            "{}",
-            match self {
-                AccessError::AlreadyInUse => {
-                    "the resource is already in use, and there is no tracking of concurrent usages"
-                }
-                AccessError::UnexpectedImageLayout { .. } => {
-                    unimplemented!() // TODO: find a description
-                }
-                AccessError::ImageNotInitialized { .. } => {
-                    "trying to use an image without transitioning it from the undefined or \
-                    preinitialized layouts first"
-                }
-                AccessError::SwapchainImageNotAcquired => {
-                    "trying to use a swapchain image without depending on a corresponding acquire \
-                    image future"
-                }
+        let value = match self {
+            AccessError::AlreadyInUse => {
+                "the resource is already in use, and there is no tracking of concurrent usages"
             }
-        )
+            AccessError::UnexpectedImageLayout { allowed, requested } => {
+                return write!(
+                    f,
+                    "unexpected image layout: requested {:?}, allowed {:?}",
+                    allowed, requested
+                )
+            }
+            AccessError::ImageNotInitialized { .. } => {
+                "trying to use an image without transitioning it from the undefined or \
+                preinitialized layouts first"
+            }
+            AccessError::SwapchainImageNotAcquired => {
+                "trying to use a swapchain image without depending on a corresponding acquire \
+                image future"
+            }
+        };
+
+        write!(f, "{}", value,)
     }
 }
 
@@ -538,14 +540,12 @@ impl Error for AccessCheckError {}
 
 impl Display for AccessCheckError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        write!(
-            f,
-            "{}",
-            match self {
-                AccessCheckError::Denied(_) => "access to the resource has been denied",
-                AccessCheckError::Unknown => "the resource is unknown",
+        match self {
+            AccessCheckError::Denied(err) => {
+                write!(f, "access to the resource has been denied: {}", err)
             }
-        )
+            AccessCheckError::Unknown => write!(f, "the resource is unknown"),
+        }
     }
 }
 


### PR DESCRIPTION
1. [X] Update documentation to reflect any user-facing changes - in this repository.

2. [ ] Make sure that the changes are covered by unit-tests. (N/A)

3. [X] Run `cargo fmt` on the changes.

4. [X] Please put changelog entries **in the description of this Pull Request**

Changelog:
```markdown
### Additions
- Improved error message display for `AccessError`
- Improved error message display for `CommandBufferExecError`

### Bugs fixed
- Fixed panics when displaying `AccessError::UnexpectedImageLayout`.
````

5. [X] Describe in common words what is the purpose of this change, related

It happened to me quite often that I've it some error and the message was lost on display because some `Display` implementation don't record the cause. Improved some of those that I've spotted while debugging some bad code I had.

Also removed the `unimplemented` for `AccessError::UnexpectedImageLayout` and now giving a more descriptive message.


