### PR TITLE
Remove uses of `Option::unwrap_unchecked` as a safety precaution

### DIFF
--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -129,11 +129,9 @@ impl<T: ?Sized> Subbuffer<T> {
     /// [`MappingState::slice`]: crate::memory::MappingState::slice
     pub fn mapped_slice(&self) -> Result<NonNull<[u8]>, HostAccessError> {
         match self.buffer().memory() {
-            BufferMemory::Normal(a) => {
-                let opt = a.mapped_slice(self.range());
-
+            BufferMemory::Normal(allocation) => {
                 // SAFETY: `self.range()` is in bounds of the allocation.
-                unsafe { opt.unwrap_unchecked() }
+                unsafe { allocation.mapped_slice_unchecked(self.range()) }
             }
             BufferMemory::Sparse => unreachable!(),
         }
@@ -510,7 +508,7 @@ impl<T> Subbuffer<[T]> {
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn slice_unchecked(mut self, range: impl RangeBounds<DeviceSize>) -> Subbuffer<[T]> {
-        let Range { start, end } = memory::range(range, ..self.len()).unwrap_unchecked();
+        let Range { start, end } = memory::range_unchecked(range, ..self.len());
 
         self.offset += start * size_of::<T>() as DeviceSize;
         self.size = (end - start) * size_of::<T>() as DeviceSize;

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -590,3 +590,27 @@ pub(crate) fn range(
 
     (start <= end && end <= len).then_some(Range { start, end })
 }
+
+/// Converts a `RangeBounds` into a `Range` without doing any bounds checking.
+pub(crate) fn range_unchecked(
+    range: impl RangeBounds<DeviceSize>,
+    bounds: RangeTo<DeviceSize>,
+) -> Range<DeviceSize> {
+    let len = bounds.end;
+
+    let start = match range.start_bound() {
+        Bound::Included(&start) => start,
+        Bound::Excluded(start) => start + 1,
+        Bound::Unbounded => 0,
+    };
+
+    let end = match range.end_bound() {
+        Bound::Included(end) => end + 1,
+        Bound::Excluded(&end) => end,
+        Bound::Unbounded => len,
+    };
+
+    debug_assert!(start <= end && end <= len);
+
+    Range { start, end }
+}


### PR DESCRIPTION
This adds a new function for converting a `RangeBounds` to a `Range`, as a replacement for where `memory::range(..., ...).unwrap_unchecked()` has been used before. `Option::unwrap_unchecked` is very dangerous, because when it goes south it can potentially end up deleting half your program from existence. Whereas with the manual unchecked implementation, the worst that can happen is arithmetic overflow and/or dereferencing an invalid pointer.