### PR TITLE
Memory (sub)allocation API 2.0

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -274,7 +274,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -293,7 +293,7 @@ fn main() {
     let uniform_buffers = (0..swapchain.image_count())
         .map(|_| {
             Buffer::new_sized(
-                &memory_allocator,
+                memory_allocator.clone(),
                 BufferCreateInfo {
                     usage: BufferUsage::UNIFORM_BUFFER,
                     ..Default::default()
@@ -312,7 +312,7 @@ fn main() {
     // is used exclusively for writing, swapping the two after each update.
     let textures = [(); 2].map(|_| {
         Image::new(
-            &memory_allocator,
+            memory_allocator.clone(),
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
                 format: Format::R8G8B8A8_UNORM,
@@ -714,7 +714,7 @@ fn run_worker(
         // out-of-date texture is the current up-to-date texture and vice-versa, cycle repeating.
         let staging_buffers = [(); 2].map(|_| {
             Buffer::from_iter(
-                &memory_allocator,
+                memory_allocator.clone(),
                 BufferCreateInfo {
                     usage: BufferUsage::TRANSFER_SRC,
                     ..Default::default()

--- a/examples/src/bin/basic-compute-shader.rs
+++ b/examples/src/bin/basic-compute-shader.rs
@@ -13,6 +13,7 @@
 // been more or more used for general-purpose operations as well. This is called "General-Purpose
 // GPU", or *GPGPU*. This is what this example demonstrates.
 
+use std::sync::Arc;
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -158,14 +159,14 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     // We start by creating the buffer that will store the data.
     let data_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::STORAGE_BUFFER,
             ..Default::default()

--- a/examples/src/bin/deferred/frame/ambient_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/ambient_lighting_system.rs
@@ -19,7 +19,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -54,7 +54,7 @@ impl AmbientLightingSystem {
     pub fn new(
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
-        memory_allocator: &impl MemoryAllocator,
+        memory_allocator: Arc<StandardMemoryAllocator>,
         command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
         descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> AmbientLightingSystem {

--- a/examples/src/bin/deferred/frame/directional_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/directional_lighting_system.rs
@@ -20,7 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -55,7 +55,7 @@ impl DirectionalLightingSystem {
     pub fn new(
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
-        memory_allocator: &impl MemoryAllocator,
+        memory_allocator: Arc<StandardMemoryAllocator>,
         command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
         descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> DirectionalLightingSystem {

--- a/examples/src/bin/deferred/frame/point_lighting_system.rs
+++ b/examples/src/bin/deferred/frame/point_lighting_system.rs
@@ -20,7 +20,7 @@ use vulkano::{
     },
     device::Queue,
     image::view::ImageView,
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::{AttachmentBlend, BlendFactor, BlendOp, ColorBlendState},
@@ -54,7 +54,7 @@ impl PointLightingSystem {
     pub fn new(
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
-        memory_allocator: &impl MemoryAllocator,
+        memory_allocator: Arc<StandardMemoryAllocator>,
         command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
         descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> PointLightingSystem {

--- a/examples/src/bin/deferred/frame/system.rs
+++ b/examples/src/bin/deferred/frame/system.rs
@@ -155,7 +155,7 @@ impl FrameSystem {
         // will be replaced the first time we call `frame()`.
         let diffuse_buffer = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator.clone(),
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::A2B10G10R10_UNORM_PACK32,
@@ -172,7 +172,7 @@ impl FrameSystem {
         .unwrap();
         let normals_buffer = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator.clone(),
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R16G16B16A16_SFLOAT,
@@ -187,7 +187,7 @@ impl FrameSystem {
         .unwrap();
         let depth_buffer = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator.clone(),
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::D16_UNORM,
@@ -211,21 +211,21 @@ impl FrameSystem {
         let ambient_lighting_system = AmbientLightingSystem::new(
             gfx_queue.clone(),
             lighting_subpass.clone(),
-            &memory_allocator,
+            memory_allocator.clone(),
             command_buffer_allocator.clone(),
             descriptor_set_allocator.clone(),
         );
         let directional_lighting_system = DirectionalLightingSystem::new(
             gfx_queue.clone(),
             lighting_subpass.clone(),
-            &memory_allocator,
+            memory_allocator.clone(),
             command_buffer_allocator.clone(),
             descriptor_set_allocator.clone(),
         );
         let point_lighting_system = PointLightingSystem::new(
             gfx_queue.clone(),
             lighting_subpass,
-            &memory_allocator,
+            memory_allocator.clone(),
             command_buffer_allocator.clone(),
             descriptor_set_allocator,
         );
@@ -281,7 +281,7 @@ impl FrameSystem {
             // render pass their content becomes undefined.
             self.diffuse_buffer = ImageView::new_default(
                 Image::new(
-                    &self.memory_allocator,
+                    self.memory_allocator.clone(),
                     ImageCreateInfo {
                         extent,
                         format: Format::A2B10G10R10_UNORM_PACK32,
@@ -297,7 +297,7 @@ impl FrameSystem {
             .unwrap();
             self.normals_buffer = ImageView::new_default(
                 Image::new(
-                    &self.memory_allocator,
+                    self.memory_allocator.clone(),
                     ImageCreateInfo {
                         extent,
                         format: Format::R16G16B16A16_SFLOAT,
@@ -313,7 +313,7 @@ impl FrameSystem {
             .unwrap();
             self.depth_buffer = ImageView::new_default(
                 Image::new(
-                    &self.memory_allocator,
+                    self.memory_allocator.clone(),
                     ImageCreateInfo {
                         extent,
                         format: Format::D16_UNORM,

--- a/examples/src/bin/deferred/main.rs
+++ b/examples/src/bin/deferred/main.rs
@@ -174,7 +174,7 @@ fn main() {
     let triangle_draw_system = TriangleDrawSystem::new(
         queue.clone(),
         frame_system.deferred_subpass(),
-        &memory_allocator,
+        memory_allocator.clone(),
         command_buffer_allocator,
     );
 

--- a/examples/src/bin/deferred/triangle_draw_system.rs
+++ b/examples/src/bin/deferred/triangle_draw_system.rs
@@ -46,7 +46,7 @@ impl TriangleDrawSystem {
     pub fn new(
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
-        memory_allocator: &StandardMemoryAllocator,
+        memory_allocator: Arc<StandardMemoryAllocator>,
         command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
     ) -> TriangleDrawSystem {
         let vertices = [

--- a/examples/src/bin/dynamic-buffers.rs
+++ b/examples/src/bin/dynamic-buffers.rs
@@ -13,7 +13,7 @@
 // Each draw or dispatch call can specify an offset into the buffer to read object data from,
 // without having to rebind descriptor sets.
 
-use std::{iter::repeat, mem::size_of};
+use std::{iter::repeat, mem::size_of, sync::Arc};
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -153,7 +153,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
@@ -188,7 +188,7 @@ fn main() {
     };
 
     let input_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::UNIFORM_BUFFER,
             ..Default::default()
@@ -203,7 +203,7 @@ fn main() {
     .unwrap();
 
     let output_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::STORAGE_BUFFER,
             ..Default::default()

--- a/examples/src/bin/dynamic-local-size.rs
+++ b/examples/src/bin/dynamic-local-size.rs
@@ -13,7 +13,7 @@
 // Workgroup parallelism capabilities vary between GPUs and setting them properly is important to
 // achieve the maximal performance that particular device can provide.
 
-use std::{fs::File, io::BufWriter, path::Path};
+use std::{fs::File, io::BufWriter, path::Path, sync::Arc};
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -209,13 +209,13 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let image = Image::new(
-        &memory_allocator,
+        memory_allocator.clone(),
         ImageCreateInfo {
             image_type: ImageType::Dim2d,
             format: Format::R8G8B8A8_UNORM,
@@ -238,7 +238,7 @@ fn main() {
     .unwrap();
 
     let buf = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::TRANSFER_DST,
             ..Default::default()

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -41,11 +41,10 @@ mod linux {
         },
         memory::{
             allocator::{
-                AllocationCreateInfo, MemoryAlloc, MemoryAllocator, MemoryTypeFilter,
-                StandardMemoryAllocator,
+                AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter, StandardMemoryAllocator,
             },
             DedicatedAllocation, DeviceMemory, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
-            MemoryAllocateInfo,
+            MemoryAllocateInfo, ResourceMemory,
         },
         pipeline::{
             graphics::{
@@ -159,7 +158,7 @@ mod linux {
 
         let image = Arc::new(
             raw_image
-                .bind_memory([MemoryAlloc::new(image_memory)])
+                .bind_memory([ResourceMemory::new_dedicated(image_memory)])
                 .map_err(|(err, _, _)| err)
                 .unwrap(),
         );
@@ -464,7 +463,7 @@ mod linux {
         Vec<Arc<Framebuffer>>,
         Arc<Sampler>,
         Arc<GraphicsPipeline>,
-        StandardMemoryAllocator,
+        Arc<StandardMemoryAllocator>,
         Subbuffer<[MyVertex]>,
     ) {
         let library = VulkanLibrary::new().unwrap();
@@ -600,7 +599,7 @@ mod linux {
             .unwrap()
         };
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
         let vertices = [
             MyVertex {
@@ -617,7 +616,7 @@ mod linux {
             },
         ];
         let vertex_buffer = Buffer::from_iter(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::VERTEX_BUFFER,
                 ..Default::default()

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -156,7 +156,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -180,7 +180,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -229,7 +229,7 @@ fn main() {
         let extent = [info.width * 2, info.height * 2, 1];
 
         let upload_buffer = Buffer::new_slice(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -248,7 +248,7 @@ fn main() {
             .unwrap();
 
         let image = Image::new(
-            &memory_allocator,
+            memory_allocator,
             ImageCreateInfo {
                 format: Format::R8G8B8A8_UNORM,
                 extent,

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -155,7 +155,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -179,7 +179,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -228,7 +228,7 @@ fn main() {
         let extent = [info.width, info.height, 1];
 
         let upload_buffer = Buffer::new_slice(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -247,7 +247,7 @@ fn main() {
             .unwrap();
 
         let image = Image::new(
-            &memory_allocator,
+            memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
                 format: Format::R8G8B8A8_SRGB,

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -161,7 +161,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -185,7 +185,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -234,7 +234,7 @@ fn main() {
         let extent = [info.width, info.height, 1];
 
         let upload_buffer = Buffer::new_slice(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -253,7 +253,7 @@ fn main() {
             .unwrap();
 
         let image = Image::new(
-            &memory_allocator,
+            memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
                 format: Format::R8G8B8A8_SRGB,

--- a/examples/src/bin/instancing.rs
+++ b/examples/src/bin/instancing.rs
@@ -168,7 +168,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     // We now create a buffer that will store the shape of our triangle. This triangle is identical
     // to the one in the `triangle.rs` example.
@@ -184,7 +184,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -222,7 +222,7 @@ fn main() {
         data
     };
     let instance_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()

--- a/examples/src/bin/interactive_fractal/app.rs
+++ b/examples/src/bin/interactive_fractal/app.rs
@@ -81,7 +81,7 @@ impl FractalApp {
             ),
             place_over_frame: RenderPassPlaceOverFrame::new(
                 gfx_queue,
-                &memory_allocator,
+                memory_allocator.clone(),
                 command_buffer_allocator,
                 descriptor_set_allocator,
                 image_format,

--- a/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/fractal_compute_pipeline.rs
@@ -59,7 +59,7 @@ impl FractalComputePipeline {
         ];
         let palette_size = colors.len() as i32;
         let palette = Buffer::from_iter(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::STORAGE_BUFFER,
                 ..Default::default()
@@ -119,7 +119,7 @@ impl FractalComputePipeline {
             colors.push([r, g, b, a]);
         }
         self.palette = Buffer::from_iter(
-            &self.memory_allocator,
+            self.memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::STORAGE_BUFFER,
                 ..Default::default()

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -22,7 +22,7 @@ use vulkano::{
         sampler::{Filter, Sampler, SamplerAddressMode, SamplerCreateInfo, SamplerMipmapMode},
         view::ImageView,
     },
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
             color_blend::ColorBlendState,
@@ -89,13 +89,13 @@ impl PixelsDrawPipeline {
     pub fn new(
         gfx_queue: Arc<Queue>,
         subpass: Subpass,
-        memory_allocator: &impl MemoryAllocator,
+        memory_allocator: Arc<StandardMemoryAllocator>,
         command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
         descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
     ) -> PixelsDrawPipeline {
         let (vertices, indices) = textured_quad(2.0, 2.0);
         let vertex_buffer = Buffer::from_iter(
-            memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::VERTEX_BUFFER,
                 ..Default::default()

--- a/examples/src/bin/interactive_fractal/place_over_frame.rs
+++ b/examples/src/bin/interactive_fractal/place_over_frame.rs
@@ -18,7 +18,7 @@ use vulkano::{
     device::Queue,
     format::Format,
     image::view::ImageView,
-    memory::allocator::MemoryAllocator,
+    memory::allocator::StandardMemoryAllocator,
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     sync::GpuFuture,
 };
@@ -34,7 +34,7 @@ pub struct RenderPassPlaceOverFrame {
 impl RenderPassPlaceOverFrame {
     pub fn new(
         gfx_queue: Arc<Queue>,
-        memory_allocator: &impl MemoryAllocator,
+        memory_allocator: Arc<StandardMemoryAllocator>,
         command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
         descriptor_set_allocator: Arc<StandardDescriptorSetAllocator>,
         output_format: Format,

--- a/examples/src/bin/msaa-renderpass.rs
+++ b/examples/src/bin/msaa-renderpass.rs
@@ -62,7 +62,7 @@
 // non-multisampled image. This operation is not a regular blit (blitting a multisampled image is
 // an error), instead it is called *resolving* the image.
 
-use std::{fs::File, io::BufWriter, path::Path};
+use std::{fs::File, io::BufWriter, path::Path, sync::Arc};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -150,7 +150,7 @@ fn main() {
     .unwrap();
     let queue = queues.next().unwrap();
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     // Creating our intermediate multisampled image.
     //
@@ -158,7 +158,7 @@ fn main() {
     // image. But we also pass the number of samples-per-pixel, which is 4 here.
     let intermediary = ImageView::new_default(
         Image::new(
-            &memory_allocator,
+            memory_allocator.clone(),
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
                 format: Format::R8G8B8A8_UNORM,
@@ -175,7 +175,7 @@ fn main() {
 
     // This is the final image that will receive the anti-aliased triangle.
     let image = Image::new(
-        &memory_allocator,
+        memory_allocator.clone(),
         ImageCreateInfo {
             image_type: ImageType::Dim2d,
             format: Format::R8G8B8A8_UNORM,
@@ -299,7 +299,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -368,7 +368,7 @@ fn main() {
     let command_buffer_allocator = StandardCommandBufferAllocator::new(device, Default::default());
 
     let buf = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::TRANSFER_DST,
             ..Default::default()

--- a/examples/src/bin/multi-window.rs
+++ b/examples/src/bin/multi-window.rs
@@ -177,7 +177,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -198,7 +198,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()

--- a/examples/src/bin/multi_window_game_of_life/game_of_life.rs
+++ b/examples/src/bin/multi_window_game_of_life/game_of_life.rs
@@ -23,7 +23,7 @@ use vulkano::{
     device::Queue,
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
-    memory::allocator::{AllocationCreateInfo, MemoryAllocator, MemoryTypeFilter},
+    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         compute::ComputePipelineCreateInfo, layout::PipelineDescriptorSetLayoutCreateInfo,
         ComputePipeline, Pipeline, PipelineBindPoint, PipelineLayout,
@@ -46,7 +46,7 @@ pub struct GameOfLifeComputePipeline {
     image: Arc<ImageView>,
 }
 
-fn rand_grid(memory_allocator: &impl MemoryAllocator, size: [u32; 2]) -> Subbuffer<[u32]> {
+fn rand_grid(memory_allocator: Arc<StandardMemoryAllocator>, size: [u32; 2]) -> Subbuffer<[u32]> {
     Buffer::from_iter(
         memory_allocator,
         BufferCreateInfo {
@@ -66,8 +66,8 @@ fn rand_grid(memory_allocator: &impl MemoryAllocator, size: [u32; 2]) -> Subbuff
 impl GameOfLifeComputePipeline {
     pub fn new(app: &App, compute_queue: Arc<Queue>, size: [u32; 2]) -> GameOfLifeComputePipeline {
         let memory_allocator = app.context.memory_allocator();
-        let life_in = rand_grid(memory_allocator, size);
-        let life_out = rand_grid(memory_allocator, size);
+        let life_in = rand_grid(memory_allocator.clone(), size);
+        let life_out = rand_grid(memory_allocator.clone(), size);
 
         let compute_life_pipeline = {
             let device = compute_queue.device();
@@ -94,7 +94,7 @@ impl GameOfLifeComputePipeline {
 
         let image = ImageView::new_default(
             Image::new(
-                memory_allocator,
+                memory_allocator.clone(),
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -91,7 +91,7 @@ impl PixelsDrawPipeline {
         let (vertices, indices) = textured_quad(2.0, 2.0);
         let memory_allocator = app.context.memory_allocator();
         let vertex_buffer = Buffer::from_iter(
-            memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::VERTEX_BUFFER,
                 ..Default::default()
@@ -105,7 +105,7 @@ impl PixelsDrawPipeline {
         )
         .unwrap();
         let index_buffer = Buffer::from_iter(
-            memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::INDEX_BUFFER,
                 ..Default::default()

--- a/examples/src/bin/multiview.rs
+++ b/examples/src/bin/multiview.rs
@@ -12,7 +12,7 @@
 // multiple perspectives or cameras are very similar like in virtual reality or other types of
 // stereoscopic rendering where the left and right eye only differ in a small position offset.
 
-use std::{fs::File, io::BufWriter, path::Path};
+use std::{fs::File, io::BufWriter, path::Path, sync::Arc};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
@@ -134,10 +134,10 @@ fn main() {
 
     let queue = queues.next().unwrap();
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     let image = Image::new(
-        &memory_allocator,
+        memory_allocator.clone(),
         ImageCreateInfo {
             image_type: ImageType::Dim2d,
             format: Format::B8G8R8A8_SRGB,
@@ -171,7 +171,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -313,7 +313,7 @@ fn main() {
 
     let create_buffer = || {
         Buffer::from_iter(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_DST,
                 ..Default::default()

--- a/examples/src/bin/occlusion-query.rs
+++ b/examples/src/bin/occlusion-query.rs
@@ -150,7 +150,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -206,7 +206,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -360,7 +360,7 @@ fn main() {
         &images,
         render_pass.clone(),
         &mut viewport,
-        &memory_allocator,
+        memory_allocator.clone(),
     );
 
     let mut recreate_swapchain = false;
@@ -401,7 +401,7 @@ fn main() {
                     &new_images,
                     render_pass.clone(),
                     &mut viewport,
-                    &memory_allocator,
+                    memory_allocator.clone(),
                 );
                 recreate_swapchain = false;
             }
@@ -565,7 +565,7 @@ fn window_size_dependent_setup(
     images: &[Arc<Image>],
     render_pass: Arc<RenderPass>,
     viewport: &mut Viewport,
-    memory_allocator: &StandardMemoryAllocator,
+    memory_allocator: Arc<StandardMemoryAllocator>,
 ) -> Vec<Arc<Framebuffer>> {
     let extent = images[0].extent();
     viewport.extent = [extent[0] as f32, extent[1] as f32];

--- a/examples/src/bin/push-constants.rs
+++ b/examples/src/bin/push-constants.rs
@@ -12,6 +12,7 @@
 // modifying and binding descriptor sets for each update. As a result, they are expected to
 // outperform such memory-backed resource updates.
 
+use std::sync::Arc;
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -140,13 +141,13 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let data_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::STORAGE_BUFFER,
             ..Default::default()

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -151,7 +151,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -175,7 +175,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -223,7 +223,7 @@ fn main() {
         let extent = [info.width, info.height, 1];
 
         let upload_buffer = Buffer::new_slice(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -242,7 +242,7 @@ fn main() {
             .unwrap();
 
         let image = Image::new(
-            &memory_allocator,
+            memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
                 format: Format::R8G8B8A8_SRGB,

--- a/examples/src/bin/runtime-shader/main.rs
+++ b/examples/src/bin/runtime-shader/main.rs
@@ -236,7 +236,7 @@ fn main() {
 
     let mut recreate_swapchain = false;
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -262,7 +262,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -163,7 +163,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -239,7 +239,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -289,7 +289,7 @@ fn main() {
         let extent = [info.width, info.height, 1];
 
         let upload_buffer = Buffer::new_slice(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -308,7 +308,7 @@ fn main() {
             .unwrap();
 
         let image = Image::new(
-            &memory_allocator,
+            memory_allocator.clone(),
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
                 format: Format::R8G8B8A8_SRGB,
@@ -338,7 +338,7 @@ fn main() {
         let extent = [info.width, info.height, 1];
 
         let upload_buffer = Buffer::new_slice(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -357,7 +357,7 @@ fn main() {
             .unwrap();
 
         let image = Image::new(
-            &memory_allocator,
+            memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
                 format: Format::R8G8B8A8_SRGB,

--- a/examples/src/bin/self-copy-buffer.rs
+++ b/examples/src/bin/self-copy-buffer.rs
@@ -11,6 +11,7 @@
 // and then we use `copy_buffer_dimensions` to copy the first half of the input buffer to the
 // second half.
 
+use std::sync::Arc;
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -132,13 +133,13 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let data_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::STORAGE_BUFFER
                 | BufferUsage::TRANSFER_SRC

--- a/examples/src/bin/shader-include/main.rs
+++ b/examples/src/bin/shader-include/main.rs
@@ -11,6 +11,7 @@
 // source code. The boilerplate is taken from the "basic-compute-shader.rs" example, where most of
 // the boilerplate is explained.
 
+use std::sync::Arc;
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -140,13 +141,13 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let data_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::STORAGE_BUFFER,
             ..Default::default()

--- a/examples/src/bin/shader-types-sharing.rs
+++ b/examples/src/bin/shader-types-sharing.rs
@@ -232,14 +232,14 @@ fn main() {
         future.wait(None).unwrap();
     }
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
 
     // Prepare test array `[0, 1, 2, 3....]`.
     let data_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::STORAGE_BUFFER,
             ..Default::default()

--- a/examples/src/bin/simple-particles.rs
+++ b/examples/src/bin/simple-particles.rs
@@ -326,7 +326,7 @@ fn main() {
         }
     }
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
@@ -353,7 +353,7 @@ fn main() {
 
         // Create a CPU-accessible buffer initialized with the vertex data.
         let temporary_accessible_buffer = Buffer::from_iter(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 // Specify this buffer will be used as a transfer source.
                 usage: BufferUsage::TRANSFER_SRC,
@@ -372,7 +372,7 @@ fn main() {
         // Create a buffer in device-local memory with enough space for `PARTICLE_COUNT` number of
         // `Vertex`.
         let device_local_buffer = Buffer::new_slice::<Vertex>(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 // Specify use as a storage buffer, vertex buffer, and transfer destination.
                 usage: BufferUsage::STORAGE_BUFFER

--- a/examples/src/bin/specialization-constants.rs
+++ b/examples/src/bin/specialization-constants.rs
@@ -9,6 +9,7 @@
 
 // TODO: Give a paragraph about what specialization are and what problems they solve.
 
+use std::sync::Arc;
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -140,13 +141,13 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
     let descriptor_set_allocator = StandardDescriptorSetAllocator::new(device.clone());
     let command_buffer_allocator =
         StandardCommandBufferAllocator::new(device.clone(), Default::default());
 
     let data_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::STORAGE_BUFFER,
             ..Default::default()

--- a/examples/src/bin/teapot/main.rs
+++ b/examples/src/bin/teapot/main.rs
@@ -162,7 +162,7 @@ fn main() {
     let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -176,7 +176,7 @@ fn main() {
     )
     .unwrap();
     let normals_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -190,7 +190,7 @@ fn main() {
     )
     .unwrap();
     let index_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::INDEX_BUFFER,
             ..Default::default()
@@ -247,7 +247,7 @@ fn main() {
         .unwrap();
 
     let (mut pipeline, mut framebuffers) = window_size_dependent_setup(
-        &memory_allocator,
+        memory_allocator.clone(),
         vs.clone(),
         fs.clone(),
         &images,
@@ -295,7 +295,7 @@ fn main() {
 
                     swapchain = new_swapchain;
                     let (new_pipeline, new_framebuffers) = window_size_dependent_setup(
-                        &memory_allocator,
+                        memory_allocator.clone(),
                         vs.clone(),
                         fs.clone(),
                         &new_images,
@@ -436,12 +436,13 @@ fn main() {
 
 /// This function is called once during initialization, then again whenever the window is resized.
 fn window_size_dependent_setup(
-    memory_allocator: &StandardMemoryAllocator,
+    memory_allocator: Arc<StandardMemoryAllocator>,
     vs: EntryPoint,
     fs: EntryPoint,
     images: &[Arc<Image>],
     render_pass: Arc<RenderPass>,
 ) -> (Arc<GraphicsPipeline>, Vec<Arc<Framebuffer>>) {
+    let device = memory_allocator.device().clone();
     let extent = images[0].extent();
 
     let depth_buffer = ImageView::new_default(
@@ -480,7 +481,6 @@ fn window_size_dependent_setup(
     // driver to optimize things, at the cost of slower window resizes.
     // https://computergraphics.stackexchange.com/questions/5742/vulkan-best-way-of-updating-pipeline-viewport
     let pipeline = {
-        let device = memory_allocator.device();
         let vertex_input_state = [Position::per_vertex(), Normal::per_vertex()]
             .definition(&vs.info().input_interface)
             .unwrap();
@@ -498,7 +498,7 @@ fn window_size_dependent_setup(
         let subpass = Subpass::from(render_pass, 0).unwrap();
 
         GraphicsPipeline::new(
-            device.clone(),
+            device,
             None,
             GraphicsPipelineCreateInfo {
                 stages: stages.into_iter().collect(),

--- a/examples/src/bin/tessellation.rs
+++ b/examples/src/bin/tessellation.rs
@@ -262,7 +262,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -301,7 +301,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -157,7 +157,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     #[derive(BufferContents, Vertex)]
     #[repr(C)]
@@ -181,7 +181,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator.clone(),
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()
@@ -235,7 +235,7 @@ fn main() {
                 .product::<DeviceSize>()
             * array_layers as DeviceSize;
         let upload_buffer = Buffer::new_slice(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -266,7 +266,7 @@ fn main() {
         }
 
         let image = Image::new(
-            &memory_allocator,
+            memory_allocator,
             ImageCreateInfo {
                 image_type: ImageType::Dim2d,
                 format,

--- a/examples/src/bin/triangle-v1_3.rs
+++ b/examples/src/bin/triangle-v1_3.rs
@@ -287,7 +287,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     // We now create a buffer that will store the shape of our triangle. We use `#[repr(C)]` here
     // to force rustc to use a defined layout for our data, as the default representation has *no
@@ -311,7 +311,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -256,7 +256,7 @@ fn main() {
         .unwrap()
     };
 
-    let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
     // We now create a buffer that will store the shape of our triangle. We use `#[repr(C)]` here
     // to force rustc to use a defined layout for our data, as the default representation has *no
@@ -280,7 +280,7 @@ fn main() {
         },
     ];
     let vertex_buffer = Buffer::from_iter(
-        &memory_allocator,
+        memory_allocator,
         BufferCreateInfo {
             usage: BufferUsage::VERTEX_BUFFER,
             ..Default::default()

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -225,7 +225,7 @@ impl VulkanoWindowRenderer {
         let final_view_image = self.final_views[0].image();
         let image = ImageView::new_default(
             Image::new(
-                &self.memory_allocator,
+                self.memory_allocator.clone(),
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format,

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -86,10 +86,10 @@ use crate::{
     memory::{
         allocator::{
             AllocationCreateInfo, AllocationType, DeviceLayout, MemoryAllocator,
-            MemoryAllocatorError, ResourceMemory,
+            MemoryAllocatorError,
         },
         DedicatedAllocation, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
-        ExternalMemoryProperties, MemoryRequirements,
+        ExternalMemoryProperties, MemoryRequirements, ResourceMemory,
     },
     range_map::RangeMap,
     sync::{future::AccessError, AccessConflict, CurrentAccess, Sharing},

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -301,7 +301,7 @@ where
     /// 64. [`SubbufferAllocator`] does this automatically.
     ///
     /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
-    /// [`invalidate_range`]: crate::memory::allocator::MemoryAlloc::invalidate_range
+    /// [`invalidate_range`]: crate::memory::allocator::ResourceMemory::invalidate_range
     /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
     /// [`write`]: Self::write
     /// [`SubbufferAllocator`]: super::allocator::SubbufferAllocator
@@ -312,8 +312,8 @@ where
         };
 
         let range = if let Some(atom_size) = allocation.atom_size() {
-            // This works because the suballocators align allocations to the non-coherent atom size
-            // when the memory is host-visible but not host-coherent.
+            // This works because the memory allocator must align allocations to the non-coherent
+            // atom size when the memory is host-visible but not host-coherent.
             let start = align_down(self.offset, atom_size);
             let end = cmp::min(
                 align_up(self.offset + self.size, atom_size),
@@ -387,7 +387,7 @@ where
     /// does this automatically.
     ///
     /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
-    /// [`flush_range`]: crate::memory::allocator::MemoryAlloc::flush_range
+    /// [`flush_range`]: crate::memory::allocator::ResourceMemory::flush_range
     /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
     /// [`read`]: Self::read
     /// [`SubbufferAllocator`]: super::allocator::SubbufferAllocator
@@ -398,8 +398,8 @@ where
         };
 
         let range = if let Some(atom_size) = allocation.atom_size() {
-            // This works because the suballocators align allocations to the non-coherent atom size
-            // when the memory is host-visible but not host-coherent.
+            // This works because the memory allocator must align allocations to the non-coherent
+            // atom size when the memory is host-visible but not host-coherent.
             let start = align_down(self.offset, atom_size);
             let end = cmp::min(
                 align_up(self.offset + self.size, atom_size),
@@ -1140,7 +1140,7 @@ mod tests {
         memory::{
             allocator::{
                 AllocationCreateInfo, AllocationType, DeviceLayout, MemoryAllocator,
-                StandardMemoryAllocator,
+                ResourceMemory, StandardMemoryAllocator,
             },
             MemoryRequirements,
         },
@@ -1211,10 +1211,10 @@ mod tests {
     #[test]
     fn split_at() {
         let (device, _) = gfx_dev_and_queue!();
-        let allocator = StandardMemoryAllocator::new_default(device);
+        let allocator = Arc::new(StandardMemoryAllocator::new_default(device));
 
         let buffer = Buffer::new_slice::<u32>(
-            &allocator,
+            allocator,
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -1248,7 +1248,7 @@ mod tests {
     #[test]
     fn cast_aligned() {
         let (device, _) = gfx_dev_and_queue!();
-        let allocator = StandardMemoryAllocator::new_default(device.clone());
+        let allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
         let raw_buffer = RawBuffer::new(
             device,
@@ -1288,6 +1288,7 @@ mod tests {
                 None,
             )
             .unwrap();
+        let allocation = unsafe { ResourceMemory::from_allocation(allocator, allocation) };
 
         let buffer = Buffer::from_raw(raw_buffer, BufferMemory::Normal(allocation));
         let buffer = Subbuffer::from(Arc::new(buffer));

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -301,7 +301,7 @@ where
     /// 64. [`SubbufferAllocator`] does this automatically.
     ///
     /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
-    /// [`invalidate_range`]: crate::memory::allocator::ResourceMemory::invalidate_range
+    /// [`invalidate_range`]: crate::memory::ResourceMemory::invalidate_range
     /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
     /// [`write`]: Self::write
     /// [`SubbufferAllocator`]: super::allocator::SubbufferAllocator
@@ -387,7 +387,7 @@ where
     /// does this automatically.
     ///
     /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
-    /// [`flush_range`]: crate::memory::allocator::ResourceMemory::flush_range
+    /// [`flush_range`]: crate::memory::ResourceMemory::flush_range
     /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
     /// [`read`]: Self::read
     /// [`SubbufferAllocator`]: super::allocator::SubbufferAllocator
@@ -1140,9 +1140,9 @@ mod tests {
         memory::{
             allocator::{
                 AllocationCreateInfo, AllocationType, DeviceLayout, MemoryAllocator,
-                ResourceMemory, StandardMemoryAllocator,
+                StandardMemoryAllocator,
             },
-            MemoryRequirements,
+            MemoryRequirements, ResourceMemory,
         },
     };
 

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -20,9 +20,9 @@ use crate::{
     instance::InstanceOwnedDebugWrapper,
     macros::impl_id_counter,
     memory::{
-        allocator::{AllocationType, DeviceLayout, ResourceMemory},
+        allocator::{AllocationType, DeviceLayout},
         is_aligned, DedicatedTo, ExternalMemoryHandleTypes, MemoryAllocateFlags,
-        MemoryPropertyFlags, MemoryRequirements,
+        MemoryPropertyFlags, MemoryRequirements, ResourceMemory,
     },
     sync::Sharing,
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version,

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -20,7 +20,7 @@ use crate::{
     instance::InstanceOwnedDebugWrapper,
     macros::impl_id_counter,
     memory::{
-        allocator::{AllocationType, DeviceLayout, MemoryAlloc},
+        allocator::{AllocationType, DeviceLayout, ResourceMemory},
         is_aligned, DedicatedTo, ExternalMemoryHandleTypes, MemoryAllocateFlags,
         MemoryPropertyFlags, MemoryRequirements,
     },
@@ -277,8 +277,8 @@ impl RawBuffer {
     /// Binds device memory to this buffer.
     pub fn bind_memory(
         self,
-        allocation: MemoryAlloc,
-    ) -> Result<Buffer, (Validated<VulkanError>, RawBuffer, MemoryAlloc)> {
+        allocation: ResourceMemory,
+    ) -> Result<Buffer, (Validated<VulkanError>, RawBuffer, ResourceMemory)> {
         if let Err(err) = self.validate_bind_memory(&allocation) {
             return Err((err.into(), self, allocation));
         }
@@ -287,7 +287,10 @@ impl RawBuffer {
             .map_err(|(err, buffer, allocation)| (err.into(), buffer, allocation))
     }
 
-    fn validate_bind_memory(&self, allocation: &MemoryAlloc) -> Result<(), Box<ValidationError>> {
+    fn validate_bind_memory(
+        &self,
+        allocation: &ResourceMemory,
+    ) -> Result<(), Box<ValidationError>> {
         assert_ne!(allocation.allocation_type(), AllocationType::NonLinear);
 
         let physical_device = self.device().physical_device();
@@ -497,8 +500,8 @@ impl RawBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn bind_memory_unchecked(
         self,
-        allocation: MemoryAlloc,
-    ) -> Result<Buffer, (VulkanError, RawBuffer, MemoryAlloc)> {
+        allocation: ResourceMemory,
+    ) -> Result<Buffer, (VulkanError, RawBuffer, ResourceMemory)> {
         let memory = allocation.device_memory();
         let memory_offset = allocation.offset();
 

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -25,9 +25,9 @@
 //! use vulkano::memory::allocator::AllocationCreateInfo;
 //!
 //! # let queue: Arc<vulkano::device::Queue> = return;
-//! # let memory_allocator: vulkano::memory::allocator::StandardMemoryAllocator = return;
+//! # let memory_allocator: Arc<vulkano::memory::allocator::StandardMemoryAllocator> = return;
 //! let buffer = Buffer::new_slice::<u32>(
-//!     &memory_allocator,
+//!     memory_allocator.clone(),
 //!     BufferCreateInfo {
 //!         usage: BufferUsage::STORAGE_TEXEL_BUFFER,
 //!         ..Default::default()
@@ -456,15 +456,16 @@ mod tests {
         format::Format,
         memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator},
     };
+    use std::sync::Arc;
 
     #[test]
     fn create_uniform() {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
         let (device, _) = gfx_dev_and_queue!();
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
 
         let buffer = Buffer::new_slice::<[u8; 4]>(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::UNIFORM_TEXEL_BUFFER,
                 ..Default::default()
@@ -488,10 +489,10 @@ mod tests {
     fn create_storage() {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
         let (device, _) = gfx_dev_and_queue!();
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
 
         let buffer = Buffer::new_slice::<[u8; 4]>(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()
@@ -514,10 +515,10 @@ mod tests {
     fn create_storage_atomic() {
         // `VK_FORMAT_R32_UINT` guaranteed to be a supported format for atomics
         let (device, _) = gfx_dev_and_queue!();
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
 
         let buffer = Buffer::new_slice::<u32>(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()
@@ -540,10 +541,10 @@ mod tests {
     fn wrong_usage() {
         // `VK_FORMAT_R8G8B8A8_UNORM` guaranteed to be a supported format
         let (device, _) = gfx_dev_and_queue!();
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
 
         let buffer = Buffer::new_slice::<[u8; 4]>(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_DST, // Dummy value
                 ..Default::default()
@@ -568,10 +569,10 @@ mod tests {
     #[test]
     fn unsupported_format() {
         let (device, _) = gfx_dev_and_queue!();
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
 
         let buffer = Buffer::new_slice::<[f64; 4]>(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::UNIFORM_TEXEL_BUFFER | BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -339,6 +339,7 @@ mod tests {
         shader::ShaderStages,
         sync::GpuFuture,
     };
+    use std::sync::Arc;
 
     #[test]
     fn basic_creation() {
@@ -376,10 +377,10 @@ mod tests {
         .unwrap();
 
         let queue = queues.next().unwrap();
-        let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
 
         let source = Buffer::from_iter(
-            &memory_allocator,
+            memory_allocator.clone(),
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC,
                 ..Default::default()
@@ -394,7 +395,7 @@ mod tests {
         .unwrap();
 
         let destination = Buffer::from_iter(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_DST,
                 ..Default::default()
@@ -506,9 +507,9 @@ mod tests {
     fn buffer_self_copy_overlapping() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
         let source = Buffer::from_iter(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC | BufferUsage::TRANSFER_DST,
                 ..Default::default()
@@ -561,9 +562,9 @@ mod tests {
     fn buffer_self_copy_not_overlapping() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
         let source = Buffer::from_iter(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_SRC | BufferUsage::TRANSFER_DST,
                 ..Default::default()
@@ -613,10 +614,10 @@ mod tests {
             )
             .unwrap();
 
-            let memory_allocator = StandardMemoryAllocator::new_default(device);
+            let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
             // Create a tiny test buffer
             let buffer = Buffer::from_data(
-                &memory_allocator,
+                memory_allocator,
                 BufferCreateInfo {
                     usage: BufferUsage::TRANSFER_DST,
                     ..Default::default()
@@ -712,9 +713,9 @@ mod tests {
             )
             .unwrap();
 
-            let memory_allocator = StandardMemoryAllocator::new_default(device);
+            let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
             let buf = Buffer::from_data(
-                &memory_allocator,
+                memory_allocator,
                 BufferCreateInfo {
                     usage: BufferUsage::VERTEX_BUFFER,
                     ..Default::default()

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -49,7 +49,7 @@
 //!   types.
 //! - Binding [imported] `DeviceMemory`.
 //!
-//! You can [create a `MemoryAlloc` from `DeviceMemory`] if you want to bind its own block of
+//! You can [create a `ResourceMemory` from `DeviceMemory`] if you want to bind its own block of
 //! memory to an image.
 //!
 //! [`ImageView`]: crate::image::view::ImageView
@@ -59,7 +59,7 @@
 //! [`DeviceMemory`]: crate::memory::DeviceMemory
 //! [allocated yourself]: crate::memory::DeviceMemory::allocate
 //! [imported]: crate::memory::DeviceMemory::import
-//! [create a `MemoryAlloc` from `DeviceMemory`]: MemoryAlloc::new
+//! [create a `ResourceMemory` from `DeviceMemory`]: ResourceMemory::new_dedicated
 
 pub use self::{aspect::*, layout::*, sys::ImageCreateInfo, usage::*};
 use self::{sys::RawImage, view::ImageViewType};
@@ -68,7 +68,7 @@ use crate::{
     format::{Format, FormatFeatures},
     macros::{vulkan_bitflags, vulkan_bitflags_enum, vulkan_enum},
     memory::{
-        allocator::{AllocationCreateInfo, MemoryAlloc, MemoryAllocator, MemoryAllocatorError},
+        allocator::{AllocationCreateInfo, MemoryAllocator, MemoryAllocatorError, ResourceMemory},
         DedicatedAllocation, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
         ExternalMemoryProperties, MemoryRequirements,
     },
@@ -128,7 +128,7 @@ pub enum ImageMemory {
     /// The image is backed by normal memory, bound with [`bind_memory`].
     ///
     /// [`bind_memory`]: RawImage::bind_memory
-    Normal(SmallVec<[MemoryAlloc; 4]>),
+    Normal(SmallVec<[ResourceMemory; 4]>),
 
     /// The image is backed by sparse memory, bound with [`bind_sparse`].
     ///
@@ -145,7 +145,7 @@ pub enum ImageMemory {
 impl Image {
     /// Creates a new uninitialized `Image`.
     pub fn new(
-        allocator: &(impl MemoryAllocator + ?Sized),
+        allocator: Arc<dyn MemoryAllocator>,
         create_info: ImageCreateInfo,
         allocation_info: AllocationCreateInfo,
     ) -> Result<Arc<Self>, Validated<ImageAllocateError>> {
@@ -168,6 +168,7 @@ impl Image {
                 Some(DedicatedAllocation::Image(&raw_image)),
             )
             .map_err(ImageAllocateError::AllocateMemory)?;
+        let allocation = unsafe { ResourceMemory::from_allocation(allocator, allocation) };
 
         let image = raw_image.bind_memory([allocation]).map_err(|(err, _, _)| {
             err.map(ImageAllocateError::BindMemory)

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -68,9 +68,9 @@ use crate::{
     format::{Format, FormatFeatures},
     macros::{vulkan_bitflags, vulkan_bitflags_enum, vulkan_enum},
     memory::{
-        allocator::{AllocationCreateInfo, MemoryAllocator, MemoryAllocatorError, ResourceMemory},
+        allocator::{AllocationCreateInfo, MemoryAllocator, MemoryAllocatorError},
         DedicatedAllocation, ExternalMemoryHandleType, ExternalMemoryHandleTypes,
-        ExternalMemoryProperties, MemoryRequirements,
+        ExternalMemoryProperties, MemoryRequirements, ResourceMemory,
     },
     range_map::RangeMap,
     swapchain::Swapchain,

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -48,7 +48,7 @@
 //! };
 //!
 //! # let device: std::sync::Arc<vulkano::device::Device> = return;
-//! # let memory_allocator: vulkano::memory::allocator::StandardMemoryAllocator = return;
+//! # let memory_allocator: std::sync::Arc<vulkano::memory::allocator::StandardMemoryAllocator> = return;
 //! # let descriptor_set_allocator: vulkano::descriptor_set::allocator::StandardDescriptorSetAllocator = return;
 //! #
 //! let conversion = SamplerYcbcrConversion::new(device.clone(), SamplerYcbcrConversionCreateInfo {
@@ -82,7 +82,7 @@
 //! .unwrap();
 //!
 //! let image = Image::new(
-//!     &memory_allocator,
+//!     memory_allocator.clone(),
 //!     ImageCreateInfo {
 //!         image_type: ImageType::Dim2d,
 //!         format: Format::G8_B8_R8_3PLANE_420_UNORM,

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -33,7 +33,7 @@ use crate::{
     instance::InstanceOwnedDebugWrapper,
     macros::impl_id_counter,
     memory::{
-        allocator::{AllocationType, DeviceLayout, MemoryAlloc},
+        allocator::{AllocationType, DeviceLayout, ResourceMemory},
         is_aligned, DedicatedTo, ExternalMemoryHandleTypes, MemoryPropertyFlags,
         MemoryRequirements,
     },
@@ -707,13 +707,13 @@ impl RawImage {
     ///   `allocations` must contain exactly `self.drm_format_modifier().unwrap().1` elements.
     pub fn bind_memory(
         self,
-        allocations: impl IntoIterator<Item = MemoryAlloc>,
+        allocations: impl IntoIterator<Item = ResourceMemory>,
     ) -> Result<
         Image,
         (
             Validated<VulkanError>,
             RawImage,
-            impl ExactSizeIterator<Item = MemoryAlloc>,
+            impl ExactSizeIterator<Item = ResourceMemory>,
         ),
     > {
         let allocations: SmallVec<[_; 4]> = allocations.into_iter().collect();
@@ -736,7 +736,7 @@ impl RawImage {
 
     fn validate_bind_memory(
         &self,
-        allocations: &[MemoryAlloc],
+        allocations: &[ResourceMemory],
     ) -> Result<(), Box<ValidationError>> {
         let physical_device = self.device().physical_device();
 
@@ -1072,13 +1072,13 @@ impl RawImage {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn bind_memory_unchecked(
         self,
-        allocations: impl IntoIterator<Item = MemoryAlloc>,
+        allocations: impl IntoIterator<Item = ResourceMemory>,
     ) -> Result<
         Image,
         (
             VulkanError,
             RawImage,
-            impl ExactSizeIterator<Item = MemoryAlloc>,
+            impl ExactSizeIterator<Item = ResourceMemory>,
         ),
     > {
         let allocations: SmallVec<[_; 4]> = allocations.into_iter().collect();

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -33,9 +33,9 @@ use crate::{
     instance::InstanceOwnedDebugWrapper,
     macros::impl_id_counter,
     memory::{
-        allocator::{AllocationType, DeviceLayout, ResourceMemory},
+        allocator::{AllocationType, DeviceLayout},
         is_aligned, DedicatedTo, ExternalMemoryHandleTypes, MemoryPropertyFlags,
-        MemoryRequirements,
+        MemoryRequirements, ResourceMemory,
     },
     sync::Sharing,
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -223,8 +223,8 @@ use self::array_vec::ArrayVec;
 pub use self::{
     layout::DeviceLayout,
     suballocator::{
-        AllocationType, BuddyAllocator, BumpAllocator, FreeListAllocator, ResourceMemory,
-        Suballocation, Suballocator, SuballocatorError,
+        AllocationType, BuddyAllocator, BumpAllocator, FreeListAllocator, Suballocation,
+        Suballocator, SuballocatorError,
     },
 };
 use super::{

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1504,11 +1504,11 @@ unsafe impl<S: Suballocator + Send + Sync + 'static> MemoryAllocator for Generic
             // know that this pointer must be valid, because all blocks are boxed and pinned in
             // memory and because a block isn't dropped until the allocator itself is dropped, at
             // which point it would be impossible to call this method. We also know that it must be
-            // valid to take create a reference to the block, because we only ever access it via
-            // shared references.
+            // valid to create a reference to the block, because we only ever access it via shared
+            // references.
             let block = &*block_ptr;
 
-            // SAFETY: The caller must guarantee that `allocation` refers to a currenltly allocated
+            // SAFETY: The caller must guarantee that `allocation` refers to a currently allocated
             // allocation of `self`.
             block.deallocate(suballocation);
         }

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1499,10 +1499,17 @@ unsafe impl<S: Suballocator + Send + Sync + 'static> MemoryAllocator for Generic
                 );
             }
 
-            // SAFETY: TODO
+            // SAFETY: The caller must guarantee that `allocation` refers to one allocated by
+            // `self`, therefore `block_ptr` must be the same one we gave out on allocation. We
+            // know that this pointer must be valid, because all blocks are boxed and pinned in
+            // memory and because a block isn't dropped until the allocator itself is dropped, at
+            // which point it would be impossible to call this method. We also know that it must be
+            // valid to take create a reference to the block, because we only ever access it via
+            // shared references.
             let block = &*block_ptr;
 
-            // SAFETY: TODO
+            // SAFETY: The caller must guarantee that `allocation` refers to a currenltly allocated
+            // allocation of `self`.
             block.deallocate(suballocation);
         }
     }

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -417,7 +417,8 @@ unsafe impl Suballocator for FreeListAllocator {
 
     #[inline]
     unsafe fn deallocate(&self, suballocation: Suballocation) {
-        // SAFETY: TODO
+        // SAFETY: The caller must guarantee that `suballocation` refers to a currently allocated
+        // allocation of `self`.
         let node_id = SlotId::new(suballocation.handle.0 as _);
 
         let mut state = self.state.lock();

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -213,16 +213,6 @@ pub enum SuballocatorError {
 
     /// The region has enough free space to satisfy the request but is too fragmented.
     FragmentedRegion,
-
-    /// The allocation was larger than the allocator's block size, meaning that this error would
-    /// arise with the parameters no matter the state the allocator was in.
-    ///
-    /// This can be used to let the [`GenericMemoryAllocator`] know that allocating a new block of
-    /// [`DeviceMemory`] and trying to suballocate it with the same parameters would not solve the
-    /// issue.
-    ///
-    /// [`GenericMemoryAllocator`]: super::GenericMemoryAllocator
-    BlockSizeExceeded,
 }
 
 impl Error for SuballocatorError {}
@@ -232,9 +222,6 @@ impl Display for SuballocatorError {
         let msg = match self {
             Self::OutOfRegionMemory => "out of region memory",
             Self::FragmentedRegion => "the region is too fragmented",
-            Self::BlockSizeExceeded => {
-                "the allocation size was greater than the suballocator's block size"
-            }
         };
 
         f.write_str(msg)

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -16,355 +16,17 @@
 use self::host::SlotId;
 use super::{
     align_down, align_up, array_vec::ArrayVec, AllocationHandle, DeviceAlignment, DeviceLayout,
-    MemoryAlloc, MemoryAllocator,
 };
-use crate::{
-    device::{Device, DeviceOwned, DeviceOwnedDebugWrapper},
-    image::ImageTiling,
-    memory::{self, is_aligned, DeviceMemory, MappedMemoryRange},
-    sync::HostAccessError,
-    DeviceSize, NonZeroDeviceSize, Validated, ValidationError, VulkanError,
-};
+use crate::{image::ImageTiling, memory::is_aligned, DeviceSize, NonZeroDeviceSize};
 use parking_lot::Mutex;
 use std::{
     cell::Cell,
     cmp,
     error::Error,
     fmt::{self, Display},
-    mem::ManuallyDrop,
-    ops::RangeBounds,
-    ptr::{self, NonNull},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    ptr,
+    sync::atomic::{AtomicU64, Ordering},
 };
-
-/// Memory that can be bound to resources.
-///
-/// Most commonly you will want to obtain this by first using a [memory allocator] and then
-/// [constructing this object from its allocation]. Alternatively, if you want to bind a whole
-/// block of `DeviceMemory` to a resource, or can't go through an allocator, you can use [the
-/// dedicated constructor].
-///
-/// [memory allocator]: super::MemoryAllocator
-/// [the dedicated constructor]: Self::new_dedicated
-#[derive(Debug)]
-pub struct ResourceMemory {
-    device_memory: ManuallyDrop<DeviceOwnedDebugWrapper<Arc<DeviceMemory>>>,
-    offset: DeviceSize,
-    size: DeviceSize,
-    allocation_type: AllocationType,
-    allocation_handle: AllocationHandle,
-    suballocation_handle: Option<AllocationHandle>,
-    allocator: Option<Arc<dyn MemoryAllocator>>,
-}
-
-impl ResourceMemory {
-    /// Creates a new `ResourceMemory` that has a whole device memory block dedicated to it. You
-    /// may use this when you obtain the memory in a way other than through the use of a memory
-    /// allocator, for instance by importing memory.
-    ///
-    /// This is safe because we take ownership of the device memory, so that there can be no
-    /// aliasing resources. On the other hand, the device memory can never be reused: it will be
-    /// freed once the returned object is dropped.
-    pub fn new_dedicated(device_memory: DeviceMemory) -> Self {
-        unsafe { Self::new_dedicated_unchecked(Arc::new(device_memory)) }
-    }
-
-    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn new_dedicated_unchecked(device_memory: Arc<DeviceMemory>) -> Self {
-        ResourceMemory {
-            offset: 0,
-            size: device_memory.allocation_size(),
-            allocation_type: AllocationType::Unknown,
-            allocation_handle: AllocationHandle(ptr::null_mut()),
-            suballocation_handle: None,
-            allocator: None,
-            device_memory: ManuallyDrop::new(DeviceOwnedDebugWrapper(device_memory)),
-        }
-    }
-
-    /// Creates a new `ResourceMemory` from an allocation of a memory allocator.
-    ///
-    /// Ownership of `allocation` is semantically transferred to this object, and it is deallocated
-    /// when the returned object is dropped.
-    ///
-    /// # Safety
-    ///
-    /// - `allocation` must refer to a **currently allocated** allocation of `allocator`.
-    /// - `allocation` must never be deallocated.
-    #[inline]
-    pub unsafe fn from_allocation(
-        allocator: Arc<dyn MemoryAllocator>,
-        allocation: MemoryAlloc,
-    ) -> Self {
-        if let Some(suballocation) = allocation.suballocation {
-            ResourceMemory {
-                offset: suballocation.offset,
-                size: suballocation.size,
-                allocation_type: allocation.allocation_type,
-                allocation_handle: allocation.allocation_handle,
-                suballocation_handle: Some(suballocation.handle),
-                allocator: Some(allocator),
-                device_memory: ManuallyDrop::new(DeviceOwnedDebugWrapper(allocation.device_memory)),
-            }
-        } else {
-            ResourceMemory {
-                offset: 0,
-                size: allocation.device_memory.allocation_size(),
-                allocation_type: allocation.allocation_type,
-                allocation_handle: allocation.allocation_handle,
-                suballocation_handle: None,
-                allocator: Some(allocator),
-                device_memory: ManuallyDrop::new(DeviceOwnedDebugWrapper(allocation.device_memory)),
-            }
-        }
-    }
-
-    /// Returns the underlying block of [`DeviceMemory`].
-    #[inline]
-    pub fn device_memory(&self) -> &Arc<DeviceMemory> {
-        &self.device_memory
-    }
-
-    /// Returns the offset (in bytes) within the [`DeviceMemory`] block where this `ResourceMemory`
-    /// beings.
-    ///
-    /// If this `ResourceMemory` is not a [suballocation], then this will be `0`.
-    ///
-    /// [suballocation]: Suballocation
-    #[inline]
-    pub fn offset(&self) -> DeviceSize {
-        self.offset
-    }
-
-    /// Returns the size (in bytes) of the `ResourceMemory`.
-    ///
-    /// If this `ResourceMemory` is not a [suballocation], then this will be equal to the
-    /// [allocation size] of the [`DeviceMemory`] block.
-    ///
-    /// [suballocation]: Suballocation
-    #[inline]
-    pub fn size(&self) -> DeviceSize {
-        self.size
-    }
-
-    /// Returns the type of resources that can be bound to this `ResourceMemory`.
-    ///
-    /// If this `ResourceMemory` is not a [suballocation], then this will be
-    /// [`AllocationType::Unknown`].
-    ///
-    /// [suballocation]: Suballocation
-    #[inline]
-    pub fn allocation_type(&self) -> AllocationType {
-        self.allocation_type
-    }
-
-    fn suballocation(&self) -> Option<Suballocation> {
-        self.suballocation_handle.map(|handle| Suballocation {
-            offset: self.offset,
-            size: self.size,
-            handle,
-        })
-    }
-
-    /// Returns the mapped pointer to a range of the `ResourceMemory`, or returns [`None`] if ouf
-    /// of bounds.
-    ///
-    /// `range` is specified in bytes relative to the beginning of `self` and must fall within the
-    /// range of the memory mapping given to [`DeviceMemory::map`].
-    ///
-    /// See [`MappingState::slice`] for the safety invariants of the returned pointer.
-    ///
-    /// [`MappingState::slice`]: crate::memory::MappingState::slice
-    #[inline]
-    pub fn mapped_slice(
-        &self,
-        range: impl RangeBounds<DeviceSize>,
-    ) -> Option<Result<NonNull<[u8]>, HostAccessError>> {
-        let mut range = memory::range(range, ..self.size())?;
-        range.start += self.offset();
-        range.end += self.offset();
-
-        let res = if let Some(state) = self.device_memory().mapping_state() {
-            state.slice(range).ok_or(HostAccessError::OutOfMappedRange)
-        } else {
-            Err(HostAccessError::NotHostMapped)
-        };
-
-        Some(res)
-    }
-
-    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    #[inline]
-    pub unsafe fn mapped_slice_unchecked(
-        &self,
-        range: impl RangeBounds<DeviceSize>,
-    ) -> Result<NonNull<[u8]>, HostAccessError> {
-        let mut range = memory::range_unchecked(range, ..self.size());
-        range.start += self.offset();
-        range.end += self.offset();
-
-        if let Some(state) = self.device_memory().mapping_state() {
-            state.slice(range).ok_or(HostAccessError::OutOfMappedRange)
-        } else {
-            Err(HostAccessError::NotHostMapped)
-        }
-    }
-
-    pub(crate) fn atom_size(&self) -> Option<DeviceAlignment> {
-        let memory = self.device_memory();
-
-        memory.is_coherent().then_some(memory.atom_size())
-    }
-
-    /// Invalidates the host cache for a range of the `ResourceMemory`.
-    ///
-    /// If the device memory is not [host-coherent], you must call this function before the memory
-    /// is read by the host, if the device previously wrote to the memory. It has no effect if the
-    /// memory is host-coherent.
-    ///
-    /// # Safety
-    ///
-    /// - If there are memory writes by the device that have not been propagated into the host
-    ///   cache, then there must not be any references in Rust code to any portion of the specified
-    ///   `memory_range`.
-    ///
-    /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
-    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
-    #[inline]
-    pub unsafe fn invalidate_range(
-        &self,
-        memory_range: MappedMemoryRange,
-    ) -> Result<(), Validated<VulkanError>> {
-        self.validate_memory_range(&memory_range)?;
-
-        self.device_memory()
-            .invalidate_range(self.create_memory_range(memory_range))
-    }
-
-    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    #[inline]
-    pub unsafe fn invalidate_range_unchecked(
-        &self,
-        memory_range: MappedMemoryRange,
-    ) -> Result<(), VulkanError> {
-        self.device_memory()
-            .invalidate_range_unchecked(self.create_memory_range(memory_range))
-    }
-
-    /// Flushes the host cache for a range of the `ResourceMemory`.
-    ///
-    /// If the device memory is not [host-coherent], you must call this function after writing to
-    /// the memory, if the device is going to read the memory. It has no effect if the memory is
-    /// host-coherent.
-    ///
-    /// # Safety
-    ///
-    /// - There must be no operations pending or executing in a device queue, that access any
-    ///   portion of the specified `memory_range`.
-    ///
-    /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
-    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
-    #[inline]
-    pub unsafe fn flush_range(
-        &self,
-        memory_range: MappedMemoryRange,
-    ) -> Result<(), Validated<VulkanError>> {
-        self.validate_memory_range(&memory_range)?;
-
-        self.device_memory()
-            .flush_range(self.create_memory_range(memory_range))
-    }
-
-    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    #[inline]
-    pub unsafe fn flush_range_unchecked(
-        &self,
-        memory_range: MappedMemoryRange,
-    ) -> Result<(), VulkanError> {
-        self.device_memory()
-            .flush_range_unchecked(self.create_memory_range(memory_range))
-    }
-
-    fn validate_memory_range(
-        &self,
-        memory_range: &MappedMemoryRange,
-    ) -> Result<(), Box<ValidationError>> {
-        let &MappedMemoryRange {
-            offset,
-            size,
-            _ne: _,
-        } = memory_range;
-
-        if !(offset <= self.size() && size <= self.size() - offset) {
-            return Err(Box::new(ValidationError {
-                context: "memory_range".into(),
-                problem: "is not contained within the allocation".into(),
-                ..Default::default()
-            }));
-        }
-
-        Ok(())
-    }
-
-    fn create_memory_range(&self, memory_range: MappedMemoryRange) -> MappedMemoryRange {
-        let MappedMemoryRange {
-            mut offset,
-            mut size,
-            _ne: _,
-        } = memory_range;
-
-        let memory = self.device_memory();
-
-        offset += self.offset();
-
-        // VUID-VkMappedMemoryRange-size-01390
-        if memory_range.offset + size == self.size() {
-            // We can align the end of the range like this without aliasing other allocations,
-            // because the memory allocator must ensure that all allocations are aligned to the
-            // atom size for non-host-coherent host-visible memory.
-            let end = cmp::min(
-                align_up(offset + size, memory.atom_size()),
-                memory.allocation_size(),
-            );
-            size = end - offset;
-        }
-
-        MappedMemoryRange {
-            offset,
-            size,
-            _ne: crate::NonExhaustive(()),
-        }
-    }
-}
-
-impl Drop for ResourceMemory {
-    #[inline]
-    fn drop(&mut self) {
-        let device_memory = unsafe { ManuallyDrop::take(&mut self.device_memory) }.0;
-
-        if let Some(allocator) = &self.allocator {
-            let allocation = MemoryAlloc {
-                device_memory,
-                suballocation: self.suballocation(),
-                allocation_type: self.allocation_type,
-                allocation_handle: self.allocation_handle,
-            };
-
-            // SAFETY: Enforced by the safety contract of [`ResourceMemory::from_allocation`].
-            unsafe { allocator.deallocate(allocation) };
-        }
-    }
-}
-
-unsafe impl DeviceOwned for ResourceMemory {
-    #[inline]
-    fn device(&self) -> &Arc<Device> {
-        self.device_memory().device()
-    }
-}
 
 /// Suballocators are used to divide a *region* into smaller *suballocations*.
 ///
@@ -388,7 +50,7 @@ unsafe impl DeviceOwned for ResourceMemory {
 /// Different applications have wildly different allocation needs, and there's no way to cover them
 /// all with a single type of allocator. Furthermore, different allocators have different
 /// trade-offs and are best suited to specific tasks. To account for all possible use-cases,
-/// Vulkano offers the ability to create *memory hierarchies*. We refer to the [`DeviceMemory`] as
+/// Vulkano offers the ability to create *memory hierarchies*. We refer to the `DeviceMemory` as
 /// the root of any such hierarchy, even though technically the driver has levels that are further
 /// up, because those `DeviceMemory` blocks need to be allocated from physical memory [pages]
 /// themselves, but since those levels are not accessible to us we don't need to consider them. You
@@ -404,6 +66,7 @@ unsafe impl DeviceOwned for ResourceMemory {
 ///
 /// TODO
 ///
+/// [`DeviceMemory`]: crate::memory::DeviceMemory
 /// [pages]: super#pages
 pub unsafe trait Suballocator {
     /// Whether this allocator needs to block or not.
@@ -464,6 +127,7 @@ pub unsafe trait Suballocator {
     ///
     /// [region]: Self#regions
     /// [buffer-image granularity]: super#buffer-image-granularity
+    /// [`DeviceMemory`]: crate::memory::DeviceMemory
     fn allocate(
         &self,
         layout: DeviceLayout,

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -293,7 +293,7 @@ impl ResourceMemory {
     pub(crate) fn atom_size(&self) -> Option<DeviceAlignment> {
         let memory = self.device_memory();
 
-        memory.is_coherent().then_some(memory.atom_size())
+        (!memory.is_coherent()).then_some(memory.atom_size())
     }
 
     /// Invalidates the host cache for a range of the `ResourceMemory`.

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -91,24 +91,357 @@
 //! get memory from that pool. By default if you don't specify any pool when creating a buffer or
 //! an image, an instance of `StandardMemoryPool` that is shared by the `Device` object is used.
 
-use self::allocator::DeviceLayout;
+use self::allocator::{
+    align_up, AllocationHandle, AllocationType, DeviceLayout, MemoryAlloc, MemoryAllocator,
+    Suballocation,
+};
 pub use self::{alignment::*, device_memory::*};
 use crate::{
     buffer::{sys::RawBuffer, Subbuffer},
+    device::{Device, DeviceOwned, DeviceOwnedDebugWrapper},
     image::{sys::RawImage, Image, ImageAspects},
     macros::vulkan_bitflags,
-    sync::semaphore::Semaphore,
-    DeviceSize,
+    sync::{semaphore::Semaphore, HostAccessError},
+    DeviceSize, Validated, ValidationError, VulkanError,
 };
 use std::{
+    cmp,
+    mem::ManuallyDrop,
     num::NonZeroU64,
     ops::{Bound, Range, RangeBounds, RangeTo},
+    ptr::{self, NonNull},
     sync::Arc,
 };
 
 mod alignment;
 pub mod allocator;
 mod device_memory;
+
+/// Memory that can be bound to resources.
+///
+/// Most commonly you will want to obtain this by first using a [memory allocator] and then
+/// [constructing this object from its allocation]. Alternatively, if you want to bind a whole
+/// block of `DeviceMemory` to a resource, or can't go through an allocator, you can use [the
+/// dedicated constructor].
+///
+/// [memory allocator]: allocator::MemoryAllocator
+/// [the dedicated constructor]: Self::new_dedicated
+#[derive(Debug)]
+pub struct ResourceMemory {
+    device_memory: ManuallyDrop<DeviceOwnedDebugWrapper<Arc<DeviceMemory>>>,
+    offset: DeviceSize,
+    size: DeviceSize,
+    allocation_type: AllocationType,
+    allocation_handle: AllocationHandle,
+    suballocation_handle: Option<AllocationHandle>,
+    allocator: Option<Arc<dyn MemoryAllocator>>,
+}
+
+impl ResourceMemory {
+    /// Creates a new `ResourceMemory` that has a whole device memory block dedicated to it. You
+    /// may use this when you obtain the memory in a way other than through the use of a memory
+    /// allocator, for instance by importing memory.
+    ///
+    /// This is safe because we take ownership of the device memory, so that there can be no
+    /// aliasing resources. On the other hand, the device memory can never be reused: it will be
+    /// freed once the returned object is dropped.
+    pub fn new_dedicated(device_memory: DeviceMemory) -> Self {
+        unsafe { Self::new_dedicated_unchecked(Arc::new(device_memory)) }
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn new_dedicated_unchecked(device_memory: Arc<DeviceMemory>) -> Self {
+        ResourceMemory {
+            offset: 0,
+            size: device_memory.allocation_size(),
+            allocation_type: AllocationType::Unknown,
+            allocation_handle: AllocationHandle(ptr::null_mut()),
+            suballocation_handle: None,
+            allocator: None,
+            device_memory: ManuallyDrop::new(DeviceOwnedDebugWrapper(device_memory)),
+        }
+    }
+
+    /// Creates a new `ResourceMemory` from an allocation of a memory allocator.
+    ///
+    /// Ownership of `allocation` is semantically transferred to this object, and it is deallocated
+    /// when the returned object is dropped.
+    ///
+    /// # Safety
+    ///
+    /// - `allocation` must refer to a **currently allocated** allocation of `allocator`.
+    /// - `allocation` must never be deallocated.
+    #[inline]
+    pub unsafe fn from_allocation(
+        allocator: Arc<dyn MemoryAllocator>,
+        allocation: MemoryAlloc,
+    ) -> Self {
+        if let Some(suballocation) = allocation.suballocation {
+            ResourceMemory {
+                offset: suballocation.offset,
+                size: suballocation.size,
+                allocation_type: allocation.allocation_type,
+                allocation_handle: allocation.allocation_handle,
+                suballocation_handle: Some(suballocation.handle),
+                allocator: Some(allocator),
+                device_memory: ManuallyDrop::new(DeviceOwnedDebugWrapper(allocation.device_memory)),
+            }
+        } else {
+            ResourceMemory {
+                offset: 0,
+                size: allocation.device_memory.allocation_size(),
+                allocation_type: allocation.allocation_type,
+                allocation_handle: allocation.allocation_handle,
+                suballocation_handle: None,
+                allocator: Some(allocator),
+                device_memory: ManuallyDrop::new(DeviceOwnedDebugWrapper(allocation.device_memory)),
+            }
+        }
+    }
+
+    /// Returns the underlying block of [`DeviceMemory`].
+    #[inline]
+    pub fn device_memory(&self) -> &Arc<DeviceMemory> {
+        &self.device_memory
+    }
+
+    /// Returns the offset (in bytes) within the [`DeviceMemory`] block where this `ResourceMemory`
+    /// beings.
+    ///
+    /// If this `ResourceMemory` is not a [suballocation], then this will be `0`.
+    ///
+    /// [suballocation]: Suballocation
+    #[inline]
+    pub fn offset(&self) -> DeviceSize {
+        self.offset
+    }
+
+    /// Returns the size (in bytes) of the `ResourceMemory`.
+    ///
+    /// If this `ResourceMemory` is not a [suballocation], then this will be equal to the
+    /// [allocation size] of the [`DeviceMemory`] block.
+    ///
+    /// [suballocation]: Suballocation
+    #[inline]
+    pub fn size(&self) -> DeviceSize {
+        self.size
+    }
+
+    /// Returns the type of resources that can be bound to this `ResourceMemory`.
+    ///
+    /// If this `ResourceMemory` is not a [suballocation], then this will be
+    /// [`AllocationType::Unknown`].
+    ///
+    /// [suballocation]: Suballocation
+    #[inline]
+    pub fn allocation_type(&self) -> AllocationType {
+        self.allocation_type
+    }
+
+    fn suballocation(&self) -> Option<Suballocation> {
+        self.suballocation_handle.map(|handle| Suballocation {
+            offset: self.offset,
+            size: self.size,
+            handle,
+        })
+    }
+
+    /// Returns the mapped pointer to a range of the `ResourceMemory`, or returns [`None`] if ouf
+    /// of bounds.
+    ///
+    /// `range` is specified in bytes relative to the beginning of `self` and must fall within the
+    /// range of the memory mapping given to [`DeviceMemory::map`].
+    ///
+    /// See [`MappingState::slice`] for the safety invariants of the returned pointer.
+    ///
+    /// [`MappingState::slice`]: crate::memory::MappingState::slice
+    #[inline]
+    pub fn mapped_slice(
+        &self,
+        range: impl RangeBounds<DeviceSize>,
+    ) -> Option<Result<NonNull<[u8]>, HostAccessError>> {
+        let mut range = self::range(range, ..self.size())?;
+        range.start += self.offset();
+        range.end += self.offset();
+
+        let res = if let Some(state) = self.device_memory().mapping_state() {
+            state.slice(range).ok_or(HostAccessError::OutOfMappedRange)
+        } else {
+            Err(HostAccessError::NotHostMapped)
+        };
+
+        Some(res)
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    #[inline]
+    pub unsafe fn mapped_slice_unchecked(
+        &self,
+        range: impl RangeBounds<DeviceSize>,
+    ) -> Result<NonNull<[u8]>, HostAccessError> {
+        let mut range = self::range_unchecked(range, ..self.size());
+        range.start += self.offset();
+        range.end += self.offset();
+
+        if let Some(state) = self.device_memory().mapping_state() {
+            state.slice(range).ok_or(HostAccessError::OutOfMappedRange)
+        } else {
+            Err(HostAccessError::NotHostMapped)
+        }
+    }
+
+    pub(crate) fn atom_size(&self) -> Option<DeviceAlignment> {
+        let memory = self.device_memory();
+
+        memory.is_coherent().then_some(memory.atom_size())
+    }
+
+    /// Invalidates the host cache for a range of the `ResourceMemory`.
+    ///
+    /// If the device memory is not [host-coherent], you must call this function before the memory
+    /// is read by the host, if the device previously wrote to the memory. It has no effect if the
+    /// memory is host-coherent.
+    ///
+    /// # Safety
+    ///
+    /// - If there are memory writes by the device that have not been propagated into the host
+    ///   cache, then there must not be any references in Rust code to any portion of the specified
+    ///   `memory_range`.
+    ///
+    /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
+    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
+    #[inline]
+    pub unsafe fn invalidate_range(
+        &self,
+        memory_range: MappedMemoryRange,
+    ) -> Result<(), Validated<VulkanError>> {
+        self.validate_memory_range(&memory_range)?;
+
+        self.device_memory()
+            .invalidate_range(self.create_memory_range(memory_range))
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    #[inline]
+    pub unsafe fn invalidate_range_unchecked(
+        &self,
+        memory_range: MappedMemoryRange,
+    ) -> Result<(), VulkanError> {
+        self.device_memory()
+            .invalidate_range_unchecked(self.create_memory_range(memory_range))
+    }
+
+    /// Flushes the host cache for a range of the `ResourceMemory`.
+    ///
+    /// If the device memory is not [host-coherent], you must call this function after writing to
+    /// the memory, if the device is going to read the memory. It has no effect if the memory is
+    /// host-coherent.
+    ///
+    /// # Safety
+    ///
+    /// - There must be no operations pending or executing in a device queue, that access any
+    ///   portion of the specified `memory_range`.
+    ///
+    /// [host-coherent]: crate::memory::MemoryPropertyFlags::HOST_COHERENT
+    /// [`non_coherent_atom_size`]: crate::device::Properties::non_coherent_atom_size
+    #[inline]
+    pub unsafe fn flush_range(
+        &self,
+        memory_range: MappedMemoryRange,
+    ) -> Result<(), Validated<VulkanError>> {
+        self.validate_memory_range(&memory_range)?;
+
+        self.device_memory()
+            .flush_range(self.create_memory_range(memory_range))
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    #[inline]
+    pub unsafe fn flush_range_unchecked(
+        &self,
+        memory_range: MappedMemoryRange,
+    ) -> Result<(), VulkanError> {
+        self.device_memory()
+            .flush_range_unchecked(self.create_memory_range(memory_range))
+    }
+
+    fn validate_memory_range(
+        &self,
+        memory_range: &MappedMemoryRange,
+    ) -> Result<(), Box<ValidationError>> {
+        let &MappedMemoryRange {
+            offset,
+            size,
+            _ne: _,
+        } = memory_range;
+
+        if !(offset <= self.size() && size <= self.size() - offset) {
+            return Err(Box::new(ValidationError {
+                context: "memory_range".into(),
+                problem: "is not contained within the allocation".into(),
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+
+    fn create_memory_range(&self, memory_range: MappedMemoryRange) -> MappedMemoryRange {
+        let MappedMemoryRange {
+            mut offset,
+            mut size,
+            _ne: _,
+        } = memory_range;
+
+        let memory = self.device_memory();
+
+        offset += self.offset();
+
+        // VUID-VkMappedMemoryRange-size-01390
+        if memory_range.offset + size == self.size() {
+            // We can align the end of the range like this without aliasing other allocations,
+            // because the memory allocator must ensure that all allocations are aligned to the
+            // atom size for non-host-coherent host-visible memory.
+            let end = cmp::min(
+                align_up(offset + size, memory.atom_size()),
+                memory.allocation_size(),
+            );
+            size = end - offset;
+        }
+
+        MappedMemoryRange {
+            offset,
+            size,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+}
+
+impl Drop for ResourceMemory {
+    #[inline]
+    fn drop(&mut self) {
+        let device_memory = unsafe { ManuallyDrop::take(&mut self.device_memory) }.0;
+
+        if let Some(allocator) = &self.allocator {
+            let allocation = MemoryAlloc {
+                device_memory,
+                suballocation: self.suballocation(),
+                allocation_type: self.allocation_type,
+                allocation_handle: self.allocation_handle,
+            };
+
+            // SAFETY: Enforced by the safety contract of [`ResourceMemory::from_allocation`].
+            unsafe { allocator.deallocate(allocation) };
+        }
+    }
+}
+
+unsafe impl DeviceOwned for ResourceMemory {
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        self.device_memory().device()
+    }
+}
 
 /// Properties of the memory in a physical device.
 #[derive(Clone, Debug)]

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -468,6 +468,7 @@ mod tests {
         shader::{ShaderModule, ShaderModuleCreateInfo},
         sync::{now, GpuFuture},
     };
+    use std::sync::Arc;
 
     // TODO: test for basic creation
     // TODO: test for pipeline layout error
@@ -531,9 +532,9 @@ mod tests {
             .unwrap()
         };
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
         let data_buffer = Buffer::from_data(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::STORAGE_BUFFER,
                 ..Default::default()
@@ -662,9 +663,9 @@ mod tests {
             .unwrap()
         };
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device.clone());
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
         let data_buffer = Buffer::from_data(
-            &memory_allocator,
+            memory_allocator,
             BufferCreateInfo {
                 usage: BufferUsage::STORAGE_BUFFER,
                 ..Default::default()

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -665,6 +665,7 @@ mod tests {
             SubpassDescription,
         },
     };
+    use std::sync::Arc;
 
     #[test]
     fn simple_create() {
@@ -687,10 +688,10 @@ mod tests {
         )
         .unwrap();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
         let view = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,
@@ -768,10 +769,10 @@ mod tests {
         )
         .unwrap();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
         let view = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8_UNORM,
@@ -818,10 +819,10 @@ mod tests {
         )
         .unwrap();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
         let view = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,
@@ -868,10 +869,10 @@ mod tests {
         )
         .unwrap();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
         let view = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,
@@ -924,10 +925,10 @@ mod tests {
         )
         .unwrap();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
         let a = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator.clone(),
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,
@@ -942,7 +943,7 @@ mod tests {
         .unwrap();
         let b = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,
@@ -998,10 +999,10 @@ mod tests {
         )
         .unwrap();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
         let view = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,
@@ -1046,10 +1047,10 @@ mod tests {
         )
         .unwrap();
 
-        let memory_allocator = StandardMemoryAllocator::new_default(device);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
         let a = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator.clone(),
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,
@@ -1064,7 +1065,7 @@ mod tests {
         .unwrap();
         let b = ImageView::new_default(
             Image::new(
-                &memory_allocator,
+                memory_allocator,
                 ImageCreateInfo {
                     image_type: ImageType::Dim2d,
                     format: Format::R8G8B8A8_UNORM,


### PR DESCRIPTION
This fixes *most* of the horrible design decisions from #1997. After I fix the ones left over, I think there will be no more reason for breaking changes in it pretty much ever. Though I've been wrong before, so I'd appreciate feedback, if there's a way it can be made more generic.

# The (many) problems

A relatively highly-requested feature, which is quite obvious when you think about it, is being able to suballocate existing buffers (as opposed to `SubbufferAllocator` which allocates its own buffer(s)). This is currently not possible because `MemoryAlloc` is tied to (sub)allocations of `DeviceMemory`: it holds a reference to the suballocator it came from and the suballocators in turn only accept a `MemoryAlloc` as a region to suballocate (`DeviceMemory` being the root of all such hierarchies).

It would have been possible to remedy this while keeping the reference to the suballocator in its returned suballocation, however there are other problems with this:
- It ties the `Suballocator` trait to be implemented on `Arc`s (so that the returned suballocation can hold this reference):
  - Due to the orphan rules, you can't implement a foreign trait on a foreign type (`Arc`), so if the user wanted to implement an allocator trait it would require double-boxing of the allocator that's put in the allocation, on top of dynamic dispatch. This is less so a consideration for suballocators since there's only so many algorithms and no reason for the user to implement one, but it's a consideration for allocators in general.
  - I forgot the rest of this. There's many more issues here trust me.
- It forces the suballocators to be `Sync` (they still are at this point, read "*most* of the horrible design decisions").
- It forces the suballocators to be `'static`.
- The allocation holding a reference to the *suballocator* rather than the `MemoryAllocator`, excludes many possibilities:
  - Reusing allocations that aren't suballocated. Currently they just die in agony each time.
  - Any other general bookkeeping, such as updating statistics for the whole allocator etc.

I guess this and some other reasons that I forgot is why allocation APIs have an explicit `deallocate` method which fixes all of that. One only needs to implement the trait for their type, and the library can blanket impl it for all references and other pointer types and standard library types. Whether the allocator is internally or externall synchronized is also up to the implementor, because the allocations are separate from the allocator. etc. I don't know why none of our allocator traits have this method, but I can only imagine the original reasoning was that this method is unsafe. Alas, I highly doubt this is a good enough justification.

# Solutions

So now `Suballocator` has an unsafe `deallocate` method, and can be used to suballocate absolutely anything: a `DeviceMemory` block, or suballocations thereof. These can then be bound to buffers which can also be suballocated into subbuffers, or you can suballocate subbuffers. If you really wanted to you could even suballocate regions of descriptors in descriptor arrays, or whatever else you might encounter in Vulkan, such as an array of `u32`s inside a buffer.

`MemoryAllocator` also has an unsafe `deallocate` method, to allow `MemoryAlloc`s to be freed directly to it rather than to a suballocator as described above. The issue is that the specific block the `MemoryAlloc` belongs to must be somehow known. The solution, while unsafe, is much more elegant than the boxing and dynamic dispatch that would be the alternative IMO: an opaque `AllocationHandle` that can represent any piece of data used to identify the allocation, most likely a pointer or index. `Suballocation` also has such a handle to identify the suballocation within the suballocator. These handles can also safely be `Send + Sync` regardless of how the (sub)allocator is synchronized, because again, (sub)allocators and their (sub)allocations are separate from each other. So the (sub)allocator can be synchronized any which way.

# `PoolAllocator`

Is bye bye. No one liked it anyway! The only thing it gave us is special-casing everywhere because it has an upper bound on the suballocation size unlike everything else, and then there's the whole headache of how to specify said block size. Or how `GenericMemoryAllocatorCreateInfo::allocation_type` existed solely because of it. That's not to say pool allocation isn't useful, it absolutely is, just that this being a *suballocator* was frankly never meant to be. The user can create a pool themself with ease, such as can be seen in the implementation of `GenericMemoryAllocator`.

Changelog:
```markdown
### Breaking changes
Changes to memory allocation:
- The memory (sub)allocation API has been completely reworked.
  - `Buffer` and `SubbufferAllocator` now take an `Arc<dyn MemoryAllocator>` on construction.
  - `Suballocator` and `MemoryAllocator` now have explicit `deallocate` methods in order to fix all the flexibility issues.
  - `Suballocator` is completely generic now in regards to the type of suballocation.
  - `SuballocationCreateInfo` was removed.
  - `MemoryAllocatePreference` and `AllocationType` are no longer marked `#[non_exhaustive]`.
  - `MemoryAlloc` was replaced by `ResourceMemory`, `MemoryAlloc` now only represents specifically allocations made by `MemoryAllocator`.
  - `PoolAllocator` was removed.
  - `GenericMemoryAllocatorCreateInfo::allocation_type` was removed.
```