### PR TITLE
Fix missing overflow check when constructing suballocators

### DIFF
--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -219,7 +219,7 @@
 mod layout;
 pub mod suballocator;
 
-use self::array_vec::ArrayVec;
+use self::{array_vec::ArrayVec, suballocator::Region};
 pub use self::{
     layout::DeviceLayout,
     suballocator::{
@@ -1535,7 +1535,10 @@ struct Block<S> {
 
 impl<S: Suballocator> Block<S> {
     fn new(device_memory: Arc<DeviceMemory>) -> Box<Self> {
-        let suballocator = S::new(0, device_memory.allocation_size());
+        let suballocator = S::new(Region {
+            offset: 0,
+            size: device_memory.allocation_size(),
+        });
 
         Box::new(Block {
             device_memory,

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1535,10 +1535,10 @@ struct Block<S> {
 
 impl<S: Suballocator> Block<S> {
     fn new(device_memory: Arc<DeviceMemory>) -> Box<Self> {
-        let suballocator = S::new(Region {
-            offset: 0,
-            size: device_memory.allocation_size(),
-        });
+        let suballocator = S::new(
+            Region::new(0, device_memory.allocation_size())
+                .expect("we somehow managed to allocate more than `DeviceLayout::MAX_SIZE` bytes"),
+        );
 
         Box::new(Block {
             device_memory,

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -159,10 +159,10 @@ mod region {
     /// buffer-image granularity conflict between the parent suballocator's allocations and the
     /// child suballocator's allocations.
     ///
-    /// [region]: Suballocator#region
-    /// [suballocator]: Suballocator
-    /// [suballocations]: Suballocation
-    /// [buffer-image granularity]: super#buffer-image-granularity
+    /// [region]: super::Suballocator#regions
+    /// [suballocator]: super::Suballocator
+    /// [suballocations]: super::Suballocation
+    /// [buffer-image granularity]: super::super#buffer-image-granularity
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub struct Region {
         offset: DeviceSize,

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -148,6 +148,12 @@ pub unsafe trait Suballocator {
     fn cleanup(&mut self);
 }
 
+impl Debug for dyn Suballocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Suballocator").finish_non_exhaustive()
+    }
+}
+
 mod region {
     use super::{DeviceLayout, DeviceSize};
 
@@ -218,12 +224,6 @@ mod region {
         pub const fn size(&self) -> DeviceSize {
             self.size
         }
-    }
-}
-
-impl Debug for dyn Suballocator {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Suballocator").finish_non_exhaustive()
     }
 }
 

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -78,14 +78,8 @@ pub unsafe trait Suballocator {
 
     /// Creates a new suballocator for the given [region].
     ///
-    /// # Arguments
-    ///
-    /// - `region_offset` - The offset where the region begins.
-    ///
-    /// - `region_size` - The size of the region.
-    ///
     /// [region]: Self#regions
-    fn new(region_offset: DeviceSize, region_size: DeviceSize) -> Self
+    fn new(region: Region) -> Self
     where
         Self: Sized;
 
@@ -139,6 +133,39 @@ pub unsafe trait Suballocator {
 
     /// Tries to free some space, if applicable.
     fn cleanup(&mut self);
+}
+
+/// A [region] for a [suballocator] to allocate within. All [suballocations] will be in bounds of
+/// this region.
+///
+/// In order to prevent arithmetic overflow when allocating, the region's end must not exceed
+/// [`DeviceLayout::MAX_SIZE`].
+///
+/// The suballocator knowing the offset of the region rather than only the size allows you to
+/// easily suballocate suballocations. Otherwise, if regions were always relative, you would have
+/// to pick some maximum alignment for a suballocation before suballocating it further, to satisfy
+/// alignment requirements. However, you might not even know the maximum alignment requirement.
+/// Instead you can feed a suballocator a region that is aligned any which way, and it makes sure
+/// that the *absolute offset* of the suballocation has the requested alignment, meaning the offset
+/// that's already offset by the region's offset.
+///
+/// There's one important caveat: if suballocating a suballocation, and the suballocation and the
+/// suballocation's suballocations aren't both only linear or only nonlinear, then the region must
+/// be aligned to the [buffer-image granularity]. Otherwise, there might be a buffer-image
+/// granularity conflict between the parent suballocator's allocations and the child suballocator's
+/// allocations.
+///
+/// [region]: Suballocator#region
+/// [suballocator]: Suballocator
+/// [suballocations]: Suballocation
+/// [buffer-image granularity]: super#buffer-image-granularity
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Region {
+    /// The offset where the region begins.
+    pub offset: DeviceSize,
+
+    /// The size of the region.
+    pub size: DeviceSize,
 }
 
 /// Tells the [suballocator] what type of resource will be bound to the allocation, so that it can
@@ -279,28 +306,34 @@ unsafe impl Suballocator for FreeListAllocator {
 
     /// Creates a new `FreeListAllocator` for the given [region].
     ///
+    /// # Panics
+    ///
+    /// - Panics if the end of the region is not less than or equal to [`DeviceLayout::MAX_SIZE`].
+    ///
     /// [region]: Suballocator#regions
-    fn new(region_offset: DeviceSize, region_size: DeviceSize) -> Self {
+    fn new(region: Region) -> Self {
         // NOTE(Marc): This number was pulled straight out of my a-
         const AVERAGE_ALLOCATION_SIZE: DeviceSize = 64 * 1024;
 
-        let free_size = Cell::new(region_size);
+        assert!(region.offset.saturating_add(region.size) <= DeviceLayout::MAX_SIZE);
 
-        let capacity = (region_size / AVERAGE_ALLOCATION_SIZE) as usize;
+        let free_size = Cell::new(region.size);
+
+        let capacity = (region.size / AVERAGE_ALLOCATION_SIZE) as usize;
         let mut nodes = host::PoolAllocator::new(capacity + 64);
         let mut free_list = Vec::with_capacity(capacity / 16 + 16);
         let root_id = nodes.allocate(SuballocationListNode {
             prev: None,
             next: None,
-            offset: region_offset,
-            size: region_size,
+            offset: region.offset,
+            size: region.size,
             ty: SuballocationType::Free,
         });
         free_list.push(root_id);
         let state = UnsafeCell::new(FreeListAllocatorState { nodes, free_list });
 
         FreeListAllocator {
-            region_offset,
+            region_offset: region.offset,
             free_size,
             state,
         }
@@ -344,9 +377,8 @@ unsafe impl Suballocator for FreeListAllocator {
                     for (index, &id) in state.free_list.iter().enumerate().skip(index) {
                         let suballoc = state.nodes.get(id);
 
-                        // This can't overflow because suballocation offsets are constrained by
-                        // the size of the root allocation, which can itself not exceed
-                        // `DeviceLayout::MAX_SIZE`.
+                        // This can't overflow because suballocation offsets are bounded by the
+                        // region, whose end can itself not exceed `DeviceLayout::MAX_SIZE`.
                         let mut offset = align_up(suballoc.offset, alignment);
 
                         if buffer_image_granularity != DeviceAlignment::MIN {
@@ -368,6 +400,14 @@ unsafe impl Suballocator for FreeListAllocator {
                             }
                         }
 
+                        // `offset`, no matter the alignment, can't end up as more than
+                        // `DeviceAlignment::MAX` for the same reason as above. `DeviceLayout`
+                        // guarantees that `size` doesn't exceed `DeviceLayout::MAX_SIZE`.
+                        // `DeviceAlignment::MAX.as_devicesize() + DeviceLayout::MAX_SIZE` is equal
+                        // to `DeviceSize::MAX`. Therefore, `offset + size` can't overflow.
+                        //
+                        // `suballoc.offset + suballoc.size` can't overflow for the same reason as
+                        // above.
                         if offset + size <= suballoc.offset + suballoc.size {
                             state.free_list.remove(index);
 
@@ -755,30 +795,32 @@ unsafe impl Suballocator for BuddyAllocator {
     ///
     /// # Panics
     ///
-    /// - Panics if `region_size` is not a power of two.
-    /// - Panics if `region_size` is not in the range \[16B,&nbsp;64GiB\].
+    /// - Panics if the end of the region is not less than or equal to [`DeviceLayout::MAX_SIZE`].
+    /// - Panics if `region.size` is not a power of two.
+    /// - Panics if `region.size` is not in the range \[16B,&nbsp;64GiB\].
     ///
     /// [region]: Suballocator#regions
-    fn new(region_offset: DeviceSize, region_size: DeviceSize) -> Self {
+    fn new(region: Region) -> Self {
         const EMPTY_FREE_LIST: Vec<DeviceSize> = Vec::new();
 
-        assert!(region_size.is_power_of_two());
-        assert!(region_size >= BuddyAllocator::MIN_NODE_SIZE);
+        assert!(region.offset.saturating_add(region.size) <= DeviceLayout::MAX_SIZE);
+        assert!(region.size.is_power_of_two());
+        assert!(region.size >= BuddyAllocator::MIN_NODE_SIZE);
 
-        let max_order = (region_size / BuddyAllocator::MIN_NODE_SIZE).trailing_zeros() as usize;
+        let max_order = (region.size / BuddyAllocator::MIN_NODE_SIZE).trailing_zeros() as usize;
 
         assert!(max_order < BuddyAllocator::MAX_ORDERS);
 
-        let free_size = Cell::new(region_size);
+        let free_size = Cell::new(region.size);
 
         let mut free_list =
             ArrayVec::new(max_order + 1, [EMPTY_FREE_LIST; BuddyAllocator::MAX_ORDERS]);
         // The root node has the lowest offset and highest order, so it's the whole region.
-        free_list[max_order].push(region_offset);
+        free_list[max_order].push(region.offset);
         let state = UnsafeCell::new(BuddyAllocatorState { free_list });
 
         BuddyAllocator {
-            region_offset,
+            region_offset: region.offset,
             free_size,
             state,
         }
@@ -848,8 +890,8 @@ unsafe impl Suballocator for BuddyAllocator {
                         // [0, log(region.size / BuddyAllocator::MIN_NODE_SIZE)].
                         let size = BuddyAllocator::MIN_NODE_SIZE << order;
 
-                        // This can't overflow because offsets are confined to the size of the root
-                        // allocation, which can itself not exceed `DeviceLayout::MAX_SIZE`.
+                        // This can't overflow because suballocations are bounded by the region,
+                        // whose end can itself not exceed `DeviceLayout::MAX_SIZE`.
                         let right_child = offset + size;
 
                         // Insert the right child in sorted order.
@@ -998,8 +1040,7 @@ struct BuddyAllocatorState {
 /// [hierarchy]: Suballocator#memory-hierarchies
 #[derive(Debug)]
 pub struct BumpAllocator {
-    region_offset: DeviceSize,
-    region_size: DeviceSize,
+    region: Region,
     free_start: Cell<DeviceSize>,
     prev_allocation_type: Cell<AllocationType>,
 }
@@ -1020,11 +1061,16 @@ unsafe impl Suballocator for BumpAllocator {
 
     /// Creates a new `BumpAllocator` for the given [region].
     ///
+    /// # Panics
+    ///
+    /// - Panics if the end of the region is not less than or equal to [`DeviceLayout::MAX_SIZE`].
+    ///
     /// [region]: Suballocator#regions
-    fn new(region_offset: DeviceSize, region_size: DeviceSize) -> Self {
+    fn new(region: Region) -> Self {
+        assert!(region.offset.saturating_add(region.size) <= DeviceLayout::MAX_SIZE);
+
         BumpAllocator {
-            region_offset,
-            region_size,
+            region,
             free_start: Cell::new(0),
             prev_allocation_type: Cell::new(AllocationType::Unknown),
         }
@@ -1044,9 +1090,9 @@ unsafe impl Suballocator for BumpAllocator {
         let size = layout.size();
         let alignment = layout.alignment();
 
-        // These can't overflow because offsets are constrained by the size of the root
-        // allocation, which can itself not exceed `DeviceLayout::MAX_SIZE`.
-        let prev_end = self.region_offset + self.free_start.get();
+        // These can't overflow because suballocation offsets are bounded by the region, whose end
+        // can itself not exceed `DeviceLayout::MAX_SIZE`.
+        let prev_end = self.region.offset + self.free_start.get();
         let mut offset = align_up(prev_end, alignment);
 
         if buffer_image_granularity != DeviceAlignment::MIN
@@ -1057,11 +1103,11 @@ unsafe impl Suballocator for BumpAllocator {
             offset = align_up(offset, buffer_image_granularity);
         }
 
-        let relative_offset = offset - self.region_offset;
+        let relative_offset = offset - self.region.offset;
 
         let free_start = relative_offset + size;
 
-        if free_start > self.region_size {
+        if free_start > self.region.size {
             return Err(SuballocatorError::OutOfRegionMemory);
         }
 
@@ -1082,7 +1128,7 @@ unsafe impl Suballocator for BumpAllocator {
 
     #[inline]
     fn free_size(&self) -> DeviceSize {
-        self.region_size - self.free_start.get()
+        self.region.size - self.free_start.get()
     }
 
     #[inline]
@@ -1247,7 +1293,10 @@ mod tests {
         const REGION_SIZE: DeviceSize =
             (ALLOCATION_STEP * (THREADS + 1) * THREADS / 2) * ALLOCATIONS_PER_THREAD;
 
-        let allocator = Mutex::new(FreeListAllocator::new(0, REGION_SIZE));
+        let allocator = Mutex::new(FreeListAllocator::new(Region {
+            offset: 0,
+            size: REGION_SIZE,
+        }));
         let allocs = ArrayQueue::new((ALLOCATIONS_PER_THREAD * THREADS) as usize);
 
         // Using threads to randomize allocation order.
@@ -1299,7 +1348,10 @@ mod tests {
         const REGION_SIZE: DeviceSize = 10 * 256;
         const LAYOUT: DeviceLayout = unwrap(DeviceLayout::from_size_alignment(1, 256));
 
-        let allocator = FreeListAllocator::new(0, REGION_SIZE);
+        let allocator = FreeListAllocator::new(Region {
+            offset: 0,
+            size: REGION_SIZE,
+        });
         let mut allocs = Vec::with_capacity(10);
 
         for _ in 0..10 {
@@ -1325,7 +1377,10 @@ mod tests {
         const GRANULARITY: DeviceAlignment = unwrap(DeviceAlignment::new(16));
         const REGION_SIZE: DeviceSize = 2 * GRANULARITY.as_devicesize();
 
-        let allocator = FreeListAllocator::new(0, REGION_SIZE);
+        let allocator = FreeListAllocator::new(Region {
+            offset: 0,
+            size: REGION_SIZE,
+        });
         let mut linear_allocs = Vec::with_capacity(REGION_SIZE as usize / 2);
         let mut nonlinear_allocs = Vec::with_capacity(REGION_SIZE as usize / 2);
 
@@ -1384,7 +1439,10 @@ mod tests {
         const MAX_ORDER: usize = 10;
         const REGION_SIZE: DeviceSize = BuddyAllocator::MIN_NODE_SIZE << MAX_ORDER;
 
-        let allocator = BuddyAllocator::new(0, REGION_SIZE);
+        let allocator = BuddyAllocator::new(Region {
+            offset: 0,
+            size: REGION_SIZE,
+        });
         let mut allocs = Vec::with_capacity(1 << MAX_ORDER);
 
         for order in 0..=MAX_ORDER {
@@ -1446,7 +1504,10 @@ mod tests {
     fn buddy_allocator_respects_alignment() {
         const REGION_SIZE: DeviceSize = 4096;
 
-        let allocator = BuddyAllocator::new(0, REGION_SIZE);
+        let allocator = BuddyAllocator::new(Region {
+            offset: 0,
+            size: REGION_SIZE,
+        });
 
         {
             let layout = DeviceLayout::from_size_alignment(1, 4096).unwrap();
@@ -1510,7 +1571,10 @@ mod tests {
         const GRANULARITY: DeviceAlignment = unwrap(DeviceAlignment::new(256));
         const REGION_SIZE: DeviceSize = 2 * GRANULARITY.as_devicesize();
 
-        let allocator = BuddyAllocator::new(0, REGION_SIZE);
+        let allocator = BuddyAllocator::new(Region {
+            offset: 0,
+            size: REGION_SIZE,
+        });
 
         {
             const ALLOCATIONS: DeviceSize = REGION_SIZE / BuddyAllocator::MIN_NODE_SIZE;
@@ -1557,7 +1621,10 @@ mod tests {
         const REGION_SIZE: DeviceSize = 10 * ALIGNMENT;
 
         let layout = DeviceLayout::from_size_alignment(1, ALIGNMENT).unwrap();
-        let mut allocator = BumpAllocator::new(0, REGION_SIZE);
+        let mut allocator = BumpAllocator::new(Region {
+            offset: 0,
+            size: REGION_SIZE,
+        });
 
         for _ in 0..10 {
             allocator
@@ -1590,7 +1657,10 @@ mod tests {
         const GRANULARITY: DeviceAlignment = unwrap(DeviceAlignment::new(1024));
         const REGION_SIZE: DeviceSize = ALLOCATIONS * GRANULARITY.as_devicesize();
 
-        let mut allocator = BumpAllocator::new(0, REGION_SIZE);
+        let mut allocator = BumpAllocator::new(Region {
+            offset: 0,
+            size: REGION_SIZE,
+        });
 
         for i in 0..ALLOCATIONS {
             for _ in 0..GRANULARITY.as_devicesize() {

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -12,7 +12,7 @@ use crate::{
     device::{Device, DeviceOwned},
     instance::InstanceOwnedDebugWrapper,
     macros::{impl_id_counter, vulkan_bitflags, vulkan_bitflags_enum},
-    memory::{allocator::DeviceLayout, is_aligned, MemoryPropertyFlags},
+    memory::{is_aligned, MemoryPropertyFlags},
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version,
     VulkanError, VulkanObject,
 };
@@ -284,9 +284,6 @@ impl DeviceMemory {
             output.assume_init()
         };
 
-        // Sanity check: this would lead to UB when suballocating.
-        assert!(allocation_size <= DeviceLayout::MAX_SIZE);
-
         let atom_size = device.physical_device().properties().non_coherent_atom_size;
 
         let is_coherent = device.physical_device().memory_properties().memory_types
@@ -332,9 +329,6 @@ impl DeviceMemory {
             flags,
             _ne: _,
         } = allocate_info;
-
-        // Sanity check: this would lead to UB when suballocating.
-        assert!(allocation_size <= DeviceLayout::MAX_SIZE);
 
         let atom_size = device.physical_device().properties().non_coherent_atom_size;
 


### PR DESCRIPTION
Fixes an oversight in #2316, where a safety precondition no longer holds. Previously all allocations were bounded by the root allocation which couldn't exceed `DeviceLayout::MAX_SIZE`, but now that regions are separate from allocations, it has to be checked separately somehow. I added a `Region` type solely for the sake of documentation, but I still don't know if it's best like this, where the suballocator would panic on construction (which results in a bit of duplication and could be more error-prone for an implementor of the trait) or whether `Region` should have private fields much like `DeviceLayout` and have both a safe and unsafe way to construct it. The thing is though that creating a suballocator isn't on the hot path unlike creating a `DeviceLayout`.