### PR TITLE
Move the `allocation_type` field to `Suballocation`, since `AllocationType` is unique to suballocations

### DIFF
--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -692,14 +692,6 @@ pub struct MemoryAlloc {
     /// allocation.
     pub suballocation: Option<Suballocation>,
 
-    /// The type of resources that can be bound to this memory block. This will be exactly equal to
-    /// the requested allocation type.
-    ///
-    /// For dedicated allocations it doesn't matter what this is, as there aren't going to be any
-    /// neighboring suballocations. Therefore the allocator implementation is advised to always set
-    /// this to [`AllocationType::Unknown`] in that case for maximum flexibility.
-    pub allocation_type: AllocationType,
-
     /// An opaque handle identifying the allocation inside the allocator.
     pub allocation_handle: AllocationHandle,
 }
@@ -1419,7 +1411,6 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
         Ok(MemoryAlloc {
             device_memory,
             suballocation: None,
-            allocation_type: AllocationType::Unknown,
             allocation_handle: AllocationHandle(ptr::null_mut()),
         })
     }
@@ -1543,7 +1534,6 @@ impl<S: Suballocator> Block<S> {
         Ok(MemoryAlloc {
             device_memory: self.device_memory.clone(),
             suballocation: Some(suballocation),
-            allocation_type,
             allocation_handle: AllocationHandle(self as *const Block<S> as _),
         })
     }

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -188,6 +188,10 @@ pub struct Suballocation {
     /// The size of the allocation. This will be exactly equal to the requested size.
     pub size: DeviceSize,
 
+    /// The type of resources that can be bound to this memory block. This will be exactly equal to
+    /// the requested allocation type.
+    pub allocation_type: AllocationType,
+
     /// An opaque handle identifying the allocation within the allocator.
     pub handle: AllocationHandle,
 }
@@ -385,6 +389,7 @@ unsafe impl Suballocator for FreeListAllocator {
                             return Ok(Suballocation {
                                 offset,
                                 size,
+                                allocation_type,
                                 handle: AllocationHandle(id.get() as _),
                             });
                         }
@@ -866,6 +871,7 @@ unsafe impl Suballocator for BuddyAllocator {
                     return Ok(Suballocation {
                         offset,
                         size: layout.size(),
+                        allocation_type,
                         handle: AllocationHandle(min_order as _),
                     });
                 }
@@ -1071,6 +1077,7 @@ unsafe impl Suballocator for BumpAllocator {
         Ok(Suballocation {
             offset,
             size,
+            allocation_type,
             handle: AllocationHandle(ptr::null_mut()),
         })
     }

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -180,7 +180,7 @@ impl ResourceMemory {
             ResourceMemory {
                 offset: suballocation.offset,
                 size: suballocation.size,
-                allocation_type: allocation.allocation_type,
+                allocation_type: suballocation.allocation_type,
                 allocation_handle: allocation.allocation_handle,
                 suballocation_handle: Some(suballocation.handle),
                 allocator: Some(allocator),
@@ -190,7 +190,7 @@ impl ResourceMemory {
             ResourceMemory {
                 offset: 0,
                 size: allocation.device_memory.allocation_size(),
-                allocation_type: allocation.allocation_type,
+                allocation_type: AllocationType::Unknown,
                 allocation_handle: allocation.allocation_handle,
                 suballocation_handle: None,
                 allocator: Some(allocator),
@@ -242,6 +242,7 @@ impl ResourceMemory {
         self.suballocation_handle.map(|handle| Suballocation {
             offset: self.offset,
             size: self.size,
+            allocation_type: self.allocation_type,
             handle,
         })
     }
@@ -426,7 +427,6 @@ impl Drop for ResourceMemory {
             let allocation = MemoryAlloc {
                 device_memory,
                 suballocation: self.suballocation(),
-                allocation_type: self.allocation_type,
                 allocation_handle: self.allocation_handle,
             };
 


### PR DESCRIPTION
The original intention was, when using a suballocator with a hard-coded `AllocationType` (e.g. suballocating a buffer), that the user wouldn't need to worry about the allocation type when deallocating (as per the safety contract of `deallocate`). However, as is documented, the `allocation_type` field will be exactly equal to the requested allocation type, so the user can hard-code it both on allocation and deallocation. This makes things more consistent and logical.