### PR TITLE
Fix typo in cargo:rerun-if-changed

### DIFF
--- a/vulkano/build.rs
+++ b/vulkano/build.rs
@@ -26,6 +26,6 @@ fn main() {
 
     // Run autogen
     println!("cargo:rerun-if-changed=vk.xml");
-    println!("cargo:rerun-if-changed=spirv-core.grammar.json");
+    println!("cargo:rerun-if-changed=spirv.core.grammar.json");
     autogen::autogen();
 }


### PR DESCRIPTION
This was causing Cargo to always consider the file changed, so everything would recompile all the time.