### PR TITLE
Make the insides of `AllocationHandle` private

### DIFF
--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -758,7 +758,7 @@ impl AllocationHandle {
     ///
     /// [`from_ptr`]: Self::from_ptr
     #[inline]
-    pub const fn into_ptr(self) -> *mut () {
+    pub const fn as_ptr(self) -> *mut () {
         self.0
     }
 
@@ -770,7 +770,7 @@ impl AllocationHandle {
     /// [`from_index`]: Self::from_index
     #[allow(clippy::transmutes_expressible_as_ptr_casts)]
     #[inline]
-    pub const fn into_index(self) -> usize {
+    pub const fn as_index(self) -> usize {
         // SAFETY: `usize` and `*mut ()` have the same layout.
         unsafe { mem::transmute::<*mut (), usize>(self.0) }
     }

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -24,7 +24,6 @@ use std::{
     cmp,
     error::Error,
     fmt::{self, Debug, Display},
-    ptr,
 };
 
 /// Suballocators are used to divide a *region* into smaller *suballocations*.
@@ -1159,7 +1158,7 @@ unsafe impl Suballocator for BumpAllocator {
             offset,
             size,
             allocation_type,
-            handle: AllocationHandle(ptr::null_mut()),
+            handle: AllocationHandle::null(),
         })
     }
 

--- a/vulkano/src/memory/allocator/suballocator.rs
+++ b/vulkano/src/memory/allocator/suballocator.rs
@@ -498,7 +498,7 @@ unsafe impl Suballocator for FreeListAllocator {
     unsafe fn deallocate(&self, suballocation: Suballocation) {
         // SAFETY: The caller must guarantee that `suballocation` refers to a currently allocated
         // allocation of `self`.
-        let node_id = SlotId::new(suballocation.handle.into_index());
+        let node_id = SlotId::new(suballocation.handle.as_index());
 
         let state = unsafe { &mut *self.state.get() };
         let node = state.nodes.get_mut(node_id);
@@ -973,7 +973,7 @@ unsafe impl Suballocator for BuddyAllocator {
     #[inline]
     unsafe fn deallocate(&self, suballocation: Suballocation) {
         let mut offset = suballocation.offset;
-        let order = suballocation.handle.into_index();
+        let order = suballocation.handle.as_index();
 
         let min_order = order;
         let state = unsafe { &mut *self.state.get() };

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -109,7 +109,7 @@ use std::{
     mem::ManuallyDrop,
     num::NonZeroU64,
     ops::{Bound, Range, RangeBounds, RangeTo},
-    ptr::{self, NonNull},
+    ptr::NonNull,
     sync::Arc,
 };
 
@@ -155,7 +155,7 @@ impl ResourceMemory {
             offset: 0,
             size: device_memory.allocation_size(),
             allocation_type: AllocationType::Unknown,
-            allocation_handle: AllocationHandle(ptr::null_mut()),
+            allocation_handle: AllocationHandle::null(),
             suballocation_handle: None,
             allocator: None,
             device_memory: ManuallyDrop::new(DeviceOwnedDebugWrapper(device_memory)),


### PR DESCRIPTION
Let's stay conservative, to for example allow adding more fields to it (in particular consider a thicc pointer) or turn it into a union (e.g. if the need for storing a `DeviceSize` ever arises).