### PR TITLE
Fix overlapping attributes when using `dualSrcBlend` feature

### DIFF
--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -1314,6 +1314,10 @@ pub struct ShaderInterfaceEntry {
     /// The location slot that the variable starts at.
     pub location: u32,
 
+    /// The index within the location slot that the variable is located.
+    /// Only meaningful for fragment outputs.
+    pub index: u32,
+
     /// The component slot that the variable starts at. Must be in the range 0..=3.
     pub component: u32,
 


### PR DESCRIPTION
1. [X] Update documentation to reflect any user-facing changes - in this repository.
N/A, it was an internal bug

2. [X] Make sure that the changes are covered by unit-tests.
Looks like shader module as a whole is missing unit tests :<

3. [X] Run `cargo fmt` on the changes.

4. [X] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.
   
   Please remove any items from the template below that are not applicable.

5. [X] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

This change allows for fragment shaders to make use of the `dualSrcBlend` feature of Vulkan 1.0, by assigning an `index` layout to color outputs. In vulkano 0.33.0, this causes a compile time error, and in the current `master` branch it causes a runtime error, due to detection of overlapping interface variables not taking `index` into account. This fixes that :>

Changelog:
```markdown
### Bugs fixed
- fragment shaders cannot use `dual_src_blend` device feature due to interface errors
````
