### PR TITLE
Refactor some shader things and add more validation

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -554,7 +554,7 @@ mod tests {
         let spirv = Spirv::new(&instructions).unwrap();
 
         let mut descriptors = Vec::new();
-        for info in reflect::entry_points(&spirv) {
+        for (_, info) in reflect::entry_points(&spirv) {
             descriptors.push(info.descriptor_binding_requirements);
         }
 
@@ -622,7 +622,7 @@ mod tests {
         .unwrap();
         let spirv = Spirv::new(comp.as_binary()).unwrap();
 
-        if let Some(info) = reflect::entry_points(&spirv).next() {
+        if let Some((_, info)) = reflect::entry_points(&spirv).next() {
             let mut bindings = Vec::new();
             for (loc, _reqs) in info.descriptor_binding_requirements {
                 bindings.push(loc);

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -28,7 +28,7 @@ use crate::{
     instance::InstanceOwnedDebugWrapper,
     macros::impl_id_counter,
     pipeline::{cache::PipelineCache, layout::PipelineLayout, Pipeline, PipelineBindPoint},
-    shader::{DescriptorBindingRequirements, ShaderExecution, ShaderStage},
+    shader::{spirv::ExecutionModel, DescriptorBindingRequirements, ShaderStage},
     Validated, ValidationError, VulkanError, VulkanObject,
 };
 use ahash::HashMap;
@@ -155,7 +155,7 @@ impl ComputePipeline {
                     },
                 ),
                 flags: flags.into(),
-                stage: ShaderStage::from(&entry_point_info.execution).into(),
+                stage: ShaderStage::from(entry_point_info.execution_model).into(),
                 module: entry_point.module().handle(),
                 p_name: name_vk.as_ptr(),
                 p_specialization_info: if specialization_info_vk.data_size == 0 {
@@ -410,7 +410,7 @@ impl ComputePipelineCreateInfo {
 
         let entry_point_info = entry_point.info();
 
-        if !matches!(entry_point_info.execution, ShaderExecution::Compute(_)) {
+        if !matches!(entry_point_info.execution_model, ExecutionModel::GLCompute) {
             return Err(Box::new(ValidationError {
                 context: "stage.entry_point".into(),
                 problem: "is not a `ShaderStage::Compute` entry point".into(),

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -3142,7 +3142,7 @@ impl GraphicsPipelineCreateInfo {
 
 /// The input primitive type that is expected by a geometry shader.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum GeometryShaderInput {
+enum GeometryShaderInput {
     Points,
     Lines,
     LinesWithAdjacency,
@@ -3153,7 +3153,7 @@ pub enum GeometryShaderInput {
 impl GeometryShaderInput {
     /// Returns true if the given primitive topology can be used as input for this geometry shader.
     #[inline]
-    pub fn is_compatible_with(self, topology: PrimitiveTopology) -> bool {
+    fn is_compatible_with(self, topology: PrimitiveTopology) -> bool {
         match self {
             Self::Points => matches!(topology, PrimitiveTopology::PointList),
             Self::Lines => matches!(


### PR DESCRIPTION
With the improved SPIR-V stuff from the previous PR, this now adds some missing checks for `PipelineShaderCreateInfo`. Other checks for `ComputePipelineCreateInfo` and `GraphicsPipelineCreateInfo` can come in future PRs, but they are not needed for 0.34.

I've also refactored away the `ShaderExecution` type, which was no longer needed.