### PR TITLE
Allow for setting the array length in a shader using a specialization constant

### DIFF
--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -581,7 +581,7 @@ impl TypeArray {
 
         let length = length_id
             .map(|id| match shader.spirv.id(id).instruction() {
-                Instruction::Constant { value, .. } => {
+                Instruction::Constant { value, .. } | Instruction::SpecConstant { value, .. } => {
                     assert!(matches!(value.len(), 1 | 2));
                     let len = value.iter().rev().fold(0u64, |a, &b| (a << 32) | b as u64);
 


### PR DESCRIPTION
To allow for something like this using vulkano-shaders:
```glsl
layout(constant_id = 0) const uint n = 64;
layout(std430, set = 0, binding = 0) uniform layout_sample { float sample[n]; };
```

Fixes #1956

Changelog:
```markdown
### Addditions
- Vulkano-shaders: support for specialization-constant-sized arrays in structs (they are generated with the size specified as fallback in the specialization constant initializer).
```
