### PR TITLE
Add support for `present_modes2` function

### DIFF
--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -620,7 +620,14 @@ impl Swapchain {
         let surface_present_modes: SmallVec<[_; PresentMode::COUNT]> = unsafe {
             device
                 .physical_device()
-                .surface_present_modes_unchecked(surface)
+                .surface_present_modes_unchecked(
+                    surface,
+                    SurfaceInfo {
+                        full_screen_exclusive,
+                        win32_monitor,
+                        ..Default::default()
+                    },
+                )
                 .map_err(|_err| {
                     Box::new(ValidationError {
                         problem: "`PhysicalDevice::surface_present_modes` \

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -52,7 +52,8 @@ pub struct Surface {
     // `Surface` is destroyed.
     pub(crate) surface_formats:
         OnceCache<(ash::vk::PhysicalDevice, SurfaceInfo), Vec<(Format, ColorSpace)>>,
-    pub(crate) surface_present_modes: OnceCache<ash::vk::PhysicalDevice, Vec<PresentMode>>,
+    pub(crate) surface_present_modes:
+        OnceCache<(ash::vk::PhysicalDevice, SurfaceInfo), Vec<PresentMode>>,
     pub(crate) surface_support: OnceCache<(ash::vk::PhysicalDevice, u32), bool>,
 }
 


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to the physical device:
- The `PhysicalDevice::surface_present_modes` method now takes an additional `SurfaceInfo` parameter.
````

This completes our coverage of `VK_EXT_full_screen_exclusive`.