### PR TITLE
Add missing pointer handling to runtime reflection

### DIFF
--- a/vulkano/src/shader/reflect.rs
+++ b/vulkano/src/shader/reflect.rs
@@ -1084,6 +1084,7 @@ fn size_of_type(spirv: &Spirv, id: Id) -> Option<DeviceSize> {
             assert!(width % 8 == 0);
             Some(width as DeviceSize / 8)
         }
+        Instruction::TypePointer { .. } => Some(8),
         Instruction::TypeVector {
             component_type,
             component_count,


### PR DESCRIPTION
This was missed in #2351 and reported by @hydos in Discord.