### PR TITLE
Use separate samplers and sampled images in the examples

### DIFF
--- a/examples/src/bin/async-update.rs
+++ b/examples/src/bin/async-update.rs
@@ -399,10 +399,11 @@ fn main() {
                 layout(location = 0) in vec2 tex_coords;
                 layout(location = 0) out vec4 f_color;
 
-                layout(set = 1, binding = 0) uniform sampler2D tex;
+                layout(set = 1, binding = 0) uniform sampler s;
+                layout(set = 1, binding = 1) uniform texture2D tex;
 
                 void main() {
-                    f_color = texture(tex, tex_coords);
+                    f_color = texture(sampler2D(tex, s), tex_coords);
                 }
             ",
         }
@@ -505,11 +506,10 @@ fn main() {
         PersistentDescriptorSet::new(
             &descriptor_set_allocator,
             pipeline.layout().set_layouts()[1].clone(),
-            [WriteDescriptorSet::image_view_sampler(
-                0,
-                ImageView::new_default(texture).unwrap(),
-                sampler.clone(),
-            )],
+            [
+                WriteDescriptorSet::sampler(0, sampler.clone()),
+                WriteDescriptorSet::image_view(1, ImageView::new_default(texture).unwrap()),
+            ],
             [],
         )
         .unwrap()

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -270,9 +270,10 @@ mod linux {
         let set = PersistentDescriptorSet::new(
             &descriptor_set_allocator,
             layout.clone(),
-            [WriteDescriptorSet::image_view_sampler(
-                0, image_view, sampler,
-            )],
+            [
+                WriteDescriptorSet::sampler(0, sampler),
+                WriteDescriptorSet::image_view(1, image_view),
+            ],
             [],
         )
         .unwrap();
@@ -798,9 +799,12 @@ mod linux {
                 #version 450
                 layout(location = 0) in vec2 tex_coords;
                 layout(location = 0) out vec4 f_color;
-                layout(set = 0, binding = 0) uniform sampler2D tex;
+
+                layout(set = 0, binding = 0) uniform sampler s;
+                layout(set = 0, binding = 1) uniform texture2D tex;
+
                 void main() {
-                    f_color = texture(tex, tex_coords);
+                    f_color = texture(sampler2D(tex, s), tex_coords);
                 }
             ",
         }

--- a/examples/src/bin/image-self-copy-blit/main.rs
+++ b/examples/src/bin/image-self-copy-blit/main.rs
@@ -389,7 +389,10 @@ fn main() {
     let set = PersistentDescriptorSet::new(
         &descriptor_set_allocator,
         layout.clone(),
-        [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
+        [
+            WriteDescriptorSet::sampler(0, sampler),
+            WriteDescriptorSet::image_view(1, texture),
+        ],
         [],
     )
     .unwrap();
@@ -578,10 +581,11 @@ mod fs {
             layout(location = 0) in vec2 tex_coords;
             layout(location = 0) out vec4 f_color;
 
-            layout(set = 0, binding = 0) uniform sampler2D tex;
+            layout(set = 0, binding = 0) uniform sampler s;
+            layout(set = 0, binding = 1) uniform texture2D tex;
 
             void main() {
-                f_color = texture(tex, tex_coords);
+                f_color = texture(sampler2D(tex, s), tex_coords);
             }
         ",
     }

--- a/examples/src/bin/image/main.rs
+++ b/examples/src/bin/image/main.rs
@@ -337,7 +337,10 @@ fn main() {
     let set = PersistentDescriptorSet::new(
         &descriptor_set_allocator,
         layout.clone(),
-        [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
+        [
+            WriteDescriptorSet::sampler(0, sampler),
+            WriteDescriptorSet::image_view(1, texture),
+        ],
         [],
     )
     .unwrap();
@@ -526,10 +529,11 @@ mod fs {
             layout(location = 0) in vec2 tex_coords;
             layout(location = 0) out vec4 f_color;
 
-            layout(set = 0, binding = 0) uniform sampler2D tex;
+            layout(set = 0, binding = 0) uniform sampler s;
+            layout(set = 0, binding = 1) uniform texture2D tex;
 
             void main() {
-                f_color = texture(tex, tex_coords);
+                f_color = texture(sampler2D(tex, s), tex_coords);
             }
         ",
     }

--- a/examples/src/bin/immutable-sampler/main.rs
+++ b/examples/src/bin/immutable-sampler/main.rs
@@ -358,7 +358,7 @@ fn main() {
     let set = PersistentDescriptorSet::new(
         &descriptor_set_allocator,
         layout.clone(),
-        [WriteDescriptorSet::image_view(0, texture)],
+        [WriteDescriptorSet::image_view(1, texture)],
         [],
     )
     .unwrap();
@@ -547,10 +547,11 @@ mod fs {
             layout(location = 0) in vec2 tex_coords;
             layout(location = 0) out vec4 f_color;
 
-            layout(set = 0, binding = 0) uniform sampler2D tex;
+            layout(set = 0, binding = 0) uniform sampler s;
+            layout(set = 0, binding = 1) uniform texture2D tex;
 
             void main() {
-                f_color = texture(tex, tex_coords);
+                f_color = texture(sampler2D(tex, s), tex_coords);
             }
         ",
     }

--- a/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
+++ b/examples/src/bin/interactive_fractal/pixels_draw_pipeline.rs
@@ -198,7 +198,10 @@ impl PixelsDrawPipeline {
         PersistentDescriptorSet::new(
             &self.descriptor_set_allocator,
             layout.clone(),
-            [WriteDescriptorSet::image_view_sampler(0, image, sampler)],
+            [
+                WriteDescriptorSet::sampler(0, sampler),
+                WriteDescriptorSet::image_view(1, image),
+            ],
             [],
         )
         .unwrap()
@@ -279,10 +282,11 @@ mod fs {
 
             layout(location = 0) out vec4 f_color;
 
-            layout(set = 0, binding = 0) uniform sampler2D tex;
+            layout(set = 0, binding = 0) uniform sampler s;
+            layout(set = 0, binding = 1) uniform texture2D tex;
 
             void main() {
-                f_color = texture(tex, v_tex_coords);
+                f_color = texture(sampler2D(tex, s), v_tex_coords);
             }
         ",
     }

--- a/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
+++ b/examples/src/bin/multi_window_game_of_life/pixels_draw.rs
@@ -194,7 +194,10 @@ impl PixelsDrawPipeline {
         PersistentDescriptorSet::new(
             &self.descriptor_set_allocator,
             layout.clone(),
-            [WriteDescriptorSet::image_view_sampler(0, image, sampler)],
+            [
+                WriteDescriptorSet::sampler(0, sampler),
+                WriteDescriptorSet::image_view(1, image),
+            ],
             [],
         )
         .unwrap()
@@ -275,10 +278,11 @@ mod fs {
 
             layout(location = 0) out vec4 f_color;
 
-            layout(set = 0, binding = 0) uniform sampler2D tex;
+            layout(set = 0, binding = 0) uniform sampler s;
+            layout(set = 0, binding = 1) uniform texture2D tex;
 
             void main() {
-                f_color = texture(tex, v_tex_coords);
+                f_color = texture(sampler2D(tex, s), v_tex_coords);
             }
         ",
     }

--- a/examples/src/bin/push-descriptors/main.rs
+++ b/examples/src/bin/push-descriptors/main.rs
@@ -428,9 +428,14 @@ fn main() {
                     PipelineBindPoint::Graphics,
                     pipeline.layout().clone(),
                     0,
-                    [WriteDescriptorSet::image_view(0, texture.clone())]
-                        .into_iter()
-                        .collect(),
+                    [
+                        // If the binding is an immutable sampler, using push descriptors
+                        // you must write dummy value to the binding.
+                        WriteDescriptorSet::none(0),
+                        WriteDescriptorSet::image_view(1, texture.clone()),
+                    ]
+                    .into_iter()
+                    .collect(),
                 )
                 .unwrap()
                 .bind_vertex_buffers(0, vertex_buffer.clone())
@@ -522,10 +527,11 @@ mod fs {
             layout(location = 0) in vec2 tex_coords;
             layout(location = 0) out vec4 f_color;
 
-            layout(set = 0, binding = 0) uniform sampler2D tex;
+            layout(set = 0, binding = 0) uniform sampler s;
+            layout(set = 0, binding = 1) uniform texture2D tex;
 
             void main() {
-                f_color = texture(tex, tex_coords);
+                f_color = texture(sampler2D(tex, s), tex_coords);
             }
         ",
     }

--- a/examples/src/bin/runtime_array/main.rs
+++ b/examples/src/bin/runtime_array/main.rs
@@ -410,10 +410,10 @@ fn main() {
             let mut layout_create_info =
                 PipelineDescriptorSetLayoutCreateInfo::from_stages(&stages);
 
-            // Adjust the info for set 0, binding 0 to make it variable with 2 descriptors.
+            // Adjust the info for set 0, binding 1 to make it variable with 2 descriptors.
             let binding = layout_create_info.set_layouts[0]
                 .bindings
-                .get_mut(&0)
+                .get_mut(&1)
                 .unwrap();
             binding.binding_flags |= DescriptorBindingFlags::VARIABLE_DESCRIPTOR_COUNT;
             binding.descriptor_count = 2;
@@ -458,14 +458,10 @@ fn main() {
         &descriptor_set_allocator,
         layout.clone(),
         2,
-        [WriteDescriptorSet::image_view_sampler_array(
-            0,
-            0,
-            [
-                (mascot_texture as _, sampler.clone()),
-                (vulkano_texture as _, sampler),
-            ],
-        )],
+        [
+            WriteDescriptorSet::sampler(0, sampler),
+            WriteDescriptorSet::image_view_array(1, 0, [mascot_texture as _, vulkano_texture as _]),
+        ],
         [],
     )
     .unwrap();
@@ -667,10 +663,11 @@ mod fs {
 
             layout(location = 0) out vec4 f_color;
 
-            layout(set = 0, binding = 0) uniform sampler2D tex[];
+            layout(set = 0, binding = 0) uniform sampler s;
+            layout(set = 0, binding = 1) uniform texture2D tex[];
 
             void main() {
-                f_color = texture(nonuniformEXT(tex[tex_i]), coords);
+                f_color = texture(nonuniformEXT(sampler2D(tex[tex_i], s)), coords);
             }
         ",
     }

--- a/examples/src/bin/texture_array/main.rs
+++ b/examples/src/bin/texture_array/main.rs
@@ -348,7 +348,10 @@ fn main() {
     let set = PersistentDescriptorSet::new(
         &descriptor_set_allocator,
         layout.clone(),
-        [WriteDescriptorSet::image_view_sampler(0, texture, sampler)],
+        [
+            WriteDescriptorSet::sampler(0, sampler),
+            WriteDescriptorSet::image_view(1, texture),
+        ],
         [],
     )
     .unwrap();
@@ -543,10 +546,11 @@ mod fs {
             layout(location = 1) flat in uint layer;
             layout(location = 0) out vec4 f_color;
 
-            layout(set = 0, binding = 0) uniform sampler2DArray tex;
+            layout(set = 0, binding = 0) uniform sampler s;
+            layout(set = 0, binding = 1) uniform texture2DArray tex;
 
             void main() {
-                f_color = texture(tex, vec3(tex_coords, layer));
+                f_color = texture(sampler2DArray(tex, s), vec3(tex_coords, layer));
             }
         ",
     }


### PR DESCRIPTION
To reflect better practice. Also fixed a bug I encountered while doing this, and made error messages a bit nicer.