### PR TITLE
Add remaining `ext_descriptor_indexing` flags

### DIFF
--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -694,7 +694,7 @@ where
 
         let descriptor_sets_vk: SmallVec<[_; 12]> = descriptor_sets
             .iter()
-            .map(|x| x.as_ref().0.inner().handle())
+            .map(|x| x.as_ref().0.handle())
             .collect();
         let dynamic_offsets_vk: SmallVec<[_; 32]> = descriptor_sets
             .iter()

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -23,7 +23,7 @@ use super::{
     sys::UnsafeDescriptorSet,
 };
 use crate::{
-    descriptor_set::layout::{DescriptorSetLayoutCreateFlags, DescriptorType},
+    descriptor_set::layout::DescriptorType,
     device::{Device, DeviceOwned},
     instance::InstanceOwnedDebugWrapper,
     Validated, VulkanError,
@@ -60,7 +60,7 @@ pub unsafe trait DescriptorSetAllocator: DeviceOwned {
         &self,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
-    ) -> Result<Self::Alloc, VulkanError>;
+    ) -> Result<Self::Alloc, Validated<VulkanError>>;
 }
 
 /// An allocated descriptor set.
@@ -70,6 +70,9 @@ pub trait DescriptorSetAlloc: Send + Sync {
 
     /// Returns the inner unsafe descriptor set object.
     fn inner_mut(&mut self) -> &mut UnsafeDescriptorSet;
+
+    /// Returns the descriptor pool that the descriptor set was allocated from.
+    fn pool(&self) -> &DescriptorPool;
 }
 
 /// Standard implementation of a descriptor set allocator.
@@ -142,38 +145,15 @@ unsafe impl DescriptorSetAllocator for StandardDescriptorSetAllocator {
     type Alloc = StandardDescriptorSetAlloc;
 
     /// Allocates a descriptor set.
-    ///
-    /// # Panics
-    ///
-    /// - Panics if the provided `layout` is for push descriptors rather than regular descriptor
-    ///   sets.
-    /// - Panics if the provided `variable_descriptor_count` is greater than the maximum number of
-    ///   variable count descriptors in the set.
     #[inline]
     fn allocate(
         &self,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
-    ) -> Result<StandardDescriptorSetAlloc, VulkanError> {
-        assert!(
-            !layout
-                .flags()
-                .intersects(DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR),
-            "the provided descriptor set layout is for push descriptors, and cannot be used to \
-            build a descriptor set object",
-        );
-
+    ) -> Result<StandardDescriptorSetAlloc, Validated<VulkanError>> {
         let max_count = layout.variable_descriptor_count();
-
-        assert!(
-            variable_descriptor_count <= max_count,
-            "the provided variable_descriptor_count ({}) is greater than the maximum number of \
-            variable count descriptors in the set ({})",
-            variable_descriptor_count,
-            max_count,
-        );
-
         let pools = self.pools.get_or(Default::default);
+
         let entry = unsafe { &mut *pools.get() }.get_or_try_insert(layout.id(), || {
             if max_count == 0 {
                 FixedEntry::new(layout.clone()).map(Entry::Fixed)
@@ -197,7 +177,7 @@ unsafe impl<T: DescriptorSetAllocator> DescriptorSetAllocator for Arc<T> {
         &self,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
-    ) -> Result<Self::Alloc, VulkanError> {
+    ) -> Result<Self::Alloc, Validated<VulkanError>> {
         (**self).allocate(layout, variable_descriptor_count)
     }
 }
@@ -221,7 +201,7 @@ struct FixedEntry {
 }
 
 impl FixedEntry {
-    fn new(layout: Arc<DescriptorSetLayout>) -> Result<Self, VulkanError> {
+    fn new(layout: Arc<DescriptorSetLayout>) -> Result<Self, Validated<VulkanError>> {
         Ok(FixedEntry {
             pool: FixedPool::new(&layout, MAX_SETS)?,
             set_count: MAX_SETS,
@@ -229,7 +209,7 @@ impl FixedEntry {
         })
     }
 
-    fn allocate(&mut self) -> Result<StandardDescriptorSetAlloc, VulkanError> {
+    fn allocate(&mut self) -> Result<StandardDescriptorSetAlloc, Validated<VulkanError>> {
         let inner = if let Some(inner) = self.pool.reserve.pop() {
             inner
         } else {
@@ -250,14 +230,17 @@ impl FixedEntry {
 struct FixedPool {
     // The actual Vulkan descriptor pool. This field isn't actually used anywhere, but we need to
     // keep the pool alive in order to keep the descriptor sets valid.
-    _inner: DescriptorPool,
+    inner: DescriptorPool,
     // List of descriptor sets. When `alloc` is called, a descriptor will be extracted from this
     // list. When a `SingleLayoutPoolAlloc` is dropped, its descriptor set is put back in this list.
     reserve: ArrayQueue<UnsafeDescriptorSet>,
 }
 
 impl FixedPool {
-    fn new(layout: &Arc<DescriptorSetLayout>, set_count: usize) -> Result<Arc<Self>, VulkanError> {
+    fn new(
+        layout: &Arc<DescriptorSetLayout>,
+        set_count: usize,
+    ) -> Result<Arc<Self>, Validated<VulkanError>> {
         let inner = DescriptorPool::new(
             layout.device().clone(),
             DescriptorPoolCreateInfo {
@@ -275,28 +258,28 @@ impl FixedPool {
         )
         .map_err(Validated::unwrap)?;
 
-        let allocate_infos = (0..set_count).map(|_| DescriptorSetAllocateInfo {
-            layout,
-            variable_descriptor_count: 0,
-        });
+        let allocate_infos = (0..set_count).map(|_| DescriptorSetAllocateInfo::new(layout));
 
         let allocs = unsafe {
             inner
                 .allocate_descriptor_sets(allocate_infos)
                 .map_err(|err| match err {
-                    VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory => err,
-                    VulkanError::FragmentedPool => {
-                        // This can't happen as we don't free individual sets.
-                        unreachable!();
-                    }
-                    VulkanError::OutOfPoolMemory => {
-                        // We created the pool with an exact size.
-                        unreachable!();
-                    }
-                    _ => {
-                        // Shouldn't ever be returned.
-                        unreachable!();
-                    }
+                    Validated::ValidationError(_) => err,
+                    Validated::Error(vk_err) => match vk_err {
+                        VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory => err,
+                        VulkanError::FragmentedPool => {
+                            // This can't happen as we don't free individual sets.
+                            unreachable!();
+                        }
+                        VulkanError::OutOfPoolMemory => {
+                            // We created the pool with an exact size.
+                            unreachable!();
+                        }
+                        _ => {
+                            // Shouldn't ever be returned.
+                            unreachable!();
+                        }
+                    },
                 })?
         };
 
@@ -305,10 +288,7 @@ impl FixedPool {
             let _ = reserve.push(alloc);
         }
 
-        Ok(Arc::new(FixedPool {
-            _inner: inner,
-            reserve,
-        }))
+        Ok(Arc::new(FixedPool { inner, reserve }))
     }
 }
 
@@ -326,7 +306,7 @@ struct VariableEntry {
 }
 
 impl VariableEntry {
-    fn new(layout: Arc<DescriptorSetLayout>) -> Result<Self, VulkanError> {
+    fn new(layout: Arc<DescriptorSetLayout>) -> Result<Self, Validated<VulkanError>> {
         let reserve = Arc::new(ArrayQueue::new(MAX_POOLS));
 
         Ok(VariableEntry {
@@ -340,7 +320,7 @@ impl VariableEntry {
     fn allocate(
         &mut self,
         variable_descriptor_count: u32,
-    ) -> Result<StandardDescriptorSetAlloc, VulkanError> {
+    ) -> Result<StandardDescriptorSetAlloc, Validated<VulkanError>> {
         if self.allocations >= MAX_SETS {
             self.pool = if let Some(inner) = self.reserve.pop() {
                 Arc::new(VariablePool {
@@ -354,8 +334,8 @@ impl VariableEntry {
         }
 
         let allocate_info = DescriptorSetAllocateInfo {
-            layout: &self.layout,
             variable_descriptor_count,
+            ..DescriptorSetAllocateInfo::new(&self.layout)
         };
 
         let mut sets = unsafe {
@@ -363,19 +343,22 @@ impl VariableEntry {
                 .inner
                 .allocate_descriptor_sets([allocate_info])
                 .map_err(|err| match err {
-                    VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory => err,
-                    VulkanError::FragmentedPool => {
-                        // This can't happen as we don't free individual sets.
-                        unreachable!();
-                    }
-                    VulkanError::OutOfPoolMemory => {
-                        // We created the pool to fit the maximum variable descriptor count.
-                        unreachable!();
-                    }
-                    _ => {
-                        // Shouldn't ever be returned.
-                        unreachable!();
-                    }
+                    Validated::ValidationError(_) => err,
+                    Validated::Error(vk_err) => match vk_err {
+                        VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory => err,
+                        VulkanError::FragmentedPool => {
+                            // This can't happen as we don't free individual sets.
+                            unreachable!();
+                        }
+                        VulkanError::OutOfPoolMemory => {
+                            // We created the pool to fit the maximum variable descriptor count.
+                            unreachable!();
+                        }
+                        _ => {
+                            // Shouldn't ever be returned.
+                            unreachable!();
+                        }
+                    },
                 })?
         };
         self.allocations += 1;
@@ -457,6 +440,16 @@ enum AllocParent {
     Variable(Arc<VariablePool>),
 }
 
+impl AllocParent {
+    #[inline]
+    fn pool(&self) -> &DescriptorPool {
+        match self {
+            Self::Fixed(pool) => &pool.inner,
+            Self::Variable(pool) => &pool.inner,
+        }
+    }
+}
+
 // This is needed because of the blanket impl of `Send` on `Arc<T>`, which requires that `T` is
 // `Send + Sync`. `FixedPool` and `VariablePool` are `Send + !Sync` because `DescriptorPool` is
 // `!Sync`. That's fine however because we never access the `DescriptorPool` concurrently.
@@ -472,6 +465,11 @@ impl DescriptorSetAlloc for StandardDescriptorSetAlloc {
     #[inline]
     fn inner_mut(&mut self) -> &mut UnsafeDescriptorSet {
         &mut self.inner
+    }
+
+    #[inline]
+    fn pool(&self) -> &DescriptorPool {
+        self.parent.pool()
     }
 }
 
@@ -567,7 +565,7 @@ mod tests {
 
         let pool1 =
             if let AllocParent::Fixed(pool) = &allocator.allocate(&layout, 0).unwrap().parent {
-                pool._inner.handle()
+                pool.inner.handle()
             } else {
                 unreachable!()
             };
@@ -575,7 +573,7 @@ mod tests {
         thread::spawn(move || {
             let pool2 =
                 if let AllocParent::Fixed(pool) = &allocator.allocate(&layout, 0).unwrap().parent {
-                    pool._inner.handle()
+                    pool.inner.handle()
                 } else {
                     unreachable!()
                 };

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -87,16 +87,16 @@ pub use self::{
         WriteDescriptorSetElements,
     },
 };
-use self::{layout::DescriptorSetLayout, sys::UnsafeDescriptorSet};
+use self::{layout::DescriptorSetLayout, pool::DescriptorPoolAlloc};
 use crate::{
     acceleration_structure::AccelerationStructure,
     buffer::view::BufferView,
     descriptor_set::layout::{
         DescriptorBindingFlags, DescriptorSetLayoutCreateFlags, DescriptorType,
     },
-    device::{DeviceOwned, DeviceOwnedDebugWrapper},
+    device::DeviceOwned,
     image::{sampler::Sampler, ImageLayout},
-    ValidationError, VulkanObject,
+    VulkanObject,
 };
 use ahash::HashMap;
 use smallvec::{smallvec, SmallVec};
@@ -116,15 +116,23 @@ mod update;
 /// Trait for objects that contain a collection of resources that will be accessible by shaders.
 ///
 /// Objects of this type can be passed when submitting a draw command.
-pub unsafe trait DescriptorSet: DeviceOwned + Send + Sync {
-    /// Returns the inner `UnsafeDescriptorSet`.
-    fn inner(&self) -> &UnsafeDescriptorSet;
+pub unsafe trait DescriptorSet:
+    VulkanObject<Handle = ash::vk::DescriptorSet> + DeviceOwned + Send + Sync
+{
+    /// Returns the allocation of the descriptor set.
+    fn alloc(&self) -> &DescriptorPoolAlloc;
 
     /// Returns the layout of this descriptor set.
-    fn layout(&self) -> &Arc<DescriptorSetLayout>;
+    #[inline]
+    fn layout(&self) -> &Arc<DescriptorSetLayout> {
+        self.alloc().layout()
+    }
 
     /// Returns the variable descriptor count that this descriptor set was allocated with.
-    fn variable_descriptor_count(&self) -> u32;
+    #[inline]
+    fn variable_descriptor_count(&self) -> u32 {
+        self.alloc().variable_descriptor_count()
+    }
 
     /// Creates a [`DescriptorSetWithOffsets`] with the given dynamic offsets.
     fn offsets(
@@ -144,7 +152,7 @@ pub unsafe trait DescriptorSet: DeviceOwned + Send + Sync {
 impl PartialEq for dyn DescriptorSet {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.inner() == other.inner()
+        self.alloc() == other.alloc()
     }
 }
 
@@ -152,160 +160,7 @@ impl Eq for dyn DescriptorSet {}
 
 impl Hash for dyn DescriptorSet {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().hash(state);
-    }
-}
-
-pub(crate) struct DescriptorSetInner {
-    layout: DeviceOwnedDebugWrapper<Arc<DescriptorSetLayout>>,
-    variable_descriptor_count: u32,
-    resources: DescriptorSetResources,
-}
-
-impl DescriptorSetInner {
-    pub(crate) fn new(
-        handle: ash::vk::DescriptorSet,
-        layout: Arc<DescriptorSetLayout>,
-        variable_descriptor_count: u32,
-        descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
-        descriptor_copies: impl IntoIterator<Item = CopyDescriptorSet>,
-    ) -> Result<Self, Box<ValidationError>> {
-        assert!(
-            !layout
-                .flags()
-                .intersects(DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR),
-            "the provided descriptor set layout is for push descriptors, and cannot be used to \
-            build a descriptor set object",
-        );
-
-        let max_variable_descriptor_count = layout.variable_descriptor_count();
-
-        assert!(
-            variable_descriptor_count <= max_variable_descriptor_count,
-            "the provided variable_descriptor_count ({}) is greater than the maximum number of \
-            variable count descriptors in the layout ({})",
-            variable_descriptor_count,
-            max_variable_descriptor_count,
-        );
-
-        let mut resources = DescriptorSetResources::new(&layout, variable_descriptor_count);
-
-        struct PerDescriptorWrite {
-            write_info: DescriptorWriteInfo,
-            acceleration_structures: ash::vk::WriteDescriptorSetAccelerationStructureKHR,
-            inline_uniform_block: ash::vk::WriteDescriptorSetInlineUniformBlock,
-        }
-
-        let writes_iter = descriptor_writes.into_iter();
-        let (lower_size_bound, _) = writes_iter.size_hint();
-        let mut writes_vk: SmallVec<[_; 8]> = SmallVec::with_capacity(lower_size_bound);
-        let mut per_writes_vk: SmallVec<[_; 8]> = SmallVec::with_capacity(lower_size_bound);
-
-        for (index, write) in writes_iter.enumerate() {
-            write
-                .validate(&layout, variable_descriptor_count)
-                .map_err(|err| err.add_context(format!("descriptor_writes[{}]", index)))?;
-            resources.write(&write, &layout);
-
-            let layout_binding = &layout.bindings()[&write.binding()];
-            writes_vk.push(write.to_vulkan(handle, layout_binding.descriptor_type));
-            per_writes_vk.push(PerDescriptorWrite {
-                write_info: write.to_vulkan_info(layout_binding.descriptor_type),
-                acceleration_structures: Default::default(),
-                inline_uniform_block: Default::default(),
-            });
-        }
-
-        if !writes_vk.is_empty() {
-            for (write_vk, per_write_vk) in writes_vk.iter_mut().zip(per_writes_vk.iter_mut()) {
-                match &mut per_write_vk.write_info {
-                    DescriptorWriteInfo::Image(info) => {
-                        write_vk.descriptor_count = info.len() as u32;
-                        write_vk.p_image_info = info.as_ptr();
-                    }
-                    DescriptorWriteInfo::Buffer(info) => {
-                        write_vk.descriptor_count = info.len() as u32;
-                        write_vk.p_buffer_info = info.as_ptr();
-                    }
-                    DescriptorWriteInfo::BufferView(info) => {
-                        write_vk.descriptor_count = info.len() as u32;
-                        write_vk.p_texel_buffer_view = info.as_ptr();
-                    }
-                    DescriptorWriteInfo::InlineUniformBlock(data) => {
-                        write_vk.descriptor_count = data.len() as u32;
-                        write_vk.p_next = &per_write_vk.inline_uniform_block as *const _ as _;
-                        per_write_vk.inline_uniform_block.data_size = write_vk.descriptor_count;
-                        per_write_vk.inline_uniform_block.p_data = data.as_ptr() as *const _;
-                    }
-                    DescriptorWriteInfo::AccelerationStructure(info) => {
-                        write_vk.descriptor_count = info.len() as u32;
-                        write_vk.p_next = &per_write_vk.acceleration_structures as *const _ as _;
-                        per_write_vk
-                            .acceleration_structures
-                            .acceleration_structure_count = write_vk.descriptor_count;
-                        per_write_vk
-                            .acceleration_structures
-                            .p_acceleration_structures = info.as_ptr();
-                    }
-                }
-            }
-        }
-
-        let copies_iter = descriptor_copies.into_iter();
-        let (lower_size_bound, _) = copies_iter.size_hint();
-        let mut copies_vk: SmallVec<[_; 8]> = SmallVec::with_capacity(lower_size_bound);
-
-        for (index, copy) in copies_iter.enumerate() {
-            copy.validate(&layout, variable_descriptor_count)
-                .map_err(|err| err.add_context(format!("descriptor_copies[{}]", index)))?;
-            resources.copy(&copy);
-
-            let &CopyDescriptorSet {
-                ref src_set,
-                src_binding,
-                src_first_array_element,
-                dst_binding,
-                dst_first_array_element,
-                descriptor_count,
-                _ne: _,
-            } = &copy;
-
-            copies_vk.push(ash::vk::CopyDescriptorSet {
-                src_set: src_set.inner().handle(),
-                src_binding,
-                src_array_element: src_first_array_element,
-                dst_set: handle,
-                dst_binding,
-                dst_array_element: dst_first_array_element,
-                descriptor_count,
-                ..Default::default()
-            });
-        }
-
-        unsafe {
-            let fns = layout.device().fns();
-            (fns.v1_0.update_descriptor_sets)(
-                layout.device().handle(),
-                writes_vk.len() as u32,
-                writes_vk.as_ptr(),
-                copies_vk.len() as u32,
-                copies_vk.as_ptr(),
-            );
-        }
-
-        Ok(DescriptorSetInner {
-            layout: DeviceOwnedDebugWrapper(layout),
-            variable_descriptor_count,
-            resources,
-        })
-    }
-
-    pub(crate) fn layout(&self) -> &Arc<DescriptorSetLayout> {
-        &self.layout
-    }
-
-    pub(crate) fn resources(&self) -> &DescriptorSetResources {
-        &self.resources
+        self.alloc().hash(state);
     }
 }
 

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -87,7 +87,10 @@ pub use self::{
         WriteDescriptorSetElements,
     },
 };
-use self::{layout::DescriptorSetLayout, pool::DescriptorPoolAlloc};
+use self::{
+    layout::DescriptorSetLayout,
+    pool::{DescriptorPool, DescriptorPoolAlloc},
+};
 use crate::{
     acceleration_structure::AccelerationStructure,
     buffer::view::BufferView,
@@ -121,6 +124,9 @@ pub unsafe trait DescriptorSet:
 {
     /// Returns the allocation of the descriptor set.
     fn alloc(&self) -> &DescriptorPoolAlloc;
+
+    /// Returns the descriptor pool that the descriptor set was allocated from.
+    fn pool(&self) -> &DescriptorPool;
 
     /// Returns the layout of this descriptor set.
     #[inline]

--- a/vulkano/src/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor_set/persistent.rs
@@ -21,7 +21,11 @@
 //! # Examples
 //! TODO:
 
-use super::{pool::DescriptorPoolAlloc, sys::UnsafeDescriptorSet, CopyDescriptorSet};
+use super::{
+    pool::{DescriptorPool, DescriptorPoolAlloc},
+    sys::UnsafeDescriptorSet,
+    CopyDescriptorSet,
+};
 use crate::{
     descriptor_set::{
         allocator::{DescriptorSetAlloc, DescriptorSetAllocator, StandardDescriptorSetAlloc},
@@ -124,6 +128,10 @@ where
 {
     fn alloc(&self) -> &DescriptorPoolAlloc {
         self.inner.alloc().inner()
+    }
+
+    fn pool(&self) -> &DescriptorPool {
+        self.inner.alloc().pool()
     }
 
     fn resources(&self) -> &DescriptorSetResources {

--- a/vulkano/src/descriptor_set/persistent.rs
+++ b/vulkano/src/descriptor_set/persistent.rs
@@ -21,18 +21,17 @@
 //! # Examples
 //! TODO:
 
-use super::CopyDescriptorSet;
+use super::{pool::DescriptorPoolAlloc, sys::UnsafeDescriptorSet, CopyDescriptorSet};
 use crate::{
     descriptor_set::{
         allocator::{DescriptorSetAlloc, DescriptorSetAllocator, StandardDescriptorSetAlloc},
-        layout::DescriptorSetLayoutCreateFlags,
         update::WriteDescriptorSet,
-        DescriptorSet, DescriptorSetInner, DescriptorSetLayout, DescriptorSetResources,
-        UnsafeDescriptorSet,
+        DescriptorSet, DescriptorSetLayout, DescriptorSetResources,
     },
     device::{Device, DeviceOwned},
-    Validated, VulkanError, VulkanObject,
+    Validated, ValidationError, VulkanError, VulkanObject,
 };
+use smallvec::SmallVec;
 use std::{
     hash::{Hash, Hasher},
     sync::Arc,
@@ -40,8 +39,8 @@ use std::{
 
 /// A simple, immutable descriptor set that is expected to be long-lived.
 pub struct PersistentDescriptorSet<P = StandardDescriptorSetAlloc> {
-    alloc: P,
-    inner: DescriptorSetInner,
+    inner: UnsafeDescriptorSet<P>,
+    resources: DescriptorSetResources,
 }
 
 impl PersistentDescriptorSet {
@@ -78,34 +77,44 @@ impl PersistentDescriptorSet {
     where
         A: DescriptorSetAllocator + ?Sized,
     {
-        assert!(
-            !layout
-                .flags()
-                .intersects(DescriptorSetLayoutCreateFlags::PUSH_DESCRIPTOR),
-            "the provided descriptor set layout is for push descriptors, and cannot be used to \
-            build a descriptor set object",
-        );
+        let mut set = PersistentDescriptorSet {
+            inner: UnsafeDescriptorSet::new(allocator, &layout, variable_descriptor_count)?,
+            resources: DescriptorSetResources::new(&layout, variable_descriptor_count),
+        };
 
-        let max_count = layout.variable_descriptor_count();
+        unsafe {
+            set.update(descriptor_writes, descriptor_copies)?;
+        }
 
-        assert!(
-            variable_descriptor_count <= max_count,
-            "the provided variable_descriptor_count ({}) is greater than the maximum number of \
-            variable count descriptors in the set ({})",
-            variable_descriptor_count,
-            max_count,
-        );
+        Ok(Arc::new(set))
+    }
+}
 
-        let alloc = allocator.allocate(&layout, variable_descriptor_count)?;
-        let inner = DescriptorSetInner::new(
-            alloc.inner().handle(),
-            layout,
-            variable_descriptor_count,
-            descriptor_writes,
-            descriptor_copies,
-        )?;
+impl<P> PersistentDescriptorSet<P>
+where
+    P: DescriptorSetAlloc,
+{
+    unsafe fn update(
+        &mut self,
+        descriptor_writes: impl IntoIterator<Item = WriteDescriptorSet>,
+        descriptor_copies: impl IntoIterator<Item = CopyDescriptorSet>,
+    ) -> Result<(), Box<ValidationError>> {
+        let descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
+        let descriptor_copies: SmallVec<[_; 8]> = descriptor_copies.into_iter().collect();
 
-        Ok(Arc::new(PersistentDescriptorSet { alloc, inner }))
+        unsafe {
+            self.inner.update(&descriptor_writes, &descriptor_copies)?;
+        }
+
+        for write in descriptor_writes {
+            self.resources.write(&write, self.inner.layout());
+        }
+
+        for copy in descriptor_copies {
+            self.resources.copy(&copy);
+        }
+
+        Ok(())
     }
 }
 
@@ -113,20 +122,23 @@ unsafe impl<P> DescriptorSet for PersistentDescriptorSet<P>
 where
     P: DescriptorSetAlloc,
 {
-    fn inner(&self) -> &UnsafeDescriptorSet {
-        self.alloc.inner()
-    }
-
-    fn layout(&self) -> &Arc<DescriptorSetLayout> {
-        self.inner.layout()
-    }
-
-    fn variable_descriptor_count(&self) -> u32 {
-        self.inner.variable_descriptor_count
+    fn alloc(&self) -> &DescriptorPoolAlloc {
+        self.inner.alloc().inner()
     }
 
     fn resources(&self) -> &DescriptorSetResources {
-        self.inner.resources()
+        &self.resources
+    }
+}
+
+unsafe impl<P> VulkanObject for PersistentDescriptorSet<P>
+where
+    P: DescriptorSetAlloc,
+{
+    type Handle = ash::vk::DescriptorSet;
+
+    fn handle(&self) -> Self::Handle {
+        self.inner.handle()
     }
 }
 
@@ -135,7 +147,7 @@ where
     P: DescriptorSetAlloc,
 {
     fn device(&self) -> &Arc<Device> {
-        self.inner.layout().device()
+        self.layout().device()
     }
 }
 
@@ -144,7 +156,7 @@ where
     P: DescriptorSetAlloc,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.inner() == other.inner()
+        self.inner == other.inner
     }
 }
 
@@ -155,6 +167,6 @@ where
     P: DescriptorSetAlloc,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner().hash(state);
+        self.inner.hash(state);
     }
 }

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -11,6 +11,7 @@
 
 use super::{
     allocator::{DescriptorSetAlloc, DescriptorSetAllocator, StandardDescriptorSetAlloc},
+    pool::DescriptorPool,
     CopyDescriptorSet,
 };
 use crate::{
@@ -60,6 +61,12 @@ where
         &self.alloc
     }
 
+    /// Returns the descriptor pool that the descriptor set was allocated from.
+    #[inline]
+    pub fn pool(&self) -> &DescriptorPool {
+        self.alloc.pool()
+    }
+
     /// Returns the layout of this descriptor set.
     #[inline]
     pub fn layout(&self) -> &Arc<DescriptorSetLayout> {
@@ -104,7 +111,7 @@ where
         }
 
         for (index, copy) in descriptor_copies.iter().enumerate() {
-            copy.validate(self.layout(), self.variable_descriptor_count())
+            copy.validate(self)
                 .map_err(|err| err.add_context(format!("descriptor_copies[{}]", index)))?;
         }
 

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -473,9 +473,12 @@ impl PipelineLayoutCreateInfo {
 
         struct DescriptorLimit {
             descriptor_types: &'static [DescriptorType],
-            get_limit: fn(&Properties) -> u32,
-            limit_name: &'static str,
-            vuids: &'static [&'static str],
+            get_limit_all: fn(&Properties) -> Option<u32>,
+            limit_name_all: &'static str,
+            vuids_all: &'static [&'static str],
+            get_limit_not_uab: fn(&Properties) -> u32,
+            limit_name_not_uab: &'static str,
+            vuids_not_uab: &'static [&'static str],
         }
 
         const PER_STAGE_DESCRIPTOR_LIMITS: [DescriptorLimit; 8] = [
@@ -484,27 +487,36 @@ impl PipelineLayoutCreateInfo {
                     DescriptorType::Sampler,
                     DescriptorType::CombinedImageSampler,
                 ],
-                get_limit: |p| p.max_per_stage_descriptor_samplers,
-                limit_name: "max_per_stage_descriptor_samplers",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03016"],
+                get_limit_all: |p| p.max_per_stage_descriptor_update_after_bind_samplers,
+                limit_name_all: "max_per_stage_descriptor_update_after_bind_samplers",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03022"],
+                get_limit_not_uab: |p| p.max_per_stage_descriptor_samplers,
+                limit_name_not_uab: "max_per_stage_descriptor_samplers",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03016"],
             },
             DescriptorLimit {
                 descriptor_types: &[
                     DescriptorType::UniformBuffer,
                     DescriptorType::UniformBufferDynamic,
                 ],
-                get_limit: |p| p.max_per_stage_descriptor_uniform_buffers,
-                limit_name: "max_per_stage_descriptor_uniform_buffers",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03017"],
+                get_limit_all: |p| p.max_per_stage_descriptor_update_after_bind_uniform_buffers,
+                limit_name_all: "max_per_stage_descriptor_update_after_bind_uniform_buffers",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03023"],
+                get_limit_not_uab: |p| p.max_per_stage_descriptor_uniform_buffers,
+                limit_name_not_uab: "max_per_stage_descriptor_uniform_buffers",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03017"],
             },
             DescriptorLimit {
                 descriptor_types: &[
                     DescriptorType::StorageBuffer,
                     DescriptorType::StorageBufferDynamic,
                 ],
-                get_limit: |p| p.max_per_stage_descriptor_storage_buffers,
-                limit_name: "max_per_stage_descriptor_storage_buffers",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03018"],
+                get_limit_all: |p| p.max_per_stage_descriptor_update_after_bind_storage_buffers,
+                limit_name_all: "max_per_stage_descriptor_update_after_bind_storage_buffers",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03024"],
+                get_limit_not_uab: |p| p.max_per_stage_descriptor_storage_buffers,
+                limit_name_not_uab: "max_per_stage_descriptor_storage_buffers",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03018"],
             },
             DescriptorLimit {
                 descriptor_types: &[
@@ -512,42 +524,62 @@ impl PipelineLayoutCreateInfo {
                     DescriptorType::SampledImage,
                     DescriptorType::UniformTexelBuffer,
                 ],
-                get_limit: |p| p.max_per_stage_descriptor_sampled_images,
-                limit_name: "max_per_stage_descriptor_sampled_images",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-06939"],
+                get_limit_all: |p| p.max_per_stage_descriptor_update_after_bind_sampled_images,
+                limit_name_all: "max_per_stage_descriptor_update_after_bind_sampled_images",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03025"],
+                get_limit_not_uab: |p| p.max_per_stage_descriptor_sampled_images,
+                limit_name_not_uab: "max_per_stage_descriptor_sampled_images",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-06939"],
             },
             DescriptorLimit {
                 descriptor_types: &[
                     DescriptorType::StorageImage,
                     DescriptorType::StorageTexelBuffer,
                 ],
-                get_limit: |p| p.max_per_stage_descriptor_storage_images,
-                limit_name: "max_per_stage_descriptor_storage_images",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03020"],
+                get_limit_all: |p| p.max_per_stage_descriptor_update_after_bind_storage_images,
+                limit_name_all: "max_per_stage_descriptor_update_after_bind_storage_images",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03026"],
+                get_limit_not_uab: |p| p.max_per_stage_descriptor_storage_images,
+                limit_name_not_uab: "max_per_stage_descriptor_storage_images",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03020"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::InputAttachment],
-                get_limit: |p| p.max_per_stage_descriptor_input_attachments,
-                limit_name: "max_per_stage_descriptor_input_attachments",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03021"],
+                get_limit_all: |p| p.max_per_stage_descriptor_update_after_bind_input_attachments,
+                limit_name_all: "max_per_stage_descriptor_update_after_bind_input_attachments",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03027"],
+                get_limit_not_uab: |p| p.max_per_stage_descriptor_input_attachments,
+                limit_name_not_uab: "max_per_stage_descriptor_input_attachments",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03021"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::InlineUniformBlock],
-                get_limit: |p| {
+                get_limit_all: |p| {
+                    p.max_per_stage_descriptor_update_after_bind_inline_uniform_blocks
+                },
+                limit_name_all: "max_per_stage_descriptor_update_after_bind_inline_uniform_blocks",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-02215"],
+                get_limit_not_uab: |p| {
                     p.max_per_stage_descriptor_inline_uniform_blocks
                         .unwrap_or(0)
                 },
-                limit_name: "max_per_stage_descriptor_inline_uniform_blocks",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-02214"],
+                limit_name_not_uab: "max_per_stage_descriptor_inline_uniform_blocks",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-02214"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::AccelerationStructure],
-                get_limit: |p| {
+                get_limit_all: |p| {
+                    p.max_per_stage_descriptor_update_after_bind_acceleration_structures
+                },
+                limit_name_all:
+                    "max_per_stage_descriptor_update_after_bind_acceleration_structures",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03572"],
+                get_limit_not_uab: |p| {
                     p.max_per_stage_descriptor_acceleration_structures
                         .unwrap_or(0)
                 },
-                limit_name: "max_per_stage_descriptor_acceleration_structures",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03571"],
+                limit_name_not_uab: "max_per_stage_descriptor_acceleration_structures",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03571"],
             },
         ];
 
@@ -557,33 +589,48 @@ impl PipelineLayoutCreateInfo {
                     DescriptorType::Sampler,
                     DescriptorType::CombinedImageSampler,
                 ],
-                get_limit: |p| p.max_descriptor_set_samplers,
-                limit_name: "max_descriptor_set_samplers",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03028"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_samplers,
+                limit_name_all: "max_descriptor_set_update_after_bind_samplers",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03036"],
+                get_limit_not_uab: |p| p.max_descriptor_set_samplers,
+                limit_name_not_uab: "max_descriptor_set_samplers",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03028"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::UniformBuffer],
-                get_limit: |p| p.max_descriptor_set_uniform_buffers,
-                limit_name: "max_descriptor_set_uniform_buffers",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03029"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_uniform_buffers,
+                limit_name_all: "max_descriptor_set_update_after_bind_uniform_buffers",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03037"],
+                get_limit_not_uab: |p| p.max_descriptor_set_uniform_buffers,
+                limit_name_not_uab: "max_descriptor_set_uniform_buffers",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03029"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::UniformBufferDynamic],
-                get_limit: |p| p.max_descriptor_set_uniform_buffers_dynamic,
-                limit_name: "max_descriptor_set_uniform_buffers_dynamic",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03030"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_uniform_buffers_dynamic,
+                limit_name_all: "max_descriptor_set_update_after_bind_uniform_buffers_dynamic",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03038"],
+                get_limit_not_uab: |p| p.max_descriptor_set_uniform_buffers_dynamic,
+                limit_name_not_uab: "max_descriptor_set_uniform_buffers_dynamic",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03030"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::StorageBuffer],
-                get_limit: |p| p.max_descriptor_set_storage_buffers,
-                limit_name: "max_descriptor_set_storage_buffers",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03031"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_storage_buffers,
+                limit_name_all: "max_descriptor_set_update_after_bind_storage_buffers",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03039"],
+                get_limit_not_uab: |p| p.max_descriptor_set_storage_buffers,
+                limit_name_not_uab: "max_descriptor_set_storage_buffers",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03031"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::StorageBufferDynamic],
-                get_limit: |p| p.max_descriptor_set_storage_buffers_dynamic,
-                limit_name: "max_descriptor_set_storage_buffers_dynamic",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03032"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_storage_buffers_dynamic,
+                limit_name_all: "max_descriptor_set_update_after_bind_storage_buffers_dynamic",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03040"],
+                get_limit_not_uab: |p| p.max_descriptor_set_storage_buffers_dynamic,
+                limit_name_not_uab: "max_descriptor_set_storage_buffers_dynamic",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03032"],
             },
             DescriptorLimit {
                 descriptor_types: &[
@@ -591,42 +638,60 @@ impl PipelineLayoutCreateInfo {
                     DescriptorType::SampledImage,
                     DescriptorType::UniformTexelBuffer,
                 ],
-                get_limit: |p| p.max_descriptor_set_sampled_images,
-                limit_name: "max_descriptor_set_sampled_images",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03033"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_sampled_images,
+                limit_name_all: "max_descriptor_set_update_after_bind_sampled_images",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03041"],
+                get_limit_not_uab: |p| p.max_descriptor_set_sampled_images,
+                limit_name_not_uab: "max_descriptor_set_sampled_images",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03033"],
             },
             DescriptorLimit {
                 descriptor_types: &[
                     DescriptorType::StorageImage,
                     DescriptorType::StorageTexelBuffer,
                 ],
-                get_limit: |p| p.max_descriptor_set_storage_images,
-                limit_name: "max_descriptor_set_storage_images",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03034"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_storage_images,
+                limit_name_all: "max_descriptor_set_update_after_bind_storage_images",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03042"],
+                get_limit_not_uab: |p| p.max_descriptor_set_storage_images,
+                limit_name_not_uab: "max_descriptor_set_storage_images",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03034"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::InputAttachment],
-                get_limit: |p| p.max_descriptor_set_input_attachments,
-                limit_name: "max_descriptor_set_input_attachments",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03035"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_input_attachments,
+                limit_name_all: "max_descriptor_set_update_after_bind_input_attachments",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03043"],
+                get_limit_not_uab: |p| p.max_descriptor_set_input_attachments,
+                limit_name_not_uab: "max_descriptor_set_input_attachments",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03035"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::InlineUniformBlock],
-                get_limit: |p| p.max_descriptor_set_inline_uniform_blocks.unwrap_or(0),
-                limit_name: "max_descriptor_set_inline_uniform_blocks",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-02216"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_inline_uniform_blocks,
+                limit_name_all: "max_descriptor_set_update_after_bind_inline_uniform_blocks",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-02217"],
+                get_limit_not_uab: |p| p.max_descriptor_set_inline_uniform_blocks.unwrap_or(0),
+                limit_name_not_uab: "max_descriptor_set_inline_uniform_blocks",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-02216"],
             },
             DescriptorLimit {
                 descriptor_types: &[DescriptorType::AccelerationStructure],
-                get_limit: |p| p.max_descriptor_set_acceleration_structures.unwrap_or(0),
-                limit_name: "max_descriptor_set_acceleration_structures",
-                vuids: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03573"],
+                get_limit_all: |p| p.max_descriptor_set_update_after_bind_acceleration_structures,
+                limit_name_all: "max_descriptor_set_update_after_bind_acceleration_structures",
+                vuids_all: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03574"],
+                get_limit_not_uab: |p| p.max_descriptor_set_acceleration_structures.unwrap_or(0),
+                limit_name_not_uab: "max_descriptor_set_acceleration_structures",
+                vuids_not_uab: &["VUID-VkPipelineLayoutCreateInfo-descriptorType-03573"],
             },
         ];
 
-        let mut per_stage_descriptors: [HashMap<ShaderStage, u32>;
+        let mut per_stage_descriptors_all: [HashMap<ShaderStage, u32>;
             PER_STAGE_DESCRIPTOR_LIMITS.len()] = array::from_fn(|_| HashMap::default());
-        let mut total_descriptors = [0; TOTAL_DESCRIPTOR_LIMITS.len()];
+        let mut per_stage_descriptors_not_uab: [HashMap<ShaderStage, u32>;
+            PER_STAGE_DESCRIPTOR_LIMITS.len()] = array::from_fn(|_| HashMap::default());
+        let mut total_descriptors_all = [0; TOTAL_DESCRIPTOR_LIMITS.len()];
+        let mut total_descriptors_not_uab = [0; TOTAL_DESCRIPTOR_LIMITS.len()];
         let mut has_push_descriptor_set = false;
 
         for (_set_num, set_layout) in set_layouts.iter().enumerate() {
@@ -650,6 +715,10 @@ impl PipelineLayoutCreateInfo {
                 has_push_descriptor_set = true;
             }
 
+            let is_not_uab = !set_layout
+                .flags()
+                .intersects(DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL);
+
             for layout_binding in set_layout.bindings().values() {
                 let &DescriptorSetLayoutBinding {
                     binding_flags: _,
@@ -660,36 +729,56 @@ impl PipelineLayoutCreateInfo {
                     _ne: _,
                 } = layout_binding;
 
-                for (limit, count) in PER_STAGE_DESCRIPTOR_LIMITS
+                for ((limit, count_all), count_not_uab) in PER_STAGE_DESCRIPTOR_LIMITS
                     .iter()
-                    .zip(&mut per_stage_descriptors)
+                    .zip(&mut per_stage_descriptors_all)
+                    .zip(&mut per_stage_descriptors_not_uab)
                 {
                     if limit.descriptor_types.contains(&descriptor_type) {
                         for stage in stages {
-                            *count.entry(stage).or_default() += descriptor_count;
+                            *count_all.entry(stage).or_default() += descriptor_count;
+
+                            if is_not_uab {
+                                *count_not_uab.entry(stage).or_default() += descriptor_count;
+                            }
                         }
                     }
                 }
 
-                for (limit, count) in TOTAL_DESCRIPTOR_LIMITS.iter().zip(&mut total_descriptors) {
+                for ((limit, count_all), count_not_uab) in TOTAL_DESCRIPTOR_LIMITS
+                    .iter()
+                    .zip(&mut total_descriptors_all)
+                    .zip(&mut total_descriptors_not_uab)
+                {
                     if limit.descriptor_types.contains(&descriptor_type) {
-                        *count += descriptor_count;
+                        *count_all += descriptor_count;
+
+                        if is_not_uab {
+                            *count_not_uab += descriptor_count;
+                        }
                     }
                 }
             }
         }
 
-        for (limit, count) in PER_STAGE_DESCRIPTOR_LIMITS
+        for ((limit, count_all), count_not_uab) in PER_STAGE_DESCRIPTOR_LIMITS
             .iter()
-            .zip(per_stage_descriptors)
+            .zip(per_stage_descriptors_all)
+            .zip(per_stage_descriptors_not_uab)
         {
-            if let Some((max_stage, max_count)) = count.into_iter().max_by_key(|(_, c)| *c) {
-                if max_count > (limit.get_limit)(properties) {
+            let limit_not_uab = (limit.get_limit_not_uab)(properties);
+
+            if let Some((max_stage, max_count)) = count_not_uab.into_iter().max_by_key(|(_, c)| *c)
+            {
+                if max_count > limit_not_uab {
                     return Err(Box::new(ValidationError {
                         context: "set_layouts".into(),
                         problem: format!(
-                            "the combined number of {} descriptors accessible to the \
-                            `ShaderStage::{:?}` stage exceeds the `{}` limit",
+                            "the combined number of {} descriptors, \
+                            belonging to descriptor set layouts without the \
+                            `DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL` flag, \
+                            accessible to the `ShaderStage::{:?}` stage, \
+                            exceeds the `{}` limit",
                             limit.descriptor_types[1..].iter().fold(
                                 format!("`DescriptorType::{:?}`", limit.descriptor_types[0]),
                                 |mut s, dt| {
@@ -698,23 +787,62 @@ impl PipelineLayoutCreateInfo {
                                 }
                             ),
                             max_stage,
-                            limit.limit_name,
+                            limit.limit_name_not_uab,
                         )
                         .into(),
-                        vuids: limit.vuids,
+                        vuids: limit.vuids_not_uab,
+                        ..Default::default()
+                    }));
+                }
+            }
+
+            let limit_all = match (limit.get_limit_all)(properties) {
+                Some(x) => x,
+                None => continue,
+            };
+
+            if let Some((max_stage, max_count)) = count_all.into_iter().max_by_key(|(_, c)| *c) {
+                if max_count > limit_all {
+                    return Err(Box::new(ValidationError {
+                        context: "set_layouts".into(),
+                        problem: format!(
+                            "the combined number of {} descriptors, \
+                            accessible to the `ShaderStage::{:?}` stage, \
+                            exceeds the `{}` limit",
+                            limit.descriptor_types[1..].iter().fold(
+                                format!("`DescriptorType::{:?}`", limit.descriptor_types[0]),
+                                |mut s, dt| {
+                                    write!(s, " + `DescriptorType::{:?}`", dt).unwrap();
+                                    s
+                                }
+                            ),
+                            max_stage,
+                            limit.limit_name_all,
+                        )
+                        .into(),
+                        vuids: limit.vuids_all,
                         ..Default::default()
                     }));
                 }
             }
         }
 
-        for (limit, count) in TOTAL_DESCRIPTOR_LIMITS.iter().zip(total_descriptors) {
-            if count > (limit.get_limit)(properties) {
+        for ((limit, count_all), count_not_uab) in TOTAL_DESCRIPTOR_LIMITS
+            .iter()
+            .zip(total_descriptors_all)
+            .zip(total_descriptors_not_uab)
+        {
+            let limit_not_uab = (limit.get_limit_not_uab)(properties);
+
+            if count_not_uab > limit_not_uab {
                 return Err(Box::new(ValidationError {
                     context: "set_layouts".into(),
                     problem: format!(
-                        "the combined number of {} descriptors accessible across all \
-                        shader stages exceeds the `{}` limit",
+                        "the combined number of {} descriptors, \
+                        belonging to descriptor set layouts without the \
+                        `DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL` flag, \
+                        accessible across all shader stages, \
+                        exceeds the `{}` limit",
                         limit.descriptor_types[1..].iter().fold(
                             format!("`DescriptorType::{:?}`", limit.descriptor_types[0]),
                             |mut s, dt| {
@@ -722,10 +850,37 @@ impl PipelineLayoutCreateInfo {
                                 s
                             }
                         ),
-                        limit.limit_name,
+                        limit.limit_name_not_uab,
                     )
                     .into(),
-                    vuids: limit.vuids,
+                    vuids: limit.vuids_not_uab,
+                    ..Default::default()
+                }));
+            }
+
+            let limit_all = match (limit.get_limit_all)(properties) {
+                Some(x) => x,
+                None => continue,
+            };
+
+            if count_all > limit_all {
+                return Err(Box::new(ValidationError {
+                    context: "set_layouts".into(),
+                    problem: format!(
+                        "the combined number of {} descriptors, \
+                        accessible across all shader stages, \
+                        exceeds the `{}` limit",
+                        limit.descriptor_types[1..].iter().fold(
+                            format!("`DescriptorType::{:?}`", limit.descriptor_types[0]),
+                            |mut s, dt| {
+                                write!(s, " + `DescriptorType::{:?}`", dt).unwrap();
+                                s
+                            }
+                        ),
+                        limit.limit_name_all,
+                    )
+                    .into(),
+                    vuids: limit.vuids_all,
                     ..Default::default()
                 }));
             }


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Added the `UPDATE_AFTER_BIND`, `UPDATE_UNUSED_WHILE_PENDING` and `PARTIALLY_BOUND` flags to `DescriptorBindingFlags`, as well as `DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL` and `DescriptorPoolCreateFlags::UPDATE_AFTER_BIND`.
````

This completes coverage of the `ext_descriptor_indexing` extension for Vulkan 1.2, but with some caveats. The new `DescriptorBindingFlags` are pretty much useless at the moment, because Vulkano doesn't support updating descriptor sets after they're created, and because the draw-time checks don't handle dynamic use yet. However, at least the flags now exist and are properly validated, so that doesn't have to be done later. `DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL` is useful for getting the increased limits.