### PR TITLE
Lower command buffer/descriptor set allocator defaults

### DIFF
--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -539,12 +539,12 @@ pub struct StandardCommandBufferAllocatorCreateInfo {
     /// would mean that the pool would have to be reset more often, or that more pools would need
     /// to be created, depending on the lifetime of the command buffers.
     ///
-    /// The default value is `256`.
+    /// The default value is `32`.
     pub primary_buffer_count: usize,
 
     /// Same as `primary_buffer_count` except for secondary command buffers.
     ///
-    /// The default value is `256`.
+    /// The default value is `0`.
     pub secondary_buffer_count: usize,
 
     pub _ne: crate::NonExhaustive,
@@ -554,8 +554,8 @@ impl Default for StandardCommandBufferAllocatorCreateInfo {
     #[inline]
     fn default() -> Self {
         StandardCommandBufferAllocatorCreateInfo {
-            primary_buffer_count: 256,
-            secondary_buffer_count: 256,
+            primary_buffer_count: 32,
+            secondary_buffer_count: 0,
             _ne: crate::NonExhaustive(()),
         }
     }

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -321,8 +321,9 @@ mod tests {
     use crate::{
         buffer::{Buffer, BufferCreateInfo, BufferUsage},
         command_buffer::{
-            allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, BufferCopy,
-            CommandBufferUsage, CopyBufferInfoTyped, PrimaryCommandBufferAbstract,
+            allocator::{StandardCommandBufferAllocator, StandardCommandBufferAllocatorCreateInfo},
+            AutoCommandBufferBuilder, BufferCopy, CommandBufferUsage, CopyBufferInfoTyped,
+            PrimaryCommandBufferAbstract,
         },
         descriptor_set::{
             allocator::StandardDescriptorSetAllocator,
@@ -447,7 +448,13 @@ mod tests {
     fn secondary_nonconcurrent_conflict() {
         let (device, queue) = gfx_dev_and_queue!();
 
-        let cb_allocator = StandardCommandBufferAllocator::new(device, Default::default());
+        let cb_allocator = StandardCommandBufferAllocator::new(
+            device,
+            StandardCommandBufferAllocatorCreateInfo {
+                secondary_buffer_count: 1,
+                ..Default::default()
+            },
+        );
 
         // Make a secondary CB that doesn't support simultaneous use.
         let builder = AutoCommandBufferBuilder::secondary(
@@ -605,8 +612,13 @@ mod tests {
         unsafe {
             let (device, queue) = gfx_dev_and_queue!();
 
-            let cb_allocator =
-                StandardCommandBufferAllocator::new(device.clone(), Default::default());
+            let cb_allocator = StandardCommandBufferAllocator::new(
+                device.clone(),
+                StandardCommandBufferAllocatorCreateInfo {
+                    secondary_buffer_count: 1,
+                    ..Default::default()
+                },
+            );
             let cbb = AutoCommandBufferBuilder::primary(
                 &cb_allocator,
                 queue.queue_family_index(),

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -465,7 +465,7 @@ pub struct StandardDescriptorSetAllocatorCreateInfo {
     /// hand would mean that the pool would have to be reset more often, or that more pools would
     /// need to be created, depending on the lifetime of the descriptor sets.
     ///
-    /// The default value is `256`.
+    /// The default value is `32`.
     pub set_count: usize,
 
     /// Whether to allocate descriptor pools with the
@@ -481,7 +481,7 @@ impl Default for StandardDescriptorSetAllocatorCreateInfo {
     #[inline]
     fn default() -> Self {
         StandardDescriptorSetAllocatorCreateInfo {
-            set_count: 256,
+            set_count: 32,
             update_after_bind: false,
             _ne: crate::NonExhaustive(()),
         }


### PR DESCRIPTION
The values may have been a bit extreme.

Changelog:
```markdown
### Breaking changes
- `StandardCommandBufferAllocatorCreateInfo::secondary_buffer_count` now defaults to 0.
```