### PR TITLE
Partial validation of queue commands

### DIFF
--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -300,7 +300,7 @@ mod linux {
                     queue
                         .with(|mut q| unsafe {
                             q.submit_unchecked(
-                                [SubmitInfo {
+                                &[SubmitInfo {
                                     signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
                                         acquire_sem.clone(),
                                     )],
@@ -317,7 +317,7 @@ mod linux {
                     queue
                         .with(|mut q| unsafe {
                             q.submit_unchecked(
-                                [SubmitInfo {
+                                &[SubmitInfo {
                                     wait_semaphores: vec![SemaphoreSubmitInfo::semaphore(
                                         release_sem.clone(),
                                     )],

--- a/examples/src/bin/gl-interop.rs
+++ b/examples/src/bin/gl-interop.rs
@@ -299,9 +299,9 @@ mod linux {
                 Event::RedrawEventsCleared => {
                     queue
                         .with(|mut q| unsafe {
-                            q.submit_unchecked(
+                            q.submit(
                                 &[SubmitInfo {
-                                    signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
+                                    signal_semaphores: vec![SemaphoreSubmitInfo::new(
                                         acquire_sem.clone(),
                                     )],
                                     ..Default::default()
@@ -316,9 +316,9 @@ mod linux {
 
                     queue
                         .with(|mut q| unsafe {
-                            q.submit_unchecked(
+                            q.submit(
                                 &[SubmitInfo {
-                                    wait_semaphores: vec![SemaphoreSubmitInfo::semaphore(
+                                    wait_semaphores: vec![SemaphoreSubmitInfo::new(
                                         release_sem.clone(),
                                     )],
                                     ..Default::default()

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -131,6 +131,10 @@ unsafe impl<A> PrimaryCommandBufferAbstract for PrimaryAutoCommandBuffer<A>
 where
     A: CommandBufferAllocator,
 {
+    fn queue_family_index(&self) -> u32 {
+        self.inner.queue_family_index()
+    }
+
     fn usage(&self) -> CommandBufferUsage {
         self.inner.usage()
     }

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -9,36 +9,24 @@
 
 use super::{Device, DeviceOwned, QueueCreateFlags};
 use crate::{
-    buffer::BufferState,
-    command_buffer::{
-        CommandBufferResourcesUsage, CommandBufferState, CommandBufferUsage, SemaphoreSubmitInfo,
-        SubmitInfo,
-    },
-    image::ImageState,
+    command_buffer::{SemaphoreSubmitInfo, SubmitInfo},
     instance::{debug::DebugUtilsLabel, InstanceOwnedDebugWrapper},
     macros::vulkan_bitflags,
     memory::{
         BindSparseInfo, SparseBufferMemoryBind, SparseImageMemoryBind, SparseImageOpaqueMemoryBind,
     },
     swapchain::{PresentInfo, SwapchainPresentInfo},
-    sync::{
-        fence::{Fence, FenceState},
-        future::{AccessCheckError, GpuFuture},
-        semaphore::SemaphoreState,
-    },
-    Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,
-    VulkanObject,
+    sync::fence::Fence,
+    Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanError, VulkanObject,
 };
-use ahash::HashMap;
 use parking_lot::{Mutex, MutexGuard};
-use smallvec::{smallvec, SmallVec};
+use smallvec::SmallVec;
 use std::{
-    collections::VecDeque,
     ffi::CString,
     hash::{Hash, Hasher},
-    mem::{take, MaybeUninit},
+    mem::MaybeUninit,
     ptr,
-    sync::{atomic::Ordering, Arc},
+    sync::Arc,
 };
 
 /// Represents a queue where commands can be submitted.
@@ -126,7 +114,7 @@ impl Queue {
     pub fn with<'a, R>(self: &'a Arc<Self>, func: impl FnOnce(QueueGuard<'a>) -> R) -> R {
         func(QueueGuard {
             queue: self,
-            state: self.state.lock(),
+            _state: self.state.lock(),
         })
     }
 }
@@ -134,8 +122,10 @@ impl Queue {
 impl Drop for Queue {
     #[inline]
     fn drop(&mut self) {
-        let state = self.state.get_mut();
-        let _ = state.wait_idle(&self.device, self.handle);
+        unsafe {
+            let fns = self.device.fns();
+            let _ = (fns.v1_0.queue_wait_idle)(self.handle);
+        }
     }
 }
 
@@ -176,14 +166,10 @@ impl Hash for Queue {
 
 pub struct QueueGuard<'a> {
     queue: &'a Arc<Queue>,
-    state: MutexGuard<'a, QueueState>,
+    _state: MutexGuard<'a, QueueState>,
 }
 
 impl<'a> QueueGuard<'a> {
-    pub(crate) unsafe fn fence_signaled(&mut self, fence: &Fence) {
-        self.state.fence_signaled(fence)
-    }
-
     /// Waits until all work on this queue has finished, then releases ownership of all resources
     /// that were in use by the queue.
     ///
@@ -194,33 +180,19 @@ impl<'a> QueueGuard<'a> {
     /// program.
     #[inline]
     pub fn wait_idle(&mut self) -> Result<(), VulkanError> {
-        self.state.wait_idle(&self.queue.device, self.queue.handle)
+        unsafe {
+            let fns = self.queue.device.fns();
+            (fns.v1_0.queue_wait_idle)(self.queue.handle)
+                .result()
+                .map_err(VulkanError::from)
+        }
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub(crate) unsafe fn bind_sparse_unchecked(
+    pub unsafe fn bind_sparse_unchecked(
         &mut self,
-        bind_infos: impl IntoIterator<Item = BindSparseInfo>,
-        fence: Option<Arc<Fence>>,
-    ) -> Result<(), VulkanError> {
-        let bind_infos: SmallVec<[_; 4]> = bind_infos.into_iter().collect();
-        let mut states = States::from_bind_infos(&bind_infos);
-
-        self.bind_sparse_unchecked_locked(
-            &bind_infos,
-            fence.as_ref().map(|fence| {
-                let state = fence.state();
-                (fence, state)
-            }),
-            &mut states,
-        )
-    }
-
-    unsafe fn bind_sparse_unchecked_locked(
-        &mut self,
-        bind_infos: &SmallVec<[BindSparseInfo; 4]>,
-        fence: Option<(&Arc<Fence>, MutexGuard<'_, FenceState>)>,
-        states: &mut States<'_>,
+        bind_infos: &[BindSparseInfo],
+        fence: Option<&Arc<Fence>>,
     ) -> Result<(), VulkanError> {
         struct PerBindSparseInfo {
             wait_semaphores_vk: SmallVec<[ash::vk::Semaphore; 4]>,
@@ -475,58 +447,16 @@ impl<'a> QueueGuard<'a> {
             bind_infos_vk.as_ptr(),
             fence
                 .as_ref()
-                .map_or_else(Default::default, |(fence, _)| fence.handle()),
+                .map_or_else(Default::default, VulkanObject::handle),
         )
         .result()
-        .map_err(VulkanError::from)?;
-
-        for bind_info in bind_infos {
-            let BindSparseInfo {
-                wait_semaphores,
-                buffer_binds: _,
-                image_opaque_binds: _,
-                image_binds: _,
-                signal_semaphores,
-                _ne: _,
-            } = bind_info;
-
-            for semaphore in wait_semaphores {
-                let state = states.semaphores.get_mut(&semaphore.handle()).unwrap();
-                state.add_queue_wait(self.queue);
-            }
-
-            for semaphore in signal_semaphores {
-                let state = states.semaphores.get_mut(&semaphore.handle()).unwrap();
-                state.add_queue_wait(self.queue);
-            }
-        }
-
-        let fence = fence.map(|(fence, mut state)| {
-            state.add_queue_signal(self.queue);
-            fence.clone()
-        });
-
-        self.state
-            .operations
-            .push_back((bind_infos.clone().into(), fence));
-
-        Ok(())
+        .map_err(VulkanError::from)
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    #[inline]
     pub unsafe fn present_unchecked(
         &mut self,
-        present_info: PresentInfo,
-    ) -> Result<impl ExactSizeIterator<Item = Result<bool, VulkanError>>, VulkanError> {
-        let mut states = States::from_present_info(&present_info);
-        self.present_unchecked_locked(&present_info, &mut states)
-    }
-
-    unsafe fn present_unchecked_locked(
-        &mut self,
         present_info: &PresentInfo,
-        states: &mut States<'_>,
     ) -> Result<impl ExactSizeIterator<Item = Result<bool, VulkanError>>, VulkanError> {
         let PresentInfo {
             wait_semaphores,
@@ -660,26 +590,6 @@ impl<'a> QueueGuard<'a> {
             return Err(VulkanError::from(result));
         }
 
-        for semaphore in wait_semaphores {
-            let state = states.semaphores.get_mut(&semaphore.handle()).unwrap();
-            state.add_queue_wait(self.queue);
-        }
-
-        self.state
-            .operations
-            .push_back((present_info.clone().into(), None));
-
-        // If a presentation results in a loss of full-screen exclusive mode,
-        // signal that to the relevant swapchain.
-        for (&result, swapchain_info) in results.iter().zip(&present_info.swapchain_infos) {
-            if result == ash::vk::Result::ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT {
-                swapchain_info
-                    .swapchain
-                    .full_screen_exclusive_held()
-                    .store(false, Ordering::SeqCst);
-            }
-        }
-
         Ok(results.into_iter().map(|result| match result {
             ash::vk::Result::SUCCESS => Ok(false),
             ash::vk::Result::SUBOPTIMAL_KHR => Ok(true),
@@ -687,195 +597,11 @@ impl<'a> QueueGuard<'a> {
         }))
     }
 
-    // Temporary function to keep futures working.
-    pub(crate) unsafe fn submit_with_future(
-        &mut self,
-        submit_info: SubmitInfo,
-        fence: Option<Arc<Fence>>,
-        future: &dyn GpuFuture,
-        queue: &Queue,
-    ) -> Result<(), Validated<VulkanError>> {
-        let submit_infos: SmallVec<[_; 4]> = smallvec![submit_info];
-        let mut states = States::from_submit_infos(&submit_infos);
-
-        for submit_info in &submit_infos {
-            for command_buffer in &submit_info.command_buffers {
-                let state = states
-                    .command_buffers
-                    .get(&command_buffer.handle())
-                    .unwrap();
-
-                match command_buffer.usage() {
-                    CommandBufferUsage::OneTimeSubmit => {
-                        if state.has_been_submitted() {
-                            return Err(Box::new(ValidationError {
-                                problem: "a command buffer, or one of the secondary \
-                                    command buffers it executes, was created with the \
-                                    `CommandBufferUsage::OneTimeSubmit` usage, but \
-                                    it has already been submitted in the past"
-                                    .into(),
-                                vuids: &["VUID-vkQueueSubmit2-commandBuffer-03874"],
-                                ..Default::default()
-                            })
-                            .into());
-                        }
-                    }
-                    CommandBufferUsage::MultipleSubmit => {
-                        if state.is_submit_pending() {
-                            return Err(Box::new(ValidationError {
-                                problem: "a command buffer, or one of the secondary \
-                                    command buffers it executes, was not created with the \
-                                    `CommandBufferUsage::SimultaneousUse` usage, but \
-                                    it is already in use by the device"
-                                    .into(),
-                                vuids: &["VUID-vkQueueSubmit2-commandBuffer-03875"],
-                                ..Default::default()
-                            })
-                            .into());
-                        }
-                    }
-                    CommandBufferUsage::SimultaneousUse => (),
-                }
-
-                let CommandBufferResourcesUsage {
-                    buffers,
-                    images,
-                    buffer_indices: _,
-                    image_indices: _,
-                } = command_buffer.resources_usage();
-
-                for usage in buffers {
-                    let state = states.buffers.get_mut(&usage.buffer.handle()).unwrap();
-
-                    for (range, range_usage) in usage.ranges.iter() {
-                        match future.check_buffer_access(
-                            &usage.buffer,
-                            range.clone(),
-                            range_usage.mutable,
-                            queue,
-                        ) {
-                            Err(AccessCheckError::Denied(error)) => {
-                                return Err(Box::new(ValidationError {
-                                    problem: format!(
-                                        "access to a resource has been denied \
-                                        (resource use: {:?}, error: {})",
-                                        range_usage.first_use, error
-                                    )
-                                    .into(),
-                                    ..Default::default()
-                                })
-                                .into());
-                            }
-                            Err(AccessCheckError::Unknown) => {
-                                let result = if range_usage.mutable {
-                                    state.check_gpu_write(range.clone())
-                                } else {
-                                    state.check_gpu_read(range.clone())
-                                };
-
-                                if let Err(error) = result {
-                                    return Err(Box::new(ValidationError {
-                                        problem: format!(
-                                            "access to a resource has been denied \
-                                            (resource use: {:?}, error: {})",
-                                            range_usage.first_use, error
-                                        )
-                                        .into(),
-                                        ..Default::default()
-                                    })
-                                    .into());
-                                }
-                            }
-                            _ => (),
-                        }
-                    }
-                }
-
-                for usage in images {
-                    let state = states.images.get_mut(&usage.image.handle()).unwrap();
-
-                    for (range, range_usage) in usage.ranges.iter() {
-                        match future.check_image_access(
-                            &usage.image,
-                            range.clone(),
-                            range_usage.mutable,
-                            range_usage.expected_layout,
-                            queue,
-                        ) {
-                            Err(AccessCheckError::Denied(error)) => {
-                                return Err(Box::new(ValidationError {
-                                    problem: format!(
-                                        "access to a resource has been denied \
-                                        (resource use: {:?}, error: {})",
-                                        range_usage.first_use, error
-                                    )
-                                    .into(),
-                                    ..Default::default()
-                                })
-                                .into());
-                            }
-                            Err(AccessCheckError::Unknown) => {
-                                let result = if range_usage.mutable {
-                                    state
-                                        .check_gpu_write(range.clone(), range_usage.expected_layout)
-                                } else {
-                                    state.check_gpu_read(range.clone(), range_usage.expected_layout)
-                                };
-
-                                if let Err(error) = result {
-                                    return Err(Box::new(ValidationError {
-                                        problem: format!(
-                                            "access to a resource has been denied \
-                                            (resource use: {:?}, error: {})",
-                                            range_usage.first_use, error
-                                        )
-                                        .into(),
-                                        ..Default::default()
-                                    })
-                                    .into());
-                                }
-                            }
-                            _ => (),
-                        };
-                    }
-                }
-            }
-        }
-
-        Ok(self.submit_unchecked_locked(
-            &submit_infos,
-            fence.as_ref().map(|fence| {
-                let state = fence.state();
-                (fence, state)
-            }),
-            &mut states,
-        )?)
-    }
-
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn submit_unchecked(
         &mut self,
-        submit_infos: impl IntoIterator<Item = SubmitInfo>,
-        fence: Option<Arc<Fence>>,
-    ) -> Result<(), VulkanError> {
-        let submit_infos: SmallVec<[_; 4]> = submit_infos.into_iter().collect();
-        let mut states = States::from_submit_infos(&submit_infos);
-
-        self.submit_unchecked_locked(
-            &submit_infos,
-            fence.as_ref().map(|fence| {
-                let state = fence.state();
-                (fence, state)
-            }),
-            &mut states,
-        )
-    }
-
-    unsafe fn submit_unchecked_locked(
-        &mut self,
-        submit_infos: &SmallVec<[SubmitInfo; 4]>,
-        fence: Option<(&Arc<Fence>, MutexGuard<'_, FenceState>)>,
-        states: &mut States<'_>,
+        submit_infos: &[SubmitInfo],
+        fence: Option<&Arc<Fence>>,
     ) -> Result<(), VulkanError> {
         if self.queue.device.enabled_features().synchronization2 {
             struct PerSubmitInfo {
@@ -991,7 +717,7 @@ impl<'a> QueueGuard<'a> {
                     submit_info_vk.as_ptr(),
                     fence
                         .as_ref()
-                        .map_or_else(Default::default, |(fence, _)| fence.handle()),
+                        .map_or_else(Default::default, VulkanObject::handle),
                 )
             } else {
                 debug_assert!(self.queue.device.enabled_extensions().khr_synchronization2);
@@ -1001,11 +727,11 @@ impl<'a> QueueGuard<'a> {
                     submit_info_vk.as_ptr(),
                     fence
                         .as_ref()
-                        .map_or_else(Default::default, |(fence, _)| fence.handle()),
+                        .map_or_else(Default::default, VulkanObject::handle),
                 )
             }
             .result()
-            .map_err(VulkanError::from)?;
+            .map_err(VulkanError::from)
         } else {
             struct PerSubmitInfo {
                 wait_semaphores_vk: SmallVec<[ash::vk::Semaphore; 4]>,
@@ -1104,86 +830,11 @@ impl<'a> QueueGuard<'a> {
                 submit_info_vk.as_ptr(),
                 fence
                     .as_ref()
-                    .map_or_else(Default::default, |(fence, _)| fence.handle()),
+                    .map_or_else(Default::default, VulkanObject::handle),
             )
             .result()
-            .map_err(VulkanError::from)?;
+            .map_err(VulkanError::from)
         }
-
-        for submit_info in submit_infos {
-            let SubmitInfo {
-                wait_semaphores,
-                command_buffers,
-                signal_semaphores,
-                _ne: _,
-            } = submit_info;
-
-            for semaphore_submit_info in wait_semaphores {
-                let state = states
-                    .semaphores
-                    .get_mut(&semaphore_submit_info.semaphore.handle())
-                    .unwrap();
-                state.add_queue_wait(self.queue);
-            }
-
-            for command_buffer in command_buffers {
-                let state = states
-                    .command_buffers
-                    .get_mut(&command_buffer.handle())
-                    .unwrap();
-                state.add_queue_submit();
-
-                let CommandBufferResourcesUsage {
-                    buffers,
-                    images,
-                    buffer_indices: _,
-                    image_indices: _,
-                } = command_buffer.resources_usage();
-
-                for usage in buffers {
-                    let state = states.buffers.get_mut(&usage.buffer.handle()).unwrap();
-
-                    for (range, range_usage) in usage.ranges.iter() {
-                        if range_usage.mutable {
-                            state.gpu_write_lock(range.clone());
-                        } else {
-                            state.gpu_read_lock(range.clone());
-                        }
-                    }
-                }
-
-                for usage in images {
-                    let state = states.images.get_mut(&usage.image.handle()).unwrap();
-
-                    for (range, range_usage) in usage.ranges.iter() {
-                        if range_usage.mutable {
-                            state.gpu_write_lock(range.clone(), range_usage.final_layout);
-                        } else {
-                            state.gpu_read_lock(range.clone());
-                        }
-                    }
-                }
-            }
-
-            for semaphore_submit_info in signal_semaphores {
-                let state = states
-                    .semaphores
-                    .get_mut(&semaphore_submit_info.semaphore.handle())
-                    .unwrap();
-                state.add_queue_signal(self.queue);
-            }
-        }
-
-        let fence = fence.map(|(fence, mut state)| {
-            state.add_queue_signal(self.queue);
-            fence.clone()
-        });
-
-        self.state
-            .operations
-            .push_back((submit_infos.clone().into(), fence));
-
-        Ok(())
     }
 
     /// Opens a queue debug label region.
@@ -1353,305 +1004,7 @@ impl<'a> QueueGuard<'a> {
 }
 
 #[derive(Debug, Default)]
-struct QueueState {
-    operations: VecDeque<(QueueOperation, Option<Arc<Fence>>)>,
-}
-
-impl QueueState {
-    fn wait_idle(&mut self, device: &Device, handle: ash::vk::Queue) -> Result<(), VulkanError> {
-        unsafe {
-            let fns = device.fns();
-            (fns.v1_0.queue_wait_idle)(handle)
-                .result()
-                .map_err(VulkanError::from)?;
-
-            // Since we now know that the queue is finished with all work,
-            // we can safely release all resources.
-            for (operation, _) in take(&mut self.operations) {
-                operation.set_finished();
-            }
-
-            Ok(())
-        }
-    }
-
-    /// Called by `fence` when it finds that it is signaled.
-    fn fence_signaled(&mut self, fence: &Fence) {
-        // Find the most recent operation that uses `fence`.
-        let fence_index = self
-            .operations
-            .iter()
-            .enumerate()
-            .rev()
-            .find_map(|(index, (_, f))| {
-                f.as_ref().map_or(false, |f| **f == *fence).then_some(index)
-            });
-
-        if let Some(index) = fence_index {
-            // Remove all operations up to this index, and perform cleanup if needed.
-            for (operation, fence) in self.operations.drain(..index + 1) {
-                unsafe {
-                    operation.set_finished();
-
-                    if let Some(fence) = fence {
-                        fence.state().set_signal_finished();
-                    }
-                }
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-enum QueueOperation {
-    BindSparse(SmallVec<[BindSparseInfo; 4]>),
-    Present(PresentInfo),
-    Submit(SmallVec<[SubmitInfo; 4]>),
-}
-
-impl QueueOperation {
-    unsafe fn set_finished(self) {
-        match self {
-            QueueOperation::BindSparse(bind_infos) => {
-                for bind_info in bind_infos {
-                    for semaphore in bind_info.wait_semaphores {
-                        semaphore.state().set_wait_finished();
-                    }
-
-                    for semaphore in bind_info.signal_semaphores {
-                        semaphore.state().set_signal_finished();
-                    }
-                }
-
-                // TODO: Do we need to unlock buffers and images here?
-            }
-            QueueOperation::Present(present_info) => {
-                for semaphore in present_info.wait_semaphores {
-                    semaphore.state().set_wait_finished();
-                }
-            }
-            QueueOperation::Submit(submit_infos) => {
-                for submit_info in submit_infos {
-                    for semaphore_submit_info in submit_info.wait_semaphores {
-                        semaphore_submit_info.semaphore.state().set_wait_finished();
-                    }
-
-                    for semaphore_submit_info in submit_info.signal_semaphores {
-                        semaphore_submit_info
-                            .semaphore
-                            .state()
-                            .set_signal_finished();
-                    }
-
-                    for command_buffer in submit_info.command_buffers {
-                        let resource_usage = command_buffer.resources_usage();
-
-                        for usage in &resource_usage.buffers {
-                            let mut state = usage.buffer.state();
-
-                            for (range, range_usage) in usage.ranges.iter() {
-                                if range_usage.mutable {
-                                    state.gpu_write_unlock(range.clone());
-                                } else {
-                                    state.gpu_read_unlock(range.clone());
-                                }
-                            }
-                        }
-
-                        for usage in &resource_usage.images {
-                            let mut state = usage.image.state();
-
-                            for (range, range_usage) in usage.ranges.iter() {
-                                if range_usage.mutable {
-                                    state.gpu_write_unlock(range.clone());
-                                } else {
-                                    state.gpu_read_unlock(range.clone());
-                                }
-                            }
-                        }
-
-                        command_buffer.state().set_submit_finished();
-                    }
-                }
-            }
-        }
-    }
-}
-
-impl From<SmallVec<[BindSparseInfo; 4]>> for QueueOperation {
-    #[inline]
-    fn from(val: SmallVec<[BindSparseInfo; 4]>) -> Self {
-        Self::BindSparse(val)
-    }
-}
-
-impl From<PresentInfo> for QueueOperation {
-    #[inline]
-    fn from(val: PresentInfo) -> Self {
-        Self::Present(val)
-    }
-}
-
-impl From<SmallVec<[SubmitInfo; 4]>> for QueueOperation {
-    #[inline]
-    fn from(val: SmallVec<[SubmitInfo; 4]>) -> Self {
-        Self::Submit(val)
-    }
-}
-
-// This struct exists to ensure that every object gets locked exactly once.
-// Otherwise we get deadlocks.
-#[derive(Debug)]
-struct States<'a> {
-    buffers: HashMap<ash::vk::Buffer, MutexGuard<'a, BufferState>>,
-    command_buffers: HashMap<ash::vk::CommandBuffer, MutexGuard<'a, CommandBufferState>>,
-    images: HashMap<ash::vk::Image, MutexGuard<'a, ImageState>>,
-    semaphores: HashMap<ash::vk::Semaphore, MutexGuard<'a, SemaphoreState>>,
-}
-
-impl<'a> States<'a> {
-    fn from_bind_infos(bind_infos: &'a [BindSparseInfo]) -> Self {
-        let mut buffers = HashMap::default();
-        let mut images = HashMap::default();
-        let mut semaphores = HashMap::default();
-
-        for bind_info in bind_infos {
-            let BindSparseInfo {
-                wait_semaphores,
-                buffer_binds,
-                image_opaque_binds,
-                image_binds,
-                signal_semaphores,
-                _ne: _,
-            } = bind_info;
-
-            for semaphore in wait_semaphores {
-                semaphores
-                    .entry(semaphore.handle())
-                    .or_insert_with(|| semaphore.state());
-            }
-
-            for (buffer, _) in buffer_binds {
-                let buffer = buffer.buffer();
-                buffers
-                    .entry(buffer.handle())
-                    .or_insert_with(|| buffer.state());
-            }
-
-            for (image, _) in image_opaque_binds {
-                images
-                    .entry(image.handle())
-                    .or_insert_with(|| image.state());
-            }
-
-            for (image, _) in image_binds {
-                images
-                    .entry(image.handle())
-                    .or_insert_with(|| image.state());
-            }
-
-            for semaphore in signal_semaphores {
-                semaphores
-                    .entry(semaphore.handle())
-                    .or_insert_with(|| semaphore.state());
-            }
-        }
-
-        Self {
-            buffers,
-            command_buffers: HashMap::default(),
-            images,
-            semaphores,
-        }
-    }
-
-    fn from_present_info(present_info: &'a PresentInfo) -> Self {
-        let mut semaphores = HashMap::default();
-
-        let PresentInfo {
-            wait_semaphores,
-            swapchain_infos: _,
-            _ne: _,
-        } = present_info;
-
-        for semaphore in wait_semaphores {
-            semaphores
-                .entry(semaphore.handle())
-                .or_insert_with(|| semaphore.state());
-        }
-
-        Self {
-            buffers: HashMap::default(),
-            command_buffers: HashMap::default(),
-            images: HashMap::default(),
-            semaphores,
-        }
-    }
-
-    fn from_submit_infos(submit_infos: &'a [SubmitInfo]) -> Self {
-        let mut buffers = HashMap::default();
-        let mut command_buffers = HashMap::default();
-        let mut images = HashMap::default();
-        let mut semaphores = HashMap::default();
-
-        for submit_info in submit_infos {
-            let SubmitInfo {
-                wait_semaphores,
-                command_buffers: info_command_buffers,
-                signal_semaphores,
-                _ne: _,
-            } = submit_info;
-
-            for semaphore_submit_info in wait_semaphores {
-                let semaphore = &semaphore_submit_info.semaphore;
-                semaphores
-                    .entry(semaphore.handle())
-                    .or_insert_with(|| semaphore.state());
-            }
-
-            for command_buffer in info_command_buffers {
-                command_buffers
-                    .entry(command_buffer.handle())
-                    .or_insert_with(|| command_buffer.state());
-
-                let CommandBufferResourcesUsage {
-                    buffers: buffers_usage,
-                    images: images_usage,
-                    buffer_indices: _,
-                    image_indices: _,
-                } = command_buffer.resources_usage();
-
-                for usage in buffers_usage {
-                    let buffer = &usage.buffer;
-                    buffers
-                        .entry(buffer.handle())
-                        .or_insert_with(|| buffer.state());
-                }
-
-                for usage in images_usage {
-                    let image = &usage.image;
-                    images
-                        .entry(image.handle())
-                        .or_insert_with(|| image.state());
-                }
-            }
-
-            for semaphore_submit_info in signal_semaphores {
-                let semaphore = &semaphore_submit_info.semaphore;
-                semaphores
-                    .entry(semaphore.handle())
-                    .or_insert_with(|| semaphore.state());
-            }
-        }
-
-        Self {
-            buffers,
-            command_buffers,
-            images,
-            semaphores,
-        }
-    }
-}
+struct QueueState {}
 
 /// Properties of a queue family in a physical device.
 #[derive(Clone, Debug)]
@@ -1745,7 +1098,7 @@ mod tests {
         let (_device, queue) = gfx_dev_and_queue!();
 
         queue
-            .with(|mut q| unsafe { q.submit_unchecked([Default::default()], None) })
+            .with(|mut q| unsafe { q.submit_unchecked(&[Default::default()], None) })
             .unwrap();
     }
 
@@ -1758,7 +1111,7 @@ mod tests {
             assert!(!fence.is_signaled().unwrap());
 
             queue
-                .with(|mut q| q.submit_unchecked([Default::default()], Some(fence.clone())))
+                .with(|mut q| q.submit_unchecked(&[Default::default()], Some(&fence)))
                 .unwrap();
 
             fence.wait(Some(Duration::from_secs(5))).unwrap();

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -695,11 +695,6 @@ impl<'a> QueueGuard<'a> {
     ///
     /// # Safety
     ///
-    /// If `fence` is `Some`:
-    /// - The fence must be kept alive while the command is being executed.
-    /// - The fence must be unsignaled and must not be associated with any other command that is
-    ///   still executing.
-    ///
     /// For every semaphore in the `wait_semaphores` elements of every `submit_infos` element:
     /// - The semaphore must be kept alive while the command is being executed.
     /// - The semaphore must be already in the signaled state, or there must be a previously
@@ -726,6 +721,11 @@ impl<'a> QueueGuard<'a> {
     /// For every semaphore in the `signal_semaphores` elements of every `submit_infos` element:
     /// - The semaphore must be kept alive while the command is being executed.
     /// - When the signal operation is executed, the semaphore must be in the unsignaled state.
+    ///
+    /// If `fence` is `Some`:
+    /// - The fence must be kept alive while the command is being executed.
+    /// - The fence must be unsignaled and must not be associated with any other command that is
+    ///   still executing.
     #[inline]
     pub unsafe fn submit(
         &mut self,

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -14,7 +14,7 @@ use crate::{
     image::{Image, ImageLayout},
     sync::{
         fence::Fence,
-        future::{AccessCheckError, AccessError, GpuFuture, SubmitAnyBuilder},
+        future::{queue_present, AccessCheckError, AccessError, GpuFuture, SubmitAnyBuilder},
         semaphore::Semaphore,
     },
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, VulkanError,
@@ -682,9 +682,7 @@ where
                         }
                     }
 
-                    Ok(self
-                        .queue
-                        .with(|mut q| q.present_unchecked(present_info))?
+                    Ok(queue_present(&self.queue, present_info)?
                         .map(|r| r.map(|_| ()))
                         .fold(Ok(()), Result::and)?)
                 }

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -308,7 +308,7 @@ where
                         )
                         .map_err(OutcomeErr::Partial)
                     } else {
-                        for swapchain_info in &present_info.swapchain_infos {
+                        for swapchain_info in &present_info.swapchains {
                             if swapchain_info.present_id.map_or(false, |present_id| {
                                 !swapchain_info.swapchain.try_claim_present_id(present_id)
                             }) {

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -263,7 +263,7 @@ where
                                     SemaphoreSubmitInfo {
                                         // TODO: correct stages ; hard
                                         stages: PipelineStages::ALL_COMMANDS,
-                                        ..SemaphoreSubmitInfo::semaphore(semaphore)
+                                        ..SemaphoreSubmitInfo::new(semaphore)
                                     }
                                 })
                                 .collect(),

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -96,24 +96,30 @@ pub use self::{
     now::{now, NowFuture},
     semaphore_signal::SemaphoreSignalFuture,
 };
-use super::{fence::Fence, semaphore::Semaphore};
+use super::{
+    fence::Fence,
+    semaphore::{Semaphore, SemaphoreState},
+};
 use crate::{
-    buffer::Buffer,
+    buffer::{Buffer, BufferState},
     command_buffer::{
-        CommandBufferExecError, CommandBufferExecFuture, PrimaryCommandBufferAbstract, SubmitInfo,
+        CommandBufferExecError, CommandBufferExecFuture, CommandBufferResourcesUsage,
+        CommandBufferState, CommandBufferUsage, PrimaryCommandBufferAbstract, SubmitInfo,
     },
     device::{DeviceOwned, Queue},
-    image::{Image, ImageLayout},
+    image::{Image, ImageLayout, ImageState},
     memory::BindSparseInfo,
     swapchain::{self, PresentFuture, PresentInfo, Swapchain, SwapchainPresentInfo},
-    DeviceSize, Validated, VulkanError,
+    DeviceSize, Validated, ValidationError, VulkanError, VulkanObject,
 };
-use smallvec::SmallVec;
+use ahash::HashMap;
+use parking_lot::MutexGuard;
+use smallvec::{smallvec, SmallVec};
 use std::{
     error::Error,
     fmt::{Display, Error as FmtError, Formatter},
     ops::Range,
-    sync::Arc,
+    sync::{atomic::Ordering, Arc},
 };
 
 mod fence_signal;
@@ -552,5 +558,459 @@ impl Display for AccessCheckError {
 impl From<AccessError> for AccessCheckError {
     fn from(err: AccessError) -> AccessCheckError {
         AccessCheckError::Denied(err)
+    }
+}
+
+pub(crate) unsafe fn queue_bind_sparse(
+    queue: &Arc<Queue>,
+    bind_infos: impl IntoIterator<Item = BindSparseInfo>,
+    fence: Option<Arc<Fence>>,
+) -> Result<(), Validated<VulkanError>> {
+    let bind_infos: SmallVec<[_; 4]> = bind_infos.into_iter().collect();
+    let mut states = States::from_bind_infos(&bind_infos);
+    let fence_state = fence.as_ref().map(|fence| fence.state());
+
+    queue.with(|mut queue_guard| queue_guard.bind_sparse_unchecked(&bind_infos, fence.as_ref()))?;
+
+    for bind_info in &bind_infos {
+        let BindSparseInfo {
+            wait_semaphores,
+            buffer_binds: _,
+            image_opaque_binds: _,
+            image_binds: _,
+            signal_semaphores,
+            _ne: _,
+        } = bind_info;
+
+        for semaphore in wait_semaphores {
+            let state = states.semaphores.get_mut(&semaphore.handle()).unwrap();
+            state.add_queue_wait();
+        }
+
+        for semaphore in signal_semaphores {
+            let state = states.semaphores.get_mut(&semaphore.handle()).unwrap();
+            state.add_queue_wait();
+        }
+    }
+
+    if let Some(mut fence_state) = fence_state {
+        fence_state.add_queue_signal();
+    }
+
+    Ok(())
+}
+
+pub(crate) unsafe fn queue_present(
+    queue: &Arc<Queue>,
+    present_info: PresentInfo,
+) -> Result<impl ExactSizeIterator<Item = Result<bool, VulkanError>>, VulkanError> {
+    let mut states = States::from_present_info(&present_info);
+
+    let results: SmallVec<[_; 1]> = queue
+        .with(|mut queue_guard| queue_guard.present_unchecked(&present_info))?
+        .collect();
+
+    let PresentInfo {
+        wait_semaphores,
+        swapchain_infos,
+        _ne: _,
+    } = &present_info;
+
+    for semaphore in wait_semaphores {
+        let state = states.semaphores.get_mut(&semaphore.handle()).unwrap();
+        state.add_queue_wait();
+    }
+
+    // If a presentation results in a loss of full-screen exclusive mode,
+    // signal that to the relevant swapchain.
+    for (&result, swapchain_info) in results.iter().zip(swapchain_infos) {
+        if result == Err(VulkanError::FullScreenExclusiveModeLost) {
+            swapchain_info
+                .swapchain
+                .full_screen_exclusive_held()
+                .store(false, Ordering::SeqCst);
+        }
+    }
+
+    Ok(results.into_iter())
+}
+
+pub(crate) unsafe fn queue_submit(
+    queue: &Arc<Queue>,
+    submit_info: SubmitInfo,
+    fence: Option<Arc<Fence>>,
+    future: &dyn GpuFuture,
+) -> Result<(), Validated<VulkanError>> {
+    let submit_infos: SmallVec<[_; 4]> = smallvec![submit_info];
+    let mut states = States::from_submit_infos(&submit_infos);
+    let fence_state = fence.as_ref().map(|fence| fence.state());
+
+    for submit_info in &submit_infos {
+        for command_buffer in &submit_info.command_buffers {
+            let state = states
+                .command_buffers
+                .get(&command_buffer.handle())
+                .unwrap();
+
+            match command_buffer.usage() {
+                CommandBufferUsage::OneTimeSubmit => {
+                    if state.has_been_submitted() {
+                        return Err(Box::new(ValidationError {
+                            problem: "a command buffer, or one of the secondary \
+                                command buffers it executes, was created with the \
+                                `CommandBufferUsage::OneTimeSubmit` usage, but \
+                                it has already been submitted in the past"
+                                .into(),
+                            vuids: &["VUID-vkQueueSubmit2-commandBuffer-03874"],
+                            ..Default::default()
+                        })
+                        .into());
+                    }
+                }
+                CommandBufferUsage::MultipleSubmit => {
+                    if state.is_submit_pending() {
+                        return Err(Box::new(ValidationError {
+                            problem: "a command buffer, or one of the secondary \
+                                command buffers it executes, was not created with the \
+                                `CommandBufferUsage::SimultaneousUse` usage, but \
+                                it is already in use by the device"
+                                .into(),
+                            vuids: &["VUID-vkQueueSubmit2-commandBuffer-03875"],
+                            ..Default::default()
+                        })
+                        .into());
+                    }
+                }
+                CommandBufferUsage::SimultaneousUse => (),
+            }
+
+            let CommandBufferResourcesUsage {
+                buffers,
+                images,
+                buffer_indices: _,
+                image_indices: _,
+            } = command_buffer.resources_usage();
+
+            for usage in buffers {
+                let state = states.buffers.get_mut(&usage.buffer.handle()).unwrap();
+
+                for (range, range_usage) in usage.ranges.iter() {
+                    match future.check_buffer_access(
+                        &usage.buffer,
+                        range.clone(),
+                        range_usage.mutable,
+                        queue,
+                    ) {
+                        Err(AccessCheckError::Denied(error)) => {
+                            return Err(Box::new(ValidationError {
+                                problem: format!(
+                                    "access to a resource has been denied \
+                                    (resource use: {:?}, error: {})",
+                                    range_usage.first_use, error
+                                )
+                                .into(),
+                                ..Default::default()
+                            })
+                            .into());
+                        }
+                        Err(AccessCheckError::Unknown) => {
+                            let result = if range_usage.mutable {
+                                state.check_gpu_write(range.clone())
+                            } else {
+                                state.check_gpu_read(range.clone())
+                            };
+
+                            if let Err(error) = result {
+                                return Err(Box::new(ValidationError {
+                                    problem: format!(
+                                        "access to a resource has been denied \
+                                        (resource use: {:?}, error: {})",
+                                        range_usage.first_use, error
+                                    )
+                                    .into(),
+                                    ..Default::default()
+                                })
+                                .into());
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+            }
+
+            for usage in images {
+                let state = states.images.get_mut(&usage.image.handle()).unwrap();
+
+                for (range, range_usage) in usage.ranges.iter() {
+                    match future.check_image_access(
+                        &usage.image,
+                        range.clone(),
+                        range_usage.mutable,
+                        range_usage.expected_layout,
+                        queue,
+                    ) {
+                        Err(AccessCheckError::Denied(error)) => {
+                            return Err(Box::new(ValidationError {
+                                problem: format!(
+                                    "access to a resource has been denied \
+                                    (resource use: {:?}, error: {})",
+                                    range_usage.first_use, error
+                                )
+                                .into(),
+                                ..Default::default()
+                            })
+                            .into());
+                        }
+                        Err(AccessCheckError::Unknown) => {
+                            let result = if range_usage.mutable {
+                                state.check_gpu_write(range.clone(), range_usage.expected_layout)
+                            } else {
+                                state.check_gpu_read(range.clone(), range_usage.expected_layout)
+                            };
+
+                            if let Err(error) = result {
+                                return Err(Box::new(ValidationError {
+                                    problem: format!(
+                                        "access to a resource has been denied \
+                                        (resource use: {:?}, error: {})",
+                                        range_usage.first_use, error
+                                    )
+                                    .into(),
+                                    ..Default::default()
+                                })
+                                .into());
+                            }
+                        }
+                        _ => (),
+                    };
+                }
+            }
+        }
+    }
+
+    queue.with(|mut queue_guard| queue_guard.submit_unchecked(&submit_infos, fence.as_ref()))?;
+
+    for submit_info in &submit_infos {
+        let SubmitInfo {
+            wait_semaphores,
+            command_buffers,
+            signal_semaphores,
+            _ne: _,
+        } = submit_info;
+
+        for semaphore_submit_info in wait_semaphores {
+            let state = states
+                .semaphores
+                .get_mut(&semaphore_submit_info.semaphore.handle())
+                .unwrap();
+            state.add_queue_wait();
+        }
+
+        for command_buffer in command_buffers {
+            let state = states
+                .command_buffers
+                .get_mut(&command_buffer.handle())
+                .unwrap();
+            state.add_queue_submit();
+
+            let CommandBufferResourcesUsage {
+                buffers,
+                images,
+                buffer_indices: _,
+                image_indices: _,
+            } = command_buffer.resources_usage();
+
+            for usage in buffers {
+                let state = states.buffers.get_mut(&usage.buffer.handle()).unwrap();
+
+                for (range, range_usage) in usage.ranges.iter() {
+                    if range_usage.mutable {
+                        state.gpu_write_lock(range.clone());
+                    } else {
+                        state.gpu_read_lock(range.clone());
+                    }
+                }
+            }
+
+            for usage in images {
+                let state = states.images.get_mut(&usage.image.handle()).unwrap();
+
+                for (range, range_usage) in usage.ranges.iter() {
+                    if range_usage.mutable {
+                        state.gpu_write_lock(range.clone(), range_usage.final_layout);
+                    } else {
+                        state.gpu_read_lock(range.clone());
+                    }
+                }
+            }
+        }
+
+        for semaphore_submit_info in signal_semaphores {
+            let state = states
+                .semaphores
+                .get_mut(&semaphore_submit_info.semaphore.handle())
+                .unwrap();
+            state.add_queue_signal();
+        }
+    }
+
+    if let Some(mut fence_state) = fence_state {
+        fence_state.add_queue_signal();
+    }
+
+    Ok(())
+}
+
+// This struct exists to ensure that every object gets locked exactly once.
+// Otherwise we get deadlocks.
+#[derive(Debug)]
+struct States<'a> {
+    buffers: HashMap<ash::vk::Buffer, MutexGuard<'a, BufferState>>,
+    command_buffers: HashMap<ash::vk::CommandBuffer, MutexGuard<'a, CommandBufferState>>,
+    images: HashMap<ash::vk::Image, MutexGuard<'a, ImageState>>,
+    semaphores: HashMap<ash::vk::Semaphore, MutexGuard<'a, SemaphoreState>>,
+}
+
+impl<'a> States<'a> {
+    fn from_bind_infos(bind_infos: &'a [BindSparseInfo]) -> Self {
+        let mut buffers = HashMap::default();
+        let mut images = HashMap::default();
+        let mut semaphores = HashMap::default();
+
+        for bind_info in bind_infos {
+            let BindSparseInfo {
+                wait_semaphores,
+                buffer_binds,
+                image_opaque_binds,
+                image_binds,
+                signal_semaphores,
+                _ne: _,
+            } = bind_info;
+
+            for semaphore in wait_semaphores {
+                semaphores
+                    .entry(semaphore.handle())
+                    .or_insert_with(|| semaphore.state());
+            }
+
+            for (buffer, _) in buffer_binds {
+                let buffer = buffer.buffer();
+                buffers
+                    .entry(buffer.handle())
+                    .or_insert_with(|| buffer.state());
+            }
+
+            for (image, _) in image_opaque_binds {
+                images
+                    .entry(image.handle())
+                    .or_insert_with(|| image.state());
+            }
+
+            for (image, _) in image_binds {
+                images
+                    .entry(image.handle())
+                    .or_insert_with(|| image.state());
+            }
+
+            for semaphore in signal_semaphores {
+                semaphores
+                    .entry(semaphore.handle())
+                    .or_insert_with(|| semaphore.state());
+            }
+        }
+
+        Self {
+            buffers,
+            command_buffers: HashMap::default(),
+            images,
+            semaphores,
+        }
+    }
+
+    fn from_present_info(present_info: &'a PresentInfo) -> Self {
+        let mut semaphores = HashMap::default();
+
+        let PresentInfo {
+            wait_semaphores,
+            swapchain_infos: _,
+            _ne: _,
+        } = present_info;
+
+        for semaphore in wait_semaphores {
+            semaphores
+                .entry(semaphore.handle())
+                .or_insert_with(|| semaphore.state());
+        }
+
+        Self {
+            buffers: HashMap::default(),
+            command_buffers: HashMap::default(),
+            images: HashMap::default(),
+            semaphores,
+        }
+    }
+
+    fn from_submit_infos(submit_infos: &'a [SubmitInfo]) -> Self {
+        let mut buffers = HashMap::default();
+        let mut command_buffers = HashMap::default();
+        let mut images = HashMap::default();
+        let mut semaphores = HashMap::default();
+
+        for submit_info in submit_infos {
+            let SubmitInfo {
+                wait_semaphores,
+                command_buffers: info_command_buffers,
+                signal_semaphores,
+                _ne: _,
+            } = submit_info;
+
+            for semaphore_submit_info in wait_semaphores {
+                let semaphore = &semaphore_submit_info.semaphore;
+                semaphores
+                    .entry(semaphore.handle())
+                    .or_insert_with(|| semaphore.state());
+            }
+
+            for command_buffer in info_command_buffers {
+                command_buffers
+                    .entry(command_buffer.handle())
+                    .or_insert_with(|| command_buffer.state());
+
+                let CommandBufferResourcesUsage {
+                    buffers: buffers_usage,
+                    images: images_usage,
+                    buffer_indices: _,
+                    image_indices: _,
+                } = command_buffer.resources_usage();
+
+                for usage in buffers_usage {
+                    let buffer = &usage.buffer;
+                    buffers
+                        .entry(buffer.handle())
+                        .or_insert_with(|| buffer.state());
+                }
+
+                for usage in images_usage {
+                    let image = &usage.image;
+                    images
+                        .entry(image.handle())
+                        .or_insert_with(|| image.state());
+                }
+            }
+
+            for semaphore_submit_info in signal_semaphores {
+                let semaphore = &semaphore_submit_info.semaphore;
+                semaphores
+                    .entry(semaphore.handle())
+                    .or_insert_with(|| semaphore.state());
+            }
+        }
+
+        Self {
+            buffers,
+            command_buffers,
+            images,
+            semaphores,
+        }
     }
 }

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -613,18 +613,21 @@ pub(crate) unsafe fn queue_present(
 
     let PresentInfo {
         wait_semaphores,
-        swapchain_infos,
+        swapchains,
         _ne: _,
     } = &present_info;
 
-    for semaphore in wait_semaphores {
-        let state = states.semaphores.get_mut(&semaphore.handle()).unwrap();
+    for semaphore_info in wait_semaphores {
+        let state = states
+            .semaphores
+            .get_mut(&semaphore_info.semaphore.handle())
+            .unwrap();
         state.add_queue_wait();
     }
 
     // If a presentation results in a loss of full-screen exclusive mode,
     // signal that to the relevant swapchain.
-    for (&result, swapchain_info) in results.iter().zip(swapchain_infos) {
+    for (&result, swapchain_info) in results.iter().zip(swapchains) {
         if result == Err(VulkanError::FullScreenExclusiveModeLost) {
             swapchain_info
                 .swapchain
@@ -943,14 +946,14 @@ impl<'a> States<'a> {
 
         let PresentInfo {
             wait_semaphores,
-            swapchain_infos: _,
+            swapchains: _,
             _ne: _,
         } = present_info;
 
-        for semaphore in wait_semaphores {
+        for semaphore_info in wait_semaphores {
             semaphores
-                .entry(semaphore.handle())
-                .or_insert_with(|| semaphore.state());
+                .entry(semaphore_info.semaphore.handle())
+                .or_insert_with(|| semaphore_info.semaphore.state());
         }
 
         Self {

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -604,11 +604,11 @@ pub(crate) unsafe fn queue_bind_sparse(
 pub(crate) unsafe fn queue_present(
     queue: &Arc<Queue>,
     present_info: PresentInfo,
-) -> Result<impl ExactSizeIterator<Item = Result<bool, VulkanError>>, VulkanError> {
+) -> Result<impl ExactSizeIterator<Item = Result<bool, VulkanError>>, Validated<VulkanError>> {
     let mut states = States::from_present_info(&present_info);
 
     let results: SmallVec<[_; 1]> = queue
-        .with(|mut queue_guard| queue_guard.present_unchecked(&present_info))?
+        .with(|mut queue_guard| queue_guard.present(&present_info))?
         .collect();
 
     let PresentInfo {

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -96,7 +96,7 @@ where
                     queue_submit(
                         &queue,
                         SubmitInfo {
-                            signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
+                            signal_semaphores: vec![SemaphoreSubmitInfo::new(
                                 self.semaphore.clone(),
                             )],
                             ..Default::default()
@@ -115,11 +115,11 @@ where
                                     SemaphoreSubmitInfo {
                                         // TODO: correct stages ; hard
                                         stages: PipelineStages::ALL_COMMANDS,
-                                        ..SemaphoreSubmitInfo::semaphore(semaphore)
+                                        ..SemaphoreSubmitInfo::new(semaphore)
                                     }
                                 })
                                 .collect(),
-                            signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
+                            signal_semaphores: vec![SemaphoreSubmitInfo::new(
                                 self.semaphore.clone(),
                             )],
                             ..Default::default()
@@ -133,7 +133,7 @@ where
 
                     submit_info
                         .signal_semaphores
-                        .push(SemaphoreSubmitInfo::semaphore(self.semaphore.clone()));
+                        .push(SemaphoreSubmitInfo::new(self.semaphore.clone()));
 
                     queue_submit(&queue, submit_info, fence, &self.previous)?;
                 }
@@ -184,7 +184,7 @@ where
                     queue_submit(
                         &queue,
                         SubmitInfo {
-                            signal_semaphores: vec![SemaphoreSubmitInfo::semaphore(
+                            signal_semaphores: vec![SemaphoreSubmitInfo::new(
                                 self.semaphore.clone(),
                             )],
                             ..Default::default()

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -144,7 +144,7 @@ where
                                      builder.submit(&queue)?;*/
                 }
                 SubmitAnyBuilder::QueuePresent(present_info) => {
-                    for swapchain_info in &present_info.swapchain_infos {
+                    for swapchain_info in &present_info.swapchains {
                         if swapchain_info.present_id.map_or(false, |present_id| {
                             !swapchain_info.swapchain.try_claim_present_id(present_id)
                         }) {


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Partially validated versions of `submit` and `present` commands (called via `QueueGuard`).
````

Back when we hadn't yet decided to go for a task graph, I had started work on making queue and command buffer commands check all the sync. This PR undoes some of that work; the queue now no longer holds onto resources, it puts that responsibility back on the futures (and future task graph).

Queue now acts similar to `UnsafeCommandBuffer(Builder)`, and therefore I added partially validated commands to it, just as I did with the command builder. They're still unsafe to use, but much less unsafe than the completely unchecked versions, and the safety requirements are now properly documented too.