### PR TITLE
Prevent examples from being tested/benchmarked/documented

### DIFF
--- a/examples/async-update/Cargo.toml
+++ b/examples/async-update/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "async-update"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 cgmath = { workspace = true }

--- a/examples/basic-compute-shader/Cargo.toml
+++ b/examples/basic-compute-shader/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "basic-compute-shader"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/buffer-allocator/Cargo.toml
+++ b/examples/buffer-allocator/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "buffer-allocator"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/clear-attachments/Cargo.toml
+++ b/examples/clear-attachments/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "clear-attachments"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/debug/Cargo.toml
+++ b/examples/debug/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "debug"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/deferred/Cargo.toml
+++ b/examples/deferred/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "deferred"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 cgmath = { workspace = true }

--- a/examples/dynamic-buffers/Cargo.toml
+++ b/examples/dynamic-buffers/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "dynamic-buffers"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/dynamic-local-size/Cargo.toml
+++ b/examples/dynamic-local-size/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "dynamic-local-size"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/gl-interop/Cargo.toml
+++ b/examples/gl-interop/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "gl-interop"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 glium = "0.32.1"

--- a/examples/image-self-copy-blit/Cargo.toml
+++ b/examples/image-self-copy-blit/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "image-self-copy-blit"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/image/Cargo.toml
+++ b/examples/image/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "image"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/immutable-sampler/Cargo.toml
+++ b/examples/immutable-sampler/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "immutable-sampler"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/indirect/Cargo.toml
+++ b/examples/indirect/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "indirect"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/instancing/Cargo.toml
+++ b/examples/instancing/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "instancing"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/interactive-fractal/Cargo.toml
+++ b/examples/interactive-fractal/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "interactive-fractal"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 cgmath = { workspace = true }

--- a/examples/msaa-renderpass/Cargo.toml
+++ b/examples/msaa-renderpass/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "msaa-renderpass"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/multi-window-game-of-life/Cargo.toml
+++ b/examples/multi-window-game-of-life/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "multi-window-game-of-life"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 cgmath = { workspace = true }

--- a/examples/multi-window/Cargo.toml
+++ b/examples/multi-window/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "multi-window"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/multiview/Cargo.toml
+++ b/examples/multiview/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "multiview"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/occlusion-query/Cargo.toml
+++ b/examples/occlusion-query/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "occlusion-query"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/pipeline-caching/Cargo.toml
+++ b/examples/pipeline-caching/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "pipeline-caching"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/push-constants/Cargo.toml
+++ b/examples/push-constants/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "push-constants"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/push-descriptors/Cargo.toml
+++ b/examples/push-descriptors/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "push-descriptors"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/runtime-array/Cargo.toml
+++ b/examples/runtime-array/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "runtime-array"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/runtime-shader/Cargo.toml
+++ b/examples/runtime-shader/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "runtime-shader"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/self-copy-buffer/Cargo.toml
+++ b/examples/self-copy-buffer/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "self-copy-buffer"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/shader-include/Cargo.toml
+++ b/examples/shader-include/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "shader-include"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/shader-types-derive/Cargo.toml
+++ b/examples/shader-types-derive/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "shader-types-derive"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 ron = { workspace = true }

--- a/examples/shader-types-sharing/Cargo.toml
+++ b/examples/shader-types-sharing/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "shader-types-sharing"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/simple-particles/Cargo.toml
+++ b/examples/simple-particles/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "simple-particles"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/specialization-constants/Cargo.toml
+++ b/examples/specialization-constants/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "specialization-constants"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/teapot/Cargo.toml
+++ b/examples/teapot/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "teapot"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 cgmath = { workspace = true }

--- a/examples/tessellation/Cargo.toml
+++ b/examples/tessellation/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "tessellation"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/texture-array/Cargo.toml
+++ b/examples/texture-array/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "texture-array"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 png = { workspace = true }

--- a/examples/triangle-v1_3/Cargo.toml
+++ b/examples/triangle-v1_3/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "triangle-v1_3"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 vulkano = { workspace = true }

--- a/examples/triangle/Cargo.toml
+++ b/examples/triangle/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [[bin]]
 name = "triangle"
 path = "main.rs"
+test = false
+bench = false
+doc = false
 
 [dependencies]
 # The `vulkano` crate is the main crate that you must use to use Vulkan.


### PR DESCRIPTION
This makes it so that `cargo test` doesn't build the examples, seeing as there are no unit tests to be found there. This will improve compilation speed of CI in particular, but also just in general. I also made it so that `cargo doc` doesn't pollute the generated docs with 12 quintillion crates that don't have any docs to begin with, and prevented `cargo bench` from compiling the examples for the future as well.