### PR TITLE
Skip `evaluate_spec_constant_op` result type assertion when converting types.

### DIFF
--- a/vulkano/src/shader/spirv/specialization.rs
+++ b/vulkano/src/shader/spirv/specialization.rs
@@ -341,8 +341,14 @@ fn evaluate_spec_constant_op(
 
     let constant_to_instruction = |constant_id: Id| -> SmallVec<[Instruction; 1]> {
         let constant = &constants[&constant_id];
-        debug_assert_eq!(constant.type_id, result_type_id);
-
+        if !matches!(
+            opcode,
+            SpecConstantInstruction::UConvert { .. }
+                | SpecConstantInstruction::SConvert { .. }
+                | SpecConstantInstruction::FConvert { .. }
+        ) {
+            debug_assert_eq!(constant.type_id, result_type_id);
+        }
         match constant.value {
             ConstantValue::Scalar(value) => smallvec![scalar_constant_to_instruction(
                 result_type_id,


### PR DESCRIPTION
Skips checking that result type of UConvert | SConvert | FConvert for OpSpecConstantOp is the same as the input, as this is a conversion between types. 

Changelog:
```markdown

### Bugs fixed
- `evaluate_spec_constant_op` panics with UConvert, SConvert, and FConvert.
````