### PR TITLE
Use concrete types from Ash for foreign handles

### DIFF
--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -425,20 +425,20 @@ impl PhysicalDevice {
     ///
     /// - `dfb` must be a valid DirectFB `IDirectFB` handle.
     #[inline]
-    pub unsafe fn directfb_presentation_support<D>(
+    pub unsafe fn directfb_presentation_support(
         &self,
         queue_family_index: u32,
-        dfb: *const D,
+        dfb: *mut ash::vk::IDirectFB,
     ) -> Result<bool, Box<ValidationError>> {
         self.validate_directfb_presentation_support(queue_family_index, dfb)?;
 
         Ok(self.directfb_presentation_support_unchecked(queue_family_index, dfb))
     }
 
-    fn validate_directfb_presentation_support<D>(
+    fn validate_directfb_presentation_support(
         &self,
         queue_family_index: u32,
-        _dfb: *const D,
+        _dfb: *mut ash::vk::IDirectFB,
     ) -> Result<(), Box<ValidationError>> {
         if !self.instance.enabled_extensions().ext_directfb_surface {
             return Err(Box::new(ValidationError {
@@ -469,17 +469,17 @@ impl PhysicalDevice {
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     #[inline]
-    pub unsafe fn directfb_presentation_support_unchecked<D>(
+    pub unsafe fn directfb_presentation_support_unchecked(
         &self,
         queue_family_index: u32,
-        dfb: *const D,
+        dfb: *mut ash::vk::IDirectFB,
     ) -> bool {
         let fns = self.instance.fns();
         (fns.ext_directfb_surface
             .get_physical_device_direct_fb_presentation_support_ext)(
             self.handle,
             queue_family_index,
-            dfb as *mut _,
+            dfb,
         ) != 0
     }
 
@@ -1678,20 +1678,20 @@ impl PhysicalDevice {
     /// # Safety
     ///
     /// - `window` must be a valid QNX Screen `_screen_window` handle.
-    pub unsafe fn qnx_screen_presentation_support<W>(
+    pub unsafe fn qnx_screen_presentation_support(
         &self,
         queue_family_index: u32,
-        window: *const W,
+        window: *mut ash::vk::_screen_window,
     ) -> Result<bool, Box<ValidationError>> {
         self.validate_qnx_screen_presentation_support(queue_family_index, window)?;
 
         Ok(self.qnx_screen_presentation_support_unchecked(queue_family_index, window))
     }
 
-    fn validate_qnx_screen_presentation_support<W>(
+    fn validate_qnx_screen_presentation_support(
         &self,
         queue_family_index: u32,
-        _window: *const W,
+        _window: *mut ash::vk::_screen_window,
     ) -> Result<(), Box<ValidationError>> {
         if !self.instance.enabled_extensions().qnx_screen_surface {
             return Err(Box::new(ValidationError {
@@ -1721,17 +1721,17 @@ impl PhysicalDevice {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn qnx_screen_presentation_support_unchecked<W>(
+    pub unsafe fn qnx_screen_presentation_support_unchecked(
         &self,
         queue_family_index: u32,
-        window: *const W,
+        window: *mut ash::vk::_screen_window,
     ) -> bool {
         let fns = self.instance.fns();
         (fns.qnx_screen_surface
             .get_physical_device_screen_presentation_support_qnx)(
             self.handle,
             queue_family_index,
-            window as *mut _,
+            window,
         ) != 0
     }
 
@@ -3016,20 +3016,20 @@ impl PhysicalDevice {
     /// # Safety
     ///
     /// - `display` must be a valid Wayland `wl_display` handle.
-    pub unsafe fn wayland_presentation_support<D>(
+    pub unsafe fn wayland_presentation_support(
         &self,
         queue_family_index: u32,
-        display: *const D,
+        display: *mut ash::vk::wl_display,
     ) -> Result<bool, Box<ValidationError>> {
         self.validate_wayland_presentation_support(queue_family_index, display)?;
 
         Ok(self.wayland_presentation_support_unchecked(queue_family_index, display))
     }
 
-    fn validate_wayland_presentation_support<D>(
+    fn validate_wayland_presentation_support(
         &self,
         queue_family_index: u32,
-        _display: *const D,
+        _display: *mut ash::vk::wl_display,
     ) -> Result<(), Box<ValidationError>> {
         if !self.instance.enabled_extensions().khr_wayland_surface {
             return Err(Box::new(ValidationError {
@@ -3059,17 +3059,17 @@ impl PhysicalDevice {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn wayland_presentation_support_unchecked<D>(
+    pub unsafe fn wayland_presentation_support_unchecked(
         &self,
         queue_family_index: u32,
-        display: *const D,
+        display: *mut ash::vk::wl_display,
     ) -> bool {
         let fns = self.instance.fns();
         (fns.khr_wayland_surface
             .get_physical_device_wayland_presentation_support_khr)(
             self.handle,
             queue_family_index,
-            display as *mut _,
+            display,
         ) != 0
     }
 
@@ -3129,10 +3129,10 @@ impl PhysicalDevice {
     /// # Safety
     ///
     /// - `connection` must be a valid X11 `xcb_connection_t` handle.
-    pub unsafe fn xcb_presentation_support<C>(
+    pub unsafe fn xcb_presentation_support(
         &self,
         queue_family_index: u32,
-        connection: *const C,
+        connection: *mut ash::vk::xcb_connection_t,
         visual_id: ash::vk::xcb_visualid_t,
     ) -> Result<bool, Box<ValidationError>> {
         self.validate_xcb_presentation_support(queue_family_index, connection, visual_id)?;
@@ -3140,10 +3140,10 @@ impl PhysicalDevice {
         Ok(self.xcb_presentation_support_unchecked(queue_family_index, connection, visual_id))
     }
 
-    fn validate_xcb_presentation_support<C>(
+    fn validate_xcb_presentation_support(
         &self,
         queue_family_index: u32,
-        _connection: *const C,
+        _connection: *mut ash::vk::xcb_connection_t,
         _visual_id: ash::vk::xcb_visualid_t,
     ) -> Result<(), Box<ValidationError>> {
         if !self.instance.enabled_extensions().khr_xcb_surface {
@@ -3174,10 +3174,10 @@ impl PhysicalDevice {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn xcb_presentation_support_unchecked<C>(
+    pub unsafe fn xcb_presentation_support_unchecked(
         &self,
         queue_family_index: u32,
-        connection: *const C,
+        connection: *mut ash::vk::xcb_connection_t,
         visual_id: ash::vk::VisualID,
     ) -> bool {
         let fns = self.instance.fns();
@@ -3185,7 +3185,7 @@ impl PhysicalDevice {
             .get_physical_device_xcb_presentation_support_khr)(
             self.handle,
             queue_family_index,
-            connection as *mut _,
+            connection,
             visual_id,
         ) != 0
     }
@@ -3196,10 +3196,10 @@ impl PhysicalDevice {
     /// # Safety
     ///
     /// - `display` must be a valid Xlib `Display` handle.
-    pub unsafe fn xlib_presentation_support<D>(
+    pub unsafe fn xlib_presentation_support(
         &self,
         queue_family_index: u32,
-        display: *const D,
+        display: *mut ash::vk::Display,
         visual_id: ash::vk::VisualID,
     ) -> Result<bool, Box<ValidationError>> {
         self.validate_xlib_presentation_support(queue_family_index, display, visual_id)?;
@@ -3207,10 +3207,10 @@ impl PhysicalDevice {
         Ok(self.xlib_presentation_support_unchecked(queue_family_index, display, visual_id))
     }
 
-    fn validate_xlib_presentation_support<D>(
+    fn validate_xlib_presentation_support(
         &self,
         queue_family_index: u32,
-        _display: *const D,
+        _display: *mut ash::vk::Display,
         _visual_id: ash::vk::VisualID,
     ) -> Result<(), Box<ValidationError>> {
         if !self.instance.enabled_extensions().khr_xlib_surface {
@@ -3241,10 +3241,10 @@ impl PhysicalDevice {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn xlib_presentation_support_unchecked<D>(
+    pub unsafe fn xlib_presentation_support_unchecked(
         &self,
         queue_family_index: u32,
-        display: *const D,
+        display: *mut ash::vk::Display,
         visual_id: ash::vk::VisualID,
     ) -> bool {
         let fns = self.instance.fns();
@@ -3252,7 +3252,7 @@ impl PhysicalDevice {
             .get_physical_device_xlib_presentation_support_khr)(
             self.handle,
             queue_family_index,
-            display as *mut _,
+            display,
             visual_id,
         ) != 0
     }

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -80,10 +80,11 @@
 //! # fn build_window() -> Arc<Window> { Arc::new(Window(ptr::null())) }
 //! let window = build_window(); // Third-party function, not provided by vulkano
 //! let _surface = unsafe {
-//!     let hinstance: *const () = ptr::null(); // Windows-specific object
+//!     let hinstance: *mut std::ffi::c_void = ptr::null_mut(); // Windows-specific object
 //!     Surface::from_win32(
 //!         instance.clone(),
-//!         hinstance, window.hwnd(),
+//!         hinstance,
+//!         window.hwnd() as ash::vk::HWND,
 //!         Some(window),
 //!     ).unwrap()
 //! };
@@ -2459,8 +2460,8 @@ impl Win32Monitor {
     /// # Safety
     ///
     /// - `hmonitor` must be a valid handle as returned by the Win32 API.
-    pub unsafe fn new<T>(hmonitor: *const T) -> Self {
-        Self(hmonitor as _)
+    pub unsafe fn new<T>(hmonitor: ash::vk::HMONITOR) -> Self {
+        Self(hmonitor)
     }
 }
 

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -19,6 +19,7 @@ use smallvec::SmallVec;
 use std::{
     any::Any,
     error::Error,
+    ffi::c_void,
     fmt::{Debug, Display, Error as FmtError, Formatter},
     mem::MaybeUninit,
     num::NonZeroU64,
@@ -104,48 +105,52 @@ impl Surface {
 
         match (window_handle.as_raw(), display_handle.as_raw()) {
             (RawWindowHandle::AndroidNdk(window), RawDisplayHandle::Android(_display)) => {
-                Self::from_android(instance, window.a_native_window.as_ptr(), None)
+                Self::from_android(
+                    instance,
+                    window.a_native_window.as_ptr() as *mut ash::vk::ANativeWindow,
+                    None,
+                )
             }
             #[cfg(target_os = "macos")]
             (RawWindowHandle::AppKit(window), RawDisplayHandle::AppKit(_display)) => {
                 // Ensure the layer is `CAMetalLayer`.
-                let layer = get_metal_layer_macos(window.ns_view.as_ptr());
+                let layer = get_metal_layer_macos(window.ns_view.as_ptr() as *mut c_void);
 
                 Self::from_mac_os(instance, layer as *const (), None)
             }
             #[cfg(target_os = "ios")]
             (RawWindowHandle::UiKit(window), RawDisplayHandle::UiKit(_display)) => {
                 // Ensure the layer is `CAMetalLayer`.
-                let layer = get_metal_layer_ios(window.ui_view.as_ptr());
+                let layer = get_metal_layer_ios(window.ui_view.as_ptr() as *mut c_void);
 
                 Self::from_ios(instance, layer, None)
             }
             (RawWindowHandle::Wayland(window), RawDisplayHandle::Wayland(display)) => {
                 Self::from_wayland(
                     instance,
-                    display.display.as_ptr(),
-                    window.surface.as_ptr(),
+                    display.display.as_ptr() as *mut ash::vk::wl_display,
+                    window.surface.as_ptr() as *mut ash::vk::wl_surface,
                     None,
                 )
             }
             (RawWindowHandle::Win32(window), RawDisplayHandle::Windows(_display)) => {
                 Self::from_win32(
                     instance,
-                    window.hinstance.unwrap().get() as *const (),
-                    window.hwnd.get() as *const (),
+                    window.hinstance.unwrap().get() as ash::vk::HINSTANCE,
+                    window.hwnd.get() as ash::vk::HWND,
                     None,
                 )
             }
             (RawWindowHandle::Xcb(window), RawDisplayHandle::Xcb(display)) => Self::from_xcb(
                 instance,
-                display.connection.unwrap().as_ptr(),
-                window.window.get(),
+                display.connection.unwrap().as_ptr() as *mut ash::vk::xcb_connection_t,
+                window.window.get() as ash::vk::xcb_window_t,
                 None,
             ),
             (RawWindowHandle::Xlib(window), RawDisplayHandle::Xlib(display)) => Self::from_xlib(
                 instance,
-                display.display.unwrap().as_ptr(),
-                window.window,
+                display.display.unwrap().as_ptr() as *mut ash::vk::Display,
+                window.window as ash::vk::Window,
                 None,
             ),
             _ => unimplemented!(
@@ -431,9 +436,9 @@ impl Surface {
     /// - `window` must be a valid Android `ANativeWindow` handle.
     /// - The object referred to by `window` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_android<W>(
+    pub unsafe fn from_android(
         instance: Arc<Instance>,
-        window: *const W,
+        window: *mut ash::vk::ANativeWindow,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_android(&instance, window)?;
@@ -441,9 +446,9 @@ impl Surface {
         Ok(Self::from_android_unchecked(instance, window, object)?)
     }
 
-    fn validate_from_android<W>(
+    fn validate_from_android(
         instance: &Instance,
-        _window: *const W,
+        _window: *mut ash::vk::ANativeWindow,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().khr_android_surface {
             return Err(Box::new(ValidationError {
@@ -461,14 +466,14 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_android_unchecked<W>(
+    pub unsafe fn from_android_unchecked(
         instance: Arc<Instance>,
-        window: *const W,
+        window: *mut ash::vk::ANativeWindow,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::AndroidSurfaceCreateInfoKHR {
             flags: ash::vk::AndroidSurfaceCreateFlagsKHR::empty(),
-            window: window as *mut _,
+            window,
             ..Default::default()
         };
 
@@ -502,10 +507,10 @@ impl Surface {
     /// - `surface` must be a valid DirectFB `IDirectFBSurface` handle.
     /// - The object referred to by `dfb` and `surface` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_directfb<D, S>(
+    pub unsafe fn from_directfb(
         instance: Arc<Instance>,
-        dfb: *const D,
-        surface: *const S,
+        dfb: *mut ash::vk::IDirectFB,
+        surface: *mut ash::vk::IDirectFBSurface,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_directfb(&instance, dfb, surface)?;
@@ -515,10 +520,10 @@ impl Surface {
         )?)
     }
 
-    fn validate_from_directfb<D, S>(
+    fn validate_from_directfb(
         instance: &Instance,
-        _dfb: *const D,
-        _surface: *const S,
+        _dfb: *mut ash::vk::IDirectFB,
+        _surface: *mut ash::vk::IDirectFBSurface,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().ext_directfb_surface {
             return Err(Box::new(ValidationError {
@@ -539,16 +544,16 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_directfb_unchecked<D, S>(
+    pub unsafe fn from_directfb_unchecked(
         instance: Arc<Instance>,
-        dfb: *const D,
-        surface: *const S,
+        dfb: *mut ash::vk::IDirectFB,
+        surface: *mut ash::vk::IDirectFBSurface,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::DirectFBSurfaceCreateInfoEXT {
             flags: ash::vk::DirectFBSurfaceCreateFlagsEXT::empty(),
-            dfb: dfb as *mut _,
-            surface: surface as *mut _,
+            dfb,
+            surface,
             ..Default::default()
         };
 
@@ -809,10 +814,9 @@ impl Surface {
     /// - The object referred to by `view` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
     /// - The `NSView` must be backed by a `CALayer` instance of type `CAMetalLayer`.
-    #[cfg(target_os = "macos")]
-    pub unsafe fn from_mac_os<V>(
+    pub unsafe fn from_mac_os(
         instance: Arc<Instance>,
-        view: *const V,
+        view: *const c_void,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_mac_os(&instance, view)?;
@@ -820,10 +824,9 @@ impl Surface {
         Ok(Self::from_mac_os_unchecked(instance, view, object)?)
     }
 
-    #[cfg(target_os = "macos")]
-    fn validate_from_mac_os<V>(
+    fn validate_from_mac_os(
         instance: &Instance,
-        _view: *const V,
+        _view: *const c_void,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().mvk_macos_surface {
             return Err(Box::new(ValidationError {
@@ -843,16 +846,15 @@ impl Surface {
         Ok(())
     }
 
-    #[cfg(target_os = "macos")]
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_mac_os_unchecked<V>(
+    pub unsafe fn from_mac_os_unchecked(
         instance: Arc<Instance>,
-        view: *const V,
+        view: *const c_void,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::MacOSSurfaceCreateInfoMVK {
             flags: ash::vk::MacOSSurfaceCreateFlagsMVK::empty(),
-            p_view: view as *const _,
+            p_view: view,
             ..Default::default()
         };
 
@@ -885,9 +887,9 @@ impl Surface {
     /// - `layer` must be a valid Metal `CAMetalLayer` handle.
     /// - The object referred to by `layer` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_metal<L>(
+    pub unsafe fn from_metal(
         instance: Arc<Instance>,
-        layer: *const L,
+        layer: *const ash::vk::CAMetalLayer,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_metal(&instance, layer)?;
@@ -895,9 +897,9 @@ impl Surface {
         Ok(Self::from_metal_unchecked(instance, layer, object)?)
     }
 
-    fn validate_from_metal<L>(
+    fn validate_from_metal(
         instance: &Instance,
-        _layer: *const L,
+        _layer: *const ash::vk::CAMetalLayer,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().ext_metal_surface {
             return Err(Box::new(ValidationError {
@@ -912,14 +914,14 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_metal_unchecked<L>(
+    pub unsafe fn from_metal_unchecked(
         instance: Arc<Instance>,
-        layer: *const L,
+        layer: *const ash::vk::CAMetalLayer,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::MetalSurfaceCreateInfoEXT {
             flags: ash::vk::MetalSurfaceCreateFlagsEXT::empty(),
-            p_layer: layer as *const _,
+            p_layer: layer,
             ..Default::default()
         };
 
@@ -953,10 +955,10 @@ impl Surface {
     /// - `window` must be a valid QNX Screen `_screen_window` handle.
     /// - The object referred to by `window` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_qnx_screen<C, W>(
+    pub unsafe fn from_qnx_screen(
         instance: Arc<Instance>,
-        context: *const C,
-        window: *const W,
+        context: *mut ash::vk::_screen_context,
+        window: *mut ash::vk::_screen_window,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_qnx_screen(&instance, context, window)?;
@@ -966,10 +968,10 @@ impl Surface {
         )?)
     }
 
-    fn validate_from_qnx_screen<C, W>(
+    fn validate_from_qnx_screen(
         instance: &Instance,
-        _context: *const C,
-        _window: *const W,
+        _context: *mut ash::vk::_screen_context,
+        _window: *mut ash::vk::_screen_window,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().qnx_screen_surface {
             return Err(Box::new(ValidationError {
@@ -990,16 +992,16 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_qnx_screen_unchecked<C, W>(
+    pub unsafe fn from_qnx_screen_unchecked(
         instance: Arc<Instance>,
-        context: *const C,
-        window: *const W,
+        context: *mut ash::vk::_screen_context,
+        window: *mut ash::vk::_screen_window,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::ScreenSurfaceCreateInfoQNX {
             flags: ash::vk::ScreenSurfaceCreateFlagsQNX::empty(),
-            context: context as *mut _,
-            window: window as *mut _,
+            context,
+            window,
             ..Default::default()
         };
 
@@ -1032,9 +1034,9 @@ impl Surface {
     /// - `window` must be a valid `nn::vi::NativeWindowHandle` handle.
     /// - The object referred to by `window` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_vi<W>(
+    pub unsafe fn from_vi(
         instance: Arc<Instance>,
-        window: *const W,
+        window: *mut c_void,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_vi(&instance, window)?;
@@ -1042,9 +1044,9 @@ impl Surface {
         Ok(Self::from_vi_unchecked(instance, window, object)?)
     }
 
-    fn validate_from_vi<W>(
+    fn validate_from_vi(
         instance: &Instance,
-        _window: *const W,
+        _window: *mut c_void,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().nn_vi_surface {
             return Err(Box::new(ValidationError {
@@ -1062,14 +1064,14 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_vi_unchecked<W>(
+    pub unsafe fn from_vi_unchecked(
         instance: Arc<Instance>,
-        window: *const W,
+        window: *mut c_void,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::ViSurfaceCreateInfoNN {
             flags: ash::vk::ViSurfaceCreateFlagsNN::empty(),
-            window: window as *mut _,
+            window,
             ..Default::default()
         };
 
@@ -1105,10 +1107,10 @@ impl Surface {
     /// - `surface` must be a valid Wayland `wl_surface` handle.
     /// - The objects referred to by `display` and `surface` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_wayland<D, S>(
+    pub unsafe fn from_wayland(
         instance: Arc<Instance>,
-        display: *const D,
-        surface: *const S,
+        display: *mut ash::vk::wl_display,
+        surface: *mut ash::vk::wl_surface,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_wayland(&instance, display, surface)?;
@@ -1118,10 +1120,10 @@ impl Surface {
         )?)
     }
 
-    fn validate_from_wayland<D, S>(
+    fn validate_from_wayland(
         instance: &Instance,
-        _display: *const D,
-        _surface: *const S,
+        _display: *mut ash::vk::wl_display,
+        _surface: *mut ash::vk::wl_surface,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().khr_wayland_surface {
             return Err(Box::new(ValidationError {
@@ -1142,16 +1144,16 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_wayland_unchecked<D, S>(
+    pub unsafe fn from_wayland_unchecked(
         instance: Arc<Instance>,
-        display: *const D,
-        surface: *const S,
+        display: *mut ash::vk::wl_display,
+        surface: *mut ash::vk::wl_surface,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::WaylandSurfaceCreateInfoKHR {
             flags: ash::vk::WaylandSurfaceCreateFlagsKHR::empty(),
-            display: display as *mut _,
-            surface: surface as *mut _,
+            display,
+            surface,
             ..Default::default()
         };
 
@@ -1187,10 +1189,10 @@ impl Surface {
     /// - `hwnd` must be a valid Win32 `HWND` handle.
     /// - The objects referred to by `hwnd` and `hinstance` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_win32<I, W>(
+    pub unsafe fn from_win32(
         instance: Arc<Instance>,
-        hinstance: *const I,
-        hwnd: *const W,
+        hinstance: ash::vk::HINSTANCE,
+        hwnd: ash::vk::HWND,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_win32(&instance, hinstance, hwnd)?;
@@ -1200,10 +1202,10 @@ impl Surface {
         )?)
     }
 
-    fn validate_from_win32<I, W>(
+    fn validate_from_win32(
         instance: &Instance,
-        _hinstance: *const I,
-        _hwnd: *const W,
+        _hinstance: ash::vk::HINSTANCE,
+        _hwnd: ash::vk::HWND,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().khr_win32_surface {
             return Err(Box::new(ValidationError {
@@ -1224,16 +1226,16 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_win32_unchecked<I, W>(
+    pub unsafe fn from_win32_unchecked(
         instance: Arc<Instance>,
-        hinstance: *const I,
-        hwnd: *const W,
+        hinstance: ash::vk::HINSTANCE,
+        hwnd: ash::vk::HWND,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::Win32SurfaceCreateInfoKHR {
             flags: ash::vk::Win32SurfaceCreateFlagsKHR::empty(),
-            hinstance: hinstance as *mut _,
-            hwnd: hwnd as *mut _,
+            hinstance,
+            hwnd,
             ..Default::default()
         };
 
@@ -1269,9 +1271,9 @@ impl Surface {
     /// - `window` must be a valid X11 `xcb_window_t` handle.
     /// - The objects referred to by `connection` and `window` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_xcb<C>(
+    pub unsafe fn from_xcb(
         instance: Arc<Instance>,
-        connection: *const C,
+        connection: *mut ash::vk::xcb_connection_t,
         window: ash::vk::xcb_window_t,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
@@ -1282,9 +1284,9 @@ impl Surface {
         )?)
     }
 
-    fn validate_from_xcb<C>(
+    fn validate_from_xcb(
         instance: &Instance,
-        _connection: *const C,
+        _connection: *mut ash::vk::xcb_connection_t,
         _window: ash::vk::xcb_window_t,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().khr_xcb_surface {
@@ -1306,15 +1308,15 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_xcb_unchecked<C>(
+    pub unsafe fn from_xcb_unchecked(
         instance: Arc<Instance>,
-        connection: *const C,
+        connection: *mut ash::vk::xcb_connection_t,
         window: ash::vk::xcb_window_t,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::XcbSurfaceCreateInfoKHR {
             flags: ash::vk::XcbSurfaceCreateFlagsKHR::empty(),
-            connection: connection as *mut _,
+            connection,
             window,
             ..Default::default()
         };
@@ -1351,9 +1353,9 @@ impl Surface {
     /// - `window` must be a valid Xlib `Window` handle.
     /// - The objects referred to by `display` and `window` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_xlib<D>(
+    pub unsafe fn from_xlib(
         instance: Arc<Instance>,
-        display: *const D,
+        display: *mut ash::vk::Display,
         window: ash::vk::Window,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
@@ -1364,9 +1366,9 @@ impl Surface {
         )?)
     }
 
-    fn validate_from_xlib<D>(
+    fn validate_from_xlib(
         instance: &Instance,
-        _display: *const D,
+        _display: *mut ash::vk::Display,
         _window: ash::vk::Window,
     ) -> Result<(), Box<ValidationError>> {
         if !instance.enabled_extensions().khr_xlib_surface {
@@ -1388,15 +1390,15 @@ impl Surface {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn from_xlib_unchecked<D>(
+    pub unsafe fn from_xlib_unchecked(
         instance: Arc<Instance>,
-        display: *const D,
+        display: *mut ash::vk::Display,
         window: ash::vk::Window,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, VulkanError> {
         let create_info = ash::vk::XlibSurfaceCreateInfoKHR {
             flags: ash::vk::XlibSurfaceCreateFlagsKHR::empty(),
-            dpy: display as *mut _,
+            dpy: display,
             window,
             ..Default::default()
         };
@@ -1515,7 +1517,7 @@ impl_id_counter!(Surface);
 
 /// Get sublayer from iOS main view (ui_view). The sublayer is created as `CAMetalLayer`.
 #[cfg(target_os = "ios")]
-unsafe fn get_metal_layer_ios(ui_view: *mut std::ffi::c_void) -> IOSMetalLayer {
+unsafe fn get_metal_layer_ios(ui_view: *mut c_void) -> IOSMetalLayer {
     use core_graphics_types::{base::CGFloat, geometry::CGRect};
 
     let view: *mut Object = ui_view.cast();
@@ -1533,7 +1535,7 @@ unsafe fn get_metal_layer_ios(ui_view: *mut std::ffi::c_void) -> IOSMetalLayer {
 
 /// Get (and set) `CAMetalLayer` to `ns_view`. This is necessary to be able to render on Mac.
 #[cfg(target_os = "macos")]
-unsafe fn get_metal_layer_macos(ns_view: *mut std::ffi::c_void) -> *mut Object {
+unsafe fn get_metal_layer_macos(ns_view: *mut c_void) -> *mut Object {
     use core_graphics_types::base::CGFloat;
     use objc::runtime::YES;
     use objc::runtime::{BOOL, NO};
@@ -2392,7 +2394,7 @@ mod tests {
     #[test]
     fn khr_win32_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_win32(instance, ptr::null::<u8>(), ptr::null::<u8>(), None) } {
+        match unsafe { Surface::from_win32(instance, ptr::null_mut(), ptr::null_mut(), None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,
@@ -2410,7 +2412,7 @@ mod tests {
     #[test]
     fn khr_xcb_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_xcb(instance, ptr::null::<u8>(), 0, None) } {
+        match unsafe { Surface::from_xcb(instance, ptr::null_mut(), 0, None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,
@@ -2428,7 +2430,7 @@ mod tests {
     #[test]
     fn khr_xlib_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_xlib(instance, ptr::null::<u8>(), 0, None) } {
+        match unsafe { Surface::from_xlib(instance, ptr::null_mut(), 0, None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,
@@ -2446,8 +2448,7 @@ mod tests {
     #[test]
     fn khr_wayland_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_wayland(instance, ptr::null::<u8>(), ptr::null::<u8>(), None) }
-        {
+        match unsafe { Surface::from_wayland(instance, ptr::null_mut(), ptr::null_mut(), None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,
@@ -2465,7 +2466,7 @@ mod tests {
     #[test]
     fn khr_android_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_android(instance, ptr::null::<u8>(), None) } {
+        match unsafe { Surface::from_android(instance, ptr::null_mut(), None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to surface creation and support functions:
- Where handles to foreign window system objects are passed, Vulkano no longer takes a generic pointer, but takes the same pointer type that Ash does.
````
