### PR TITLE
Staging buffer helper

### DIFF
--- a/examples/async-update/Cargo.toml
+++ b/examples/async-update/Cargo.toml
@@ -14,6 +14,6 @@ doc = false
 [dependencies]
 cgmath = { workspace = true }
 rand = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/basic-compute-shader/Cargo.toml
+++ b/examples/basic-compute-shader/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/buffer-allocator/Cargo.toml
+++ b/examples/buffer-allocator/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/deferred/Cargo.toml
+++ b/examples/deferred/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 cgmath = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/dynamic-buffers/Cargo.toml
+++ b/examples/dynamic-buffers/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/dynamic-local-size/Cargo.toml
+++ b/examples/dynamic-local-size/Cargo.toml
@@ -13,5 +13,5 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/gl-interop/Cargo.toml
+++ b/examples/gl-interop/Cargo.toml
@@ -13,7 +13,7 @@ doc = false
 
 [dependencies]
 glium = "0.32.1"
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }
 # Glium has still not been updated to the latest winit version

--- a/examples/image-self-copy-blit/Cargo.toml
+++ b/examples/image-self-copy-blit/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/image/Cargo.toml
+++ b/examples/image/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/immutable-sampler/Cargo.toml
+++ b/examples/immutable-sampler/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/indirect/Cargo.toml
+++ b/examples/indirect/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/instancing/Cargo.toml
+++ b/examples/instancing/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/interactive-fractal/Cargo.toml
+++ b/examples/interactive-fractal/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 [dependencies]
 cgmath = { workspace = true }
 rand = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 vulkano-util = { workspace = true }
 winit = { workspace = true }

--- a/examples/msaa-renderpass/Cargo.toml
+++ b/examples/msaa-renderpass/Cargo.toml
@@ -13,5 +13,5 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/multi-window-game-of-life/Cargo.toml
+++ b/examples/multi-window-game-of-life/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 [dependencies]
 cgmath = { workspace = true }
 rand = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 vulkano-util = { workspace = true }
 winit = { workspace = true }

--- a/examples/multi-window/Cargo.toml
+++ b/examples/multi-window/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/multiview/Cargo.toml
+++ b/examples/multiview/Cargo.toml
@@ -13,5 +13,5 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/occlusion-query/Cargo.toml
+++ b/examples/occlusion-query/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/pipeline-caching/Cargo.toml
+++ b/examples/pipeline-caching/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/push-constants/Cargo.toml
+++ b/examples/push-constants/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/push-descriptors/Cargo.toml
+++ b/examples/push-descriptors/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/runtime-array/Cargo.toml
+++ b/examples/runtime-array/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/self-copy-buffer/Cargo.toml
+++ b/examples/self-copy-buffer/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/shader-include/Cargo.toml
+++ b/examples/shader-include/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/shader-types-derive/Cargo.toml
+++ b/examples/shader-types-derive/Cargo.toml
@@ -14,6 +14,6 @@ doc = false
 [dependencies]
 ron = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-vulkano = { workspace = true, features = ["serde"] }
+vulkano = { workspace = true, features = ["serde", "macros"] }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/shader-types-sharing/Cargo.toml
+++ b/examples/shader-types-sharing/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/simple-particles/Cargo.toml
+++ b/examples/simple-particles/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/specialization-constants/Cargo.toml
+++ b/examples/specialization-constants/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }

--- a/examples/teapot/Cargo.toml
+++ b/examples/teapot/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 cgmath = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"] }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/tessellation/Cargo.toml
+++ b/examples/tessellation/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"] }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/texture-array/Cargo.toml
+++ b/examples/texture-array/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/triangle-v1_3/Cargo.toml
+++ b/examples/triangle-v1_3/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }

--- a/examples/triangle/Cargo.toml
+++ b/examples/triangle/Cargo.toml
@@ -13,7 +13,7 @@ doc = false
 
 [dependencies]
 # The `vulkano` crate is the main crate that you must use to use Vulkan.
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["macros"] }
 # Provides the `shader!` macro that is used to generate code for using shaders.
 vulkano-shaders = { workspace = true }
 # The Vulkan library doesn't provide any functionality to create and handle windows, as

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -71,6 +71,7 @@
 //! [the `shader` module documentation]: crate::shader
 
 pub use self::{subbuffer::*, sys::*, usage::*};
+use crate::memory::allocator::MemoryTypeFilter;
 use crate::{
     device::{physical::PhysicalDevice, Device, DeviceOwned},
     macros::{vulkan_bitflags, vulkan_enum},
@@ -289,6 +290,51 @@ impl Buffer {
         }
 
         Ok(buffer)
+    }
+
+    /// Creates a staging buffer with the data `iter` and a device-local buffer with the same size.
+    /// Returns a tuple of [`Subbuffer`]s (staging, device-local) spanning the whole buffers.
+    /// Useful for passing into `copy_buffer` command as (source, destination).
+    pub fn pair_from_iter<T, I>(
+        allocator: Arc<dyn MemoryAllocator>,
+        iter: I,
+        usage: BufferUsage,
+    ) -> Result<(Subbuffer<[T]>, Subbuffer<[T]>), Validated<AllocateBufferError>>
+    where
+        T: BufferContents,
+        I: IntoIterator<Item = T>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let iter = iter.into_iter();
+
+        let device_local_buffer = Buffer::new_slice::<T>(
+            allocator.clone(),
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_DST | usage,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE,
+                ..Default::default()
+            },
+            iter.len() as DeviceSize,
+        )?;
+
+        let staging_buffer = Buffer::from_iter(
+            allocator.clone(),
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_SRC,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                memory_type_filter: MemoryTypeFilter::PREFER_HOST
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
+                ..Default::default()
+            },
+            iter,
+        )?;
+
+        Ok((staging_buffer, device_local_buffer))
     }
 
     /// Creates a new uninitialized `Buffer` for sized data. Returns a [`Subbuffer`] spanning the


### PR DESCRIPTION
Buffer::pair_from_iter Creates a staging buffer with the data `iter` and a device-local buffer with the same size.
Returns a tuple of [`Subbuffer`]s (staging, device-local) spanning the whole buffers.
Useful for passing into the `copy_buffer` command as (source, destination).
The order of the tuple is consistent with `CopyBufferInfo::buffer`

The order 

Changelog:
```markdown
### Additions
- Buffer::from_iter to make it easier to create a (staging, device-local) buffer pair
````

1. [X] Update documentation to reflect any user-facing changes - in this repository.

2. [X] Make sure that the changes are covered by unit tests.

3. [X] Run `cargo fmt` on the changes.

4. [X] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.
   
   Please remove any items from the template below that are not applicable.

5. [X] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.
