### PR TITLE
Some shader parse refactoring and additions

### DIFF
--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -918,7 +918,7 @@ impl GraphicsPipeline {
             if matches!(entry_point_info.execution_model, ExecutionModel::Fragment) {
                 fragment_tests_stages = Some(FragmentTestsStages::Late);
 
-                for instruction in entry_point_function.iter_execution_mode() {
+                for instruction in entry_point_function.execution_modes() {
                     if let Instruction::ExecutionMode { mode, .. } = *instruction {
                         match mode {
                             ExecutionMode::EarlyFragmentTests => {
@@ -2431,7 +2431,8 @@ impl GraphicsPipelineCreateInfo {
             let entry_point_function = spirv.function(geometry_stage.entry_point.id());
 
             let input = entry_point_function
-                .iter_execution_mode()
+                .execution_modes()
+                .iter()
                 .find_map(|instruction| {
                     if let Instruction::ExecutionMode { mode, .. } = *instruction {
                         match mode {

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -451,7 +451,7 @@ impl PipelineShaderStageCreateInfo {
         let mut clip_distance_array_size = 0;
         let mut cull_distance_array_size = 0;
 
-        for instruction in spirv.iter_decoration() {
+        for instruction in spirv.decorations() {
             if let Instruction::Decorate {
                 target,
                 decoration: Decoration::BuiltIn { built_in },
@@ -556,7 +556,7 @@ impl PipelineShaderStageCreateInfo {
             }));
         }
 
-        for instruction in entry_point_function.iter_execution_mode() {
+        for instruction in entry_point_function.execution_modes() {
             if let Instruction::ExecutionMode {
                 mode: ExecutionMode::OutputVertices { vertex_count },
                 ..
@@ -617,7 +617,8 @@ impl PipelineShaderStageCreateInfo {
         }
 
         let local_size = (spirv
-            .iter_decoration()
+            .decorations()
+            .iter()
             .find_map(|instruction| match *instruction {
                 Instruction::Decorate {
                     target,
@@ -647,7 +648,8 @@ impl PipelineShaderStageCreateInfo {
             }))
         .or_else(|| {
             entry_point_function
-                .iter_execution_mode()
+                .execution_modes()
+                .iter()
                 .find_map(|instruction| match *instruction {
                     Instruction::ExecutionMode {
                         mode:

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -528,7 +528,8 @@ impl<'a> ShaderModuleCreateInfo<'a> {
         })?;
 
         for &capability in spirv
-            .iter_capability()
+            .capabilities()
+            .iter()
             .filter_map(|instruction| match instruction {
                 Instruction::Capability { capability } => Some(capability),
                 _ => None,
@@ -538,7 +539,8 @@ impl<'a> ShaderModuleCreateInfo<'a> {
         }
 
         for extension in spirv
-            .iter_extension()
+            .extensions()
+            .iter()
             .filter_map(|instruction| match instruction {
                 Instruction::Extension { name } => Some(name.as_str()),
                 _ => None,


### PR DESCRIPTION
This is needed for some future changes I'm working on. `Spirv` now returns slices of instructions directly, instead of iterators, and the reflected SPIR-V internal types receive a few additional items.