### PR TITLE
Validate the fragment output against color blend state

### DIFF
--- a/examples/deferred/triangle_draw_system.rs
+++ b/examples/deferred/triangle_draw_system.rs
@@ -9,7 +9,7 @@ use vulkano::{
     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
     pipeline::{
         graphics::{
-            color_blend::{ColorBlendAttachmentState, ColorBlendState},
+            color_blend::{ColorBlendAttachmentState, ColorBlendState, ColorComponents},
             depth_stencil::{DepthState, DepthStencilState},
             input_assembly::InputAssemblyState,
             multisample::MultisampleState,
@@ -107,7 +107,12 @@ impl TriangleDrawSystem {
                     multisample_state: Some(MultisampleState::default()),
                     color_blend_state: Some(ColorBlendState::with_attachment_states(
                         subpass.num_color_attachments(),
-                        ColorBlendAttachmentState::default(),
+                        ColorBlendAttachmentState {
+                            // Don't write the alpha component, as it's not used and
+                            // the fragment shader doesn't output it.
+                            color_write_mask: ColorComponents::all() - ColorComponents::A,
+                            ..ColorBlendAttachmentState::default()
+                        },
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.clone().into()),

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -18,7 +18,7 @@ use crate::{
         graphics::{
             input_assembly::PrimitiveTopology,
             subpass::PipelineSubpassType,
-            vertex_input::{self, RequiredVertexInputsVUIDs, VertexInputRate},
+            vertex_input::{RequiredVertexInputsVUIDs, VertexInputRate},
         },
         DynamicState, GraphicsPipeline, Pipeline, PipelineLayout,
     },
@@ -2163,28 +2163,28 @@ impl<L> AutoCommandBufferBuilder<L> {
                 }
                 DynamicState::VertexInput => {
                     if let Some(vertex_input_state) = &self.builder_state.vertex_input {
-                        vertex_input::validate_required_vertex_inputs(
-                            &vertex_input_state.attributes,
-                            pipeline.required_vertex_inputs().unwrap(),
-                            RequiredVertexInputsVUIDs {
-                                not_present: vuids!(vuid_type, "Input-07939"),
-                                numeric_type: vuids!(vuid_type, "Input-08734"),
-                                requires32: vuids!(vuid_type, "format-08936"),
-                                requires64: vuids!(vuid_type, "format-08937"),
-                                requires_second_half: vuids!(vuid_type, "None-09203"),
-                            },
-                        )
-                        .map_err(|mut err| {
-                            err.problem = format!(
-                                "the currently bound graphics pipeline requires the \
+                        vertex_input_state
+                            .validate_required_vertex_inputs(
+                                pipeline.required_vertex_inputs().unwrap(),
+                                RequiredVertexInputsVUIDs {
+                                    not_present: vuids!(vuid_type, "Input-07939"),
+                                    numeric_type: vuids!(vuid_type, "Input-08734"),
+                                    requires32: vuids!(vuid_type, "format-08936"),
+                                    requires64: vuids!(vuid_type, "format-08937"),
+                                    requires_second_half: vuids!(vuid_type, "None-09203"),
+                                },
+                            )
+                            .map_err(|mut err| {
+                                err.problem = format!(
+                                    "the currently bound graphics pipeline requires the \
                                 `DynamicState::VertexInput` dynamic state, but \
                                 the dynamic vertex input does not meet the requirements of the \
                                 vertex shader in the pipeline: {}",
-                                err.problem,
-                            )
-                            .into();
-                            err
-                        })?;
+                                    err.problem,
+                                )
+                                .into();
+                                err
+                            })?;
                     } else {
                         return Err(Box::new(ValidationError {
                             problem: format!(

--- a/vulkano/src/macros.rs
+++ b/vulkano/src/macros.rs
@@ -39,6 +39,12 @@ macro_rules! vulkan_bitflags {
                 )*
             }
 
+            /// Returns the number of flags set in self.
+            #[inline]
+            pub const fn count(self) -> u32 {
+                self.0.count_ones()
+            }
+
             /// Returns whether no flags are set in `self`.
             #[inline]
             pub const fn is_empty(self) -> bool {

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -56,12 +56,13 @@ use self::{
     rasterization::RasterizationState,
     subpass::PipelineSubpassType,
     tessellation::TessellationState,
-    vertex_input::{RequiredVertexInputsVUIDs, VertexInputLocationRequirements, VertexInputState},
+    vertex_input::{RequiredVertexInputsVUIDs, VertexInputState},
     viewport::ViewportState,
 };
 use super::{
     cache::PipelineCache, shader::validate_interfaces_compatible, DynamicState, Pipeline,
     PipelineBindPoint, PipelineCreateFlags, PipelineLayout, PipelineShaderStageCreateInfo,
+    ShaderInterfaceLocationInfo,
 };
 use crate::{
     device::{Device, DeviceOwned, DeviceOwnedDebugWrapper},
@@ -80,7 +81,7 @@ use crate::{
         },
     },
     shader::{
-        spirv::{ExecutionMode, ExecutionModel, Instruction},
+        spirv::{ExecutionMode, ExecutionModel, Instruction, StorageClass},
         DescriptorBindingRequirements, ShaderStage, ShaderStages,
     },
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, VulkanError, VulkanObject,
@@ -137,7 +138,7 @@ pub struct GraphicsPipeline {
     fixed_state: HashSet<DynamicState>,
     fragment_tests_stages: Option<FragmentTestsStages>,
     // Note: this is only `Some` if `vertex_input_state` is `None`.
-    required_vertex_inputs: Option<HashMap<u32, VertexInputLocationRequirements>>,
+    required_vertex_inputs: Option<HashMap<u32, ShaderInterfaceLocationInfo>>,
 }
 
 impl GraphicsPipeline {
@@ -939,9 +940,10 @@ impl GraphicsPipeline {
             match entry_point_info.execution_model {
                 ExecutionModel::Vertex => {
                     if vertex_input_state.is_none() {
-                        required_vertex_inputs = Some(vertex_input::required_vertex_inputs(
+                        required_vertex_inputs = Some(super::shader_interface_location_info(
                             entry_point.module().spirv(),
                             entry_point.id(),
+                            StorageClass::Input,
                         ));
                     }
                 }
@@ -1182,7 +1184,7 @@ impl GraphicsPipeline {
     #[inline]
     pub(crate) fn required_vertex_inputs(
         &self,
-    ) -> Option<&HashMap<u32, VertexInputLocationRequirements>> {
+    ) -> Option<&HashMap<u32, ShaderInterfaceLocationInfo>> {
         self.required_vertex_inputs.as_ref()
     }
 }
@@ -2421,34 +2423,35 @@ impl GraphicsPipelineCreateInfo {
         */
 
         if let (Some(vertex_stage), Some(vertex_input_state)) = (vertex_stage, vertex_input_state) {
-            let required_vertex_inputs = vertex_input::required_vertex_inputs(
+            let required_vertex_inputs = super::shader_interface_location_info(
                 vertex_stage.entry_point.module().spirv(),
                 vertex_stage.entry_point.id(),
+                StorageClass::Input,
             );
 
-            vertex_input::validate_required_vertex_inputs(
-                &vertex_input_state.attributes,
-                &required_vertex_inputs,
-                RequiredVertexInputsVUIDs {
-                    not_present: &["VUID-VkGraphicsPipelineCreateInfo-Input-07904"],
-                    numeric_type: &["VUID-VkGraphicsPipelineCreateInfo-Input-08733"],
-                    requires32: &["VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08929"],
-                    requires64: &["VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08930"],
-                    requires_second_half: &[
-                        "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-09198",
-                    ],
-                },
-            )
-            .map_err(|mut err| {
-                err.problem = format!(
-                    "{}: {}",
-                    "`vertex_input_state` does not meet the requirements \
-                    of the vertex shader in `stages`",
-                    err.problem,
+            vertex_input_state
+                .validate_required_vertex_inputs(
+                    &required_vertex_inputs,
+                    RequiredVertexInputsVUIDs {
+                        not_present: &["VUID-VkGraphicsPipelineCreateInfo-Input-07904"],
+                        numeric_type: &["VUID-VkGraphicsPipelineCreateInfo-Input-08733"],
+                        requires32: &["VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08929"],
+                        requires64: &["VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08930"],
+                        requires_second_half: &[
+                            "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-09198",
+                        ],
+                    },
                 )
-                .into();
-                err
-            })?;
+                .map_err(|mut err| {
+                    err.problem = format!(
+                        "{}: {}",
+                        "`vertex_input_state` does not meet the requirements \
+                    of the vertex shader in `stages`",
+                        err.problem,
+                    )
+                    .into();
+                    err
+                })?;
         }
 
         if let (Some(_), Some(_)) = (tessellation_control_stage, tessellation_evaluation_stage) {
@@ -2508,25 +2511,27 @@ impl GraphicsPipelineCreateInfo {
             }
         }
 
-        if let (Some(fragment_stage), Some(subpass)) = (fragment_stage, subpass) {
-            let entry_point_info = fragment_stage.entry_point.info();
+        if let (Some(fragment_stage), Some(color_blend_state), Some(subpass)) =
+            (fragment_stage, color_blend_state, subpass)
+        {
+            let fragment_shader_outputs = super::shader_interface_location_info(
+                fragment_stage.entry_point.module().spirv(),
+                fragment_stage.entry_point.id(),
+                StorageClass::Output,
+            );
 
-            // Check that the subpass can accept the output of the fragment shader.
-            match subpass {
-                PipelineSubpassType::BeginRenderPass(subpass) => {
-                    if !subpass.is_compatible_with(&entry_point_info.output_interface) {
-                        return Err(Box::new(ValidationError {
-                            problem: "`subpass` is not compatible with the \
-                                output interface of the fragment shader"
-                                .into(),
-                            ..Default::default()
-                        }));
-                    }
-                }
-                PipelineSubpassType::BeginRendering(_) => {
-                    // TODO:
-                }
-            }
+            color_blend_state
+                .validate_required_fragment_outputs(subpass, &fragment_shader_outputs)
+                .map_err(|mut err| {
+                    err.problem = format!(
+                        "{}: {}",
+                        "the fragment shader in `stages` does not meet the requirements of \
+                        `color_blend_state` and `subpass`",
+                        err.problem,
+                    )
+                    .into();
+                    err
+                })?;
 
             // TODO:
             // VUID-VkGraphicsPipelineCreateInfo-pStages-01565


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to render passes:
- The `is_compatible_with_shader` methods of `RenderPass` and `Subpass` are removed.

### Bugs fixed
- Improved and more accurate validation of fragment output.
````

This gives fragment output the same thorough treatment that was added to vertex input before. The new validation code will first determine which components (RGBA) of the color attachment are going to be written to, and then figure out which source values coming from the fragment shader are used to calculate that output value. Such more complicated treatment is needed in the case of blending, where for example the final value of the red component might be calculated using the alpha component as input.

After I finished this, the deferred example turned out to have a slight bug that was now being caught by the new code. The color blending for the normals attachment was set to write all four components, but the fragment shader was not providing the alpha component, which meant that some undefined value was being written instead. This wasn't an issue because the example never read back the alpha component, but it feels a bit neater now that it's fixed.