### PR TITLE
Allow executing raw secondary command buffers

### DIFF
--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -171,6 +171,12 @@ impl Debug for SecondaryAutoCommandBuffer {
 }
 
 impl SecondaryAutoCommandBuffer {
+    /// Returns the inner raw command buffer.
+    #[inline]
+    pub fn inner(&self) -> &RawCommandBuffer {
+        &self.inner
+    }
+
     /// Returns the usage of this command buffer.
     #[inline]
     pub fn usage(&self) -> CommandBufferUsage {


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to command buffers:
- `RawRecordingCommandBuffer::execute_commands` now takes `&RawCommandBuffer`s as argument.
```