### PR TITLE
Allow binding raw descriptor sets

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -843,14 +843,12 @@ impl Task for RenderTask {
             0,
             &[
                 // Bind the uniform buffer designated for this frame.
-                self.uniform_buffer_sets[frame_index as usize]
-                    .clone()
-                    .into(),
+                self.uniform_buffer_sets[frame_index as usize].as_raw(),
                 // Bind the currently most up-to-date texture.
                 self.sampler_sets[self.current_texture_index.load(Ordering::Relaxed) as usize]
-                    .clone()
-                    .into(),
+                    .as_raw(),
             ],
+            &[],
         )?;
         cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
 

--- a/examples/bloom/bloom.rs
+++ b/examples/bloom/bloom.rs
@@ -1,5 +1,5 @@
 use crate::{App, RenderContext};
-use std::{slice, sync::Arc};
+use std::sync::Arc;
 use vulkano::{
     image::{mip_level_extent, Image},
     pipeline::{
@@ -80,7 +80,8 @@ impl Task for BloomTask {
             PipelineBindPoint::Compute,
             &rcx.pipeline_layout,
             0,
-            slice::from_ref(&rcx.descriptor_set),
+            &[&rcx.descriptor_set],
+            &[],
         )?;
 
         let bloom_image = tcx.image(self.bloom_image_id)?.image();
@@ -141,7 +142,7 @@ impl Task for BloomTask {
         }
 
         cbf.destroy_object(bloom_image.clone());
-        cbf.destroy_object(rcx.descriptor_set.as_ref().0.clone());
+        cbf.destroy_object(rcx.descriptor_set.clone());
 
         Ok(())
     }

--- a/examples/bloom/tonemap.rs
+++ b/examples/bloom/tonemap.rs
@@ -124,7 +124,8 @@ impl Task for TonemapTask {
             PipelineBindPoint::Graphics,
             &rcx.pipeline_layout,
             0,
-            slice::from_ref(&rcx.descriptor_set),
+            &[&rcx.descriptor_set],
+            &[],
         )?;
 
         let swapchain_state = tcx.swapchain(self.swapchain_id)?;

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -144,6 +144,12 @@ impl DescriptorSet {
         Ok(Arc::new(set))
     }
 
+    /// Returns the inner raw descriptor set.
+    #[inline]
+    pub fn as_raw(&self) -> &RawDescriptorSet {
+        &self.inner
+    }
+
     /// Returns the allocation of the descriptor set.
     #[inline]
     pub fn alloc(&self) -> &DescriptorPoolAlloc {


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to command buffers:
- `RecordingCommandBuffer::bind_descriptor_sets` now takes `&RawDescriptorSet`s as argument.
````
