### PR TITLE
Improve clarity of `MemoryTypeFilter` docs

### DIFF
--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -367,6 +367,8 @@ impl Debug for dyn MemoryAllocator {
 ///
 /// # Examples
 ///
+/// #### Direct device access only
+///
 /// For resources that the device frequently accesses, e.g. textures, render targets, or
 /// intermediary buffers, you want device-local memory without any host access:
 ///
@@ -395,6 +397,8 @@ impl Debug for dyn MemoryAllocator {
 /// )
 /// .unwrap();
 /// ```
+///
+/// #### Sequential writes from host, indirect device access
 ///
 /// For staging, the resource is only ever written to sequentially. Also, since the device will
 /// only read the staging resourse once, it would yield no benefit to place it in device-local
@@ -425,6 +429,8 @@ impl Debug for dyn MemoryAllocator {
 /// # let staging_buffer: vulkano::buffer::Subbuffer<u32> = staging_buffer;
 /// ```
 ///
+/// #### Sequential writes from host, direct device access
+///
 /// For resources that the device accesses directly, aka a buffer/image used for anything other
 /// than transfers, it's probably best to put it in device-local memory:
 ///
@@ -452,6 +458,8 @@ impl Debug for dyn MemoryAllocator {
 /// #
 /// # let uniform_buffer: vulkano::buffer::Subbuffer<u32> = uniform_buffer;
 /// ```
+///
+/// #### Readback to host
 ///
 /// For readback, e.g. getting the results of a compute shader back to the host:
 ///

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -401,7 +401,7 @@ impl Debug for dyn MemoryAllocator {
 /// #### Sequential writes from host, indirect device access
 ///
 /// For staging, the resource is only ever written to sequentially. Also, since the device will
-/// only read the staging resourse once, it would yield no benefit to place it in device-local
+/// only read the staging resource once, it would yield no benefit to place it in device-local
 /// memory, in fact it would be wasteful. Therefore, it's best to put it in host-local memory:
 ///
 /// ```


### PR DESCRIPTION
Hopefully this helps newcommers to not keep missing the relevant information. I moved the information about needing to combine e.g. `PREFER_HOST` with either `HOST_SEQUENTIAL_WRITE` or `HOST_RANDOM_ACCESS` to the top of the constant's docs and made it bold, whereas it was at the bottom before. And the corresponding constants have the same information duplicated at the top as well now.