### PR TITLE
Document shader safety requirements, make draw/dispatch unsafe

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -602,6 +602,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -631,13 +632,15 @@ fn main() -> Result<(), impl Error> {
                     )
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 acquire_future.wait(None).unwrap();
                 previous_frame_end.as_mut().unwrap().cleanup_finished();
 

--- a/examples/basic-compute-shader/main.rs
+++ b/examples/basic-compute-shader/main.rs
@@ -206,14 +206,12 @@ fn main() {
         },
     )
     .unwrap();
+
+    // Note that we clone the pipeline and the set. Since they are both wrapped in an `Arc`,
+    // this only clones the `Arc` and not the whole pipeline or set (which aren't cloneable
+    // anyway). In this example we would avoid cloning them since this is the last time we use
+    // them, but in real code you would probably need to clone them.
     builder
-        // The command buffer only does one thing: execute the compute pipeline. This is called a
-        // *dispatch* operation.
-        //
-        // Note that we clone the pipeline and the set. Since they are both wrapped in an `Arc`,
-        // this only clones the `Arc` and not the whole pipeline or set (which aren't cloneable
-        // anyway). In this example we would avoid cloning them since this is the last time we use
-        // them, but in real code you would probably need to clone them.
         .bind_pipeline_compute(pipeline.clone())
         .unwrap()
         .bind_descriptor_sets(
@@ -222,9 +220,13 @@ fn main() {
             0,
             set,
         )
-        .unwrap()
-        .dispatch([1024, 1, 1])
         .unwrap();
+
+    unsafe {
+        // The command buffer only does one thing: execute the compute pipeline. This is called a
+        // *dispatch* operation.
+        builder.dispatch([1024, 1, 1]).unwrap();
+    }
 
     // Finish building the command buffer by calling `build`.
     let command_buffer = builder.end().unwrap();

--- a/examples/buffer-allocator/main.rs
+++ b/examples/buffer-allocator/main.rs
@@ -379,6 +379,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -396,13 +397,15 @@ fn main() -> Result<(), impl Error> {
                     .bind_pipeline_graphics(pipeline.clone())
                     .unwrap()
                     .bind_vertex_buffers(0, buffer)
-                    .unwrap()
-                    .draw(num_vertices, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(num_vertices, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/deferred/frame/ambient_lighting_system.rs
+++ b/examples/deferred/frame/ambient_lighting_system.rs
@@ -197,6 +197,7 @@ impl AmbientLightingSystem {
             },
         )
         .unwrap();
+
         builder
             .set_viewport(0, [viewport].into_iter().collect())
             .unwrap()
@@ -212,9 +213,14 @@ impl AmbientLightingSystem {
             .push_constants(self.pipeline.layout().clone(), 0, push_constants)
             .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
-            .unwrap()
-            .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
             .unwrap();
+
+        unsafe {
+            builder
+                .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
+                .unwrap();
+        }
+
         builder.end().unwrap()
     }
 }

--- a/examples/deferred/frame/directional_lighting_system.rs
+++ b/examples/deferred/frame/directional_lighting_system.rs
@@ -211,6 +211,7 @@ impl DirectionalLightingSystem {
             },
         )
         .unwrap();
+
         builder
             .set_viewport(0, [viewport].into_iter().collect())
             .unwrap()
@@ -226,9 +227,14 @@ impl DirectionalLightingSystem {
             .push_constants(self.pipeline.layout().clone(), 0, push_constants)
             .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
-            .unwrap()
-            .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
             .unwrap();
+
+        unsafe {
+            builder
+                .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
+                .unwrap();
+        }
+
         builder.end().unwrap()
     }
 }

--- a/examples/deferred/frame/point_lighting_system.rs
+++ b/examples/deferred/frame/point_lighting_system.rs
@@ -224,6 +224,7 @@ impl PointLightingSystem {
             },
         )
         .unwrap();
+
         builder
             .set_viewport(0, [viewport].into_iter().collect())
             .unwrap()
@@ -239,9 +240,14 @@ impl PointLightingSystem {
             .push_constants(self.pipeline.layout().clone(), 0, push_constants)
             .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
-            .unwrap()
-            .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
             .unwrap();
+
+        unsafe {
+            builder
+                .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
+                .unwrap();
+        }
+
         builder.end().unwrap()
     }
 }

--- a/examples/deferred/triangle_draw_system.rs
+++ b/examples/deferred/triangle_draw_system.rs
@@ -143,6 +143,7 @@ impl TriangleDrawSystem {
             },
         )
         .unwrap();
+
         builder
             .set_viewport(
                 0,
@@ -158,9 +159,14 @@ impl TriangleDrawSystem {
             .bind_pipeline_graphics(self.pipeline.clone())
             .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
-            .unwrap()
-            .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
             .unwrap();
+
+        unsafe {
+            builder
+                .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
+                .unwrap();
+        }
+
         builder.end().unwrap()
     }
 }

--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -248,37 +248,23 @@ fn main() {
     )
     .unwrap();
 
-    #[allow(clippy::erasing_op, clippy::identity_op)]
-    builder
-        .bind_pipeline_compute(pipeline.clone())
-        .unwrap()
-        .bind_descriptor_sets(
-            PipelineBindPoint::Compute,
-            pipeline.layout().clone(),
-            0,
-            set.clone().offsets([0 * align as u32]),
-        )
-        .unwrap()
-        .dispatch([12, 1, 1])
-        .unwrap()
-        .bind_descriptor_sets(
-            PipelineBindPoint::Compute,
-            pipeline.layout().clone(),
-            0,
-            set.clone().offsets([1 * align as u32]),
-        )
-        .unwrap()
-        .dispatch([12, 1, 1])
-        .unwrap()
-        .bind_descriptor_sets(
-            PipelineBindPoint::Compute,
-            pipeline.layout().clone(),
-            0,
-            set.offsets([2 * align as u32]),
-        )
-        .unwrap()
-        .dispatch([12, 1, 1])
-        .unwrap();
+    builder.bind_pipeline_compute(pipeline.clone()).unwrap();
+
+    for index in 0..3 {
+        builder
+            .bind_descriptor_sets(
+                PipelineBindPoint::Compute,
+                pipeline.layout().clone(),
+                0,
+                set.clone().offsets([index * align as u32]),
+            )
+            .unwrap();
+
+        unsafe {
+            builder.dispatch([12, 1, 1]).unwrap();
+        }
+    }
+
     let command_buffer = builder.end().unwrap();
 
     let future = sync::now(device)

--- a/examples/dynamic-local-size/main.rs
+++ b/examples/dynamic-local-size/main.rs
@@ -259,6 +259,7 @@ fn main() {
         },
     )
     .unwrap();
+
     builder
         .bind_pipeline_compute(pipeline.clone())
         .unwrap()
@@ -268,12 +269,19 @@ fn main() {
             0,
             set,
         )
-        .unwrap()
+        .unwrap();
+
+    unsafe {
         // Note that dispatch dimensions must be proportional to the local size.
-        .dispatch([1024 / local_size_x, 1024 / local_size_y, 1])
-        .unwrap()
+        builder
+            .dispatch([1024 / local_size_x, 1024 / local_size_y, 1])
+            .unwrap();
+    }
+
+    builder
         .copy_image_to_buffer(CopyImageToBufferInfo::image_buffer(image, buf.clone()))
         .unwrap();
+
     let command_buffer = builder.end().unwrap();
 
     let future = sync::now(device)

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -401,6 +401,7 @@ mod linux {
                         },
                     )
                     .unwrap();
+
                     builder
                         .begin_render_pass(
                             RenderPassBeginInfo {
@@ -424,13 +425,15 @@ mod linux {
                         )
                         .unwrap()
                         .bind_vertex_buffers(0, vertex_buffer.clone())
-                        .unwrap()
-                        .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap()
-                        .end_render_pass(Default::default())
                         .unwrap();
-                    let command_buffer = builder.end().unwrap();
 
+                    unsafe {
+                        builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                    }
+
+                    builder.end_render_pass(Default::default()).unwrap();
+
+                    let command_buffer = builder.end().unwrap();
                     let future = previous_frame_end.take().unwrap().join(acquire_future);
 
                     let future = future

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -485,6 +485,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -508,13 +509,15 @@ fn main() -> Result<(), impl Error> {
                     )
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -432,6 +432,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -455,13 +456,15 @@ fn main() -> Result<(), impl Error> {
                     )
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -450,6 +450,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -473,13 +474,15 @@ fn main() -> Result<(), impl Error> {
                     )
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -489,9 +489,13 @@ fn main() -> Result<(), impl Error> {
                         0,
                         cs_desciptor_set,
                     )
-                    .unwrap()
-                    .dispatch([1, 1, 1])
-                    .unwrap()
+                    .unwrap();
+
+                unsafe {
+                    builder.dispatch([1, 1, 1]).unwrap();
+                }
+
+                builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
                             clear_values: vec![Some([0.0, 0.0, 1.0, 1.0].into())],
@@ -507,13 +511,16 @@ fn main() -> Result<(), impl Error> {
                     .bind_pipeline_graphics(render_pipeline.clone())
                     .unwrap()
                     .bind_vertex_buffers(0, vertices)
-                    .unwrap()
+                    .unwrap();
+
+                unsafe {
                     // The indirect draw call is placed in the command buffer with a reference to
                     // the buffer that will contain the arguments for the draw.
-                    .draw_indirect(indirect_buffer)
-                    .unwrap()
-                    .end_render_pass(Default::default())
-                    .unwrap();
+                    builder.draw_indirect(indirect_buffer).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
                 let command_buffer = builder.end().unwrap();
 
                 let future = previous_frame_end

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -412,6 +412,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -429,18 +430,22 @@ fn main() -> Result<(), impl Error> {
                     .unwrap()
                     // We pass both our lists of vertices here.
                     .bind_vertex_buffers(0, (vertex_buffer.clone(), instance_buffer.clone()))
-                    .unwrap()
-                    .draw(
-                        vertex_buffer.len() as u32,
-                        instance_buffer.len() as u32,
-                        0,
-                        0,
-                    )
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder
+                        .draw(
+                            vertex_buffer.len() as u32,
+                            instance_buffer.len() as u32,
+                            0,
+                            0,
+                        )
+                        .unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/interactive-fractal/fractal_compute_pipeline.rs
+++ b/examples/interactive-fractal/fractal_compute_pipeline.rs
@@ -168,15 +168,21 @@ impl FractalComputePipeline {
             max_iters: max_iters as i32,
             is_julia: is_julia as u32,
         };
+
         builder
             .bind_pipeline_compute(self.pipeline.clone())
             .unwrap()
             .bind_descriptor_sets(PipelineBindPoint::Compute, pipeline_layout.clone(), 0, set)
             .unwrap()
             .push_constants(pipeline_layout.clone(), 0, push_constants)
-            .unwrap()
-            .dispatch([image_extent[0] / 8, image_extent[1] / 8, 1])
             .unwrap();
+
+        unsafe {
+            builder
+                .dispatch([image_extent[0] / 8, image_extent[1] / 8, 1])
+                .unwrap();
+        }
+
         let command_buffer = builder.end().unwrap();
         let finished = command_buffer.execute(self.queue.clone()).unwrap();
         finished.then_signal_fence_and_flush().unwrap().boxed()

--- a/examples/interactive-fractal/pixels_draw_pipeline.rs
+++ b/examples/interactive-fractal/pixels_draw_pipeline.rs
@@ -215,7 +215,7 @@ impl PixelsDrawPipeline {
             },
         )
         .unwrap();
-        let desc_set = self.create_descriptor_set(image);
+
         builder
             .set_viewport(
                 0,
@@ -234,15 +234,20 @@ impl PixelsDrawPipeline {
                 PipelineBindPoint::Graphics,
                 self.pipeline.layout().clone(),
                 0,
-                desc_set,
+                self.create_descriptor_set(image),
             )
             .unwrap()
             .bind_vertex_buffers(0, self.vertices.clone())
             .unwrap()
             .bind_index_buffer(self.indices.clone())
-            .unwrap()
-            .draw_indexed(self.indices.len() as u32, 1, 0, 0, 0)
             .unwrap();
+
+        unsafe {
+            builder
+                .draw_indexed(self.indices.len() as u32, 1, 0, 0, 0)
+                .unwrap();
+        }
+
         builder.end().unwrap()
     }
 }

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -390,6 +390,7 @@ fn main() {
         },
     )
     .unwrap();
+
     builder
         .begin_render_pass(
             RenderPassBeginInfo {
@@ -404,15 +405,19 @@ fn main() {
         .bind_pipeline_graphics(pipeline)
         .unwrap()
         .bind_vertex_buffers(0, vertex_buffer.clone())
-        .unwrap()
-        .draw(vertex_buffer.len() as u32, 1, 0, 0)
-        .unwrap()
+        .unwrap();
+
+    unsafe {
+        builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+    }
+
+    builder
         .end_render_pass(Default::default())
         .unwrap()
         .copy_image_to_buffer(CopyImageToBufferInfo::image_buffer(image, buf.clone()))
         .unwrap();
-    let command_buffer = builder.end().unwrap();
 
+    let command_buffer = builder.end().unwrap();
     let finished = command_buffer.execute(queue).unwrap();
     finished
         .then_signal_fence_and_flush()

--- a/examples/multi-window-game-of-life/game_of_life.rs
+++ b/examples/multi-window-game-of-life/game_of_life.rs
@@ -200,9 +200,13 @@ impl GameOfLifeComputePipeline {
             .bind_descriptor_sets(PipelineBindPoint::Compute, pipeline_layout.clone(), 0, set)
             .unwrap()
             .push_constants(pipeline_layout.clone(), 0, push_constants)
-            .unwrap()
-            .dispatch([image_extent[0] / 8, image_extent[1] / 8, 1])
             .unwrap();
+
+        unsafe {
+            builder
+                .dispatch([image_extent[0] / 8, image_extent[1] / 8, 1])
+                .unwrap();
+        }
     }
 }
 

--- a/examples/multi-window-game-of-life/pixels_draw.rs
+++ b/examples/multi-window-game-of-life/pixels_draw.rs
@@ -211,7 +211,7 @@ impl PixelsDrawPipeline {
             },
         )
         .unwrap();
-        let desc_set = self.create_image_sampler_nearest(image);
+
         builder
             .set_viewport(
                 0,
@@ -230,15 +230,20 @@ impl PixelsDrawPipeline {
                 PipelineBindPoint::Graphics,
                 self.pipeline.layout().clone(),
                 0,
-                desc_set,
+                self.create_image_sampler_nearest(image),
             )
             .unwrap()
             .bind_vertex_buffers(0, self.vertices.clone())
             .unwrap()
             .bind_index_buffer(self.indices.clone())
-            .unwrap()
-            .draw_indexed(self.indices.len() as u32, 1, 0, 0, 0)
             .unwrap();
+
+        unsafe {
+            builder
+                .draw_indexed(self.indices.len() as u32, 1, 0, 0, 0)
+                .unwrap();
+        }
+
         builder.end().unwrap()
     }
 }

--- a/examples/multi-window/main.rs
+++ b/examples/multi-window/main.rs
@@ -474,13 +474,15 @@ fn main() -> Result<(), impl Error> {
                     .bind_pipeline_graphics(pipeline.clone())
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/multiview/main.rs
+++ b/examples/multiview/main.rs
@@ -342,8 +342,6 @@ fn main() {
     )
     .unwrap();
 
-    // Drawing commands are broadcast to each view in the view mask of the active renderpass which
-    // means only a single draw call is needed to draw to multiple layers of the framebuffer.
     builder
         .begin_render_pass(
             RenderPassBeginInfo {
@@ -356,11 +354,15 @@ fn main() {
         .bind_pipeline_graphics(pipeline)
         .unwrap()
         .bind_vertex_buffers(0, vertex_buffer.clone())
-        .unwrap()
-        .draw(vertex_buffer.len() as u32, 1, 0, 0)
-        .unwrap()
-        .end_render_pass(Default::default())
         .unwrap();
+
+    unsafe {
+        // Drawing commands are broadcast to each view in the view mask of the active renderpass which
+        // means only a single draw call is needed to draw to multiple layers of the framebuffer.
+        builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+    }
+
+    builder.end_render_pass(Default::default()).unwrap();
 
     // Copy the image layers to different buffers to save them as individual images to disk.
     builder

--- a/examples/push-constants/main.rs
+++ b/examples/push-constants/main.rs
@@ -191,6 +191,7 @@ fn main() {
         },
     )
     .unwrap();
+
     builder
         .bind_pipeline_compute(pipeline.clone())
         .unwrap()
@@ -202,9 +203,12 @@ fn main() {
         )
         .unwrap()
         .push_constants(pipeline.layout().clone(), 0, push_constants)
-        .unwrap()
-        .dispatch([1024, 1, 1])
         .unwrap();
+
+    unsafe {
+        builder.dispatch([1024, 1, 1]).unwrap();
+    }
+
     let command_buffer = builder.end().unwrap();
 
     let future = sync::now(device)

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -419,6 +419,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -449,13 +450,15 @@ fn main() -> Result<(), impl Error> {
                     )
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -553,6 +553,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -576,13 +577,15 @@ fn main() -> Result<(), impl Error> {
                     )
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -358,6 +358,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -374,13 +375,15 @@ fn main() -> Result<(), impl Error> {
                     .bind_pipeline_graphics(graphics_pipeline.clone())
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/self-copy-buffer/main.rs
+++ b/examples/self-copy-buffer/main.rs
@@ -172,6 +172,7 @@ fn main() {
         },
     )
     .unwrap();
+
     builder
         // Copy from the first half to the second half (inside the same buffer) before we run the
         // computation.
@@ -194,9 +195,12 @@ fn main() {
             0,
             set,
         )
-        .unwrap()
-        .dispatch([1024, 1, 1])
         .unwrap();
+
+    unsafe {
+        builder.dispatch([1024, 1, 1]).unwrap();
+    }
+
     let command_buffer = builder.end().unwrap();
 
     let future = sync::now(device)

--- a/examples/shader-include/main.rs
+++ b/examples/shader-include/main.rs
@@ -177,6 +177,7 @@ fn main() {
         },
     )
     .unwrap();
+
     builder
         .bind_pipeline_compute(pipeline.clone())
         .unwrap()
@@ -186,9 +187,12 @@ fn main() {
             0,
             set,
         )
-        .unwrap()
-        .dispatch([1024, 1, 1])
         .unwrap();
+
+    unsafe {
+        builder.dispatch([1024, 1, 1]).unwrap();
+    }
+
     let command_buffer = builder.end().unwrap();
     let future = sync::now(device)
         .then_execute(queue, command_buffer)

--- a/examples/shader-types-sharing/main.rs
+++ b/examples/shader-types-sharing/main.rs
@@ -203,6 +203,7 @@ fn main() {
             },
         )
         .unwrap();
+
         builder
             .bind_pipeline_compute(pipeline.clone())
             .unwrap()
@@ -214,11 +215,13 @@ fn main() {
             )
             .unwrap()
             .push_constants(pipeline.layout().clone(), 0, parameters)
-            .unwrap()
-            .dispatch([1024, 1, 1])
             .unwrap();
-        let command_buffer = builder.end().unwrap();
 
+        unsafe {
+            builder.dispatch([1024, 1, 1]).unwrap();
+        }
+
+        let command_buffer = builder.end().unwrap();
         let future = sync::now(queue.device().clone())
             .then_execute(queue.clone(), command_buffer)
             .unwrap()

--- a/examples/specialization-constants/main.rs
+++ b/examples/specialization-constants/main.rs
@@ -178,6 +178,7 @@ fn main() {
         },
     )
     .unwrap();
+
     builder
         .bind_pipeline_compute(pipeline.clone())
         .unwrap()
@@ -187,9 +188,12 @@ fn main() {
             0,
             set,
         )
-        .unwrap()
-        .dispatch([1024, 1, 1])
         .unwrap();
+
+    unsafe {
+        builder.dispatch([1024, 1, 1]).unwrap();
+    }
+
     let command_buffer = builder.end().unwrap();
 
     let future = sync::now(device)

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -375,6 +375,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -401,13 +402,17 @@ fn main() -> Result<(), impl Error> {
                     .bind_vertex_buffers(0, (vertex_buffer.clone(), normals_buffer.clone()))
                     .unwrap()
                     .bind_index_buffer(index_buffer.clone())
-                    .unwrap()
-                    .draw_indexed(index_buffer.len() as u32, 1, 0, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder
+                        .draw_indexed(index_buffer.len() as u32, 1, 0, 0, 0)
+                        .unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -476,6 +476,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -492,13 +493,15 @@ fn main() -> Result<(), impl Error> {
                     .bind_pipeline_graphics(pipeline.clone())
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -443,6 +443,7 @@ fn main() -> Result<(), impl Error> {
                     },
                 )
                 .unwrap();
+
                 builder
                     .begin_render_pass(
                         RenderPassBeginInfo {
@@ -466,13 +467,15 @@ fn main() -> Result<(), impl Error> {
                     )
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    .draw(vertex_buffer.len() as u32, 3, 0, 0)
-                    .unwrap()
-                    .end_render_pass(Default::default())
                     .unwrap();
-                let command_buffer = builder.end().unwrap();
 
+                unsafe {
+                    builder.draw(vertex_buffer.len() as u32, 3, 0, 0).unwrap();
+                }
+
+                builder.end_render_pass(Default::default()).unwrap();
+
+                let command_buffer = builder.end().unwrap();
                 let future = previous_frame_end
                     .take()
                     .unwrap()

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -588,10 +588,10 @@ fn main() -> Result<(), impl Error> {
                     recreate_swapchain = true;
                 }
 
-                // In order to draw, we have to build a *command buffer*. The command buffer object
+                // In order to draw, we have to record a *command buffer*. The command buffer object
                 // holds the list of commands that are going to be executed.
                 //
-                // Building a command buffer is an expensive operation (usually a few hundred
+                // Recording a command buffer is an expensive operation (usually a few hundred
                 // microseconds), but it is known to be a hot path in the driver and is expected to
                 // be optimized.
                 //
@@ -645,15 +645,21 @@ fn main() -> Result<(), impl Error> {
                     .bind_pipeline_graphics(pipeline.clone())
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    // We add a draw command.
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
+                    .unwrap();
+
+                unsafe {
+                    builder
+                        // We add a draw command.
+                        .draw(vertex_buffer.len() as u32, 1, 0, 0)
+                        .unwrap();
+                }
+
+                builder
                     // We leave the render pass.
                     .end_rendering()
                     .unwrap();
 
-                // Finish building the command buffer by calling `build`.
+                // Finish recording the command buffer by calling `end`.
                 let command_buffer = builder.end().unwrap();
 
                 let future = previous_frame_end

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -591,10 +591,10 @@ fn main() -> Result<(), impl Error> {
                     recreate_swapchain = true;
                 }
 
-                // In order to draw, we have to build a *command buffer*. The command buffer object
+                // In order to draw, we have to record a *command buffer*. The command buffer object
                 // holds the list of commands that are going to be executed.
                 //
-                // Building a command buffer is an expensive operation (usually a few hundred
+                // Recording a command buffer is an expensive operation (usually a few hundred
                 // microseconds), but it is known to be a hot path in the driver and is expected to
                 // be optimized.
                 //
@@ -644,16 +644,22 @@ fn main() -> Result<(), impl Error> {
                     .bind_pipeline_graphics(pipeline.clone())
                     .unwrap()
                     .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap()
-                    // We add a draw command.
-                    .draw(vertex_buffer.len() as u32, 1, 0, 0)
-                    .unwrap()
+                    .unwrap();
+
+                unsafe {
+                    builder
+                        // We add a draw command.
+                        .draw(vertex_buffer.len() as u32, 1, 0, 0)
+                        .unwrap();
+                }
+
+                builder
                     // We leave the render pass. Note that if we had multiple subpasses we could
                     // have called `next_subpass` to jump to the next subpass.
                     .end_render_pass(Default::default())
                     .unwrap();
 
-                // Finish building the command buffer by calling `build`.
+                // Finish recording the command buffer by calling `end`.
                 let command_buffer = builder.end().unwrap();
 
                 let future = previous_frame_end

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -50,7 +50,14 @@ impl RecordingCommandBuffer {
     /// A compute pipeline must have been bound using
     /// [`bind_pipeline_compute`](Self::bind_pipeline_compute). Any resources used by the compute
     /// pipeline, such as descriptor sets, must have been set beforehand.
-    pub fn dispatch(&mut self, group_counts: [u32; 3]) -> Result<&mut Self, Box<ValidationError>> {
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements](crate::shader#safety) apply.
+    pub unsafe fn dispatch(
+        &mut self,
+        group_counts: [u32; 3],
+    ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_dispatch(group_counts)?;
 
         unsafe { Ok(self.dispatch_unchecked(group_counts)) }
@@ -116,7 +123,13 @@ impl RecordingCommandBuffer {
     /// A compute pipeline must have been bound using
     /// [`bind_pipeline_compute`](Self::bind_pipeline_compute). Any resources used by the compute
     /// pipeline, such as descriptor sets, must have been set beforehand.
-    pub fn dispatch_indirect(
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements](crate::shader#safety) apply.
+    /// - The [safety requirements for `DispatchIndirectCommand`](DispatchIndirectCommand#safety)
+    ///   apply.
+    pub unsafe fn dispatch_indirect(
         &mut self,
         indirect_buffer: Subbuffer<[DispatchIndirectCommand]>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -197,7 +210,11 @@ impl RecordingCommandBuffer {
     /// pipeline, such as descriptor sets, vertex buffers and dynamic state, must have been set
     /// beforehand. If the bound graphics pipeline uses vertex buffers, then the provided vertex and
     /// instance ranges must be in range of the bound vertex buffers.
-    pub fn draw(
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements](crate::shader#safety) apply.
+    pub unsafe fn draw(
         &mut self,
         vertex_count: u32,
         instance_count: u32,
@@ -384,7 +401,13 @@ impl RecordingCommandBuffer {
     /// beforehand. If the bound graphics pipeline uses vertex buffers, then the vertex and instance
     /// ranges of each `DrawIndirectCommand` in the indirect buffer must be in range of the bound
     /// vertex buffers.
-    pub fn draw_indirect(
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements](crate::shader#safety) apply.
+    /// - The [safety requirements for `DrawIndirectCommand`](DrawIndirectCommand#safety)
+    ///   apply.
+    pub unsafe fn draw_indirect(
         &mut self,
         indirect_buffer: Subbuffer<[DrawIndirectCommand]>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -489,7 +512,13 @@ impl RecordingCommandBuffer {
     /// beforehand. If the bound graphics pipeline uses vertex buffers, then the provided instance
     /// range must be in range of the bound vertex buffers. The vertex indices in the index buffer
     /// must be in range of the bound vertex buffers.
-    pub fn draw_indexed(
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements](crate::shader#safety) apply.
+    /// - All vertex numbers retrieved from the index buffer must fall within the range of
+    ///   the bound vertex-rate vertex buffers.
+    pub unsafe fn draw_indexed(
         &mut self,
         index_count: u32,
         instance_count: u32,
@@ -718,7 +747,13 @@ impl RecordingCommandBuffer {
     /// beforehand. If the bound graphics pipeline uses vertex buffers, then the instance ranges of
     /// each `DrawIndexedIndirectCommand` in the indirect buffer must be in range of the bound
     /// vertex buffers.
-    pub fn draw_indexed_indirect(
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements](crate::shader#safety) apply.
+    /// - The [safety requirements for `DrawIndexedIndirectCommand`](DrawIndexedIndirectCommand#safety)
+    ///   apply.
+    pub unsafe fn draw_indexed_indirect(
         &mut self,
         indirect_buffer: Subbuffer<[DrawIndexedIndirectCommand]>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1070,7 +1105,7 @@ impl RecordingCommandBuffer {
                                     is not equal to the view type required by the pipeline"
                                 )
                                 .into(),
-                                // vuids?
+                                vuids: vuids!(vuid_type, "viewType-07752"),
                                 ..Default::default()
                             }));
                         }
@@ -1147,7 +1182,7 @@ impl RecordingCommandBuffer {
                                     `{view_numeric_type:?}` numeric type"
                                 )
                                 .into(),
-                                // vuids?
+                                vuids: vuids!(vuid_type, "format-07753"),
                                 ..Default::default()
                             }));
                         }
@@ -1196,7 +1231,7 @@ impl RecordingCommandBuffer {
                                     sampler YCbCr conversion"
                                 )
                                 .into(),
-                                // vuids?
+                                vuids: vuids!(vuid_type, "None-06550", "ConstOffset-06551"),
                                 ..Default::default()
                             }));
                         }

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -115,6 +115,11 @@ use crate::{
     },
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError,
 };
+#[cfg(doc)]
+use crate::{
+    device::{Features, Properties},
+    pipeline::graphics::vertex_input::VertexInputRate,
+};
 use ahash::HashMap;
 use bytemuck::{Pod, Zeroable};
 use std::{ops::Range, sync::Arc};
@@ -126,6 +131,35 @@ pub mod pool;
 pub mod sys;
 mod traits;
 
+/// Used as buffer contents to provide input for the
+/// [`RecordingCommandBuffer::dispatch_indirect`] command.
+///
+/// # Safety
+///
+/// - The `x`, `y` and `z` values must not be greater than the respective elements of the
+/// [`:max_compute_work_group_count`](Properties::max_compute_work_group_count) device limit.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
+pub struct DispatchIndirectCommand {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+}
+
+/// Used as buffer contents to provide input for the
+/// [`RecordingCommandBuffer::draw_indirect`] command.
+///
+/// # Safety
+///
+/// - All vertex numbers within the specified range must fall within the range of
+///   the bound vertex-rate vertex buffers.
+/// - All instance numbers within the specified range must fall within the range of
+///   the bound instance-rate vertex buffers.
+/// - If the [`draw_indirect_first_instance`](Features::draw_indirect_first_instance) feature
+///   is not enabled, then `first_instance` must be `0`.
+/// - If an [instance divisor](VertexInputRate::Instance) other than 1 is used, and
+///   the [`supports_non_zero_first_instance`](Properties::supports_non_zero_first_instance)
+///   device property is `false`, then `first_instance` must be `0`.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
 pub struct DrawIndirectCommand {
@@ -135,6 +169,21 @@ pub struct DrawIndirectCommand {
     pub first_instance: u32,
 }
 
+/// Used as buffer contents to provide input for the
+/// [`RecordingCommandBuffer::draw_indexed_indirect`] command.
+///
+/// # Safety
+///
+/// - All indexes within the specified range must fall within the range of the bound index buffer.
+/// - All vertex numbers retrieved from the index buffer must fall within the range of
+///   the bound vertex-rate vertex buffers.
+/// - All instance numbers within the specified range must fall within the range of
+///   the bound instance-rate vertex buffers.
+/// - If the [`draw_indirect_first_instance`](Features::draw_indirect_first_instance) feature
+///   is not enabled, then `first_instance` must be `0`.
+/// - If an [instance divisor](VertexInputRate::Instance) other than 1 is used, and
+///   the [`supports_non_zero_first_instance`](Properties::supports_non_zero_first_instance)
+///   device property is `false`, then `first_instance` must be `0`.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
 pub struct DrawIndexedIndirectCommand {
@@ -143,14 +192,6 @@ pub struct DrawIndexedIndirectCommand {
     pub first_index: u32,
     pub vertex_offset: u32,
     pub first_instance: u32,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
-pub struct DispatchIndirectCommand {
-    pub x: u32,
-    pub y: u32,
-    pub z: u32,
 }
 
 vulkan_enum! {

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -567,6 +567,7 @@ mod tests {
             },
         )
         .unwrap();
+
         cbb.bind_pipeline_compute(pipeline.clone())
             .unwrap()
             .bind_descriptor_sets(
@@ -575,9 +576,12 @@ mod tests {
                 0,
                 set,
             )
-            .unwrap()
-            .dispatch([1, 1, 1])
             .unwrap();
+
+        unsafe {
+            cbb.dispatch([1, 1, 1]).unwrap();
+        }
+
         let cb = cbb.end().unwrap();
 
         let future = now(device)
@@ -718,6 +722,7 @@ mod tests {
             },
         )
         .unwrap();
+
         cbb.bind_pipeline_compute(pipeline.clone())
             .unwrap()
             .bind_descriptor_sets(
@@ -726,9 +731,12 @@ mod tests {
                 0,
                 set,
             )
-            .unwrap()
-            .dispatch([128, 1, 1])
             .unwrap();
+
+        unsafe {
+            cbb.dispatch([128, 1, 1]).unwrap();
+        }
+
         let cb = cbb.end().unwrap();
 
         let future = now(device)


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to draw/dispatch commands:
- These are now `unsafe`, as the shader can perform invalid operations outside of Vulkano's control.

### Additions
- Documented the safety requirements of shaders in the `shader` module.
````
