### PR TITLE
Add support for the `ext_mesh_shader` extension

### DIFF
--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -173,6 +173,31 @@ pub struct DrawIndirectCommand {
 }
 
 /// Used as buffer contents to provide input for the
+/// [`RecordingCommandBuffer::draw_mesh_tasks_indirect`] command.
+///
+/// # Safety
+///
+/// - If the graphics pipeline **does not** include a task shader, then the
+///   `group_count_x`, `group_count_y` and `group_count_z` values must not be greater than the
+///   respective elements of the
+///   [`max_mesh_work_group_count`](Properties::max_mesh_work_group_count) device limit,
+///   and the product of these three values must not be greater than the
+///   [`max_mesh_work_group_total_count`](Properties::max_mesh_work_group_total_count) device limit.
+/// - If the graphics pipeline **does** include a task shader, then the
+///   `group_count_x`, `group_count_y` and `group_count_z` values must not be greater than the
+///   respective elements of the
+///   [`max_task_work_group_count`](Properties::max_task_work_group_count) device limit,
+///   and the product of these three values must not be greater than the
+///   [`max_task_work_group_total_count`](Properties::max_task_work_group_total_count) device limit.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
+pub struct DrawMeshTasksIndirectCommand {
+    pub group_count_x: u32,
+    pub group_count_y: u32,
+    pub group_count_z: u32,
+}
+
+/// Used as buffer contents to provide input for the
 /// [`RecordingCommandBuffer::draw_indexed_indirect`] command.
 ///
 /// # Safety

--- a/vulkano/src/pipeline/shader.rs
+++ b/vulkano/src/pipeline/shader.rs
@@ -74,8 +74,8 @@ impl PipelineShaderStageCreateInfo {
                 .set_vuids(&["VUID-VkPipelineShaderStageCreateInfo-flags-parameter"])
         })?;
 
-        let entry_point_info = entry_point.info();
-        let stage_enum = ShaderStage::from(entry_point_info.execution_model);
+        let execution_model = entry_point.info().execution_model;
+        let stage_enum = ShaderStage::from(execution_model);
 
         stage_enum.validate_device(device).map_err(|err| {
             err.add_context("entry_point.info().execution")
@@ -144,18 +144,6 @@ impl PipelineShaderStageCreateInfo {
             ShaderStage::Miss => (),
             ShaderStage::Intersection => (),
             ShaderStage::Callable => (),
-            ShaderStage::Task => {
-                if !device.enabled_features().task_shader {
-                    return Err(Box::new(ValidationError {
-                        context: "entry_point".into(),
-                        problem: "specifies a `ShaderStage::Task` entry point".into(),
-                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
-                            "task_shader",
-                        )])]),
-                        vuids: &["VUID-VkPipelineShaderStageCreateInfo-stage-02092"],
-                    }));
-                }
-            }
             ShaderStage::Mesh => {
                 if !device.enabled_features().mesh_shader {
                     return Err(Box::new(ValidationError {
@@ -165,6 +153,18 @@ impl PipelineShaderStageCreateInfo {
                             "mesh_shader",
                         )])]),
                         vuids: &["VUID-VkPipelineShaderStageCreateInfo-stage-02091"],
+                    }));
+                }
+            }
+            ShaderStage::Task => {
+                if !device.enabled_features().task_shader {
+                    return Err(Box::new(ValidationError {
+                        context: "entry_point".into(),
+                        problem: "specifies a `ShaderStage::Task` entry point".into(),
+                        requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::Feature(
+                            "task_shader",
+                        )])]),
+                        vuids: &["VUID-VkPipelineShaderStageCreateInfo-stage-02092"],
                     }));
                 }
             }


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Support for the `ext_mesh_shader` extension.
````

This adds full mesh shader support for the EXT mesh shader extension. If we do want to support the NV version, that could be a little trickier, because it has its own `draw_mesh_tasks*` commands, which must be matched with the type of mesh and task shader. In other words, calling the EXT command requires EXT mesh shaders, and calling the NV command requires NV mesh shaders. Right now, the commands at least check to make sure you're using EXT mesh shaders. Other than the commands, NV mesh shaders are already handled properly so the commands are the only thing left, if we want to do it.

One item is still missing: `VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT`. I think this is better left to a separate PR because there is a non-mesh-shading equivalent to this as well that we're still missing, and they are better handled together.

I haven't added an example that uses mesh shaders, as I don't really fully know how they're supposed to be used. This is something we definitely want. Perhaps a mesh-shaderfied version of the triangle example to demonstrate the differences, and then a more elaborate example using task shaders as well?