### PR TITLE
vulkan-utils -> vulkan-tools README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Use your package manager to install the required dev-tools and Vulkan drivers
 
 For example on ubuntu:
 ```
-sudo apt-get install build-essential git python cmake libvulkan-dev vulkan-utils
+sudo apt-get install build-essential git python cmake libvulkan-dev vulkan-tools
 ```
 On arch based system
 ```


### PR DESCRIPTION
There is no `vulkan-utils` package in current Ubuntu repos. But there used to be one in ubuntu 20.04, which was a compatibility alias for the `vulkan-tools` package that is still around. So I guess you meant `vulkan-tools`?