### PR TITLE
Add Minimal Offscreen Rendering Example

### DIFF
--- a/examples/offscreen/Cargo.toml
+++ b/examples/offscreen/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "offscreen"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "offscreen"
+path = "main.rs"
+test = false
+bench = false
+doc = false
+
+[dependencies]
+vulkano = { workspace = true, features = ["macros"]  }
+vulkano-shaders = { workspace = true }
+winit = { workspace = true }
+anyhow = "1.0.79"
+image = "0.24.7"

--- a/examples/offscreen/Cargo.toml
+++ b/examples/offscreen/Cargo.toml
@@ -15,5 +15,4 @@ doc = false
 vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true }
-anyhow = "1.0.79"
-image = "0.24.7"
+png = { workspace = true }

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -1,5 +1,5 @@
-// Offscreen rendering example, renders a blue and red triangle to a buffer in memory then exports
-// to a PNG. No swapchains here!
+// Offscreen rendering example, renders a red triangle on a blue background to a buffer in memory
+// then exports to a PNG. No swapchains here!
 use std::{default::Default, fs::File, io::BufWriter, path::Path, sync::Arc};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},


### PR DESCRIPTION
Adds a minimal offscreen rendering example. I spent a few hours stuck on a bug adapting the triangle example before getting here. I hope this will help fill in the mental model of vulkan for future readers by providing a minimal starting point without the complexity of swapchains.

![triangle](https://github.com/vulkano-rs/vulkano/assets/3277097/bf19d140-b6fa-45b6-a0ca-0bc08876d971)

Changelog:
```markdown
### Public dependency updates

### Breaking changes

### Additions

* Add an example for offscreen rendering

### Bugs fixed
````
