### PR TITLE
Add support for querying memory requirements directly from the device

### DIFF
--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -108,13 +108,11 @@ impl RawBuffer {
         let mut external_memory_info_vk = None;
 
         if !external_memory_handle_types.is_empty() {
-            let _ = external_memory_info_vk.insert(ash::vk::ExternalMemoryBufferCreateInfo {
+            let next = external_memory_info_vk.insert(ash::vk::ExternalMemoryBufferCreateInfo {
                 handle_types: external_memory_handle_types.into(),
                 ..Default::default()
             });
-        }
 
-        if let Some(next) = external_memory_info_vk.as_mut() {
             next.p_next = create_info_vk.p_next;
             create_info_vk.p_next = next as *const _ as *const _;
         }

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -2619,7 +2619,7 @@ impl ImageCreateInfo {
             if format.planes().len() < 2 {
                 return Err(Box::new(ValidationError {
                     problem: "`flags` contains `ImageCreateFlags::DISJOINT`, but `format` \
-                        is not a multi-planat format"
+                        is not a multi-planar format"
                         .into(),
                     vuids: &["VUID-VkImageCreateInfo-format-01577"],
                     ..Default::default()


### PR DESCRIPTION
Changelog:
```markdown
### Additions
- Support for querying memory requirements directly from the device.
````

This adds two of the functions from the `khr_maintenance4` extension. I've left out the third (sparse memory requirements) to be added when sparse memory is properly implemented.