### PR TITLE
Fix alignment checks when allocating buffers

### DIFF
--- a/vulkano/src/buffer/allocator.rs
+++ b/vulkano/src/buffer/allocator.rs
@@ -252,13 +252,7 @@ where
     }
 
     /// Allocates a subbuffer with the given `layout`.
-    ///
-    /// # Panics
-    ///
-    /// - Panics if `layout.alignment()` exceeds `64`.
     pub fn allocate(&self, layout: DeviceLayout) -> Result<Subbuffer<[u8]>, MemoryAllocatorError> {
-        assert!(layout.alignment().as_devicesize() <= 64);
-
         unsafe { &mut *self.state.get() }.allocate(layout)
     }
 }

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -376,14 +376,12 @@ impl Buffer {
     /// # Panics
     ///
     /// - Panics if `create_info.size` is not zero.
-    /// - Panics if `layout.alignment()` is greater than 64.
     pub fn new(
         allocator: Arc<dyn MemoryAllocator>,
         mut create_info: BufferCreateInfo,
         allocation_info: AllocationCreateInfo,
         layout: DeviceLayout,
     ) -> Result<Arc<Self>, Validated<AllocateBufferError>> {
-        assert!(layout.alignment().as_devicesize() <= 64);
         // TODO: Enable once sparse binding materializes
         // assert!(!allocate_info.flags.contains(BufferCreateFlags::SPARSE_BINDING));
 

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -300,6 +300,8 @@ where
     /// [`SubbufferAllocator`]: super::allocator::SubbufferAllocator
     /// [`RawBuffer::assume_bound`]: crate::buffer::sys::RawBuffer::assume_bound
     pub fn read(&self) -> Result<BufferReadGuard<'_, T>, HostAccessError> {
+        assert!(T::LAYOUT.alignment().as_devicesize() <= 64);
+
         let allocation = match self.buffer().memory() {
             BufferMemory::Normal(a) => a,
             BufferMemory::Sparse => todo!("`Subbuffer::read` doesn't support sparse binding yet"),
@@ -391,6 +393,8 @@ where
     /// [`SubbufferAllocator`]: super::allocator::SubbufferAllocator
     /// [`RawBuffer::assume_bound`]: crate::buffer::sys::RawBuffer::assume_bound
     pub fn write(&self) -> Result<BufferWriteGuard<'_, T>, HostAccessError> {
+        assert!(T::LAYOUT.alignment().as_devicesize() <= 64);
+
         let allocation = match self.buffer().memory() {
             BufferMemory::Normal(a) => a,
             BufferMemory::Sparse => todo!("`Subbuffer::write` doesn't support sparse binding yet"),


### PR DESCRIPTION
Reported by @YouSafe on Discord.

Changelog:
```markdown
### Bugs fixed
- Fixed the alignment check when (sub)allocating buffers that would limit the alignment to 64 at maximum, even though some applications might need buffers with higher alignments that aren't read/written by the host. The check is now only present when reading/writing a buffer.
```