### PR TITLE
vulkano-shaders: support `glam` as a linear algebra backend

### DIFF
--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -188,6 +188,7 @@
 //!
 //! - `std`
 //! - `cgmath`
+//! - `glam`
 //! - `nalgebra`
 //!
 //! The default is `std`, which uses arrays to represent vectors and matrices. Note that if the
@@ -681,8 +682,12 @@ impl Parse for MacroInput {
                     linalg_type = Some(match lit.value().as_str() {
                         "std" => LinAlgType::Std,
                         "cgmath" => LinAlgType::CgMath,
+                        "glam" => LinAlgType::Glam,
                         "nalgebra" => LinAlgType::Nalgebra,
-                        ty => bail!(lit, "expected `std`, `cgmath` or `nalgebra`, found `{ty}`"),
+                        ty => bail!(
+                            lit,
+                            "expected `std`, `cgmath`, `glam` or `nalgebra`, found `{ty}`"
+                        ),
                     });
                 }
                 "dump" => {
@@ -749,6 +754,7 @@ enum LinAlgType {
     #[default]
     Std,
     CgMath,
+    Glam,
     Nalgebra,
 }
 


### PR DESCRIPTION
Fixes #2478.

1. [ ] Update documentation to reflect any user-facing changes - in this repository.

2. [ ] Make sure that the changes are covered by unit-tests.

3. [ ] Run `cargo clippy` on the changes.

4. [ ] Run `cargo +nightly fmt` on the changes.

5. [ ] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [ ] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Additions
- Support for `linalg_type: "nalgebra"`.
````
