### PR TITLE
Add `DepthState::reverse` helper method

### DIFF
--- a/vulkano/src/pipeline/graphics/depth_stencil.rs
+++ b/vulkano/src/pipeline/graphics/depth_stencil.rs
@@ -216,6 +216,15 @@ impl DepthState {
         }
     }
 
+    /// Returns a `DepthState` with a `Greater` depth test and depth writes enabled.
+    #[inline]
+    pub fn reverse() -> Self {
+        Self {
+            compare_op: CompareOp::Greater,
+            write_enable: true,
+        }
+    }
+
     pub(crate) fn validate(self, device: &Device) -> Result<(), Box<ValidationError>> {
         let Self {
             write_enable: _,


### PR DESCRIPTION
Add `DepthState::reverse` as an alternative for `DepthState::simple` with a suitable comparison for a reverse depth buffer (ranging from the farthest level 0 to the nearest point 1)

---

1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [ ] Make sure that the changes are covered by unit-tests. _Not needed? I don't see tests for `DepthState::simple` either..._

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Additions
- Add `DepthState::reverse` helper method.
````
