### PR TITLE
Rewrite `VertexDefinition`

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -432,9 +432,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = MyVertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/buffer-allocator/main.rs
+++ b/examples/buffer-allocator/main.rs
@@ -222,9 +222,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/deferred/frame/ambient_lighting_system.rs
+++ b/examples/deferred/frame/ambient_lighting_system.rs
@@ -87,9 +87,7 @@ impl AmbientLightingSystem {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
-            let vertex_input_state = LightingVertex::per_vertex()
-                .definition(&vs.info().input_interface)
-                .unwrap();
+            let vertex_input_state = LightingVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(vs),
                 PipelineShaderStageCreateInfo::new(fs),

--- a/examples/deferred/frame/directional_lighting_system.rs
+++ b/examples/deferred/frame/directional_lighting_system.rs
@@ -88,9 +88,7 @@ impl DirectionalLightingSystem {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
-            let vertex_input_state = LightingVertex::per_vertex()
-                .definition(&vs.info().input_interface)
-                .unwrap();
+            let vertex_input_state = LightingVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(vs),
                 PipelineShaderStageCreateInfo::new(fs),

--- a/examples/deferred/frame/point_lighting_system.rs
+++ b/examples/deferred/frame/point_lighting_system.rs
@@ -87,9 +87,7 @@ impl PointLightingSystem {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
-            let vertex_input_state = LightingVertex::per_vertex()
-                .definition(&vs.info().input_interface)
-                .unwrap();
+            let vertex_input_state = LightingVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(vs),
                 PipelineShaderStageCreateInfo::new(fs),

--- a/examples/deferred/triangle_draw_system.rs
+++ b/examples/deferred/triangle_draw_system.rs
@@ -77,9 +77,7 @@ impl TriangleDrawSystem {
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
-            let vertex_input_state = TriangleVertex::per_vertex()
-                .definition(&vs.info().input_interface)
-                .unwrap();
+            let vertex_input_state = TriangleVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(vs),
                 PipelineShaderStageCreateInfo::new(fs),

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -694,9 +694,7 @@ mod linux {
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let vertex_input_state = MyVertex::per_vertex()
-                .definition(&vs.info().input_interface)
-                .unwrap();
+            let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(vs),
                 PipelineShaderStageCreateInfo::new(fs),

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -343,9 +343,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -290,9 +290,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -296,9 +296,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -314,9 +314,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -290,7 +290,7 @@ fn main() -> Result<(), impl Error> {
             .entry_point("main")
             .unwrap();
         let vertex_input_state = [TriangleVertex::per_vertex(), InstanceData::per_instance()]
-            .definition(&vs.info().input_interface)
+            .definition(&vs)
             .unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -313,9 +313,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/multi-window/main.rs
+++ b/examples/multi-window/main.rs
@@ -259,9 +259,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/multiview/main.rs
+++ b/examples/multiview/main.rs
@@ -260,9 +260,7 @@ fn main() {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/occlusion-query/main.rs
+++ b/examples/occlusion-query/main.rs
@@ -300,9 +300,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -206,9 +206,7 @@ fn main() {
             .entry_point("main")
             .unwrap();
 
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
 
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -281,9 +281,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -400,9 +400,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -187,9 +187,7 @@ fn main() -> Result<(), impl Error> {
             module.entry_point("main").unwrap()
         };
 
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -460,9 +460,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -497,7 +497,7 @@ fn window_size_dependent_setup(
     // https://computergraphics.stackexchange.com/questions/5742/vulkan-best-way-of-updating-pipeline-viewport
     let pipeline = {
         let vertex_input_state = [Position::per_vertex(), Normal::per_vertex()]
-            .definition(&vs.info().input_interface)
+            .definition(&vs)
             .unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -340,9 +340,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(tcs),

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -301,9 +301,7 @@ fn main() -> Result<(), impl Error> {
             .unwrap()
             .entry_point("main")
             .unwrap();
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(vs),
             PipelineShaderStageCreateInfo::new(fs),

--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -197,9 +197,7 @@ fn main() -> Result<(), impl Error> {
 
         // Automatically generate a vertex input state from the vertex shader's input interface,
         // that takes a single vertex buffer containing `Vertex` structs.
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
 
         // Make a list of the shader stages that the pipeline will have.
         let stages = [

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -385,9 +385,7 @@ fn main() -> Result<(), impl Error> {
 
         // Automatically generate a vertex input state from the vertex shader's input interface,
         // that takes a single vertex buffer containing `Vertex` structs.
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
 
         // Make a list of the shader stages that the pipeline will have.
         let stages = [

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -390,9 +390,7 @@ fn main() -> Result<(), impl Error> {
 
         // Automatically generate a vertex input state from the vertex shader's input interface,
         // that takes a single vertex buffer containing `Vertex` structs.
-        let vertex_input_state = Vertex::per_vertex()
-            .definition(&vs.info().input_interface)
-            .unwrap();
+        let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
 
         // Make a list of the shader stages that the pipeline will have.
         let stages = [

--- a/vulkano-macros/src/derive_vertex.rs
+++ b/vulkano-macros/src/derive_vertex.rs
@@ -61,7 +61,7 @@ pub fn derive_vertex(crate_ident: &Ident, ast: syn::DeriveInput) -> Result<Token
 
                     let field_size = ::std::mem::size_of::<#field_ty>();
                     let format = #format;
-                    let format_size = format.block_size() as usize;
+                    let format_size = usize::try_from(format.block_size()).unwrap();
                     let num_elements = field_size / format_size;
                     let remainder = field_size % format_size;
                     ::std::assert!(
@@ -76,6 +76,7 @@ pub fn derive_vertex(crate_ident: &Ident, ast: syn::DeriveInput) -> Result<Token
                             offset: offset.try_into().unwrap(),
                             format,
                             num_elements: num_elements.try_into().unwrap(),
+                            stride: format_size.try_into().unwrap(),
                         },
                     );
 

--- a/vulkano/autogen/formats.rs
+++ b/vulkano/autogen/formats.rs
@@ -144,6 +144,19 @@ fn formats_output(members: &[FormatMember]) -> TokenStream {
             }
         },
     );
+    let locations_items = members.iter().filter_map(
+        |FormatMember {
+             name, components, ..
+         }| {
+            if components.starts_with(&[64, 64, 64]) {
+                Some(quote! {
+                    Self::#name => 2,
+                })
+            } else {
+                None
+            }
+        },
+    );
     let compression_items = members.iter().filter_map(
         |FormatMember {
              name, compression, ..
@@ -416,6 +429,15 @@ fn formats_output(members: &[FormatMember]) -> TokenStream {
             pub fn components(self) -> [u8; 4] {
                 match self {
                     #(#components_items)*
+                }
+            }
+
+            /// Returns the number of shader input/output locations that a single element of this
+            /// format takes up.
+            pub fn locations(self) -> u32 {
+                match self {
+                    #(#locations_items)*
+                    _ => 1,
                 }
             }
 

--- a/vulkano/src/pipeline/graphics/vertex_input/buffers.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/buffers.rs
@@ -1,7 +1,7 @@
-use super::VertexBufferDescription;
+use super::{definition::VertexDefinition, VertexBufferDescription};
 use crate::{
-    pipeline::graphics::vertex_input::{Vertex, VertexDefinition, VertexInputState},
-    shader::ShaderInterface,
+    pipeline::graphics::vertex_input::{Vertex, VertexInputState},
+    shader::EntryPoint,
     ValidationError,
 };
 
@@ -55,8 +55,8 @@ unsafe impl VertexDefinition for BuffersDefinition {
     #[inline]
     fn definition(
         &self,
-        interface: &ShaderInterface,
+        entry_point: &EntryPoint,
     ) -> Result<VertexInputState, Box<ValidationError>> {
-        self.0.definition(interface)
+        self.0.definition(entry_point)
     }
 }

--- a/vulkano/src/pipeline/graphics/vertex_input/definition.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/definition.rs
@@ -1,17 +1,30 @@
 use super::{
     VertexBufferDescription, VertexInputAttributeDescription, VertexInputBindingDescription,
+    VertexMemberInfo,
 };
 use crate::{
-    pipeline::graphics::vertex_input::VertexInputState, shader::ShaderInterface, DeviceSize,
+    pipeline::{
+        graphics::vertex_input::VertexInputState,
+        inout_interface::{
+            input_output_map, InputOutputData, InputOutputKey, InputOutputUserKey,
+            InputOutputVariableBlock,
+        },
+    },
+    shader::{
+        spirv::{ExecutionModel, Instruction, StorageClass},
+        EntryPoint,
+    },
     ValidationError,
 };
+use ahash::HashMap;
+use std::{borrow::Cow, collections::hash_map::Entry};
 
-/// Trait for types that can create a [`VertexInputState`] from a [`ShaderInterface`].
+/// Trait for types that can create a [`VertexInputState`] from an [`EntryPoint`].
 pub unsafe trait VertexDefinition {
-    /// Builds the `VertexInputState` for the provided `interface`.
+    /// Builds the `VertexInputState` for the provided `entry_point`.
     fn definition(
         &self,
-        interface: &ShaderInterface,
+        entry_point: &EntryPoint,
     ) -> Result<VertexInputState, Box<ValidationError>>;
 }
 
@@ -19,89 +32,198 @@ unsafe impl VertexDefinition for &[VertexBufferDescription] {
     #[inline]
     fn definition(
         &self,
-        interface: &ShaderInterface,
+        entry_point: &EntryPoint,
     ) -> Result<VertexInputState, Box<ValidationError>> {
-        let bindings = self.iter().enumerate().map(|(binding, buffer)| {
-            (
-                binding as u32,
-                VertexInputBindingDescription {
-                    stride: buffer.stride,
-                    input_rate: buffer.input_rate,
-                    ..Default::default()
-                },
-            )
-        });
-        let mut attributes: Vec<(u32, VertexInputAttributeDescription)> = Vec::new();
+        let spirv = entry_point.module().spirv();
+        let Some(&Instruction::EntryPoint {
+            execution_model,
+            ref interface,
+            ..
+        }) = spirv.function(entry_point.id()).entry_point()
+        else {
+            unreachable!()
+        };
 
-        for element in interface.elements() {
-            let name = element.name.as_ref().unwrap();
-
-            let (infos, binding) = self
-                .iter()
-                .enumerate()
-                .find_map(|(binding, buffer)| {
-                    buffer
-                        .members
-                        .get(name.as_ref())
-                        .map(|infos| (infos.clone(), binding as u32))
-                })
-                .ok_or_else(|| {
-                    Box::new(ValidationError {
-                        problem: format!(
-                            "the shader interface contains a variable named \"{}\", \
-                        but no such attribute exists in the vertex definition",
-                            name,
-                        )
-                        .into(),
-                        ..Default::default()
-                    })
-                })?;
-
-            // TODO: ShaderInterfaceEntryType does not properly support 64bit.
-            //       Once it does the below logic around num_elements and num_locations
-            //       might have to be updated.
-            if infos.num_components() != element.ty.num_components
-                || infos.num_elements != element.ty.num_locations()
-            {
-                return Err(Box::new(ValidationError {
-                    problem: format!(
-                        "for the variable \"{}\", the number of locations and components \
-                        required by the shader don't match the number of locations and components \
-                        of the type provided in the vertex definition",
-                        name,
-                    )
-                    .into(),
-                    ..Default::default()
-                }));
-            }
-
-            let mut offset = infos.offset as DeviceSize;
-            let block_size = infos.format.block_size();
-            // Double precision formats can exceed a single location.
-            // R64B64G64A64_SFLOAT requires two locations, so we need to adapt how we bind
-            let location_range = if block_size > 16 {
-                (element.location..element.location + 2 * element.ty.num_locations()).step_by(2)
-            } else {
-                (element.location..element.location + element.ty.num_locations()).step_by(1)
-            };
-
-            for location in location_range {
-                attributes.push((
-                    location,
-                    VertexInputAttributeDescription {
-                        binding,
-                        format: infos.format,
-                        offset: offset as u32,
-                        ..Default::default()
-                    },
-                ));
-                offset += block_size;
-            }
+        if execution_model != ExecutionModel::Vertex {
+            return Err(Box::new(ValidationError {
+                context: "entry_point".into(),
+                problem: "is not a vertex shader".into(),
+                ..Default::default()
+            }));
         }
 
-        Ok(VertexInputState::new()
-            .bindings(bindings)
-            .attributes(attributes))
+        let bindings = self
+            .iter()
+            .enumerate()
+            .map(|(binding, buffer_description)| {
+                let &VertexBufferDescription {
+                    members: _,
+                    stride,
+                    input_rate,
+                } = buffer_description;
+
+                (
+                    binding.try_into().unwrap(),
+                    VertexInputBindingDescription {
+                        stride,
+                        input_rate,
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+        let mut attributes: HashMap<u32, VertexInputAttributeDescription> = HashMap::default();
+
+        for variable_id in interface.iter().copied() {
+            input_output_map(
+                spirv,
+                execution_model,
+                variable_id,
+                StorageClass::Input,
+                |key, data| -> Result<(), Box<ValidationError>> {
+                    let InputOutputKey::User(key) = key else {
+                        return Ok(());
+                    };
+                    let InputOutputUserKey {
+                        mut location,
+                        component,
+                        index: _,
+                    } = key;
+
+                    // TODO: can we make this work somehow?
+                    if component != 0 {
+                        return Err(Box::new(ValidationError {
+                            problem: format!(
+                                "the shader interface contains an input variable (location {}) \
+                                with a non-zero component decoration ({}), which is not yet \
+                                supported by `VertexDefinition` in Vulkano",
+                                location, component,
+                            )
+                            .into(),
+                            ..Default::default()
+                        }));
+                    }
+
+                    let InputOutputData {
+                        variable_id,
+                        pointer_type_id: _,
+                        block,
+                        type_id: _,
+                    } = data;
+
+                    // Find the name of the variable defined in the shader,
+                    // or use a default placeholder.
+                    let names = if let Some(block) = block {
+                        let InputOutputVariableBlock {
+                            type_id,
+                            member_index,
+                        } = block;
+
+                        spirv.id(type_id).members()[member_index].names()
+                    } else {
+                        spirv.id(variable_id).names()
+                    };
+                    let name = names
+                        .iter()
+                        .find_map(|instruction| match *instruction {
+                            Instruction::Name { ref name, .. }
+                            | Instruction::MemberName { ref name, .. } => {
+                                Some(Cow::Borrowed(name.as_str()))
+                            }
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| Cow::Owned(format!("vertex_input_{}", location)));
+
+                    // Find a vertex member whose name matches the one in the shader.
+                    let (vertex_member_info, binding) = self
+                        .iter()
+                        .enumerate()
+                        .find_map(|(binding, buffer)| {
+                            buffer
+                                .members
+                                .get(name.as_ref())
+                                .map(|info| (info, binding.try_into().unwrap()))
+                        })
+                        .ok_or_else(|| {
+                            Box::new(ValidationError {
+                                problem: format!(
+                                    "the shader interface contains an input variable named \"{}\" \
+                                    (location {}, component {}), but no such attribute exists in \
+                                    the vertex definition",
+                                    name, location, component,
+                                )
+                                .into(),
+                                ..Default::default()
+                            })
+                        })?;
+
+                    let &VertexMemberInfo {
+                        mut offset,
+                        format,
+                        num_elements,
+                        mut stride,
+                    } = vertex_member_info;
+
+                    let locations_per_element;
+
+                    if num_elements > 1 {
+                        locations_per_element = format.locations();
+
+                        if u64::from(stride) < format.block_size() {
+                            return Err(Box::new(ValidationError {
+                                problem: format!(
+                                    "in the vertex member named \"{}\" in buffer {}, the `stride` is \
+                                    less than the block size of `format`",
+                                    name, binding,
+                                )
+                                .into(),
+                                ..Default::default()
+                            }));
+                        }
+                    } else {
+                        stride = 0;
+                        locations_per_element = 0;
+                    }
+
+                    // Add an attribute description for every element in the member.
+                    for _ in 0..num_elements {
+                        match attributes.entry(location) {
+                            Entry::Occupied(_) => {
+                                return Err(Box::new(ValidationError {
+                                    problem: format!(
+                                        "the vertex definition specifies a variable at \
+                                        location {}, but that location is already occupied by \
+                                        another variable",
+                                        location,
+                                    )
+                                    .into(),
+                                    ..Default::default()
+                                }));
+                            }
+                            Entry::Vacant(entry) => {
+                                entry.insert(VertexInputAttributeDescription {
+                                    binding,
+                                    format,
+                                    offset,
+                                    ..Default::default()
+                                });
+                            }
+                        }
+
+                        location = location.checked_add(locations_per_element).unwrap();
+                        offset = offset.checked_add(stride).unwrap();
+                    }
+
+                    Ok(())
+                },
+            )?;
+        }
+
+        Ok(VertexInputState {
+            bindings,
+            attributes,
+            ..Default::default()
+        })
     }
 }
 
@@ -109,9 +231,9 @@ unsafe impl<const N: usize> VertexDefinition for [VertexBufferDescription; N] {
     #[inline]
     fn definition(
         &self,
-        interface: &ShaderInterface,
+        entry_point: &EntryPoint,
     ) -> Result<VertexInputState, Box<ValidationError>> {
-        self.as_slice().definition(interface)
+        self.as_slice().definition(entry_point)
     }
 }
 
@@ -119,9 +241,9 @@ unsafe impl VertexDefinition for Vec<VertexBufferDescription> {
     #[inline]
     fn definition(
         &self,
-        interface: &ShaderInterface,
+        entry_point: &EntryPoint,
     ) -> Result<VertexInputState, Box<ValidationError>> {
-        self.as_slice().definition(interface)
+        self.as_slice().definition(entry_point)
     }
 }
 
@@ -129,8 +251,8 @@ unsafe impl VertexDefinition for VertexBufferDescription {
     #[inline]
     fn definition(
         &self,
-        interface: &ShaderInterface,
+        entry_point: &EntryPoint,
     ) -> Result<VertexInputState, Box<ValidationError>> {
-        std::slice::from_ref(self).definition(interface)
+        std::slice::from_ref(self).definition(entry_point)
     }
 }

--- a/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
@@ -57,9 +57,10 @@ macro_rules! impl_vertex {
                         let member_ptr = (&dummy.$member) as *const _;
 
                         members.insert(stringify!($member).to_string(), VertexMemberInfo {
-                            offset: member_ptr as usize - dummy_ptr as usize,
+                            offset: u32::try_from(member_ptr as usize - dummy_ptr as usize).unwrap(),
                             format,
                             num_elements,
+                            stride: format_size,
                         });
                     }
                 )*

--- a/vulkano/src/pipeline/graphics/vertex_input/mod.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/mod.rs
@@ -304,7 +304,7 @@ impl VertexInputState {
         // the location following it needs to be empty.
         let unassigned_locations = attributes
             .iter()
-            .filter(|&(_, attribute_desc)| attribute_desc.format.block_size() > 16)
+            .filter(|&(_, attribute_desc)| attribute_desc.format.locations() == 2)
             .map(|(location, _)| location + 1);
 
         for location in unassigned_locations {
@@ -342,12 +342,7 @@ impl VertexInputState {
                         location.checked_sub(1).and_then(|location| {
                             self.attributes
                                 .get(&location)
-                                .filter(|attribute_desc| {
-                                    attribute_desc
-                                        .format
-                                        .components()
-                                        .starts_with(&[64, 64, 64])
-                                })
+                                .filter(|attribute_desc| attribute_desc.format.locations() == 2)
                                 .map(|d| (true, d))
                         })
                     })

--- a/vulkano/src/pipeline/graphics/vertex_input/vertex.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/vertex.rs
@@ -83,13 +83,19 @@ impl VertexBufferDescription {
 /// Information about a member of a vertex struct.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VertexMemberInfo {
-    /// Offset of the member in bytes from the start of the struct.
-    pub offset: usize,
-    /// Attribute format of the member. Implicitly provides number of components.
+    /// The offset of the member in bytes from the start of the struct.
+    pub offset: u32,
+
+    /// The attribute format of the member. Implicitly provides the number of components.
     pub format: Format,
-    /// Number of consecutive array elements or matrix columns using format. The corresponding
-    /// number of locations might defer depending on the size of the format.
+
+    /// The number of consecutive array elements or matrix columns using `format`.
+    /// The corresponding number of locations might differ depending on the size of the format.
     pub num_elements: u32,
+
+    /// If `num_elements` is greater than 1, the stride in bytes between the start of consecutive
+    /// elements.
+    pub stride: u32,
 }
 
 impl VertexMemberInfo {

--- a/vulkano/src/pipeline/shader/validate_runtime.rs
+++ b/vulkano/src/pipeline/shader/validate_runtime.rs
@@ -18,7 +18,7 @@ use crate::{
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version,
 };
 use ahash::HashMap;
-use std::cmp::max;
+use std::{cmp::max, convert::Infallible};
 
 pub(crate) fn validate_runtime(
     device: &Device,
@@ -1366,7 +1366,7 @@ impl<'a> RuntimeValidator<'a> {
                             self.execution_model,
                             result_id,
                             storage_class,
-                            |key, data| {
+                            |key, data| -> Result<(), Infallible> {
                                 let InputOutputData { type_id, .. } = data;
 
                                 match key {
@@ -1386,8 +1386,11 @@ impl<'a> RuntimeValidator<'a> {
                                         // https://github.com/KhronosGroup/Vulkan-Docs/issues/2293
                                     }
                                 }
+
+                                Ok(())
                             },
-                        );
+                        )
+                        .unwrap();
                     }
 
                     if is_in_interface && storage_class == StorageClass::Output {


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to vertex input:
- The `VertexDefinition::definition` trait method now takes an `EntryPoint` instead of a `ShaderInterface`.
- `VertexMemberInfo` now has a `stride` member.

Changes to shaders:
- `ShaderInterface` and subtypes are removed. `EntryPointInfo` no longer has `input_interface` and `output_interface` members.

### Additions
- `VertexDefinition` now fully supports 64-bit types and struct types in input/output interfaces.
- `VertexDefinition` now uses a placeholder name if a name is not present in the shader, instead of panicking.
````
