### PR TITLE
Fix using `is_some` when checking for `None` in render subpass valida…

### DIFF
--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -2793,7 +2793,7 @@ impl SubpassDescription {
         }
 
         if let Some(stencil_resolve_mode) = stencil_resolve_mode {
-            if depth_stencil_resolve_attachment.is_some() {
+            if depth_stencil_resolve_attachment.is_none() {
                 return Err(Box::new(ValidationError {
                     problem: "`stencil_resolve_mode` is `Some`, but \
                         `depth_stencil_resolve_attachment` is `None`"


### PR DESCRIPTION
```
### Bugs fixed
- when checking whether `depth_stencil_resolve_attachment` is `None`, the `is_some` method was used
```
