### PR TITLE
add null-check for empty arrays in debug trampoline

### DIFF
--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -340,13 +340,29 @@ pub(super) unsafe extern "system" fn trampoline(
             message_id_number,
             message: CStr::from_ptr(p_message).to_str().unwrap(),
             queue_labels: DebugUtilsMessengerCallbackLabelIter(
-                slice::from_raw_parts(p_queue_labels, queue_label_count as usize).iter(),
+                // Some drivers give a null pointer for empty data.
+                if p_queue_labels.is_null() {
+                    &[]
+                } else {
+                    slice::from_raw_parts(p_queue_labels, queue_label_count as usize)
+                }
+                .iter(),
             ),
             cmd_buf_labels: DebugUtilsMessengerCallbackLabelIter(
-                slice::from_raw_parts(p_cmd_buf_labels, cmd_buf_label_count as usize).iter(),
+                if p_cmd_buf_labels.is_null() {
+                    &[]
+                } else {
+                    slice::from_raw_parts(p_cmd_buf_labels, cmd_buf_label_count as usize)
+                }
+                .iter(),
             ),
             objects: DebugUtilsMessengerCallbackObjectNameInfoIter(
-                slice::from_raw_parts(p_objects, object_count as usize).iter(),
+                if p_objects.is_null() {
+                    &[]
+                } else {
+                    slice::from_raw_parts(p_objects, object_count as usize)
+                }
+                .iter(),
             ),
         };
 


### PR DESCRIPTION
1. [X] Update documentation to reflect any user-facing changes - in this repository.
N/A

2. [X] Make sure that the changes are covered by unit-tests.
Covered already in `debug` example binary.

3. [X] Run `cargo clippy` on the changes.
None new, some exist already upstream.

4. [X] Run `cargo +nightly fmt` on the changes.

5. [X] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [X] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

A simple check for null pointers in the debug callback. My current device (`Mesa 24.0.2-arch1.1`  on device `Intel(R) HD Graphics 2500 (IVB GT1)`) reports a null pointer with count of zero for empty arrays - this is allowable under the [vulkan spec for `VkDebugUtilsMessengerCallbackDataEXT`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDebugUtilsMessengerCallbackDataEXT.html) but  is invalid for use in `slice::from_raw_parts` which needs a well-aligned non-null pointer part even for zero length slices.

Changelog:
```markdown
### Bugs fixed
Fix UB in debug messenger when driver reports null pointers for empty arrays.
````
