### PR TITLE
PhysicalDevice::surface_present_modes should return Vec result

### DIFF
--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -1981,7 +1981,7 @@ impl PhysicalDevice {
         } = surface_info;
 
         if let Some(present_mode) = present_mode {
-            let mut present_modes = unsafe {
+            let present_modes = unsafe {
                 self.surface_present_modes_unchecked(
                     surface,
                     SurfaceInfo {
@@ -1999,7 +1999,7 @@ impl PhysicalDevice {
                 })?
             };
 
-            if !present_modes.any(|mode| mode == present_mode) {
+            if !present_modes.into_iter().any(|mode| mode == present_mode) {
                 return Err(Box::new(ValidationError {
                     problem: "`surface_info.present_mode` is not supported for `surface`".into(),
                     vuids: &["VUID-VkSurfacePresentModeEXT-presentMode-07780"],
@@ -2355,7 +2355,7 @@ impl PhysicalDevice {
         } = surface_info;
 
         if let Some(present_mode) = present_mode {
-            let mut present_modes = unsafe {
+            let present_modes = unsafe {
                 self.surface_present_modes_unchecked(
                     surface,
                     SurfaceInfo {
@@ -2373,7 +2373,7 @@ impl PhysicalDevice {
                 })?
             };
 
-            if !present_modes.any(|mode| mode == present_mode) {
+            if !present_modes.into_iter().any(|mode| mode == present_mode) {
                 return Err(Box::new(ValidationError {
                     problem: "`surface_info.present_mode` is not supported for `surface`".into(),
                     vuids: &["VUID-VkSurfacePresentModeEXT-presentMode-07780"],
@@ -2601,7 +2601,7 @@ impl PhysicalDevice {
         &self,
         surface: &Surface,
         surface_info: SurfaceInfo,
-    ) -> Result<impl Iterator<Item = PresentMode>, Validated<VulkanError>> {
+    ) -> Result<Vec<PresentMode>, Validated<VulkanError>> {
         self.validate_surface_present_modes(surface, &surface_info)?;
 
         unsafe { Ok(self.surface_present_modes_unchecked(surface, surface_info)?) }
@@ -2718,7 +2718,7 @@ impl PhysicalDevice {
         &self,
         surface: &Surface,
         surface_info: SurfaceInfo,
-    ) -> Result<impl Iterator<Item = PresentMode>, VulkanError> {
+    ) -> Result<Vec<PresentMode>, VulkanError> {
         surface
             .surface_present_modes
             .get_or_try_insert((self.handle, surface_info), |(_, surface_info)| {
@@ -2838,7 +2838,6 @@ impl PhysicalDevice {
                         .collect())
                 }
             })
-            .map(IntoIterator::into_iter)
     }
 
     /// Returns whether queues of the given queue family can draw on the given surface.

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -2719,9 +2719,9 @@ impl PhysicalDevice {
         surface: &Surface,
         surface_info: SurfaceInfo,
     ) -> Result<Vec<PresentMode>, VulkanError> {
-        surface
-            .surface_present_modes
-            .get_or_try_insert((self.handle, surface_info), |(_, surface_info)| {
+        surface.surface_present_modes.get_or_try_insert(
+            (self.handle, surface_info),
+            |(_, surface_info)| {
                 let &SurfaceInfo {
                     present_mode: _,
                     full_screen_exclusive,
@@ -2837,7 +2837,8 @@ impl PhysicalDevice {
                         .filter_map(|mode_vk| mode_vk.try_into().ok())
                         .collect())
                 }
-            })
+            },
+        )
     }
 
     /// Returns whether queues of the given queue family can draw on the given surface.

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -621,7 +621,7 @@ impl Swapchain {
                     })
                 })?
         };
-        let surface_present_modes: SmallVec<[_; PresentMode::COUNT]> = SmallVec::from_vec(unsafe {
+        let surface_present_modes = unsafe {
             device
                 .physical_device()
                 .surface_present_modes_unchecked(
@@ -644,7 +644,7 @@ impl Swapchain {
                         ..Default::default()
                     })
                 })?
-        });
+        };
 
         if surface_capabilities
             .max_image_count

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -621,7 +621,7 @@ impl Swapchain {
                     })
                 })?
         };
-        let surface_present_modes: SmallVec<[_; PresentMode::COUNT]> = unsafe {
+        let surface_present_modes: SmallVec<[_; PresentMode::COUNT]> = SmallVec::from_vec(unsafe {
             device
                 .physical_device()
                 .surface_present_modes_unchecked(
@@ -644,8 +644,7 @@ impl Swapchain {
                         ..Default::default()
                     })
                 })?
-                .collect()
-        };
+        });
 
         if surface_capabilities
             .max_image_count


### PR DESCRIPTION
`PhysicalDevice::surface_present_modes` should return `Vec` result as any other this struct functions for consistency and to eliminate composing result back to `Vec` in outer crate usages, such as:

```rust
    let present_mode = physical_device
        .surface_present_modes(surface, SurfaceInfo::default())?
        .collect();
    Ok(SwapChainSupportDetails {
        _capabilities: capabilities,
        formats,
        present_mode,
    })
```

1. [ ] Update documentation to reflect any user-facing changes - in this repository.

2. [ ] Make sure that the changes are covered by unit-tests: no unit-test exists to cover these functions

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Breaking changes
Changes to `PhysicalDevice`:
- Return type of function `surface_present_modes` changed to `Result<Vec<PresentMode>, VulkanError>`.
- Return type of function `surface_present_modes_unchecked` changed to `Result<Vec<PresentMode>, VulkanError>`.
```
