### PR TITLE
Add `Suballocator::suballocations`

### DIFF
--- a/vulkano/src/memory/allocator/suballocator/bump.rs
+++ b/vulkano/src/memory/allocator/suballocator/bump.rs
@@ -1,4 +1,7 @@
-use super::{AllocationType, Region, Suballocation, Suballocator, SuballocatorError};
+use super::{
+    AllocationType, Region, Suballocation, SuballocationNode, SuballocationType, Suballocator,
+    SuballocatorError,
+};
 use crate::{
     memory::{
         allocator::{
@@ -8,7 +11,7 @@ use crate::{
     },
     DeviceSize,
 };
-use std::cell::Cell;
+use std::iter::FusedIterator;
 
 /// A [suballocator] which can allocate dynamically, but can only free all allocations at once.
 ///
@@ -53,8 +56,8 @@ use std::cell::Cell;
 #[derive(Debug)]
 pub struct BumpAllocator {
     region: Region,
-    free_start: Cell<DeviceSize>,
-    prev_allocation_type: Cell<AllocationType>,
+    free_start: DeviceSize,
+    prev_allocation_type: AllocationType,
 }
 
 impl BumpAllocator {
@@ -63,26 +66,46 @@ impl BumpAllocator {
     /// [region]: Suballocator#regions
     #[inline]
     pub fn reset(&mut self) {
-        *self.free_start.get_mut() = 0;
-        *self.prev_allocation_type.get_mut() = AllocationType::Unknown;
+        self.free_start = 0;
+        self.prev_allocation_type = AllocationType::Unknown;
+    }
+
+    fn suballocation_node(&self, part: usize) -> SuballocationNode {
+        if part == 0 {
+            SuballocationNode {
+                offset: self.region.offset(),
+                size: self.free_start,
+                allocation_type: self.prev_allocation_type.into(),
+            }
+        } else {
+            debug_assert_eq!(part, 1);
+
+            SuballocationNode {
+                offset: self.region.offset() + self.free_start,
+                size: self.free_size(),
+                allocation_type: SuballocationType::Free,
+            }
+        }
     }
 }
 
 unsafe impl Suballocator for BumpAllocator {
+    type Suballocations<'a> = Suballocations<'a>;
+
     /// Creates a new `BumpAllocator` for the given [region].
     ///
     /// [region]: Suballocator#regions
     fn new(region: Region) -> Self {
         BumpAllocator {
             region,
-            free_start: Cell::new(0),
-            prev_allocation_type: Cell::new(AllocationType::Unknown),
+            free_start: 0,
+            prev_allocation_type: AllocationType::Unknown,
         }
     }
 
     #[inline]
     fn allocate(
-        &self,
+        &mut self,
         layout: DeviceLayout,
         allocation_type: AllocationType,
         buffer_image_granularity: DeviceAlignment,
@@ -96,13 +119,13 @@ unsafe impl Suballocator for BumpAllocator {
 
         // These can't overflow because suballocation offsets are bounded by the region, whose end
         // can itself not exceed `DeviceLayout::MAX_SIZE`.
-        let prev_end = self.region.offset() + self.free_start.get();
+        let prev_end = self.region.offset() + self.free_start;
         let mut offset = align_up(prev_end, alignment);
 
         if buffer_image_granularity != DeviceAlignment::MIN
             && prev_end > 0
             && are_blocks_on_same_page(0, prev_end, offset, buffer_image_granularity)
-            && has_granularity_conflict(self.prev_allocation_type.get(), allocation_type)
+            && has_granularity_conflict(self.prev_allocation_type, allocation_type)
         {
             offset = align_up(offset, buffer_image_granularity);
         }
@@ -115,8 +138,8 @@ unsafe impl Suballocator for BumpAllocator {
             return Err(SuballocatorError::OutOfRegionMemory);
         }
 
-        self.free_start.set(free_start);
-        self.prev_allocation_type.set(allocation_type);
+        self.free_start = free_start;
+        self.prev_allocation_type = allocation_type;
 
         Ok(Suballocation {
             offset,
@@ -127,17 +150,91 @@ unsafe impl Suballocator for BumpAllocator {
     }
 
     #[inline]
-    unsafe fn deallocate(&self, _suballocation: Suballocation) {
+    unsafe fn deallocate(&mut self, _suballocation: Suballocation) {
         // such complex, very wow
     }
 
     #[inline]
     fn free_size(&self) -> DeviceSize {
-        self.region.size() - self.free_start.get()
+        self.region.size() - self.free_start
     }
 
     #[inline]
     fn cleanup(&mut self) {
         self.reset();
     }
+
+    #[inline]
+    fn suballocations(&self) -> Self::Suballocations<'_> {
+        let start = if self.free_start == 0 { 1 } else { 0 };
+        let end = if self.free_start == self.region.size() {
+            1
+        } else {
+            2
+        };
+
+        Suballocations {
+            allocator: self,
+            start,
+            end,
+        }
+    }
 }
+
+#[derive(Clone)]
+pub struct Suballocations<'a> {
+    allocator: &'a BumpAllocator,
+    start: usize,
+    end: usize,
+}
+
+impl Iterator for Suballocations<'_> {
+    type Item = SuballocationNode;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len() != 0 {
+            let node = self.allocator.suballocation_node(self.start);
+            self.start += 1;
+
+            Some(node)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+
+        (len, Some(len))
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<Self::Item> {
+        self.next_back()
+    }
+}
+
+impl DoubleEndedIterator for Suballocations<'_> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.len() != 0 {
+            self.end -= 1;
+            let node = self.allocator.suballocation_node(self.end);
+
+            Some(node)
+        } else {
+            None
+        }
+    }
+}
+
+impl ExactSizeIterator for Suballocations<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.end - self.start
+    }
+}
+
+impl FusedIterator for Suballocations<'_> {}

--- a/vulkano/src/memory/allocator/suballocator/bump.rs
+++ b/vulkano/src/memory/allocator/suballocator/bump.rs
@@ -1,12 +1,10 @@
 use super::{
-    AllocationType, Region, Suballocation, SuballocationNode, SuballocationType, Suballocator,
-    SuballocatorError,
+    are_blocks_on_same_page, AllocationType, Region, Suballocation, SuballocationNode,
+    SuballocationType, Suballocator, SuballocatorError,
 };
 use crate::{
     memory::{
-        allocator::{
-            align_up, suballocator::are_blocks_on_same_page, AllocationHandle, DeviceLayout,
-        },
+        allocator::{align_up, AllocationHandle, DeviceLayout},
         DeviceAlignment,
     },
     DeviceSize,

--- a/vulkano/src/memory/allocator/suballocator/free_list.rs
+++ b/vulkano/src/memory/allocator/suballocator/free_list.rs
@@ -522,6 +522,9 @@ pub struct Suballocations<'a> {
     marker: PhantomData<&'a SuballocationList>,
 }
 
+unsafe impl Send for Suballocations<'_> {}
+unsafe impl Sync for Suballocations<'_> {}
+
 impl Iterator for Suballocations<'_> {
     type Item = SuballocationNode;
 

--- a/vulkano/src/memory/allocator/suballocator/mod.rs
+++ b/vulkano/src/memory/allocator/suballocator/mod.rs
@@ -78,6 +78,9 @@ mod free_list;
 /// [page]: super#pages
 /// [buffer-image granularity]: super#buffer-image-granularity
 pub unsafe trait Suballocator {
+    /// The type of iterator returned by [`suballocations`].
+    ///
+    /// [`suballocations`]: Self::suballocations
     type Suballocations<'a>: Iterator<Item = SuballocationNode>
         + DoubleEndedIterator
         + ExactSizeIterator


### PR DESCRIPTION
This allows the user to display debug information about individual memory blocks internal to the allocator. `MemoryAllocator` isn't integrated into this yet. This unfortunately required me to change `Suballocator::allocate` and `Suballocator::deallocate` to take `&mut self`, which makes it a bit more inconvenient to work with in many cases. But alas, the alternative would have been to keep the internal mutability but change it to a `RefCell`, and I'm not a fan of internal synchronization if it can be helped. It just means that the user will have to put the `RefCell` externally if needed.

Changelog:
```markdown
### Breaking changes
Changes to memory allocation:
- `Suballocator::{allocate,deallocate}` now take `&mut self`.
- `Suballocator` has new required items `Suballocations` and `suballocations` for iterating over suballocations.
```
