### PR TITLE
Add `GenericMemoryAllocator::pools` for allocation introspection

### DIFF
--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1540,7 +1540,7 @@ unsafe impl<S> DeviceOwned for GenericMemoryAllocator<S> {
     }
 }
 
-/// A pool of `DeviceMemory` blocks within [`GenericMemoryAllocator`], specific to a memory type.
+/// A pool of [`DeviceMemory`] blocks within [`GenericMemoryAllocator`], specific to a memory type.
 #[derive(Debug)]
 pub struct DeviceMemoryPool<S> {
     blocks: Mutex<Vec<Box<DeviceMemoryBlock<S>>>>,

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1627,8 +1627,6 @@ impl<S: Suballocator> DeviceMemoryBlock<S> {
     }
 
     /// Returns the suballocator used to suballocate this block.
-    ///
-    /// Using the suballocator to allocate is discouraged, although it can't lead to unsoundness.
     #[inline]
     pub fn suballocator(&self) -> &S {
         &self.suballocator


### PR DESCRIPTION
Together with #2499, this allows the user to fully inspect all allocated and free allocations. Useful for example for debug screens.

Fixes #2326
cc @aedm, @Michaelschnabel-DM

Changelog:
```markdown
### Additions
- Added `GenericMemoryAllocator::pools` for introspection of memory allocations, along with `DeviceMemoryPool`, `DeviceMemoryBlocks`, `DeviceMemoryBlock` and `Suballocator::suballocations`.
```
