### PR TITLE
Pass timeout to acquire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Changes to vulkano-shaders:
 
 Changes to vulkano-util:
 - `VulkanoWindowRenderer::acquire` now takes in an `FnOnce(&[Arc<ImageView>])`. This means that a closure can be called when the swapchain gets recreated.
+- `VulkanoWindowRenderer::acquire` now also takes in `Option<Duration>` for the swapchain acquire timeout.
 
 ### Additions
 

--- a/examples/interactive-fractal/main.rs
+++ b/examples/interactive-fractal/main.rs
@@ -145,19 +145,17 @@ fn compute_then_render(
     target_image_id: usize,
 ) {
     // Start the frame.
-    let before_pipeline_future = match renderer.acquire(
-        |swapchain_image_views| {
+    let before_pipeline_future =
+        match renderer.acquire(Some(Duration::from_millis(1)), |swapchain_image_views| {
             app.place_over_frame
                 .recreate_framebuffers(swapchain_image_views)
-        },
-        Some(Duration::from_millis(1)),
-    ) {
-        Err(e) => {
-            println!("{e}");
-            return;
-        }
-        Ok(future) => future,
-    };
+        }) {
+            Err(e) => {
+                println!("{e}");
+                return;
+            }
+            Ok(future) => future,
+        };
 
     // Retrieve the target image.
     let image = renderer.get_additional_image_view(target_image_id);

--- a/examples/interactive-fractal/main.rs
+++ b/examples/interactive-fractal/main.rs
@@ -11,7 +11,7 @@
 // - A simple `InputState` to interact with the application.
 
 use crate::app::FractalApp;
-use std::error::Error;
+use std::{error::Error, time::Duration};
 use vulkano::{image::ImageUsage, swapchain::PresentMode, sync::GpuFuture};
 use vulkano_util::{
     context::{VulkanoConfig, VulkanoContext},
@@ -145,10 +145,13 @@ fn compute_then_render(
     target_image_id: usize,
 ) {
     // Start the frame.
-    let before_pipeline_future = match renderer.acquire(|swapchain_image_views| {
-        app.place_over_frame
-            .recreate_framebuffers(swapchain_image_views)
-    }) {
+    let before_pipeline_future = match renderer.acquire(
+        |swapchain_image_views| {
+            app.place_over_frame
+                .recreate_framebuffers(swapchain_image_views)
+        },
+        Some(Duration::from_millis(1)),
+    ) {
         Err(e) => {
             println!("{e}");
             return;

--- a/examples/multi-window-game-of-life/main.rs
+++ b/examples/multi-window-game-of-life/main.rs
@@ -14,7 +14,10 @@ mod render_pass;
 
 use crate::app::{App, RenderPipeline};
 use glam::{f32::Vec2, IVec2};
-use std::{error::Error, time::Instant};
+use std::{
+    error::Error,
+    time::{Duration, Instant},
+};
 use vulkano_util::renderer::VulkanoWindowRenderer;
 use winit::{
     event::{ElementState, Event, MouseButton, WindowEvent},
@@ -194,11 +197,14 @@ fn compute_then_render(
     }
 
     // Start the frame.
-    let before_pipeline_future = match window_renderer.acquire(|swapchain_image_views| {
-        pipeline
-            .place_over_frame
-            .recreate_framebuffers(swapchain_image_views)
-    }) {
+    let before_pipeline_future = match window_renderer.acquire(
+        |swapchain_image_views| {
+            pipeline
+                .place_over_frame
+                .recreate_framebuffers(swapchain_image_views)
+        },
+        Some(Duration::from_millis(1)),
+    ) {
         Err(e) => {
             println!("{e}");
             return;

--- a/examples/multi-window-game-of-life/main.rs
+++ b/examples/multi-window-game-of-life/main.rs
@@ -197,20 +197,18 @@ fn compute_then_render(
     }
 
     // Start the frame.
-    let before_pipeline_future = match window_renderer.acquire(
-        |swapchain_image_views| {
+    let before_pipeline_future =
+        match window_renderer.acquire(Some(Duration::from_millis(1)), |swapchain_image_views| {
             pipeline
                 .place_over_frame
                 .recreate_framebuffers(swapchain_image_views)
-        },
-        Some(Duration::from_millis(1)),
-    ) {
-        Err(e) => {
-            println!("{e}");
-            return;
-        }
-        Ok(future) => future,
-    };
+        }) {
+            Err(e) => {
+                println!("{e}");
+                return;
+            }
+            Ok(future) => future,
+        };
 
     // Compute.
     let after_compute = pipeline

--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -7,7 +7,7 @@
 // that you want to learn Vulkan. This means that for example it won't go into details about what a
 // vertex or a shader is.
 
-use std::{error::Error, sync::Arc};
+use std::{error::Error, sync::Arc, time::Duration};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
@@ -331,17 +331,20 @@ fn main() -> Result<(), impl Error> {
 
                 // Begin rendering by acquiring the gpu future from the window renderer.
                 let previous_frame_end = window_renderer
-                    .acquire(|swapchain_images| {
-                        // Whenever the window resizes we need to recreate everything dependent on
-                        // the window size. In this example that includes
-                        // the swapchain, the framebuffers and the dynamic
-                        // state viewport.
-                        framebuffers = window_size_dependent_setup(
-                            swapchain_images,
-                            render_pass.clone(),
-                            &mut viewport,
-                        );
-                    })
+                    .acquire(
+                        |swapchain_images| {
+                            // Whenever the window resizes we need to recreate everything dependent
+                            // on the window size. In this example that
+                            // includes the swapchain, the framebuffers
+                            // and the dynamic state viewport.
+                            framebuffers = window_size_dependent_setup(
+                                swapchain_images,
+                                render_pass.clone(),
+                                &mut viewport,
+                            );
+                        },
+                        Some(Duration::from_millis(1)),
+                    )
                     .unwrap();
 
                 // In order to draw, we have to record a *command buffer*. The command buffer object

--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -331,20 +331,17 @@ fn main() -> Result<(), impl Error> {
 
                 // Begin rendering by acquiring the gpu future from the window renderer.
                 let previous_frame_end = window_renderer
-                    .acquire(
-                        |swapchain_images| {
-                            // Whenever the window resizes we need to recreate everything dependent
-                            // on the window size. In this example that
-                            // includes the swapchain, the framebuffers
-                            // and the dynamic state viewport.
-                            framebuffers = window_size_dependent_setup(
-                                swapchain_images,
-                                render_pass.clone(),
-                                &mut viewport,
-                            );
-                        },
-                        Some(Duration::from_millis(1)),
-                    )
+                    .acquire(Some(Duration::from_millis(1)), |swapchain_images| {
+                        // Whenever the window resizes we need to recreate everything dependent
+                        // on the window size. In this example that
+                        // includes the swapchain, the framebuffers
+                        // and the dynamic state viewport.
+                        framebuffers = window_size_dependent_setup(
+                            swapchain_images,
+                            render_pass.clone(),
+                            &mut viewport,
+                        );
+                    })
                     .unwrap();
 
                 // In order to draw, we have to record a *command buffer*. The command buffer object

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -1,6 +1,6 @@
 use crate::{context::VulkanoContext, window::WindowDescriptor};
 use ahash::HashMap;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use vulkano::{
     device::{Device, Queue},
     format::Format,
@@ -264,6 +264,7 @@ impl VulkanoWindowRenderer {
     pub fn acquire(
         &mut self,
         on_recreate_swapchain: impl FnOnce(&[Arc<ImageView>]),
+        timeout: Option<Duration>,
     ) -> Result<Box<dyn GpuFuture>, VulkanError> {
         // Recreate swap chain if needed (when resizing of window occurs or swapchain is outdated)
         // Also resize render views if needed
@@ -274,7 +275,7 @@ impl VulkanoWindowRenderer {
 
         // Acquire next image in the swapchain
         let (image_index, suboptimal, acquire_future) =
-            match swapchain::acquire_next_image(self.swapchain.clone(), None)
+            match swapchain::acquire_next_image(self.swapchain.clone(), timeout)
                 .map_err(Validated::unwrap)
             {
                 Ok(r) => r,

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -263,8 +263,8 @@ impl VulkanoWindowRenderer {
     #[inline]
     pub fn acquire(
         &mut self,
-        on_recreate_swapchain: impl FnOnce(&[Arc<ImageView>]),
         timeout: Option<Duration>,
+        on_recreate_swapchain: impl FnOnce(&[Arc<ImageView>]),
     ) -> Result<Box<dyn GpuFuture>, VulkanError> {
         // Recreate swap chain if needed (when resizing of window occurs or swapchain is outdated)
         // Also resize render views if needed


### PR DESCRIPTION
It seems that (at least on windows), the timeout param is required. Min 2 Swapchain images is also.

https://github.com/hakolao/egui_winit_vulkano/issues/61

```
VUID-vkAcquireNextImageKHR-surface-07783(ERROR / SPEC): msgNum: -1391585802 - Validation Error: [ VUID-vkAcquireNextImageKHR-surface-07783 ] Object 0: handle = 0xcb1c7c000000001b, type = VK_OBJECT_TYPE_SWAPCHAIN_KHR; | 
MessageID = 0xad0e15f6 | vkAcquireNextImageKHR: Application has already previously acquired 1 image from swapchain. Only 1 is available to be acquired using a timeout of UINT64_MAX (given the swapchain has 2, and VkSurfaceCapabilitiesKHR::minImageCount is 2). The Vulkan spec states: If forward progress cannot be guaranteed for the surface used to create the swapchain member of pAcquireInfo, the timeout member of pAcquireInfo must not 
be UINT64_MAX (https://vulkan.lunarg.com/doc/view/1.3.243.0/windows/1.3-extensions/vkspec.html#VUID-vkAcquireNextImageKHR-surface-07783)
    Objects: 1
        [0] 0xcb1c7c000000001b, type: 1000001000, name: NULL
```

So thus changing the `acquire` api to let user to pass the timeout param.