### PR TITLE
Use workspace lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,24 @@ png = "0.17"
 rand = "0.8"
 ron = "0.8"
 
+[workspace.lints]
+rust.missing-docs = "allow"                # TODO: warn eventually
+rust.rust-2018-idioms = "warn"
+rust.rust-2024-compatibility = "allow"     # TODO: warn eventually
+clippy.missing-safety-doc = "allow"        # TODO: warn eventually
+clippy.trivially-copy-pass-by-ref = "warn"
+# These lints are a bit too pedantic, so they're disabled here.
+# They can be removed if they no longer happen in the future.
+clippy.arc-with-non-send-sync = "allow"
+clippy.collapsible-else-if = "allow"
+clippy.collapsible-if = "allow"
+clippy.len-without-is-empty = "allow"
+clippy.needless-borrowed-reference = "allow"
+clippy.nonminimal-bool = "allow"
+clippy.result-large-err = "allow"
+clippy.too-many-arguments = "allow"
+clippy.type-complexity = "allow"
+
 [profile.CI]
 inherits = "dev"
 debug = 0

--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -24,6 +24,9 @@ shaderc = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }
 vulkano = { workspace = true }
 
+[lints]
+workspace = true
+
 [features]
 shaderc-build-from-source = ["shaderc/build-from-source"]
 shaderc-debug = []

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -225,8 +225,6 @@
 
 #![doc(html_logo_url = "https://raw.githubusercontent.com/vulkano-rs/vulkano/master/logo.png")]
 #![recursion_limit = "1024"]
-#![allow(clippy::needless_borrowed_reference)]
-#![warn(rust_2018_idioms, rust_2021_compatibility)]
 
 use crate::codegen::ShaderKind;
 use ahash::HashMap;

--- a/vulkano-util/Cargo.toml
+++ b/vulkano-util/Cargo.toml
@@ -16,3 +16,6 @@ readme = "../README.md"
 ahash = { workspace = true }
 vulkano = { workspace = true }
 winit = { workspace = true }
+
+[lints]
+workspace = true

--- a/vulkano-util/src/lib.rs
+++ b/vulkano-util/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::missing_safety_doc)]
-#![warn(rust_2018_idioms, rust_2021_compatibility)]
-
 pub mod context;
 pub mod renderer;
 pub mod window;

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -45,6 +45,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 vk-parse = { workspace = true }
 
+[lints]
+workspace = true
+
 [features]
 default = ["macros"]
 macros = ["dep:vulkano-macros"]

--- a/vulkano/autogen/errors.rs
+++ b/vulkano/autogen/errors.rs
@@ -3,7 +3,7 @@ use heck::ToUpperCamelCase;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
-pub fn write(vk_data: &VkRegistryData) {
+pub fn write(vk_data: &VkRegistryData<'_>) {
     write_file(
         "errors.rs",
         format!(

--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -26,7 +26,7 @@ fn conflicts_extensions(name: &str) -> &'static [&'static str] {
     }
 }
 
-pub fn write(vk_data: &VkRegistryData) {
+pub fn write(vk_data: &VkRegistryData<'_>) {
     write_device_extensions(vk_data);
     write_instance_extensions(vk_data);
 }
@@ -55,7 +55,7 @@ pub enum Requires {
     InstanceExtension(String),
 }
 
-fn write_device_extensions(vk_data: &VkRegistryData) {
+fn write_device_extensions(vk_data: &VkRegistryData<'_>) {
     write_file(
         "device_extensions.rs",
         format!(
@@ -66,7 +66,7 @@ fn write_device_extensions(vk_data: &VkRegistryData) {
     );
 }
 
-fn write_instance_extensions(vk_data: &VkRegistryData) {
+fn write_instance_extensions(vk_data: &VkRegistryData<'_>) {
     write_file(
         "instance_extensions.rs",
         format!(
@@ -890,7 +890,7 @@ fn extensions_members(ty: &str, extensions: &IndexMap<&str, &Extension>) -> Vec<
 }
 
 fn from_one_of(
-    one_of: Vec<DependsExpression>,
+    one_of: Vec<DependsExpression<'_>>,
     extensions: &IndexMap<&str, &Extension>,
 ) -> Result<Vec<RequiresOneOf>, String> {
     let mut requires_all_of = vec![RequiresOneOf::default()];
@@ -979,14 +979,14 @@ fn parse_depends(depends: &str) -> Result<DependsExpression<'_>, String> {
         take_while1(|c: char| c.is_ascii_alphanumeric() || c == '_')(input)
     }
 
-    fn term(input: &str) -> IResult<&str, DependsExpression> {
+    fn term(input: &str) -> IResult<&str, DependsExpression<'_>> {
         alt((
             name.map(DependsExpression::Name),
             delimited(complete::char('('), expression, complete::char(')')),
         ))(input)
     }
 
-    fn expression(input: &str) -> IResult<&str, DependsExpression> {
+    fn expression(input: &str) -> IResult<&str, DependsExpression<'_>> {
         let (input, first) = term(input)?;
 
         if let Some(input) = input.strip_prefix('+') {

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -50,7 +50,7 @@ fn required_by_extensions(name: &str) -> &'static [(&'static str, &'static str)]
     }
 }
 
-pub fn write(vk_data: &VkRegistryData) {
+pub fn write(vk_data: &VkRegistryData<'_>) {
     let features_output = features_output(&features_members(&vk_data.types));
     let features_ffi_output =
         features_ffi_output(&features_ffi_members(&vk_data.types, &vk_data.extensions));

--- a/vulkano/autogen/fns.rs
+++ b/vulkano/autogen/fns.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use vk_parse::{Extension, ExtensionChild, InterfaceItem};
 
-pub fn write(vk_data: &VkRegistryData) {
+pub fn write(vk_data: &VkRegistryData<'_>) {
     let entry_fns_output = fns_output(
         &[],
         "Entry",

--- a/vulkano/autogen/formats.rs
+++ b/vulkano/autogen/formats.rs
@@ -8,7 +8,7 @@ use vk_parse::{
     Enum, EnumSpec, Extension, ExtensionChild, Feature, Format, FormatChild, InterfaceItem,
 };
 
-pub fn write(vk_data: &VkRegistryData) {
+pub fn write(vk_data: &VkRegistryData<'_>) {
     write_file(
         "formats.rs",
         format!(

--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -13,7 +13,7 @@ use quote::{format_ident, quote};
 use std::{collections::hash_map::Entry, fmt::Write as _};
 use vk_parse::{Extension, Type, TypeMember, TypeMemberMarkup, TypeSpec};
 
-pub fn write(vk_data: &VkRegistryData) {
+pub fn write(vk_data: &VkRegistryData<'_>) {
     let properties_output = properties_output(&properties_members(&vk_data.types));
     let properties_ffi_output =
         properties_ffi_output(&properties_ffi_members(&vk_data.types, &vk_data.extensions));
@@ -430,7 +430,7 @@ struct Member<'a> {
     len: Option<&'a str>,
 }
 
-fn members(ty: &Type) -> Vec<Member> {
+fn members(ty: &Type) -> Vec<Member<'_>> {
     fn array_len(input: &str) -> IResult<&str, &str> {
         let (input, _) = take_until("[")(input)?;
         all_consuming(delimited(

--- a/vulkano/autogen/spirv_reqs.rs
+++ b/vulkano/autogen/spirv_reqs.rs
@@ -15,7 +15,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use vk_parse::SpirvExtOrCap;
 
-pub fn write(vk_data: &VkRegistryData, grammar: &SpirvGrammar) {
+pub fn write(vk_data: &VkRegistryData<'_>, grammar: &SpirvGrammar) {
     let grammar_enumerants = grammar
         .operand_kinds
         .iter()

--- a/vulkano/autogen/version.rs
+++ b/vulkano/autogen/version.rs
@@ -2,7 +2,7 @@ use super::{write_file, VkRegistryData};
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 
-pub fn write(vk_data: &VkRegistryData) {
+pub fn write(vk_data: &VkRegistryData<'_>) {
     let version_output = version_output(vk_data.header_version);
     write_file(
         "version.rs",

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -2730,7 +2730,7 @@ impl RenderingInfo {
         if let (Some(depth_attachment_info), Some(stencil_attachment_info)) =
             (depth_attachment, stencil_attachment)
         {
-            if &depth_attachment_info.image_view != &stencil_attachment_info.image_view {
+            if depth_attachment_info.image_view != stencil_attachment_info.image_view {
                 return Err(Box::new(ValidationError {
                     problem: "`depth_attachment` and `stencil_attachment` are both `Some`, but \
                         `depth_attachment.image_view` does not equal \
@@ -2809,7 +2809,7 @@ impl RenderingInfo {
                         }));
                     }
 
-                    if &depth_resolve_info.image_view != &stencil_resolve_info.image_view {
+                    if depth_resolve_info.image_view != stencil_resolve_info.image_view {
                         return Err(Box::new(ValidationError {
                             problem: "`depth_attachment` and `stencil_attachment` are both \
                                 `Some`, and `depth_attachment.resolve_info` and \

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -22,17 +22,16 @@
 //!    uses, you can add one of the [features](https://docs.rs/crate/winit/latest/features) that
 //!    starts with `rwh` to `winit`. Currently, vulkano is compatible with `rwh_06`.
 //!    
-//!
 //! 4. [Enumerate the physical devices] that are available on the `Instance`, and choose one that
 //!    is suitable for your program. A [`PhysicalDevice`] represents a Vulkan-capable device that
 //!    is available on the system, such as a graphics card, a software implementation, etc.
 //!
-//! 6. Create a [`Device`] and accompanying [`Queue`]s from the selected `PhysicalDevice`. The
+//! 5. Create a [`Device`] and accompanying [`Queue`]s from the selected `PhysicalDevice`. The
 //!    `Device` is the most important object of Vulkan, and you need one to create almost every
 //!    other object. `Queue`s are created together with the `Device`, and are used to submit work
 //!    to the device to make it do something.
 //!
-//! 7. If you created a `Surface` earlier, create a [`Swapchain`]. This object contains special
+//! 6. If you created a `Surface` earlier, create a [`Swapchain`]. This object contains special
 //!    images that correspond to the contents of the surface. Whenever you want to change the
 //!    contents (show something new to the user), you must first *acquire* one of these images from
 //!    the swapchain, fill it with the new contents (by rendering, copying or any other means), and
@@ -40,7 +39,7 @@
 //!    of the surface change, such as when the size of the window changes. It then becomes
 //!    necessary to create a new swapchain.
 //!
-//! 8. Record a [*command buffer*](command_buffer), containing commands that the device must
+//! 7. Record a [*command buffer*](command_buffer), containing commands that the device must
 //!    execute. Then build the command buffer and submit it to a `Queue`.
 //!
 //! Many different operations can be recorded to a command buffer, such as *draw*, *compute* and
@@ -119,34 +118,6 @@
 //! [`Framebuffer`]: render_pass::Framebuffer
 //! [`vulkano-macros`]: vulkano_macros
 //! [`serde`]: https://crates.io/crates/serde
-
-//#![warn(missing_docs)]        // TODO: activate
-#![warn(
-    rust_2018_idioms,
-    rust_2021_compatibility,
-    clippy::trivially_copy_pass_by_ref
-)]
-// These lints are a bit too pedantic, so they're disabled here.
-#![allow(
-    clippy::arc_with_non_send_sync,
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::derivable_impls, // TODO: remove
-    clippy::large_enum_variant,
-    clippy::len_without_is_empty,
-    clippy::missing_safety_doc, // TODO: remove
-    clippy::module_inception,
-    clippy::mutable_key_type,
-    clippy::needless_borrowed_reference,
-    clippy::new_without_default,
-    clippy::nonminimal_bool,
-    clippy::op_ref, // Seems to be bugged, the fixed code triggers a compile error
-    clippy::result_large_err,
-    clippy::too_many_arguments,
-    clippy::type_complexity,
-    clippy::vec_box,
-    clippy::wrong_self_convention
-)]
 
 pub use ash::vk::Handle;
 use bytemuck::{Pod, Zeroable};


### PR DESCRIPTION
This converts all the inline lints in the crate roots to workspace lints instead. I've also removed the ones that no longer trigger.
