### PR TITLE
Use `f64` in vulkano-util to avoid precision loss

### DIFF
--- a/examples/multi-window-game-of-life/main.rs
+++ b/examples/multi-window-game-of-life/main.rs
@@ -13,7 +13,7 @@ mod pixels_draw;
 mod render_pass;
 
 use crate::app::{App, RenderPipeline};
-use glam::{f32::Vec2, IVec2};
+use glam::{f64::DVec2, IVec2};
 use std::{error::Error, time::Instant};
 use vulkano_util::renderer::VulkanoWindowRenderer;
 use winit::{
@@ -21,11 +21,11 @@ use winit::{
     event_loop::{ControlFlow, EventLoop},
 };
 
-pub const WINDOW_WIDTH: f32 = 1024.0;
-pub const WINDOW_HEIGHT: f32 = 1024.0;
-pub const WINDOW2_WIDTH: f32 = 512.0;
-pub const WINDOW2_HEIGHT: f32 = 512.0;
-pub const SCALING: f32 = 2.0;
+pub const WINDOW_WIDTH: f64 = 1024.0;
+pub const WINDOW_HEIGHT: f64 = 1024.0;
+pub const WINDOW2_WIDTH: f64 = 512.0;
+pub const WINDOW2_HEIGHT: f64 = 512.0;
+pub const SCALING: f64 = 2.0;
 
 fn main() -> Result<(), impl Error> {
     println!("Welcome to Vulkano Game of Life\nUse the mouse to draw life on the grid(s)\n");
@@ -39,7 +39,7 @@ fn main() -> Result<(), impl Error> {
 
     // Time & inputs...
     let mut time = Instant::now();
-    let mut cursor_pos = Vec2::ZERO;
+    let mut cursor_pos = DVec2::ZERO;
 
     // An extremely crude way to handle input state... but works for this example.
     let mut mouse_is_pressed_w1 = false;
@@ -84,7 +84,7 @@ fn main() -> Result<(), impl Error> {
 pub fn process_event(
     event: &Event<()>,
     app: &mut App,
-    cursor_pos: &mut Vec2,
+    cursor_pos: &mut DVec2,
     mouse_pressed_w1: &mut bool,
     mouse_pressed_w2: &mut bool,
 ) -> bool {
@@ -109,7 +109,7 @@ pub fn process_event(
             }
             // Handle mouse position events.
             WindowEvent::CursorMoved { position, .. } => {
-                *cursor_pos = Vec2::new(position.x as f32, position.y as f32)
+                *cursor_pos = DVec2::new(position.x, position.y)
             }
             // Handle mouse button events.
             WindowEvent::MouseInput { state, button, .. } => {
@@ -134,7 +134,7 @@ pub fn process_event(
 
 fn draw_life(
     app: &mut App,
-    cursor_pos: Vec2,
+    cursor_pos: DVec2,
     mouse_is_pressed_w1: bool,
     mouse_is_pressed_w2: bool,
 ) {
@@ -149,7 +149,7 @@ fn draw_life(
 
         let window_size = window.window_size();
         let compute_pipeline = &mut app.pipelines.get_mut(id).unwrap().compute;
-        let mut normalized_pos = Vec2::new(
+        let mut normalized_pos = DVec2::new(
             (cursor_pos.x / window_size[0]).clamp(0.0, 1.0),
             (cursor_pos.y / window_size[1]).clamp(0.0, 1.0),
         );
@@ -158,8 +158,8 @@ fn draw_life(
         normalized_pos.y = 1.0 - normalized_pos.y;
         let image_extent = compute_pipeline.color_image().image().extent();
         compute_pipeline.draw_life(IVec2::new(
-            (image_extent[0] as f32 * normalized_pos.x) as i32,
-            (image_extent[1] as f32 * normalized_pos.y) as i32,
+            (image_extent[0] as f64 * normalized_pos.x) as i32,
+            (image_extent[1] as f64 * normalized_pos.y) as i32,
         ))
     }
 }

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -167,9 +167,9 @@ impl VulkanoWindowRenderer {
 
     /// Size of the physical window.
     #[inline]
-    pub fn window_size(&self) -> [f32; 2] {
+    pub fn window_size(&self) -> [f64; 2] {
         let size = self.window().inner_size();
-        [size.width as f32, size.height as f32]
+        [size.width.into(), size.height.into()]
     }
 
     /// Size of the final swapchain image (surface).
@@ -188,17 +188,17 @@ impl VulkanoWindowRenderer {
 
     /// Return scale factor accounted window size.
     #[inline]
-    pub fn resolution(&self) -> [f32; 2] {
+    pub fn resolution(&self) -> [f64; 2] {
         let size = self.window().inner_size();
         let scale_factor = self.window().scale_factor();
         [
-            (size.width as f64 / scale_factor) as f32,
-            (size.height as f64 / scale_factor) as f32,
+            (size.width as f64 / scale_factor),
+            (size.height as f64 / scale_factor),
         ]
     }
 
     #[inline]
-    pub fn aspect_ratio(&self) -> f32 {
+    pub fn aspect_ratio(&self) -> f64 {
         let dims = self.window_size();
         dims[0] / dims[1]
     }

--- a/vulkano-util/src/window.rs
+++ b/vulkano-util/src/window.rs
@@ -70,7 +70,7 @@ impl VulkanoWindows {
                 )),
             )),
             _ => {
-                let WindowDescriptor {
+                let &WindowDescriptor {
                     width,
                     height,
                     position,
@@ -79,27 +79,23 @@ impl VulkanoWindows {
                 } = window_descriptor;
 
                 if let Some(position) = position {
-                    if let Some(sf) = scale_factor_override {
+                    if let Some(scale_factor_override) = scale_factor_override {
                         winit_window_builder = winit_window_builder.with_position(
-                            winit::dpi::LogicalPosition::new(
-                                position[0] as f64,
-                                position[1] as f64,
-                            )
-                            .to_physical::<f64>(*sf),
+                            winit::dpi::LogicalPosition::new(position[0], position[1])
+                                .to_physical::<f64>(scale_factor_override),
                         );
                     } else {
-                        winit_window_builder =
-                            winit_window_builder.with_position(winit::dpi::LogicalPosition::new(
-                                position[0] as f64,
-                                position[1] as f64,
-                            ));
+                        winit_window_builder = winit_window_builder.with_position(
+                            winit::dpi::LogicalPosition::new(position[0], position[1]),
+                        );
                     }
                 }
-                if let Some(sf) = scale_factor_override {
-                    winit_window_builder
-                        .with_inner_size(LogicalSize::new(*width, *height).to_physical::<f64>(*sf))
+                if let Some(scale_factor_override) = scale_factor_override {
+                    winit_window_builder.with_inner_size(
+                        LogicalSize::new(width, height).to_physical::<f64>(scale_factor_override),
+                    )
                 } else {
-                    winit_window_builder.with_inner_size(LogicalSize::new(*width, *height))
+                    winit_window_builder.with_inner_size(LogicalSize::new(width, height))
                 }
             }
             .with_resizable(window_descriptor.resizable)
@@ -309,38 +305,50 @@ pub struct WindowDescriptor {
     /// The requested logical width of the window's client area.
     ///
     /// May vary from the physical width due to different pixel density on different monitors.
-    pub width: f32,
+    pub width: f64,
+
     /// The requested logical height of the window's client area.
     ///
     /// May vary from the physical height due to different pixel density on different monitors.
-    pub height: f32,
+    pub height: f64,
+
     /// The position on the screen that the window will be centered at.
     ///
     /// If set to `None`, some platform-specific position will be chosen.
-    pub position: Option<[f32; 2]>,
+    pub position: Option<[f64; 2]>,
+
     /// Sets minimum and maximum resize limits.
     pub resize_constraints: WindowResizeConstraints,
+
     /// Overrides the window's ratio of physical pixels to logical pixels.
     ///
     /// If there are some scaling problems on X11 try to set this option to `Some(1.0)`.
     pub scale_factor_override: Option<f64>,
+
     /// Sets the title that displays on the window top bar, on the system task bar and other OS
     /// specific places.
     pub title: String,
+
     /// The window's [`PresentMode`].
     ///
     /// Used to select whether or not VSync is used
     pub present_mode: PresentMode,
+
     /// Sets whether the window is resizable.
     pub resizable: bool,
+
     /// Sets whether the window should have borders and bars.
     pub decorations: bool,
+
     /// Sets whether the cursor is visible when the window has focus.
     pub cursor_visible: bool,
+
     /// Sets whether the window locks the cursor inside its borders when the window has focus.
     pub cursor_locked: bool,
+
     /// Sets the [`WindowMode`].
     pub mode: WindowMode,
+
     /// Sets whether the background of the window should be transparent.
     pub transparent: bool,
 }
@@ -375,10 +383,10 @@ impl Default for WindowDescriptor {
 /// required to disable maximizing is not yet exposed by winit.
 #[derive(Debug, Clone, Copy)]
 pub struct WindowResizeConstraints {
-    pub min_width: f32,
-    pub min_height: f32,
-    pub max_width: f32,
-    pub max_height: f32,
+    pub min_width: f64,
+    pub min_height: f64,
+    pub max_width: f64,
+    pub max_height: f64,
 }
 
 impl Default for WindowResizeConstraints {
@@ -387,8 +395,8 @@ impl Default for WindowResizeConstraints {
         Self {
             min_width: 180.,
             min_height: 120.,
-            max_width: f32::INFINITY,
-            max_height: f32::INFINITY,
+            max_width: f64::INFINITY,
+            max_height: f64::INFINITY,
         }
     }
 }

--- a/vulkano-util/src/window.rs
+++ b/vulkano-util/src/window.rs
@@ -65,8 +65,8 @@ impl VulkanoWindows {
             WindowMode::SizedFullscreen => winit_window_builder.with_fullscreen(Some(
                 winit::window::Fullscreen::Exclusive(get_fitting_videomode(
                     &event_loop.primary_monitor().unwrap(),
-                    window_descriptor.width as u32,
-                    window_descriptor.height as u32,
+                    window_descriptor.width,
+                    window_descriptor.height,
                 )),
             )),
             _ => {
@@ -235,8 +235,8 @@ impl VulkanoWindows {
 
 fn get_fitting_videomode(
     monitor: &winit::monitor::MonitorHandle,
-    width: u32,
-    height: u32,
+    width: f64,
+    height: f64,
 ) -> winit::monitor::VideoMode {
     fn abs_diff(a: u32, b: u32) -> u32 {
         if a > b {
@@ -244,6 +244,9 @@ fn get_fitting_videomode(
         }
         b - a
     }
+
+    let width = width.round() as u32;
+    let height = height.round() as u32;
 
     monitor
         .video_modes()


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to vulkano-util:
- `f64` is now used instead of casting to `f32` whenever manipulating `u32` or `f64` values received from the window library.
```

Winit uses `u32` or `f64` to represent sizes, positions, etc. Casting either of those to `f32` results in precision loss. By using `f64` throughout, the user is given the choice of losing precision instead of having it forced on them by Vulkano.