### PR TITLE
Enable and fix pointer cast lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,14 @@ rand = "0.8"
 ron = "0.8"
 
 [workspace.lints]
-rust.missing_docs = "allow"                # TODO: warn eventually
+rust.missing_docs = "allow"            # TODO: warn eventually
 rust.rust_2018_idioms = "warn"
-rust.rust_2024_compatibility = "allow"     # TODO: warn eventually
-clippy.missing_safety_doc = "allow"        # TODO: warn eventually
+rust.rust_2024_compatibility = "allow" # TODO: warn eventually
+clippy.borrow_as_ptr = "warn"
+clippy.missing_safety_doc = "allow"    # TODO: warn eventually
+clippy.ptr_as_ptr = "warn"
+clippy.ptr_cast_constness = "warn"
+# clippy.ref_as_ptr = "warn"                 # TODO: enable once it's stable
 clippy.trivially_copy_pass_by_ref = "warn"
 # These lints are a bit too pedantic, so they're disabled here.
 # They can be removed if they no longer happen in the future.

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -631,7 +631,7 @@ fn features_ffi_output(members: &[FeaturesFfiMember]) -> TokenStream {
                     self.#name = Some(Default::default());
                     let member = self.#name.as_mut().unwrap();
                     member.p_next = head.p_next;
-                    head.p_next = member as *mut _ as _;
+                    head.p_next = core::ptr::from_mut(member).cast();
                 }
             }
         },

--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -277,7 +277,7 @@ fn properties_ffi_output(members: &[PropertiesFfiMember]) -> TokenStream {
                     self.#name = Some(Default::default());
                     let member = self.#name.as_mut().unwrap();
                     member.p_next = head.p_next;
-                    head.p_next = member as *mut _ as _;
+                    head.p_next = core::ptr::from_mut(member).cast();
                 }
             }
         },

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -88,7 +88,7 @@ impl RawBuffer {
         } = &create_info;
 
         let (sharing_mode, queue_family_index_count, p_queue_family_indices) = match sharing {
-            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, &[] as _),
+            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, ptr::null()),
             Sharing::Concurrent(queue_family_indices) => (
                 ash::vk::SharingMode::CONCURRENT,
                 queue_family_indices.len() as u32,
@@ -114,7 +114,7 @@ impl RawBuffer {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let handle = {
@@ -245,7 +245,7 @@ impl RawBuffer {
                 .insert(ash::vk::MemoryDedicatedRequirements::default());
 
             next.p_next = memory_requirements2_vk.p_next;
-            memory_requirements2_vk.p_next = next as *mut _ as *mut _;
+            memory_requirements2_vk.p_next = ptr::from_mut(next).cast();
         }
 
         unsafe {
@@ -864,7 +864,7 @@ impl BufferCreateInfo {
 #[cfg(test)]
 mod tests {
     use super::{BufferCreateInfo, BufferUsage, RawBuffer};
-    use crate::device::{Device, DeviceOwned};
+    use crate::device::DeviceOwned;
 
     #[test]
     fn create() {
@@ -882,7 +882,7 @@ mod tests {
 
         assert!(reqs.layout.size() >= 128);
         assert_eq!(buf.size(), 128);
-        assert_eq!(&**buf.device() as *const Device, &*device as *const Device);
+        assert_eq!(buf.device(), &device);
     }
 
     /* Re-enable when sparse binding is properly implemented

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -21,7 +21,7 @@ use crate::{
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
 use smallvec::SmallVec;
-use std::{mem::size_of, sync::Arc};
+use std::{mem::size_of, ptr, sync::Arc};
 
 /// # Commands to do operations on acceleration structures.
 impl RecordingCommandBuffer {
@@ -1568,7 +1568,7 @@ impl RawRecordingCommandBuffer {
             .collect();
         let build_range_info_pointers_vk: SmallVec<[_; 8]> = build_range_info_elements_vk
             .iter()
-            .map(|element| element as *const _)
+            .map(ptr::from_ref)
             .collect();
 
         let fns = self.device().fns();

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -1146,7 +1146,9 @@ impl RawRecordingCommandBuffer {
             let push_size = remaining_size.min(range.offset + range.size - current_offset);
             let data_offset = (current_offset - offset) as usize;
             debug_assert!(data_offset < size as usize);
-            let data = (push_constants as *const Pc as *const c_void).add(data_offset);
+            let data = ptr::from_ref(push_constants)
+                .cast::<c_void>()
+                .add(data_offset);
 
             (fns.v1_0.cmd_push_constants)(
                 self.handle(),
@@ -1348,13 +1350,13 @@ impl RawRecordingCommandBuffer {
                 }
                 DescriptorWriteInfo::InlineUniformBlock(data) => {
                     write_vk.descriptor_count = data.len() as u32;
-                    write_vk.p_next = &per_write_vk.inline_uniform_block as *const _ as _;
+                    write_vk.p_next = ptr::addr_of!(per_write_vk.inline_uniform_block).cast();
                     per_write_vk.inline_uniform_block.data_size = write_vk.descriptor_count;
-                    per_write_vk.inline_uniform_block.p_data = data.as_ptr() as *const _;
+                    per_write_vk.inline_uniform_block.p_data = data.as_ptr().cast();
                 }
                 DescriptorWriteInfo::AccelerationStructure(info) => {
                     write_vk.descriptor_count = info.len() as u32;
-                    write_vk.p_next = &per_write_vk.acceleration_structures as *const _ as _;
+                    write_vk.p_next = ptr::addr_of!(per_write_vk.acceleration_structures).cast();
                     per_write_vk
                         .acceleration_structures
                         .acceleration_structure_count = write_vk.descriptor_count;

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -11,7 +11,7 @@ use crate::{
     VulkanObject,
 };
 use smallvec::{smallvec, SmallVec};
-use std::{mem::size_of_val, sync::Arc};
+use std::{mem::size_of_val, ptr, sync::Arc};
 
 /// # Commands to fill resources with new data.
 impl RecordingCommandBuffer {
@@ -630,7 +630,7 @@ impl RawRecordingCommandBuffer {
             dst_buffer.buffer().handle(),
             dst_buffer.offset(),
             size_of_val(data) as DeviceSize,
-            data as *const _ as *const _,
+            ptr::from_ref(data).cast(),
         );
 
         self

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -172,7 +172,7 @@ impl RawRecordingCommandBuffer {
                                 });
 
                             inheritance_info_vk.p_next =
-                                inheritance_rendering_info_vk as *const _ as *const _;
+                                ptr::from_ref(inheritance_rendering_info_vk).cast();
                         }
                     }
                 }

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -155,7 +155,7 @@ impl DescriptorSetLayout {
                 });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let handle = {

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -96,7 +96,7 @@ impl DescriptorPool {
             );
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let handle = unsafe {
@@ -287,7 +287,7 @@ impl DescriptorPool {
                 descriptor_set_count: layouts_vk.len() as u32,
                 p_set_layouts: layouts_vk.as_ptr(),
                 p_next: if let Some(next) = variable_desc_count_alloc_info.as_ref() {
-                    next as *const _ as *const _
+                    ptr::from_ref(next).cast()
                 } else {
                     ptr::null()
                 },

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -18,6 +18,7 @@ use std::{
     fmt::Debug,
     hash::{Hash, Hasher},
     mem::ManuallyDrop,
+    ptr,
     sync::Arc,
 };
 
@@ -152,13 +153,13 @@ impl RawDescriptorSet {
                 }
                 DescriptorWriteInfo::InlineUniformBlock(data) => {
                     write_vk.descriptor_count = data.len() as u32;
-                    write_vk.p_next = &per_write_vk.inline_uniform_block as *const _ as _;
+                    write_vk.p_next = ptr::addr_of!(per_write_vk.inline_uniform_block).cast();
                     per_write_vk.inline_uniform_block.data_size = write_vk.descriptor_count;
-                    per_write_vk.inline_uniform_block.p_data = data.as_ptr() as *const _;
+                    per_write_vk.inline_uniform_block.p_data = data.as_ptr().cast();
                 }
                 DescriptorWriteInfo::AccelerationStructure(info) => {
                     write_vk.descriptor_count = info.len() as u32;
-                    write_vk.p_next = &per_write_vk.acceleration_structures as *const _ as _;
+                    write_vk.p_next = ptr::addr_of!(per_write_vk.acceleration_structures).cast();
                     per_write_vk
                         .acceleration_structures
                         .acceleration_structure_count = write_vk.descriptor_count;

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -415,7 +415,7 @@ impl Device {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *mut _ as *mut _;
+            create_info_vk.p_next = ptr::from_mut(next).cast();
         }
 
         let mut private_data_create_info_vk = None;
@@ -427,12 +427,12 @@ impl Device {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *mut _ as *mut _;
+            create_info_vk.p_next = ptr::from_mut(next).cast();
         }
 
         // VUID-VkDeviceCreateInfo-pNext-00373
         if has_khr_get_physical_device_properties2 {
-            create_info_vk.p_next = features_ffi.head_as_ref() as *const _ as _;
+            create_info_vk.p_next = ptr::from_ref(features_ffi.head_as_ref()).cast();
         } else {
             create_info_vk.p_enabled_features = &features_ffi.head_as_ref().features;
         }
@@ -976,13 +976,13 @@ impl Device {
                 });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
 
             let next = variable_descriptor_count_support_vk
                 .insert(ash::vk::DescriptorSetVariableDescriptorCountLayoutSupport::default());
 
             next.p_next = support_vk.p_next;
-            support_vk.p_next = next as *mut _ as *mut _;
+            support_vk.p_next = ptr::from_mut(next).cast();
         }
 
         let fns = self.fns();
@@ -1060,7 +1060,7 @@ impl Device {
         } = &create_info;
 
         let (sharing_mode, queue_family_index_count, p_queue_family_indices) = match sharing {
-            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, &[] as _),
+            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, ptr::null()),
             Sharing::Concurrent(queue_family_indices) => (
                 ash::vk::SharingMode::CONCURRENT,
                 queue_family_indices.len() as u32,
@@ -1086,7 +1086,7 @@ impl Device {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let info_vk = ash::vk::DeviceBufferMemoryRequirements {
@@ -1104,7 +1104,7 @@ impl Device {
                 .insert(ash::vk::MemoryDedicatedRequirements::default());
 
             next.p_next = memory_requirements2_vk.p_next;
-            memory_requirements2_vk.p_next = next as *mut _ as *mut _;
+            memory_requirements2_vk.p_next = ptr::from_mut(next).cast();
         }
 
         unsafe {
@@ -1302,7 +1302,7 @@ impl Device {
         } = &create_info;
 
         let (sharing_mode, queue_family_index_count, p_queue_family_indices) = match sharing {
-            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, &[] as _),
+            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, ptr::null()),
             Sharing::Concurrent(queue_family_indices) => (
                 ash::vk::SharingMode::CONCURRENT,
                 queue_family_indices.len() as u32,
@@ -1346,7 +1346,7 @@ impl Device {
             );
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if !external_memory_handle_types.is_empty() {
@@ -1356,7 +1356,7 @@ impl Device {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if !view_formats.is_empty() {
@@ -1373,7 +1373,7 @@ impl Device {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if let Some(stencil_usage) = stencil_usage {
@@ -1383,7 +1383,7 @@ impl Device {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         // This is currently necessary because of an issue with the spec. The plane aspect should
@@ -1429,7 +1429,7 @@ impl Device {
                 .insert(ash::vk::MemoryDedicatedRequirements::default());
 
             next.p_next = memory_requirements2_vk.p_next;
-            memory_requirements2_vk.p_next = next as *mut _ as *mut _;
+            memory_requirements2_vk.p_next = ptr::from_mut(next).cast();
         }
 
         unsafe {
@@ -2262,7 +2262,7 @@ pub(crate) struct DeviceOwnedDebugWrapper<T>(pub(crate) T);
 impl<T> DeviceOwnedDebugWrapper<T> {
     pub fn cast_slice_inner(slice: &[Self]) -> &[T] {
         // SAFETY: `DeviceOwnedDebugWrapper<T>` and `T` have the same layout.
-        unsafe { slice::from_raw_parts(slice as *const _ as *const _, slice.len()) }
+        unsafe { slice::from_raw_parts(ptr::from_ref(slice).cast(), slice.len()) }
     }
 }
 

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -1205,7 +1205,7 @@ impl PhysicalDevice {
                         });
 
                     next.p_next = external_semaphore_info_vk.p_next;
-                    external_semaphore_info_vk.p_next = next as *const _ as *const _;
+                    external_semaphore_info_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 /* Output */
@@ -1288,14 +1288,14 @@ impl PhysicalDevice {
             {
                 let next = format_properties3_vk.insert(ash::vk::FormatProperties3KHR::default());
                 next.p_next = format_properties2_vk.p_next;
-                format_properties2_vk.p_next = next as *mut _ as *mut _;
+                format_properties2_vk.p_next = ptr::from_mut(next).cast();
             }
 
             if self.supported_extensions().ext_image_drm_format_modifier {
                 let next = drm_format_modifier_properties_list_vk
                     .insert(ash::vk::DrmFormatModifierPropertiesListEXT::default());
                 next.p_next = format_properties2_vk.p_next;
-                format_properties2_vk.p_next = next as *mut _ as *mut _;
+                format_properties2_vk.p_next = ptr::from_mut(next).cast();
 
                 if self.api_version() >= Version::V1_3
                     || self.supported_extensions().khr_format_feature_flags2
@@ -1303,7 +1303,7 @@ impl PhysicalDevice {
                     let next = drm_format_modifier_properties_list2_vk
                         .insert(ash::vk::DrmFormatModifierPropertiesList2EXT::default());
                     next.p_next = format_properties2_vk.p_next;
-                    format_properties2_vk.p_next = next as *mut _ as *mut _;
+                    format_properties2_vk.p_next = ptr::from_mut(next).cast();
                 }
             }
 
@@ -1514,7 +1514,7 @@ impl PhysicalDevice {
 
                     let (sharing_mode, queue_family_index_count, p_queue_family_indices) =
                         match sharing {
-                            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, &[] as _),
+                            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, ptr::null()),
                             Sharing::Concurrent(queue_family_indices) => (
                                 ash::vk::SharingMode::CONCURRENT,
                                 queue_family_indices.len() as u32,
@@ -1533,7 +1533,7 @@ impl PhysicalDevice {
                     );
 
                     next.p_next = info2_vk.p_next;
-                    info2_vk.p_next = next as *const _ as *const _;
+                    info2_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 if let Some(handle_type) = external_memory_handle_type {
@@ -1544,7 +1544,7 @@ impl PhysicalDevice {
                         });
 
                     next.p_next = info2_vk.p_next;
-                    info2_vk.p_next = next as *const _ as *const _;
+                    info2_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 if !view_formats.is_empty() {
@@ -1561,7 +1561,7 @@ impl PhysicalDevice {
                     });
 
                     next.p_next = info2_vk.p_next;
-                    info2_vk.p_next = next as *const _ as *const _;
+                    info2_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 if let Some(image_view_type) = image_view_type {
@@ -1572,8 +1572,8 @@ impl PhysicalDevice {
                         },
                     );
 
-                    next.p_next = info2_vk.p_next as *mut _;
-                    info2_vk.p_next = next as *const _ as *const _;
+                    next.p_next = info2_vk.p_next.cast_mut();
+                    info2_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 if let Some(stencil_usage) = stencil_usage {
@@ -1582,8 +1582,8 @@ impl PhysicalDevice {
                         ..Default::default()
                     });
 
-                    next.p_next = info2_vk.p_next as *mut _;
-                    info2_vk.p_next = next as *const _ as *const _;
+                    next.p_next = info2_vk.p_next.cast_mut();
+                    info2_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 /* Output */
@@ -1597,7 +1597,7 @@ impl PhysicalDevice {
                         .insert(ash::vk::ExternalImageFormatProperties::default());
 
                     next.p_next = properties2_vk.p_next;
-                    properties2_vk.p_next = next as *mut _ as *mut _;
+                    properties2_vk.p_next = ptr::from_mut(next).cast();
                 }
 
                 if image_view_info_vk.is_some() {
@@ -1605,7 +1605,7 @@ impl PhysicalDevice {
                         .insert(ash::vk::FilterCubicImageViewImageFormatPropertiesEXT::default());
 
                     next.p_next = properties2_vk.p_next;
-                    properties2_vk.p_next = next as *mut _ as *mut _;
+                    properties2_vk.p_next = ptr::from_mut(next).cast();
                 }
 
                 let result = {
@@ -2069,8 +2069,8 @@ impl PhysicalDevice {
                 ..Default::default()
             });
 
-            next.p_next = info_vk.p_next as *mut _;
-            info_vk.p_next = next as *const _ as *const _;
+            next.p_next = info_vk.p_next.cast_mut();
+            info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if full_screen_exclusive != FullScreenExclusive::Default {
@@ -2080,8 +2080,8 @@ impl PhysicalDevice {
                     ..Default::default()
                 });
 
-            next.p_next = info_vk.p_next as *mut _;
-            info_vk.p_next = next as *const _ as *const _;
+            next.p_next = info_vk.p_next.cast_mut();
+            info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if let Some(win32_monitor) = win32_monitor {
@@ -2092,8 +2092,8 @@ impl PhysicalDevice {
                 },
             );
 
-            next.p_next = info_vk.p_next as *mut _;
-            info_vk.p_next = next as *const _ as *const _;
+            next.p_next = info_vk.p_next.cast_mut();
+            info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         /* Output */
@@ -2110,8 +2110,8 @@ impl PhysicalDevice {
             let next = capabilities_full_screen_exclusive_vk
                 .insert(ash::vk::SurfaceCapabilitiesFullScreenExclusiveEXT::default());
 
-            next.p_next = capabilities_vk.p_next as *mut _;
-            capabilities_vk.p_next = next as *mut _ as *mut _;
+            next.p_next = capabilities_vk.p_next.cast();
+            capabilities_vk.p_next = ptr::from_mut(next).cast();
         }
 
         if present_mode.is_some() {
@@ -2124,16 +2124,16 @@ impl PhysicalDevice {
                     },
                 );
 
-                next.p_next = capabilities_vk.p_next as *mut _;
-                capabilities_vk.p_next = next as *mut _ as *mut _;
+                next.p_next = capabilities_vk.p_next.cast();
+                capabilities_vk.p_next = ptr::from_mut(next).cast();
             }
 
             {
                 let next = capabilities_present_scaling_vk
                     .insert(ash::vk::SurfacePresentScalingCapabilitiesEXT::default());
 
-                next.p_next = capabilities_vk.p_next as *mut _;
-                capabilities_vk.p_next = next as *mut _ as *mut _;
+                next.p_next = capabilities_vk.p_next.cast();
+                capabilities_vk.p_next = ptr::from_mut(next).cast();
             }
         }
 
@@ -2145,8 +2145,8 @@ impl PhysicalDevice {
             let next = capabilities_protected_vk
                 .insert(ash::vk::SurfaceProtectedCapabilitiesKHR::default());
 
-            next.p_next = capabilities_vk.p_next as *mut _;
-            capabilities_vk.p_next = next as *mut _ as *mut _;
+            next.p_next = capabilities_vk.p_next.cast();
+            capabilities_vk.p_next = ptr::from_mut(next).cast();
         }
 
         let fns = self.instance.fns();
@@ -2472,8 +2472,8 @@ impl PhysicalDevice {
                         ..Default::default()
                     });
 
-                    next.p_next = info_vk.p_next as *mut _;
-                    info_vk.p_next = next as *const _ as *const _;
+                    next.p_next = info_vk.p_next.cast_mut();
+                    info_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 if full_screen_exclusive != FullScreenExclusive::Default {
@@ -2484,8 +2484,8 @@ impl PhysicalDevice {
                         },
                     );
 
-                    next.p_next = info_vk.p_next as *mut _;
-                    info_vk.p_next = next as *const _ as *const _;
+                    next.p_next = info_vk.p_next.cast_mut();
+                    info_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 if let Some(win32_monitor) = win32_monitor {
@@ -2496,8 +2496,8 @@ impl PhysicalDevice {
                         },
                     );
 
-                    next.p_next = info_vk.p_next as *mut _;
-                    info_vk.p_next = next as *const _ as *const _;
+                    next.p_next = info_vk.p_next.cast_mut();
+                    info_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 let fns = self.instance.fns();
@@ -2751,8 +2751,8 @@ impl PhysicalDevice {
                         },
                     );
 
-                    next.p_next = info_vk.p_next as *mut _;
-                    info_vk.p_next = next as *const _ as *const _;
+                    next.p_next = info_vk.p_next.cast_mut();
+                    info_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 if let Some(win32_monitor) = win32_monitor {
@@ -2763,8 +2763,8 @@ impl PhysicalDevice {
                         },
                     );
 
-                    next.p_next = info_vk.p_next as *mut _;
-                    info_vk.p_next = next as *const _ as *const _;
+                    next.p_next = info_vk.p_next.cast_mut();
+                    info_vk.p_next = ptr::from_ref(next).cast();
                 }
 
                 let fns = self.instance.fns();

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -671,7 +671,7 @@ impl<'a> QueueGuard<'a> {
             });
 
             next.p_next = info_vk.p_next;
-            info_vk.p_next = next as *const _ as *const _;
+            info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if has_present_modes {
@@ -681,8 +681,8 @@ impl<'a> QueueGuard<'a> {
                 ..Default::default()
             });
 
-            next.p_next = info_vk.p_next as _;
-            info_vk.p_next = next as *const _ as *const _;
+            next.p_next = info_vk.p_next.cast();
+            info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if has_present_regions {
@@ -702,7 +702,7 @@ impl<'a> QueueGuard<'a> {
             });
 
             next.p_next = info_vk.p_next;
-            info_vk.p_next = next as *const _ as *const _;
+            info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let fns = self.queue.device().fns();
@@ -1187,7 +1187,7 @@ impl<'a> QueueGuard<'a> {
                     };
 
                     timeline_semaphore_submit_info_vk.p_next = submit_info_vk.p_next;
-                    submit_info_vk.p_next = timeline_semaphore_submit_info_vk as *mut _ as *mut _;
+                    submit_info_vk.p_next = ptr::from_mut(timeline_semaphore_submit_info_vk).cast();
                 }
             }
 

--- a/vulkano/src/image/sampler/mod.rs
+++ b/vulkano/src/image/sampler/mod.rs
@@ -194,7 +194,7 @@ impl Sampler {
             );
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if let Some(sampler_ycbcr_conversion) = sampler_ycbcr_conversion {
@@ -205,7 +205,7 @@ impl Sampler {
                 });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let handle = unsafe {

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -124,7 +124,7 @@ impl RawImage {
         } = &create_info;
 
         let (sharing_mode, queue_family_index_count, p_queue_family_indices) = match sharing {
-            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, &[] as _),
+            Sharing::Exclusive => (ash::vk::SharingMode::EXCLUSIVE, 0, ptr::null()),
             Sharing::Concurrent(queue_family_indices) => (
                 ash::vk::SharingMode::CONCURRENT,
                 queue_family_indices.len() as u32,
@@ -171,7 +171,7 @@ impl RawImage {
                 );
 
                 next.p_next = create_info_vk.p_next;
-                create_info_vk.p_next = next as *const _ as *const _;
+                create_info_vk.p_next = ptr::from_ref(next).cast();
             } else {
                 drm_format_modifier_plane_layouts_vk = drm_format_modifier_plane_layouts
                     .iter()
@@ -205,7 +205,7 @@ impl RawImage {
                 );
 
                 next.p_next = create_info_vk.p_next;
-                create_info_vk.p_next = next as *const _ as *const _;
+                create_info_vk.p_next = ptr::from_ref(next).cast();
             }
         }
 
@@ -216,7 +216,7 @@ impl RawImage {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if !view_formats.is_empty() {
@@ -233,7 +233,7 @@ impl RawImage {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if let Some(stencil_usage) = stencil_usage {
@@ -243,7 +243,7 @@ impl RawImage {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let handle = {
@@ -444,7 +444,7 @@ impl RawImage {
             });
 
             next.p_next = info_vk.p_next;
-            info_vk.p_next = next as *mut _ as *mut _;
+            info_vk.p_next = ptr::from_mut(next).cast();
         }
 
         let mut memory_requirements2_vk = ash::vk::MemoryRequirements2::default();
@@ -462,7 +462,7 @@ impl RawImage {
                 .insert(ash::vk::MemoryDedicatedRequirements::default());
 
             next.p_next = memory_requirements2_vk.p_next;
-            memory_requirements2_vk.p_next = next as *mut _ as *mut _;
+            memory_requirements2_vk.p_next = ptr::from_mut(next).cast();
         }
 
         unsafe {
@@ -1197,7 +1197,7 @@ impl RawImage {
             };
 
             for (info_vk, plane_info_vk) in infos_vk.iter_mut().zip(plane_infos_vk.iter_mut()) {
-                info_vk.p_next = plane_info_vk as *mut _ as *mut _;
+                info_vk.p_next = ptr::from_mut(plane_info_vk).cast();
             }
 
             if self.device.api_version() >= Version::V1_1 {

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -595,7 +595,7 @@ impl ImageView {
             });
 
             next.p_next = info_vk.p_next;
-            info_vk.p_next = next as *const _ as *const _;
+            info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if let Some(conversion) = sampler_ycbcr_conversion {
@@ -606,7 +606,7 @@ impl ImageView {
                 });
 
             next.p_next = info_vk.p_next;
-            info_vk.p_next = next as *const _ as *const _;
+            info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let handle = {

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -109,7 +109,7 @@ impl DebugUtilsMessenger {
             message_severity: message_severity.into(),
             message_type: message_type.into(),
             pfn_user_callback: Some(trampoline),
-            p_user_data: user_callback.as_ptr() as *const c_void as *mut _,
+            p_user_data: user_callback.as_ptr().cast_mut().cast(),
             ..Default::default()
         };
 
@@ -305,7 +305,7 @@ impl DebugUtilsMessengerCallback {
     }
 
     pub(crate) fn as_ptr(&self) -> *const CallbackData {
-        &self.0 as _
+        ptr::addr_of!(self.0)
     }
 }
 
@@ -366,7 +366,7 @@ pub(super) unsafe extern "system" fn trampoline(
             ),
         };
 
-        let user_callback = &*(user_data_vk as *mut CallbackData as *const CallbackData);
+        let user_callback: &CallbackData = &*user_data_vk.cast_const().cast();
 
         user_callback(
             message_severity_vk.into(),

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -186,7 +186,7 @@ impl DeviceMemory {
             });
 
             next.p_next = allocate_info_vk.p_next;
-            allocate_info_vk.p_next = next as *const _ as *const _;
+            allocate_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if !export_handle_types.is_empty() {
@@ -196,7 +196,7 @@ impl DeviceMemory {
             });
 
             next.p_next = allocate_info_vk.p_next;
-            allocate_info_vk.p_next = next as *const _ as *const _;
+            allocate_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let imported_handle_type = import_info.as_ref().map(|import_info| match import_info {
@@ -226,7 +226,7 @@ impl DeviceMemory {
                     });
 
                     next.p_next = allocate_info_vk.p_next;
-                    allocate_info_vk.p_next = next as *const _ as *const _;
+                    allocate_info_vk.p_next = ptr::from_ref(next).cast();
                 }
                 MemoryImportInfo::Win32 {
                     handle_type,
@@ -241,7 +241,7 @@ impl DeviceMemory {
                     );
 
                     next.p_next = allocate_info_vk.p_next;
-                    allocate_info_vk.p_next = next as *const _ as *const _;
+                    allocate_info_vk.p_next = ptr::from_ref(next).cast();
                 }
             }
         }
@@ -253,7 +253,7 @@ impl DeviceMemory {
             });
 
             next.p_next = allocate_info_vk.p_next;
-            allocate_info_vk.p_next = next as *const _ as *const _;
+            allocate_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         // VUID-vkAllocateMemory-maxMemoryAllocationCount-04101
@@ -2017,7 +2017,9 @@ impl MappedDeviceMemory {
     #[inline]
     pub unsafe fn read_unchecked(&self, range: Range<DeviceSize>) -> &[u8] {
         slice::from_raw_parts(
-            self.pointer.add((range.start - self.range.start) as usize) as *const u8,
+            self.pointer
+                .add((range.start - self.range.start) as usize)
+                .cast(),
             (range.end - range.start) as usize,
         )
     }
@@ -2055,8 +2057,10 @@ impl MappedDeviceMemory {
     #[allow(clippy::mut_from_ref)]
     pub unsafe fn write_unchecked(&self, range: Range<DeviceSize>) -> &mut [u8] {
         slice::from_raw_parts_mut(
-            self.pointer.add((range.start - self.range.start) as usize) as *mut u8,
-            (range.end - range.start) as usize,
+            self.pointer
+                .add((range.start - self.range.start).try_into().unwrap())
+                .cast::<u8>(),
+            (range.end - range.start).try_into().unwrap(),
         )
     }
 

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -118,7 +118,7 @@ impl PipelineCache {
             p_initial_data: if initial_data.is_empty() {
                 ptr::null()
             } else {
-                initial_data.as_ptr() as _
+                initial_data.as_ptr().cast()
             },
             ..Default::default()
         };
@@ -215,7 +215,7 @@ impl PipelineCache {
                     self.device.handle(),
                     self.handle,
                     &mut count,
-                    data.as_mut_ptr() as *mut _,
+                    data.as_mut_ptr().cast(),
                 );
 
                 match result {

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -129,7 +129,7 @@ impl ComputePipeline {
                 map_entry_count: specialization_map_entries_vk.len() as u32,
                 p_map_entries: specialization_map_entries_vk.as_ptr(),
                 data_size: specialization_data_vk.len(),
-                p_data: specialization_data_vk.as_ptr() as *const _,
+                p_data: specialization_data_vk.as_ptr().cast(),
             };
             required_subgroup_size_create_info =
                 required_subgroup_size.map(|required_subgroup_size| {
@@ -142,7 +142,7 @@ impl ComputePipeline {
                 p_next: required_subgroup_size_create_info.as_ref().map_or(
                     ptr::null(),
                     |required_subgroup_size_create_info| {
-                        required_subgroup_size_create_info as *const _ as _
+                        ptr::from_ref(required_subgroup_size_create_info).cast()
                     },
                 ),
                 flags: flags.into(),

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -312,7 +312,7 @@ impl GraphicsPipeline {
                 p_next: required_subgroup_size_create_info.as_ref().map_or(
                     ptr::null(),
                     |required_subgroup_size_create_info| {
-                        required_subgroup_size_create_info as *const _ as _
+                        ptr::from_ref(required_subgroup_size_create_info).cast()
                     },
                 ),
                 p_name: name_vk.as_ptr(),
@@ -322,7 +322,7 @@ impl GraphicsPipeline {
 
             *specialization_info_vk = ash::vk::SpecializationInfo {
                 p_map_entries: specialization_map_entries_vk.as_ptr(),
-                p_data: specialization_data_vk.as_ptr() as _,
+                p_data: specialization_data_vk.as_ptr().cast(),
                 ..*specialization_info_vk
             };
         }
@@ -402,7 +402,7 @@ impl GraphicsPipeline {
 
                 // VUID-VkPipelineVertexInputDivisorStateCreateInfoEXT-vertexBindingDivisorCount-arraylength
                 if !vertex_binding_divisor_descriptions_vk.is_empty() {
-                    vertex_input_state.p_next = vertex_binding_divisor_state_vk.insert(
+                    let next = vertex_binding_divisor_state_vk.insert(
                         ash::vk::PipelineVertexInputDivisorStateCreateInfoEXT {
                             vertex_binding_divisor_count: vertex_binding_divisor_descriptions_vk
                                 .len()
@@ -411,7 +411,8 @@ impl GraphicsPipeline {
                                 .as_ptr(),
                             ..Default::default()
                         },
-                    ) as *const _ as *const _;
+                    );
+                    vertex_input_state.p_next = ptr::from_ref(next).cast();
                 }
             }
         }
@@ -459,7 +460,7 @@ impl GraphicsPipeline {
 
                 tessellation_domain_origin_state_vk.p_next = tessellation_state_vk.p_next;
                 tessellation_state_vk.p_next =
-                    tessellation_domain_origin_state_vk as *const _ as *const _;
+                    ptr::from_ref(tessellation_domain_origin_state_vk).cast();
             }
         }
 
@@ -553,7 +554,7 @@ impl GraphicsPipeline {
                         (ash::vk::FALSE, 1, 0)
                     };
 
-                rasterization_state.p_next = rasterization_line_state_vk.insert(
+                let next = rasterization_line_state_vk.insert(
                     ash::vk::PipelineRasterizationLineStateCreateInfoEXT {
                         line_rasterization_mode: line_rasterization_mode.into(),
                         stippled_line_enable,
@@ -561,7 +562,8 @@ impl GraphicsPipeline {
                         line_stipple_pattern,
                         ..Default::default()
                     },
-                ) as *const _ as *const _;
+                );
+                rasterization_state.p_next = ptr::from_ref(next).cast();
             }
         }
 
@@ -589,7 +591,7 @@ impl GraphicsPipeline {
                 rasterization_samples: rasterization_samples.into(),
                 sample_shading_enable,
                 min_sample_shading,
-                p_sample_mask: sample_mask as _,
+                p_sample_mask: sample_mask.as_ptr(),
                 alpha_to_coverage_enable: alpha_to_coverage_enable as ash::vk::Bool32,
                 alpha_to_one_enable: alpha_to_one_enable as ash::vk::Bool32,
                 ..Default::default()
@@ -737,12 +739,12 @@ impl GraphicsPipeline {
                     },
                 ));
 
-                color_blend_state_vk.p_next =
-                    color_write_vk.insert(ash::vk::PipelineColorWriteCreateInfoEXT {
-                        attachment_count: color_write_enables_vk.len() as u32,
-                        p_color_write_enables: color_write_enables_vk.as_ptr(),
-                        ..Default::default()
-                    }) as *const _ as *const _;
+                let next = color_write_vk.insert(ash::vk::PipelineColorWriteCreateInfoEXT {
+                    attachment_count: color_write_enables_vk.len() as u32,
+                    p_color_write_enables: color_write_enables_vk.as_ptr(),
+                    ..Default::default()
+                });
+                color_blend_state_vk.p_next = ptr::from_ref(next).cast();
             }
         }
 
@@ -828,39 +830,39 @@ impl GraphicsPipeline {
             p_stages: stages_vk.as_ptr(),
             p_vertex_input_state: vertex_input_state_vk
                 .as_ref()
-                .map(|p| p as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             p_input_assembly_state: input_assembly_state_vk
                 .as_ref()
-                .map(|p| p as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             p_tessellation_state: tessellation_state_vk
                 .as_ref()
-                .map(|p| p as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             p_viewport_state: viewport_state_vk
                 .as_ref()
-                .map(|p| p as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             p_rasterization_state: rasterization_state_vk
                 .as_ref()
-                .map(|p| p as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             p_multisample_state: multisample_state_vk
                 .as_ref()
-                .map(|p| p as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             p_depth_stencil_state: depth_stencil_state_vk
                 .as_ref()
-                .map(|p| p as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             p_color_blend_state: color_blend_state_vk
                 .as_ref()
-                .map(|p| p as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             p_dynamic_state: dynamic_state_vk
                 .as_ref()
-                .map(|s| s as *const _)
+                .map(ptr::from_ref)
                 .unwrap_or(ptr::null()),
             layout: layout.handle(),
             render_pass: render_pass_vk,
@@ -874,12 +876,12 @@ impl GraphicsPipeline {
 
         if let Some(info) = discard_rectangle_state_vk.as_mut() {
             info.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = info as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(info).cast();
         }
 
         if let Some(info) = rendering_create_info_vk.as_mut() {
             info.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = info as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(info).cast();
         }
 
         let cache_handle = match cache.as_ref() {

--- a/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
@@ -41,7 +41,7 @@ macro_rules! impl_vertex {
                         let format = f(&dummy.$member);
                         let field_size = {
                             let p = unsafe {
-                                core::ptr::addr_of!((*(&dummy as *const _ as *const $out)).$member)
+                                core::ptr::addr_of!((*(core::ptr::addr_of!(dummy).cast::<$out>())).$member)
                             };
                             const fn size_of_raw<T>(_: *const T) -> usize {
                                 core::mem::size_of::<T>()
@@ -53,8 +53,8 @@ macro_rules! impl_vertex {
                         let remainder = field_size % format_size;
                         assert!(remainder == 0, "struct field `{}` size does not fit multiple of format size", stringify!($member));
 
-                        let dummy_ptr = (&dummy) as *const _;
-                        let member_ptr = (&dummy.$member) as *const _;
+                        let dummy_ptr = core::ptr::addr_of!(dummy);
+                        let member_ptr = core::ptr::addr_of!(dummy.$member);
 
                         members.insert(stringify!($member).to_string(), VertexMemberInfo {
                             offset: u32::try_from(member_ptr as usize - dummy_ptr as usize).unwrap(),

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -13,7 +13,6 @@ use crate::{
     VulkanError, VulkanObject,
 };
 use std::{
-    ffi::c_void,
     mem::{size_of_val, MaybeUninit},
     num::NonZeroU64,
     ops::Range,
@@ -286,7 +285,7 @@ impl QueryPool {
                 range.start,
                 range.len() as u32,
                 size_of_val(destination),
-                destination.as_mut_ptr() as *mut c_void,
+                destination.as_mut_ptr().cast(),
                 stride,
                 ash::vk::QueryResultFlags::from(flags) | T::FLAG,
             )

--- a/vulkano/src/render_pass/create.rs
+++ b/vulkano/src/render_pass/create.rs
@@ -78,8 +78,8 @@ impl RenderPass {
             let PerAttachment { stencil_layout_vk } = per_attachment_vk;
 
             if let Some(next) = stencil_layout_vk {
-                next.p_next = attachment_vk.p_next as *mut _;
-                attachment_vk.p_next = next as *const _ as *const _;
+                next.p_next = attachment_vk.p_next.cast_mut();
+                attachment_vk.p_next = ptr::from_ref(next).cast();
             }
         }
 
@@ -349,8 +349,8 @@ impl RenderPass {
                 let PerAttachmentReferenceVk { stencil_layout_vk } = per_input_attachment_vk;
 
                 if let Some(stencil_layout_vk) = stencil_layout_vk {
-                    stencil_layout_vk.p_next = input_attachment_vk.p_next as *mut _;
-                    input_attachment_vk.p_next = stencil_layout_vk as *const _ as *const _;
+                    stencil_layout_vk.p_next = input_attachment_vk.p_next.cast_mut();
+                    input_attachment_vk.p_next = ptr::from_ref(stencil_layout_vk).cast();
                 }
             }
 
@@ -359,8 +359,8 @@ impl RenderPass {
                     per_depth_stencil_attachment_vk;
 
                 if let Some(stencil_layout_vk) = stencil_layout_vk {
-                    stencil_layout_vk.p_next = depth_stencil_attachment_vk.p_next as *mut _;
-                    depth_stencil_attachment_vk.p_next = stencil_layout_vk as *const _ as *const _;
+                    stencil_layout_vk.p_next = depth_stencil_attachment_vk.p_next.cast_mut();
+                    depth_stencil_attachment_vk.p_next = ptr::from_ref(stencil_layout_vk).cast();
                 }
             }
 
@@ -369,9 +369,10 @@ impl RenderPass {
                     per_depth_stencil_resolve_attachment_vk;
 
                 if let Some(stencil_layout_vk) = stencil_layout_vk {
-                    stencil_layout_vk.p_next = depth_stencil_resolve_attachment_vk.p_next as *mut _;
+                    stencil_layout_vk.p_next =
+                        depth_stencil_resolve_attachment_vk.p_next.cast_mut();
                     depth_stencil_resolve_attachment_vk.p_next =
-                        stencil_layout_vk as *const _ as *const _;
+                        ptr::from_ref(stencil_layout_vk).cast();
                 }
             }
 
@@ -404,7 +405,7 @@ impl RenderPass {
                 };
 
                 depth_stencil_resolve_vk.p_next = subpass_vk.p_next;
-                subpass_vk.p_next = depth_stencil_resolve_vk as *const _ as *const _;
+                subpass_vk.p_next = ptr::from_ref(depth_stencil_resolve_vk).cast();
             }
         }
 
@@ -464,7 +465,7 @@ impl RenderPass {
 
             if let Some(next) = memory_barrier_vk {
                 next.p_next = dependency_vk.p_next;
-                dependency_vk.p_next = next as *const _ as *const _;
+                dependency_vk.p_next = ptr::from_ref(next).cast();
             }
         }
 
@@ -836,7 +837,7 @@ impl RenderPass {
                 );
 
                 next.p_next = create_info_vk.p_next;
-                create_info_vk.p_next = next as *const _ as *const _;
+                create_info_vk.p_next = ptr::from_ref(next).cast();
             }
         }
 
@@ -869,7 +870,7 @@ impl RenderPass {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         Ok({

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -1056,7 +1056,7 @@ impl Swapchain {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if full_screen_exclusive != FullScreenExclusive::Default {
@@ -1066,8 +1066,8 @@ impl Swapchain {
                     ..Default::default()
                 });
 
-            next.p_next = create_info_vk.p_next as *mut _;
-            create_info_vk.p_next = next as *const _ as *const _;
+            next.p_next = create_info_vk.p_next.cast_mut();
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if let Some(Win32Monitor(hmonitor)) = win32_monitor {
@@ -1078,8 +1078,8 @@ impl Swapchain {
                 },
             );
 
-            next.p_next = create_info_vk.p_next as *mut _;
-            create_info_vk.p_next = next as *const _ as *const _;
+            next.p_next = create_info_vk.p_next.cast_mut();
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if !present_modes.is_empty() {
@@ -1091,8 +1091,8 @@ impl Swapchain {
                 ..Default::default()
             });
 
-            next.p_next = create_info_vk.p_next as *mut _;
-            create_info_vk.p_next = next as *const _ as *const _;
+            next.p_next = create_info_vk.p_next.cast_mut();
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if scaling_behavior.is_some() || present_gravity.is_some() {
@@ -1106,8 +1106,8 @@ impl Swapchain {
                     ..Default::default()
                 });
 
-            next.p_next = create_info_vk.p_next as *mut _;
-            create_info_vk.p_next = next as *const _ as *const _;
+            next.p_next = create_info_vk.p_next.cast_mut();
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let fns = device.fns();

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -105,31 +105,27 @@ impl Surface {
 
         match (window_handle.as_raw(), display_handle.as_raw()) {
             (RawWindowHandle::AndroidNdk(window), RawDisplayHandle::Android(_display)) => {
-                Self::from_android(
-                    instance,
-                    window.a_native_window.as_ptr() as *mut ash::vk::ANativeWindow,
-                    None,
-                )
+                Self::from_android(instance, window.a_native_window.as_ptr().cast(), None)
             }
             #[cfg(target_os = "macos")]
             (RawWindowHandle::AppKit(window), RawDisplayHandle::AppKit(_display)) => {
                 // Ensure the layer is `CAMetalLayer`.
-                let metal_layer = get_metal_layer_macos(window.ns_view.as_ptr() as *mut c_void);
+                let metal_layer = get_metal_layer_macos(window.ns_view.as_ptr().cast());
 
-                Self::from_mac_os(instance, metal_layer as *const c_void, None)
+                Self::from_mac_os(instance, metal_layer.cast(), None)
             }
             #[cfg(target_os = "ios")]
             (RawWindowHandle::UiKit(window), RawDisplayHandle::UiKit(_display)) => {
                 // Ensure the layer is `CAMetalLayer`.
-                let metal_layer = get_metal_layer_ios(window.ui_view.as_ptr() as *mut c_void);
+                let metal_layer = get_metal_layer_ios(window.ui_view.as_ptr().cast());
 
-                Self::from_ios(instance, metal_layer.render_layer.0 as *const c_void, None)
+                Self::from_ios(instance, metal_layer.render_layer.0.cast(), None)
             }
             (RawWindowHandle::Wayland(window), RawDisplayHandle::Wayland(display)) => {
                 Self::from_wayland(
                     instance,
-                    display.display.as_ptr() as *mut ash::vk::wl_display,
-                    window.surface.as_ptr() as *mut ash::vk::wl_surface,
+                    display.display.as_ptr().cast(),
+                    window.surface.as_ptr().cast(),
                     None,
                 )
             }
@@ -143,13 +139,13 @@ impl Surface {
             }
             (RawWindowHandle::Xcb(window), RawDisplayHandle::Xcb(display)) => Self::from_xcb(
                 instance,
-                display.connection.unwrap().as_ptr() as *mut ash::vk::xcb_connection_t,
+                display.connection.unwrap().as_ptr().cast(),
                 window.window.get() as ash::vk::xcb_window_t,
                 None,
             ),
             (RawWindowHandle::Xlib(window), RawDisplayHandle::Xlib(display)) => Self::from_xlib(
                 instance,
-                display.display.unwrap().as_ptr() as *mut ash::vk::Display,
+                display.display.unwrap().as_ptr().cast(),
                 window.window as ash::vk::Window,
                 None,
             ),

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -108,7 +108,7 @@ impl Fence {
 
         if let Some(info) = export_fence_create_info_vk.as_mut() {
             info.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = info as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(info).cast();
         }
 
         let handle = {

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -140,7 +140,7 @@ impl Semaphore {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         if !export_handle_types.is_empty() {
@@ -150,7 +150,7 @@ impl Semaphore {
             });
 
             next.p_next = create_info_vk.p_next;
-            create_info_vk.p_next = next as *const _ as *const _;
+            create_info_vk.p_next = ptr::from_ref(next).cast();
         }
 
         let handle = {


### PR DESCRIPTION
This enables and fixes the following Clippy lints:
- `borrow_as_ptr`, fixed with `ptr::addr_of!` and `ptr::addr_of_mut!`
- `ptr_as_ptr`, fixed with `ptr::cast`
- `ptr_cast_constness`, fixed with `ptr::cast_const` and `ptr::cast_mut`
- `ref_as_ptr`, fixed with `ptr::from_ref` and `ptr::from_mut`. This one isn't stable yet, so I left it disabled, but fixed all the instances that are reported by nightly Clippy.

I think there should be no more raw pointer casts left using `as` at all now, they should all be explicitly marked as above.