### PR TITLE
Add details for error messages in validate_pipeline_descriptor_sets

### DIFF
--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1832,12 +1832,10 @@ impl RecordingCommandBuffer {
                         if format != required_format {
                             return Err(Box::new(ValidationError {
                                 problem: format!(
-                                    "the currently bound pipeline accesses the image view \
+                                    "The currently bound pipeline requires the image view \
                                     bound to descriptor set {set_num}, binding {binding_num}, \
-                                    descriptor index {index}, but the format of the image view \
-                                    is not equal to the format required by the pipeline: \
-                                    expected `{required_format:?}`, found `{format:?}`
-                                    "
+                                    descriptor index {index} to have a format of `{required_format:?}`, \
+                                    but the actual format is `{format:?}`"
                                 )
                                 .into(),
                                 // vuids?
@@ -1852,11 +1850,10 @@ impl RecordingCommandBuffer {
                         if image_view_type != required_image_view_type {
                             return Err(Box::new(ValidationError {
                                 problem: format!(
-                                    "the currently bound pipeline accesses the image view \
+                                    "the currently bound pipeline requires the image view \
                                     bound to descriptor set {set_num}, binding {binding_num}, \
-                                    descriptor index {index}, but the view type of the image view \
-                                    is not equal to the view type required by the pipeline: \
-                                    expected `{required_image_view_type:?}`, found `{image_view_type:?}`
+                                    descriptor index {index} to have a view type of `{required_image_view_type:?}`, \
+                                    but the actual view type is `{image_view_type:?}`
                                     "
                                 )
                                 .into(),

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1832,7 +1832,7 @@ impl RecordingCommandBuffer {
                         if format != required_format {
                             return Err(Box::new(ValidationError {
                                 problem: format!(
-                                    "The currently bound pipeline requires the image view \
+                                    "the currently bound pipeline requires the image view \
                                     bound to descriptor set {set_num}, binding {binding_num}, \
                                     descriptor index {index} to have a format of `{required_format:?}`, \
                                     but the actual format is `{format:?}`"

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1827,14 +1827,17 @@ impl RecordingCommandBuffer {
                     */
 
                     // The SPIR-V Image Format is not compatible with the image view’s format.
-                    if let Some(format) = binding_reqs.image_format {
-                        if image_view.format() != format {
+                    if let Some(required_format) = binding_reqs.image_format {
+                        let format = image_view.format();
+                        if format != required_format {
                             return Err(Box::new(ValidationError {
                                 problem: format!(
                                     "the currently bound pipeline accesses the image view \
                                     bound to descriptor set {set_num}, binding {binding_num}, \
                                     descriptor index {index}, but the format of the image view \
-                                    is not equal to the format required by the pipeline"
+                                    is not equal to the format required by the pipeline: \
+                                    expected `{required_format:?}`, found `{format:?}`
+                                    "
                                 )
                                 .into(),
                                 // vuids?
@@ -1844,14 +1847,17 @@ impl RecordingCommandBuffer {
                     }
 
                     // Rules for viewType
-                    if let Some(image_view_type) = binding_reqs.image_view_type {
-                        if image_view.view_type() != image_view_type {
+                    if let Some(required_image_view_type) = binding_reqs.image_view_type {
+                        let image_view_type = image_view.view_type();
+                        if image_view_type != required_image_view_type {
                             return Err(Box::new(ValidationError {
                                 problem: format!(
                                     "the currently bound pipeline accesses the image view \
                                     bound to descriptor set {set_num}, binding {binding_num}, \
                                     descriptor index {index}, but the view type of the image view \
-                                    is not equal to the view type required by the pipeline"
+                                    is not equal to the view type required by the pipeline: \
+                                    expected `{required_image_view_type:?}`, found `{image_view_type:?}`
+                                    "
                                 )
                                 .into(),
                                 vuids: vuids!(vuid_type, "viewType-07752"),


### PR DESCRIPTION
Add details for `format` and `image_view_type` checks in `RecordingCommandBuffer::validate_pipeline_descriptor_sets` to make debugging easier.