### PR TITLE
Handle more depends values in vk.xml

### DIFF
--- a/vulkano/autogen/conjunctive_normal_form.rs
+++ b/vulkano/autogen/conjunctive_normal_form.rs
@@ -1,0 +1,71 @@
+use std::ops::BitOrAssign;
+
+pub struct ConjunctiveNormalForm<T> {
+    all_of: Vec<T>,
+}
+
+impl<T> ConjunctiveNormalForm<T>
+where
+    T: for<'a> BitOrAssign<&'a T> + Clone,
+{
+    pub fn empty() -> Self {
+        Self { all_of: Vec::new() }
+    }
+
+    pub fn take(self) -> Vec<T> {
+        self.all_of
+    }
+
+    /// Adds a conjunction (AND) to the conjunctive normal form expression.
+    ///
+    /// For example, if the existing conjunctive normal form expression is represented as
+    /// ```
+    /// a and b and c
+    /// ```
+    /// the CNF of adding AND d is
+    /// ```
+    /// a and b and c and d
+    /// ```
+    pub fn add_conjunction(&mut self, item: T) {
+        self.all_of.push(item)
+    }
+
+    /// Adds a bijection (OR) to the conjunctive normal form expression.
+    ///
+    /// For example, if the existing conjunctive normal form expression is represented as
+    /// ```
+    /// a and b
+    /// ```
+    ///
+    /// the CNF of adding OR (c AND D)
+    /// ```
+    /// (a and b) or (c and d)
+    /// ```
+    /// is
+    /// ```
+    /// (a and b) or (c and d)
+    /// (a or (c and d)) and (b or (c and d))
+    /// (a or c) and (a or d) and (b or c) and (b or d)
+    /// ```
+    ///
+    /// using the distributive law.
+    pub fn add_bijection(&mut self, other: Self) {
+        let mut result = vec![];
+
+        if self.all_of.is_empty() {
+            self.all_of = other.all_of;
+            return;
+        }
+
+        for outer in &self.all_of {
+            for inner in &other.all_of {
+                let mut inner = inner.clone();
+                inner |= outer;
+
+                result.push(inner);
+            }
+        }
+
+        self.all_of = result;
+    }
+}

--- a/vulkano/autogen/extensions.rs
+++ b/vulkano/autogen/extensions.rs
@@ -828,15 +828,12 @@ fn extensions_members(ty: &str, extensions: &IndexMap<&str, &Extension>) -> Vec<
             let name = raw.strip_prefix("VK_").unwrap().to_snake_case();
 
             let requires_all_of = extension.depends.as_ref().map_or_else(Vec::new, |depends| {
-                let depends_panic = |err| -> ! {
+                let depends_expression = parse_depends(depends).unwrap_or_else(|err| {
                     panic!(
-                        "couldn't parse `depends={}` attribute for extension `{}`: {}",
+                        "couldn't parse `depends={:?}` attribute for extension `{}`: {}",
                         extension.name, depends, err
                     )
-                };
-
-                let depends_expression =
-                    parse_depends(depends).unwrap_or_else(|err| depends_panic(err));
+                });
 
                 convert_depends_expression(depends_expression, extensions).take()
             });

--- a/vulkano/autogen/mod.rs
+++ b/vulkano/autogen/mod.rs
@@ -22,6 +22,7 @@ use vk_parse::{
     Registry, RegistryChild, SpirvExtOrCap, Type, TypeSpec, TypesChild,
 };
 
+mod conjunctive_normal_form;
 mod errors;
 mod extensions;
 mod features;


### PR DESCRIPTION
## Overview

These changes are necessary to support the [vk.xml from the latest version of ash](https://github.com/KhronosGroup/Vulkan-Headers/blob/38899bf60605f0a2c50f7968e5c4c9826a824683/registry/vk.xml). To exercise these codepaths, cherry pick this commit https://github.com/0xcaff/vulkano/commit/f43f1188

* Adds a conjunctive normal form helper to express arbitrarily nested depends constrains. Can now handle strings like

  ```
  ((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_depth_stencil_resolve),VK_VERSION_1_2
  ```

* Add parsing for depends values like
  
  ```
  a+b,c
  ```

  This evaluates to

  ```
  (A AND B) OR C
  ```

  Previously, it would crash the parse_depends function because parens were missing and the grouping order was ambiguous.

## Merge Order
These changes add behavior which is used when the new vk.xml is used. This can be safely merged independently of https://github.com/vulkano-rs/vulkano/pull/2510 (either before or after).

I plan to make a PR on top of both these changes and https://github.com/vulkano-rs/vulkano/pull/2510 pulling in the new vk.xml.

## Details

1. It would be nice to have tests for parse_depends but given this is code in a buildscript, not sure how to set that up. Open to ideas here. Would like to do this in a separate PR as the priors lack test coverage.

2. This conjuctive normal form transformation is kinda complex. It is clever but not the most straightforward thing. I think it would be simpler to store the original boolean expression instead and evaluate against that. Left it as is as I don't completely understand the usages of `requires_all_of` enough to safely change them.