### PR TITLE
Handle arrays in autogen

### DIFF
--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -1,5 +1,5 @@
 use super::{write_file, IndexMap, VkRegistryData};
-use ahash::HashMap;
+use ahash::{HashMap, HashSet};
 use heck::ToSnakeCase;
 use nom::{
     bytes::complete::{tag, take_until, take_while1},
@@ -8,10 +8,10 @@ use nom::{
     sequence::{delimited, tuple},
     IResult,
 };
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use std::{collections::hash_map::Entry, fmt::Write as _};
-use vk_parse::{Extension, Type, TypeMember, TypeMemberMarkup, TypeSpec};
+use vk_parse::{Extension, Type, TypeMember, TypeMemberDefinition, TypeMemberMarkup, TypeSpec};
 
 pub fn write(vk_data: &VkRegistryData<'_>) {
     let properties_output = properties_output(&properties_members(&vk_data.types));
@@ -37,8 +37,15 @@ struct PropertiesMember {
     doc: String,
     raw: String,
     ffi_name: Ident,
-    ffi_members: Vec<(Ident, TokenStream)>,
+    ffi_members: Vec<FFIMember>,
     optional: bool,
+}
+
+#[derive(Debug, Clone)]
+struct FFIMember {
+    ident: Ident,
+    tokens: TokenStream,
+    len_field_name: Option<String>,
 }
 
 fn properties_output(members: &[PropertiesMember]) -> TokenStream {
@@ -80,8 +87,23 @@ fn properties_output(members: &[PropertiesMember]) -> TokenStream {
              ..
          }| {
             if *optional {
-                let ffi_members = ffi_members.iter().map(|(ffi_member, ffi_member_field)| {
-                    quote! { properties_ffi.#ffi_member.map(|s| s #ffi_member_field .#ffi_name) }
+                let ffi_members = ffi_members.iter().map(|FFIMember { ident: ffi_member, tokens: ffi_member_field, len_field_name }| {
+                    if let Some(len_field_name) = len_field_name {
+                        let len_field_name = Ident::new(len_field_name.as_str(), Span::call_site());
+
+                        quote! {
+                            properties_ffi.#ffi_member.map(|s|
+                                unsafe {
+                                    std::slice::from_raw_parts(
+                                        s #ffi_member_field .#ffi_name as _,
+                                        s #ffi_member_field .#len_field_name as _,
+                                    )
+                                }
+                            )
+                        }
+                    } else {
+                        quote! { properties_ffi.#ffi_member.map(|s| s #ffi_member_field .#ffi_name) }
+                    }
                 });
 
                 quote! {
@@ -90,7 +112,8 @@ fn properties_output(members: &[PropertiesMember]) -> TokenStream {
                     ].into_iter().flatten().next().and_then(<#ty>::from_vulkan),
                 }
             } else {
-                let ffi_members = ffi_members.iter().map(|(ffi_member, ffi_member_field)| {
+                let ffi_members = ffi_members.iter().map(|FFIMember { ident: ffi_member, tokens: ffi_member_field, len_field_name }| {
+                    assert_eq!(*len_field_name, None);
                     quote! { properties_ffi.#ffi_member #ffi_member_field .#ffi_name }
                 });
 
@@ -190,7 +213,7 @@ fn properties_members(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<Properti
                     return;
                 }
 
-                let vulkano_member = name.to_snake_case();
+                let ffi_name = name.to_snake_case();
                 let vulkano_ty = match name {
                     "apiVersion" => quote! { Version },
                     "bufferImageGranularity"
@@ -208,35 +231,71 @@ fn properties_members(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<Properti
                     }
                     _ => vulkano_type(ty, len),
                 };
-                match properties.entry(vulkano_member.clone()) {
+
+                let len_field_name = len.and_then(|it| match it {
+                    LenKind::Field(it) => Some(it.to_snake_case()),
+                    _ => None,
+                });
+
+                let vulkano_member = if len_field_name.is_some() {
+                    ffi_name
+                        .strip_prefix("p_")
+                        .map(|it| it.to_string())
+                        .unwrap()
+                } else {
+                    ffi_name.clone()
+                };
+
+                let ffi_member = FFIMember {
+                    ident: ty_name.0.clone(),
+                    tokens: ty_name.1.clone(),
+                    len_field_name,
+                };
+
+                match properties.entry(ffi_name.clone()) {
                     Entry::Vacant(entry) => {
                         let mut member = PropertiesMember {
                             name: format_ident!("{}", vulkano_member),
                             ty: vulkano_ty,
                             doc: String::new(),
                             raw: name.to_owned(),
-                            ffi_name: format_ident!("{}", vulkano_member),
-                            ffi_members: vec![ty_name.clone()],
+                            ffi_name: format_ident!("{}", ffi_name),
+                            ffi_members: vec![ffi_member],
                             optional,
                         };
                         make_doc(&mut member, vulkan_ty_name);
                         entry.insert(member);
                     }
                     Entry::Occupied(entry) => {
-                        entry.into_mut().ffi_members.push(ty_name.clone());
+                        entry.into_mut().ffi_members.push(ffi_member);
                     }
                 };
             });
     });
 
-    let mut names: Vec<_> = properties
+    let mut ffi_names: Vec<_> = properties
         .values()
-        .map(|prop| prop.name.to_string())
+        .map(|prop| prop.ffi_name.to_string())
         .collect();
-    names.sort_unstable();
-    names
+    ffi_names.sort_unstable();
+
+    let to_remove = properties
+        .values()
+        .flat_map(|value| {
+            value
+                .ffi_members
+                .iter()
+                .flat_map(|ffi_member| ffi_member.len_field_name.clone())
+        })
+        .collect::<HashSet<String>>();
+
+    let ffi_names = ffi_names
+        .iter()
+        .filter(|it| !to_remove.contains(it.as_str()));
+
+    ffi_names
         .into_iter()
-        .map(|name| properties.remove(&name).unwrap())
+        .map(|name| properties.remove(name).unwrap())
         .collect()
 }
 
@@ -248,7 +307,7 @@ fn make_doc(prop: &mut PropertiesMember, vulkan_ty_name: &str) {
         vulkan_ty_name,
         prop.raw
     )
-    .unwrap();
+        .unwrap();
 }
 
 #[derive(Clone, Debug)]
@@ -427,7 +486,14 @@ fn ffi_member(ty_name: &str) -> String {
 struct Member<'a> {
     name: &'a str,
     ty: &'a str,
-    len: Option<&'a str>,
+    len: Option<LenKind<'a>>,
+}
+
+#[derive(Copy, Clone)]
+enum LenKind<'a> {
+    /// Length information in a member with this name
+    Field(&'a str),
+    Raw(&'a str),
 }
 
 fn members(ty: &Type) -> Vec<Member<'_>> {
@@ -438,6 +504,32 @@ fn members(ty: &Type) -> Vec<Member<'_>> {
             take_while1(|c: char| c.is_ascii_alphanumeric() || c == '_'),
             complete::char(']'),
         ))(input)
+    }
+
+    fn type_member_name(def: &TypeMemberDefinition) -> Option<&str> {
+        def.markup.iter().find_map(|markup| match markup {
+            TypeMemberMarkup::Name(name) => Some(name.as_str()),
+            _ => None,
+        })
+    }
+
+    fn member_by_name<'a>(
+        members: &'a [TypeMember],
+        name: &str,
+    ) -> Option<&'a TypeMemberDefinition> {
+        members.iter().find_map(|it| {
+            let TypeMember::Definition(defs) = it else {
+                return None;
+            };
+
+            let member_name = type_member_name(defs)?;
+
+            if member_name != name {
+                return None;
+            };
+
+            Some(defs)
+        })
     }
 
     let TypeSpec::Members(members) = &ty.spec else {
@@ -451,10 +543,7 @@ fn members(ty: &Type) -> Vec<Member<'_>> {
                 return None;
             };
 
-            let name = def.markup.iter().find_map(|markup| match markup {
-                TypeMemberMarkup::Name(name) => Some(name.as_str()),
-                _ => None,
-            });
+            let name = type_member_name(def);
             let ty = def.markup.iter().find_map(|markup| match markup {
                 TypeMemberMarkup::Type(ty) => Some(ty.as_str()),
                 _ => None,
@@ -467,7 +556,14 @@ fn members(ty: &Type) -> Vec<Member<'_>> {
                     TypeMemberMarkup::Enum(len) => Some(len.as_str()),
                     _ => None,
                 })
-                .or_else(|| array_len(&def.code).map(|(_, len)| len).ok());
+                .or_else(|| array_len(&def.code).map(|(_, len)| len).ok())
+                .map(LenKind::Raw)
+                .or_else(|| {
+                    let len = def.len.as_ref()?;
+                    let _member = member_by_name(members.as_slice(), len)?;
+
+                    Some(LenKind::Field(len.as_str()))
+                });
 
             if name == Some("sType") || name == Some("pNext") {
                 return None;
@@ -482,9 +578,9 @@ fn members(ty: &Type) -> Vec<Member<'_>> {
         .collect()
 }
 
-fn vulkano_type(ty: &str, len: Option<&str>) -> TokenStream {
-    if let Some(len) = len {
-        match ty {
+fn vulkano_type(ty: &str, len: Option<LenKind<'_>>) -> TokenStream {
+    match len {
+        Some(LenKind::Raw(len)) => match ty {
             "char" => quote! { String },
             "uint8_t" if len == "VK_LUID_SIZE" => quote! { [u8; 8] },
             "uint8_t" if len == "VK_UUID_SIZE" => quote! { [u8; 16] },
@@ -492,9 +588,13 @@ fn vulkano_type(ty: &str, len: Option<&str>) -> TokenStream {
             "uint32_t" if len == "3" => quote! { [u32; 3] },
             "float" if len == "2" => quote! { [f32; 2] },
             _ => unimplemented!("{}[{}]", ty, len),
+        },
+        Some(LenKind::Field(_)) => {
+            let inner = vulkano_type(ty, None);
+
+            quote! { Vec<#inner> }
         }
-    } else {
-        match ty {
+        None => match ty {
             "float" => quote! { f32 },
             "int32_t" => quote! { i32 },
             "int64_t" => quote! { i64 },
@@ -523,6 +623,6 @@ fn vulkano_type(ty: &str, len: Option<&str>) -> TokenStream {
             "VkShaderStageFlags" => quote! { ShaderStages },
             "VkSubgroupFeatureFlags" => quote! { SubgroupFeatures },
             _ => unimplemented!("{}", ty),
-        }
+        },
     }
 }

--- a/vulkano/src/device/properties.rs
+++ b/vulkano/src/device/properties.rs
@@ -261,6 +261,7 @@ impl<U: for<'a> FromVulkan<&'a T>, T> FromVulkan<&[T]> for Vec<U> {
 }
 
 impl<U: FromVulkan<T>, T: Copy> FromVulkan<&T> for U {
+    #[inline]
     fn from_vulkan(val: &T) -> Option<Self> {
         U::from_vulkan(*val)
     }

--- a/vulkano/src/device/properties.rs
+++ b/vulkano/src/device/properties.rs
@@ -250,3 +250,12 @@ impl FromVulkan<ash::vk::SubgroupFeatureFlags> for SubgroupFeatures {
         Some(val.into())
     }
 }
+
+impl<U: FromVulkan<T>, T: Clone> FromVulkan<&[T]> for Vec<U> {
+    #[inline]
+    fn from_vulkan(val: &[T]) -> Option<Vec<U>> {
+        val.iter()
+            .map(|it| U::from_vulkan(it.clone()))
+            .collect::<Option<Vec<_>>>()
+    }
+}

--- a/vulkano/src/device/properties.rs
+++ b/vulkano/src/device/properties.rs
@@ -251,11 +251,11 @@ impl FromVulkan<ash::vk::SubgroupFeatureFlags> for SubgroupFeatures {
     }
 }
 
-impl<U: FromVulkan<T>, T: Clone> FromVulkan<&[T]> for Vec<U> {
+impl<U: for<'a> FromVulkan<&'a T>, T: Clone> FromVulkan<&[T]> for Vec<U> {
     #[inline]
     fn from_vulkan(val: &[T]) -> Option<Vec<U>> {
         val.iter()
-            .map(|it| U::from_vulkan(it.clone()))
+            .map(|it| U::from_vulkan(it))
             .collect::<Option<Vec<_>>>()
     }
 }

--- a/vulkano/src/device/properties.rs
+++ b/vulkano/src/device/properties.rs
@@ -259,3 +259,9 @@ impl<U: for<'a> FromVulkan<&'a T>, T> FromVulkan<&[T]> for Vec<U> {
             .collect::<Option<Vec<_>>>()
     }
 }
+
+impl<U: FromVulkan<T>, T: Copy> FromVulkan<&T> for U {
+    fn from_vulkan(val: &T) -> Option<Self> {
+        U::from_vulkan(*val)
+    }
+}

--- a/vulkano/src/device/properties.rs
+++ b/vulkano/src/device/properties.rs
@@ -251,7 +251,7 @@ impl FromVulkan<ash::vk::SubgroupFeatureFlags> for SubgroupFeatures {
     }
 }
 
-impl<U: for<'a> FromVulkan<&'a T>, T: Clone> FromVulkan<&[T]> for Vec<U> {
+impl<U: for<'a> FromVulkan<&'a T>, T> FromVulkan<&[T]> for Vec<U> {
     #[inline]
     fn from_vulkan(val: &[T]) -> Option<Vec<U>> {
         val.iter()


### PR DESCRIPTION
## Overview
In the vk.xml added in ash 0.38, the newly added `VkPhysicalDeviceHostImageCopyPropertiesEXT` struct has the following xml:

```
<type category="struct" name="VkPhysicalDeviceHostImageCopyPropertiesEXT" structextends="VkPhysicalDeviceProperties2">
    <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
    <member optional="true"><type>void</type>*                                                        <name>pNext</name></member>
    <member optional="true" limittype="noauto"><type>uint32_t</type>                                  <name>copySrcLayoutCount</name></member>
    <member optional="true" limittype="noauto" len="copySrcLayoutCount"><type>VkImageLayout</type>*   <name>pCopySrcLayouts</name></member>
    <member optional="true" limittype="noauto"><type>uint32_t</type>                                  <name>copyDstLayoutCount</name></member>
    <member optional="true" limittype="noauto" len="copyDstLayoutCount"><type>VkImageLayout</type>*   <name>pCopyDstLayouts</name></member>
    <member optional="true" limittype="noauto"><type>uint8_t</type>                                   <name>optimalTilingLayoutUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
    <member limittype="bitmask"><type>VkBool32</type>                                                 <name>identicalMemoryTypeRequirements</name></member>
</type>
```

Currently, the `pCopySrcLayouts` and `pCopyDstLayouts` arrays get a type of `*mut T` (where T is defined by the `vulkano_type` function). This PR changes the autogen behavior to do the following.

1. Interpret the `*mut T` as a `&[T]` with a length specified by the `len` attribute.
2. Omit the field corresponding to the length attribute as its information is available in the array field.
3. Rename the field containing the array from `p_{field_name}` to `{field_name}`

## Merge Order
This is safe to merge today as this code adds functionality to handle the new vk.xml. The behavior for the current vk.xml will remain unchanged.

Related PRs:
* https://github.com/vulkano-rs/vulkano/pull/2511
* https://github.com/vulkano-rs/vulkano/pull/2510
* https://github.com/0xcaff/vulkano/pull/1

## Reviewing
I've broken up the changes int logical commits which have straightforward diffs to make it a bit easier to review.
