### PR TITLE
Integrate latest vk.xml changes

### DIFF
--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -95,7 +95,7 @@ fn properties_output(members: &[PropertiesMember]) -> TokenStream {
                             properties_ffi.#ffi_member.map(|s|
                                 unsafe {
                                     std::slice::from_raw_parts(
-                                        s #ffi_member_field .#ffi_name as _,
+                                        s #ffi_member_field .#ffi_name .cast_const(),
                                         s #ffi_member_field .#len_field_name as _,
                                     )
                                 }

--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -622,6 +622,14 @@ fn vulkano_type(ty: &str, len: Option<LenKind<'_>>) -> TokenStream {
             "VkShaderFloatControlsIndependence" => quote! { ShaderFloatControlsIndependence },
             "VkShaderStageFlags" => quote! { ShaderStages },
             "VkSubgroupFeatureFlags" => quote! { SubgroupFeatures },
+            "VkImageLayout" => quote! { ImageLayout },
+            "VkImageUsageFlags" => quote! { ImageUsage },
+            "VkBufferUsageFlags" => quote! { BufferUsage },
+            "VkChromaLocation" => quote! { ChromaLocation },
+            "VkLayeredDriverUnderlyingApiMSFT" => quote! { LayeredDriverUnderlyingApi },
+            "VkPhysicalDeviceSchedulingControlsFlagsARM" => {
+                quote! { PhysicalDeviceSchedulingControlsFlags }
+            }
             _ => unimplemented!("{}", ty),
         },
     }

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -3624,22 +3624,26 @@ impl From<ash::vk::ShaderCorePropertiesFlagsAMD> for ShaderCoreProperties {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct LayeredDriverUnderlyingApi {}
+pub struct LayeredDriverUnderlyingApi {
+    pub value: ash::vk::LayeredDriverUnderlyingApiMSFT,
+}
 
 impl From<ash::vk::LayeredDriverUnderlyingApiMSFT> for LayeredDriverUnderlyingApi {
-    fn from(_value: ash::vk::LayeredDriverUnderlyingApiMSFT) -> Self {
-        Self {}
+    fn from(value: ash::vk::LayeredDriverUnderlyingApiMSFT) -> Self {
+        Self { value }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct PhysicalDeviceSchedulingControlsFlags {}
+pub struct PhysicalDeviceSchedulingControlsFlags {
+    pub value: ash::vk::PhysicalDeviceSchedulingControlsFlagsARM,
+}
 
 impl From<ash::vk::PhysicalDeviceSchedulingControlsFlagsARM>
     for PhysicalDeviceSchedulingControlsFlags
 {
-    fn from(_value: ash::vk::PhysicalDeviceSchedulingControlsFlagsARM) -> Self {
-        Self {}
+    fn from(value: ash::vk::PhysicalDeviceSchedulingControlsFlagsARM) -> Self {
+        Self { value }
     }
 }
 

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -3623,28 +3623,25 @@ impl From<ash::vk::ShaderCorePropertiesFlagsAMD> for ShaderCoreProperties {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct LayeredDriverUnderlyingApi {
-    pub value: ash::vk::LayeredDriverUnderlyingApiMSFT,
+vulkan_enum! {
+    #[non_exhaustive]
+
+    LayeredDriverUnderlyingApi = LayeredDriverUnderlyingApiMSFT(i32);
+
+    // TODO: document
+    None = NONE,
+
+    // TODO: document
+    D3D12 = D3D12,
 }
 
-impl From<ash::vk::LayeredDriverUnderlyingApiMSFT> for LayeredDriverUnderlyingApi {
-    fn from(value: ash::vk::LayeredDriverUnderlyingApiMSFT) -> Self {
-        Self { value }
-    }
-}
+vulkan_bitflags! {
+    #[non_exhaustive]
 
-#[derive(Clone, Debug)]
-pub struct PhysicalDeviceSchedulingControlsFlags {
-    pub value: ash::vk::PhysicalDeviceSchedulingControlsFlagsARM,
-}
+    PhysicalDeviceSchedulingControlsFlags = PhysicalDeviceSchedulingControlsFlagsARM(u64);
 
-impl From<ash::vk::PhysicalDeviceSchedulingControlsFlagsARM>
-    for PhysicalDeviceSchedulingControlsFlags
-{
-    fn from(value: ash::vk::PhysicalDeviceSchedulingControlsFlagsARM) -> Self {
-        Self { value }
-    }
+    // todo: document
+    SHADER_CORE_COUNT = SHADER_CORE_COUNT,
 }
 
 vulkan_bitflags! {

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -3623,6 +3623,26 @@ impl From<ash::vk::ShaderCorePropertiesFlagsAMD> for ShaderCoreProperties {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct LayeredDriverUnderlyingApi {}
+
+impl From<ash::vk::LayeredDriverUnderlyingApiMSFT> for LayeredDriverUnderlyingApi {
+    fn from(_value: ash::vk::LayeredDriverUnderlyingApiMSFT) -> Self {
+        Self {}
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PhysicalDeviceSchedulingControlsFlags {}
+
+impl From<ash::vk::PhysicalDeviceSchedulingControlsFlagsARM>
+    for PhysicalDeviceSchedulingControlsFlags
+{
+    fn from(_value: ash::vk::PhysicalDeviceSchedulingControlsFlagsARM) -> Self {
+        Self {}
+    }
+}
+
 vulkan_bitflags! {
     #[non_exhaustive]
 

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -3640,7 +3640,7 @@ vulkan_bitflags! {
 
     PhysicalDeviceSchedulingControlsFlags = PhysicalDeviceSchedulingControlsFlagsARM(u64);
 
-    // todo: document
+    // TODO: document
     SHADER_CORE_COUNT = SHADER_CORE_COUNT,
 }
 

--- a/vulkano/src/device/properties.rs
+++ b/vulkano/src/device/properties.rs
@@ -296,7 +296,7 @@ impl FromVulkan<ash::vk::PhysicalDeviceSchedulingControlsFlagsARM>
 impl FromVulkan<ash::vk::LayeredDriverUnderlyingApiMSFT> for LayeredDriverUnderlyingApi {
     #[inline]
     fn from_vulkan(val: ash::vk::LayeredDriverUnderlyingApiMSFT) -> Option<Self> {
-        Some(val.into())
+        val.try_into().ok()
     }
 }
 

--- a/vulkano/src/device/properties.rs
+++ b/vulkano/src/device/properties.rs
@@ -5,8 +5,12 @@ use super::physical::{
     ShaderFloatControlsIndependence, SubgroupFeatures,
 };
 use crate::{
-    device::{DeviceExtensions, QueueFlags},
-    image::{SampleCount, SampleCounts},
+    buffer::BufferUsage,
+    device::{
+        physical::{LayeredDriverUnderlyingApi, PhysicalDeviceSchedulingControlsFlags},
+        DeviceExtensions, QueueFlags,
+    },
+    image::{sampler::ycbcr::ChromaLocation, ImageLayout, ImageUsage, SampleCount, SampleCounts},
     instance::InstanceExtensions,
     memory::DeviceAlignment,
     render_pass::ResolveModes,
@@ -256,6 +260,50 @@ impl FromVulkan<ash::vk::SubgroupFeatureFlags> for SubgroupFeatures {
     #[inline]
     fn from_vulkan(val: ash::vk::SubgroupFeatureFlags) -> Option<Self> {
         Some(val.into())
+    }
+}
+
+impl FromVulkan<ash::vk::BufferUsageFlags> for BufferUsage {
+    #[inline]
+    fn from_vulkan(val: ash::vk::BufferUsageFlags) -> Option<Self> {
+        Some(val.into())
+    }
+}
+
+impl FromVulkan<ash::vk::ImageUsageFlags> for ImageUsage {
+    #[inline]
+    fn from_vulkan(val: ash::vk::ImageUsageFlags) -> Option<Self> {
+        Some(val.into())
+    }
+}
+
+impl FromVulkan<ash::vk::ChromaLocation> for ChromaLocation {
+    #[inline]
+    fn from_vulkan(val: ash::vk::ChromaLocation) -> Option<Self> {
+        val.try_into().ok()
+    }
+}
+
+impl FromVulkan<ash::vk::PhysicalDeviceSchedulingControlsFlagsARM>
+    for PhysicalDeviceSchedulingControlsFlags
+{
+    #[inline]
+    fn from_vulkan(val: ash::vk::PhysicalDeviceSchedulingControlsFlagsARM) -> Option<Self> {
+        Some(val.into())
+    }
+}
+
+impl FromVulkan<ash::vk::LayeredDriverUnderlyingApiMSFT> for LayeredDriverUnderlyingApi {
+    #[inline]
+    fn from_vulkan(val: ash::vk::LayeredDriverUnderlyingApiMSFT) -> Option<Self> {
+        Some(val.into())
+    }
+}
+
+impl FromVulkan<ash::vk::ImageLayout> for ImageLayout {
+    #[inline]
+    fn from_vulkan(val: ash::vk::ImageLayout) -> Option<Self> {
+        val.try_into().ok()
     }
 }
 

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -406,6 +406,7 @@ pub(crate) enum FormatCompatibilityInner {
     Class_10bit_2plane_444,
     Class_12bit_2plane_444,
     Class_16bit_2plane_444,
+    Class_8bit_alpha,
 }
 
 /// Describes a uniform value that will be used to fill an image.

--- a/vulkano/vk.xml
+++ b/vulkano/vk.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <comment>
-Copyright 2015-2023 The Khronos Group Inc.
+Copyright 2015-2024 The Khronos Group Inc.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
     </comment>
@@ -38,7 +38,7 @@ branch of the member gitlab server.
     </platforms>
 
     <tags comment="Vulkan vendor/author tags for extensions and layers">
-        <tag name="IMG"         author="Imagination Technologies"      contact="Michael Worcester @michaelworcester"/>
+        <tag name="IMG"         author="Imagination Technologies"      contact="Andrew Garrard @fluppeteer"/>
         <tag name="AMD"         author="Advanced Micro Devices, Inc."  contact="Daniel Rakos @drakos-amd"/>
         <tag name="AMDX"        author="Advanced Micro Devices, Inc."  contact="Daniel Rakos @drakos-amd"/>
         <tag name="ARM"         author="ARM Limited"                   contact="Jan-Harald Fredriksen @janharaldfredriksen-arm"/>
@@ -71,7 +71,7 @@ branch of the member gitlab server.
         <tag name="INTEL"       author="Intel Corporation"             contact="Slawek Grajewski @sgrajewski"/>
         <tag name="HUAWEI"      author="Huawei Technologies Co. Ltd."  contact="Pan Gao @PanGao-h, Juntao Li @Lawrenceleehw"/>
         <tag name="VALVE"       author="Valve Corporation"             contact="Pierre-Loup Griffais @plagman, Joshua Ashton @Joshua-Ashton, Hans-Kristian Arntzen @HansKristian-Work"/>
-        <tag name="QNX"         author="BlackBerry Limited"            contact="Mike Gorchak @mgorchak-blackberry"/>
+        <tag name="QNX"         author="BlackBerry Limited"            contact="Mike Gorchak @mgorchak-blackberry, Aaron Ruby @aruby-blackberry"/>
         <tag name="JUICE"       author="Juice Technologies, Inc."      contact="David McCloskey @damcclos, Dean Beeler @canadacow"/>
         <tag name="FB"          author="Facebook, Inc"                 contact="Artem Bolgar @artyom17"/>
         <tag name="RASTERGRID"  author="RasterGrid Kft."               contact="Daniel Rakos @aqnuep"/>
@@ -134,6 +134,7 @@ branch of the member gitlab server.
         <type requires="ggp_c/vulkan_types.h" name="GgpFrameToken"/>
         <type requires="screen/screen.h" name="_screen_context"/>
         <type requires="screen/screen.h" name="_screen_window"/>
+        <type requires="screen/screen.h" name="_screen_buffer"/>
         <type requires="nvscisync.h" name="NvSciSyncAttrList"/>
         <type requires="nvscisync.h" name="NvSciSyncObj"/>
         <type requires="nvscisync.h" name="NvSciSyncFence"/>
@@ -174,11 +175,11 @@ branch of the member gitlab server.
 #define <name>VKSC_API_VERSION_1_0</name> <type>VK_MAKE_API_VERSION</type>(VKSC_API_VARIANT, 1, 0, 0)// Patch version should always be set to 0</type>
 
         <type api="vulkan" category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 251</type>
+#define <name>VK_HEADER_VERSION</name> 281</type>
         <type api="vulkan" category="define" requires="VK_HEADER_VERSION">// Complete version of this file
 #define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 3, VK_HEADER_VERSION)</type>
         <type api="vulkansc" category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 12</type>
+#define <name>VK_HEADER_VERSION</name> 14</type>
         <type api="vulkansc" category="define" requires="VKSC_API_VARIANT">// Complete version of this file
 #define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(VKSC_API_VARIANT, 1, 0, VK_HEADER_VERSION)</type>
 
@@ -189,7 +190,7 @@ branch of the member gitlab server.
 
         <type category="define" name="VK_USE_64_BIT_PTR_DEFINES">
 #ifndef VK_USE_64_BIT_PTR_DEFINES
-    #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) &amp;&amp; !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+    #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) &amp;&amp; !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__) || (defined(__riscv) &amp;&amp; __riscv_xlen == 64)
         #define VK_USE_64_BIT_PTR_DEFINES 1
     #else
         #define VK_USE_64_BIT_PTR_DEFINES 0
@@ -337,7 +338,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkCommandBufferResetFlagBits"     category="bitmask">typedef <type>VkFlags</type> <name>VkCommandBufferResetFlags</name>;</type>
         <type requires="VkCommandBufferUsageFlagBits"     category="bitmask">typedef <type>VkFlags</type> <name>VkCommandBufferUsageFlags</name>;</type>
         <type requires="VkQueryPipelineStatisticFlagBits" category="bitmask">typedef <type>VkFlags</type> <name>VkQueryPipelineStatisticFlags</name>;</type>
-        <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryMapFlags</name>;</type>
+        <type requires="VkMemoryMapFlagBits"              category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryMapFlags</name>;</type>
+        <type requires="VkMemoryUnmapFlagBitsKHR"         category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryUnmapFlagsKHR</name>;</type>
         <type requires="VkImageAspectFlagBits"            category="bitmask">typedef <type>VkFlags</type> <name>VkImageAspectFlags</name>;</type>
         <type requires="VkSparseMemoryBindFlagBits"       category="bitmask">typedef <type>VkFlags</type> <name>VkSparseMemoryBindFlags</name>;</type>
         <type requires="VkSparseImageFormatFlagBits"      category="bitmask">typedef <type>VkFlags</type> <name>VkSparseImageFormatFlags</name>;</type>
@@ -388,6 +390,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkBuildMicromapFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkBuildMicromapFlagsEXT</name>;</type>
         <type requires="VkMicromapCreateFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkMicromapCreateFlagsEXT</name>;</type>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkDirectDriverLoadingFlagsLUNARG</name>;</type>
+        <type bitvalues="VkPipelineCreateFlagBits2KHR"    category="bitmask">typedef <type>VkFlags64</type> <name>VkPipelineCreateFlags2KHR</name>;</type>
+        <type bitvalues="VkBufferUsageFlagBits2KHR"       category="bitmask">typedef <type>VkFlags64</type> <name>VkBufferUsageFlags2KHR</name>;</type>
 
             <comment>WSI extensions</comment>
         <type requires="VkCompositeAlphaFlagBitsKHR"      category="bitmask">typedef <type>VkFlags</type> <name>VkCompositeAlphaFlagsKHR</name>;</type>
@@ -463,6 +467,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkSubmitFlagBits"                 category="bitmask">typedef <type>VkFlags</type> <name>VkSubmitFlags</name>;</type>
         <type                                             category="bitmask" name="VkSubmitFlagsKHR"                          alias="VkSubmitFlags"/>
         <type                                             category="bitmask">typedef <type>VkFlags</type> <name>VkImageFormatConstraintsFlagsFUCHSIA</name>;</type>
+        <type requires="VkHostImageCopyFlagBitsEXT"       category="bitmask">typedef <type>VkFlags</type> <name>VkHostImageCopyFlagsEXT</name>;</type>
         <type requires="VkImageConstraintsInfoFlagBitsFUCHSIA"   category="bitmask">typedef <type>VkFlags</type> <name>VkImageConstraintsInfoFlagsFUCHSIA</name>;</type>
         <type requires="VkGraphicsPipelineLibraryFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkGraphicsPipelineLibraryFlagsEXT</name>;</type>
         <type requires="VkImageCompressionFlagBitsEXT"          category="bitmask">typedef <type>VkFlags</type> <name>VkImageCompressionFlagsEXT</name>;</type>
@@ -473,9 +478,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkOpticalFlowUsageFlagBitsNV"           category="bitmask">typedef <type>VkFlags</type>   <name>VkOpticalFlowUsageFlagsNV</name>;</type>
         <type requires="VkOpticalFlowSessionCreateFlagBitsNV"   category="bitmask">typedef <type>VkFlags</type>   <name>VkOpticalFlowSessionCreateFlagsNV</name>;</type>
         <type requires="VkOpticalFlowExecuteFlagBitsNV"         category="bitmask">typedef <type>VkFlags</type>   <name>VkOpticalFlowExecuteFlagsNV</name>;</type>
+        <type requires="VkFrameBoundaryFlagBitsEXT"       category="bitmask">typedef <type>VkFlags</type> <name>VkFrameBoundaryFlagsEXT</name>;</type>
         <type requires="VkPresentScalingFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkPresentScalingFlagsEXT</name>;</type>
         <type requires="VkPresentGravityFlagBitsEXT" category="bitmask">typedef <type>VkFlags</type> <name>VkPresentGravityFlagsEXT</name>;</type>
         <type requires="VkShaderCreateFlagBitsEXT"        category="bitmask">typedef <type>VkFlags</type> <name>VkShaderCreateFlagsEXT</name>;</type>
+        <type bitvalues="VkPhysicalDeviceSchedulingControlsFlagBitsARM" category="bitmask">typedef <type>VkFlags64</type> <name>VkPhysicalDeviceSchedulingControlsFlagsARM</name>;</type>
 
             <comment>Video Core extension</comment>
         <type requires="VkVideoCodecOperationFlagBitsKHR"           category="bitmask">typedef <type>VkFlags</type> <name>VkVideoCodecOperationFlagsKHR</name>;</type>
@@ -495,7 +502,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkVideoDecodeH264PictureLayoutFlagBitsKHR"  category="bitmask">typedef <type>VkFlags</type> <name>VkVideoDecodeH264PictureLayoutFlagsKHR</name>;</type>
 
             <comment>Video Encode Core extension</comment>
-        <type                                                       category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeFlagBitsKHR"                   category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeFlagsKHR</name>;</type>
         <type requires="VkVideoEncodeUsageFlagBitsKHR"              category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeUsageFlagsKHR</name>;</type>
         <type requires="VkVideoEncodeContentFlagBitsKHR"            category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeContentFlagsKHR</name>;</type>
         <type requires="VkVideoEncodeCapabilityFlagBitsKHR"         category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeCapabilityFlagsKHR</name>;</type>
@@ -506,13 +513,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="VkVideoComponentBitDepthFlagBitsKHR"        category="bitmask">typedef <type>VkFlags</type> <name>VkVideoComponentBitDepthFlagsKHR</name>;</type>
 
             <comment>Video Encode H.264 extension</comment>
-        <type requires="VkVideoEncodeH264CapabilityFlagBitsEXT"     category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH264CapabilityFlagsEXT</name>;</type>
+        <type requires="VkVideoEncodeH264CapabilityFlagBitsKHR"             category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH264CapabilityFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeH264StdFlagBitsKHR"                    category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH264StdFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeH264RateControlFlagBitsKHR"            category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH264RateControlFlagsKHR</name>;</type>
 
             <comment>Video Encode H.265 extension</comment>
-        <type requires="VkVideoEncodeH265CapabilityFlagBitsEXT"     category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265CapabilityFlagsEXT</name>;</type>
-        <type requires="VkVideoEncodeH265CtbSizeFlagBitsEXT"        category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265CtbSizeFlagsEXT</name>;</type>
-        <type requires="VkVideoEncodeH265TransformBlockSizeFlagBitsEXT"        category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265TransformBlockSizeFlagsEXT</name>;</type>
-        <type category="bitmask">typedef <type>VkFlags</type> <name>VkMemoryUnmapFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeH265CapabilityFlagBitsKHR"             category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265CapabilityFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeH265StdFlagBitsKHR"                    category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265StdFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeH265RateControlFlagBitsKHR"            category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265RateControlFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeH265CtbSizeFlagBitsKHR"                category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265CtbSizeFlagsKHR</name>;</type>
+        <type requires="VkVideoEncodeH265TransformBlockSizeFlagBitsKHR"     category="bitmask">typedef <type>VkFlags</type> <name>VkVideoEncodeH265TransformBlockSizeFlagsKHR</name>;</type>
 
             <comment>Types which can be void pointers or class pointers, selected at compile time</comment>
         <type category="handle"                           objtypeenum="VK_OBJECT_TYPE_INSTANCE"><type>VK_DEFINE_HANDLE</type>(<name>VkInstance</name>)</type>
@@ -609,6 +619,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkFormat" category="enum"/>
         <type name="VkFormatFeatureFlagBits" category="enum"/>
         <type name="VkFrontFace" category="enum"/>
+        <type name="VkMemoryMapFlagBits" category="enum"/>
         <type name="VkImageAspectFlagBits" category="enum"/>
         <type name="VkImageCreateFlagBits" category="enum"/>
         <type name="VkImageLayout" category="enum"/>
@@ -676,7 +687,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkShaderInfoTypeAMD" category="enum"/>
         <type name="VkQueueGlobalPriorityKHR" category="enum"/>
         <type name="VkQueueGlobalPriorityEXT" category="enum"                      alias="VkQueueGlobalPriorityKHR"/>
-        <type name="VkTimeDomainEXT" category="enum"/>
+        <type name="VkTimeDomainKHR" category="enum"/>
+        <type name="VkTimeDomainEXT" category="enum" alias="VkTimeDomainKHR"/>
         <type name="VkConservativeRasterizationModeEXT" category="enum"/>
         <type name="VkResolveModeFlagBits" category="enum"/>
         <type category="enum" name="VkResolveModeFlagBitsKHR"                      alias="VkResolveModeFlagBits"/>
@@ -706,8 +718,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkAccelerationStructureCompatibilityKHR" category="enum"/>
         <type name="VkShaderGroupShaderKHR" category="enum"/>
         <type name="VkMemoryOverallocationBehaviorAMD" category="enum"/>
-        <type name="VkScopeNV" category="enum"/>
-        <type name="VkComponentTypeNV" category="enum"/>
         <type name="VkDeviceDiagnosticsConfigFlagBitsNV" category="enum"/>
         <type name="VkPipelineCreationFeedbackFlagBits" category="enum"/>
         <type category="enum" name="VkPipelineCreationFeedbackFlagBitsEXT"         alias="VkPipelineCreationFeedbackFlagBits"/>
@@ -723,7 +733,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkPerformanceOverrideTypeINTEL" category="enum"/>
         <type name="VkPerformanceParameterTypeINTEL" category="enum"/>
         <type name="VkPerformanceValueTypeINTEL" category="enum"/>
-        <type name="VkLineRasterizationModeEXT" category="enum"/>
+        <type name="VkLineRasterizationModeKHR" category="enum"/>
+        <type name="VkLineRasterizationModeEXT" category="enum" alias="VkLineRasterizationModeKHR"/>
         <type name="VkShaderModuleCreateFlagBits" category="enum"/>
         <type name="VkPipelineCompilerControlFlagBitsAMD" category="enum"/>
         <type name="VkShaderCorePropertiesFlagBitsAMD" category="enum"/>
@@ -746,6 +757,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkProvokingVertexModeEXT" category="enum"/>
         <type name="VkPipelineCacheValidationVersion" category="enum"/>
         <type name="VkImageFormatConstraintsFlagBitsFUCHSIA" category="enum"/>
+        <type name="VkHostImageCopyFlagBitsEXT" category="enum"/>
         <type name="VkImageConstraintsInfoFlagBitsFUCHSIA" category="enum"/>
         <type name="VkFormatFeatureFlagBits2" category="enum"/>
         <type category="enum" name="VkFormatFeatureFlagBits2KHR"                   alias="VkFormatFeatureFlagBits2"/>
@@ -768,11 +780,22 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkOpacityMicromapFormatEXT" category="enum"/>
         <type name="VkOpacityMicromapSpecialIndexEXT" category="enum"/>
         <type name="VkDeviceFaultVendorBinaryHeaderVersionEXT" category="enum"/>
+        <type name="VkFrameBoundaryFlagBitsEXT" category="enum"/>
         <type name="VkMemoryDecompressionMethodFlagBitsNV" category="enum"/>
+        <type name="VkDepthBiasRepresentationEXT" category="enum"/>
         <type name="VkDirectDriverLoadingModeLUNARG" category="enum"/>
+        <type name="VkPipelineCreateFlagBits2KHR" category="enum"/>
+        <type name="VkBufferUsageFlagBits2KHR" category="enum"/>
         <type name="VkDisplacementMicromapFormatNV" category="enum"/>
         <type name="VkShaderCreateFlagBitsEXT" category="enum"/>
         <type name="VkShaderCodeTypeEXT" category="enum"/>
+        <type name="VkScopeKHR" category="enum"/>
+        <type name="VkComponentTypeKHR" category="enum"/>
+        <type category="enum" name="VkScopeNV"                                     alias="VkScopeKHR"/>
+        <type category="enum" name="VkComponentTypeNV"                             alias="VkComponentTypeKHR"/>
+        <type name="VkCubicFilterWeightsQCOM" category="enum"/>
+        <type name="VkBlockMatchWindowCompareModeQCOM" category="enum"/>
+        <type name="VkLayeredDriverUnderlyingApiMSFT" category="enum"/>
 
             <comment>WSI extensions</comment>
         <type name="VkColorSpaceKHR" category="enum"/>
@@ -846,6 +869,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkDeviceFaultAddressTypeEXT" category="enum"/>
         <type name="VkPresentScalingFlagBitsEXT" category="enum"/>
         <type name="VkPresentGravityFlagBitsEXT" category="enum"/>
+        <type name="VkLayerSettingTypeEXT" category="enum"/>
+        <type name="VkLatencyMarkerNV" category="enum"/>
+        <type name="VkOutOfBandQueueTypeNV" category="enum"/>
+        <type name="VkPhysicalDeviceSchedulingControlsFlagBitsARM" category="enum"/>
+        <type name="VkMemoryUnmapFlagBitsKHR" category="enum"/>
 
             <comment>Enumerated types in the header, but not used by the API</comment>
         <type name="VkVendorId" category="enum"/>
@@ -874,6 +902,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <comment>Video H.265 Decode extensions</comment>
 
             <comment>Video Encode extensions</comment>
+        <type name="VkVideoEncodeFlagBitsKHR" category="enum"/>
         <type name="VkVideoEncodeUsageFlagBitsKHR" category="enum"/>
         <type name="VkVideoEncodeContentFlagBitsKHR" category="enum"/>
         <type name="VkVideoEncodeTuningModeKHR" category="enum"/>
@@ -882,14 +911,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkVideoEncodeRateControlModeFlagBitsKHR" category="enum"/>
 
            <comment>Video H.264 Encode extensions</comment>
-        <type name="VkVideoEncodeH264CapabilityFlagBitsEXT"     category="enum"/>
-        <type name="VkVideoEncodeH264RateControlStructureEXT"   category="enum"/>
+        <type name="VkVideoEncodeH264CapabilityFlagBitsKHR"             category="enum"/>
+        <type name="VkVideoEncodeH264StdFlagBitsKHR"                    category="enum"/>
+        <type name="VkVideoEncodeH264RateControlFlagBitsKHR"            category="enum"/>
 
            <comment>Video H.265 Encode extensions</comment>
-        <type name="VkVideoEncodeH265CapabilityFlagBitsEXT"     category="enum"/>
-        <type name="VkVideoEncodeH265RateControlStructureEXT"   category="enum"/>
-        <type name="VkVideoEncodeH265CtbSizeFlagBitsEXT"        category="enum"/>
-        <type name="VkVideoEncodeH265TransformBlockSizeFlagBitsEXT"        category="enum"/>
+        <type name="VkVideoEncodeH265CapabilityFlagBitsKHR"             category="enum"/>
+        <type name="VkVideoEncodeH265StdFlagBitsKHR"                    category="enum"/>
+        <type name="VkVideoEncodeH265RateControlFlagBitsKHR"            category="enum"/>
+        <type name="VkVideoEncodeH265CtbSizeFlagBitsKHR"                category="enum"/>
+        <type name="VkVideoEncodeH265TransformBlockSizeFlagBitsKHR"     category="enum"/>
 
         <comment>The PFN_vk*Function types are used by VkAllocationCallbacks below</comment>
         <type category="funcpointer">typedef void (VKAPI_PTR *<name>PFN_vkInternalAllocationNotification</name>)(
@@ -1014,20 +1045,20 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member limittype="noauto"><type>uint32_t</type>       <name>vendorID</name></member>
             <member limittype="noauto"><type>uint32_t</type>       <name>deviceID</name></member>
             <member limittype="noauto"><type>VkPhysicalDeviceType</type> <name>deviceType</name></member>
-            <member limittype="noauto"><type>char</type>           <name>deviceName</name>[<enum>VK_MAX_PHYSICAL_DEVICE_NAME_SIZE</enum>]</member>
+            <member limittype="noauto" len="null-terminated"><type>char</type>           <name>deviceName</name>[<enum>VK_MAX_PHYSICAL_DEVICE_NAME_SIZE</enum>]</member>
             <member limittype="noauto"><type>uint8_t</type>        <name>pipelineCacheUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
             <member limittype="struct"><type>VkPhysicalDeviceLimits</type> <name>limits</name></member>
             <member limittype="struct"><type>VkPhysicalDeviceSparseProperties</type> <name>sparseProperties</name></member>
         </type>
         <type category="struct" name="VkExtensionProperties" returnedonly="true">
-            <member><type>char</type>            <name>extensionName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]<comment>extension name</comment></member>
-            <member><type>uint32_t</type>        <name>specVersion</name><comment>version of the extension specification implemented</comment></member>
+            <member len="null-terminated"><type>char</type> <name>extensionName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]<comment>extension name</comment></member>
+            <member><type>uint32_t</type>                   <name>specVersion</name><comment>version of the extension specification implemented</comment></member>
         </type>
         <type category="struct" name="VkLayerProperties" returnedonly="true">
-            <member><type>char</type>            <name>layerName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]<comment>layer name</comment></member>
-            <member><type>uint32_t</type>        <name>specVersion</name><comment>version of the layer specification implemented</comment></member>
-            <member><type>uint32_t</type>        <name>implementationVersion</name><comment>build or release version of the layer's library</comment></member>
-            <member><type>char</type>            <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]<comment>Free-form description of the layer</comment></member>
+            <member len="null-terminated"><type>char</type> <name>layerName</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]<comment>layer name</comment></member>
+            <member><type>uint32_t</type>                   <name>specVersion</name><comment>version of the layer specification implemented</comment></member>
+            <member><type>uint32_t</type>                   <name>implementationVersion</name><comment>build or release version of the layer's library</comment></member>
+            <member len="null-terminated"><type>char</type> <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]<comment>Free-form description of the layer</comment></member>
         </type>
         <type category="struct" name="VkApplicationInfo">
             <member values="VK_STRUCTURE_TYPE_APPLICATION_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -1083,10 +1114,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member limittype="min,mul"><type>VkExtent3D</type>             <name>minImageTransferGranularity</name><comment>Minimum alignment requirement for image transfers</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMemoryProperties" returnedonly="true">
-            <member><type>uint32_t</type>               <name>memoryTypeCount</name></member>
-            <member><type>VkMemoryType</type>           <name>memoryTypes</name>[<enum>VK_MAX_MEMORY_TYPES</enum>]</member>
-            <member><type>uint32_t</type>               <name>memoryHeapCount</name></member>
-            <member><type>VkMemoryHeap</type>           <name>memoryHeaps</name>[<enum>VK_MAX_MEMORY_HEAPS</enum>]</member>
+            <member><type>uint32_t</type>                                     <name>memoryTypeCount</name></member>
+            <member len="memoryTypeCount"><type>VkMemoryType</type>           <name>memoryTypes</name>[<enum>VK_MAX_MEMORY_TYPES</enum>]</member>
+            <member><type>uint32_t</type>                                     <name>memoryHeapCount</name></member>
+            <member len="memoryHeapCount"><type>VkMemoryHeap</type>           <name>memoryHeaps</name>[<enum>VK_MAX_MEMORY_HEAPS</enum>]</member>
         </type>
         <type category="struct" name="VkMemoryAllocateInfo">
             <member values="VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
@@ -1171,12 +1202,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>dstArrayElement</name><comment>Array element within the destination binding to copy to</comment></member>
             <member><type>uint32_t</type>               <name>descriptorCount</name><comment>Number of descriptors to write (determines the size of the array pointed by pDescriptors)</comment></member>
         </type>
+        <type category="struct" name="VkBufferUsageFlags2CreateInfoKHR" structextends="VkBufferViewCreateInfo,VkBufferCreateInfo,VkPhysicalDeviceExternalBufferInfo,VkDescriptorBufferBindingInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBufferUsageFlags2KHR</type>         <name>usage</name></member>
+        </type>
         <type category="struct" name="VkBufferCreateInfo">
             <member values="VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkBufferCreateFlags</type>    <name>flags</name><comment>Buffer creation flags</comment></member>
             <member><type>VkDeviceSize</type>           <name>size</name><comment>Specified in bytes</comment></member>
-            <member><type>VkBufferUsageFlags</type>     <name>usage</name><comment>Buffer usage flags</comment></member>
+            <member noautovalidity="true"><type>VkBufferUsageFlags</type>     <name>usage</name><comment>Buffer usage flags</comment></member>
             <member><type>VkSharingMode</type>          <name>sharingMode</name></member>
             <member optional="true"><type>uint32_t</type>               <name>queueFamilyIndexCount</name></member>
             <member noautovalidity="true" len="queueFamilyIndexCount">const <type>uint32_t</type>*        <name>pQueueFamilyIndices</name></member>
@@ -1425,11 +1461,23 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
-            <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member><type>VkPipelineShaderStageCreateInfo</type> <name>stage</name></member>
             <member><type>VkPipelineLayout</type>       <name>layout</name><comment>Interface layout of the pipeline</comment></member>
             <member noautovalidity="true" optional="true"><type>VkPipeline</type>      <name>basePipelineHandle</name><comment>If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is nonzero, it specifies the handle of the base pipeline this is a derivative of</comment></member>
             <member><type>int32_t</type>                <name>basePipelineIndex</name><comment>If VK_PIPELINE_CREATE_DERIVATIVE_BIT is set and this value is not -1, it specifies an index into pCreateInfos of the base pipeline this is a derivative of</comment></member>
+        </type>
+        <type category="struct" name="VkComputePipelineIndirectBufferInfoNV" structextends="VkComputePipelineCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_INDIRECT_BUFFER_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*   <name>pNext</name></member>
+            <member><type>VkDeviceAddress</type>               <name>deviceAddress</name></member>
+            <member><type>VkDeviceSize</type>                  <name>size</name></member>
+            <member><type>VkDeviceAddress</type>               <name>pipelineDeviceAddressCaptureReplay</name></member>
+        </type>
+        <type category="struct" name="VkPipelineCreateFlags2CreateInfoKHR" structextends="VkComputePipelineCreateInfo,VkGraphicsPipelineCreateInfo,VkRayTracingPipelineCreateInfoNV,VkRayTracingPipelineCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
+            <member><type>VkPipelineCreateFlags2KHR</type>      <name>flags</name></member>
         </type>
         <type category="struct" name="VkVertexInputBindingDescription">
             <member><type>uint32_t</type>               <name>binding</name><comment>Vertex buffer binding id</comment></member>
@@ -1552,7 +1600,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
-            <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member noautovalidity="true" optional="true"><type>uint32_t</type> <name>stageCount</name></member>
             <member api="vulkan" noautovalidity="true" len="stageCount" optional="true">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
             <member api="vulkansc" noautovalidity="true" len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
@@ -1616,7 +1664,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>               <name>offset</name><comment>Start of the range, in bytes</comment></member>
             <member><type>uint32_t</type>               <name>size</name><comment>Size of the range, in bytes</comment></member>
         </type>
-        <type category="struct" name="VkPipelineLayoutCreateInfo">
+        <type category="struct" name="VkPipelineLayoutCreateInfo" structextends="VkBindDescriptorSetsInfoKHR,VkPushConstantsInfoKHR,VkPushDescriptorSetInfoKHR,VkPushDescriptorSetWithTemplateInfoKHR,VkSetDescriptorBufferOffsetsInfoEXT,VkBindDescriptorBufferEmbeddedSamplersInfoEXT">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineLayoutCreateFlags</type>    <name>flags</name></member>
@@ -1819,7 +1867,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member limittype="bitmask"><type>VkBool32</type>           <name>residencyStandard2DBlockShape</name><comment>Sparse resources support: GPU will access all 2D (single sample) sparse resources using the standard sparse image block shapes (based on pixel format)</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>           <name>residencyStandard2DMultisampleBlockShape</name><comment>Sparse resources support: GPU will access all 2D (multisample) sparse resources using the standard sparse image block shapes (based on pixel format)</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>           <name>residencyStandard3DBlockShape</name><comment>Sparse resources support: GPU will access all 3D sparse resources using the standard sparse image block shapes (based on pixel format)</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>           <name>residencyAlignedMipSize</name><comment>Sparse resources support: Images with mip level dimensions that are NOT a multiple of the sparse image block dimensions will be placed in the mip tail</comment></member>
+            <member limittype="not"><type>VkBool32</type>           <name>residencyAlignedMipSize</name><comment>Sparse resources support: Images with mip level dimensions that are NOT a multiple of the sparse image block dimensions will be placed in the mip tail</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>           <name>residencyNonResidentStrict</name><comment>Sparse resources support: GPU can consistently access non-resident regions of a resource, all reads return as if data is 0, writes are discarded</comment></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceLimits" returnedonly="true">
@@ -2193,6 +2241,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>uint32_t</type>                         <name>disabledValidationFeatureCount</name><comment>Number of validation features to disable</comment></member>
             <member len="disabledValidationFeatureCount">const <type>VkValidationFeatureDisableEXT</type>* <name>pDisabledValidationFeatures</name><comment>Validation features to disable</comment></member>
         </type>
+        <type category="struct" name="VkLayerSettingsCreateInfoEXT" allowduplicate="true" structextends="VkInstanceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT"><type>VkStructureType</type>  <name>sType</name><comment>Must be VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT</comment></member>
+            <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>                         <name>settingCount</name><comment>Number of settings to configure</comment></member>
+            <member len="settingCount">const <type>VkLayerSettingEXT</type>* <name>pSettings</name><comment>Validation features to enable</comment></member>
+        </type>
+        <type category="struct" name="VkLayerSettingEXT">
+            <member len="null-terminated">const <type>char</type>* <name>pLayerName</name></member>
+            <member len="null-terminated">const <type>char</type>* <name>pSettingName</name></member>
+            <member><type>VkLayerSettingTypeEXT</type>       <name>type</name><comment>The type of the object</comment></member>
+            <member optional="true"><type>uint32_t</type>                         <name>valueCount</name><comment>Number of values of the setting</comment></member>
+            <member len="valueCount">const <type>void</type>* <name>pValues</name><comment>Values to pass for a setting</comment></member>
+        </type>
         <type category="struct" name="VkApplicationParametersEXT" allowduplicate="true" structextends="VkApplicationInfo,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_APPLICATION_PARAMETERS_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*        <name>pNext</name></member>
@@ -2317,6 +2378,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                       <name>deviceGeneratedCommands</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*          <name>pNext</name></member>
+            <member><type>VkBool32</type>                       <name>deviceGeneratedCompute</name></member>
+            <member><type>VkBool32</type>                       <name>deviceGeneratedComputePipelines</name></member>
+            <member><type>VkBool32</type>                       <name>deviceGeneratedComputeCaptureReplay</name></member>
+        </type>
         <type category="struct" name="VkDevicePrivateDataCreateInfo" allowduplicate="true" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                            <name>pNext</name></member>
@@ -2420,7 +2488,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
             <member><type>VkPipelineBindPoint</type>                <name>pipelineBindPoint</name></member>
-            <member><type>VkPipeline</type>                         <name>pipeline</name></member>
+            <member optional="true"><type>VkPipeline</type>         <name>pipeline</name></member>
             <member><type>VkIndirectCommandsLayoutNV</type>         <name>indirectCommandsLayout</name></member>
             <member><type>uint32_t</type>                           <name>streamCount</name></member>
             <member len="streamCount">const <type>VkIndirectCommandsStreamNV</type>*  <name>pStreams</name></member>
@@ -2437,9 +2505,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                 <name>pNext</name></member>
             <member><type>VkPipelineBindPoint</type>         <name>pipelineBindPoint</name></member>
-            <member><type>VkPipeline</type>                  <name>pipeline</name></member>
+            <member optional="true"><type>VkPipeline</type>  <name>pipeline</name></member>
             <member><type>VkIndirectCommandsLayoutNV</type>  <name>indirectCommandsLayout</name></member>
             <member><type>uint32_t</type>                    <name>maxSequencesCount</name></member>
+        </type>
+        <type category="struct" name="VkPipelineIndirectDeviceAddressInfoNV">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_INDIRECT_DEVICE_ADDRESS_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*   <name>pNext</name></member>
+            <member><type>VkPipelineBindPoint</type>           <name>pipelineBindPoint</name></member>
+            <member><type>VkPipeline</type>                    <name>pipeline</name></member>
+        </type>
+        <type category="struct" name="VkBindPipelineIndirectCommandNV">
+            <member><type>VkDeviceAddress</type>               <name>pipelineAddress</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFeatures2" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2"><type>VkStructureType</type> <name>sType</name></member>
@@ -2519,8 +2596,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member limittype="exact"><type>VkDriverId</type>                  <name>driverID</name></member>
-            <member limittype="exact"><type>char</type>                        <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE</enum>]</member>
-            <member limittype="exact"><type>char</type>                        <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE</enum>]</member>
+            <member limittype="exact" len="null-terminated"><type>char</type>  <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE</enum>]</member>
+            <member limittype="exact" len="null-terminated"><type>char</type>  <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE</enum>]</member>
             <member limittype="exact"><type>VkConformanceVersion</type>        <name>conformanceVersion</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDriverPropertiesKHR"                     alias="VkPhysicalDeviceDriverProperties"/>
@@ -2570,7 +2647,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                      <name>pNext</name></member>
             <member optional="true"><type>VkBufferCreateFlags</type> <name>flags</name></member>
-            <member><type>VkBufferUsageFlags</type>               <name>usage</name></member>
+            <member optional="true" noautovalidity="true"><type>VkBufferUsageFlags</type> <name>usage</name></member>
             <member><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceExternalBufferInfoKHR"                   alias="VkPhysicalDeviceExternalBufferInfo"/>
@@ -2881,7 +2958,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkSemaphoreSciSyncPoolNV</type>               <name>semaphorePool</name></member>
             <member>const <type>NvSciSyncFence</type>*                  <name>pFence</name></member>
         </type>
-        <type category="struct" name="VkDeviceSemaphoreSciSyncPoolReservationCreateInfoNV" allowduplicate="true" structextends="VkDeviceObjectReservationCreateInfo">
+        <type category="struct" name="VkDeviceSemaphoreSciSyncPoolReservationCreateInfoNV" allowduplicate="true" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DEVICE_SEMAPHORE_SCI_SYNC_POOL_RESERVATION_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>uint32_t</type>                               <name>semaphoreSciSyncPoolRequestCount</name></member>
@@ -2951,7 +3028,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>physicalDeviceCount</name></member>
-            <member><type>VkPhysicalDevice</type>                 <name>physicalDevices</name>[<enum>VK_MAX_DEVICE_GROUP_SIZE</enum>]</member>
+            <member len="physicalDeviceCount"><type>VkPhysicalDevice</type>       <name>physicalDevices</name>[<enum>VK_MAX_DEVICE_GROUP_SIZE</enum>]</member>
             <member><type>VkBool32</type>                         <name>subsetAllocation</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceGroupPropertiesKHR"                      alias="VkPhysicalDeviceGroupProperties"/>
@@ -3234,7 +3311,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkPhysicalDeviceSurfaceInfo2KHR">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>* <name>pNext</name></member>
-            <member optional="true"><type>VkSurfaceKHR</type> <name>surface</name></member>
+            <member noautovalidity="true" optional="true"><type>VkSurfaceKHR</type> <name>surface</name></member>
         </type>
         <type category="struct" name="VkSurfaceCapabilities2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -3630,6 +3707,42 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member limittype="max"><type>VkDeviceSize</type>                     <name>maxBufferSize</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceMaintenance4PropertiesKHR" alias="VkPhysicalDeviceMaintenance4Properties"/>
+        <type category="struct" name="VkPhysicalDeviceMaintenance5FeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                                         <name>maintenance5</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMaintenance5PropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                     <name>earlyFragmentMultisampleCoverageAfterSampleCounting</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                     <name>earlyFragmentSampleMaskTestBeforeSampleCounting</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                     <name>depthStencilSwizzleOneSupport</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                     <name>polygonModePointSize</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                     <name>nonStrictSinglePixelWideLinesUseParallelogram</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                     <name>nonStrictWideLinesUseParallelogram</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMaintenance6FeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                                         <name>maintenance6</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMaintenance6PropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
+            <member><type>VkBool32</type>                                         <name>blockTexelViewCompatibleMultipleLayers</name></member>
+            <member><type>uint32_t</type>                                         <name>maxCombinedImageSamplerDescriptorCount</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                     <name>fragmentShadingRateClampCombinerInputs</name></member>
+        </type>
+        <type category="struct" name="VkRenderingAreaInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_RENDERING_AREA_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                                <name>pNext</name></member>
+            <member><type>uint32_t</type>                                                                   <name>viewMask</name></member>
+            <member optional="true"><type>uint32_t</type>                                                   <name>colorAttachmentCount</name></member>
+            <member noautovalidity="true" len="colorAttachmentCount">const <type>VkFormat</type>*           <name>pColorAttachmentFormats</name></member>
+            <member noautovalidity="true"><type>VkFormat</type>                                             <name>depthAttachmentFormat</name></member>
+            <member noautovalidity="true"><type>VkFormat</type>                                             <name>stencilAttachmentFormat</name></member>
+        </type>
         <type category="struct" name="VkDescriptorSetLayoutSupport" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*            <name>pNext</name></member>
@@ -3729,11 +3842,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type>                    <name>globalPriorityQuery</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT" alias="VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR"/>
-        <type category="struct" name="VkQueueFamilyGlobalPriorityPropertiesKHR" structextends="VkQueueFamilyProperties2">
+        <type category="struct" name="VkQueueFamilyGlobalPriorityPropertiesKHR" structextends="VkQueueFamilyProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*    <name>pNext</name></member>
-            <member limittype="max"><type>uint32_t</type>                     <name>priorityCount</name></member>
-            <member limittype="bitmask"><type>VkQueueGlobalPriorityKHR</type> <name>priorities</name>[<enum>VK_MAX_GLOBAL_PRIORITY_SIZE_KHR</enum>]</member>
+            <member optional="true"><type>void</type>*                                            <name>pNext</name></member>
+            <member limittype="max"><type>uint32_t</type>                                         <name>priorityCount</name></member>
+            <member limittype="bitmask" len="priorityCount"><type>VkQueueGlobalPriorityKHR</type> <name>priorities</name>[<enum>VK_MAX_GLOBAL_PRIORITY_SIZE_KHR</enum>]</member>
         </type>
         <type category="struct" name="VkQueueFamilyGlobalPriorityPropertiesEXT" alias="VkQueueFamilyGlobalPriorityPropertiesKHR"/>
         <type category="struct" name="VkDebugUtilsObjectNameInfoEXT" structextends="VkPipelineShaderStageCreateInfo">
@@ -3773,7 +3886,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>VkDebugUtilsMessengerCallbackDataFlagsEXT</type>                          <name>flags</name></member>
             <member optional="true" len="null-terminated">const <type>char</type>*                                  <name>pMessageIdName</name></member>
             <member><type>int32_t</type>                                                            <name>messageIdNumber</name></member>
-            <member len="null-terminated">const <type>char</type>*                                                  <name>pMessage</name></member>
+            <member optional="true" len="null-terminated">const <type>char</type>*                                  <name>pMessage</name></member>
             <member optional="true"><type>uint32_t</type>                                                           <name>queueLabelCount</name></member>
             <member len="queueLabelCount">const <type>VkDebugUtilsLabelEXT</type>*                  <name>pQueueLabels</name></member>
             <member optional="true"><type>uint32_t</type>                                                           <name>cmdBufLabelCount</name></member>
@@ -3808,7 +3921,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></member>
-            <member optional="false"><type>void</type>* <name>pHostPointer</name></member>
+            <member><type>void</type>* <name>pHostPointer</name></member>
         </type>
         <type category="struct" name="VkMemoryHostPointerPropertiesEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -3833,11 +3946,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member limittype="bitmask"><type>VkBool32</type>               <name>fullyCoveredFragmentShaderInputVariable</name><comment>true if the implementation supports the FullyCoveredEXT SPIR-V builtin fragment shader input variable</comment></member>
             <member limittype="bitmask"><type>VkBool32</type>               <name>conservativeRasterizationPostDepthCoverage</name><comment>true if the implementation supports both conservative rasterization and post depth coverage sample coverage mask</comment></member>
         </type>
-        <type category="struct" name="VkCalibratedTimestampInfoEXT">
-            <member values="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkCalibratedTimestampInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
-            <member><type>VkTimeDomainEXT</type>        <name>timeDomain</name></member>
+            <member><type>VkTimeDomainKHR</type>                        <name>timeDomain</name></member>
         </type>
+        <type category="struct" name="VkCalibratedTimestampInfoEXT" alias="VkCalibratedTimestampInfoKHR"/>
         <type category="struct" name="VkPhysicalDeviceShaderCorePropertiesAMD" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*    <name>pNext</name></member>
@@ -4062,20 +4176,28 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint64_t</type>               <name>value</name></member>
         </type>
         <type category="struct" name="VkSemaphoreSignalInfoKHR"                                alias="VkSemaphoreSignalInfo"/>
-        <type category="struct" name="VkVertexInputBindingDivisorDescriptionEXT">
+        <type category="struct" name="VkVertexInputBindingDivisorDescriptionKHR">
             <member><type>uint32_t</type>          <name>binding</name></member>
             <member><type>uint32_t</type>          <name>divisor</name></member>
         </type>
-        <type category="struct" name="VkPipelineVertexInputDivisorStateCreateInfoEXT" structextends="VkPipelineVertexInputStateCreateInfo">
-            <member values="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVertexInputBindingDivisorDescriptionEXT" alias="VkVertexInputBindingDivisorDescriptionKHR"/>
+        <type category="struct" name="VkPipelineVertexInputDivisorStateCreateInfoKHR" structextends="VkPipelineVertexInputStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>vertexBindingDivisorCount</name></member>
-            <member len="vertexBindingDivisorCount">const <type>VkVertexInputBindingDivisorDescriptionEXT</type>*      <name>pVertexBindingDivisors</name></member>
+            <member len="vertexBindingDivisorCount">const <type>VkVertexInputBindingDivisorDescriptionKHR</type>*      <name>pVertexBindingDivisors</name></member>
         </type>
+        <type category="struct" name="VkPipelineVertexInputDivisorStateCreateInfoEXT" alias="VkPipelineVertexInputDivisorStateCreateInfoKHR"/>
         <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member limittype="max"><type>uint32_t</type>               <name>maxVertexAttribDivisor</name><comment>max value of vertex attribute divisor</comment></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member limittype="max"><type>uint32_t</type>               <name>maxVertexAttribDivisor</name><comment>max value of vertex attribute divisor</comment></member>
+            <member limittype="max"><type>VkBool32</type>               <name>supportsNonZeroFirstInstance</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePCIBusInfoPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -4123,7 +4245,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*                         <name>pNext</name></member>
             <member><type>VkBool32</type>                            <name>conditionalRenderingEnable</name><comment>Whether this secondary command buffer may be executed during an active conditional rendering</comment></member>
         </type>
-        <type category="struct" name="VkExternalFormatANDROID" structextends="VkImageCreateInfo,VkSamplerYcbcrConversionCreateInfo">
+        <type category="struct" name="VkExternalFormatANDROID" structextends="VkImageCreateInfo,VkSamplerYcbcrConversionCreateInfo,VkAttachmentDescription2,VkGraphicsPipelineCreateInfo,VkCommandBufferInheritanceInfo">
             <member values="VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                              <name>pNext</name></member>
             <member><type>uint64_t</type>                           <name>externalFormat</name></member>
@@ -4189,12 +4311,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type>                            <name>shaderImageFloat32AtomicMinMax</name></member>
             <member><type>VkBool32</type>                            <name>sparseImageFloat32AtomicMinMax</name></member>
         </type>
-        <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
-            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>vertexAttributeInstanceRateDivisor</name></member>
             <member><type>VkBool32</type>                           <name>vertexAttributeInstanceRateZeroDivisor</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT" alias="VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR"/>
         <type category="struct" name="VkQueueFamilyCheckpointPropertiesNV" structextends="VkQueueFamilyProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*           <name>pNext</name></member>
@@ -4465,7 +4588,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkRayTracingPipelineCreateInfoNV">
             <member values="VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
-            <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member><type>uint32_t</type>               <name>stageCount</name></member>
             <member len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
             <member><type>uint32_t</type>               <name>groupCount</name></member>
@@ -4478,7 +4601,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkRayTracingPipelineCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
-            <member optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
+            <member noautovalidity="true" optional="true"><type>VkPipelineCreateFlags</type>  <name>flags</name><comment>Pipeline creation flags</comment></member>
             <member optional="true"><type>uint32_t</type> <name>stageCount</name></member>
             <member len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>* <name>pStages</name><comment>One entry for each active shader stage</comment></member>
             <member optional="true"><type>uint32_t</type> <name>groupCount</name></member>
@@ -4687,7 +4810,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>* <name>pNext</name></member>
             <member><type>uint64_t</type> <name>drmFormatModifier</name></member>
-            <member optional="false"><type>uint32_t</type> <name>drmFormatModifierPlaneCount</name></member>
+            <member><type>uint32_t</type> <name>drmFormatModifierPlaneCount</name></member>
             <member len="drmFormatModifierPlaneCount">const <type>VkSubresourceLayout</type>* <name>pPlaneLayouts</name></member>
         </type>
         <type category="struct" name="VkImageDrmFormatModifierPropertiesEXT" returnedonly="true">
@@ -4897,7 +5020,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member limittype="bitmask"><type>VkShaderStageFlags</type>                  <name>cooperativeMatrixSupportedStages</name></member>
         </type>
-        <type category="struct" name="VkCooperativeMatrixPropertiesNV">
+        <type category="struct" name="VkCooperativeMatrixPropertiesNV" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member><type>uint32_t</type>                            <name>MSize</name></member>
@@ -4937,7 +5060,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint64_t</type>                            <name>duration</name></member>
         </type>
         <type category="struct" name="VkPipelineCreationFeedbackEXT" alias="VkPipelineCreationFeedback"/>
-        <type category="struct" name="VkPipelineCreationFeedbackCreateInfo" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo,VkRayTracingPipelineCreateInfoNV,VkRayTracingPipelineCreateInfoKHR">
+        <type category="struct" name="VkPipelineCreationFeedbackCreateInfo" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo,VkRayTracingPipelineCreateInfoNV,VkRayTracingPipelineCreateInfoKHR,VkExecutionGraphPipelineCreateInfoAMDX">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*         <name>pNext</name></member>
             <member><type>VkPipelineCreationFeedback</type>*         <name>pPipelineCreationFeedback</name><comment>Output pipeline creation feedback.</comment></member>
@@ -4998,9 +5121,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_DESCRIPTION_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                   <name>pNext</name></member>
             <member optional="true"><type>VkPerformanceCounterDescriptionFlagsKHR</type> <name>flags</name></member>
-            <member><type>char</type>                                    <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
-            <member><type>char</type>                                    <name>category</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
-            <member><type>char</type>                                    <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type>              <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type>              <name>category</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type>              <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
         </type>
         <type category="struct" name="VkQueryPoolPerformanceCreateInfoKHR" structextends="VkQueryPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -5028,7 +5151,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*         <name>pNext</name></member>
             <member><type>uint32_t</type>            <name>counterPassIndex</name><comment>Index for which counter pass to submit</comment></member>
         </type>
-        <type category="struct" name="VkPerformanceQueryReservationInfoKHR" allowduplicate="true" structextends="VkDeviceObjectReservationCreateInfo">
+        <type category="struct" name="VkPerformanceQueryReservationInfoKHR" allowduplicate="true" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_RESERVATION_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*         <name>pNext</name></member>
             <member><type>uint32_t</type>            <name>maxPerformanceQueriesPerPool</name><comment>Maximum number of VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR queries in a query pool</comment></member>
@@ -5069,7 +5192,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member selection="VK_PERFORMANCE_VALUE_TYPE_BOOL_INTEL"><type>VkBool32</type>                             <name>valueBool</name></member>
             <member selection="VK_PERFORMANCE_VALUE_TYPE_STRING_INTEL" len="null-terminated">const <type>char</type>*  <name>valueString</name></member>
         </type>
-        <type category="struct" name="VkPerformanceValueINTEL">
+        <type category="struct" name="VkPerformanceValueINTEL" returnedonly="true">
             <member><type>VkPerformanceValueTypeINTEL</type>        <name>type</name></member>
             <member selector="type" noautovalidity="true"><type>VkPerformanceValueDataINTEL</type>        <name>data</name></member>
         </type>
@@ -5112,11 +5235,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type>                            <name>shaderSubgroupClock</name></member>
             <member><type>VkBool32</type>                            <name>shaderDeviceClock</name></member>
         </type>
-        <type category="struct" name="VkPhysicalDeviceIndexTypeUint8FeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
-            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkPhysicalDeviceIndexTypeUint8FeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>indexTypeUint8</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceIndexTypeUint8FeaturesEXT"  alias="VkPhysicalDeviceIndexTypeUint8FeaturesKHR"/>
         <type category="struct" name="VkPhysicalDeviceShaderSMBuiltinsPropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                          <name>pNext</name></member>
@@ -5174,10 +5298,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkPipelineExecutablePropertiesKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*              <name>pNext</name></member>
-            <member><type>VkShaderStageFlags</type> <name>stages</name></member>
-            <member><type>char</type>               <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
-            <member><type>char</type>               <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
-            <member><type>uint32_t</type>           <name>subgroupSize</name></member>
+            <member><type>VkShaderStageFlags</type>                 <name>stages</name></member>
+            <member len="null-terminated"><type>char</type>         <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type>         <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member><type>uint32_t</type>                           <name>subgroupSize</name></member>
         </type>
         <type category="struct" name="VkPipelineExecutableInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -5193,19 +5317,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkPipelineExecutableStatisticKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*              <name>pNext</name></member>
-            <member><type>char</type>               <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
-            <member><type>char</type>               <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member len="null-terminated"><type>char</type>             <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type>             <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
             <member><type>VkPipelineExecutableStatisticFormatKHR</type> <name>format</name></member>
             <member selector="format" noautovalidity="true"><type>VkPipelineExecutableStatisticValueKHR</type>  <name>value</name></member>
         </type>
         <type category="struct" name="VkPipelineExecutableInternalRepresentationKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*              <name>pNext</name></member>
-            <member><type>char</type>               <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
-            <member><type>char</type>               <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
-            <member><type>VkBool32</type>           <name>isText</name></member>
-            <member><type>size_t</type>             <name>dataSize</name></member>
+            <member optional="true"><type>void</type>*                <name>pNext</name></member>
+            <member len="null-terminated"><type>char</type>           <name>name</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type>           <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member><type>VkBool32</type>                             <name>isText</name></member>
+            <member><type>size_t</type>                               <name>dataSize</name></member>
             <member optional="true" len="dataSize"><type>void</type>* <name>pData</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
@@ -5251,7 +5375,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT" alias="VkPipelineShaderStageRequiredSubgroupSizeCreateInfo"/>
         <type category="struct" name="VkShaderRequiredSubgroupSizeCreateInfoEXT" alias="VkPipelineShaderStageRequiredSubgroupSizeCreateInfo"/>
-        <type category="struct" name="VkSubpassShadingPipelineCreateInfoHUAWEI" returnedonly="true" structextends="VkComputePipelineCreateInfo">
+        <type category="struct" name="VkSubpassShadingPipelineCreateInfoHUAWEI" structextends="VkComputePipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SUBPASS_SHADING_PIPELINE_CREATE_INFO_HUAWEI"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                  <name>pNext</name></member>
             <member><type>VkRenderPass</type>           <name>renderPass</name></member>
@@ -5282,8 +5406,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkDeviceMemory</type>                   <name>memory</name></member>
         </type>
         <type category="struct" name="VkDeviceMemoryOpaqueCaptureAddressInfoKHR"               alias="VkDeviceMemoryOpaqueCaptureAddressInfo"/>
-        <type category="struct" name="VkPhysicalDeviceLineRasterizationFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
-            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkPhysicalDeviceLineRasterizationFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>rectangularLines</name></member>
             <member><type>VkBool32</type>                           <name>bresenhamLines</name></member>
@@ -5292,19 +5416,22 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type>                           <name>stippledBresenhamLines</name></member>
             <member><type>VkBool32</type>                           <name>stippledSmoothLines</name></member>
         </type>
-        <type category="struct" name="VkPhysicalDeviceLineRasterizationPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
-            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkPhysicalDeviceLineRasterizationFeaturesEXT" alias="VkPhysicalDeviceLineRasterizationFeaturesKHR"/>
+        <type category="struct" name="VkPhysicalDeviceLineRasterizationPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                               <name>pNext</name></member>
             <member limittype="bits"><type>uint32_t</type>                            <name>lineSubPixelPrecisionBits</name></member>
         </type>
-        <type category="struct" name="VkPipelineRasterizationLineStateCreateInfoEXT" structextends="VkPipelineRasterizationStateCreateInfo">
-            <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                                                      <name>pNext</name></member>
-            <member><type>VkLineRasterizationModeEXT</type>                                       <name>lineRasterizationMode</name></member>
+        <type category="struct" name="VkPhysicalDeviceLineRasterizationPropertiesEXT" alias="VkPhysicalDeviceLineRasterizationPropertiesKHR"/>
+        <type category="struct" name="VkPipelineRasterizationLineStateCreateInfoKHR" structextends="VkPipelineRasterizationStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                      <name>pNext</name></member>
+            <member><type>VkLineRasterizationModeKHR</type>                                       <name>lineRasterizationMode</name></member>
             <member><type>VkBool32</type>                                                         <name>stippledLineEnable</name></member>
             <member><type>uint32_t</type>                                                         <name>lineStippleFactor</name></member>
             <member><type>uint16_t</type>                                                         <name>lineStipplePattern</name></member>
         </type>
+        <type category="struct" name="VkPipelineRasterizationLineStateCreateInfoEXT" alias="VkPipelineRasterizationLineStateCreateInfoKHR"/>
         <type category="struct" name="VkPhysicalDevicePipelineCreationCacheControlFeatures" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>* <name>pNext</name></member>
@@ -5401,56 +5528,56 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member limittype="noauto"><type>VkDriverId</type>                       <name>driverID</name></member>
-            <member limittype="noauto"><type>char</type>                             <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE</enum>]</member>
-            <member limittype="noauto"><type>char</type>                             <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE</enum>]</member>
+            <member limittype="noauto" len="null-terminated"><type>char</type>       <name>driverName</name>[<enum>VK_MAX_DRIVER_NAME_SIZE</enum>]</member>
+            <member limittype="noauto" len="null-terminated"><type>char</type>       <name>driverInfo</name>[<enum>VK_MAX_DRIVER_INFO_SIZE</enum>]</member>
             <member limittype="noauto"><type>VkConformanceVersion</type>             <name>conformanceVersion</name></member>
             <member limittype="exact"><type>VkShaderFloatControlsIndependence</type> <name>denormBehaviorIndependence</name></member>
             <member limittype="exact"><type>VkShaderFloatControlsIndependence</type> <name>roundingModeIndependence</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderSignedZeroInfNanPreserveFloat16</name><comment>An implementation can preserve signed zero, nan, inf</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderSignedZeroInfNanPreserveFloat32</name><comment>An implementation can preserve signed zero, nan, inf</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderSignedZeroInfNanPreserveFloat64</name><comment>An implementation can preserve signed zero, nan, inf</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderDenormPreserveFloat16</name><comment>An implementation can preserve  denormals</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderDenormPreserveFloat32</name><comment>An implementation can preserve  denormals</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderDenormPreserveFloat64</name><comment>An implementation can preserve  denormals</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderDenormFlushToZeroFloat16</name><comment>An implementation can flush to zero  denormals</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderDenormFlushToZeroFloat32</name><comment>An implementation can flush to zero  denormals</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderDenormFlushToZeroFloat64</name><comment>An implementation can flush to zero  denormals</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTEFloat16</name><comment>An implementation can support RTE</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTEFloat32</name><comment>An implementation can support RTE</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTEFloat64</name><comment>An implementation can support RTE</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat16</name><comment>An implementation can support RTZ</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat32</name><comment>An implementation can support RTZ</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderRoundingModeRTZFloat64</name><comment>An implementation can support RTZ</comment></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxUpdateAfterBindDescriptorsInAllPools</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderUniformBufferArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderSampledImageArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageBufferArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderStorageImageArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>shaderInputAttachmentArrayNonUniformIndexingNative</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>robustBufferAccessUpdateAfterBind</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>quadDivergentImplicitLod</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSamplers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxPerStageUpdateAfterBindResources</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSamplers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindSampledImages</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindStorageImages</name></member>
-            <member limittype="max"><type>uint32_t</type>                         <name>maxDescriptorSetUpdateAfterBindInputAttachments</name></member>
-            <member limittype="bitmask"><type>VkResolveModeFlags</type>               <name>supportedDepthResolveModes</name><comment>supported depth resolve modes</comment></member>
-            <member limittype="bitmask"><type>VkResolveModeFlags</type>               <name>supportedStencilResolveModes</name><comment>supported stencil resolve modes</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>independentResolveNone</name><comment>depth and stencil resolve modes can be set independently if one of them is none</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>independentResolve</name><comment>depth and stencil resolve modes can be set independently</comment></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxSingleComponentFormats</name></member>
-            <member limittype="bitmask"><type>VkBool32</type>                         <name>filterMinmaxImageComponentMapping</name></member>
-            <member limittype="max"><type>uint64_t</type>                         <name>maxTimelineSemaphoreValueDifference</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderSignedZeroInfNanPreserveFloat16</name><comment>An implementation can preserve signed zero, nan, inf</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderSignedZeroInfNanPreserveFloat32</name><comment>An implementation can preserve signed zero, nan, inf</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderSignedZeroInfNanPreserveFloat64</name><comment>An implementation can preserve signed zero, nan, inf</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderDenormPreserveFloat16</name><comment>An implementation can preserve  denormals</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderDenormPreserveFloat32</name><comment>An implementation can preserve  denormals</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderDenormPreserveFloat64</name><comment>An implementation can preserve  denormals</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderDenormFlushToZeroFloat16</name><comment>An implementation can flush to zero  denormals</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderDenormFlushToZeroFloat32</name><comment>An implementation can flush to zero  denormals</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderDenormFlushToZeroFloat64</name><comment>An implementation can flush to zero  denormals</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderRoundingModeRTEFloat16</name><comment>An implementation can support RTE</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderRoundingModeRTEFloat32</name><comment>An implementation can support RTE</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderRoundingModeRTEFloat64</name><comment>An implementation can support RTE</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderRoundingModeRTZFloat16</name><comment>An implementation can support RTZ</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderRoundingModeRTZFloat32</name><comment>An implementation can support RTZ</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderRoundingModeRTZFloat64</name><comment>An implementation can support RTZ</comment></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxUpdateAfterBindDescriptorsInAllPools</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderUniformBufferArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderSampledImageArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderStorageBufferArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderStorageImageArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>shaderInputAttachmentArrayNonUniformIndexingNative</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>robustBufferAccessUpdateAfterBind</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>quadDivergentImplicitLod</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxPerStageDescriptorUpdateAfterBindSamplers</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxPerStageDescriptorUpdateAfterBindUniformBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxPerStageDescriptorUpdateAfterBindStorageBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxPerStageDescriptorUpdateAfterBindSampledImages</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxPerStageDescriptorUpdateAfterBindStorageImages</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxPerStageDescriptorUpdateAfterBindInputAttachments</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxPerStageUpdateAfterBindResources</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDescriptorSetUpdateAfterBindSamplers</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDescriptorSetUpdateAfterBindUniformBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDescriptorSetUpdateAfterBindUniformBuffersDynamic</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDescriptorSetUpdateAfterBindStorageBuffers</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDescriptorSetUpdateAfterBindStorageBuffersDynamic</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDescriptorSetUpdateAfterBindSampledImages</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDescriptorSetUpdateAfterBindStorageImages</name></member>
+            <member limittype="max"><type>uint32_t</type>                            <name>maxDescriptorSetUpdateAfterBindInputAttachments</name></member>
+            <member limittype="bitmask"><type>VkResolveModeFlags</type>              <name>supportedDepthResolveModes</name><comment>supported depth resolve modes</comment></member>
+            <member limittype="bitmask"><type>VkResolveModeFlags</type>              <name>supportedStencilResolveModes</name><comment>supported stencil resolve modes</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>independentResolveNone</name><comment>depth and stencil resolve modes can be set independently if one of them is none</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>independentResolve</name><comment>depth and stencil resolve modes can be set independently</comment></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>filterMinmaxSingleComponentFormats</name></member>
+            <member limittype="bitmask"><type>VkBool32</type>                        <name>filterMinmaxImageComponentMapping</name></member>
+            <member limittype="max"><type>uint64_t</type>                            <name>maxTimelineSemaphoreValueDifference</name></member>
             <member limittype="bitmask" optional="true"><type>VkSampleCountFlags</type> <name>framebufferIntegerColorSampleCounts</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceVulkan13Features" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
@@ -5521,7 +5648,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member limittype="exact"><type>VkBool32</type>                  <name>uniformTexelBufferOffsetSingleTexelAlignment</name></member>
             <member limittype="max"><type>VkDeviceSize</type>                   <name>maxBufferSize</name></member>
         </type>
-        <type category="struct" name="VkPipelineCompilerControlCreateInfoAMD" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo">
+        <type category="struct" name="VkPipelineCompilerControlCreateInfoAMD" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo,VkExecutionGraphPipelineCreateInfoAMDX">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD"><type>VkStructureType</type>   <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                                                            <name>pNext</name></member>
             <member optional="true"><type>VkPipelineCompilerControlFlagsAMD</type>                                      <name>compilerControlFlags</name></member>
@@ -5539,19 +5666,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkFaultCallbackInfo" structextends="VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_FAULT_CALLBACK_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*              <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*        <name>pNext</name></member>
             <member optional="true"><type>uint32_t</type>           <name>faultCount</name></member>
             <member optional="true" len="faultCount"><type>VkFaultData</type>*<name>pFaults</name></member>
             <member><type>PFN_vkFaultCallbackFunction</type>        <name>pfnFaultCallback</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceToolProperties" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>* <name>pNext</name></member>
-            <member><type>char</type>                  <name>name</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member>
-            <member><type>char</type>                  <name>version</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member>
-            <member><type>VkToolPurposeFlags</type>    <name>purposes</name></member>
-            <member><type>char</type>                  <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
-            <member><type>char</type>                  <name>layer</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member>
+            <member optional="true"><type>void</type>*      <name>pNext</name></member>
+            <member len="null-terminated"><type>char</type> <name>name</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type> <name>version</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member>
+            <member><type>VkToolPurposeFlags</type>         <name>purposes</name></member>
+            <member len="null-terminated"><type>char</type> <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type> <name>layer</name>[<enum>VK_MAX_EXTENSION_NAME_SIZE</enum>]</member>
         </type>
         <type category="struct" name="VkPhysicalDeviceToolPropertiesEXT" alias="VkPhysicalDeviceToolProperties"/>
         <type category="struct" name="VkSamplerCustomBorderColorCreateInfoEXT" structextends="VkSamplerCreateInfo">
@@ -5588,6 +5715,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member noautovalidity="true"><type>void</type>*                      <name>hostAddress</name></member>
         </type>
         <type category="union" name="VkDeviceOrHostAddressConstKHR">
+            <member noautovalidity="true"><type>VkDeviceAddress</type>            <name>deviceAddress</name></member>
+            <member noautovalidity="true">const <type>void</type>*                <name>hostAddress</name></member>
+        </type>
+        <type category="union" name="VkDeviceOrHostAddressConstAMDX">
             <member noautovalidity="true"><type>VkDeviceAddress</type>            <name>deviceAddress</name></member>
             <member noautovalidity="true">const <type>void</type>*                <name>hostAddress</name></member>
         </type>
@@ -5910,7 +6041,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*<name>pNext</name></member>
             <member><type>VkBool32</type> <name>clustercullingShader</name></member>
             <member><type>VkBool32</type> <name>multiviewClusterCullingShader</name></member>
-       </type>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI" structextends="VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI"><type>VkStructureType</type>  <name>sType</name></member>
+            <member optional="true"><type>void</type>*<name>pNext</name></member>
+            <member><type>VkBool32</type> <name>clusterShadingRate</name></member>
+        </type>
         <type category="struct" name="VkBufferCopy2">
             <member values="VK_STRUCTURE_TYPE_BUFFER_COPY_2"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*        <name>pNext</name></member>
@@ -6099,7 +6235,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member noautovalidity="true"><type>VkFragmentShadingRateNV</type>            <name>shadingRate</name></member>
             <member noautovalidity="true"><type>VkFragmentShadingRateCombinerOpKHR</type> <name>combinerOps</name>[2]</member>
         </type>
-        <type category="struct" name="VkAccelerationStructureBuildSizesInfoKHR">
+        <type category="struct" name="VkAccelerationStructureBuildSizesInfoKHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*        <name>pNext</name></member>
             <member><type>VkDeviceSize</type>                       <name>accelerationStructureSize</name></member>
@@ -6282,6 +6418,89 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type>                           <name>synchronization2</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceSynchronization2FeaturesKHR" alias="VkPhysicalDeviceSynchronization2Features"/>
+        <type category="struct" name="VkPhysicalDeviceHostImageCopyFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>VkBool32</type>                     <name>hostImageCopy</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceHostImageCopyPropertiesEXT" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                                                        <name>pNext</name></member>
+            <member optional="true" limittype="noauto"><type>uint32_t</type>                                  <name>copySrcLayoutCount</name></member>
+            <member optional="true" limittype="noauto" len="copySrcLayoutCount"><type>VkImageLayout</type>*   <name>pCopySrcLayouts</name></member>
+            <member optional="true" limittype="noauto"><type>uint32_t</type>                                  <name>copyDstLayoutCount</name></member>
+            <member optional="true" limittype="noauto" len="copyDstLayoutCount"><type>VkImageLayout</type>*   <name>pCopyDstLayouts</name></member>
+            <member optional="true" limittype="noauto"><type>uint8_t</type>                                   <name>optimalTilingLayoutUUID</name>[<enum>VK_UUID_SIZE</enum>]</member>
+            <member limittype="bitmask"><type>VkBool32</type>                                                 <name>identicalMemoryTypeRequirements</name></member>
+        </type>
+        <type category="struct" name="VkMemoryToImageCopyEXT">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
+            <member>const <type>void</type>*                                    <name>pHostPointer</name></member>
+            <member><type>uint32_t</type>                                       <name>memoryRowLength</name><comment>Specified in texels</comment></member>
+            <member><type>uint32_t</type>                                       <name>memoryImageHeight</name></member>
+            <member><type>VkImageSubresourceLayers</type>                       <name>imageSubresource</name></member>
+            <member><type>VkOffset3D</type>                                     <name>imageOffset</name></member>
+            <member><type>VkExtent3D</type>                                     <name>imageExtent</name></member>
+        </type>
+        <type category="struct" name="VkImageToMemoryCopyEXT">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_TO_MEMORY_COPY_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
+            <member><type>void</type>*                                          <name>pHostPointer</name></member>
+            <member><type>uint32_t</type>                                       <name>memoryRowLength</name><comment>Specified in texels</comment></member>
+            <member><type>uint32_t</type>                                       <name>memoryImageHeight</name></member>
+            <member><type>VkImageSubresourceLayers</type>                       <name>imageSubresource</name></member>
+            <member><type>VkOffset3D</type>                                     <name>imageOffset</name></member>
+            <member><type>VkExtent3D</type>                                     <name>imageExtent</name></member>
+        </type>
+        <type category="struct" name="VkCopyMemoryToImageInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                <name>pNext</name></member>
+            <member optional="true"><type>VkHostImageCopyFlagsEXT</type>    <name>flags</name></member>
+            <member><type>VkImage</type>                                    <name>dstImage</name></member>
+            <member><type>VkImageLayout</type>                              <name>dstImageLayout</name></member>
+            <member><type>uint32_t</type>                                   <name>regionCount</name></member>
+            <member len="regionCount">const <type>VkMemoryToImageCopyEXT</type>* <name>pRegions</name></member>
+        </type>
+        <type category="struct" name="VkCopyImageToMemoryInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_COPY_IMAGE_TO_MEMORY_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                <name>pNext</name></member>
+            <member optional="true"><type>VkHostImageCopyFlagsEXT</type>    <name>flags</name></member>
+            <member><type>VkImage</type>                                    <name>srcImage</name></member>
+            <member><type>VkImageLayout</type>                              <name>srcImageLayout</name></member>
+            <member><type>uint32_t</type>                                   <name>regionCount</name></member>
+            <member len="regionCount">const <type>VkImageToMemoryCopyEXT</type>* <name>pRegions</name></member>
+        </type>
+        <type category="struct" name="VkCopyImageToImageInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_COPY_IMAGE_TO_IMAGE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                <name>pNext</name></member>
+            <member optional="true"><type>VkHostImageCopyFlagsEXT</type>    <name>flags</name></member>
+            <member><type>VkImage</type>                                    <name>srcImage</name></member>
+            <member><type>VkImageLayout</type>                              <name>srcImageLayout</name></member>
+            <member><type>VkImage</type>                                    <name>dstImage</name></member>
+            <member><type>VkImageLayout</type>                              <name>dstImageLayout</name></member>
+            <member><type>uint32_t</type>                                   <name>regionCount</name></member>
+            <member len="regionCount">const <type>VkImageCopy2</type>*      <name>pRegions</name></member>
+        </type>
+        <type category="struct" name="VkHostImageLayoutTransitionInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*  <name>pNext</name></member>
+            <member><type>VkImage</type>                      <name>image</name></member>
+            <member><type>VkImageLayout</type>                <name>oldLayout</name></member>
+            <member><type>VkImageLayout</type>                <name>newLayout</name></member>
+            <member><type>VkImageSubresourceRange</type>      <name>subresourceRange</name></member>
+        </type>
+        <type category="struct" name="VkSubresourceHostMemcpySizeEXT" returnedonly="true" structextends="VkSubresourceLayout2KHR">
+            <member values="VK_STRUCTURE_TYPE_SUBRESOURCE_HOST_MEMCPY_SIZE_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>VkDeviceSize</type>                 <name>size</name><comment>Specified in bytes</comment></member>
+        </type>
+        <type category="struct" name="VkHostImageCopyDevicePerformanceQueryEXT" returnedonly="true" structextends="VkImageFormatProperties2">
+            <member values="VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>VkBool32</type>                     <name>optimalDeviceAccess</name><comment>Specifies if device access is optimal</comment></member>
+            <member><type>VkBool32</type>                     <name>identicalMemoryLayout</name><comment>Specifies if memory layout is identical</comment></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceVulkanSC10Properties" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_SC_1_0_PROPERTIES"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*          <name>pNext</name></member>
@@ -6358,8 +6577,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkCommandPoolMemoryReservationCreateInfo" structextends="VkCommandPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_COMMAND_POOL_MEMORY_RESERVATION_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*    <name>pNext</name></member>
-            <member optional="false"><type>VkDeviceSize</type>  <name>commandPoolReservedSize</name></member>
-            <member optional="false"><type>uint32_t</type>      <name>commandPoolMaxCommandBuffers</name></member>
+            <member><type>VkDeviceSize</type>  <name>commandPoolReservedSize</name></member>
+            <member><type>uint32_t</type>      <name>commandPoolMaxCommandBuffers</name></member>
         </type>
         <type category="struct" name="VkCommandPoolMemoryConsumption" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_COMMAND_POOL_MEMORY_CONSUMPTION"><type>VkStructureType</type> <name>sType</name></member>
@@ -6508,6 +6727,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>uint32_t</type>               <name>referenceSlotCount</name></member>
             <member len="referenceSlotCount">const <type>VkVideoReferenceSlotInfoKHR</type>* <name>pReferenceSlots</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceVideoMaintenance1FeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_1_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>videoMaintenance1</name></member>
+        </type>
+        <type category="struct" name="VkVideoInlineQueryInfoKHR" structextends="VkVideoDecodeInfoKHR,VkVideoEncodeInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_INLINE_QUERY_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkQueryPool</type>            <name>queryPool</name></member>
+            <member><type>uint32_t</type>                               <name>firstQuery</name></member>
+            <member><type>uint32_t</type>                               <name>queryCount</name></member>
+        </type>
             <comment>Video Decode Codec Standard specific structures</comment>
         <type category="include" name="vk_video/vulkan_video_codec_h264std.h">#include "vk_video/vulkan_video_codec_h264std.h"</type>
         <type requires="vk_video/vulkan_video_codec_h264std.h" name="StdVideoH264ProfileIdc"/>
@@ -6638,6 +6869,44 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*             <name>pNext</name></member>
             <member>const <type>StdVideoDecodeH265ReferenceInfo</type>*  <name>pStdReferenceInfo</name></member>
         </type>
+        <type category="include" name="vk_video/vulkan_video_codec_av1std.h">#include "vk_video/vulkan_video_codec_av1std.h"</type>
+        <type requires="vk_video/vulkan_video_codec_av1std.h" name="StdVideoAV1Profile"/>
+        <type requires="vk_video/vulkan_video_codec_av1std.h" name="StdVideoAV1Level"/>
+        <type requires="vk_video/vulkan_video_codec_av1std.h" name="StdVideoAV1SequenceHeader"/>
+        <type category="include" name="vk_video/vulkan_video_codec_av1std_decode.h">#include "vk_video/vulkan_video_codec_av1std_decode.h"</type>
+        <type requires="vk_video/vulkan_video_codec_av1std_decode.h" name="StdVideoDecodeAV1PictureInfo"/>
+        <type requires="vk_video/vulkan_video_codec_av1std_decode.h" name="StdVideoDecodeAV1ReferenceInfo"/>
+        <type category="struct" name="VkVideoDecodeAV1ProfileInfoKHR" structextends="VkVideoProfileInfoKHR,VkQueryPoolCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PROFILE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>StdVideoAV1Profile</type>                     <name>stdProfile</name></member>
+            <member><type>VkBool32</type>                               <name>filmGrainSupport</name></member>
+        </type>
+        <type category="struct" name="VkVideoDecodeAV1CapabilitiesKHR" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member><type>StdVideoAV1Level</type>                       <name>maxLevel</name></member>
+        </type>
+        <type category="struct" name="VkVideoDecodeAV1SessionParametersCreateInfoKHR" structextends="VkVideoSessionParametersCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_SESSION_PARAMETERS_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member>const <type>StdVideoAV1SequenceHeader</type>*       <name>pStdSequenceHeader</name></member>
+        </type>
+        <type category="struct" name="VkVideoDecodeAV1PictureInfoKHR" structextends="VkVideoDecodeInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PICTURE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member>const <type>StdVideoDecodeAV1PictureInfo</type>*    <name>pStdPictureInfo</name></member>
+            <member><type>int32_t</type>                                <name>referenceNameSlotIndices</name>[<enum>VK_MAX_VIDEO_AV1_REFERENCES_PER_FRAME_KHR</enum>]</member>
+            <member><type>uint32_t</type>                               <name>frameHeaderOffset</name></member>
+            <member><type>uint32_t</type>                               <name>tileCount</name></member>
+            <member len="tileCount">const <type>uint32_t</type>*        <name>pTileOffsets</name></member>
+            <member len="tileCount">const <type>uint32_t</type>*        <name>pTileSizes</name></member>
+        </type>
+        <type category="struct" name="VkVideoDecodeAV1DpbSlotInfoKHR" structextends="VkVideoReferenceSlotInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_DPB_SLOT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member>const <type>StdVideoDecodeAV1ReferenceInfo</type>*  <name>pStdReferenceInfo</name></member>
+        </type>
         <type category="struct" name="VkVideoSessionCreateInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_SESSION_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                   <name>pNext</name></member>
@@ -6663,6 +6932,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*                                            <name>pNext</name></member>
             <member><type>uint32_t</type>                                               <name>updateSequenceCount</name></member>
         </type>
+        <type category="struct" name="VkVideoEncodeSessionParametersGetInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_GET_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
+            <member><type>VkVideoSessionParametersKHR</type>                    <name>videoSessionParameters</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeSessionParametersFeedbackInfoKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_FEEDBACK_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                          <name>pNext</name></member>
+            <member><type>VkBool32</type>                                       <name>hasOverrides</name></member>
+        </type>
         <type category="struct" name="VkVideoBeginCodingInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                             <name>pNext</name></member>
@@ -6680,7 +6959,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkVideoCodingControlInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_CODING_CONTROL_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                    <name>pNext</name></member>
-            <member optional="false"><type>VkVideoCodingControlFlagsKHR</type>  <name>flags</name></member>
+            <member><type>VkVideoCodingControlFlagsKHR</type>                   <name>flags</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeUsageInfoKHR" structextends="VkVideoProfileInfoKHR,VkQueryPoolCreateInfo">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -6693,7 +6972,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member optional="true"><type>VkVideoEncodeFlagsKHR</type>  <name>flags</name></member>
-            <member><type>uint32_t</type>                               <name>qualityLevel</name></member>
             <member><type>VkBuffer</type>                               <name>dstBuffer</name></member>
             <member><type>VkDeviceSize</type>                           <name>dstBufferOffset</name></member>
             <member><type>VkDeviceSize</type>                           <name>dstBufferRange</name></member>
@@ -6708,23 +6986,40 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkVideoEncodeFeedbackFlagsKHR</type>          <name>encodeFeedbackFlags</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeRateControlInfoKHR" structextends="VkVideoCodingControlInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*              <name>pNext</name></member>
-            <member optional="true"><type>VkVideoEncodeRateControlFlagsKHR</type> <name>flags</name></member>
-            <member optional="true"><type>VkVideoEncodeRateControlModeFlagBitsKHR</type>  <name>rateControlMode</name></member>
-            <member optional="true"><type>uint32_t</type>                                 <name>layerCount</name></member>
-            <member len="layerCount">const <type>VkVideoEncodeRateControlLayerInfoKHR</type>* <name>pLayers</name></member>
+        <type category="struct" name="VkVideoEncodeQualityLevelInfoKHR" structextends="VkVideoCodingControlInfoKHR,VkVideoSessionParametersCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>uint32_t</type>                               <name>qualityLevel</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeRateControlLayerInfoKHR" structextends="VkVideoCodingControlInfoKHR">
+        <type category="struct" name="VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member>const <type>VkVideoProfileInfoKHR</type>*           <name>pVideoProfile</name></member>
+            <member><type>uint32_t</type>                               <name>qualityLevel</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeQualityLevelPropertiesKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkVideoEncodeRateControlModeFlagBitsKHR</type> <name>preferredRateControlMode</name></member>
+            <member><type>uint32_t</type>                               <name>preferredRateControlLayerCount</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeRateControlInfoKHR" structextends="VkVideoCodingControlInfoKHR,VkVideoBeginCodingInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member optional="true"><type>VkVideoEncodeRateControlFlagsKHR</type> <name>flags</name></member>
+            <member optional="true"><type>VkVideoEncodeRateControlModeFlagBitsKHR</type> <name>rateControlMode</name></member>
+            <member optional="true"><type>uint32_t</type>               <name>layerCount</name></member>
+            <member len="layerCount">const <type>VkVideoEncodeRateControlLayerInfoKHR</type>* <name>pLayers</name></member>
+            <member><type>uint32_t</type>                               <name>virtualBufferSizeInMs</name></member>
+            <member><type>uint32_t</type>                               <name>initialVirtualBufferSizeInMs</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeRateControlLayerInfoKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*              <name>pNext</name></member>
-            <member><type>uint64_t</type>                                 <name>averageBitrate</name></member>
-            <member><type>uint64_t</type>                                 <name>maxBitrate</name></member>
-            <member><type>uint32_t</type>                                 <name>frameRateNumerator</name></member>
-            <member><type>uint32_t</type>                                 <name>frameRateDenominator</name></member>
-            <member><type>uint32_t</type>                                 <name>virtualBufferSizeInMs</name></member>
-            <member><type>uint32_t</type>                                 <name>initialVirtualBufferSizeInMs</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>uint64_t</type>                               <name>averageBitrate</name></member>
+            <member><type>uint64_t</type>                               <name>maxBitrate</name></member>
+            <member><type>uint32_t</type>                               <name>frameRateNumerator</name></member>
+            <member><type>uint32_t</type>                               <name>frameRateDenominator</name></member>
         </type>
         <type category="struct" name="VkVideoEncodeCapabilitiesKHR" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
             <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
@@ -6732,22 +7027,40 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member noautovalidity="true"><type>VkVideoEncodeCapabilityFlagsKHR</type>       <name>flags</name></member>
             <member><type>VkVideoEncodeRateControlModeFlagsKHR</type>  <name>rateControlModes</name></member>
             <member><type>uint32_t</type>                              <name>maxRateControlLayers</name></member>
+            <member><type>uint64_t</type>                              <name>maxBitrate</name></member>
             <member><type>uint32_t</type>                              <name>maxQualityLevels</name></member>
-            <member><type>VkExtent2D</type>                            <name>inputImageDataFillAlignment</name></member>
+            <member><type>VkExtent2D</type>                            <name>encodeInputPictureGranularity</name></member>
             <member><type>VkVideoEncodeFeedbackFlagsKHR</type>         <name>supportedEncodeFeedbackFlags</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264CapabilitiesEXT" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH264CapabilitiesKHR" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                 <name>pNext</name></member>
-            <member noautovalidity="true"><type>VkVideoEncodeH264CapabilityFlagsEXT</type>   <name>flags</name></member>
+            <member noautovalidity="true"><type>VkVideoEncodeH264CapabilityFlagsKHR</type> <name>flags</name></member>
+            <member><type>StdVideoH264LevelIdc</type>                  <name>maxLevelIdc</name></member>
+            <member><type>uint32_t</type>                              <name>maxSliceCount</name></member>
             <member><type>uint32_t</type>                              <name>maxPPictureL0ReferenceCount</name></member>
             <member><type>uint32_t</type>                              <name>maxBPictureL0ReferenceCount</name></member>
             <member><type>uint32_t</type>                              <name>maxL1ReferenceCount</name></member>
-            <member><type>VkBool32</type>                              <name>motionVectorsOverPicBoundariesFlag</name></member>
-            <member><type>uint32_t</type>                              <name>maxBytesPerPicDenom</name></member>
-            <member><type>uint32_t</type>                              <name>maxBitsPerMbDenom</name></member>
-            <member><type>uint32_t</type>                              <name>log2MaxMvLengthHorizontal</name></member>
-            <member><type>uint32_t</type>                              <name>log2MaxMvLengthVertical</name></member>
+            <member><type>uint32_t</type>                              <name>maxTemporalLayerCount</name></member>
+            <member><type>VkBool32</type>                              <name>expectDyadicTemporalLayerPattern</name></member>
+            <member><type>int32_t</type>                               <name>minQp</name></member>
+            <member><type>int32_t</type>                               <name>maxQp</name></member>
+            <member><type>VkBool32</type>                              <name>prefersGopRemainingFrames</name></member>
+            <member><type>VkBool32</type>                              <name>requiresGopRemainingFrames</name></member>
+            <member noautovalidity="true"><type>VkVideoEncodeH264StdFlagsKHR</type> <name>stdSyntaxFlags</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH264QualityLevelPropertiesKHR" returnedonly="true" structextends="VkVideoEncodeQualityLevelPropertiesKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUALITY_LEVEL_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkVideoEncodeH264RateControlFlagsKHR</type>   <name>preferredRateControlFlags</name></member>
+            <member><type>uint32_t</type>                               <name>preferredGopFrameCount</name></member>
+            <member><type>uint32_t</type>                               <name>preferredIdrPeriod</name></member>
+            <member><type>uint32_t</type>                               <name>preferredConsecutiveBFrameCount</name></member>
+            <member><type>uint32_t</type>                               <name>preferredTemporalLayerCount</name></member>
+            <member><type>VkVideoEncodeH264QpKHR</type>                 <name>preferredConstantQp</name></member>
+            <member><type>uint32_t</type>                               <name>preferredMaxL0ReferenceCount</name></member>
+            <member><type>uint32_t</type>                               <name>preferredMaxL1ReferenceCount</name></member>
+            <member><type>VkBool32</type>                               <name>preferredStdEntropyCodingModeFlag</name></member>
         </type>
         <type category="include" name="vk_video/vulkan_video_codec_h264std_encode.h">#include "vk_video/vulkan_video_codec_h264std_encode.h"</type>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264SliceHeader"/>
@@ -6760,99 +7073,133 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefMgmtFlags"/>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefListModEntry"/>
         <type requires="vk_video/vulkan_video_codec_h264std_encode.h" name="StdVideoEncodeH264RefPicMarkingEntry"/>
-        <type category="struct" name="VkVideoEncodeH264SessionParametersAddInfoEXT" structextends="VkVideoSessionParametersUpdateInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                                                               <name>pNext</name></member>
-            <member><type>uint32_t</type>                                                                  <name>stdSPSCount</name></member>
+        <type category="struct" name="VkVideoEncodeH264SessionCreateInfoKHR" structextends="VkVideoSessionCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                               <name>useMaxLevelIdc</name></member>
+            <member><type>StdVideoH264LevelIdc</type>                   <name>maxLevelIdc</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH264SessionParametersAddInfoKHR" structextends="VkVideoSessionParametersUpdateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                               <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>                                                  <name>stdSPSCount</name></member>
             <member len="stdSPSCount" optional="true">const <type>StdVideoH264SequenceParameterSet</type>* <name>pStdSPSs</name></member>
-            <member><type>uint32_t</type>                                                                  <name>stdPPSCount</name></member>
+            <member optional="true"><type>uint32_t</type>                                                  <name>stdPPSCount</name></member>
             <member len="stdPPSCount" optional="true">const <type>StdVideoH264PictureParameterSet</type>*  <name>pStdPPSs</name><comment>List of Picture Parameters associated with the spsStd, above</comment></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264SessionParametersCreateInfoEXT" structextends="VkVideoSessionParametersCreateInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH264SessionParametersCreateInfoKHR" structextends="VkVideoSessionParametersCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                         <name>pNext</name></member>
             <member><type>uint32_t</type>                                                            <name>maxStdSPSCount</name></member>
             <member><type>uint32_t</type>                                                            <name>maxStdPPSCount</name></member>
-            <member optional="true">const <type>VkVideoEncodeH264SessionParametersAddInfoEXT</type>* <name>pParametersAddInfo</name></member>
+            <member optional="true">const <type>VkVideoEncodeH264SessionParametersAddInfoKHR</type>* <name>pParametersAddInfo</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264DpbSlotInfoEXT" structextends="VkVideoReferenceSlotInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH264SessionParametersGetInfoKHR" structextends="VkVideoEncodeSessionParametersGetInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_GET_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                               <name>writeStdSPS</name></member>
+            <member><type>VkBool32</type>                               <name>writeStdPPS</name></member>
+            <member><type>uint32_t</type>                               <name>stdSPSId</name></member>
+            <member><type>uint32_t</type>                               <name>stdPPSId</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH264SessionParametersFeedbackInfoKHR" structextends="VkVideoEncodeSessionParametersFeedbackInfoKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_FEEDBACK_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkBool32</type>                               <name>hasStdSPSOverrides</name></member>
+            <member><type>VkBool32</type>                               <name>hasStdPPSOverrides</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH264DpbSlotInfoKHR" structextends="VkVideoReferenceSlotInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                          <name>pNext</name></member>
             <member>const <type>StdVideoEncodeH264ReferenceInfo</type>*                               <name>pStdReferenceInfo</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264VclFrameInfoEXT" structextends="VkVideoEncodeInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_VCL_FRAME_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH264PictureInfoKHR" structextends="VkVideoEncodeInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                        <name>pNext</name></member>
-            <member optional="true">const <type>StdVideoEncodeH264ReferenceListsInfo</type>*        <name>pStdReferenceFinalLists</name></member>
             <member><type>uint32_t</type>                                                           <name>naluSliceEntryCount</name></member>
-            <member len="naluSliceEntryCount">const <type>VkVideoEncodeH264NaluSliceInfoEXT</type>* <name>pNaluSliceEntries</name></member>
+            <member len="naluSliceEntryCount">const <type>VkVideoEncodeH264NaluSliceInfoKHR</type>* <name>pNaluSliceEntries</name></member>
             <member>const <type>StdVideoEncodeH264PictureInfo</type>*                               <name>pStdPictureInfo</name></member>
+            <member><type>VkBool32</type>                                                           <name>generatePrefixNalu</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264ProfileInfoEXT" structextends="VkVideoProfileInfoKHR,VkQueryPoolCreateInfo">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH264ProfileInfoKHR" structextends="VkVideoProfileInfoKHR,VkQueryPoolCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*             <name>pNext</name></member>
             <member><type>StdVideoH264ProfileIdc</type>                  <name>stdProfileIdc</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264NaluSliceInfoEXT">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH264NaluSliceInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
-            <member><type>uint32_t</type>                                        <name>mbCount</name></member>
-            <member optional="true">const <type>StdVideoEncodeH264ReferenceListsInfo</type>* <name>pStdReferenceFinalLists</name></member>
+            <member><type>int32_t</type>                                         <name>constantQp</name></member>
             <member>const <type>StdVideoEncodeH264SliceHeader</type>*            <name>pStdSliceHeader</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264RateControlInfoEXT" structextends="VkVideoCodingControlInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH264RateControlInfoKHR" structextends="VkVideoCodingControlInfoKHR,VkVideoBeginCodingInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
+            <member optional="true"><type>VkVideoEncodeH264RateControlFlagsKHR</type> <name>flags</name></member>
             <member><type>uint32_t</type>                                        <name>gopFrameCount</name></member>
             <member><type>uint32_t</type>                                        <name>idrPeriod</name></member>
             <member><type>uint32_t</type>                                        <name>consecutiveBFrameCount</name></member>
-            <member><type>VkVideoEncodeH264RateControlStructureEXT</type>        <name>rateControlStructure</name></member>
             <member><type>uint32_t</type>                                        <name>temporalLayerCount</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264QpEXT">
+        <type category="struct" name="VkVideoEncodeH264QpKHR">
             <member noautovalidity="true"><type>int32_t</type> <name>qpI</name></member>
             <member noautovalidity="true"><type>int32_t</type> <name>qpP</name></member>
             <member noautovalidity="true"><type>int32_t</type> <name>qpB</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264FrameSizeEXT">
+        <type category="struct" name="VkVideoEncodeH264FrameSizeKHR">
             <member noautovalidity="true"><type>uint32_t</type> <name>frameISize</name></member>
             <member noautovalidity="true"><type>uint32_t</type> <name>framePSize</name></member>
             <member noautovalidity="true"><type>uint32_t</type> <name>frameBSize</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH264RateControlLayerInfoEXT" structextends="VkVideoCodingControlInfoKHR,VkVideoEncodeRateControlLayerInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
-            <member><type>uint32_t</type>                                        <name>temporalLayerId</name></member>
-            <member><type>VkBool32</type>                                        <name>useInitialRcQp</name></member>
-            <member><type>VkVideoEncodeH264QpEXT</type>                          <name>initialRcQp</name></member>
-            <member><type>VkBool32</type>                                        <name>useMinQp</name></member>
-            <member><type>VkVideoEncodeH264QpEXT</type>                          <name>minQp</name></member>
-            <member><type>VkBool32</type>                                        <name>useMaxQp</name></member>
-            <member><type>VkVideoEncodeH264QpEXT</type>                          <name>maxQp</name></member>
-            <member><type>VkBool32</type>                                        <name>useMaxFrameSize</name></member>
-            <member><type>VkVideoEncodeH264FrameSizeEXT</type>                   <name>maxFrameSize</name></member>
+        <type category="struct" name="VkVideoEncodeH264GopRemainingFrameInfoKHR" structextends="VkVideoBeginCodingInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_GOP_REMAINING_FRAME_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type>                       <name>useGopRemainingFrames</name></member>
+            <member><type>uint32_t</type>                       <name>gopRemainingI</name></member>
+            <member><type>uint32_t</type>                       <name>gopRemainingP</name></member>
+            <member><type>uint32_t</type>                       <name>gopRemainingB</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265CapabilitiesEXT" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH264RateControlLayerInfoKHR" structextends="VkVideoEncodeRateControlLayerInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>useMinQp</name></member>
+            <member><type>VkVideoEncodeH264QpKHR</type>                          <name>minQp</name></member>
+            <member><type>VkBool32</type>                                        <name>useMaxQp</name></member>
+            <member><type>VkVideoEncodeH264QpKHR</type>                          <name>maxQp</name></member>
+            <member><type>VkBool32</type>                                        <name>useMaxFrameSize</name></member>
+            <member><type>VkVideoEncodeH264FrameSizeKHR</type>                   <name>maxFrameSize</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH265CapabilitiesKHR" returnedonly="true" structextends="VkVideoCapabilitiesKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                 <name>pNext</name></member>
-            <member noautovalidity="true"><type>VkVideoEncodeH265CapabilityFlagsEXT</type>   <name>flags</name></member>
-            <member><type>VkVideoEncodeH265CtbSizeFlagsEXT</type>      <name>ctbSizes</name></member>
-            <member><type>VkVideoEncodeH265TransformBlockSizeFlagsEXT</type>      <name>transformBlockSizes</name></member>
+            <member noautovalidity="true"><type>VkVideoEncodeH265CapabilityFlagsKHR</type> <name>flags</name></member>
+            <member><type>StdVideoH265LevelIdc</type>                  <name>maxLevelIdc</name></member>
+            <member><type>uint32_t</type>                              <name>maxSliceSegmentCount</name></member>
+            <member><type>VkExtent2D</type>                            <name>maxTiles</name></member>
+            <member><type>VkVideoEncodeH265CtbSizeFlagsKHR</type>      <name>ctbSizes</name></member>
+            <member><type>VkVideoEncodeH265TransformBlockSizeFlagsKHR</type>      <name>transformBlockSizes</name></member>
             <member><type>uint32_t</type>                              <name>maxPPictureL0ReferenceCount</name></member>
             <member><type>uint32_t</type>                              <name>maxBPictureL0ReferenceCount</name></member>
             <member><type>uint32_t</type>                              <name>maxL1ReferenceCount</name></member>
-            <member><type>uint32_t</type>                              <name>maxSubLayersCount</name></member>
-            <member><type>uint32_t</type>                              <name>minLog2MinLumaCodingBlockSizeMinus3</name></member>
-            <member><type>uint32_t</type>                              <name>maxLog2MinLumaCodingBlockSizeMinus3</name></member>
-            <member><type>uint32_t</type>                              <name>minLog2MinLumaTransformBlockSizeMinus2</name></member>
-            <member><type>uint32_t</type>                              <name>maxLog2MinLumaTransformBlockSizeMinus2</name></member>
-            <member><type>uint32_t</type>                              <name>minMaxTransformHierarchyDepthInter</name></member>
-            <member><type>uint32_t</type>                              <name>maxMaxTransformHierarchyDepthInter</name></member>
-            <member><type>uint32_t</type>                              <name>minMaxTransformHierarchyDepthIntra</name></member>
-            <member><type>uint32_t</type>                              <name>maxMaxTransformHierarchyDepthIntra</name></member>
-            <member><type>uint32_t</type>                              <name>maxDiffCuQpDeltaDepth</name></member>
-            <member><type>uint32_t</type>                              <name>minMaxNumMergeCand</name></member>
-            <member><type>uint32_t</type>                              <name>maxMaxNumMergeCand</name></member>
+            <member><type>uint32_t</type>                              <name>maxSubLayerCount</name></member>
+            <member><type>VkBool32</type>                              <name>expectDyadicTemporalSubLayerPattern</name></member>
+            <member><type>int32_t</type>                               <name>minQp</name></member>
+            <member><type>int32_t</type>                               <name>maxQp</name></member>
+            <member><type>VkBool32</type>                              <name>prefersGopRemainingFrames</name></member>
+            <member><type>VkBool32</type>                              <name>requiresGopRemainingFrames</name></member>
+            <member noautovalidity="true"><type>VkVideoEncodeH265StdFlagsKHR</type> <name>stdSyntaxFlags</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH265QualityLevelPropertiesKHR" returnedonly="true" structextends="VkVideoEncodeQualityLevelPropertiesKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUALITY_LEVEL_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkVideoEncodeH265RateControlFlagsKHR</type>   <name>preferredRateControlFlags</name></member>
+            <member><type>uint32_t</type>                               <name>preferredGopFrameCount</name></member>
+            <member><type>uint32_t</type>                               <name>preferredIdrPeriod</name></member>
+            <member><type>uint32_t</type>                               <name>preferredConsecutiveBFrameCount</name></member>
+            <member><type>uint32_t</type>                               <name>preferredSubLayerCount</name></member>
+            <member><type>VkVideoEncodeH265QpKHR</type>                 <name>preferredConstantQp</name></member>
+            <member><type>uint32_t</type>                               <name>preferredMaxL0ReferenceCount</name></member>
+            <member><type>uint32_t</type>                               <name>preferredMaxL1ReferenceCount</name></member>
         </type>
         <type category="include" name="vk_video/vulkan_video_codec_h265std_encode.h">#include "vk_video/vulkan_video_codec_h265std_encode.h"</type>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265PictureInfoFlags"/>
@@ -6863,78 +7210,104 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265SliceSegmentHeaderFlags"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceInfoFlags"/>
         <type requires="vk_video/vulkan_video_codec_h265std_encode.h" name="StdVideoEncodeH265ReferenceModificationFlags"/>
-        <type category="struct" name="VkVideoEncodeH265SessionParametersAddInfoEXT" structextends="VkVideoSessionParametersUpdateInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH265SessionCreateInfoKHR" structextends="VkVideoSessionCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                               <name>useMaxLevelIdc</name></member>
+            <member><type>StdVideoH265LevelIdc</type>                   <name>maxLevelIdc</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH265SessionParametersAddInfoKHR" structextends="VkVideoSessionParametersUpdateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                               <name>pNext</name></member>
-            <member><type>uint32_t</type>                                                                  <name>stdVPSCount</name></member>
+            <member optional="true"><type>uint32_t</type>                                                  <name>stdVPSCount</name></member>
             <member len="stdVPSCount" optional="true">const <type>StdVideoH265VideoParameterSet</type>*    <name>pStdVPSs</name></member>
-            <member><type>uint32_t</type>                                                                  <name>stdSPSCount</name></member>
+            <member optional="true"><type>uint32_t</type>                                                  <name>stdSPSCount</name></member>
             <member len="stdSPSCount" optional="true">const <type>StdVideoH265SequenceParameterSet</type>* <name>pStdSPSs</name></member>
-            <member><type>uint32_t</type>                                                                  <name>stdPPSCount</name></member>
+            <member optional="true"><type>uint32_t</type>                                                  <name>stdPPSCount</name></member>
             <member len="stdPPSCount" optional="true">const <type>StdVideoH265PictureParameterSet</type>*  <name>pStdPPSs</name><comment>List of Picture Parameters associated with the spsStd, above</comment></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265SessionParametersCreateInfoEXT" structextends="VkVideoSessionParametersCreateInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH265SessionParametersCreateInfoKHR" structextends="VkVideoSessionParametersCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                         <name>pNext</name></member>
             <member><type>uint32_t</type>                                                            <name>maxStdVPSCount</name></member>
             <member><type>uint32_t</type>                                                            <name>maxStdSPSCount</name></member>
             <member><type>uint32_t</type>                                                            <name>maxStdPPSCount</name></member>
-            <member optional="true">const <type>VkVideoEncodeH265SessionParametersAddInfoEXT</type>* <name>pParametersAddInfo</name></member>
+            <member optional="true">const <type>VkVideoEncodeH265SessionParametersAddInfoKHR</type>* <name>pParametersAddInfo</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265VclFrameInfoEXT" structextends="VkVideoEncodeInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_VCL_FRAME_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH265SessionParametersGetInfoKHR" structextends="VkVideoEncodeSessionParametersGetInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_GET_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                               <name>writeStdVPS</name></member>
+            <member><type>VkBool32</type>                               <name>writeStdSPS</name></member>
+            <member><type>VkBool32</type>                               <name>writeStdPPS</name></member>
+            <member><type>uint32_t</type>                               <name>stdVPSId</name></member>
+            <member><type>uint32_t</type>                               <name>stdSPSId</name></member>
+            <member><type>uint32_t</type>                               <name>stdPPSId</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH265SessionParametersFeedbackInfoKHR" structextends="VkVideoEncodeSessionParametersFeedbackInfoKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_FEEDBACK_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkBool32</type>                               <name>hasStdVPSOverrides</name></member>
+            <member><type>VkBool32</type>                               <name>hasStdSPSOverrides</name></member>
+            <member><type>VkBool32</type>                               <name>hasStdPPSOverrides</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH265PictureInfoKHR" structextends="VkVideoEncodeInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                       <name>pNext</name></member>
-            <member optional="true">const <type>StdVideoEncodeH265ReferenceListsInfo</type>*       <name>pStdReferenceFinalLists</name></member>
             <member><type>uint32_t</type>                                                          <name>naluSliceSegmentEntryCount</name></member>
-            <member len="naluSliceSegmentEntryCount">const <type>VkVideoEncodeH265NaluSliceSegmentInfoEXT</type>* <name>pNaluSliceSegmentEntries</name></member>
+            <member len="naluSliceSegmentEntryCount">const <type>VkVideoEncodeH265NaluSliceSegmentInfoKHR</type>* <name>pNaluSliceSegmentEntries</name></member>
             <member>const <type>StdVideoEncodeH265PictureInfo</type>*                              <name>pStdPictureInfo</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265NaluSliceSegmentInfoEXT">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH265NaluSliceSegmentInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                <name>pNext</name></member>
-            <member><type>uint32_t</type>                                                   <name>ctbCount</name></member>
-            <member optional="true">const <type>StdVideoEncodeH265ReferenceListsInfo</type>* <name>pStdReferenceFinalLists</name></member>
+            <member><type>int32_t</type>                                                    <name>constantQp</name></member>
             <member>const <type>StdVideoEncodeH265SliceSegmentHeader</type>*                <name>pStdSliceSegmentHeader</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265RateControlInfoEXT" structextends="VkVideoCodingControlInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH265RateControlInfoKHR" structextends="VkVideoCodingControlInfoKHR,VkVideoBeginCodingInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
+            <member optional="true"><type>VkVideoEncodeH265RateControlFlagsKHR</type> <name>flags</name></member>
             <member><type>uint32_t</type>                                        <name>gopFrameCount</name></member>
             <member><type>uint32_t</type>                                        <name>idrPeriod</name></member>
             <member><type>uint32_t</type>                                        <name>consecutiveBFrameCount</name></member>
-            <member><type>VkVideoEncodeH265RateControlStructureEXT</type>        <name>rateControlStructure</name></member>
             <member><type>uint32_t</type>                                        <name>subLayerCount</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265QpEXT">
+        <type category="struct" name="VkVideoEncodeH265QpKHR">
             <member noautovalidity="true"><type>int32_t</type> <name>qpI</name></member>
             <member noautovalidity="true"><type>int32_t</type> <name>qpP</name></member>
             <member noautovalidity="true"><type>int32_t</type> <name>qpB</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265FrameSizeEXT">
+        <type category="struct" name="VkVideoEncodeH265FrameSizeKHR">
             <member noautovalidity="true"><type>uint32_t</type> <name>frameISize</name></member>
             <member noautovalidity="true"><type>uint32_t</type> <name>framePSize</name></member>
             <member noautovalidity="true"><type>uint32_t</type> <name>frameBSize</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265RateControlLayerInfoEXT" structextends="VkVideoCodingControlInfoKHR,VkVideoEncodeRateControlLayerInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
-            <member><type>uint32_t</type>                                        <name>temporalId</name></member>
-            <member><type>VkBool32</type>                                        <name>useInitialRcQp</name></member>
-            <member><type>VkVideoEncodeH265QpEXT</type>                          <name>initialRcQp</name></member>
-            <member><type>VkBool32</type>                                        <name>useMinQp</name></member>
-            <member><type>VkVideoEncodeH265QpEXT</type>                          <name>minQp</name></member>
-            <member><type>VkBool32</type>                                        <name>useMaxQp</name></member>
-            <member><type>VkVideoEncodeH265QpEXT</type>                          <name>maxQp</name></member>
-            <member><type>VkBool32</type>                                        <name>useMaxFrameSize</name></member>
-            <member><type>VkVideoEncodeH265FrameSizeEXT</type>                   <name>maxFrameSize</name></member>
+        <type category="struct" name="VkVideoEncodeH265GopRemainingFrameInfoKHR" structextends="VkVideoBeginCodingInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_GOP_REMAINING_FRAME_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type>                       <name>useGopRemainingFrames</name></member>
+            <member><type>uint32_t</type>                       <name>gopRemainingI</name></member>
+            <member><type>uint32_t</type>                       <name>gopRemainingP</name></member>
+            <member><type>uint32_t</type>                       <name>gopRemainingB</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265ProfileInfoEXT" structextends="VkVideoProfileInfoKHR,VkQueryPoolCreateInfo">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH265RateControlLayerInfoKHR" structextends="VkVideoEncodeRateControlLayerInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>useMinQp</name></member>
+            <member><type>VkVideoEncodeH265QpKHR</type>                          <name>minQp</name></member>
+            <member><type>VkBool32</type>                                        <name>useMaxQp</name></member>
+            <member><type>VkVideoEncodeH265QpKHR</type>                          <name>maxQp</name></member>
+            <member><type>VkBool32</type>                                        <name>useMaxFrameSize</name></member>
+            <member><type>VkVideoEncodeH265FrameSizeKHR</type>                   <name>maxFrameSize</name></member>
+        </type>
+        <type category="struct" name="VkVideoEncodeH265ProfileInfoKHR" structextends="VkVideoProfileInfoKHR,VkQueryPoolCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*    <name>pNext</name></member>
             <member><type>StdVideoH265ProfileIdc</type>         <name>stdProfileIdc</name></member>
         </type>
-        <type category="struct" name="VkVideoEncodeH265DpbSlotInfoEXT" structextends="VkVideoReferenceSlotInfoKHR">
-            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkVideoEncodeH265DpbSlotInfoKHR" structextends="VkVideoReferenceSlotInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*              <name>pNext</name></member>
             <member>const <type>StdVideoEncodeH265ReferenceInfo</type>*   <name>pStdReferenceInfo</name></member>
         </type>
@@ -6975,8 +7348,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type category="struct" name="VkCuModuleCreateInfoNVX">
             <member values="VK_STRUCTURE_TYPE_CU_MODULE_CREATE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
-            <member><type>size_t</type>                 <name>dataSize</name></member>
-            <member len="dataSize">const <type>void</type>*            <name>pData</name></member>
+            <member optional="true"><type>size_t</type>                 <name>dataSize</name></member>
+            <member len="dataSize">const <type>void</type>*             <name>pData</name></member>
         </type>
         <type category="struct" name="VkCuFunctionCreateInfoNVX">
             <member values="VK_STRUCTURE_TYPE_CU_FUNCTION_CREATE_INFO_NVX"><type>VkStructureType</type> <name>sType</name></member>
@@ -7061,7 +7434,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                   <name>pNext</name></member>
             <member><type>VkDeviceAddress</type>                         <name>address</name></member>
-            <member><type>VkBufferUsageFlags</type>                      <name>usage</name></member>
+            <member optional="true" noautovalidity="true"><type>VkBufferUsageFlags</type> <name>usage</name></member>
         </type>
         <type category="struct" name="VkDescriptorBufferBindingPushDescriptorBufferHandleEXT" structextends="VkDescriptorBufferBindingInfoEXT">
             <member values="VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_PUSH_DESCRIPTOR_BUFFER_HANDLE_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -7184,6 +7557,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkBool32</type>                           <name>rayTracingMotionBlur</name></member>
             <member><type>VkBool32</type>                           <name>rayTracingMotionBlurPipelineTraceRaysIndirect</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceRayTracingValidationFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
+            <member><type>VkBool32</type>                                           <name>rayTracingValidation</name></member>
+        </type>
         <type name="VkAccelerationStructureMotionInstanceTypeNV" category="enum"/>
         <type category="struct" name="VkAccelerationStructureGeometryMotionTrianglesDataNV" structextends="VkAccelerationStructureGeometryTrianglesDataKHR">
             <member values="VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MOTION_TRIANGLES_DATA_NV"><type>VkStructureType</type> <name>sType</name></member>
@@ -7274,7 +7652,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>void</type>*      <name>pNext</name></member>
             <member><type>zx_handle_t</type>                      <name>collectionToken</name></member>
         </type>
-        <type category="struct" name="VkBufferCollectionPropertiesFUCHSIA">
+        <type category="struct" name="VkBufferCollectionPropertiesFUCHSIA" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_BUFFER_COLLECTION_PROPERTIES_FUCHSIA"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*            <name>pNext</name></member>
             <member><type>uint32_t</type>                         <name>memoryTypeBits</name></member>
@@ -7327,6 +7705,36 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>                        <name>minBufferCountForCamping</name></member>
             <member><type>uint32_t</type>                        <name>minBufferCountForDedicatedSlack</name></member>
             <member><type>uint32_t</type>                        <name>minBufferCountForSharedSlack</name></member>
+        </type>
+        <type category="handle" parent="VkDevice" objtypeenum="VK_OBJECT_TYPE_CUDA_MODULE_NV"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkCudaModuleNV</name>)</type>
+        <type category="handle" parent="VkDevice" objtypeenum="VK_OBJECT_TYPE_CUDA_FUNCTION_NV"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkCudaFunctionNV</name>)</type>
+        <type category="struct" name="VkCudaModuleCreateInfoNV">
+            <member values="VK_STRUCTURE_TYPE_CUDA_MODULE_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>size_t</type>                 <name>dataSize</name></member>
+            <member len="dataSize">const <type>void</type>*            <name>pData</name></member>
+        </type>
+        <type category="struct" name="VkCudaFunctionCreateInfoNV">
+            <member values="VK_STRUCTURE_TYPE_CUDA_FUNCTION_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>VkCudaModuleNV</type>         <name>module</name></member>
+            <member len="null-terminated">const <type>char</type>*            <name>pName</name></member>
+        </type>
+        <type category="struct" name="VkCudaLaunchInfoNV">
+            <member values="VK_STRUCTURE_TYPE_CUDA_LAUNCH_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member><type>VkCudaFunctionNV</type>       <name>function</name></member>
+            <member><type>uint32_t</type>               <name>gridDimX</name></member>
+            <member><type>uint32_t</type>               <name>gridDimY</name></member>
+            <member><type>uint32_t</type>               <name>gridDimZ</name></member>
+            <member><type>uint32_t</type>               <name>blockDimX</name></member>
+            <member><type>uint32_t</type>               <name>blockDimY</name></member>
+            <member><type>uint32_t</type>               <name>blockDimZ</name></member>
+            <member><type>uint32_t</type>               <name>sharedMemBytes</name></member>
+            <member optional="true"><type>size_t</type>                                     <name>paramCount</name></member>
+            <member noautovalidity="true" len="paramCount">const <type>void</type>* const * <name>pParams</name></member>
+            <member optional="true"><type>size_t</type>                                     <name>extraCount</name></member>
+            <member noautovalidity="true" len="extraCount">const <type>void</type>* const * <name>pExtras</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -7482,7 +7890,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkGraphicsPipelineLibraryCreateInfoEXT" structextends="VkGraphicsPipelineCreateInfo">
             <member values="VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*        <name>pNext</name></member>
+            <member optional="true">const <type>void</type>*       <name>pNext</name></member>
             <member><type>VkGraphicsPipelineLibraryFlagsEXT</type> <name>flags</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
@@ -7501,6 +7909,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>void</type>*                                                                    <name>pNext</name></member>
             <member><type>size_t</type>                                                                                   <name>descriptorOffset</name></member>
             <member><type>uint32_t</type>                                                                                 <name>descriptorSize</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceNestedCommandBufferFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>nestedCommandBuffer</name></member>
+            <member><type>VkBool32</type>                                        <name>nestedCommandBufferRendering</name></member>
+            <member><type>VkBool32</type>                                        <name>nestedCommandBufferSimultaneousUse</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceNestedCommandBufferPropertiesEXT" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                           <name>pNext</name></member>
+            <member limittype="max"><type>uint32_t</type>                        <name>maxCommandBufferNestingLevel</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -7522,7 +7942,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*          <name>pNext</name></member>
             <member noautovalidity="true"><type>uint32_t</type> <name>identifierSize</name></member>
-            <member><type>uint8_t</type>                        <name>identifier</name>[<enum>VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT</enum>]</member>
+            <member len="identifierSize"><type>uint8_t</type>   <name>identifier</name>[<enum>VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT</enum>]</member>
         </type>
         <type category="struct" name="VkImageCompressionControlEXT" structextends="VkImageCreateInfo,VkSwapchainCreateInfoKHR,VkPhysicalDeviceImageFormatInfo2">
             <member values="VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_CONTROL_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -7536,7 +7956,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true" noautovalidity="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type>                             <name>imageCompressionControl</name></member>
         </type>
-        <type category="struct" name="VkImageCompressionPropertiesEXT" structextends="VkImageFormatProperties2,VkSurfaceFormat2KHR,VkSubresourceLayout2EXT" returnedonly="true">
+        <type category="struct" name="VkImageCompressionPropertiesEXT" structextends="VkImageFormatProperties2,VkSurfaceFormat2KHR,VkSubresourceLayout2KHR" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*                <name>pNext</name></member>
             <member><type>VkImageCompressionFlagsEXT</type>           <name>imageCompressionFlags</name></member>
@@ -7547,16 +7967,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true" noautovalidity="true"><type>void</type>* <name>pNext</name></member>
             <member><type>VkBool32</type>                             <name>imageCompressionControlSwapchain</name></member>
         </type>
-        <type category="struct" name="VkImageSubresource2EXT">
-            <member values="VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkImageSubresource2KHR">
+            <member values="VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*  <name>pNext</name></member>
             <member><type>VkImageSubresource</type>     <name>imageSubresource</name></member>
         </type>
-        <type category="struct" name="VkSubresourceLayout2EXT"  returnedonly="true">
-            <member values="VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_EXT"><type>VkStructureType</type> <name>sType</name></member>
+        <type category="struct" name="VkImageSubresource2EXT" alias="VkImageSubresource2KHR"/>
+        <type category="struct" name="VkSubresourceLayout2KHR"  returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*  <name>pNext</name></member>
             <member><type>VkSubresourceLayout</type>    <name>subresourceLayout</name></member>
         </type>
+        <type category="struct" name="VkSubresourceLayout2EXT" alias="VkSubresourceLayout2KHR"/>
         <type category="struct" name="VkRenderPassCreationControlEXT" structextends="VkRenderPassCreateInfo2,VkSubpassDescription2">
             <member values="VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_CONTROL_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*                                                 <name>pNext</name></member>
@@ -7572,7 +7994,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkRenderPassSubpassFeedbackInfoEXT" returnedonly="true">
             <member><type>VkSubpassMergeStatusEXT</type>                                                          <name>subpassMergeStatus</name></member>
-            <member><type>char</type>                                                                             <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
+            <member len="null-terminated"><type>char</type>                                                       <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]</member>
             <member><type>uint32_t</type>                                                                         <name>postMergeIndex</name></member>
         </type>
         <type category="struct" name="VkRenderPassSubpassFeedbackCreateInfoEXT" structextends="VkSubpassDescription2">
@@ -7713,7 +8135,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
 
             <member optional="true"><type>VkMicromapEXT</type>                          <name>micromap</name></member>
         </type>
-        <type category="struct" name="VkPipelinePropertiesIdentifierEXT">
+        <type category="struct" name="VkPipelinePropertiesIdentifierEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PIPELINE_PROPERTIES_IDENTIFIER_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*              <name>pNext</name></member>
             <member><type>uint8_t</type>                            <name>pipelineIdentifier</name>[<enum>VK_UUID_SIZE</enum>]</member>
@@ -7727,6 +8149,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD"><type>VkStructureType</type> <name>sType</name></member>
             <member noautovalidity="true" optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>shaderEarlyAndLateFragmentTests</name></member>
+        </type>
+        <type category="struct" name="VkExternalMemoryAcquireUnmodifiedEXT" structextends="VkBufferMemoryBarrier,VkBufferMemoryBarrier2,VkImageMemoryBarrier,VkImageMemoryBarrier2">
+            <member values="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type>                       <name>acquireUnmodifiedMemory</name></member>
         </type>
         <type category="struct" name="VkExportMetalObjectCreateInfoEXT" structextends="VkInstanceCreateInfo,VkMemoryAllocateInfo,VkImageCreateInfo,VkImageViewCreateInfo,VkBufferViewCreateInfo,VkSemaphoreCreateInfo,VkEventCreateInfo" allowduplicate="true">
             <member values="VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -7816,7 +8243,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkPipelineRobustnessImageBehaviorEXT</type>    <name>images</name></member>
         </type>
         <type category="struct" name="VkPhysicalDevicePipelineRobustnessPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
-                <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>* <name>pNext</name></member>
             <member limittype="exact"><type>VkPipelineRobustnessBufferBehaviorEXT</type>   <name>defaultRobustnessStorageBuffers</name></member>
             <member limittype="exact"><type>VkPipelineRobustnessBufferBehaviorEXT</type>   <name>defaultRobustnessUniformBuffers</name></member>
@@ -7960,9 +8387,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>VkDeviceSize</type>                        <name>addressPrecision</name></member>
         </type>
         <type category="struct" name="VkDeviceFaultVendorInfoEXT">
-            <member noautovalidity="true"><type>char</type>          <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]<comment>Free-form description of the fault</comment></member>
-            <member><type>uint64_t</type>                            <name>vendorFaultCode</name></member>
-            <member><type>uint64_t</type>                            <name>vendorFaultData</name></member>
+            <member noautovalidity="true" len="null-terminated"><type>char</type> <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]<comment>Free-form description of the fault</comment></member>
+            <member><type>uint64_t</type>                                         <name>vendorFaultCode</name></member>
+            <member><type>uint64_t</type>                                         <name>vendorFaultData</name></member>
         </type>
         <type category="struct" name="VkDeviceFaultCountsEXT">
             <member values="VK_STRUCTURE_TYPE_DEVICE_FAULT_COUNTS_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -7971,13 +8398,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>uint32_t</type>                            <name>vendorInfoCount</name></member>
             <member optional="true"><type>VkDeviceSize</type>                        <name>vendorBinarySize</name><comment>Specified in bytes</comment></member>
         </type>
-        <type category="struct" name="VkDeviceFaultInfoEXT">
+        <type category="struct" name="VkDeviceFaultInfoEXT" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_DEVICE_FAULT_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true"><type>void</type>*               <name>pNext</name></member>
-            <member noautovalidity="true"><type>char</type>          <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]<comment>Free-form description of the fault</comment></member>
-            <member optional="true"><type>VkDeviceFaultAddressInfoEXT</type>* <name>pAddressInfos</name></member>
-            <member optional="true"><type>VkDeviceFaultVendorInfoEXT</type>*  <name>pVendorInfos</name></member>
-            <member optional="true"><type>void</type>*                        <name>pVendorBinaryData</name></member>
+            <member optional="true"><type>void</type>*                            <name>pNext</name></member>
+            <member noautovalidity="true" len="null-terminated"><type>char</type> <name>description</name>[<enum>VK_MAX_DESCRIPTION_SIZE</enum>]<comment>Free-form description of the fault</comment></member>
+            <member optional="true"><type>VkDeviceFaultAddressInfoEXT</type>*     <name>pAddressInfos</name></member>
+            <member optional="true"><type>VkDeviceFaultVendorInfoEXT</type>*      <name>pVendorInfos</name></member>
+            <member optional="true"><type>void</type>*                            <name>pVendorBinaryData</name></member>
         </type>
         <type category="struct" name="VkDeviceFaultVendorBinaryHeaderVersionOneEXT">
             <comment>The fields in this structure are non-normative since structure packing is implementation-defined in C. The specification defines the normative layout.</comment>
@@ -7998,6 +8425,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true" noautovalidity="true"><type>void</type>*                                                            <name>pNext</name></member>
             <member><type>VkBool32</type>                                                                                               <name>pipelineLibraryGroupHandles</name></member>
         </type>
+        <type category="struct" name="VkDepthBiasInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_DEPTH_BIAS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*        <name>pNext</name></member>
+            <member><type>float</type>                              <name>depthBiasConstantFactor</name></member>
+            <member><type>float</type>                              <name>depthBiasClamp</name></member>
+            <member><type>float</type>                              <name>depthBiasSlopeFactor</name></member>
+        </type>
+        <type category="struct" name="VkDepthBiasRepresentationInfoEXT" structextends="VkDepthBiasInfoEXT,VkPipelineRasterizationStateCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*        <name>pNext</name></member>
+            <member><type>VkDepthBiasRepresentationEXT</type>       <name>depthBiasRepresentation</name></member>
+            <member><type>VkBool32</type>                           <name>depthBiasExact</name></member>
+        </type>
         <type category="struct" name="VkDecompressMemoryRegionNV">
             <member><type>VkDeviceAddress</type>   <name>srcAddress</name></member>
             <member><type>VkDeviceAddress</type>   <name>dstAddress</name></member>
@@ -8016,6 +8456,24 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*    <name>pNext</name></member>
             <member><type>VkBool32</type>                 <name>shaderCoreBuiltins</name></member>
+        </type>
+        <type category="struct" name="VkFrameBoundaryEXT" structextends="VkSubmitInfo,VkSubmitInfo2,VkPresentInfoKHR,VkBindSparseInfo">
+            <member values="VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true"><type>VkFrameBoundaryFlagsEXT</type>            <name>flags</name></member>
+            <member><type>uint64_t</type>                                           <name>frameID</name></member>
+            <member optional="true"><type>uint32_t</type>                           <name>imageCount</name></member>
+            <member optional="true" len="imageCount">const <type>VkImage</type>*    <name>pImages</name></member>
+            <member optional="true"><type>uint32_t</type>                           <name>bufferCount</name></member>
+            <member optional="true" len="bufferCount">const <type>VkBuffer</type>*  <name>pBuffers</name></member>
+            <member optional="true"><type>uint64_t</type>                           <name>tagName</name></member>
+            <member optional="true"><type>size_t</type>                             <name>tagSize</name></member>
+            <member optional="true" len="tagSize">const <type>void</type>*          <name>pTag</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceFrameBoundaryFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type>                 <name>frameBoundary</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
@@ -8079,6 +8537,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member><type>uint32_t</type>                                    <name>imageIndexCount</name><comment>Number of indices to release</comment></member>
             <member len="imageIndexCount">const <type>uint32_t</type>*       <name>pImageIndices</name><comment>Indices of which presentable images to release</comment></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceDepthBiasControlFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
+            <member><type>VkBool32</type>                           <name>depthBiasControl</name></member>
+            <member><type>VkBool32</type>                           <name>leastRepresentableValueForceUnormRepresentation</name></member>
+            <member><type>VkBool32</type>                           <name>floatRepresentation</name></member>
+            <member><type>VkBool32</type>                           <name>depthBiasExact</name></member>
+        </type>
         <type category="struct" name="VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true" noautovalidity="true"><type>void</type>*                                                      <name>pNext</name></member>
@@ -8089,6 +8555,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true" noautovalidity="true"><type>void</type>* <name>pNext</name></member>
             <member limittype="noauto"><type>VkRayTracingInvocationReorderModeNV</type>                                    <name>rayTracingInvocationReorderReorderingHint</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*  <name>pNext</name></member>
+            <member><type>VkBool32</type>                                     <name>extendedSparseAddressSpace</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                        <name>pNext</name></member>
+            <member limittype="max"><type>VkDeviceSize</type>                 <name>extendedSparseAddressSpaceSize</name><comment>Total address space available for extended sparse allocations (bytes)</comment></member>
+            <member limittype="bitmask"><type>VkImageUsageFlags</type>        <name>extendedSparseImageUsageFlags</name><comment>Bitfield of which image usages are supported for extended sparse allocations</comment></member>
+            <member limittype="bitmask"><type>VkBufferUsageFlags</type>       <name>extendedSparseBufferUsageFlags</name><comment>Bitfield of which buffer usages are supported for extended sparse allocations</comment></member>
+        </type>
         <type category="struct" name="VkDirectDriverLoadingInfoLUNARG">
             <member values="VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_INFO_LUNARG"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true" noautovalidity="true"><type>void</type>*                                  <name>pNext</name></member>
@@ -8097,7 +8575,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkDirectDriverLoadingListLUNARG" structextends="VkInstanceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_LIST_LUNARG"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true" noautovalidity="true"><type>void</type>*                 <name>pNext</name></member>
+            <member optional="true" noautovalidity="true">const <type>void</type>*           <name>pNext</name></member>
             <member><type>VkDirectDriverLoadingModeLUNARG</type>                             <name>mode</name></member>
             <member><type>uint32_t</type>                                                    <name>driverCount</name></member>
             <member len="driverCount">const <type>VkDirectDriverLoadingInfoLUNARG</type>*    <name>pDrivers</name></member>
@@ -8111,6 +8589,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                     <name>rayTracingPositionFetch</name></member>
+        </type>
+        <type category="struct" name="VkDeviceImageSubresourceInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_IMAGE_SUBRESOURCE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                              <name>pNext</name></member>
+            <member>const <type>VkImageCreateInfo</type>*                                                 <name>pCreateInfo</name></member>
+            <member>const <type>VkImageSubresource2KHR</type>*                                            <name>pSubresource</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderCorePropertiesARM" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_ARM"><type>VkStructureType</type> <name>sType</name></member>
@@ -8177,18 +8661,457 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true">const <type>VkSpecializationInfo</type>*                             <name>pSpecializationInfo</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderTileImageFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
-          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-          <member optional="true"><type>void</type>*        <name>pNext</name></member>
-          <member><type>VkBool32</type>                     <name>shaderTileImageColorReadAccess</name></member>
-          <member><type>VkBool32</type>                     <name>shaderTileImageDepthReadAccess</name></member>
-          <member><type>VkBool32</type>                     <name>shaderTileImageStencilReadAccess</name></member>
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
+            <member><type>VkBool32</type>                           <name>shaderTileImageColorReadAccess</name></member>
+            <member><type>VkBool32</type>                           <name>shaderTileImageDepthReadAccess</name></member>
+            <member><type>VkBool32</type>                           <name>shaderTileImageStencilReadAccess</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceShaderTileImagePropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
-          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
+            <member limittype="noauto"><type>VkBool32</type>        <name>shaderTileImageCoherentReadAccelerated</name></member>
+            <member limittype="noauto"><type>VkBool32</type>        <name>shaderTileImageReadSampleFromPixelRateInvocation</name></member>
+            <member limittype="noauto"><type>VkBool32</type>        <name>shaderTileImageReadFromHelperInvocation</name></member>
+        </type>
+        <type category="struct" name="VkImportScreenBufferInfoQNX" structextends="VkMemoryAllocateInfo">
+            <member values="VK_STRUCTURE_TYPE_IMPORT_SCREEN_BUFFER_INFO_QNX"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
+            <member noautovalidity="true">struct <type>_screen_buffer</type>*       <name>buffer</name></member>
+        </type>
+        <type category="struct" name="VkScreenBufferPropertiesQNX" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_SCREEN_BUFFER_PROPERTIES_QNX"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
+            <member><type>VkDeviceSize</type>                       <name>allocationSize</name></member>
+            <member><type>uint32_t</type>                           <name>memoryTypeBits</name></member>
+        </type>
+        <type category="struct" name="VkScreenBufferFormatPropertiesQNX" structextends="VkScreenBufferPropertiesQNX" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_SCREEN_BUFFER_FORMAT_PROPERTIES_QNX"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
+            <member><type>VkFormat</type>                           <name>format</name></member>
+            <member><type>uint64_t</type>                           <name>externalFormat</name></member>
+            <member><type>uint64_t</type>                           <name>screenUsage</name></member>
+            <member><type>VkFormatFeatureFlags</type>               <name>formatFeatures</name></member>
+            <member><type>VkComponentMapping</type>                 <name>samplerYcbcrConversionComponents</name></member>
+            <member><type>VkSamplerYcbcrModelConversion</type>      <name>suggestedYcbcrModel</name></member>
+            <member><type>VkSamplerYcbcrRange</type>                <name>suggestedYcbcrRange</name></member>
+            <member><type>VkChromaLocation</type>                   <name>suggestedXChromaOffset</name></member>
+            <member><type>VkChromaLocation</type>                   <name>suggestedYChromaOffset</name></member>
+        </type>
+        <type category="struct" name="VkExternalFormatQNX" structextends="VkImageCreateInfo,VkSamplerYcbcrConversionCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                              <name>pNext</name></member>
+            <member><type>uint64_t</type>                           <name>externalFormat</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCREEN_BUFFER_FEATURES_QNX"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                       <name>pNext</name></member>
+            <member><type>VkBool32</type>                                    <name>screenBufferImport</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCooperativeMatrixFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*               <name>pNext</name></member>
+            <member><type>VkBool32</type>                            <name>cooperativeMatrix</name></member>
+            <member><type>VkBool32</type>                            <name>cooperativeMatrixRobustBufferAccess</name></member>
+        </type>
+        <type category="struct" name="VkCooperativeMatrixPropertiesKHR" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
+            <member><type>uint32_t</type>                            <name>MSize</name></member>
+            <member><type>uint32_t</type>                            <name>NSize</name></member>
+            <member><type>uint32_t</type>                            <name>KSize</name></member>
+            <member><type>VkComponentTypeKHR</type>                  <name>AType</name></member>
+            <member><type>VkComponentTypeKHR</type>                  <name>BType</name></member>
+            <member><type>VkComponentTypeKHR</type>                  <name>CType</name></member>
+            <member><type>VkComponentTypeKHR</type>                  <name>ResultType</name></member>
+            <member><type>VkBool32</type>                            <name>saturatingAccumulation</name></member>
+            <member><type>VkScopeKHR</type>                          <name>scope</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCooperativeMatrixPropertiesKHR" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                               <name>pNext</name></member>
+            <member limittype="bitmask"><type>VkShaderStageFlags</type>              <name>cooperativeMatrixSupportedStages</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderEnqueuePropertiesAMDX" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"  optional="true"><type>void</type>*               <name>pNext</name></member>
+            <member limittype="max"><type>uint32_t</type>                                   <name>maxExecutionGraphDepth</name></member>
+            <member limittype="max"><type>uint32_t</type>                                   <name>maxExecutionGraphShaderOutputNodes</name></member>
+            <member limittype="max"><type>uint32_t</type>                                   <name>maxExecutionGraphShaderPayloadSize</name></member>
+            <member limittype="max"><type>uint32_t</type>                                   <name>maxExecutionGraphShaderPayloadCount</name></member>
+            <member limittype="noauto"><type>uint32_t</type>                                <name>executionGraphDispatchAddressAlignment</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderEnqueueFeaturesAMDX" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true" optional="true"><type>void</type>*                <name>pNext</name></member>
+            <member><type>VkBool32</type>                                                   <name>shaderEnqueue</name></member>
+        </type>
+        <type category="struct" name="VkExecutionGraphPipelineCreateInfoAMDX">
+            <member values="VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                <name>pNext</name></member>
+            <member noautovalidity="true" optional="true"><type>VkPipelineCreateFlags</type>                      <name>flags</name></member>
+            <member optional="true"><type>uint32_t</type>                                   <name>stageCount</name></member>
+            <member optional="true" len="stageCount">const <type>VkPipelineShaderStageCreateInfo</type>*    <name>pStages</name></member>
+            <member optional="true">const <type>VkPipelineLibraryCreateInfoKHR</type>*      <name>pLibraryInfo</name></member>
+            <member><type>VkPipelineLayout</type>                                           <name>layout</name></member>
+            <member noautovalidity="true" optional="true"><type>VkPipeline</type>           <name>basePipelineHandle</name></member>
+            <member><type>int32_t</type>                                                    <name>basePipelineIndex</name></member>
+        </type>
+        <type category="struct" name="VkPipelineShaderStageNodeCreateInfoAMDX" structextends="VkPipelineShaderStageCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX">  <type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                <name>pNext</name></member>
+            <member optional="true" len="null-terminated">const <type>char</type>*          <name>pName</name></member>
+            <member><type>uint32_t</type>                                                   <name>index</name></member>
+        </type>
+        <type category="struct" name="VkExecutionGraphPipelineScratchSizeAMDX">
+            <member values="VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true" optional="true"><type>void</type>*                <name>pNext</name></member>
+            <member><type>VkDeviceSize</type>                                               <name>size</name></member>
+        </type>
+        <type category="struct" name="VkDispatchGraphInfoAMDX">
+            <member><type>uint32_t</type>                                                   <name>nodeIndex</name></member>
+            <member optional="true"><type>uint32_t</type>                                   <name>payloadCount</name></member>
+            <member noautovalidity="true"><type>VkDeviceOrHostAddressConstAMDX</type>           <name>payloads</name></member>
+            <member><type>uint64_t</type>                                                   <name>payloadStride</name></member>
+        </type>
+        <type category="struct" name="VkDispatchGraphCountInfoAMDX">
+            <member optional="true"><type>uint32_t</type>                                   <name>count</name></member>
+            <member noautovalidity="true"><type>VkDeviceOrHostAddressConstAMDX</type>                  <name>infos</name></member>
+            <member><type>uint64_t</type>                                                   <name>stride</name></member>
+        </type>
+        <type category="struct" name="VkBindMemoryStatusKHR" structextends="VkBindBufferMemoryInfo,VkBindImageMemoryInfo">
+            <member values="VK_STRUCTURE_TYPE_BIND_MEMORY_STATUS_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                <name>pNext</name></member>
+            <member><type>VkResult</type>*                                                  <name>pResult</name></member>
+        </type>
+        <type category="struct" name="VkBindDescriptorSetsInfoKHR">
+          <member values="VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true">const <type>void</type>*                                              <name>pNext</name></member>
+          <member><type>VkShaderStageFlags</type>                                                       <name>stageFlags</name></member>
+          <member optional="true"><type>VkPipelineLayout</type>                                         <name>layout</name></member>
+          <member optional="true"><type>uint32_t</type>                                                 <name>firstSet</name></member>
+          <member><type>uint32_t</type>                                                                 <name>descriptorSetCount</name></member>
+          <member len="descriptorSetCount">const <type>VkDescriptorSet</type>*                          <name>pDescriptorSets</name></member>
+          <member optional="true"><type>uint32_t</type>                                                 <name>dynamicOffsetCount</name></member>
+          <member optional="true,true" len="dynamicOffsetCount">const <type>uint32_t</type>*            <name>pDynamicOffsets</name></member>
+        </type>
+        <type category="struct" name="VkPushConstantsInfoKHR">
+          <member values="VK_STRUCTURE_TYPE_PUSH_CONSTANTS_INFO_KHR"><type>VkStructureType</type>          <name>sType</name></member>
+          <member optional="true">const <type>void</type>*                                                 <name>pNext</name></member>
+          <member optional="true"><type>VkPipelineLayout</type>                                            <name>layout</name></member>
+          <member><type>VkShaderStageFlags</type>                                                          <name>stageFlags</name></member>
+          <member optional="true"><type>uint32_t</type>                                                    <name>offset</name></member>
+          <member><type>uint32_t</type>                                                                    <name>size</name></member>
+          <member len="size">const <type>void</type>*                                                      <name>pValues</name></member>
+        </type>
+        <type category="struct" name="VkPushDescriptorSetInfoKHR">
+          <member values="VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true">const <type>void</type>*                                             <name>pNext</name></member>
+          <member><type>VkShaderStageFlags</type>                                                      <name>stageFlags</name></member>
+          <member optional="true"><type>VkPipelineLayout</type>                                        <name>layout</name></member>
+          <member optional="true"><type>uint32_t</type>                                                <name>set</name></member>
+          <member><type>uint32_t</type>                                                                <name>descriptorWriteCount</name></member>
+          <member len="descriptorWriteCount">const <type>VkWriteDescriptorSet</type>*                  <name>pDescriptorWrites</name></member>
+        </type>
+        <type category="struct" name="VkPushDescriptorSetWithTemplateInfoKHR">
+          <member values="VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_WITH_TEMPLATE_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true">const <type>void</type>*                                                           <name>pNext</name></member>
+          <member><type>VkDescriptorUpdateTemplate</type>                                                            <name>descriptorUpdateTemplate</name></member>
+          <member optional="true"><type>VkPipelineLayout</type>                                                      <name>layout</name></member>
+          <member optional="true"><type>uint32_t</type>                                                              <name>set</name></member>
+          <member>const <type>void</type>*                                                                           <name>pData</name></member>
+        </type>
+        <type category="struct" name="VkSetDescriptorBufferOffsetsInfoEXT">
+          <member values="VK_STRUCTURE_TYPE_SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true">const <type>void</type>*                                                       <name>pNext</name></member>
+          <member><type>VkShaderStageFlags</type>                                                                <name>stageFlags</name></member>
+          <member optional="true"><type>VkPipelineLayout</type>                                                  <name>layout</name></member>
+          <member optional="true"><type>uint32_t</type>                                                          <name>firstSet</name></member>
+          <member><type>uint32_t</type>                                                                          <name>setCount</name></member>
+          <member len="setCount">const <type>uint32_t</type>*                                                    <name>pBufferIndices</name></member>
+          <member len="setCount">const <type>VkDeviceSize</type>*                                                <name>pOffsets</name></member>
+        </type>
+        <type category="struct" name="VkBindDescriptorBufferEmbeddedSamplersInfoEXT">
+          <member values="VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_BUFFER_EMBEDDED_SAMPLERS_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true">const <type>void</type>*                                                                  <name>pNext</name></member>
+          <member><type>VkShaderStageFlags</type>                                                                           <name>stageFlags</name></member>
+          <member optional="true"><type>VkPipelineLayout</type>                                                             <name>layout</name></member>
+          <member optional="true"><type>uint32_t</type>                                                                     <name>set</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCubicClampFeaturesQCOM" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>cubicRangeClamp</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceYcbcrDegammaFeaturesQCOM" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>VkBool32</type>                     <name>ycbcrDegamma</name></member>
+        </type>
+        <type category="struct" name="VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM" structextends="VkSamplerYcbcrConversionCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_YCBCR_DEGAMMA_CREATE_INFO_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*              <name>pNext</name></member>
+            <member><type>VkBool32</type>                           <name>enableYDegamma</name></member>
+            <member><type>VkBool32</type>                           <name>enableCbCrDegamma</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCubicWeightsFeaturesQCOM" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>selectableCubicWeights</name></member>
+        </type>
+        <type category="struct" name="VkSamplerCubicWeightsCreateInfoQCOM" structextends="VkSamplerCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*      <name>pNext</name></member>
+            <member><type>VkCubicFilterWeightsQCOM</type>         <name>cubicWeights</name></member>
+        </type>
+        <type category="struct" name="VkBlitImageCubicWeightsInfoQCOM" structextends="VkBlitImageInfo2">
+            <member values="VK_STRUCTURE_TYPE_BLIT_IMAGE_CUBIC_WEIGHTS_INFO_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*      <name>pNext</name></member>
+            <member><type>VkCubicFilterWeightsQCOM</type>         <name>cubicWeights</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceImageProcessing2FeaturesQCOM" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*   <name>pNext</name></member>
+            <member><type>VkBool32</type>                                      <name>textureBlockMatch2</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceImageProcessing2PropertiesQCOM" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_PROPERTIES_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                        <name>pNext</name></member>
+            <member limittype="max" optional="true"><type>VkExtent2D</type>  <name>maxBlockMatchWindow</name></member>
+        </type>
+        <type category="struct" name="VkSamplerBlockMatchWindowCreateInfoQCOM" structextends="VkSamplerCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                  <name>pNext</name></member>
+            <member><type>VkExtent2D</type>                                   <name>windowExtent</name></member>
+            <member><type>VkBlockMatchWindowCompareModeQCOM</type>            <name>windowCompareMode</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>descriptorPoolOverallocation</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceLayeredDriverPropertiesMSFT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_DRIVER_PROPERTIES_MSFT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                       <name>pNext</name></member>
+            <member><type>VkLayeredDriverUnderlyingApiMSFT</type>            <name>underlyingAPI</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDevicePerStageDescriptorSetFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PER_STAGE_DESCRIPTOR_SET_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>perStageDescriptorSet</name></member>
+            <member><type>VkBool32</type>                                        <name>dynamicPipelineLayout</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalFormatResolveFeaturesANDROID" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
           <member optional="true"><type>void</type>*        <name>pNext</name></member>
-          <member limittype="noauto"><type>VkBool32</type>  <name>shaderTileImageCoherentReadAccelerated</name></member>
-          <member limittype="noauto"><type>VkBool32</type>  <name>shaderTileImageReadSampleFromPixelRateInvocation</name></member>
-          <member limittype="noauto"><type>VkBool32</type>  <name>shaderTileImageReadFromHelperInvocation</name></member>
+          <member><type>VkBool32</type>                     <name>externalFormatResolve</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceExternalFormatResolvePropertiesANDROID" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
+          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_PROPERTIES_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true"><type>void</type>*        <name>pNext</name></member>
+          <member limittype="not"><type>VkBool32</type>  <name>nullColorAttachmentWithExternalFormatResolve</name></member>
+          <member limittype="noauto"><type>VkChromaLocation</type>  <name>externalFormatResolveChromaOffsetX</name></member>
+          <member limittype="noauto"><type>VkChromaLocation</type>  <name>externalFormatResolveChromaOffsetY</name></member>
+        </type>
+        <type category="struct" name="VkAndroidHardwareBufferFormatResolvePropertiesANDROID" structextends="VkAndroidHardwareBufferPropertiesANDROID" returnedonly="true">
+          <member values="VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_RESOLVE_PROPERTIES_ANDROID"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true"><type>void</type>*        <name>pNext</name></member>
+          <member><type>VkFormat</type>                     <name>colorAttachmentFormat</name></member>
+        </type>
+        <type category="struct" name="VkLatencySleepModeInfoNV">
+            <member values="VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>VkBool32</type> <name>lowLatencyMode</name></member>
+            <member><type>VkBool32</type> <name>lowLatencyBoost</name></member>
+            <member><type>uint32_t</type> <name>minimumIntervalUs</name></member>
+        </type>
+        <type category="struct" name="VkLatencySleepInfoNV">
+            <member values="VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>VkSemaphore</type> <name>signalSemaphore</name></member>
+            <member><type>uint64_t</type> <name>value</name></member>
+        </type>
+        <type category="struct" name="VkSetLatencyMarkerInfoNV">
+            <member values="VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>uint64_t</type> <name>presentID</name></member>
+            <member><type>VkLatencyMarkerNV</type> <name>marker</name></member>
+        </type>
+        <type category="struct" name="VkGetLatencyMarkerInfoNV">
+            <member values="VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type> <name>timingCount</name></member>
+            <member optional="true" len="timingCount"><type>VkLatencyTimingsFrameReportNV</type>* <name>pTimings</name></member>
+        </type>
+        <type category="struct" name="VkLatencyTimingsFrameReportNV" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_LATENCY_TIMINGS_FRAME_REPORT_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>uint64_t</type>               <name>presentID</name></member>
+            <member><type>uint64_t</type>               <name>inputSampleTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>simStartTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>simEndTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>renderSubmitStartTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>renderSubmitEndTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>presentStartTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>presentEndTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>driverStartTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>driverEndTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>osRenderQueueStartTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>osRenderQueueEndTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>gpuRenderStartTimeUs</name></member>
+            <member><type>uint64_t</type>               <name>gpuRenderEndTimeUs</name></member>
+        </type>
+        <type category="struct" name="VkOutOfBandQueueTypeInfoNV">
+            <member values="VK_STRUCTURE_TYPE_OUT_OF_BAND_QUEUE_TYPE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>VkOutOfBandQueueTypeNV</type> <name>queueType</name></member>
+        </type>
+        <type category="struct" name="VkLatencySubmissionPresentIdNV" structextends="VkSubmitInfo,VkSubmitInfo2">
+            <member values="VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*      <name>pNext</name></member>
+            <member><type>uint64_t</type>                         <name>presentID</name></member>
+        </type>
+        <type category="struct" name="VkSwapchainLatencyCreateInfoNV" structextends="VkSwapchainCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_SWAPCHAIN_LATENCY_CREATE_INFO_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                        <name>pNext</name></member>
+            <member optional="true"><type>VkBool32</type>                           <name>latencyModeEnable</name></member>
+        </type>
+        <type category="struct" name="VkLatencySurfaceCapabilitiesNV" structextends="VkSurfaceCapabilities2KHR">
+            <member values="VK_STRUCTURE_TYPE_LATENCY_SURFACE_CAPABILITIES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                              <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>                                 <name>presentModeCount</name></member>
+            <member optional="true" len="presentModeCount"><type>VkPresentModeKHR</type>* <name>pPresentModes</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCudaKernelLaunchFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type>                       <name>cudaKernelLaunchFeatures</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCudaKernelLaunchPropertiesNV" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
+            <member limittype="max"><type>uint32_t</type>         <name>computeCapabilityMinor</name></member>
+            <member limittype="min"><type>uint32_t</type>         <name>computeCapabilityMajor</name></member>
+        </type>
+        <type category="struct" name="VkDeviceQueueShaderCoreControlCreateInfoARM" structextends="VkDeviceQueueCreateInfo,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_QUEUE_SHADER_CORE_CONTROL_CREATE_INFO_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
+            <member><type>uint32_t</type>                         <name>shaderCoreCount</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceSchedulingControlsFeaturesARM" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_FEATURES_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>schedulingControls</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceSchedulingControlsPropertiesARM" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_PROPERTIES_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                       <name>pNext</name></member>
+            <member><type>VkPhysicalDeviceSchedulingControlsFlagsARM</type>  <name>schedulingControlsFlags</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RELAXED_LINE_RASTERIZATION_FEATURES_IMG"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true"><type>void</type>*        <name>pNext</name></member>
+          <member><type>VkBool32</type>  <name>relaxedLineRasterization</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceRenderPassStripedFeaturesARM" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>renderPassStriped</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceRenderPassStripedPropertiesARM" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_PROPERTIES_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                           <name>pNext</name></member>
+            <member><type>VkExtent2D</type>                                      <name>renderPassStripeGranularity</name></member>
+            <member><type>uint32_t</type>                                        <name>maxRenderPassStripes</name></member>
+        </type>
+        <type category="struct" name="VkRenderPassStripeInfoARM">
+            <member values="VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_INFO_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>VkRect2D</type>                                        <name>stripeArea</name></member>
+        </type>
+        <type category="struct" name="VkRenderPassStripeBeginInfoARM" structextends="VkRenderingInfo,VkRenderPassBeginInfo">
+            <member values="VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_BEGIN_INFO_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>uint32_t</type>                                          <name>stripeInfoCount</name></member>
+            <member len="stripeInfoCount">const <type>VkRenderPassStripeInfoARM</type>*  <name>pStripeInfos</name></member>
+        </type>
+        <type category="struct" name="VkRenderPassStripeSubmitInfoARM" structextends="VkCommandBufferSubmitInfo">
+            <member values="VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_SUBMIT_INFO_ARM"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>* <name>pNext</name></member>
+            <member><type>uint32_t</type>                                                    <name>stripeSemaphoreInfoCount</name></member>
+            <member len="stripeSemaphoreInfoCount">const <type>VkSemaphoreSubmitInfo</type>* <name>pStripeSemaphoreInfos</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type> <name>shaderMaximalReconvergence</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderSubgroupRotateFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type> <name>shaderSubgroupRotate</name></member>
+            <member><type>VkBool32</type> <name>shaderSubgroupRotateClustered</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderExpectAssumeFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EXPECT_ASSUME_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*     <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>shaderExpectAssume</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderFloatControls2FeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+          <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT_CONTROLS_2_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+          <member optional="true"><type>void</type>*        <name>pNext</name></member>
+          <member><type>VkBool32</type>                     <name>shaderFloatControls2</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*                                <name>pNext</name></member>
+            <member><type>VkBool32</type>                                                                   <name>dynamicRenderingLocalRead</name></member>
+        </type>
+        <type category="struct" name="VkRenderingAttachmentLocationInfoKHR" structextends="VkGraphicsPipelineCreateInfo,VkCommandBufferInheritanceInfo">
+            <member values="VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                                <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>                                                   <name>colorAttachmentCount</name></member>
+            <member noautovalidity="true" len="colorAttachmentCount">const <type>uint32_t</type>*           <name>pColorAttachmentLocations</name></member>
+        </type>
+        <type category="struct" name="VkRenderingInputAttachmentIndexInfoKHR" structextends="VkGraphicsPipelineCreateInfo,VkCommandBufferInheritanceInfo">
+            <member values="VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*                                                <name>pNext</name></member>
+            <member optional="true"><type>uint32_t</type>                                                   <name>colorAttachmentCount</name></member>
+            <member len="colorAttachmentCount" optional="true">const <type>uint32_t</type>*                 <name>pColorAttachmentInputIndices</name></member>
+            <member optional="true">const <type>uint32_t</type>*                                            <name>pDepthInputAttachmentIndex</name></member>
+            <member optional="true">const <type>uint32_t</type>*                                            <name>pStencilInputAttachmentIndex</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderQuadControlFeaturesKHR" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true" noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>VkBool32</type>                           <name>shaderQuadControl</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*               <name>pNext</name></member>
+            <member><type>VkBool32</type>                            <name>shaderFloat16VectorAtomics</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMapMemoryPlacedFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
+            <member><type>VkBool32</type>                         <name>memoryMapPlaced</name></member>
+            <member><type>VkBool32</type>                         <name>memoryMapRangePlaced</name></member>
+            <member><type>VkBool32</type>                         <name>memoryUnmapReserve</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceMapMemoryPlacedPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*            <name>pNext</name></member>
+            <member limittype="min,pot"><type>VkDeviceSize</type> <name>minPlacedMemoryMapAlignment</name></member>
+        </type>
+        <type category="struct" name="VkMemoryMapPlacedInfoEXT" structextends="VkMemoryMapInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_MEMORY_MAP_PLACED_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true">const <type>void</type>*  <name>pNext</name></member>
+            <member noautovalidity="true"><type>void</type>*  <name>pPlacedAddress</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceRawAccessChainsFeaturesNV" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>*                           <name>pNext</name></member>
+            <member><type>VkBool32</type>                                        <name>shaderRawAccessChains</name></member>
         </type>
     </types>
 
@@ -8228,6 +9151,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum type="uint32_t" value="16"        name="VK_MAX_GLOBAL_PRIORITY_SIZE_KHR"/>
         <enum                                   name="VK_MAX_GLOBAL_PRIORITY_SIZE_EXT" alias="VK_MAX_GLOBAL_PRIORITY_SIZE_KHR"/>
         <enum type="uint32_t" value="32"        name="VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT"/>
+        <enum type="uint32_t" value="7"         name="VK_MAX_VIDEO_AV1_REFERENCES_PER_FRAME_KHR"/>
+        <enum type="uint32_t" value="(~0U)"     name="VK_SHADER_INDEX_UNUSED_AMDX"/>
     </enums>
 
     <comment>
@@ -8835,6 +9760,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="7"    name="VK_BUFFER_USAGE_VERTEX_BUFFER_BIT"                 comment="Can be used as source of fixed-function vertex fetch (VBO)"/>
         <enum bitpos="8"    name="VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT"               comment="Can be the source of indirect parameters (e.g. indirect buffer, parameter buffer)"/>
     </enums>
+    <enums name="VkBufferUsageFlagBits2KHR" type="bitmask" bitwidth="64">
+        <enum bitpos="0"    name="VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR"/>
+        <enum bitpos="3"    name="VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT_KHR"/>
+        <enum bitpos="4"    name="VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT_KHR"/>
+        <enum bitpos="5"    name="VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR"/>
+        <enum bitpos="6"    name="VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT_KHR"/>
+        <enum bitpos="7"    name="VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT_KHR"/>
+        <enum bitpos="8"    name="VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT_KHR"/>
+    </enums>
     <enums name="VkBufferCreateFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_BUFFER_CREATE_SPARSE_BINDING_BIT"               comment="Buffer should support sparse backing"/>
         <enum bitpos="1"    name="VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT"             comment="Buffer should support sparse backing with partial residency"/>
@@ -8871,10 +9807,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkSamplerCreateFlagBits" type="bitmask">
     </enums>
-    <enums name="VkPipelineCreateFlagBits" type="bitmask" comment="Note that the gap at bitpos 10 is unused, and can be reserved">
+    <enums name="VkPipelineCreateFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT"/>
         <enum bitpos="1"    name="VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT"/>
         <enum bitpos="2"    name="VK_PIPELINE_CREATE_DERIVATIVE_BIT"/>
+    </enums>
+    <enums name="VkPipelineCreateFlagBits2KHR" type="bitmask" bitwidth="64">
+        <enum bitpos="0"    name="VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_PIPELINE_CREATE_2_ALLOW_DERIVATIVES_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_PIPELINE_CREATE_2_DERIVATIVE_BIT_KHR"/>
     </enums>
     <enums name="VkPipelineShaderStageCreateFlagBits" type="bitmask">
     </enums>
@@ -8930,6 +9871,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="8"    name="VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT"        comment="Optional"/>
         <enum bitpos="9"    name="VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT" comment="Optional"/>
         <enum bitpos="10"   name="VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT"                 comment="Optional"/>
+    </enums>
+    <enums name="VkMemoryMapFlagBits" type="bitmask">
     </enums>
     <enums name="VkImageAspectFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_IMAGE_ASPECT_COLOR_BIT"/>
@@ -9043,11 +9986,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
     <enums name="VkSwapchainImageUsageFlagBitsANDROID" type="bitmask">
       <enum bitpos="0"      name="VK_SWAPCHAIN_IMAGE_USAGE_SHARED_BIT_ANDROID"/>
     </enums>
-    <enums name="VkTimeDomainEXT" type="enum">
-        <enum value="0"     name="VK_TIME_DOMAIN_DEVICE_EXT"/>
-        <enum value="1"     name="VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT"/>
-        <enum value="2"     name="VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT"/>
-        <enum value="3"     name="VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT"/>
+    <enums name="VkTimeDomainKHR" type="enum">
+        <enum value="0"     name="VK_TIME_DOMAIN_DEVICE_KHR"/>
+        <enum value="1"     name="VK_TIME_DOMAIN_CLOCK_MONOTONIC_KHR"/>
+        <enum value="2"     name="VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_KHR"/>
+        <enum value="3"     name="VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR"/>
     </enums>
     <enums name="VkDebugReportFlagBitsEXT" type="bitmask">
         <enum bitpos="0"    name="VK_DEBUG_REPORT_INFORMATION_BIT_EXT"/>
@@ -9138,6 +10081,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="5"     name="VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT"/>
         <enum value="6"     name="VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT"/>
         <enum value="7"     name="VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHE_EXT"/>
+    </enums>
+    <enums name="VkLayerSettingTypeEXT" type="enum">
+        <enum value="0"     name="VK_LAYER_SETTING_TYPE_BOOL32_EXT"/>
+        <enum value="1"     name="VK_LAYER_SETTING_TYPE_INT32_EXT"/>
+        <enum value="2"     name="VK_LAYER_SETTING_TYPE_INT64_EXT"/>
+        <enum value="3"     name="VK_LAYER_SETTING_TYPE_UINT32_EXT"/>
+        <enum value="4"     name="VK_LAYER_SETTING_TYPE_UINT64_EXT"/>
+        <enum value="5"     name="VK_LAYER_SETTING_TYPE_FLOAT32_EXT"/>
+        <enum value="6"     name="VK_LAYER_SETTING_TYPE_FLOAT64_EXT"/>
+        <enum value="7"     name="VK_LAYER_SETTING_TYPE_STRING_EXT"/>
     </enums>
     <enums name="VkSubgroupFeatureFlagBits" type="bitmask">
         <enum bitpos="0"    name="VK_SUBGROUP_FEATURE_BASIC_BIT"              comment="Basic subgroup operations"/>
@@ -9386,6 +10339,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="23"      name="VK_DRIVER_ID_MESA_DOZEN"                    comment="Mesa open source project"/>
         <enum value="24"      name="VK_DRIVER_ID_MESA_NVK"                      comment="Mesa open source project"/>
         <enum value="25"      name="VK_DRIVER_ID_IMAGINATION_OPEN_SOURCE_MESA"  comment="Imagination Technologies"/>
+        <enum value="26"      name="VK_DRIVER_ID_MESA_AGXV"                     comment="Mesa open source project"/>
     </enums>
     <enums name="VkConditionalRenderingFlagBitsEXT" type="bitmask">
         <enum bitpos="0"    name="VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT"/>
@@ -9490,25 +10444,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkFramebufferCreateFlagBits" type="bitmask">
     </enums>
-    <enums name="VkScopeNV" type="enum">
-        <enum value="1"     name="VK_SCOPE_DEVICE_NV"/>
-        <enum value="2"     name="VK_SCOPE_WORKGROUP_NV"/>
-        <enum value="3"     name="VK_SCOPE_SUBGROUP_NV"/>
-        <enum value="5"     name="VK_SCOPE_QUEUE_FAMILY_NV"/>
-    </enums>
-    <enums name="VkComponentTypeNV" type="enum">
-        <enum value="0"     name="VK_COMPONENT_TYPE_FLOAT16_NV"/>
-        <enum value="1"     name="VK_COMPONENT_TYPE_FLOAT32_NV"/>
-        <enum value="2"     name="VK_COMPONENT_TYPE_FLOAT64_NV"/>
-        <enum value="3"     name="VK_COMPONENT_TYPE_SINT8_NV"/>
-        <enum value="4"     name="VK_COMPONENT_TYPE_SINT16_NV"/>
-        <enum value="5"     name="VK_COMPONENT_TYPE_SINT32_NV"/>
-        <enum value="6"     name="VK_COMPONENT_TYPE_SINT64_NV"/>
-        <enum value="7"     name="VK_COMPONENT_TYPE_UINT8_NV"/>
-        <enum value="8"     name="VK_COMPONENT_TYPE_UINT16_NV"/>
-        <enum value="9"     name="VK_COMPONENT_TYPE_UINT32_NV"/>
-        <enum value="10"    name="VK_COMPONENT_TYPE_UINT64_NV"/>
-    </enums>
     <enums name="VkDeviceDiagnosticsConfigFlagBitsNV" type="bitmask">
         <enum bitpos="0" name="VK_DEVICE_DIAGNOSTICS_CONFIG_ENABLE_SHADER_DEBUG_INFO_BIT_NV"/>
         <enum bitpos="1" name="VK_DEVICE_DIAGNOSTICS_CONFIG_ENABLE_RESOURCE_TRACKING_BIT_NV"/>
@@ -9605,11 +10540,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="2" name="VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_UINT64_KHR"/>
         <enum value="3" name="VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_FLOAT64_KHR"/>
     </enums>
-    <enums name="VkLineRasterizationModeEXT" type="enum">
-        <enum value="0"     name="VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT"/>
-        <enum value="1"     name="VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT"/>
-        <enum value="2"     name="VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT"/>
-        <enum value="3"     name="VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT"/>
+    <enums name="VkLineRasterizationModeKHR" type="enum">
+        <enum value="0"     name="VK_LINE_RASTERIZATION_MODE_DEFAULT_KHR"/>
+        <enum               name="VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT"             alias="VK_LINE_RASTERIZATION_MODE_DEFAULT_KHR"/>
+        <enum value="1"     name="VK_LINE_RASTERIZATION_MODE_RECTANGULAR_KHR"/>
+        <enum               name="VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT"         alias="VK_LINE_RASTERIZATION_MODE_RECTANGULAR_KHR"/>
+        <enum value="2"     name="VK_LINE_RASTERIZATION_MODE_BRESENHAM_KHR"/>
+        <enum               name="VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT"           alias="VK_LINE_RASTERIZATION_MODE_BRESENHAM_KHR"/>
+        <enum value="3"     name="VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_KHR"/>
+        <enum               name="VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT"  alias="VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_KHR"/>
     </enums>
     <enums name="VkShaderModuleCreateFlagBits" type="bitmask">
     </enums>
@@ -9835,6 +10774,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="0"     name="VK_DEVICE_ADDRESS_BINDING_TYPE_BIND_EXT"/>
         <enum value="1"     name="VK_DEVICE_ADDRESS_BINDING_TYPE_UNBIND_EXT"/>
     </enums>
+    <enums name="VkFrameBoundaryFlagBitsEXT" type="bitmask">
+        <enum bitpos="0"     name="VK_FRAME_BOUNDARY_FRAME_END_BIT_EXT"/>
+    </enums>
     <enums name="VkPresentScalingFlagBitsEXT" type="bitmask">
         <enum bitpos="0"    name="VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT"/>
         <enum bitpos="1"    name="VK_PRESENT_SCALING_ASPECT_RATIO_STRETCH_BIT_EXT"/>
@@ -9844,6 +10786,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="0"    name="VK_PRESENT_GRAVITY_MIN_BIT_EXT"/>
         <enum bitpos="1"    name="VK_PRESENT_GRAVITY_MAX_BIT_EXT"/>
         <enum bitpos="2"    name="VK_PRESENT_GRAVITY_CENTERED_BIT_EXT"/>
+    </enums>
+    <enums name="VkPhysicalDeviceSchedulingControlsFlagBitsARM" type="bitmask" bitwidth="64">
+        <enum bitpos="0"    name="VK_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_SHADER_CORE_COUNT_ARM"/>
     </enums>
 
     <enums name="VkVideoCodecOperationFlagBitsKHR" type="bitmask">
@@ -9892,6 +10837,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="0"    name="VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_COINCIDE_BIT_KHR"/>
         <enum bitpos="1"    name="VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_DISTINCT_BIT_KHR"/>
     </enums>
+    <enums name="VkVideoEncodeFlagBitsKHR" type="bitmask">
+    </enums>
     <enums name="VkVideoEncodeUsageFlagBitsKHR" type="bitmask">
         <enum value="0"     name="VK_VIDEO_ENCODE_USAGE_DEFAULT_KHR"/>
         <enum bitpos="0"    name="VK_VIDEO_ENCODE_USAGE_TRANSCODING_BIT_KHR"/>
@@ -9914,10 +10861,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
     </enums>
     <enums name="VkVideoEncodeCapabilityFlagBitsKHR" type="bitmask">
         <enum bitpos="0"    name="VK_VIDEO_ENCODE_CAPABILITY_PRECEDING_EXTERNALLY_ENCODED_BYTES_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_VIDEO_ENCODE_CAPABILITY_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_DETECTION_BIT_KHR"/>
     </enums>
     <enums name="VkVideoEncodeFeedbackFlagBitsKHR" type="bitmask">
         <enum bitpos="0"    name="VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BUFFER_OFFSET_BIT_KHR"/>
         <enum bitpos="1"    name="VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_BYTES_WRITTEN_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_VIDEO_ENCODE_FEEDBACK_BITSTREAM_HAS_OVERRIDES_BIT_KHR"/>
     </enums>
     <enums name="VkVideoEncodeRateControlModeFlagBitsKHR" type="bitmask">
         <enum value="0"     name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DEFAULT_KHR"/>
@@ -9925,38 +10874,48 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="1"    name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_CBR_BIT_KHR"/>
         <enum bitpos="2"    name="VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR"/>
     </enums>
-    <enums name="VkVideoEncodeH264CapabilityFlagBitsEXT" type="bitmask">
-        <enum bitpos="0"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_DIRECT_8X8_INFERENCE_ENABLED_BIT_EXT"/>
-        <enum bitpos="1"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_DIRECT_8X8_INFERENCE_DISABLED_BIT_EXT"/>
-        <enum bitpos="2"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_SEPARATE_COLOUR_PLANE_BIT_EXT"/>
-        <enum bitpos="3"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_QPPRIME_Y_ZERO_TRANSFORM_BYPASS_BIT_EXT"/>
-        <enum bitpos="4"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_SCALING_LISTS_BIT_EXT"/>
-        <enum bitpos="5"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_HRD_COMPLIANCE_BIT_EXT"/>
-        <enum bitpos="6"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_CHROMA_QP_OFFSET_BIT_EXT"/>
-        <enum bitpos="7"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_SECOND_CHROMA_QP_OFFSET_BIT_EXT"/>
-        <enum bitpos="8"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_PIC_INIT_QP_MINUS26_BIT_EXT"/>
-        <enum bitpos="9"     name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_PRED_BIT_EXT"/>
-        <enum bitpos="10"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_BIPRED_EXPLICIT_BIT_EXT"/>
-        <enum bitpos="11"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_BIPRED_IMPLICIT_BIT_EXT"/>
-        <enum bitpos="12"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_WEIGHTED_PRED_NO_TABLE_BIT_EXT"/>
-        <enum bitpos="13"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_TRANSFORM_8X8_BIT_EXT"/>
-        <enum bitpos="14"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_CABAC_BIT_EXT"/>
-        <enum bitpos="15"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_CAVLC_BIT_EXT"/>
-        <enum bitpos="16"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DEBLOCKING_FILTER_DISABLED_BIT_EXT"/>
-        <enum bitpos="17"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DEBLOCKING_FILTER_ENABLED_BIT_EXT"/>
-        <enum bitpos="18"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DEBLOCKING_FILTER_PARTIAL_BIT_EXT"/>
-        <enum bitpos="19"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DISABLE_DIRECT_SPATIAL_MV_PRED_BIT_EXT"/>
-        <enum bitpos="20"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_MULTIPLE_SLICE_PER_FRAME_BIT_EXT"/>
-        <enum bitpos="21"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_SLICE_MB_COUNT_BIT_EXT"/>
-        <enum bitpos="22"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_ROW_UNALIGNED_SLICE_BIT_EXT"/>
-        <enum bitpos="23"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DIFFERENT_SLICE_TYPE_BIT_EXT"/>
-        <enum bitpos="24"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_B_FRAME_IN_L1_LIST_BIT_EXT"/>
-        <enum bitpos="25"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DIFFERENT_REFERENCE_FINAL_LISTS_BIT_EXT"/>
+    <enums name="VkVideoEncodeH264CapabilityFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_HRD_COMPLIANCE_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_PREDICTION_WEIGHT_TABLE_GENERATED_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_ROW_UNALIGNED_SLICE_BIT_KHR"/>
+        <enum bitpos="3"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_DIFFERENT_SLICE_TYPE_BIT_KHR"/>
+        <enum bitpos="4"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_B_FRAME_IN_L0_LIST_BIT_KHR"/>
+        <enum bitpos="5"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_B_FRAME_IN_L1_LIST_BIT_KHR"/>
+        <enum bitpos="6"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_PER_PICTURE_TYPE_MIN_MAX_QP_BIT_KHR"/>
+        <enum bitpos="7"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_PER_SLICE_CONSTANT_QP_BIT_KHR"/>
+        <enum bitpos="8"    name="VK_VIDEO_ENCODE_H264_CAPABILITY_GENERATE_PREFIX_NALU_BIT_KHR"/>
     </enums>
-    <enums name="VkVideoEncodeH264RateControlStructureEXT" type="enum">
-        <enum value="0"       name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_STRUCTURE_UNKNOWN_EXT"/>
-        <enum value="1"       name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_STRUCTURE_FLAT_EXT"/>
-        <enum value="2"       name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_STRUCTURE_DYADIC_EXT"/>
+    <enums name="VkVideoEncodeH264StdFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"    name="VK_VIDEO_ENCODE_H264_STD_SEPARATE_COLOR_PLANE_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_VIDEO_ENCODE_H264_STD_QPPRIME_Y_ZERO_TRANSFORM_BYPASS_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_VIDEO_ENCODE_H264_STD_SCALING_MATRIX_PRESENT_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="3"    name="VK_VIDEO_ENCODE_H264_STD_CHROMA_QP_INDEX_OFFSET_BIT_KHR"/>
+        <enum bitpos="4"    name="VK_VIDEO_ENCODE_H264_STD_SECOND_CHROMA_QP_INDEX_OFFSET_BIT_KHR"/>
+        <enum bitpos="5"    name="VK_VIDEO_ENCODE_H264_STD_PIC_INIT_QP_MINUS26_BIT_KHR"/>
+        <enum bitpos="6"    name="VK_VIDEO_ENCODE_H264_STD_WEIGHTED_PRED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="7"    name="VK_VIDEO_ENCODE_H264_STD_WEIGHTED_BIPRED_IDC_EXPLICIT_BIT_KHR"/>
+        <enum bitpos="8"    name="VK_VIDEO_ENCODE_H264_STD_WEIGHTED_BIPRED_IDC_IMPLICIT_BIT_KHR"/>
+        <enum bitpos="9"    name="VK_VIDEO_ENCODE_H264_STD_TRANSFORM_8X8_MODE_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="10"   name="VK_VIDEO_ENCODE_H264_STD_DIRECT_SPATIAL_MV_PRED_FLAG_UNSET_BIT_KHR"/>
+        <enum bitpos="11"   name="VK_VIDEO_ENCODE_H264_STD_ENTROPY_CODING_MODE_FLAG_UNSET_BIT_KHR"/>
+        <enum bitpos="12"   name="VK_VIDEO_ENCODE_H264_STD_ENTROPY_CODING_MODE_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="13"   name="VK_VIDEO_ENCODE_H264_STD_DIRECT_8X8_INFERENCE_FLAG_UNSET_BIT_KHR"/>
+        <enum bitpos="14"   name="VK_VIDEO_ENCODE_H264_STD_CONSTRAINED_INTRA_PRED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="15"   name="VK_VIDEO_ENCODE_H264_STD_DEBLOCKING_FILTER_DISABLED_BIT_KHR"/>
+        <enum bitpos="16"   name="VK_VIDEO_ENCODE_H264_STD_DEBLOCKING_FILTER_ENABLED_BIT_KHR"/>
+        <enum bitpos="17"   name="VK_VIDEO_ENCODE_H264_STD_DEBLOCKING_FILTER_PARTIAL_BIT_KHR"/>
+        <enum bitpos="19"   name="VK_VIDEO_ENCODE_H264_STD_SLICE_QP_DELTA_BIT_KHR"/>
+        <enum bitpos="20"   name="VK_VIDEO_ENCODE_H264_STD_DIFFERENT_SLICE_QP_DELTA_BIT_KHR"/>
+    </enums>
+    <enums name="VkVideoEncodeH264RateControlFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"    name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_ATTEMPT_HRD_COMPLIANCE_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_REGULAR_GOP_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_REFERENCE_PATTERN_FLAT_BIT_KHR"/>
+        <enum bitpos="3"    name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_REFERENCE_PATTERN_DYADIC_BIT_KHR"/>
+        <enum bitpos="4"    name="VK_VIDEO_ENCODE_H264_RATE_CONTROL_TEMPORAL_LAYER_PATTERN_DYADIC_BIT_KHR"/>
+    </enums>
+    <enums name="VkHostImageCopyFlagBitsEXT" type="bitmask">
+        <enum bitpos="0"    name="VK_HOST_IMAGE_COPY_MEMCPY_EXT"/>
     </enums>
     <enums name="VkImageFormatConstraintsFlagBitsFUCHSIA" type="bitmask">
     </enums>
@@ -10031,50 +10990,58 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="2"    name="VK_RENDERING_RESUMING_BIT"/>
         <enum               name="VK_RENDERING_RESUMING_BIT_KHR" alias="VK_RENDERING_RESUMING_BIT"/>
     </enums>
-    <enums name="VkVideoEncodeH265CapabilityFlagBitsEXT" type="bitmask">
-        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_SEPARATE_COLOUR_PLANE_BIT_EXT"/>
-        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_SCALING_LISTS_BIT_EXT"/>
-        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_SAMPLE_ADAPTIVE_OFFSET_ENABLED_BIT_EXT"/>
-        <enum bitpos="3"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_PCM_ENABLE_BIT_EXT"/>
-        <enum bitpos="4"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_SPS_TEMPORAL_MVP_ENABLED_BIT_EXT"/>
-        <enum bitpos="5"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_HRD_COMPLIANCE_BIT_EXT"/>
-        <enum bitpos="6"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_INIT_QP_MINUS26_BIT_EXT"/>
-        <enum bitpos="7"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_LOG2_PARALLEL_MERGE_LEVEL_MINUS2_BIT_EXT"/>
-        <enum bitpos="8"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_SIGN_DATA_HIDING_ENABLED_BIT_EXT"/>
-        <enum bitpos="9"      name="VK_VIDEO_ENCODE_H265_CAPABILITY_TRANSFORM_SKIP_ENABLED_BIT_EXT"/>
-        <enum bitpos="10"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_TRANSFORM_SKIP_DISABLED_BIT_EXT"/>
-        <enum bitpos="11"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT_BIT_EXT"/>
-        <enum bitpos="12"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_WEIGHTED_PRED_BIT_EXT"/>
-        <enum bitpos="13"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_WEIGHTED_BIPRED_BIT_EXT"/>
-        <enum bitpos="14"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_WEIGHTED_PRED_NO_TABLE_BIT_EXT"/>
-        <enum bitpos="15"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_TRANSQUANT_BYPASS_ENABLED_BIT_EXT"/>
-        <enum bitpos="16"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_ENTROPY_CODING_SYNC_ENABLED_BIT_EXT"/>
-        <enum bitpos="17"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_DEBLOCKING_FILTER_OVERRIDE_ENABLED_BIT_EXT"/>
-        <enum bitpos="18"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_MULTIPLE_TILE_PER_FRAME_BIT_EXT"/>
-        <enum bitpos="19"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_MULTIPLE_SLICE_PER_TILE_BIT_EXT"/>
-        <enum bitpos="20"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_MULTIPLE_TILE_PER_SLICE_BIT_EXT"/>
-        <enum bitpos="21"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_SLICE_SEGMENT_CTB_COUNT_BIT_EXT"/>
-        <enum bitpos="22"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_ROW_UNALIGNED_SLICE_SEGMENT_BIT_EXT"/>
-        <enum bitpos="23"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_DEPENDENT_SLICE_SEGMENT_BIT_EXT"/>
-        <enum bitpos="24"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_DIFFERENT_SLICE_TYPE_BIT_EXT"/>
-        <enum bitpos="25"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_B_FRAME_IN_L1_LIST_BIT_EXT"/>
-        <enum bitpos="26"     name="VK_VIDEO_ENCODE_H265_CAPABILITY_DIFFERENT_REFERENCE_FINAL_LISTS_BIT_EXT"/>
+    <enums name="VkVideoEncodeH265CapabilityFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_HRD_COMPLIANCE_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_PREDICTION_WEIGHT_TABLE_GENERATED_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_ROW_UNALIGNED_SLICE_SEGMENT_BIT_KHR"/>
+        <enum bitpos="3"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_DIFFERENT_SLICE_SEGMENT_TYPE_BIT_KHR"/>
+        <enum bitpos="4"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_B_FRAME_IN_L0_LIST_BIT_KHR"/>
+        <enum bitpos="5"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_B_FRAME_IN_L1_LIST_BIT_KHR"/>
+        <enum bitpos="6"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_PER_PICTURE_TYPE_MIN_MAX_QP_BIT_KHR"/>
+        <enum bitpos="7"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_PER_SLICE_SEGMENT_CONSTANT_QP_BIT_KHR"/>
+        <enum bitpos="8"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_MULTIPLE_TILES_PER_SLICE_SEGMENT_BIT_KHR"/>
+        <enum bitpos="9"    name="VK_VIDEO_ENCODE_H265_CAPABILITY_MULTIPLE_SLICE_SEGMENTS_PER_TILE_BIT_KHR"/>
     </enums>
-    <enums name="VkVideoEncodeH265RateControlStructureEXT" type="enum">
-        <enum value="0"       name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_STRUCTURE_UNKNOWN_EXT"/>
-        <enum value="1"       name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_STRUCTURE_FLAT_EXT"/>
-        <enum value="2"       name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_STRUCTURE_DYADIC_EXT"/>
+    <enums name="VkVideoEncodeH265StdFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"    name="VK_VIDEO_ENCODE_H265_STD_SEPARATE_COLOR_PLANE_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="1"    name="VK_VIDEO_ENCODE_H265_STD_SAMPLE_ADAPTIVE_OFFSET_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="2"    name="VK_VIDEO_ENCODE_H265_STD_SCALING_LIST_DATA_PRESENT_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="3"    name="VK_VIDEO_ENCODE_H265_STD_PCM_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="4"    name="VK_VIDEO_ENCODE_H265_STD_SPS_TEMPORAL_MVP_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="5"    name="VK_VIDEO_ENCODE_H265_STD_INIT_QP_MINUS26_BIT_KHR"/>
+        <enum bitpos="6"    name="VK_VIDEO_ENCODE_H265_STD_WEIGHTED_PRED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="7"    name="VK_VIDEO_ENCODE_H265_STD_WEIGHTED_BIPRED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="8"    name="VK_VIDEO_ENCODE_H265_STD_LOG2_PARALLEL_MERGE_LEVEL_MINUS2_BIT_KHR"/>
+        <enum bitpos="9"    name="VK_VIDEO_ENCODE_H265_STD_SIGN_DATA_HIDING_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="10"   name="VK_VIDEO_ENCODE_H265_STD_TRANSFORM_SKIP_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="11"   name="VK_VIDEO_ENCODE_H265_STD_TRANSFORM_SKIP_ENABLED_FLAG_UNSET_BIT_KHR"/>
+        <enum bitpos="12"   name="VK_VIDEO_ENCODE_H265_STD_PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="13"   name="VK_VIDEO_ENCODE_H265_STD_TRANSQUANT_BYPASS_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="14"   name="VK_VIDEO_ENCODE_H265_STD_CONSTRAINED_INTRA_PRED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="15"   name="VK_VIDEO_ENCODE_H265_STD_ENTROPY_CODING_SYNC_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="16"   name="VK_VIDEO_ENCODE_H265_STD_DEBLOCKING_FILTER_OVERRIDE_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="17"   name="VK_VIDEO_ENCODE_H265_STD_DEPENDENT_SLICE_SEGMENTS_ENABLED_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="18"   name="VK_VIDEO_ENCODE_H265_STD_DEPENDENT_SLICE_SEGMENT_FLAG_SET_BIT_KHR"/>
+        <enum bitpos="19"   name="VK_VIDEO_ENCODE_H265_STD_SLICE_QP_DELTA_BIT_KHR"/>
+        <enum bitpos="20"   name="VK_VIDEO_ENCODE_H265_STD_DIFFERENT_SLICE_QP_DELTA_BIT_KHR"/>
     </enums>
-    <enums name="VkVideoEncodeH265CtbSizeFlagBitsEXT" type="bitmask">
-        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H265_CTB_SIZE_16_BIT_EXT"/>
-        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H265_CTB_SIZE_32_BIT_EXT"/>
-        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H265_CTB_SIZE_64_BIT_EXT"/>
+    <enums name="VkVideoEncodeH265RateControlFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_ATTEMPT_HRD_COMPLIANCE_BIT_KHR"/>
+        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_REGULAR_GOP_BIT_KHR"/>
+        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_REFERENCE_PATTERN_FLAT_BIT_KHR"/>
+        <enum bitpos="3"      name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_REFERENCE_PATTERN_DYADIC_BIT_KHR"/>
+        <enum bitpos="4"      name="VK_VIDEO_ENCODE_H265_RATE_CONTROL_TEMPORAL_SUB_LAYER_PATTERN_DYADIC_BIT_KHR"/>
     </enums>
-    <enums name="VkVideoEncodeH265TransformBlockSizeFlagBitsEXT" type="bitmask">
-        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_4_BIT_EXT"/>
-        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_8_BIT_EXT"/>
-        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_16_BIT_EXT"/>
-        <enum bitpos="3"      name="VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_32_BIT_EXT"/>
+    <enums name="VkVideoEncodeH265CtbSizeFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H265_CTB_SIZE_16_BIT_KHR"/>
+        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H265_CTB_SIZE_32_BIT_KHR"/>
+        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H265_CTB_SIZE_64_BIT_KHR"/>
+    </enums>
+    <enums name="VkVideoEncodeH265TransformBlockSizeFlagBitsKHR" type="bitmask">
+        <enum bitpos="0"      name="VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_4_BIT_KHR"/>
+        <enum bitpos="1"      name="VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_8_BIT_KHR"/>
+        <enum bitpos="2"      name="VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_16_BIT_KHR"/>
+        <enum bitpos="3"      name="VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_32_BIT_KHR"/>
     </enums>
     <enums name="VkExportMetalObjectTypeFlagBitsEXT" type="bitmask">
         <enum bitpos="0"      name="VK_EXPORT_METAL_OBJECT_TYPE_METAL_DEVICE_BIT_EXT"/>
@@ -10203,6 +11170,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum value="-3" name="VK_OPACITY_MICROMAP_SPECIAL_INDEX_FULLY_UNKNOWN_TRANSPARENT_EXT"/>
         <enum value="-4" name="VK_OPACITY_MICROMAP_SPECIAL_INDEX_FULLY_UNKNOWN_OPAQUE_EXT"/>
     </enums>
+    <enums name="VkDepthBiasRepresentationEXT" type="enum">
+        <enum value="0"     name="VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORMAT_EXT"/>
+        <enum value="1"     name="VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT"/>
+        <enum value="2"     name="VK_DEPTH_BIAS_REPRESENTATION_FLOAT_EXT"/>
+    </enums>
     <enums name="VkDeviceFaultAddressTypeEXT" type="enum">
         <enum value="0"     name="VK_DEVICE_FAULT_ADDRESS_TYPE_NONE_EXT" comment="Currently unused"/>
         <enum value="1"     name="VK_DEVICE_FAULT_ADDRESS_TYPE_READ_INVALID_EXT"/>
@@ -10226,6 +11198,59 @@ typedef void* <name>MTLSharedEvent_id</name>;
     <enums name="VkShaderCodeTypeEXT" type="enum">
         <enum value="0" name="VK_SHADER_CODE_TYPE_BINARY_EXT"/>
         <enum value="1" name="VK_SHADER_CODE_TYPE_SPIRV_EXT"/>
+    </enums>
+    <enums name="VkScopeKHR" type="enum">
+        <enum value="1"     name="VK_SCOPE_DEVICE_KHR"/>
+        <enum value="2"     name="VK_SCOPE_WORKGROUP_KHR"/>
+        <enum value="3"     name="VK_SCOPE_SUBGROUP_KHR"/>
+        <enum value="5"     name="VK_SCOPE_QUEUE_FAMILY_KHR"/>
+    </enums>
+    <enums name="VkComponentTypeKHR" type="enum">
+        <enum value="0"     name="VK_COMPONENT_TYPE_FLOAT16_KHR"/>
+        <enum value="1"     name="VK_COMPONENT_TYPE_FLOAT32_KHR"/>
+        <enum value="2"     name="VK_COMPONENT_TYPE_FLOAT64_KHR"/>
+        <enum value="3"     name="VK_COMPONENT_TYPE_SINT8_KHR"/>
+        <enum value="4"     name="VK_COMPONENT_TYPE_SINT16_KHR"/>
+        <enum value="5"     name="VK_COMPONENT_TYPE_SINT32_KHR"/>
+        <enum value="6"     name="VK_COMPONENT_TYPE_SINT64_KHR"/>
+        <enum value="7"     name="VK_COMPONENT_TYPE_UINT8_KHR"/>
+        <enum value="8"     name="VK_COMPONENT_TYPE_UINT16_KHR"/>
+        <enum value="9"     name="VK_COMPONENT_TYPE_UINT32_KHR"/>
+        <enum value="10"    name="VK_COMPONENT_TYPE_UINT64_KHR"/>
+    </enums>
+    <enums name="VkCubicFilterWeightsQCOM" type="enum">
+        <enum value="0"     name="VK_CUBIC_FILTER_WEIGHTS_CATMULL_ROM_QCOM"/>
+        <enum value="1"     name="VK_CUBIC_FILTER_WEIGHTS_ZERO_TANGENT_CARDINAL_QCOM"/>
+        <enum value="2"     name="VK_CUBIC_FILTER_WEIGHTS_B_SPLINE_QCOM"/>
+        <enum value="3"     name="VK_CUBIC_FILTER_WEIGHTS_MITCHELL_NETRAVALI_QCOM"/>
+    </enums>
+    <enums name="VkBlockMatchWindowCompareModeQCOM" type="enum">
+        <enum value="0" name="VK_BLOCK_MATCH_WINDOW_COMPARE_MODE_MIN_QCOM"/>
+        <enum value="1" name="VK_BLOCK_MATCH_WINDOW_COMPARE_MODE_MAX_QCOM"/>
+    </enums>
+    <enums name="VkLayeredDriverUnderlyingApiMSFT" type="enum">
+        <enum value="0" name="VK_LAYERED_DRIVER_UNDERLYING_API_NONE_MSFT"/>
+        <enum value="1" name="VK_LAYERED_DRIVER_UNDERLYING_API_D3D12_MSFT"/>
+    </enums>
+    <enums name="VkLatencyMarkerNV" type="enum">
+        <enum value="0"    name="VK_LATENCY_MARKER_SIMULATION_START_NV"/>
+        <enum value="1"    name="VK_LATENCY_MARKER_SIMULATION_END_NV"/>
+        <enum value="2"    name="VK_LATENCY_MARKER_RENDERSUBMIT_START_NV"/>
+        <enum value="3"    name="VK_LATENCY_MARKER_RENDERSUBMIT_END_NV"/>
+        <enum value="4"    name="VK_LATENCY_MARKER_PRESENT_START_NV"/>
+        <enum value="5"    name="VK_LATENCY_MARKER_PRESENT_END_NV"/>
+        <enum value="6"    name="VK_LATENCY_MARKER_INPUT_SAMPLE_NV"/>
+        <enum value="7"    name="VK_LATENCY_MARKER_TRIGGER_FLASH_NV"/>
+        <enum value="8"    name="VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_START_NV"/>
+        <enum value="9"    name="VK_LATENCY_MARKER_OUT_OF_BAND_RENDERSUBMIT_END_NV"/>
+        <enum value="10"   name="VK_LATENCY_MARKER_OUT_OF_BAND_PRESENT_START_NV"/>
+        <enum value="11"   name="VK_LATENCY_MARKER_OUT_OF_BAND_PRESENT_END_NV"/>
+    </enums>
+    <enums name="VkOutOfBandQueueTypeNV" type="enum">
+        <enum value="0"    name="VK_OUT_OF_BAND_QUEUE_TYPE_RENDER_NV"/>
+        <enum value="1"    name="VK_OUT_OF_BAND_QUEUE_TYPE_PRESENT_NV"/>
+    </enums>
+    <enums name="VkMemoryUnmapFlagBitsKHR" type="bitmask">
     </enums>
 
     <commands comment="Vulkan command definitions">
@@ -10345,6 +11370,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
             <param optional="true" len="pPropertyCount"><type>VkLayerProperties</type>* <name>pProperties</name></param>
         </command>
+
         <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_LAYER_NOT_PRESENT">
             <proto><type>VkResult</type> <name>vkEnumerateDeviceExtensionProperties</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
@@ -10720,11 +11746,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
             <param len="createInfoCount"><type>VkPipeline</type>* <name>pPipelines</name></param>
         </command>
-        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR">
             <proto><type>VkResult</type> <name>vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkRenderPass</type> <name>renderpass</name></param>
-            <param><type>VkExtent2D</type>* <name>pMaxWorkgroupSize</name></param>
+            <param len="1"><type>VkExtent2D</type>* <name>pMaxWorkgroupSize</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkDestroyPipeline</name></proto>
@@ -10844,6 +11870,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <proto><type>void</type> <name>vkGetRenderAreaGranularity</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkRenderPass</type> <name>renderPass</name></param>
+            <param><type>VkExtent2D</type>* <name>pGranularity</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetRenderingAreaGranularityKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkRenderingAreaInfoKHR</type>* <name>pRenderingAreaInfo</name></param>
             <param><type>VkExtent2D</type>* <name>pGranularity</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
@@ -10981,7 +12013,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
             <proto><type>void</type> <name>vkCmdBindIndexBuffer</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
-            <param><type>VkBuffer</type> <name>buffer</name></param>
+            <param optional="true"><type>VkBuffer</type> <name>buffer</name></param>
             <param><type>VkDeviceSize</type> <name>offset</name></param>
             <param><type>VkIndexType</type> <name>indexType</name></param>
         </command>
@@ -11074,6 +12106,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>VkBuffer</type> <name>buffer</name></param>
             <param><type>VkDeviceSize</type> <name>offset</name></param>
+        </command>
+        <command queues="transfer,graphics,compute" renderpass="outside" cmdbufferlevel="primary,secondary" tasks="action">
+            <proto><type>void</type> <name>vkCmdUpdatePipelineIndirectBufferNV</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>VkPipelineBindPoint</type>           <name>pipelineBindPoint</name></param>
+            <param><type>VkPipeline</type>                    <name>pipeline</name></param>
         </command>
         <command queues="transfer,graphics,compute" renderpass="outside" cmdbufferlevel="primary,secondary" tasks="action">
             <proto><type>void</type> <name>vkCmdCopyBuffer</name></proto>
@@ -11301,7 +12339,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <proto><type>void</type> <name>vkCmdEndRenderPass</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
         </command>
-        <command queues="transfer,graphics,compute" renderpass="both" cmdbufferlevel="primary" tasks="indirection">
+        <command queues="transfer,graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="indirection">
             <proto><type>void</type> <name>vkCmdExecuteCommands</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>commandBufferCount</name></param>
@@ -12300,8 +13338,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkImage</type> <name>image</name></param>
             <param><type>int</type> <name>nativeFenceFd</name></param>
-            <param><type>VkSemaphore</type> <name>semaphore</name></param>
-            <param><type>VkFence</type> <name>fence</name></param>
+            <param optional="true"><type>VkSemaphore</type> <name>semaphore</name></param>
+            <param optional="true"><type>VkFence</type> <name>fence</name></param>
         </command>
         <command>
             <proto><type>VkResult</type> <name>vkQueueSignalReleaseImageANDROID</name></proto>
@@ -12327,19 +13365,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkBool32</type> <name>localDimmingEnable</name></param>
         </command>
         <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
-            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceCalibrateableTimeDomainsEXT</name></proto>
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceCalibrateableTimeDomainsKHR</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
             <param optional="false,true"><type>uint32_t</type>* <name>pTimeDomainCount</name></param>
-            <param optional="true" len="pTimeDomainCount"><type>VkTimeDomainEXT</type>* <name>pTimeDomains</name></param>
+            <param optional="true" len="pTimeDomainCount"><type>VkTimeDomainKHR</type>* <name>pTimeDomains</name></param>
         </command>
+        <command name="vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" alias="vkGetPhysicalDeviceCalibrateableTimeDomainsKHR"/>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
-            <proto><type>VkResult</type> <name>vkGetCalibratedTimestampsEXT</name></proto>
+            <proto><type>VkResult</type> <name>vkGetCalibratedTimestampsKHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>uint32_t</type> <name>timestampCount</name></param>
-            <param len="timestampCount">const <type>VkCalibratedTimestampInfoEXT</type>* <name>pTimestampInfos</name></param>
+            <param len="timestampCount">const <type>VkCalibratedTimestampInfoKHR</type>* <name>pTimestampInfos</name></param>
             <param len="timestampCount"><type>uint64_t</type>* <name>pTimestamps</name></param>
             <param><type>uint64_t</type>* <name>pMaxDeviation</name></param>
         </command>
+        <command name="vkGetCalibratedTimestampsEXT" alias="vkGetCalibratedTimestampsKHR"/>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkSetDebugUtilsObjectNameEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
@@ -12402,7 +13442,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <proto><type>VkResult</type> <name>vkGetMemoryHostPointerPropertiesEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkExternalMemoryHandleTypeFlagBits</type> <name>handleType</name></param>
-            <param optional="false">const <type>void</type>* <name>pHostPointer</name></param>
+            <param>const <type>void</type>* <name>pHostPointer</name></param>
             <param><type>VkMemoryHostPointerPropertiesEXT</type>* <name>pMemoryHostPointerProperties</name></param>
         </command>
         <command queues="transfer,graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="action">
@@ -12900,7 +13940,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkImageViewHandleInfoNVX</type>* <name>pInfo</name></param>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_UNKNOWN">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY">
             <proto><type>VkResult</type> <name>vkGetImageViewAddressNVX</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkImageView</type> <name>imageView</name></param>
@@ -13058,17 +14098,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="true" len="pInternalRepresentationCount"><type>VkPipelineExecutableInternalRepresentationKHR</type>* <name>pInternalRepresentations</name></param>
         </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
-            <proto><type>void</type> <name>vkCmdSetLineStippleEXT</name></proto>
+            <proto><type>void</type> <name>vkCmdSetLineStippleKHR</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>lineStippleFactor</name></param>
             <param><type>uint16_t</type> <name>lineStipplePattern</name></param>
         </command>
+        <command name="vkCmdSetLineStippleEXT" alias="vkCmdSetLineStippleKHR"/>
         <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
             <proto><type>VkResult</type> <name>vkGetFaultData</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkFaultQueryBehavior</type> <name>faultQueryBehavior</name></param>
             <param><type>VkBool32</type>* <name>pUnrecordedFaults</name></param>
-            <param><type>uint32_t</type>* <name>pFaultCount</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pFaultCount</name></param>
             <param optional="true" len="pFaultCount"><type>VkFaultData</type>* <name>pFaults</name></param>
         </command>
         <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY">
@@ -13141,6 +14182,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkDeferredOperationKHR</type> <name>operation</name></param>
         </command>
+        <command>
+            <proto><type>void</type> <name>vkGetPipelineIndirectMemoryRequirementsNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkComputePipelineCreateInfo</type>* <name>pCreateInfo</name></param>
+            <param><type>VkMemoryRequirements2</type>* <name>pMemoryRequirements</name></param>
+        </command>
+        <command>
+            <proto><type>VkDeviceAddress</type> <name>vkGetPipelineIndirectDeviceAddressNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkPipelineIndirectDeviceAddressInfoNV</type>* <name>pInfo</name></param>
+        </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
             <proto><type>void</type> <name>vkCmdSetCullMode</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
@@ -13173,6 +14225,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param len="scissorCount">const <type>VkRect2D</type>* <name>pScissors</name></param>
         </command>
         <command name="vkCmdSetScissorWithCountEXT" alias="vkCmdSetScissorWithCount"/>
+        <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdBindIndexBuffer2KHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param optional="true"><type>VkBuffer</type> <name>buffer</name></param>
+            <param><type>VkDeviceSize</type> <name>offset</name></param>
+            <param><type>VkDeviceSize</type> <name>size</name></param>
+            <param><type>VkIndexType</type> <name>indexType</name></param>
+        </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
             <proto><type>void</type> <name>vkCmdBindVertexBuffers2</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
@@ -13597,6 +14657,27 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param optional="false,true"><type>uint32_t</type>* <name>pCheckpointDataCount</name></param>
             <param optional="true" len="pCheckpointDataCount"><type>VkCheckpointData2NV</type>* <name>pCheckpointData</name></param>
         </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED">
+            <proto><type>VkResult</type> <name>vkCopyMemoryToImageEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkCopyMemoryToImageInfoEXT</type>* <name>pCopyMemoryToImageInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED">
+            <proto><type>VkResult</type> <name>vkCopyImageToMemoryEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkCopyImageToMemoryInfoEXT</type>* <name>pCopyImageToMemoryInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED">
+            <proto><type>VkResult</type> <name>vkCopyImageToImageEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkCopyImageToImageInfoEXT</type>* <name>pCopyImageToImageInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED">
+            <proto><type>VkResult</type> <name>vkTransitionImageLayoutEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>uint32_t</type> <name>transitionCount</name></param>
+            <param len="transitionCount">const <type>VkHostImageLayoutTransitionInfoEXT</type>* <name>pTransitions</name></param>
+        </command>
         <command>
             <proto><type>void</type> <name>vkGetCommandPoolMemoryConsumption</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
@@ -13616,6 +14697,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param>const <type>VkPhysicalDeviceVideoFormatInfoKHR</type>* <name>pVideoFormatInfo</name></param>
             <param optional="false,true"><type>uint32_t</type>* <name>pVideoFormatPropertyCount</name></param>
             <param optional="true" len="pVideoFormatPropertyCount"><type>VkVideoFormatPropertiesKHR</type>* <name>pVideoFormatProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param>const <type>VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR</type>* <name>pQualityLevelInfo</name></param>
+            <param><type>VkVideoEncodeQualityLevelPropertiesKHR</type>* <name>pQualityLevelProperties</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR">
             <proto><type>VkResult</type> <name>vkCreateVideoSessionKHR</name></proto>
@@ -13642,6 +14729,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>VkVideoSessionParametersKHR</type> <name>videoSessionParameters</name></param>
             <param>const <type>VkVideoSessionParametersUpdateInfoKHR</type>* <name>pUpdateInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetEncodedVideoSessionParametersKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkVideoEncodeSessionParametersGetInfoKHR</type>* <name>pVideoSessionParametersInfo</name></param>
+            <param optional="true"><type>VkVideoEncodeSessionParametersFeedbackInfoKHR</type>* <name>pFeedbackInfo</name></param>
+            <param optional="false,true"><type>size_t</type>* <name>pDataSize</name></param>
+            <param optional="true" len="pDataSize"><type>void</type>* <name>pData</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkDestroyVideoSessionParametersKHR</name></proto>
@@ -13862,6 +14957,44 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkBufferCollectionFUCHSIA</type> <name>collection</name></param>
             <param><type>VkBufferCollectionPropertiesFUCHSIA</type>* <name>pProperties</name></param>
         </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateCudaModuleNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkCudaModuleCreateInfoNV</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkCudaModuleNV</type>* <name>pModule</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkGetCudaModuleCacheNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkCudaModuleNV</type> <name>module</name></param>
+            <param optional="false,true"><type>size_t</type>* <name>pCacheSize</name></param>
+            <param optional="true" len="pCacheSize"><type>void</type>* <name>pCacheData</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateCudaFunctionNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkCudaFunctionCreateInfoNV</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkCudaFunctionNV</type>* <name>pFunction</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkDestroyCudaModuleNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkCudaModuleNV</type> <name>module</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkDestroyCudaFunctionNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkCudaFunctionNV</type> <name>function</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="action">
+            <proto><type>void</type> <name>vkCmdCudaLaunchKernelNV</name></proto>
+            <param><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkCudaLaunchInfoNV</type>* <name>pLaunchInfo</name></param>
+        </command>
         <command queues="graphics" renderpass="outside" cmdbufferlevel="primary,secondary" tasks="action,state">
             <proto><type>void</type> <name>vkCmdBeginRendering</name></proto>
             <param externsync="true"><type>VkCommandBuffer</type>                   <name>commandBuffer</name></param>
@@ -13990,12 +15123,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkShaderModuleIdentifierEXT</type>* <name>pIdentifier</name></param>
         </command>
         <command>
-           <proto><type>void</type> <name>vkGetImageSubresourceLayout2EXT</name></proto>
-           <param><type>VkDevice</type> <name>device</name></param>
-           <param><type>VkImage</type> <name>image</name></param>
-           <param>const <type>VkImageSubresource2EXT</type>* <name>pSubresource</name></param>
-           <param><type>VkSubresourceLayout2EXT</type>* <name>pLayout</name></param>
+            <proto><type>void</type> <name>vkGetImageSubresourceLayout2KHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkImage</type> <name>image</name></param>
+            <param>const <type>VkImageSubresource2KHR</type>* <name>pSubresource</name></param>
+            <param><type>VkSubresourceLayout2KHR</type>* <name>pLayout</name></param>
         </command>
+        <command name="vkGetImageSubresourceLayout2EXT"        alias="vkGetImageSubresourceLayout2KHR"/>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY">
             <proto><type>VkResult</type> <name>vkGetPipelinePropertiesEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
@@ -14060,10 +15194,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>VkDeviceFaultCountsEXT</type>* <name>pFaultCounts</name></param>
             <param optional="true"><type>VkDeviceFaultInfoEXT</type>* <name>pFaultInfo</name></param>
         </command>
+        <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdSetDepthBias2EXT</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkDepthBiasInfoEXT</type>*         <name>pDepthBiasInfo</name></param>
+        </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_SURFACE_LOST_KHR">
             <proto><type>VkResult</type> <name>vkReleaseSwapchainImagesEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkReleaseSwapchainImagesInfoEXT</type>* <name>pReleaseInfo</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetDeviceImageSubresourceLayoutKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkDeviceImageSubresourceInfoKHR</type>* <name>pInfo</name></param>
+            <param><type>VkSubresourceLayout2KHR</type>* <name>pLayout</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED">
             <proto><type>VkResult</type> <name>vkMapMemory2KHR</name></proto>
@@ -14071,12 +15216,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param>const <type>VkMemoryMapInfoKHR</type>* <name>pMemoryMapInfo</name></param>
             <param optional="false,true"><type>void</type>** <name>ppData</name></param>
         </command>
-        <command successcodes="VK_SUCCESS">
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_MEMORY_MAP_FAILED">
             <proto><type>VkResult</type> <name>vkUnmapMemory2KHR</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param>const <type>VkMemoryUnmapInfoKHR</type>* <name>pMemoryUnmapInfo</name></param>
         </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT">
+        <command successcodes="VK_SUCCESS,VK_INCOMPATIBLE_SHADER_BINARY_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED">
             <proto><type>VkResult</type> <name>vkCreateShadersEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>uint32_t</type> <name>createInfoCount</name></param>
@@ -14087,7 +15232,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <command>
             <proto><type>void</type> <name>vkDestroyShaderEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
-            <param externsync="true"><type>VkShaderEXT</type> <name>shader</name></param>
+            <param optional="true" externsync="true"><type>VkShaderEXT</type> <name>shader</name></param>
             <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
         </command>
         <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
@@ -14103,6 +15248,132 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <param><type>uint32_t</type> <name>stageCount</name></param>
             <param len="stageCount">const <type>VkShaderStageFlagBits</type>* <name>pStages</name></param>
             <param optional="true,true" len="stageCount">const <type>VkShaderEXT</type>* <name>pShaders</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR">
+            <proto><type>VkResult</type> <name>vkGetScreenBufferPropertiesQNX</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const struct <type>_screen_buffer</type>* <name>buffer</name></param>
+            <param><type>VkScreenBufferPropertiesQNX</type>* <name>pProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_INCOMPLETE" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR</name></proto>
+            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pPropertyCount</name></param>
+            <param optional="true" len="pPropertyCount"><type>VkCooperativeMatrixPropertiesKHR</type>* <name>pProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetExecutionGraphPipelineScratchSizeAMDX</name></proto>
+            <param><type>VkDevice</type>                                        <name>device</name></param>
+            <param><type>VkPipeline</type>                                      <name>executionGraph</name></param>
+            <param><type>VkExecutionGraphPipelineScratchSizeAMDX</type>*         <name>pSizeInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkGetExecutionGraphPipelineNodeIndexAMDX</name></proto>
+            <param><type>VkDevice</type>                                        <name>device</name></param>
+            <param><type>VkPipeline</type>                                      <name>executionGraph</name></param>
+            <param>const <type>VkPipelineShaderStageNodeCreateInfoAMDX</type>*   <name>pNodeInfo</name></param>
+            <param><type>uint32_t</type>*                                       <name>pNodeIndex</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS,VK_PIPELINE_COMPILE_REQUIRED_EXT" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateExecutionGraphPipelinesAMDX</name></proto>
+            <param><type>VkDevice</type>                                        <name>device</name></param>
+            <param optional="true"><type>VkPipelineCache</type>                 <name>pipelineCache</name></param>
+            <param><type>uint32_t</type>                                        <name>createInfoCount</name></param>
+            <param len="createInfoCount">const <type>VkExecutionGraphPipelineCreateInfoAMDX</type>* <name>pCreateInfos</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>*    <name>pAllocator</name></param>
+            <param len="createInfoCount"><type>VkPipeline</type>*               <name>pPipelines</name></param>
+        </command>
+        <command queues="graphics,compute" tasks="action" renderpass="outside" cmdbufferlevel="primary">
+            <proto><type>void</type> <name>vkCmdInitializeGraphScratchMemoryAMDX</name></proto>
+            <param><type>VkCommandBuffer</type>                                 <name>commandBuffer</name></param>
+            <param><type>VkDeviceAddress</type>                                 <name>scratch</name></param>
+        </command>
+        <command queues="graphics,compute" tasks="action" renderpass="outside" cmdbufferlevel="primary">
+            <proto><type>void</type> <name>vkCmdDispatchGraphAMDX</name></proto>
+            <param><type>VkCommandBuffer</type>                                 <name>commandBuffer</name></param>
+            <param><type>VkDeviceAddress</type>                                 <name>scratch</name></param>
+            <param>const <type>VkDispatchGraphCountInfoAMDX</type>*              <name>pCountInfo</name></param>
+        </command>
+        <command queues="graphics,compute" tasks="action" renderpass="outside" cmdbufferlevel="primary">
+            <proto><type>void</type> <name>vkCmdDispatchGraphIndirectAMDX</name></proto>
+            <param><type>VkCommandBuffer</type>                                 <name>commandBuffer</name></param>
+            <param><type>VkDeviceAddress</type>                                 <name>scratch</name></param>
+            <param>const <type>VkDispatchGraphCountInfoAMDX</type>*              <name>pCountInfo</name></param>
+        </command>
+        <command queues="graphics,compute" tasks="action" renderpass="outside" cmdbufferlevel="primary">
+            <proto><type>void</type> <name>vkCmdDispatchGraphIndirectCountAMDX</name></proto>
+            <param><type>VkCommandBuffer</type>                                 <name>commandBuffer</name></param>
+            <param><type>VkDeviceAddress</type>                                 <name>scratch</name></param>
+            <param><type>VkDeviceAddress</type>                                 <name>countInfo</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdBindDescriptorSets2KHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkBindDescriptorSetsInfoKHR</type>* <name>pBindDescriptorSetsInfo</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdPushConstants2KHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkPushConstantsInfoKHR</type>* <name>pPushConstantsInfo</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdPushDescriptorSet2KHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkPushDescriptorSetInfoKHR</type>* <name>pPushDescriptorSetInfo</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdPushDescriptorSetWithTemplate2KHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkPushDescriptorSetWithTemplateInfoKHR</type>* <name>pPushDescriptorSetWithTemplateInfo</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdSetDescriptorBufferOffsets2EXT</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkSetDescriptorBufferOffsetsInfoEXT</type>* <name>pSetDescriptorBufferOffsetsInfo</name></param>
+        </command>
+        <command queues="graphics,compute" renderpass="both" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdBindDescriptorBufferEmbeddedSamplers2EXT</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkBindDescriptorBufferEmbeddedSamplersInfoEXT</type>* <name>pBindDescriptorBufferEmbeddedSamplersInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_INITIALIZATION_FAILED">
+            <proto><type>VkResult</type> <name>vkSetLatencySleepModeNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param>const <type>VkLatencySleepModeInfoNV</type>* <name>pSleepModeInfo</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS">
+            <proto><type>VkResult</type> <name>vkLatencySleepNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param>const <type>VkLatencySleepInfoNV</type>* <name>pSleepInfo</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkSetLatencyMarkerNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param>const <type>VkSetLatencyMarkerInfoNV</type>* <name>pLatencyMarkerInfo</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkGetLatencyTimingsNV</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param><type>VkGetLatencyMarkerInfoNV</type>* <name>pLatencyMarkerInfo</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkQueueNotifyOutOfBandNV</name></proto>
+            <param><type>VkQueue</type> <name>queue</name></param>
+            <param>const <type>VkOutOfBandQueueTypeInfoNV</type>* <name>pQueueTypeInfo</name></param>
+        </command>
+        <command queues="graphics" renderpass="inside" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdSetRenderingAttachmentLocationsKHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkRenderingAttachmentLocationInfoKHR</type>* <name>pLocationInfo</name></param>
+        </command>
+        <command queues="graphics" renderpass="inside" cmdbufferlevel="primary,secondary" tasks="state">
+            <proto><type>void</type> <name>vkCmdSetRenderingInputAttachmentIndicesKHR</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param>const <type>VkRenderingInputAttachmentIndexInfoKHR</type>* <name>pLocationInfo</name></param>
         </command>
     </commands>
 
@@ -14261,6 +15532,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <require comment="Memory commands">
             <type name="VkMappedMemoryRange"/>
             <type name="VkMemoryAllocateInfo"/>
+            <type name="VkMemoryMapFlagBits"/>
             <type name="VkMemoryMapFlags"/>
             <command name="vkAllocateMemory"/>
             <command name="vkFreeMemory"/>
@@ -15486,13 +16758,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <type name="VkShaderModuleCreateFlagBits"/>
             <type name="VkShaderModuleCreateInfo"/>
             <type name="VkCommandPoolTrimFlags"/>
-            <type name="VkCommandPoolTrimFlagsKHR"/>
             <command name="vkCreateShaderModule"/>
             <command name="vkDestroyShaderModule"/>
             <command name="vkMergePipelineCaches"/>
             <command name="vkGetPipelineCacheData"/>
             <command name="vkTrimCommandPool"/>
-            <command name="vkTrimCommandPoolKHR"/>
             <command name="vkDestroyCommandPool"/>
             <command name="vkDestroyDescriptorPool"/>
             <command name="vkDestroyQueryPool"/>
@@ -15772,7 +17042,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0" extends="VkResult" dir="-"                     name="VK_ERROR_INVALID_SHADER_NV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_depth_range_unrestricted" type="device" number="14" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_depth_range_unrestricted" type="device" number="14" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_DEPTH_RANGE_UNRESTRICTED_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_depth_range_unrestricted&quot;"       name="VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME"/>
@@ -15851,7 +17121,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdDebugMarkerInsertEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_video_queue" number="24" type="device" depends="VK_VERSION_1_1+VK_KHR_synchronization2" author="KHR" contact="Tony Zlatinski @tzlatinski" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_video_queue" number="24" type="device" depends="(VK_VERSION_1_1+VK_KHR_synchronization2),VK_VERSION_1_3" author="KHR" contact="Tony Zlatinski @tzlatinski" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="8"                                         name="VK_KHR_VIDEO_QUEUE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_queue&quot;"            name="VK_KHR_VIDEO_QUEUE_EXTENSION_NAME"/>
@@ -15940,9 +17210,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdControlVideoCodingKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_video_decode_queue" number="25" type="device" depends="VK_KHR_video_queue+VK_KHR_synchronization2" author="KHR" contact="jake.beju@amd.com" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_video_decode_queue" number="25" type="device" depends="VK_KHR_video_queue+(VK_KHR_synchronization2,VK_VERSION_1_3)" author="KHR" contact="jake.beju@amd.com" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="7"                                         name="VK_KHR_VIDEO_DECODE_QUEUE_SPEC_VERSION"/>
+                <enum value="8"                                         name="VK_KHR_VIDEO_DECODE_QUEUE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_decode_queue&quot;"     name="VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_DECODE_INFO_KHR"/>
                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR"/>
@@ -15976,7 +17246,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoDecodeInfoKHR"/>
                 <command name="vkCmdDecodeVideoKHR"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
                 <enum bitpos="25" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR"/>
                 <enum bitpos="26" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR"/>
             </require>
@@ -16005,7 +17275,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_28&quot;"                   name="VK_EXT_EXTENSION_28_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_transform_feedback" number="29" type="device" author="NV" contact="Piers Daniell @pdaniell-nv" specialuse="glemulation,d3demulation,devtools" supported="vulkan" depends="VK_KHR_get_physical_device_properties2">
+        <extension name="VK_EXT_transform_feedback" number="29" type="device" author="NV" contact="Piers Daniell @pdaniell-nv" specialuse="glemulation,d3demulation,devtools" supported="vulkan" ratified="vulkan" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1">
             <require>
                 <enum value="1"                                                 name="VK_EXT_TRANSFORM_FEEDBACK_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_transform_feedback&quot;"             name="VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME"/>
@@ -16047,8 +17317,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="2" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_CU_LAUNCH_INFO_NVX"/>
                 <enum offset="0" extends="VkObjectType"                         name="VK_OBJECT_TYPE_CU_MODULE_NVX"/>
                 <enum offset="1" extends="VkObjectType"                         name="VK_OBJECT_TYPE_CU_FUNCTION_NVX"/>
-                <enum offset="0" extends="VkDebugReportObjectTypeEXT"           name="VK_DEBUG_REPORT_OBJECT_TYPE_CU_MODULE_NVX_EXT"/>
-                <enum offset="1" extends="VkDebugReportObjectTypeEXT"           name="VK_DEBUG_REPORT_OBJECT_TYPE_CU_FUNCTION_NVX_EXT"/>
                 <type name="VkCuModuleNVX"/>
                 <type name="VkCuFunctionNVX"/>
                 <type name="VkCuModuleCreateInfoNVX"/>
@@ -16059,6 +17327,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkDestroyCuModuleNVX"/>
                 <command name="vkDestroyCuFunctionNVX"/>
                 <command name="vkCmdCuLaunchKernelNVX"/>
+            </require>
+            <require depends="VK_EXT_debug_report">
+                <enum offset="0" extends="VkDebugReportObjectTypeEXT"           name="VK_DEBUG_REPORT_OBJECT_TYPE_CU_MODULE_NVX_EXT"/>
+                <enum offset="1" extends="VkDebugReportObjectTypeEXT"           name="VK_DEBUG_REPORT_OBJECT_TYPE_CU_FUNCTION_NVX_EXT"/>
             </require>
         </extension>
         <extension name="VK_NVX_image_view_handle" number="31" type="device" author="NVX" contact="Eric Werness @ewerness-nv" supported="vulkan">
@@ -16117,76 +17389,101 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_shader_ballot&quot;"                  name="VK_AMD_SHADER_BALLOT_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_video_encode_h264" number="39" type="device" depends="VK_KHR_video_encode_queue" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan">
+        <extension name="VK_KHR_video_encode_h264" number="39" type="device" depends="VK_KHR_video_encode_queue" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="10"                                                name="VK_EXT_VIDEO_ENCODE_H264_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_video_encode_h264&quot;"              name="VK_EXT_VIDEO_ENCODE_H264_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="1" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="2" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="3" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_VCL_FRAME_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="4" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="5" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="7" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="8" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="9" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="16" extends="VkVideoCodecOperationFlagBitsKHR"    name="VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum value="14"                                                name="VK_KHR_VIDEO_ENCODE_H264_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_video_encode_h264&quot;"              name="VK_KHR_VIDEO_ENCODE_H264_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR"/>
+                <enum offset="1" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR"/>
+                <enum offset="3" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR"/>
+                <enum offset="4" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR"/>
+                <enum offset="5" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR"/>
+                <enum offset="6" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_GOP_REMAINING_FRAME_INFO_KHR"/>
+                <enum offset="7" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_KHR"/>
+                <enum offset="8" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_KHR"/>
+                <enum offset="9" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_KHR"/>
+                <enum offset="10" extends="VkStructureType"                     name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_CREATE_INFO_KHR"/>
+                <enum offset="11" extends="VkStructureType"                     name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUALITY_LEVEL_PROPERTIES_KHR"/>
+                <enum offset="12" extends="VkStructureType"                     name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_GET_INFO_KHR"/>
+                <enum offset="13" extends="VkStructureType"                     name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_FEEDBACK_INFO_KHR"/>
+                <enum bitpos="16" extends="VkVideoCodecOperationFlagBitsKHR"    name="VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR"/>
 
-                <type name="VkVideoEncodeH264CapabilityFlagBitsEXT"/>
-                <type name="VkVideoEncodeH264CapabilityFlagsEXT"/>
-                <type name="VkVideoEncodeH264CapabilitiesEXT"/>
-                <type name="VkVideoEncodeH264SessionParametersCreateInfoEXT"/>
-                <type name="VkVideoEncodeH264SessionParametersAddInfoEXT"/>
-                <type name="VkVideoEncodeH264VclFrameInfoEXT"/>
-                <type name="VkVideoEncodeH264DpbSlotInfoEXT"/>
-                <type name="VkVideoEncodeH264NaluSliceInfoEXT"/>
-                <type name="VkVideoEncodeH264ProfileInfoEXT"/>
-                <type name="VkVideoEncodeH264RateControlInfoEXT"/>
-                <type name="VkVideoEncodeH264RateControlStructureEXT"/>
-                <type name="VkVideoEncodeH264RateControlLayerInfoEXT"/>
-                <type name="VkVideoEncodeH264QpEXT"/>
-                <type name="VkVideoEncodeH264FrameSizeEXT"/>
+                <type name="VkVideoEncodeH264CapabilityFlagBitsKHR"/>
+                <type name="VkVideoEncodeH264CapabilityFlagsKHR"/>
+                <type name="VkVideoEncodeH264StdFlagBitsKHR"/>
+                <type name="VkVideoEncodeH264StdFlagsKHR"/>
+                <type name="VkVideoEncodeH264CapabilitiesKHR"/>
+                <type name="VkVideoEncodeH264QualityLevelPropertiesKHR"/>
+                <type name="VkVideoEncodeH264SessionCreateInfoKHR"/>
+                <type name="VkVideoEncodeH264SessionParametersCreateInfoKHR"/>
+                <type name="VkVideoEncodeH264SessionParametersAddInfoKHR"/>
+                <type name="VkVideoEncodeH264SessionParametersGetInfoKHR"/>
+                <type name="VkVideoEncodeH264SessionParametersFeedbackInfoKHR"/>
+                <type name="VkVideoEncodeH264PictureInfoKHR"/>
+                <type name="VkVideoEncodeH264DpbSlotInfoKHR"/>
+                <type name="VkVideoEncodeH264NaluSliceInfoKHR"/>
+                <type name="VkVideoEncodeH264ProfileInfoKHR"/>
+                <type name="VkVideoEncodeH264RateControlInfoKHR"/>
+                <type name="VkVideoEncodeH264RateControlFlagBitsKHR"/>
+                <type name="VkVideoEncodeH264RateControlFlagsKHR"/>
+                <type name="VkVideoEncodeH264RateControlLayerInfoKHR"/>
+                <type name="VkVideoEncodeH264QpKHR"/>
+                <type name="VkVideoEncodeH264FrameSizeKHR"/>
+                <type name="VkVideoEncodeH264GopRemainingFrameInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_video_encode_h265" number="40" type="device" depends="VK_KHR_video_encode_queue" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan">
+        <extension name="VK_KHR_video_encode_h265" number="40" type="device" depends="VK_KHR_video_encode_queue" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="10"                                             name="VK_EXT_VIDEO_ENCODE_H265_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_video_encode_h265&quot;"           name="VK_EXT_VIDEO_ENCODE_H265_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="1" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="2" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="3" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_VCL_FRAME_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="4" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="5" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="7" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="9" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="10" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="17" extends="VkVideoCodecOperationFlagBitsKHR" name="VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_EXT" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum value="14"                                             name="VK_KHR_VIDEO_ENCODE_H265_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_video_encode_h265&quot;"           name="VK_KHR_VIDEO_ENCODE_H265_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_KHR"/>
+                <enum offset="1" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR"/>
+                <enum offset="3" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_KHR"/>
+                <enum offset="4" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_KHR"/>
+                <enum offset="5" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_KHR"/>
+                <enum offset="6" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_GOP_REMAINING_FRAME_INFO_KHR"/>
+                <enum offset="7" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_KHR"/>
+                <enum offset="9" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_KHR"/>
+                <enum offset="10" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_KHR"/>
+                <enum offset="11" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_CREATE_INFO_KHR"/>
+                <enum offset="12" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUALITY_LEVEL_PROPERTIES_KHR"/>
+                <enum offset="13" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_GET_INFO_KHR"/>
+                <enum offset="14" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_FEEDBACK_INFO_KHR"/>
+                <enum bitpos="17" extends="VkVideoCodecOperationFlagBitsKHR" name="VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR"/>
 
-                <type name="VkVideoEncodeH265CapabilityFlagBitsEXT"/>
-                <type name="VkVideoEncodeH265CapabilityFlagsEXT"/>
-
-                <type name="VkVideoEncodeH265CtbSizeFlagBitsEXT"/>
-                <type name="VkVideoEncodeH265CtbSizeFlagsEXT"/>
-                <type name="VkVideoEncodeH265TransformBlockSizeFlagBitsEXT"/>
-                <type name="VkVideoEncodeH265TransformBlockSizeFlagsEXT"/>
-                <type name="VkVideoEncodeH265CapabilitiesEXT"/>
-                <type name="VkVideoEncodeH265SessionParametersCreateInfoEXT"/>
-                <type name="VkVideoEncodeH265SessionParametersAddInfoEXT"/>
-                <type name="VkVideoEncodeH265VclFrameInfoEXT"/>
-                <type name="VkVideoEncodeH265DpbSlotInfoEXT"/>
-                <type name="VkVideoEncodeH265NaluSliceSegmentInfoEXT"/>
-                <type name="VkVideoEncodeH265ProfileInfoEXT"/>
-                <type name="VkVideoEncodeH265RateControlInfoEXT"/>
-                <type name="VkVideoEncodeH265RateControlStructureEXT"/>
-                <type name="VkVideoEncodeH265RateControlLayerInfoEXT"/>
-                <type name="VkVideoEncodeH265QpEXT"/>
-                <type name="VkVideoEncodeH265FrameSizeEXT"/>
+                <type name="VkVideoEncodeH265CapabilityFlagBitsKHR"/>
+                <type name="VkVideoEncodeH265CapabilityFlagsKHR"/>
+                <type name="VkVideoEncodeH265StdFlagBitsKHR"/>
+                <type name="VkVideoEncodeH265StdFlagsKHR"/>
+                <type name="VkVideoEncodeH265CtbSizeFlagBitsKHR"/>
+                <type name="VkVideoEncodeH265CtbSizeFlagsKHR"/>
+                <type name="VkVideoEncodeH265TransformBlockSizeFlagBitsKHR"/>
+                <type name="VkVideoEncodeH265TransformBlockSizeFlagsKHR"/>
+                <type name="VkVideoEncodeH265CapabilitiesKHR"/>
+                <type name="VkVideoEncodeH265SessionCreateInfoKHR"/>
+                <type name="VkVideoEncodeH265QualityLevelPropertiesKHR"/>
+                <type name="VkVideoEncodeH265SessionParametersCreateInfoKHR"/>
+                <type name="VkVideoEncodeH265SessionParametersAddInfoKHR"/>
+                <type name="VkVideoEncodeH265SessionParametersGetInfoKHR"/>
+                <type name="VkVideoEncodeH265SessionParametersFeedbackInfoKHR"/>
+                <type name="VkVideoEncodeH265PictureInfoKHR"/>
+                <type name="VkVideoEncodeH265DpbSlotInfoKHR"/>
+                <type name="VkVideoEncodeH265NaluSliceSegmentInfoKHR"/>
+                <type name="VkVideoEncodeH265ProfileInfoKHR"/>
+                <type name="VkVideoEncodeH265RateControlInfoKHR"/>
+                <type name="VkVideoEncodeH265RateControlFlagBitsKHR"/>
+                <type name="VkVideoEncodeH265RateControlFlagsKHR"/>
+                <type name="VkVideoEncodeH265RateControlLayerInfoKHR"/>
+                <type name="VkVideoEncodeH265QpKHR"/>
+                <type name="VkVideoEncodeH265FrameSizeKHR"/>
+                <type name="VkVideoEncodeH265GopRemainingFrameInfoKHR"/>
             </require>
         </extension>
         <extension name="VK_KHR_video_decode_h264" number="41" type="device" depends="VK_KHR_video_decode_queue" author="KHR" contact="peter.fang@amd.com" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="8"                                              name="VK_KHR_VIDEO_DECODE_H264_SPEC_VERSION"/>
+                <enum value="9"                                              name="VK_KHR_VIDEO_DECODE_H264_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_decode_h264&quot;"           name="VK_KHR_VIDEO_DECODE_H264_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR"/>
                 <enum offset="1" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PICTURE_INFO_KHR"/>
@@ -16205,7 +17502,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoDecodeH264DpbSlotInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_AMD_texture_gather_bias_lod" number="42" author="AMD" contact="Rex Xu @amdrexu" supported="vulkan" type="device" depends="VK_KHR_get_physical_device_properties2">
+        <extension name="VK_AMD_texture_gather_bias_lod" number="42" author="AMD" contact="Rex Xu @amdrexu" supported="vulkan" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1">
             <require>
                 <enum value="1"                                                 name="VK_AMD_TEXTURE_GATHER_BIAS_LOD_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_texture_gather_bias_lod&quot;"        name="VK_AMD_TEXTURE_GATHER_BIAS_LOD_EXTENSION_NAME"/>
@@ -16229,7 +17526,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_44&quot;"                   name="VK_AMD_EXTENSION_44_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_dynamic_rendering" number="45" author="KHR" type="device" depends="VK_KHR_depth_stencil_resolve+VK_KHR_get_physical_device_properties2" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
+        <extension name="VK_KHR_dynamic_rendering" number="45" author="KHR" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_depth_stencil_resolve),VK_VERSION_1_2" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_DYNAMIC_RENDERING_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_dynamic_rendering&quot;"              name="VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME"/>
@@ -16308,7 +17605,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCreateStreamDescriptorSurfaceGGP"/>
             </require>
         </extension>
-        <extension name="VK_NV_corner_sampled_image" number="51" author="NV" type="device" depends="VK_KHR_get_physical_device_properties2" contact="Daniel Koch @dgkoch" supported="vulkan">
+        <extension name="VK_NV_corner_sampled_image" number="51" author="NV" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Daniel Koch @dgkoch" supported="vulkan">
             <require>
                 <enum value="2"                                                 name="VK_NV_CORNER_SAMPLED_IMAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_corner_sampled_image&quot;"            name="VK_NV_CORNER_SAMPLED_IMAGE_EXTENSION_NAME"/>
@@ -16321,7 +17618,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="2"                                                 name="VK_NV_PRIVATE_VENDOR_INFO_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_private_vendor_info&quot;"             name="VK_NV_PRIVATE_VENDOR_INFO_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PRIVATE_VENDOR_INFO_RESERVED_OFFSET_0_NV"/>
+                <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PRIVATE_VENDOR_INFO_PLACEHOLDER_OFFSET_0_NV"/>
             </require>
         </extension>
         <extension name="VK_NV_extension_53" number="53" author="NV" contact="Jeff Bolz @jeffbolznv" supported="disabled">
@@ -16330,7 +17627,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_53&quot;"                    name="VK_NV_EXTENSION_53_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_multiview" number="54" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_multiview" number="54" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_MULTIVIEW_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_multiview&quot;"                      name="VK_KHR_MULTIVIEW_EXTENSION_NAME"/>
@@ -16490,9 +17787,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkAcquireNextImage2KHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_validation_flags" number="62" type="instance" author="GOOGLE" contact="Tobin Ehlis @tobine" specialuse="debugging" supported="vulkan" deprecatedby="VK_EXT_validation_features">
+        <extension name="VK_EXT_validation_flags" number="62" type="instance" author="GOOGLE" contact="Tobin Ehlis @tobine" specialuse="debugging" supported="vulkan" deprecatedby="VK_EXT_layer_settings">
             <require>
-                <enum value="2"                                                 name="VK_EXT_VALIDATION_FLAGS_SPEC_VERSION"/>
+                <enum value="3"                                                 name="VK_EXT_VALIDATION_FLAGS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_validation_flags&quot;"               name="VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT"/>
                 <type name="VkValidationFlagsEXT"/>
@@ -16559,7 +17856,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceASTCDecodeFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pipeline_robustness" depends="VK_KHR_get_physical_device_properties2" number="69" type="device" author="IMG" contact="Jarred Davies" supported="vulkan">
+        <extension name="VK_EXT_pipeline_robustness" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" number="69" type="device" author="IMG" contact="Jarred Davies" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_PIPELINE_ROBUSTNESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pipeline_robustness&quot;"            name="VK_EXT_PIPELINE_ROBUSTNESS_EXTENSION_NAME"/>
@@ -16600,7 +17897,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkMemoryHeapFlagBits"                            name="VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHR" alias="VK_MEMORY_HEAP_MULTI_INSTANCE_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_memory_capabilities" number="72" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_external_memory_capabilities" number="72" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_memory_capabilities&quot;"   name="VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME"/>
@@ -16633,7 +17930,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceExternalBufferPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_memory" number="73" type="device" depends="VK_KHR_external_memory_capabilities" author="KHR" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_external_memory" number="73" type="device" depends="VK_KHR_external_memory_capabilities,VK_VERSION_1_1" author="KHR" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_memory&quot;"                name="VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME"/>
@@ -16647,7 +17944,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkExportMemoryAllocateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_memory_win32" number="74" type="device" depends="VK_KHR_external_memory" author="KHR" contact="James Jones @cubanismo" platform="win32" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_external_memory_win32" number="74" type="device" depends="VK_KHR_external_memory,VK_VERSION_1_1" author="KHR" contact="James Jones @cubanismo" platform="win32" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_MEMORY_WIN32_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_memory_win32&quot;"          name="VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"/>
@@ -16685,7 +17982,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkWin32KeyedMutexAcquireReleaseInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_semaphore_capabilities" number="77" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_external_semaphore_capabilities" number="77" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_semaphore_capabilities&quot;" name="VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME"/>
@@ -16749,7 +18046,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetSemaphoreFdKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_push_descriptor" number="81" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_push_descriptor" number="81" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Jeff Bolz @jeffbolznv" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="2"                                             name="VK_KHR_PUSH_DESCRIPTOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_push_descriptor&quot;"            name="VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME"/>
@@ -16767,7 +18064,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="1" extends="VkDescriptorUpdateTemplateType"    name="VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR" comment="Create descriptor update template for pushed descriptor updates"/>
             </require>
         </extension>
-        <extension name="VK_EXT_conditional_rendering" number="82" type="device" author="NV" contact="Vikram Kushwaha @vkushwaha" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_EXT_conditional_rendering" number="82" type="device" author="NV" contact="Vikram Kushwaha @vkushwaha" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_CONDITIONAL_RENDERING_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_conditional_rendering&quot;"      name="VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME"/>
@@ -16786,7 +18083,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkCommandBufferInheritanceConditionalRenderingInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_float16_int8" number="83" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_shader_float16_int8" number="83" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SHADER_FLOAT16_INT8_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_float16_int8&quot;"        name="VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME"/>
@@ -16796,7 +18093,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFloat16Int8FeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_16bit_storage" number="84" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class" author="KHR" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_16bit_storage" number="84" type="device" depends="(VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class),VK_VERSION_1_1" author="KHR" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_16BIT_STORAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_16bit_storage&quot;"              name="VK_KHR_16BIT_STORAGE_EXTENSION_NAME"/>
@@ -16947,7 +18244,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum alias="VK_NV_VIEWPORT_ARRAY_2_EXTENSION_NAME"         name="VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME" deprecated="aliased"/>
             </require>
         </extension>
-        <extension name="VK_NVX_multiview_per_view_attributes" number="98" type="device" depends="VK_KHR_multiview" author="NVX" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_NVX_multiview_per_view_attributes" number="98" type="device" depends="VK_KHR_multiview,VK_VERSION_1_1" author="NVX" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_SPEC_VERSION"/>
                 <enum value="&quot;VK_NVX_multiview_per_view_attributes&quot;" name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_EXTENSION_NAME"/>
@@ -16968,7 +18265,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineViewportSwizzleStateCreateFlagsNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_discard_rectangles" number="100" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_discard_rectangles" number="100" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc" ratified="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_DISCARD_RECTANGLES_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_discard_rectangles&quot;"         name="VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME"/>
@@ -17004,7 +18301,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkConservativeRasterizationModeEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_depth_clip_enable" number="103" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Piers Daniell @pdaniell-nv" specialuse="d3demulation" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_depth_clip_enable" number="103" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Piers Daniell @pdaniell-nv" specialuse="d3demulation" supported="vulkan,vulkansc" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_DEPTH_CLIP_ENABLE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_depth_clip_enable&quot;"          name="VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME"/>
@@ -17043,7 +18340,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum api="vulkan" extends="VkColorSpaceKHR"                name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT" alias="VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT" deprecated="aliased"/>
             </require>
         </extension>
-        <extension name="VK_EXT_hdr_metadata" number="106" type="device" depends="VK_KHR_swapchain" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_hdr_metadata" number="106" type="device" depends="VK_KHR_swapchain" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney-g" supported="vulkan,vulkansc" ratified="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_HDR_METADATA_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_hdr_metadata&quot;"               name="VK_EXT_HDR_METADATA_EXTENSION_NAME"/>
@@ -17065,7 +18362,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_IMG_extension_108&quot;"              name="VK_IMG_EXTENSION_108_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_imageless_framebuffer" depends="VK_KHR_maintenance2+VK_KHR_image_format_list+VK_KHR_get_physical_device_properties2" number="109" author="KHR" contact="Tobias Hector @tobias" type="device" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_imageless_framebuffer" depends="(((VK_KHR_get_physical_device_properties2+VK_KHR_maintenance2),VK_VERSION_1_1)+VK_KHR_image_format_list),VK_VERSION_1_2" number="109" author="KHR" contact="Tobias Hector @tobias" type="device" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_IMAGELESS_FRAMEBUFFER_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_imageless_framebuffer&quot;"      name="VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME"/>
@@ -17080,7 +18377,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkFramebufferCreateFlagBits"                 name="VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR" alias="VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_create_renderpass2" depends="VK_KHR_multiview+VK_KHR_maintenance2" number="110" author="KHR" contact="Tobias Hector @tobias" type="device" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_create_renderpass2" depends="(VK_KHR_multiview+VK_KHR_maintenance2),VK_VERSION_1_1" number="110" author="KHR" contact="Tobias Hector @tobias" type="device" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_CREATE_RENDERPASS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_create_renderpass2&quot;"         name="VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME"/>
@@ -17104,10 +18401,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSubpassEndInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_IMG_extension_111" number="111" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+        <extension name="VK_IMG_relaxed_line_rasterization" number="111" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="IMG" contact="James Fitzpatrick @jamesfitzpatrick" supported="vulkan" specialuse="glemulation">
             <require>
-                <enum value="0"                                             name="VK_IMG_EXTENSION_111_SPEC_VERSION"/>
-                <enum value="&quot;VK_IMG_extension_111&quot;"              name="VK_IMG_EXTENSION_111_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_IMG_RELAXED_LINE_RASTERIZATION_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_relaxed_line_rasterization&quot;" name="VK_IMG_RELAXED_LINE_RASTERIZATION_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RELAXED_LINE_RASTERIZATION_FEATURES_IMG"/>
+                <type name="VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG"/>
             </require>
         </extension>
         <extension name="VK_KHR_shared_presentable_image" number="112" type="device" depends="VK_KHR_swapchain+VK_KHR_get_surface_capabilities2+(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)" author="KHR" contact="Alon Or-bach @alonorbach" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
@@ -17122,7 +18421,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetSwapchainStatusKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_external_fence_capabilities" number="113" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_external_fence_capabilities" number="113" type="instance" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_EXTERNAL_FENCE_CAPABILITIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_external_fence_capabilities&quot;" name="VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME"/>
@@ -17267,7 +18566,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceSurfaceFormats2KHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_variable_pointers" number="121" type="device" author="KHR" contact="Jesse Hall @critsec" depends="VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_variable_pointers" number="121" type="device" author="KHR" contact="Jesse Hall @critsec" depends="(VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class),VK_VERSION_1_1" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_VARIABLE_POINTERS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_variable_pointers&quot;"          name="VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME"/>
@@ -17330,14 +18629,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="9" extends="VkExternalMemoryHandleTypeFlagBits" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_queue_family_foreign" number="127" type="device" author="EXT" depends="VK_KHR_external_memory,VK_VERSION_1_1" contact="Lina Versace @versalinyaa" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_queue_family_foreign" number="127" type="device" author="EXT" depends="VK_KHR_external_memory,VK_VERSION_1_1" contact="Lina Versace @versalinyaa" supported="vulkan,vulkansc" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_QUEUE_FAMILY_FOREIGN_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_queue_family_foreign&quot;"       name="VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME"/>
                 <enum                                                       name="VK_QUEUE_FAMILY_FOREIGN_EXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_dedicated_allocation" number="128" type="device" author="KHR" depends="VK_KHR_get_memory_requirements2" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_dedicated_allocation" number="128" type="device" author="KHR" depends="VK_KHR_get_memory_requirements2,VK_VERSION_1_1" contact="James Jones @cubanismo" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="3"                                             name="VK_KHR_DEDICATED_ALLOCATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_dedicated_allocation&quot;"       name="VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME"/>
@@ -17383,7 +18682,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkSubmitDebugUtilsMessageEXT"/>
             </require>
         </extension>
-        <extension name="VK_ANDROID_external_memory_android_hardware_buffer" number="130" type="device" author="ANDROID" depends="VK_KHR_sampler_ycbcr_conversion+VK_KHR_external_memory+VK_EXT_queue_family_foreign+VK_KHR_dedicated_allocation" platform="android" contact="Jesse Hall @critsec" supported="vulkan">
+        <extension name="VK_ANDROID_external_memory_android_hardware_buffer" number="130" type="device" author="ANDROID" depends="((VK_KHR_sampler_ycbcr_conversion+VK_KHR_external_memory+VK_KHR_dedicated_allocation),VK_VERSION_1_1)+VK_EXT_queue_family_foreign" platform="android" contact="Jesse Hall @critsec" supported="vulkan">
             <require>
                 <enum value="5"                                             name="VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_SPEC_VERSION"/>
                 <enum value="&quot;VK_ANDROID_external_memory_android_hardware_buffer&quot;" name="VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME"/>
@@ -17404,12 +18703,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMemoryAndroidHardwareBufferANDROID"/>
                 <type name="AHardwareBuffer"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
                 <type name="VkAndroidHardwareBufferFormatProperties2ANDROID"/>
                 <enum offset="6" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID"/>
             </require>
         </extension>
-        <extension name="VK_EXT_sampler_filter_minmax" number="131" type="device" author="NV" depends="VK_KHR_get_physical_device_properties2" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_EXT_sampler_filter_minmax" number="131" type="device" author="NV" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
             <require>
                 <enum value="2"                                             name="VK_EXT_SAMPLER_FILTER_MINMAX_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_sampler_filter_minmax&quot;"      name="VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME"/>
@@ -17442,17 +18741,50 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_134&quot;"              name="VK_AMD_EXTENSION_134_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_extension_135" number="135" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+        <extension name="VK_AMDX_shader_enqueue" number="135" author="AMD" depends="(((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_synchronization2),VK_VERSION_1_3)+VK_KHR_pipeline_library+VK_KHR_spirv_1_4" type="device" contact="Tobias Hector @tobski" provisional="true" platform="provisional" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_AMD_EXTENSION_135_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_extension_135&quot;"              name="VK_AMD_EXTENSION_135_EXTENSION_NAME"/>
-                <enum bitpos="25" extends="VkBufferUsageFlagBits"           name="VK_BUFFER_USAGE_RESERVED_25_BIT_AMD"/>
+                <enum value="1"                                             name="VK_AMDX_SHADER_ENQUEUE_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMDX_shader_enqueue&quot;"             name="VK_AMDX_SHADER_ENQUEUE_EXTENSION_NAME"/>
+                <enum                                                       name="VK_SHADER_INDEX_UNUSED_AMDX"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="4" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum bitpos="25" extends="VkBufferUsageFlagBits"           name="VK_BUFFER_USAGE_EXECUTION_GRAPH_SCRATCH_BIT_AMDX" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="0" extends="VkPipelineBindPoint"              name="VK_PIPELINE_BIND_POINT_EXECUTION_GRAPH_AMDX" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <type name="VkPhysicalDeviceShaderEnqueueFeaturesAMDX"/>
+                <type name="VkPhysicalDeviceShaderEnqueuePropertiesAMDX"/>
+                <type name="VkExecutionGraphPipelineScratchSizeAMDX"/>
+                <type name="VkExecutionGraphPipelineCreateInfoAMDX"/>
+                <type name="VkDispatchGraphInfoAMDX"/>
+                <type name="VkDispatchGraphCountInfoAMDX"/>
+                <type name="VkPipelineShaderStageNodeCreateInfoAMDX"/>
+                <type name="VkDeviceOrHostAddressConstAMDX"/>
+                <command name="vkCreateExecutionGraphPipelinesAMDX"/>
+                <command name="vkGetExecutionGraphPipelineScratchSizeAMDX"/>
+                <command name="vkGetExecutionGraphPipelineNodeIndexAMDX"/>
+                <command name="vkCmdInitializeGraphScratchMemoryAMDX"/>
+                <command name="vkCmdDispatchGraphAMDX"/>
+                <command name="vkCmdDispatchGraphIndirectAMDX"/>
+                <command name="vkCmdDispatchGraphIndirectCountAMDX"/>
+            </require>
+            <require depends="VK_KHR_maintenance5">
+                <enum bitpos="25" extends="VkBufferUsageFlagBits2KHR"       name="VK_BUFFER_USAGE_2_EXECUTION_GRAPH_SCRATCH_BIT_AMDX"/>
             </require>
         </extension>
-        <extension name="VK_AMD_extension_136" number="136" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+        <extension name="VK_KHR_extension_136" number="136" type="device" author="KHR" contact="Tobias Hector @tobski" supported="disabled">
             <require>
-                <enum value="0"                                             name="VK_AMD_EXTENSION_136_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_extension_136&quot;"              name="VK_AMD_EXTENSION_136_EXTENSION_NAME"/>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_136_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_136&quot;"              name="VK_KHR_EXTENSION_136_EXTENSION_NAME"/>
+                <enum bitpos="28" extends="VkBufferUsageFlagBits"           name="VK_BUFFER_USAGE_RESERVED_28_BIT_KHR"/>
+                <enum bitpos="29" extends="VkBufferUsageFlagBits"           name="VK_BUFFER_USAGE_RESERVED_29_BIT_KHR"/>
+                <enum bitpos="30" extends="VkBufferUsageFlagBits"           name="VK_BUFFER_USAGE_RESERVED_30_BIT_KHR"/>
+            </require>
+            <require depends="VK_KHR_maintenance5">
+                <enum bitpos="28" extends="VkBufferUsageFlagBits2KHR"       name="VK_BUFFER_USAGE_2_RESERVED_28_BIT_KHR"/>
+                <enum bitpos="29" extends="VkBufferUsageFlagBits2KHR"       name="VK_BUFFER_USAGE_2_RESERVED_29_BIT_KHR"/>
+                <enum bitpos="30" extends="VkBufferUsageFlagBits2KHR"       name="VK_BUFFER_USAGE_2_RESERVED_30_BIT_KHR"/>
             </require>
         </extension>
         <extension name="VK_AMD_mixed_attachment_samples" number="137" type="device" author="AMD" contact="Matthaeus G. Chajdas @anteru" supported="vulkan">
@@ -17467,7 +18799,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_shader_fragment_mask&quot;"       name="VK_AMD_SHADER_FRAGMENT_MASK_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_inline_uniform_block" number="139" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2+VK_KHR_maintenance1" contact="Daniel Rakos @aqnuep" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_inline_uniform_block" number="139" type="device" author="EXT" depends="(VK_KHR_get_physical_device_properties2+VK_KHR_maintenance1),VK_VERSION_1_1" contact="Daniel Rakos @aqnuep" supported="vulkan" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_INLINE_UNIFORM_BLOCK_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_inline_uniform_block&quot;"       name="VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME"/>
@@ -17637,7 +18969,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineCoverageToColorStateCreateInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_acceleration_structure" number="151" type="device" depends="VK_VERSION_1_1+VK_EXT_descriptor_indexing+VK_KHR_buffer_device_address+VK_KHR_deferred_host_operations" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1" ratified="vulkan">
+        <extension name="VK_KHR_acceleration_structure" number="151" type="device" depends="((VK_VERSION_1_1+VK_EXT_descriptor_indexing+VK_KHR_buffer_device_address),VK_VERSION_1_2)+VK_KHR_deferred_host_operations" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1" ratified="vulkan">
             <require>
                 <enum value="13"                                            name="VK_KHR_ACCELERATION_STRUCTURE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_acceleration_structure&quot;"     name="VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME"/>
@@ -17663,7 +18995,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0"  extends="VkQueryType"                     name="VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR"/>
                 <enum offset="1"  extends="VkQueryType"                     name="VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR"/>
                 <enum offset="0"  extends="VkObjectType"                    name="VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR"/>
-                <enum offset="0"  extends="VkDebugReportObjectTypeEXT"      name="VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT"/>
                 <enum offset="0"  extends="VkIndexType" extnumber="166"     name="VK_INDEX_TYPE_NONE_KHR"/>
                 <enum bitpos="29" extends="VkFormatFeatureFlagBits"         name="VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR"/>
                 <enum bitpos="19" extends="VkBufferUsageFlagBits"           name="VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR"/>
@@ -17722,8 +19053,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDeviceAccelerationStructureCompatibilityKHR"/>
                 <command name="vkGetAccelerationStructureBuildSizesKHR"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
                 <enum bitpos="29" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR"/>
+            </require>
+            <require depends="VK_EXT_debug_report">
+                <enum offset="0"  extends="VkDebugReportObjectTypeEXT"      name="VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT"/>
             </require>
         </extension>
         <extension name="VK_KHR_ray_tracing_pipeline" number="348" type="device" depends="VK_KHR_spirv_1_4+VK_KHR_acceleration_structure" author="KHR" contact="Daniel Koch @dgkoch" supported="vulkan" sortorder="1" ratified="vulkan">
@@ -17818,7 +19152,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_post_depth_coverage&quot;"        name="VK_EXT_POST_DEPTH_COVERAGE_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_sampler_ycbcr_conversion" number="157" type="device" depends="VK_KHR_maintenance1+VK_KHR_bind_memory2+VK_KHR_get_memory_requirements2+VK_KHR_get_physical_device_properties2" author="KHR" contact="Andrew Garrard @fluppeteer" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_sampler_ycbcr_conversion" number="157" type="device" depends="(VK_KHR_maintenance1+VK_KHR_bind_memory2+VK_KHR_get_memory_requirements2+VK_KHR_get_physical_device_properties2),VK_VERSION_1_1" author="KHR" contact="Andrew Garrard @fluppeteer" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="14"                                            name="VK_KHR_SAMPLER_YCBCR_CONVERSION_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_sampler_ycbcr_conversion&quot;"   name="VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME"/>
@@ -17828,7 +19162,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO_KHR" alias="VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO"/>
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES"/>
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES_KHR" alias="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES"/>
-                <enum extends="VkDebugReportObjectTypeEXT"                  name="VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_KHR_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT"/>
                 <enum extends="VkObjectType"                                name="VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_KHR" alias="VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION"/>
                 <enum extends="VkFormat"                                    name="VK_FORMAT_G8B8G8R8_422_UNORM_KHR" alias="VK_FORMAT_G8B8G8R8_422_UNORM"/>
                 <enum extends="VkFormat"                                    name="VK_FORMAT_B8G8R8G8_422_UNORM_KHR" alias="VK_FORMAT_B8G8R8G8_422_UNORM"/>
@@ -17899,6 +19232,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             </require>
             <require depends="VK_EXT_debug_report">
                 <enum extends="VkDebugReportObjectTypeEXT" offset="0"       name="VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT"/>
+                <enum extends="VkDebugReportObjectTypeEXT"                  name="VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_KHR_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT"/>
             </require>
         </extension>
         <extension name="VK_KHR_bind_memory2" number="158" type="device" author="KHR" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
@@ -17914,7 +19248,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkBindImageMemoryInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_drm_format_modifier" number="159" type="device" depends="((VK_KHR_bind_memory2+VK_KHR_get_physical_device_properties2+VK_KHR_sampler_ycbcr_conversion),VK_VERSION_1_1)+(VK_KHR_image_format_list,VK_VERSION_1_2)" author="EXT" contact="Lina Versace @versalinyaa" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_image_drm_format_modifier" number="159" type="device" depends="(((VK_KHR_bind_memory2+VK_KHR_get_physical_device_properties2+VK_KHR_sampler_ycbcr_conversion),VK_VERSION_1_1)+VK_KHR_image_format_list),VK_VERSION_1_2" author="EXT" contact="Lina Versace @versalinyaa" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_drm_format_modifier&quot;"  name="VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME"/>
@@ -17937,7 +19271,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkImageDrmFormatModifierPropertiesEXT"/>
                 <command name="vkGetImageDrmFormatModifierPropertiesEXT"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
                 <type name="VkDrmFormatModifierPropertiesList2EXT"/>
                 <type name="VkDrmFormatModifierProperties2EXT"/>
                 <enum offset="6" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_2_EXT"/>
@@ -17967,7 +19301,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetValidationCacheDataEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_descriptor_indexing" number="162" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_maintenance3" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_EXT_descriptor_indexing" number="162" type="device" depends="(VK_KHR_get_physical_device_properties2+VK_KHR_maintenance3),VK_VERSION_1_1" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_2">
             <require>
                 <enum value="2"                                             name="VK_EXT_DESCRIPTOR_INDEXING_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_descriptor_indexing&quot;"        name="VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME"/>
@@ -17998,7 +19332,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_shader_viewport_index_layer&quot;" name="VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_portability_subset" number="164" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Bill Hollings @billhollings" platform="provisional" supported="vulkan" provisional="true" ratified="vulkan">
+        <extension name="VK_KHR_portability_subset" number="164" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Bill Hollings @billhollings" platform="provisional" supported="vulkan" provisional="true" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_PORTABILITY_SUBSET_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_portability_subset&quot;"         name="VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME"/>
@@ -18008,7 +19342,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePortabilitySubsetPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_shading_rate_image" number="165" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_shading_rate_image" number="165" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
                 <enum value="3"                                             name="VK_NV_SHADING_RATE_IMAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_shading_rate_image&quot;"          name="VK_NV_SHADING_RATE_IMAGE_EXTENSION_NAME"/>
@@ -18036,7 +19370,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetCoarseSampleOrderNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_ray_tracing" number="166" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_get_memory_requirements2" author="NV" contact="Eric Werness @ewerness-nv" supported="vulkan">
+        <extension name="VK_NV_ray_tracing" number="166" type="device" depends="(VK_KHR_get_physical_device_properties2+VK_KHR_get_memory_requirements2),VK_VERSION_1_1" author="NV" contact="Eric Werness @ewerness-nv" supported="vulkan">
             <require>
                 <enum value="3"                               name="VK_NV_RAY_TRACING_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_ray_tracing&quot;"   name="VK_NV_RAY_TRACING_EXTENSION_NAME"/>
@@ -18068,7 +19402,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0" extends="VkQueryType"        name="VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV"/>
                 <enum bitpos="5" extends="VkPipelineCreateFlagBits"      name="VK_PIPELINE_CREATE_DEFER_COMPILE_BIT_NV"/>
                 <enum offset="0" extends="VkObjectType"       name="VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV"/>
-                <enum offset="0" extends="VkDebugReportObjectTypeEXT" name="VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT"/>
                 <enum extends="VkIndexType"                   name="VK_INDEX_TYPE_NONE_NV" alias="VK_INDEX_TYPE_NONE_KHR"/>
                 <type name="VkRayTracingShaderGroupCreateInfoNV"/>
                 <type name="VkRayTracingShaderGroupTypeNV"/>
@@ -18113,7 +19446,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkWriteDescriptorSetAccelerationStructureNV"/>
                 <type name="VkAccelerationStructureMemoryRequirementsInfoNV"/>
                 <type name="VkPhysicalDeviceRayTracingPropertiesNV"/>
-                <type name="VkMemoryRequirements2KHR"/>
                 <type name="VkAccelerationStructureMemoryRequirementsTypeNV"/>
                 <type name="VkTransformMatrixNV"/>
                 <type name="VkAabbPositionsNV"/>
@@ -18131,8 +19463,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdWriteAccelerationStructuresPropertiesNV"/>
                 <command name="vkCompileDeferredNV"/>
             </require>
+            <require depends="VK_KHR_get_memory_requirements2,VK_VERSION_1_1">
+                <type name="VkMemoryRequirements2KHR"/>
+            </require>
+            <require depends="VK_EXT_debug_report">
+                <enum offset="0" extends="VkDebugReportObjectTypeEXT" name="VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT"/>
+            </require>
         </extension>
-        <extension name="VK_NV_representative_fragment_test" number="167" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_NV_representative_fragment_test" number="167" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_NV_REPRESENTATIVE_FRAGMENT_TEST_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_representative_fragment_test&quot;" name="VK_NV_REPRESENTATIVE_FRAGMENT_TEST_EXTENSION_NAME"/>
@@ -18148,7 +19486,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_168&quot;"               name="VK_NV_EXTENSION_168_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_maintenance3" number="169" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
+        <extension name="VK_KHR_maintenance3" number="169" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Jeff Bolz @jeffbolznv" supported="vulkan" promotedto="VK_VERSION_1_1" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_MAINTENANCE_3_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_maintenance3&quot;"               name="VK_KHR_MAINTENANCE_3_EXTENSION_NAME"/>
@@ -18169,7 +19507,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdDrawIndexedIndirectCountKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_filter_cubic" number="171" type="device" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_filter_cubic" number="171" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan,vulkansc">
             <require>
                 <enum value="3"                                             name="VK_EXT_FILTER_CUBIC_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_filter_cubic&quot;"               name="VK_EXT_FILTER_CUBIC_EXTENSION_NAME"/>
@@ -18181,7 +19519,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkFilterCubicImageViewImageFormatPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_render_pass_shader_resolve" number="172" type="device" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="vulkan">
+        <extension name="VK_QCOM_render_pass_shader_resolve" number="172" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="4"                                                 name="VK_QCOM_RENDER_PASS_SHADER_RESOLVE_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_render_pass_shader_resolve&quot;"    name="VK_QCOM_RENDER_PASS_SHADER_RESOLVE_EXTENSION_NAME"/>
@@ -18189,16 +19527,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="3" extends="VkSubpassDescriptionFlagBits"         name="VK_SUBPASS_DESCRIPTION_SHADER_RESOLVE_BIT_QCOM"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_173" number="173" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="disabled">
+        <extension name="VK_QCOM_extension_173" number="173" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_QCOM_EXTENSION_173_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_173&quot;"             name="VK_QCOM_EXTENSION_173_EXTENSION_NAME"/>
-                <enum bitpos="18" extends="VkBufferUsageFlagBits"           name="VK_BUFFER_USAGE_RESERVED_18_BIT_QCOM"/>
-                <enum bitpos="16" extends="VkImageUsageFlagBits"            name="VK_IMAGE_USAGE_RESERVED_16_BIT_QCOM"/>
-                <enum bitpos="17" extends="VkImageUsageFlagBits"            name="VK_IMAGE_USAGE_RESERVED_17_BIT_QCOM"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_174" number="174" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="disabled">
+        <extension name="VK_QCOM_extension_174" number="174" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_QCOM_EXTENSION_174_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_174&quot;"             name="VK_QCOM_EXTENSION_174_EXTENSION_NAME"/>
@@ -18228,7 +19563,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_177&quot;"              name="VK_EXT_EXTENSION_177_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_8bit_storage" number="178" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_8bit_storage" number="178" type="device" depends="(VK_KHR_get_physical_device_properties2+VK_KHR_storage_buffer_storage_class),VK_VERSION_1_1" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_8BIT_STORAGE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_8bit_storage&quot;"               name="VK_KHR_8BIT_STORAGE_EXTENSION_NAME"/>
@@ -18258,7 +19593,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdWriteBufferMarkerAMD"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_atomic_int64" number="181" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Aaron Hagan @ahagan" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_shader_atomic_int64" number="181" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Aaron Hagan @ahagan" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SHADER_ATOMIC_INT64_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_atomic_int64&quot;"        name="VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME"/>
@@ -18290,18 +19625,22 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineCompilerControlCreateInfoAMD"/>
             </require>
         </extension>
-        <extension name="VK_EXT_calibrated_timestamps" number="185" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Daniel Rakos @drakos-amd" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_calibrated_timestamps" number="185" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Daniel Rakos @drakos-amd" promotedto="VK_KHR_calibrated_timestamps" supported="vulkan,vulkansc">
             <require>
                 <enum value="2"                                             name="VK_EXT_CALIBRATED_TIMESTAMPS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_calibrated_timestamps&quot;"      name="VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT"/>
+                <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT" alias="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR"/>
+                <enum extends="VkTimeDomainKHR"                             name="VK_TIME_DOMAIN_DEVICE_EXT"                       alias="VK_TIME_DOMAIN_DEVICE_KHR"/>
+                <enum extends="VkTimeDomainKHR"                             name="VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT"              alias="VK_TIME_DOMAIN_CLOCK_MONOTONIC_KHR"/>
+                <enum extends="VkTimeDomainKHR"                             name="VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT"          alias="VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_KHR"/>
+                <enum extends="VkTimeDomainKHR"                             name="VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT"    alias="VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_KHR"/>
                 <type name="VkTimeDomainEXT"/>
                 <type name="VkCalibratedTimestampInfoEXT"/>
                 <command name="vkGetPhysicalDeviceCalibrateableTimeDomainsEXT"/>
                 <command name="vkGetCalibratedTimestampsEXT"/>
             </require>
         </extension>
-        <extension name="VK_AMD_shader_core_properties" number="186" type="device" author="AMD" depends="VK_KHR_get_physical_device_properties2" contact="Martin Dinkov @mdinkov" supported="vulkan">
+        <extension name="VK_AMD_shader_core_properties" number="186" type="device" author="AMD" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Martin Dinkov @mdinkov" supported="vulkan">
             <require>
                 <enum value="2"                                          name="VK_AMD_SHADER_CORE_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_core_properties&quot;"  name="VK_AMD_SHADER_CORE_PROPERTIES_EXTENSION_NAME"/>
@@ -18317,7 +19656,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </extension>
         <extension name="VK_KHR_video_decode_h265" number="188" type="device" depends="VK_KHR_video_decode_queue" author="KHR" contact="peter.fang@amd.com" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="7"                                             name="VK_KHR_VIDEO_DECODE_H265_SPEC_VERSION"/>
+                <enum value="8"                                             name="VK_KHR_VIDEO_DECODE_H265_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_decode_h265&quot;"          name="VK_KHR_VIDEO_DECODE_H265_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR"/>
@@ -18336,7 +19675,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoDecodeH265DpbSlotInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_global_priority" number="189" type="device" author="KHR" contact="Tobias Hector @tobski" depends="VK_KHR_get_physical_device_properties2" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_global_priority" number="189" type="device" author="KHR" contact="Tobias Hector @tobski" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_GLOBAL_PRIORITY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_global_priority&quot;"            name="VK_KHR_GLOBAL_PRIORITY_EXTENSION_NAME"/>
@@ -18360,13 +19699,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkDeviceMemoryOverallocationCreateInfoAMD"/>
             </require>
         </extension>
-        <extension name="VK_EXT_vertex_attribute_divisor" number="191" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Vikram Kushwaha @vkushwaha" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_vertex_attribute_divisor" number="191" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Vikram Kushwaha @vkushwaha" supported="vulkan,vulkansc" promotedto="VK_KHR_vertex_attribute_divisor">
             <require>
-                <enum value="3"                                         name="VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_vertex_attribute_divisor&quot;"   name="VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT"/>
-                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT"/>
-                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT"/>
+                <enum value="3"                                           name="VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_vertex_attribute_divisor&quot;" name="VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT"/>
+                <enum            extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT" alias="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_KHR"/>
+                <enum            extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_KHR"/>
                 <type name="VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT"/>
                 <type name="VkVertexInputBindingDivisorDescriptionEXT"/>
                 <type name="VkPipelineVertexInputDivisorStateCreateInfoEXT"/>
@@ -18408,10 +19747,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                         name="VK_GOOGLE_EXTENSION_196_SPEC_VERSION"/>
                 <enum value="&quot;VK_GOOGLE_extension_196&quot;"       name="VK_GOOGLE_EXTENSION_196_EXTENSION_NAME"/>
-                <enum extends="VkPipelineCacheCreateFlagBits"           name="VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT_EXT" alias="VK_PIPELINE_CACHE_CREATE_READ_ONLY_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_driver_properties" number="197" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Daniel Rakos @drakos-amd" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_driver_properties" number="197" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Daniel Rakos @drakos-amd" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_DRIVER_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_driver_properties&quot;"          name="VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME"/>
@@ -18435,7 +19773,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceDriverPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_float_controls" number="198" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_shader_float_controls" number="198" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Alexander Galazin @alegal-arm" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="4"                                             name="VK_KHR_SHADER_FLOAT_CONTROLS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_float_controls&quot;"      name="VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME"/>
@@ -18454,7 +19792,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="8" extends="VkSubgroupFeatureFlagBits"        name="VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_depth_stencil_resolve" number="200" type="device" depends="VK_KHR_create_renderpass2" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_depth_stencil_resolve" number="200" type="device" depends="VK_KHR_create_renderpass2,VK_VERSION_1_2" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_DEPTH_STENCIL_RESOLVE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_depth_stencil_resolve&quot;"      name="VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME"/>
@@ -18478,7 +19816,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="2" extends="VkSwapchainCreateFlagBitsKHR" name="VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_compute_shader_derivatives" number="202" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_compute_shader_derivatives" number="202" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_COMPUTE_SHADER_DERIVATIVES_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_compute_shader_derivatives&quot;" name="VK_NV_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME"/>
@@ -18486,7 +19824,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceComputeShaderDerivativesFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_mesh_shader" number="203" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
+        <extension name="VK_NV_mesh_shader" number="203" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_MESH_SHADER_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_mesh_shader&quot;"             name="VK_NV_MESH_SHADER_EXTENSION_NAME"/>
@@ -18504,7 +19842,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkDrawMeshTasksIndirectCommandNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_fragment_shader_barycentric" number="204" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan" promotedto="VK_KHR_fragment_shader_barycentric">
+        <extension name="VK_NV_fragment_shader_barycentric" number="204" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan" promotedto="VK_KHR_fragment_shader_barycentric">
             <require>
                 <enum value="1"                                         name="VK_NV_FRAGMENT_SHADER_BARYCENTRIC_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_fragment_shader_barycentric&quot;" name="VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME"/>
@@ -18512,7 +19850,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_shader_image_footprint" number="205" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_shader_image_footprint" number="205" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_NV_SHADER_IMAGE_FOOTPRINT_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_shader_image_footprint&quot;"  name="VK_NV_SHADER_IMAGE_FOOTPRINT_EXTENSION_NAME"/>
@@ -18520,7 +19858,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderImageFootprintFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_scissor_exclusive" number="206" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
+        <extension name="VK_NV_scissor_exclusive" number="206" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Pat Brown @nvpbrown" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_NV_SCISSOR_EXCLUSIVE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_scissor_exclusive&quot;"       name="VK_NV_SCISSOR_EXCLUSIVE_EXTENSION_NAME"/>
@@ -18534,7 +19872,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetExclusiveScissorNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_device_diagnostic_checkpoints" type="device" number="207" depends="VK_KHR_get_physical_device_properties2" author="NVIDIA" contact="Nuno Subtil @nsubtil" supported="vulkan">
+        <extension name="VK_NV_device_diagnostic_checkpoints" type="device" number="207" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NVIDIA" contact="Nuno Subtil @nsubtil" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_device_diagnostic_checkpoints&quot;" name="VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME"/>
@@ -18546,7 +19884,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetQueueCheckpointDataNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_timeline_semaphore" number="208" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Faith Ekstrand @gfxstrand" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_timeline_semaphore" number="208" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Faith Ekstrand @gfxstrand" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="2"                                         name="VK_KHR_TIMELINE_SEMAPHORE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_timeline_semaphore&quot;"     name="VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME"/>
@@ -18579,7 +19917,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_209&quot;"          name="VK_KHR_EXTENSION_209_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_INTEL_shader_integer_functions2" number="210" type="device" depends="VK_KHR_get_physical_device_properties2" author="INTEL" contact="Ian Romanick @ianromanick" supported="vulkan">
+        <extension name="VK_INTEL_shader_integer_functions2" number="210" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="INTEL" contact="Ian Romanick @ianromanick" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_INTEL_SHADER_INTEGER_FUNCTIONS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_INTEL_shader_integer_functions2&quot;" name="VK_INTEL_SHADER_INTEGER_FUNCTIONS_2_EXTENSION_NAME"/>
@@ -18626,7 +19964,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPerformanceParameterINTEL"/>
             </require>
         </extension>
-        <extension name="VK_KHR_vulkan_memory_model" number="212" type="device" author="KHR" contact="Jeff Bolz @jeffbolznv" depends="VK_KHR_get_physical_device_properties2" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_vulkan_memory_model" number="212" type="device" author="KHR" contact="Jeff Bolz @jeffbolznv" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="3"                                         name="VK_KHR_VULKAN_MEMORY_MODEL_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_vulkan_memory_model&quot;"    name="VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME"/>
@@ -18642,7 +19980,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePCIBusInfoPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_AMD_display_native_hdr" number="214" type="device" author="AMD" depends="VK_KHR_get_physical_device_properties2+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" contact="Matthaeus G. Chajdas @anteru" supported="vulkan">
+        <extension name="VK_AMD_display_native_hdr" number="214" type="device" author="AMD" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" contact="Matthaeus G. Chajdas @anteru" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_AMD_DISPLAY_NATIVE_HDR_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_display_native_hdr&quot;"     name="VK_AMD_DISPLAY_NATIVE_HDR_EXTENSION_NAME"/>
@@ -18689,7 +20027,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="CAMetalLayer"/>
             </require>
         </extension>
-        <extension name="VK_EXT_fragment_density_map" number="219" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Matthew Netsch @mnetsch" supported="vulkan">
+        <extension name="VK_EXT_fragment_density_map" number="219" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_FRAGMENT_DENSITY_MAP_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_fragment_density_map&quot;"       name="VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME"/>
@@ -18709,7 +20047,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFragmentDensityMapPropertiesEXT"/>
                 <type name="VkRenderPassFragmentDensityMapCreateInfoEXT"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
                 <enum bitpos="24" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT"/>
             </require>
         </extension>
@@ -18726,7 +20064,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="0" extends="VkRenderPassCreateFlagBits"        name="VK_RENDER_PASS_CREATE_RESERVED_0_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_scalar_block_layout" number="222" depends="VK_KHR_get_physical_device_properties2" type="device" author="EXT" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_2">
+        <extension name="VK_EXT_scalar_block_layout" number="222" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" type="device" author="EXT" contact="Tobias Hector @tobski" supported="vulkan" promotedto="VK_VERSION_1_2">
             <require>
                 <enum value="1"                                             name="VK_EXT_SCALAR_BLOCK_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_scalar_block_layout&quot;"        name="VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME"/>
@@ -18768,7 +20106,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkPipelineShaderStageCreateFlagBits"         name="VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT" alias="VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_fragment_shading_rate" number="227" type="device" depends="(VK_KHR_create_renderpass2,VK_VERSION_1_2)+(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)" author="KHR" contact="Tobias Hector @tobski" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
+        <extension name="VK_KHR_fragment_shading_rate" number="227" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_create_renderpass2),VK_VERSION_1_2" author="KHR" contact="Tobias Hector @tobski" supported="vulkan,vulkansc" ratified="vulkan,vulkansc">
             <require>
                 <enum value="2"                                                 name="VK_KHR_FRAGMENT_SHADING_RATE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_fragment_shading_rate&quot;" name="VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME"/>
@@ -18792,7 +20130,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="22" extends="VkPipelineStageFlagBits"             name="VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
                 <enum bitpos="30" extends="VkFormatFeatureFlagBits"             name="VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
                 <enum bitpos="30" extends="VkFormatFeatureFlagBits2"            name="VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
             </require>
         </extension>
@@ -18812,7 +20150,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_229&quot;"              name="VK_AMD_EXTENSION_229_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_device_coherent_memory" number="230" type="device" author="AMD" contact="Tobias Hector @tobski" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_AMD_device_coherent_memory" number="230" type="device" author="AMD" contact="Tobias Hector @tobski" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_AMD_DEVICE_COHERENT_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_device_coherent_memory&quot;"     name="VK_AMD_DEVICE_COHERENT_MEMORY_EXTENSION_NAME"/>
@@ -18834,10 +20172,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_232&quot;"              name="VK_AMD_EXTENSION_232_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_extension_233" number="233" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+        <extension name="VK_KHR_dynamic_rendering_local_read" number="233" type="device" depends="VK_KHR_dynamic_rendering,VK_VERSION_1_3" author="AMD" contact="Tobias Hector @tobski" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_AMD_EXTENSION_233_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_extension_233&quot;"              name="VK_AMD_EXTENSION_233_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_dynamic_rendering_local_read&quot;" name="VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkImageLayout"                    name="VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR"/>
+                <command name="vkCmdSetRenderingAttachmentLocationsKHR"/>
+                <command name="vkCmdSetRenderingInputAttachmentIndicesKHR"/>
+                <type name="VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR"/>
+                <type name="VkRenderingAttachmentLocationInfoKHR"/>
+                <type name="VkRenderingInputAttachmentIndexInfoKHR"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES_KHR"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR"/>
             </require>
         </extension>
         <extension name="VK_AMD_extension_234" number="234" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
@@ -18854,10 +20201,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_AMD_extension_236" number="236" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
+        <extension name="VK_KHR_shader_quad_control" number="236" type="device" depends="VK_VERSION_1_1+VK_KHR_vulkan_memory_model+VK_KHR_shader_maximal_reconvergence" author="KHR" contact="Tobias Hector @tobski" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_AMD_EXTENSION_236_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_extension_236&quot;"              name="VK_AMD_EXTENSION_236_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_KHR_SHADER_QUAD_CONTROL_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_shader_quad_control&quot;"          name="VK_KHR_SHADER_QUAD_CONTROL_EXTENSION_NAME"/>
+                <type                                                       name="VkPhysicalDeviceShaderQuadControlFeaturesKHR"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR"/>
             </require>
         </extension>
         <extension name="VK_KHR_spirv_1_4" number="237" type="device" depends="VK_VERSION_1_1+VK_KHR_shader_float_controls" author="KHR" contact="Jesse Hall @critsec" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
@@ -18874,7 +20223,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceMemoryBudgetPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_memory_priority" number="239" type="device" depends="VK_KHR_get_physical_device_properties2"  author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_EXT_memory_priority" number="239" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1"  author="EXT" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_MEMORY_PRIORITY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_memory_priority&quot;"            name="VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME"/>
@@ -18892,7 +20241,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSurfaceProtectedCapabilitiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_dedicated_allocation_image_aliasing" number="241" type="device" depends="VK_KHR_dedicated_allocation+VK_KHR_get_physical_device_properties2" author="NVIDIA" contact="Nuno Subtil @nsubtil" supported="vulkan">
+        <extension name="VK_NV_dedicated_allocation_image_aliasing" number="241" type="device" depends="(VK_KHR_dedicated_allocation+VK_KHR_get_physical_device_properties2),VK_VERSION_1_1" author="NVIDIA" contact="Nuno Subtil @nsubtil" supported="vulkan">
             <require>
                 <enum value="1"                                                         name="VK_NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_dedicated_allocation_image_aliasing&quot;"     name="VK_NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_EXTENSION_NAME"/>
@@ -18900,7 +20249,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_separate_depth_stencil_layouts" number="242" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_create_renderpass2" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_separate_depth_stencil_layouts" number="242" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_create_renderpass2),VK_VERSION_1_2" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                                   name="VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_separate_depth_stencil_layouts&quot;"   name="VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME"/>
@@ -18920,7 +20269,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                              name="VK_INTEL_EXTENSION_243_SPEC_VERSION"/>
                 <enum value="&quot;VK_INTEL_extension_243&quot;"             name="VK_INTEL_EXTENSION_243_EXTENSION_NAME"/>
-                <enum bitpos="46" extends="VkAccessFlagBits2"                name="VK_ACCESS_2_RESERVED_46_BIT_EXT"/>
+                <enum bitpos="46" extends="VkAccessFlagBits2"                name="VK_ACCESS_2_RESERVED_46_BIT_INTEL"/>
             </require>
         </extension>
         <extension name="VK_MESA_extension_244" number="244" author="MESA" contact="Andres Rodriguez @lostgoat" supported="disabled">
@@ -18929,7 +20278,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_MESA_extension_244&quot;"              name="VK_MESA_EXTENSION_244_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_buffer_device_address" number="245" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Jeff Bolz @jeffbolznv"  deprecatedby="VK_KHR_buffer_device_address" supported="vulkan">
+        <extension name="VK_EXT_buffer_device_address" number="245" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Jeff Bolz @jeffbolznv"  deprecatedby="VK_KHR_buffer_device_address" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_BUFFER_DEVICE_ADDRESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_buffer_device_address&quot;"      name="VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME"/>
@@ -18976,9 +20325,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkImageStencilUsageCreateInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_validation_features" number="248" type="instance" author="LUNARG" contact="Karl Schultz @karl-lunarg" specialuse="debugging" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_validation_features" number="248" type="instance" author="LUNARG" contact="Karl Schultz @karl-lunarg" specialuse="debugging" supported="vulkan,vulkansc" deprecatedby="VK_EXT_layer_settings">
             <require>
-                <enum value="5"                                             name="VK_EXT_VALIDATION_FEATURES_SPEC_VERSION"/>
+                <enum value="6"                                             name="VK_EXT_VALIDATION_FEATURES_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_validation_features&quot;"        name="VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT"/>
                 <type name="VkValidationFeaturesEXT"/>
@@ -18995,7 +20344,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePresentWaitFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_cooperative_matrix" number="250" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_NV_cooperative_matrix" number="250" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
             <require>
                 <enum value="1"                                              name="VK_NV_COOPERATIVE_MATRIX_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_cooperative_matrix&quot;"           name="VK_NV_COOPERATIVE_MATRIX_EXTENSION_NAME"/>
@@ -19004,13 +20353,28 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="2" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV"/>
                 <type name="VkCooperativeMatrixPropertiesNV"/>
                 <type name="VkScopeNV"/>
+                <enum extends="VkScopeKHR" name="VK_SCOPE_DEVICE_NV"         alias="VK_SCOPE_DEVICE_KHR"/>
+                <enum extends="VkScopeKHR" name="VK_SCOPE_WORKGROUP_NV"      alias="VK_SCOPE_WORKGROUP_KHR"/>
+                <enum extends="VkScopeKHR" name="VK_SCOPE_SUBGROUP_NV"       alias="VK_SCOPE_SUBGROUP_KHR"/>
+                <enum extends="VkScopeKHR" name="VK_SCOPE_QUEUE_FAMILY_NV"   alias="VK_SCOPE_QUEUE_FAMILY_KHR"/>
                 <type name="VkComponentTypeNV"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_FLOAT16_NV"  alias="VK_COMPONENT_TYPE_FLOAT16_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_FLOAT32_NV"  alias="VK_COMPONENT_TYPE_FLOAT32_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_FLOAT64_NV"  alias="VK_COMPONENT_TYPE_FLOAT64_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_SINT8_NV"    alias="VK_COMPONENT_TYPE_SINT8_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_SINT16_NV"   alias="VK_COMPONENT_TYPE_SINT16_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_SINT32_NV"   alias="VK_COMPONENT_TYPE_SINT32_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_SINT64_NV"   alias="VK_COMPONENT_TYPE_SINT64_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_UINT8_NV"    alias="VK_COMPONENT_TYPE_UINT8_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_UINT16_NV"   alias="VK_COMPONENT_TYPE_UINT16_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_UINT32_NV"   alias="VK_COMPONENT_TYPE_UINT32_KHR"/>
+                <enum extends="VkComponentTypeKHR" name="VK_COMPONENT_TYPE_UINT64_NV"   alias="VK_COMPONENT_TYPE_UINT64_KHR"/>
                 <type name="VkPhysicalDeviceCooperativeMatrixFeaturesNV"/>
                 <type name="VkPhysicalDeviceCooperativeMatrixPropertiesNV"/>
                 <command name="vkGetPhysicalDeviceCooperativeMatrixPropertiesNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_coverage_reduction_mode" number="251" depends="VK_NV_framebuffer_mixed_samples+VK_KHR_get_physical_device_properties2" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
+        <extension name="VK_NV_coverage_reduction_mode" number="251" depends="VK_NV_framebuffer_mixed_samples+(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)" type="device" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_COVERAGE_REDUCTION_MODE_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_coverage_reduction_mode&quot;"     name="VK_NV_COVERAGE_REDUCTION_MODE_EXTENSION_NAME"/>
@@ -19041,7 +20405,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceYcbcrImageArraysFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_uniform_buffer_standard_layout" number="254" depends="VK_KHR_get_physical_device_properties2" type="device" author="KHR" contact="Graeme Leese @gnl21" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
+        <extension name="VK_KHR_uniform_buffer_standard_layout" number="254" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" type="device" author="KHR" contact="Graeme Leese @gnl21" supported="vulkan" promotedto="VK_VERSION_1_2" ratified="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_uniform_buffer_standard_layout&quot;" name="VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME"/>
@@ -19049,7 +20413,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES"/>
             </require>
         </extension>
-        <extension name="VK_EXT_provoking_vertex" number="255" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2" contact="Jesse Hall @jessehall" specialuse="glemulation" supported="vulkan">
+        <extension name="VK_EXT_provoking_vertex" number="255" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Jesse Hall @jessehall" specialuse="glemulation" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_PROVOKING_VERTEX_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_provoking_vertex&quot;"           name="VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME"/>
@@ -19062,7 +20426,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkProvokingVertexModeEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_full_screen_exclusive" number="256" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2+VK_KHR_surface+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" platform="win32" contact="James Jones @cubanismo" supported="vulkan">
+        <extension name="VK_EXT_full_screen_exclusive" number="256" type="device" author="EXT" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_surface+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" platform="win32" contact="James Jones @cubanismo" supported="vulkan">
             <require>
                 <enum value="4"                                             name="VK_EXT_FULL_SCREEN_EXCLUSIVE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_full_screen_exclusive&quot;"      name="VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME"/>
@@ -19131,14 +20495,14 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="19" extends="VkImageCreateFlagBits"           name="VK_IMAGE_CREATE_RESERVED_19_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_line_rasterization" number="260" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Jeff Bolz @jeffbolznv" specialuse="cadsupport" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_line_rasterization" number="260" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Jeff Bolz @jeffbolznv" specialuse="cadsupport" supported="vulkan,vulkansc" promotedto="VK_KHR_line_rasterization">
             <require>
                 <enum value="1"                                             name="VK_EXT_LINE_RASTERIZATION_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_line_rasterization&quot;"         name="VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT"/>
-                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT"/>
-                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT"/>
-                <enum offset="0" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_LINE_STIPPLE_EXT"/>
+                <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_KHR"/>
+                <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT" alias="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_KHR"/>
+                <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_KHR"/>
+                <enum extends="VkDynamicState"                              name="VK_DYNAMIC_STATE_LINE_STIPPLE_EXT" alias="VK_DYNAMIC_STATE_LINE_STIPPLE_KHR"/>
                 <type name="VkPhysicalDeviceLineRasterizationFeaturesEXT"/>
                 <type name="VkPhysicalDeviceLineRasterizationPropertiesEXT"/>
                 <type name="VkPipelineRasterizationLineStateCreateInfoEXT"/>
@@ -19154,7 +20518,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderAtomicFloatFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_host_query_reset" number="262" author="EXT" contact="Bas Nieuwenhuizen @BNieuwenhuizen" supported="vulkan" type="device" depends="VK_KHR_get_physical_device_properties2" promotedto="VK_VERSION_1_2">
+        <extension name="VK_EXT_host_query_reset" number="262" author="EXT" contact="Bas Nieuwenhuizen @BNieuwenhuizen" supported="vulkan" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" promotedto="VK_VERSION_1_2">
             <require>
                 <enum value="1"                                             name="VK_EXT_HOST_QUERY_RESET_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_host_query_reset&quot;"           name="VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME"/>
@@ -19181,12 +20545,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_BRCM_extension_265&quot;"             name="VK_BRCM_EXTENSION_265_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_index_type_uint8" number="266" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc">
+        <extension name="VK_EXT_index_type_uint8" number="266" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Piers Daniell @pdaniell-nv" supported="vulkan,vulkansc" promotedto="VK_KHR_index_type_uint8">
             <require>
                 <enum value="1"                                             name="VK_EXT_INDEX_TYPE_UINT8_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_index_type_uint8&quot;"           name="VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT"/>
-                <enum offset="0" extends="VkIndexType"                      name="VK_INDEX_TYPE_UINT8_EXT"/>
+                <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT" alias="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_KHR"/>
+                <enum extends="VkIndexType"                                 name="VK_INDEX_TYPE_UINT8_EXT" alias="VK_INDEX_TYPE_UINT8_KHR"/>
                 <type name="VkPhysicalDeviceIndexTypeUint8FeaturesEXT"/>
             </require>
         </extension>
@@ -19245,7 +20609,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extends="VkResult"       offset="3"       name="VK_OPERATION_NOT_DEFERRED_KHR" />
             </require>
         </extension>
-        <extension name="VK_KHR_pipeline_executable_properties" number="270" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Faith Ekstrand @gfxstrand" specialuse="devtools" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_pipeline_executable_properties" number="270" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Faith Ekstrand @gfxstrand" specialuse="devtools" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                         name="VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_pipeline_executable_properties&quot;"   name="VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME"/>
@@ -19270,12 +20634,42 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPipelineExecutableInternalRepresentationsKHR"/>
             </require>
         </extension>
-        <extension name="VK_INTEL_extension_271" number="271" type="device" author="INTEL" contact="Faith Ekstrand @gfxstrand" supported="disabled">
+        <extension name="VK_EXT_host_image_copy" number="271" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_copy_commands2+VK_KHR_format_feature_flags2),VK_VERSION_1_3" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_INTEL_EXTENSION_271_SPEC_VERSION"/>
-                <enum value="&quot;VK_INTEL_extension_271&quot;"            name="VK_INTEL_EXTENSION_271_EXTENSION_NAME"/>
-                <enum bitpos="22" extends="VkImageUsageFlagBits"            name="VK_IMAGE_USAGE_RESERVED_22_BIT_EXT"/>
-                <enum bitpos="46" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_RESERVED_46_BIT_EXT"/>
+                <enum value="1"                                         name="VK_EXT_HOST_IMAGE_COPY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_host_image_copy&quot;"        name="VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME"/>
+                <enum offset="0"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT"/>
+                <enum offset="1"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT"/>
+                <enum offset="2"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT"/>
+                <enum offset="3"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_IMAGE_TO_MEMORY_COPY_EXT"/>
+                <enum offset="4"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_COPY_IMAGE_TO_MEMORY_INFO_EXT"/>
+                <enum offset="5"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT"/>
+                <enum offset="6"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT"/>
+                <enum offset="7"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_COPY_IMAGE_TO_IMAGE_INFO_EXT"/>
+                <enum offset="8"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_SUBRESOURCE_HOST_MEMCPY_SIZE_EXT"/>
+                <enum offset="9"  extends="VkStructureType"             name="VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT"/>
+                <enum bitpos="22" extends="VkImageUsageFlagBits"        name="VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT"               comment="Can be used with host image copies"/>
+                <enum bitpos="46" extends="VkFormatFeatureFlagBits2"    name="VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT"    comment="Host image copies are supported"/>
+                <type name="VkPhysicalDeviceHostImageCopyFeaturesEXT"/>
+                <type name="VkPhysicalDeviceHostImageCopyPropertiesEXT"/>
+                <type name="VkHostImageCopyFlagBitsEXT"/>
+                <type name="VkHostImageCopyFlagsEXT"/>
+                <type name="VkMemoryToImageCopyEXT"/>
+                <type name="VkImageToMemoryCopyEXT"/>
+                <type name="VkCopyMemoryToImageInfoEXT"/>
+                <type name="VkCopyImageToMemoryInfoEXT"/>
+                <type name="VkCopyImageToImageInfoEXT"/>
+                <type name="VkHostImageLayoutTransitionInfoEXT"/>
+                <type name="VkSubresourceHostMemcpySizeEXT"/>
+                <type name="VkHostImageCopyDevicePerformanceQueryEXT"/>
+                <command name="vkCopyMemoryToImageEXT"/>
+                <command name="vkCopyImageToMemoryEXT"/>
+                <command name="vkCopyImageToImageEXT"/>
+                <command name="vkTransitionImageLayoutEXT"/>
+
+                <type name="VkSubresourceLayout2EXT"/>
+                <type name="VkImageSubresource2EXT"/>
+                <command name="vkGetImageSubresourceLayout2EXT" comment="Taken from VK_EXT_image_compression_control. VkStructureType enums defined in that extension"/>
             </require>
         </extension>
         <extension name="VK_KHR_map_memory2" number="272" type="device" author="KHR" contact="Faith Ekstrand @gfxstrand" supported="vulkan" ratified="vulkan">
@@ -19286,15 +20680,24 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="1" extends="VkStructureType"    name="VK_STRUCTURE_TYPE_MEMORY_UNMAP_INFO_KHR"/>
                 <type name="VkMemoryMapInfoKHR"/>
                 <type name="VkMemoryUnmapInfoKHR"/>
+                <type name="VkMemoryUnmapFlagBitsKHR"/>
                 <type name="VkMemoryUnmapFlagsKHR"/>
                 <command name="vkMapMemory2KHR"/>
                 <command name="vkUnmapMemory2KHR"/>
             </require>
         </extension>
-        <extension name="VK_INTEL_extension_273" number="273" type="device" author="INTEL" contact="Faith Ekstrand @gfxstrand" supported="disabled">
+        <extension name="VK_EXT_map_memory_placed" number="273" type="device" depends="VK_KHR_map_memory2" author="EXT" contact="Faith Ekstrand @gfxstrand" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_INTEL_EXTENSION_273_SPEC_VERSION"/>
-                <enum value="&quot;VK_INTEL_extension_273&quot;"            name="VK_INTEL_EXTENSION_273_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_EXT_MAP_MEMORY_PLACED_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_map_memory_placed&quot;"      name="VK_EXT_MAP_MEMORY_PLACED_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_FEATURES_EXT"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_PROPERTIES_EXT"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MEMORY_MAP_PLACED_INFO_EXT"/>
+                <enum bitpos="0" extends="VkMemoryMapFlagBits"          name="VK_MEMORY_MAP_PLACED_BIT_EXT"/>
+                <enum bitpos="0" extends="VkMemoryUnmapFlagBitsKHR"     name="VK_MEMORY_UNMAP_RESERVE_BIT_EXT"/>
+                <type name="VkPhysicalDeviceMapMemoryPlacedFeaturesEXT"/>
+                <type name="VkPhysicalDeviceMapMemoryPlacedPropertiesEXT"/>
+                <type name="VkMemoryMapPlacedInfoEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_shader_atomic_float2" number="274" type="device" depends="VK_EXT_shader_atomic_float" author="EXT" contact="Faith Ekstrand @gfxstrand" supported="vulkan">
@@ -19321,7 +20724,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSurfacePresentModeCompatibilityEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_swapchain_maintenance1" number="276" type="device" depends="VK_KHR_swapchain+VK_EXT_surface_maintenance1+VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
+        <extension name="VK_EXT_swapchain_maintenance1" number="276" type="device" depends="VK_KHR_swapchain+VK_EXT_surface_maintenance1+(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_SWAPCHAIN_MAINTENANCE_1_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_swapchain_maintenance1&quot;"     name="VK_EXT_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME"/>
@@ -19349,7 +20752,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_device_generated_commands" number="278" type="device" depends="VK_VERSION_1_1+VK_KHR_buffer_device_address" author="NV" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
+        <extension name="VK_NV_device_generated_commands" number="278" type="device" depends="(VK_VERSION_1_1+VK_KHR_buffer_device_address),VK_VERSION_1_2" author="NV" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
             <require>
                 <comment>
                     This extension requires buffer_device_address functionality.
@@ -19397,7 +20800,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkDestroyIndirectCommandsLayoutNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_inherited_viewport_scissor" number="279" type="device" author="NV" contact="David Zhao Akeley @akeley98" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_NV_inherited_viewport_scissor" number="279" type="device" author="NV" contact="David Zhao Akeley @akeley98" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_INHERITED_VIEWPORT_SCISSOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_inherited_viewport_scissor&quot;"  name="VK_NV_INHERITED_VIEWPORT_SCISSOR_EXTENSION_NAME"/>
@@ -19407,13 +20810,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkCommandBufferInheritanceViewportScissorInfoNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_280" number="280" type="device" author="KHR" contact="Kevin Petit @kevinpetit" supported="disabled">
+        <extension name="VK_KHR_extension_280" number="280" type="device" author="KHR" contact="Kevin Petit @kpet" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_KHR_EXTENSION_280_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_extension_280&quot;"              name="VK_KHR_EXTENSION_280_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_shader_integer_dot_product" number="281" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2" contact="Kevin Petit @kevinpetit" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
+        <extension name="VK_KHR_shader_integer_dot_product" number="281" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Kevin Petit @kpet" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="1"                                             name="VK_KHR_SHADER_INTEGER_DOT_PRODUCT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_shader_integer_dot_product&quot;" name="VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME"/>
@@ -19433,9 +20836,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_render_pass_transform" number="283" type="device" depends="VK_KHR_swapchain+VK_KHR_surface" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_render_pass_transform" number="283" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
-                <enum value="3"                                             name="VK_QCOM_RENDER_PASS_TRANSFORM_SPEC_VERSION"/>
+                <enum value="4"                                             name="VK_QCOM_RENDER_PASS_TRANSFORM_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_render_pass_transform&quot;"     name="VK_QCOM_RENDER_PASS_TRANSFORM_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM"/>
@@ -19444,13 +20847,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkCommandBufferInheritanceRenderPassTransformInfoQCOM"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_284" number="284" type="device" author="EXT" contact="Samuel Pitoiset @hakzsam" supported="disabled">
+        <extension name="VK_EXT_depth_bias_control" number="284" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Joshua Ashton @Joshua-Ashton" specialuse="d3demulation" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_284_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_284&quot;"              name="VK_EXT_EXTENSION_284_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_EXT_DEPTH_BIAS_CONTROL_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_depth_bias_control&quot;"         name="VK_EXT_DEPTH_BIAS_CONTROL_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEPTH_BIAS_INFO_EXT"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT"/>
+                <type name="VkPhysicalDeviceDepthBiasControlFeaturesEXT"/>
+                <type name="VkDepthBiasInfoEXT"/>
+                <type name="VkDepthBiasRepresentationEXT"/>
+                <type name="VkDepthBiasRepresentationInfoEXT"/>
+                <command name="vkCmdSetDepthBias2EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_device_memory_report" number="285" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Yiwei Zhang @zhangyiwei" specialuse="devtools" supported="vulkan">
+        <extension name="VK_EXT_device_memory_report" number="285" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Yiwei Zhang @zhangyiwei" specialuse="devtools" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_DEVICE_MEMORY_REPORT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_device_memory_report&quot;"       name="VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME"/>
@@ -19559,7 +20970,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_NV_extension_292&quot;"               name="VK_NV_EXTENSION_292_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_present_barrier" number="293" type="device" author="NV" depends="VK_KHR_get_physical_device_properties2+VK_KHR_surface+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" contact="Liya Li @liyli" supported="vulkan">
+        <extension name="VK_NV_present_barrier" number="293" type="device" author="NV" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_surface+VK_KHR_get_surface_capabilities2+VK_KHR_swapchain" contact="Liya Li @liyli" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_PRESENT_BARRIER_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_present_barrier&quot;"             name="VK_NV_PRESENT_BARRIER_EXTENSION_NAME"/>
@@ -19577,7 +20988,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_shader_non_semantic_info&quot;"   name="VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_present_id" number="295" type="device" depends="VK_KHR_swapchain+VK_KHR_get_physical_device_properties2" author="KHR" contact="Keith Packard @keithp" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_present_id" number="295" type="device" depends="VK_KHR_swapchain+VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Keith Packard @keithp" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                         name="VK_KHR_PRESENT_ID_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_present_id&quot;"             name="VK_KHR_PRESENT_ID_EXTENSION_NAME"/>
@@ -19587,7 +20998,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePresentIdFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_private_data" number="296" type="device" author="NV" contact="Matthew Rusch @mattruschnv" supported="vulkan" depends="VK_KHR_get_physical_device_properties2" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_private_data" number="296" type="device" author="NV" contact="Matthew Rusch @mattruschnv" supported="vulkan" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="1"                                             name="VK_EXT_PRIVATE_DATA_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_private_data&quot;"               name="VK_EXT_PRIVATE_DATA_EXTENSION_NAME"/>
@@ -19613,7 +21024,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="3" extends="VkPipelineShaderStageCreateFlagBits"  name="VK_PIPELINE_SHADER_STAGE_CREATE_RESERVED_3_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pipeline_creation_cache_control" number="298" type="device" author="AMD" contact="Gregory Grebe @grgrebe_amd" depends="VK_KHR_get_physical_device_properties2" supported="vulkan" promotedto="VK_VERSION_1_3">
+        <extension name="VK_EXT_pipeline_creation_cache_control" number="298" type="device" author="AMD" contact="Gregory Grebe @grgrebe_amd" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan" promotedto="VK_VERSION_1_3">
             <require>
                 <enum value="3"                                             name="VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pipeline_creation_cache_control&quot;"    name="VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME"/>
@@ -19633,36 +21044,43 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_299&quot;"          name="VK_KHR_EXTENSION_299_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_video_encode_queue" number="300"  type="device" depends="VK_KHR_video_queue+VK_KHR_synchronization2" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" provisional="true" platform="provisional" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_video_encode_queue" number="300"  type="device" depends="VK_KHR_video_queue+(VK_KHR_synchronization2,VK_VERSION_1_3)" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="8"                                         name="VK_KHR_VIDEO_ENCODE_QUEUE_SPEC_VERSION"/>
+                <enum value="12"                                        name="VK_KHR_VIDEO_ENCODE_QUEUE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_video_encode_queue&quot;"     name="VK_KHR_VIDEO_ENCODE_QUEUE_EXTENSION_NAME"/>
                 <!-- VkPipelineStageFlagBits bitpos="27" is reserved by this extension, but not used -->
-                <enum bitpos="27" extends="VkPipelineStageFlagBits2"    name="VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS" />
-                <enum bitpos="37" extends="VkAccessFlagBits2"           name="VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS" />
-                <enum bitpos="38" extends="VkAccessFlagBits2"           name="VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="6" extends="VkQueueFlagBits"              name="VK_QUEUE_VIDEO_ENCODE_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="1" extends="VkVideoCodingControlFlagBitsKHR" name="VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="2" extends="VkVideoCodingControlFlagBitsKHR" name="VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_LAYER_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="15" extends="VkBufferUsageFlagBits"       name="VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="16" extends="VkBufferUsageFlagBits"       name="VK_BUFFER_USAGE_VIDEO_ENCODE_SRC_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="13" extends="VkImageUsageFlagBits"        name="VK_IMAGE_USAGE_VIDEO_ENCODE_DST_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="14" extends="VkImageUsageFlagBits"        name="VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="15" extends="VkImageUsageFlagBits"        name="VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="27" extends="VkFormatFeatureFlagBits"     name="VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="28" extends="VkFormatFeatureFlagBits"     name="VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="0" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_DST_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="1" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="2" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_DPB_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum offset="0" extends="VkQueryType"                  name="VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum bitpos="27" extends="VkPipelineStageFlagBits2"    name="VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"/>
+                <enum bitpos="37" extends="VkAccessFlagBits2"           name="VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR"/>
+                <enum bitpos="38" extends="VkAccessFlagBits2"           name="VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR"/>
+                <enum offset="6" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR"/>
+                <enum offset="7" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_PROPERTIES_KHR"/>
+                <enum offset="8" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR"/>
+                <enum offset="9" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_GET_INFO_KHR"/>
+                <enum offset="10" extends="VkStructureType"             name="VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_FEEDBACK_INFO_KHR"/>
+                <enum bitpos="6" extends="VkQueueFlagBits"              name="VK_QUEUE_VIDEO_ENCODE_BIT_KHR"/>
+                <enum bitpos="1" extends="VkVideoCodingControlFlagBitsKHR" name="VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR"/>
+                <enum bitpos="2" extends="VkVideoCodingControlFlagBitsKHR" name="VK_VIDEO_CODING_CONTROL_ENCODE_QUALITY_LEVEL_BIT_KHR"/>
+                <enum bitpos="15" extends="VkBufferUsageFlagBits"       name="VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR"/>
+                <enum bitpos="16" extends="VkBufferUsageFlagBits"       name="VK_BUFFER_USAGE_VIDEO_ENCODE_SRC_BIT_KHR"/>
+                <enum bitpos="13" extends="VkImageUsageFlagBits"        name="VK_IMAGE_USAGE_VIDEO_ENCODE_DST_BIT_KHR"/>
+                <enum bitpos="14" extends="VkImageUsageFlagBits"        name="VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR"/>
+                <enum bitpos="15" extends="VkImageUsageFlagBits"        name="VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR"/>
+                <enum bitpos="27" extends="VkFormatFeatureFlagBits"     name="VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR"/>
+                <enum bitpos="28" extends="VkFormatFeatureFlagBits"     name="VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR"/>
+                <enum bitpos="1" extends="VkVideoSessionCreateFlagBitsKHR" name="VK_VIDEO_SESSION_CREATE_ALLOW_ENCODE_PARAMETER_OPTIMIZATIONS_BIT_KHR"/>
+                <enum offset="0" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_DST_KHR"/>
+                <enum offset="1" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR"/>
+                <enum offset="2" extends="VkImageLayout"                name="VK_IMAGE_LAYOUT_VIDEO_ENCODE_DPB_KHR"/>
+                <enum offset="0" extends="VkQueryType"                  name="VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR"/>
+                <enum offset="0" extends="VkQueryResultStatusKHR" dir="-" name="VK_QUERY_RESULT_STATUS_INSUFFICIENT_BITSTREAM_BUFFER_RANGE_KHR"/>
 
-                <enum offset="0" extends="VkResult" dir="-"             name="VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+                <enum offset="0" extends="VkResult" dir="-"             name="VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR"/>
 
                 <type name="VkVideoEncodeFlagsKHR"/>
                 <type name="VkVideoEncodeInfoKHR"/>
@@ -19688,14 +21106,23 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkVideoEncodeRateControlInfoKHR"/>
                 <type name="VkVideoEncodeRateControlLayerInfoKHR"/>
 
+                <type name="VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR"/>
+                <type name="VkVideoEncodeQualityLevelPropertiesKHR"/>
+                <type name="VkVideoEncodeQualityLevelInfoKHR"/>
+
+                <type name="VkVideoEncodeSessionParametersGetInfoKHR"/>
+                <type name="VkVideoEncodeSessionParametersFeedbackInfoKHR"/>
+
+                <command name="vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR"/>
+                <command name="vkGetEncodedVideoSessionParametersKHR"/>
                 <command name="vkCmdEncodeVideoKHR"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
-                <enum bitpos="27" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
-                <enum bitpos="28" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR" protect="VK_ENABLE_BETA_EXTENSIONS"/>
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
+                <enum bitpos="27" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR"/>
+                <enum bitpos="28" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_NV_device_diagnostics_config" number="301" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
+        <extension name="VK_NV_device_diagnostics_config" number="301" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Kedarnath Thangudu @kthangudu" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_NV_DEVICE_DIAGNOSTICS_CONFIG_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_device_diagnostics_config&quot;"   name="VK_NV_DEVICE_DIAGNOSTICS_CONFIG_EXTENSION_NAME"/>
@@ -19707,47 +21134,71 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkDeviceDiagnosticsConfigFlagBitsNV"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_render_pass_store_ops" number="302" type="device" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="vulkan">
+        <extension name="VK_QCOM_render_pass_store_ops" number="302" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_QCOM_RENDER_PASS_STORE_OPS_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_render_pass_store_ops&quot;"     name="VK_QCOM_RENDER_PASS_STORE_OPS_EXTENSION_NAME"/>
                 <enum extends="VkAttachmentStoreOp"                         name="VK_ATTACHMENT_STORE_OP_NONE_QCOM" alias="VK_ATTACHMENT_STORE_OP_NONE"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_303" number="303" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="disabled">
+        <extension name="VK_QCOM_extension_303" number="303" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_QCOM_EXTENSION_303_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_303&quot;"             name="VK_QCOM_EXTENSION_303_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_304" number="304" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="disabled">
+        <extension name="VK_QCOM_extension_304" number="304" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_QCOM_EXTENSION_304_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_304&quot;"             name="VK_QCOM_EXTENSION_304_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_305" number="305" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="disabled">
+        <extension name="VK_QCOM_extension_305" number="305" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_QCOM_EXTENSION_305_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_305&quot;"             name="VK_QCOM_EXTENSION_305_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_306" number="306" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="disabled">
+        <extension name="VK_QCOM_extension_306" number="306" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_QCOM_EXTENSION_306_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_306&quot;"             name="VK_QCOM_EXTENSION_306_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_307" number="307" author="QCOM" contact="Bill Licea-Kane @wwlk" supported="disabled">
+        <extension name="VK_QCOM_extension_307" number="307" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_QCOM_EXTENSION_307_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_307&quot;"             name="VK_QCOM_EXTENSION_307_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_308" number="308" type="device" author="NV" contact="Tristan Lorach @tlorach" supported="disabled">
+        <extension name="VK_NV_cuda_kernel_launch" number="308" type="device" author="NV" contact="Tristan Lorach @tlorach" supported="vulkan" provisional="true">
             <require>
-                <enum value="0"                                             name="VK_NV_EXTENSION_308_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_308&quot;"               name="VK_NV_EXTENSION_308_EXTENSION_NAME"/>
+                <enum value="2"                                             name="VK_NV_CUDA_KERNEL_LAUNCH_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_cuda_kernel_launch&quot;"          name="VK_NV_CUDA_KERNEL_LAUNCH_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_CUDA_MODULE_CREATE_INFO_NV"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_CUDA_FUNCTION_CREATE_INFO_NV"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_CUDA_LAUNCH_INFO_NV"/>
+                <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV"/>
+                <enum offset="4" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV"/>
+                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_CUDA_MODULE_NV"/>
+                <enum offset="1" extends="VkObjectType"                     name="VK_OBJECT_TYPE_CUDA_FUNCTION_NV"/>
+                <type name="VkCudaModuleNV"/>
+                <type name="VkCudaFunctionNV"/>
+                <type name="VkCudaModuleCreateInfoNV"/>
+                <type name="VkCudaFunctionCreateInfoNV"/>
+                <type name="VkCudaLaunchInfoNV"/>
+                <type name="VkPhysicalDeviceCudaKernelLaunchFeaturesNV"/>
+                <type name="VkPhysicalDeviceCudaKernelLaunchPropertiesNV"/>
+                <command name="vkCreateCudaModuleNV"/>
+                <command name="vkGetCudaModuleCacheNV"/>
+                <command name="vkCreateCudaFunctionNV"/>
+                <command name="vkDestroyCudaModuleNV"/>
+                <command name="vkDestroyCudaFunctionNV"/>
+                <command name="vkCmdCudaLaunchKernelNV"/>
+            </require>
+            <require depends="VK_EXT_debug_report">
+                <enum offset="0" extends="VkDebugReportObjectTypeEXT"       name="VK_DEBUG_REPORT_OBJECT_TYPE_CUDA_MODULE_NV_EXT"/>
+                <enum offset="1" extends="VkDebugReportObjectTypeEXT"       name="VK_DEBUG_REPORT_OBJECT_TYPE_CUDA_FUNCTION_NV_EXT"/>
             </require>
         </extension>
         <extension name="VK_KHR_object_refresh" number="309" type="device" author="KHR" contact="Aidan Fabius @afabius" supported="vulkansc" ratified="vulkansc">
@@ -19763,11 +21214,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceRefreshableObjectTypesKHR"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_310" number="310" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+        <extension name="VK_QCOM_extension_310" number="310" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_QCOM_EXTENSION_310_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_310&quot;"             name="VK_QCOM_EXTENSION_310_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_RESERVED_QCOM"/>
+                <enum bitpos="27" extends="VkBufferUsageFlagBits"           name="VK_BUFFER_USAGE_RESERVED_27_BIT_QCOM"/>
+                <enum bitpos="27" extends="VkBufferUsageFlagBits2KHR"       name="VK_BUFFER_USAGE_2_RESERVED_27_BIT_QCOM"/>
+                <enum bitpos="51" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_RESERVED_51_BIT_QCOM"/>
+                <enum bitpos="52" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_RESERVED_52_BIT_QCOM"/>
+                <enum bitpos="53" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_RESERVED_53_BIT_QCOM"/>
+                <enum bitpos="54" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_RESERVED_54_BIT_QCOM"/>
             </require>
         </extension>
         <extension name="VK_NV_low_latency" number="311" author="NV" type="device" supported="vulkan" contact="Charles Hansen @cshansen" >
@@ -19937,7 +21393,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_316&quot;"              name="VK_AMD_EXTENSION_316_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_descriptor_buffer" number="317" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2+VK_KHR_buffer_device_address+VK_KHR_synchronization2+VK_EXT_descriptor_indexing" contact="Tobias Hector @tobski" supported="vulkan">
+        <extension name="VK_EXT_descriptor_buffer" number="317" type="device" author="EXT" depends="((((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_buffer_device_address+VK_EXT_descriptor_indexing),VK_VERSION_1_2)+VK_KHR_synchronization2),VK_VERSION_1_3" contact="Tobias Hector @tobski" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_DESCRIPTOR_BUFFER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_descriptor_buffer&quot;"              name="VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME"/>
@@ -20015,7 +21471,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_320&quot;"              name="VK_AMD_EXTENSION_320_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_graphics_pipeline_library" number="321" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_pipeline_library" author="AMD" contact="Tobias Hector @tobski" supported="vulkan">
+        <extension name="VK_EXT_graphics_pipeline_library" number="321" type="device" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_pipeline_library" author="AMD" contact="Tobias Hector @tobski" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_GRAPHICS_PIPELINE_LIBRARY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_graphics_pipeline_library&quot;"  name="VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME"/>
@@ -20033,7 +21489,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="1" extends="VkPipelineLayoutCreateFlagBits" name="VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_AMD_shader_early_and_late_fragment_tests" number="322" author="EXT" contact="Tobias Hector @tobski" type="device" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_AMD_shader_early_and_late_fragment_tests" number="322" author="EXT" contact="Tobias Hector @tobski" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_early_and_late_fragment_tests&quot;" name="VK_AMD_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_EXTENSION_NAME"/>
@@ -20041,7 +21497,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD"/>
             </require>
         </extension>
-        <extension name="VK_KHR_fragment_shader_barycentric" number="323" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Stu Smith" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_fragment_shader_barycentric" number="323" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Stu Smith" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                              name="VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_fragment_shader_barycentric&quot;" name="VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME"/>
@@ -20065,7 +21521,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_325&quot;"              name="VK_KHR_EXTENSION_325_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_zero_initialize_workgroup_memory" number="326" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Alan Baker @alan-baker" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
+        <extension name="VK_KHR_zero_initialize_workgroup_memory" number="326" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Alan Baker @alan-baker" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="1"                                                   name="VK_KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_zero_initialize_workgroup_memory&quot;" name="VK_KHR_ZERO_INITIALIZE_WORKGROUP_MEMORY_EXTENSION_NAME"/>
@@ -20175,9 +21631,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceFragmentDensityMap2PropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_rotated_copy_commands" number="334" type="device" depends="VK_KHR_swapchain+VK_KHR_copy_commands2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_rotated_copy_commands" number="334" type="device" depends="VK_KHR_copy_commands2,VK_VERSION_1_3" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
-                <enum value="1"                                             name="VK_QCOM_ROTATED_COPY_COMMANDS_SPEC_VERSION"/>
+                <enum value="2"                                             name="VK_QCOM_ROTATED_COPY_COMMANDS_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_rotated_copy_commands&quot;"     name="VK_QCOM_ROTATED_COPY_COMMANDS_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_COPY_COMMAND_TRANSFORM_INFO_QCOM"/>
                 <type name="VkCopyCommandTransformInfoQCOM"/>
@@ -20197,7 +21653,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceImageRobustnessFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_KHR_workgroup_memory_explicit_layout" number="337" type="device" depends="VK_KHR_get_physical_device_properties2" author="KHR" contact="Caio Marcelo de Oliveira Filho @cmarcelo" supported="vulkan" ratified="vulkan">
+        <extension name="VK_KHR_workgroup_memory_explicit_layout" number="337" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Caio Marcelo de Oliveira Filho @cmarcelo" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                                      name="VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_workgroup_memory_explicit_layout&quot;"    name="VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_EXTENSION_NAME"/>
@@ -20239,7 +21695,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdResolveImage2KHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_compression_control" number="339" type="device" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_EXT_image_compression_control" number="339" type="device" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_COMPRESSION_CONTROL_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_compression_control&quot;"  name="VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME"/>
@@ -20247,9 +21703,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceImageCompressionControlFeaturesEXT"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_CONTROL_EXT"/>
                 <type name="VkImageCompressionControlEXT"/>
-                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_EXT"/>
+                <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_EXT" alias="VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR"/>
                 <type name="VkSubresourceLayout2EXT"/>
-                <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_EXT"/>
+                <enum extends="VkStructureType"                             name="VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_EXT" alias="VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR"/>
                 <type name="VkImageSubresource2EXT"/>
                 <enum offset="4" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT"/>
                 <type name="VkImageCompressionPropertiesEXT"/>
@@ -20261,7 +21717,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetImageSubresourceLayout2EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_attachment_feedback_loop_layout" number="340" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan">
+        <extension name="VK_EXT_attachment_feedback_loop_layout" number="340" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="2"                                                    name="VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_attachment_feedback_loop_layout&quot;"   name="VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME"/>
@@ -20289,7 +21745,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevice4444FormatsFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_device_fault" number="342" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Ralph Potter gitlab:@r_potter" supported="vulkan">
+        <extension name="VK_EXT_device_fault" number="342" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Ralph Potter gitlab:@r_potter" supported="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_DEVICE_FAULT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_device_fault&quot;"               name="VK_EXT_DEVICE_FAULT_EXTENSION_NAME"/>
@@ -20307,7 +21763,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDeviceFaultInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_ARM_rasterization_order_attachment_access" number="343" type="device" depends="VK_KHR_get_physical_device_properties2" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" promotedto="VK_EXT_rasterization_order_attachment_access">
+        <extension name="VK_ARM_rasterization_order_attachment_access" number="343" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan" promotedto="VK_EXT_rasterization_order_attachment_access">
             <require>
                 <enum value="1"                                                        name="VK_ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_ARM_rasterization_order_attachment_access&quot;" name="VK_ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXTENSION_NAME"/>
@@ -20327,7 +21783,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_ARM_extension_344&quot;"              name="VK_ARM_EXTENSION_344_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_rgba10x6_formats" number="345" type="device" depends="VK_KHR_sampler_ycbcr_conversion" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
+        <extension name="VK_EXT_rgba10x6_formats" number="345" type="device" depends="VK_KHR_sampler_ycbcr_conversion,VK_VERSION_1_1" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
              <require>
                     <enum value="1"                                                name="VK_EXT_RGBA10X6_FORMATS_SPEC_VERSION"/>
                     <enum value="&quot;VK_EXT_rgba10x6_formats&quot;"              name="VK_EXT_RGBA10X6_FORMATS_EXTENSION_NAME"/>
@@ -20394,7 +21850,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetVertexInputEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_physical_device_drm" number="354" author="EXT" type="device" contact="Simon Ser @emersion" supported="vulkan" depends="VK_KHR_get_physical_device_properties2">
+        <extension name="VK_EXT_physical_device_drm" number="354" author="EXT" type="device" contact="Simon Ser @emersion" supported="vulkan" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1">
             <require>
                 <enum value="1"                                             name="VK_EXT_PHYSICAL_DEVICE_DRM_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_physical_device_drm&quot;"        name="VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME"/>
@@ -20404,7 +21860,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceDrmPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_device_address_binding_report" number="355" type="device" depends="VK_KHR_get_physical_device_properties2+VK_EXT_debug_utils" author="EXT" contact="Ralph Potter gitlab:@r_potter" specialuse="debugging,devtools" supported="vulkan">
+        <extension name="VK_EXT_device_address_binding_report" number="355" type="device" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_EXT_debug_utils" author="EXT" contact="Ralph Potter gitlab:@r_potter" specialuse="debugging,devtools" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_DEVICE_ADDRESS_BINDING_REPORT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_device_address_binding_report&quot;"  name="VK_EXT_DEVICE_ADDRESS_BINDING_REPORT_EXTENSION_NAME"/>
@@ -20418,7 +21874,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkDeviceAddressBindingTypeEXT" />
             </require>
         </extension>
-        <extension name="VK_EXT_depth_clip_control" number="356" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
+        <extension name="VK_EXT_depth_clip_control" number="356" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
             <require>
                 <enum value="1"                                             name="VK_EXT_DEPTH_CLIP_CONTROL_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_depth_clip_control&quot;"         name="VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME"/>
@@ -20428,7 +21884,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPipelineViewportDepthClipControlCreateInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_primitive_topology_list_restart" number="357" type="device" author="EXT" contact="Shahbaz Youssefi @syoussefi" depends="VK_KHR_get_physical_device_properties2" supported="vulkan" specialuse="glemulation">
+        <extension name="VK_EXT_primitive_topology_list_restart" number="357" type="device" author="EXT" contact="Shahbaz Youssefi @syoussefi" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan" specialuse="glemulation">
             <require>
                 <enum value="1"                                             name="VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_primitive_topology_list_restart&quot;"           name="VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME"/>
@@ -20454,7 +21910,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_360&quot;"              name="VK_EXT_EXTENSION_360_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_format_feature_flags2" number="361" author="KHR" type="device" depends="VK_KHR_get_physical_device_properties2" contact="Lionel Landwerlin @llandwerlin" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
+        <extension name="VK_KHR_format_feature_flags2" number="361" author="KHR" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Lionel Landwerlin @llandwerlin" supported="vulkan" promotedto="VK_VERSION_1_3" ratified="vulkan">
             <require>
                 <enum value="2"                                             name="VK_KHR_FORMAT_FEATURE_FLAGS_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_format_feature_flags2&quot;"      name="VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME"/>
@@ -20482,7 +21938,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_FUCHSIA_extension_364&quot;"          name="VK_FUCHSIA_EXTENSION_364_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_FUCHSIA_external_memory" number="365" type="device" depends="VK_KHR_external_memory_capabilities+VK_KHR_external_memory" author="FUCHSIA" contact="John Rosasco @rosasco" platform="fuchsia" supported="vulkan">
+        <extension name="VK_FUCHSIA_external_memory" number="365" type="device" depends="(VK_KHR_external_memory_capabilities+VK_KHR_external_memory),VK_VERSION_1_1" author="FUCHSIA" contact="John Rosasco @rosasco" platform="fuchsia" supported="vulkan">
             <require>
                 <enum value="1"                                                name="VK_FUCHSIA_EXTERNAL_MEMORY_SPEC_VERSION"/>
                 <enum value="&quot;VK_FUCHSIA_external_memory&quot;"           name="VK_FUCHSIA_EXTERNAL_MEMORY_EXTENSION_NAME"/>
@@ -20510,13 +21966,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetSemaphoreZirconHandleFUCHSIA"/>
             </require>
         </extension>
-        <extension name="VK_FUCHSIA_buffer_collection" number="367" type="device" depends="VK_FUCHSIA_external_memory+VK_KHR_sampler_ycbcr_conversion" author="FUCHSIA" contact="John Rosasco @rosasco" supported="vulkan" platform="fuchsia">
+        <extension name="VK_FUCHSIA_buffer_collection" number="367" type="device" depends="VK_FUCHSIA_external_memory+(VK_KHR_sampler_ycbcr_conversion,VK_VERSION_1_1)" author="FUCHSIA" contact="John Rosasco @rosasco" supported="vulkan" platform="fuchsia">
             <require>
                 <enum value="2"                                         name="VK_FUCHSIA_BUFFER_COLLECTION_SPEC_VERSION"/>
                 <enum value="&quot;VK_FUCHSIA_buffer_collection&quot;"  name="VK_FUCHSIA_BUFFER_COLLECTION_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BUFFER_COLLECTION_CREATE_INFO_FUCHSIA"/>
                 <enum offset="0" extends="VkObjectType"                 name="VK_OBJECT_TYPE_BUFFER_COLLECTION_FUCHSIA" comment="VkBufferCollectionFUCHSIA"/>
-                <enum offset="0" extends="VkDebugReportObjectTypeEXT"   name="VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_COLLECTION_FUCHSIA_EXT"/>
                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMPORT_MEMORY_BUFFER_COLLECTION_FUCHSIA"/>
                 <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BUFFER_COLLECTION_IMAGE_CREATE_INFO_FUCHSIA"/>
                 <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BUFFER_COLLECTION_PROPERTIES_FUCHSIA"/>
@@ -20546,6 +22001,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkDestroyBufferCollectionFUCHSIA"/>
                 <command name="vkGetBufferCollectionPropertiesFUCHSIA"/>
             </require>
+            <require depends="VK_EXT_debug_report">
+                <enum offset="0" extends="VkDebugReportObjectTypeEXT"   name="VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_COLLECTION_FUCHSIA_EXT"/>
+            </require>
         </extension>
         <extension name="VK_FUCHSIA_extension_368" number="368" author="FUCHSIA" contact="Craig Stout @cdotstout" supported="disabled">
             <require>
@@ -20560,15 +22018,16 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="4" extends="VkDescriptorBindingFlagBits"  name="VK_DESCRIPTOR_BINDING_RESERVED_4_BIT_QCOM"/>
             </require>
         </extension>
-        <extension name="VK_HUAWEI_subpass_shading" number="370" type="device" author="HUAWEI" contact="Pan Gao @PanGao-h" depends="VK_KHR_create_renderpass2+VK_KHR_synchronization2" supported="vulkan">
+        <extension name="VK_HUAWEI_subpass_shading" number="370" type="device" author="HUAWEI" contact="Pan Gao @PanGao-h" depends="((VK_KHR_create_renderpass2,VK_VERSION_1_2)+VK_KHR_synchronization2),VK_VERSION_1_3" supported="vulkan">
             <require>
-                <enum value="2"                                         name="VK_HUAWEI_SUBPASS_SHADING_SPEC_VERSION"/>
+                <enum value="3"                                         name="VK_HUAWEI_SUBPASS_SHADING_SPEC_VERSION"/>
                 <enum value="&quot;VK_HUAWEI_subpass_shading&quot;"         name="VK_HUAWEI_SUBPASS_SHADING_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SUBPASS_SHADING_PIPELINE_CREATE_INFO_HUAWEI"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_FEATURES_HUAWEI"/>
                 <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI"/>
                 <enum offset="3" extends="VkPipelineBindPoint" extnumber="370" name="VK_PIPELINE_BIND_POINT_SUBPASS_SHADING_HUAWEI"/>
-                <enum bitpos="39" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI"/>
+                <enum bitpos="39" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI"/>
+                <enum             extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_SUBPASS_SHADING_BIT_HUAWEI" alias="VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI" deprecated="aliased"/>
                 <enum bitpos="14" extends="VkShaderStageFlagBits"           name="VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI"/>
                 <type name="VkSubpassShadingPipelineCreateInfoHUAWEI"/>
                 <type name="VkPhysicalDeviceSubpassShadingFeaturesHUAWEI"/>
@@ -20577,7 +22036,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSubpassShadingHUAWEI"/>
             </require>
         </extension>
-        <extension name="VK_HUAWEI_invocation_mask" number="371" type="device" depends="VK_KHR_ray_tracing_pipeline+VK_KHR_synchronization2" author="Huawei" contact="Pan Gao @PanGao-h" supported="vulkan">
+        <extension name="VK_HUAWEI_invocation_mask" number="371" type="device" depends="VK_KHR_ray_tracing_pipeline+(VK_KHR_synchronization2,VK_VERSION_1_3)" author="Huawei" contact="Pan Gao @PanGao-h" supported="vulkan">
             <require>
                 <enum value="1"                                              name="VK_HUAWEI_INVOCATION_MASK_SPEC_VERSION"/>
                 <enum value="&quot;VK_HUAWEI_invocation_mask&quot;"        name="VK_HUAWEI_INVOCATION_MASK_EXTENSION_NAME"/>
@@ -20589,7 +22048,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdBindInvocationMaskHUAWEI"/>
             </require>
         </extension>
-        <extension name="VK_NV_external_memory_rdma" number="372" type="device" depends="VK_KHR_external_memory" author="NV" contact="Carsten Rohde @crohde" supported="vulkan">
+        <extension name="VK_NV_external_memory_rdma" number="372" type="device" depends="VK_KHR_external_memory,VK_VERSION_1_1" author="NV" contact="Carsten Rohde @crohde" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_NV_EXTERNAL_MEMORY_RDMA_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_external_memory_rdma&quot;"            name="VK_NV_EXTERNAL_MEMORY_RDMA_EXTENSION_NAME"/>
@@ -20603,7 +22062,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMemoryRemoteAddressNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pipeline_properties" number="373" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Mukund Keshava @mkeshavanv" supported="vulkan">
+        <extension name="VK_EXT_pipeline_properties" number="373" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Mukund Keshava @mkeshavanv" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_PIPELINE_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pipeline_properties&quot;"        name="VK_EXT_PIPELINE_PROPERTIES_EXTENSION_NAME"/>
@@ -20672,13 +22131,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetPhysicalDeviceSciBufAttributesNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_376" number="376" author="EXT" contact="Melih Yasin Yalcin @yalcinmelihyasin" supported="disabled">
+        <extension name="VK_EXT_frame_boundary" number="376" type="device" author="EXT" contact="James Fitzpatrick @jamesfitzpatrick" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_EXT_EXTENSION_376_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_376&quot;"          name="VK_EXT_EXTENSION_376_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_EXT_FRAME_BOUNDARY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_frame_boundary&quot;"         name="VK_EXT_FRAME_BOUNDARY_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT"/>
+                <type name="VkPhysicalDeviceFrameBoundaryFeaturesEXT"/>
+                <type name="VkFrameBoundaryEXT"/>
+                <type name="VkFrameBoundaryFlagBitsEXT"/>
+                <type name="VkFrameBoundaryFlagsEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_multisampled_render_to_single_sampled" number="377" type="device" depends="VK_KHR_create_renderpass2+VK_KHR_depth_stencil_resolve" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
+        <extension name="VK_EXT_multisampled_render_to_single_sampled" number="377" type="device" depends="(VK_KHR_create_renderpass2+VK_KHR_depth_stencil_resolve),VK_VERSION_1_2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_multisampled_render_to_single_sampled&quot;"   name="VK_EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_EXTENSION_NAME"/>
@@ -20780,11 +22245,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="1" extends="VkQueryType"                      name="VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SIZE_KHR"/>
                 <type name="VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR"/>
             </require>
-            <require depends="VK_KHR_synchronization2">
+            <require depends="VK_KHR_synchronization2,VK_VERSION_1_3">
                 <!-- VkPipelineStageFlagBits bitpos="28" is reserved by this extension, but not used -->
                 <enum bitpos="28" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR"/>
             </require>
-            <require depends="VK_KHR_synchronization2+VK_KHR_ray_tracing_pipeline">
+            <require depends="(VK_KHR_synchronization2,VK_VERSION_1_3)+VK_KHR_ray_tracing_pipeline">
                 <enum bitpos="40" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR"/>
             </require>
             <require depends="VK_KHR_ray_tracing_pipeline">
@@ -20798,7 +22263,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_388&quot;"              name="VK_EXT_EXTENSION_388_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_global_priority_query" number="389" type="device" depends="VK_EXT_global_priority+VK_KHR_get_physical_device_properties2" author="EXT" contact="Yiwei Zhang @zhangyiwei" supported="vulkan" promotedto="VK_KHR_global_priority">
+        <extension name="VK_EXT_global_priority_query" number="389" type="device" depends="VK_EXT_global_priority+(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)" author="EXT" contact="Yiwei Zhang @zhangyiwei" supported="vulkan" promotedto="VK_KHR_global_priority">
             <require>
                 <enum value="1"                                         name="VK_EXT_GLOBAL_PRIORITY_QUERY_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_global_priority_query&quot;"  name="VK_EXT_GLOBAL_PRIORITY_QUERY_EXTENSION_NAME"/>
@@ -20821,7 +22286,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_391&quot;"              name="VK_EXT_EXTENSION_391_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_view_min_lod" number="392" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan">
+        <extension name="VK_EXT_image_view_min_lod" number="392" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_VIEW_MIN_LOD_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_view_min_lod&quot;"         name="VK_EXT_IMAGE_VIEW_MIN_LOD_EXTENSION_NAME"/>
@@ -20831,7 +22296,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type                                                       name="VkImageViewMinLodCreateInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_multi_draw" number="393" author="EXT" contact="Mike Blumenkrantz @zmike" type="device" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_EXT_multi_draw" number="393" author="EXT" contact="Mike Blumenkrantz @zmike" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_EXT_MULTI_DRAW_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_multi_draw&quot;"             name="VK_EXT_MULTI_DRAW_EXTENSION_NAME"/>
@@ -20845,7 +22310,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkMultiDrawIndexedInfoEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_2d_view_of_3d" number="394" depends="VK_KHR_maintenance1+VK_KHR_get_physical_device_properties2" author="EXT" contact="Mike Blumenkrantz @zmike" specialuse="glemulation" type="device" supported="vulkan">
+        <extension name="VK_EXT_image_2d_view_of_3d" number="394" depends="(VK_KHR_maintenance1+VK_KHR_get_physical_device_properties2),VK_VERSION_1_1" author="EXT" contact="Mike Blumenkrantz @zmike" specialuse="glemulation" type="device" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_2D_VIEW_OF_3D_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_2d_view_of_3d&quot;"              name="VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME"/>
@@ -20871,7 +22336,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderTileImagePropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_opacity_micromap" number="397" type="device"  depends="VK_KHR_acceleration_structure+VK_KHR_synchronization2" author="EXT" contact="Christoph Kubisch @pixeljetstream, Eric Werness" supported="vulkan">
+        <extension name="VK_EXT_opacity_micromap" number="397" type="device"  depends="VK_KHR_acceleration_structure+(VK_KHR_synchronization2,VK_VERSION_1_3)" author="EXT" contact="Christoph Kubisch @pixeljetstream, Eric Werness" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="2"                                             name="VK_EXT_OPACITY_MICROMAP_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_opacity_micromap&quot;"           name="VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME"/>
@@ -20937,9 +22402,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetMicromapBuildSizesEXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_displacement_micromap" number="398" type="device" depends="VK_EXT_opacity_micromap" author="NV" contact="Christoph Kubisch @pixeljetstream, Eric Werness" supported="vulkan" provisional="true" platform="provisional">
+        <extension name="VK_NV_displacement_micromap" number="398" type="device" depends="VK_EXT_opacity_micromap" author="NV" contact="Christoph Kubisch @pixeljetstream, Eric Werness @ewerness-nv" supported="vulkan" provisional="true" platform="provisional">
             <require>
-                <enum value="1"                                        name="VK_NV_DISPLACEMENT_MICROMAP_SPEC_VERSION"/>
+                <enum value="2"                                        name="VK_NV_DISPLACEMENT_MICROMAP_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_displacement_micromap&quot;"  name="VK_NV_DISPLACEMENT_MICROMAP_EXTENSION_NAME"/>
                 <enum offset="0"  extends="VkStructureType"            name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV" protect="VK_ENABLE_BETA_EXTENSIONS"/>
                 <enum offset="1"  extends="VkStructureType"            name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV" protect="VK_ENABLE_BETA_EXTENSIONS"/>
@@ -20965,11 +22430,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_JUICE_extension_400&quot;"        name="VK_JUICE_EXTENSION_400_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_load_store_op_none" number="401" author="EXT" type="device" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
+        <extension name="VK_EXT_load_store_op_none" number="401" author="EXT" type="device" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" promotedto="VK_KHR_load_store_op_none" ratified="vulkan">
             <require>
                 <enum value="1"                                         name="VK_EXT_LOAD_STORE_OP_NONE_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_load_store_op_none&quot;"          name="VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkAttachmentLoadOp" name="VK_ATTACHMENT_LOAD_OP_NONE_EXT"/>
+                <enum value="&quot;VK_EXT_load_store_op_none&quot;"     name="VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME"/>
+                <enum extends="VkAttachmentLoadOp" name="VK_ATTACHMENT_LOAD_OP_NONE_EXT" alias="VK_ATTACHMENT_LOAD_OP_NONE_KHR"/>
                 <enum extends="VkAttachmentStoreOp" name="VK_ATTACHMENT_STORE_OP_NONE_EXT" alias="VK_ATTACHMENT_STORE_OP_NONE"/>
             </require>
         </extension>
@@ -20991,12 +22456,13 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_FB_extension_404&quot;"           name="VK_FB_EXTENSION_404_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_HUAWEI_cluster_culling_shader" number="405" type="device" depends="VK_KHR_get_physical_device_properties2" author="HUAWEI" contact="Yuchang Wang @richard_Wang2" supported="vulkan">
+        <extension name="VK_HUAWEI_cluster_culling_shader" number="405" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="HUAWEI" contact="Yuchang Wang @richard_Wang2" supported="vulkan">
             <require>
-                <enum value="2"                                              name="VK_HUAWEI_CLUSTER_CULLING_SHADER_SPEC_VERSION"/>
+                <enum value="3"                                              name="VK_HUAWEI_CLUSTER_CULLING_SHADER_SPEC_VERSION"/>
                 <enum value="&quot;VK_HUAWEI_cluster_culling_shader&quot;"   name="VK_HUAWEI_CLUSTER_CULLING_SHADER_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI"/>
                 <enum offset="1" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_PROPERTIES_HUAWEI"/>
+                <enum offset="2" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI"/>
                 <enum bitpos="41" extends="VkPipelineStageFlagBits2"         name="VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
                 <enum bitpos="19" extends="VkShaderStageFlagBits"            name="VK_SHADER_STAGE_CLUSTER_CULLING_BIT_HUAWEI"/>
                 <enum bitpos="13" extends="VkQueryPipelineStatisticFlagBits" name="VK_QUERY_PIPELINE_STATISTIC_CLUSTER_CULLING_SHADER_INVOCATIONS_BIT_HUAWEI"/>
@@ -21004,6 +22470,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdDrawClusterIndirectHUAWEI"/>
                 <type name="VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI"/>
                 <type name="VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI"/>
+                <type name="VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI"/>
             </require>
         </extension>
         <extension name="VK_HUAWEI_extension_406" number="406" author="HUAWEI" contact="Hueilong Wang @wyvernathuawei" supported="disabled">
@@ -21093,19 +22560,31 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceShaderCorePropertiesARM"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_417" number="417" author="KHR" contact="Kevin Petit @kevinpetit" supported="disabled">
+        <extension name="VK_KHR_shader_subgroup_rotate" number="417" author="KHR" contact="Kevin Petit @kpet" type="device" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_417_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_417&quot;"          name="VK_KHR_EXTENSION_417_EXTENSION_NAME"/>
+                <enum value="2"                                         name="VK_KHR_SHADER_SUBGROUP_ROTATE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_shader_subgroup_rotate&quot;" name="VK_KHR_SHADER_SUBGROUP_ROTATE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES_KHR"/>
+                <enum bitpos="9" extends="VkSubgroupFeatureFlagBits"    name="VK_SUBGROUP_FEATURE_ROTATE_BIT_KHR"/>
+                <enum bitpos="10" extends="VkSubgroupFeatureFlagBits"   name="VK_SUBGROUP_FEATURE_ROTATE_CLUSTERED_BIT_KHR"/>
+                <type name="VkPhysicalDeviceShaderSubgroupRotateFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_ARM_extension_418" number="418" author="ARM" contact="Kevin Petit @kevinpetit" supported="disabled">
+        <extension name="VK_ARM_scheduling_controls" number="418" author="ARM" contact="Kevin Petit @kpet" type="device" depends="VK_ARM_shader_core_builtins" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_ARM_EXTENSION_418_SPEC_VERSION"/>
-                <enum value="&quot;VK_ARM_extension_418&quot;"          name="VK_ARM_EXTENSION_418_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_ARM_SCHEDULING_CONTROLS_SPEC_VERSION"/>
+                <enum value="&quot;VK_ARM_scheduling_controls&quot;"    name="VK_ARM_SCHEDULING_CONTROLS_EXTENSION_NAME"/>
+                <enum extends="VkStructureType" offset="0"              name="VK_STRUCTURE_TYPE_DEVICE_QUEUE_SHADER_CORE_CONTROL_CREATE_INFO_ARM"/>
+                <enum extends="VkStructureType" offset="1"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_FEATURES_ARM"/>
+                <enum extends="VkStructureType" offset="2"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_PROPERTIES_ARM"/>
+                <type name="VkDeviceQueueShaderCoreControlCreateInfoARM"/>
+                <type name="VkPhysicalDeviceSchedulingControlsFeaturesARM"/>
+                <type name="VkPhysicalDeviceSchedulingControlsPropertiesARM"/>
+                <type name="VkPhysicalDeviceSchedulingControlsFlagsARM"/>
+                <type name="VkPhysicalDeviceSchedulingControlsFlagBitsARM"/>
             </require>
         </extension>
-        <extension name="VK_EXT_image_sliced_view_of_3d" number="419" depends="VK_KHR_maintenance1+VK_KHR_get_physical_device_properties2" author="EXT" contact="Mike Blumenkrantz @zmike" specialuse="d3demulation" type="device" supported="vulkan">
+        <extension name="VK_EXT_image_sliced_view_of_3d" number="419" depends="(VK_KHR_maintenance1+VK_KHR_get_physical_device_properties2),VK_VERSION_1_1" author="EXT" contact="Mike Blumenkrantz @zmike" specialuse="d3demulation" type="device" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_IMAGE_SLICED_VIEW_OF_3D_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_image_sliced_view_of_3d&quot;"    name="VK_EXT_IMAGE_SLICED_VIEW_OF_3D_EXTENSION_NAME"/>
@@ -21123,7 +22602,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="4" extends="VkSwapchainCreateFlagBitsKHR" name="VK_SWAPCHAIN_CREATE_RESERVED_4_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_VALVE_descriptor_set_host_mapping" number="421" type="device" author="VALVE" contact="Hans-Kristian Arntzen @HansKristian-Work" specialuse="d3demulation" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_VALVE_descriptor_set_host_mapping" number="421" type="device" author="VALVE" contact="Hans-Kristian Arntzen @HansKristian-Work" specialuse="d3demulation" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                                 name="VK_VALVE_DESCRIPTOR_SET_HOST_MAPPING_SPEC_VERSION"/>
                 <enum value="&quot;VK_VALVE_descriptor_set_host_mapping&quot;"  name="VK_VALVE_DESCRIPTOR_SET_HOST_MAPPING_EXTENSION_NAME"/>
@@ -21137,7 +22616,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetDescriptorSetHostMappingVALVE"/>
             </require>
         </extension>
-        <extension name="VK_EXT_depth_clamp_zero_one" number="422" author="EXT" type="device" contact="Graeme Leese @gnl21" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_EXT_depth_clamp_zero_one" number="422" author="EXT" type="device" contact="Graeme Leese @gnl21" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_DEPTH_CLAMP_ZERO_ONE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_depth_clamp_zero_one&quot;"       name="VK_EXT_DEPTH_CLAMP_ZERO_ONE_EXTENSION_NAME"/>
@@ -21145,7 +22624,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceDepthClampZeroOneFeaturesEXT" />
             </require>
         </extension>
-        <extension name="VK_EXT_non_seamless_cube_map" number="423" author="EXT" type="device" contact="Georg Lehmann @DadSchoorse" specialuse="d3demulation,glemulation" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_EXT_non_seamless_cube_map" number="423" author="EXT" type="device" contact="Georg Lehmann @DadSchoorse" specialuse="d3demulation,glemulation" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_NON_SEAMLESS_CUBE_MAP_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_non_seamless_cube_map&quot;"      name="VK_EXT_NON_SEAMLESS_CUBE_MAP_EXTENSION_NAME"/>
@@ -21160,13 +22639,23 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_ARM_extension_424&quot;"          name="VK_ARM_EXTENSION_424_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_ARM_extension_425" number="425" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="disabled">
+        <extension name="VK_ARM_render_pass_striped" number="425" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_synchronization2),VK_VERSION_1_3" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_ARM_EXTENSION_425_SPEC_VERSION"/>
-                <enum value="&quot;VK_ARM_extension_425&quot;"          name="VK_ARM_EXTENSION_425_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_ARM_RENDER_PASS_STRIPED_SPEC_VERSION"/>
+                <enum value="&quot;VK_ARM_render_pass_striped&quot;"    name="VK_ARM_RENDER_PASS_STRIPED_EXTENSION_NAME"/>
+                <enum offset="0"  extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM"/>
+                <enum offset="1"  extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_PROPERTIES_ARM"/>
+                <enum offset="2"  extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_BEGIN_INFO_ARM"/>
+                <enum offset="3"  extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_INFO_ARM"/>
+                <enum offset="4"  extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_SUBMIT_INFO_ARM"/>
+                <type name="VkPhysicalDeviceRenderPassStripedFeaturesARM"/>
+                <type name="VkPhysicalDeviceRenderPassStripedPropertiesARM"/>
+                <type name="VkRenderPassStripeBeginInfoARM"/>
+                <type name="VkRenderPassStripeInfoARM"/>
+                <type name="VkRenderPassStripeSubmitInfoARM"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_fragment_density_map_offset" number="426" type="device" depends="VK_KHR_get_physical_device_properties2+VK_EXT_fragment_density_map" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
+        <extension name="VK_QCOM_fragment_density_map_offset" number="426" type="device" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_EXT_fragment_density_map" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="1"                                               name="VK_QCOM_FRAGMENT_DENSITY_MAP_OFFSET_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_fragment_density_map_offset&quot;" name="VK_QCOM_FRAGMENT_DENSITY_MAP_OFFSET_EXTENSION_NAME"/>
@@ -21179,7 +22668,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkSubpassFragmentDensityMapOffsetEndInfoQCOM"/>
             </require>
         </extension>
-        <extension name="VK_NV_copy_memory_indirect" number="427" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_buffer_device_address" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
+        <extension name="VK_NV_copy_memory_indirect" number="427" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_buffer_device_address),VK_VERSION_1_2" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_COPY_MEMORY_INDIRECT_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_copy_memory_indirect&quot;"    name="VK_NV_COPY_MEMORY_INDIRECT_EXTENSION_NAME"/>
@@ -21193,7 +22682,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdCopyMemoryToImageIndirectNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_memory_decompression" number="428" type="device" depends="VK_KHR_get_physical_device_properties2+VK_KHR_buffer_device_address" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
+        <extension name="VK_NV_memory_decompression" number="428" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_buffer_device_address),VK_VERSION_1_2" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_MEMORY_DECOMPRESSION_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_memory_decompression&quot;"       name="VK_NV_MEMORY_DECOMPRESSION_EXTENSION_NAME"/>
@@ -21208,26 +22697,41 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdDecompressMemoryIndirectCountNV"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_429" number="429" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="disabled">
+        <extension name="VK_NV_device_generated_commands_compute" number="429" type="device" depends="VK_NV_device_generated_commands" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_429_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_429&quot;"           name="VK_NV_EXTENSION_429_EXTENSION_NAME"/>
+                <enum value="2"                                           name="VK_NV_DEVICE_GENERATED_COMMANDS_COMPUTE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_device_generated_commands_compute&quot;"  name="VK_NV_DEVICE_GENERATED_COMMANDS_COMPUTE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV"/>
+                <enum offset="1" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_INDIRECT_BUFFER_INFO_NV"/>
+                <enum offset="2" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PIPELINE_INDIRECT_DEVICE_ADDRESS_INFO_NV"/>
+                <enum offset="3" extends="VkIndirectCommandsTokenTypeNV"  name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_PIPELINE_NV"/>
+                <enum offset="4" extends="VkIndirectCommandsTokenTypeNV"  name="VK_INDIRECT_COMMANDS_TOKEN_TYPE_DISPATCH_NV"/>
+                <enum bitpos="7" extends="VkDescriptorSetLayoutCreateFlagBits"  name="VK_DESCRIPTOR_SET_LAYOUT_CREATE_INDIRECT_BINDABLE_BIT_NV"/>
+                <type name="VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV"/>
+                <type name="VkComputePipelineIndirectBufferInfoNV"/>
+                <type name="VkPipelineIndirectDeviceAddressInfoNV"/>
+                <type name="VkBindPipelineIndirectCommandNV"/>
+                <command name="vkGetPipelineIndirectMemoryRequirementsNV"/>
+                <command name="vkCmdUpdatePipelineIndirectBufferNV"/>
+                <command name="vkGetPipelineIndirectDeviceAddressNV"/>
             </require>
         </extension>
         <extension name="VK_NV_extension_430" number="430" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="disabled">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_430_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_430&quot;"           name="VK_NV_EXTENSION_430_EXTENSION_NAME"/>
+                <enum value="0"                                          name="VK_NV_EXTENSION_430_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_430&quot;"            name="VK_NV_EXTENSION_430_EXTENSION_NAME"/>
+                <enum bitpos="33" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RESERVED_33_BIT_KHR"/>
+                <enum bitpos="51" extends="VkFormatFeatureFlagBits2"     name="VK_FORMAT_FEATURE_2_RESERVED_51_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_linear_color_attachment" number="431" type="device" author="NVIDIA" contact="sourav parmar @souravpNV" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_NV_linear_color_attachment" number="431" type="device" author="NVIDIA" contact="sourav parmar @souravpNV" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_LINEAR_COLOR_ATTACHMENT_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_linear_color_attachment&quot;" name="VK_NV_LINEAR_COLOR_ATTACHMENT_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV"/>
                 <type                                                   name="VkPhysicalDeviceLinearColorAttachmentFeaturesNV"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
                 <enum bitpos="38" extends="VkFormatFeatureFlagBits2"    name="VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV" comment="Format support linear image as render target, it cannot be mixed with non linear attachment"/>
             </require>
         </extension>
@@ -21249,10 +22753,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_GOOGLE_surfaceless_query&quot;"   name="VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_435" number="435" author="KHR" contact="Alan Baker @alan-baker" supported="disabled">
+        <extension name="VK_KHR_shader_maximal_reconvergence" number="435" type="device" author="KHR" depends="VK_VERSION_1_1" contact="Alan Baker @alan-baker" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_435_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_435&quot;"          name="VK_KHR_EXTENSION_435_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_SHADER_MAXIMAL_RECONVERGENCE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_shader_maximal_reconvergence&quot;"          name="VK_KHR_SHADER_MAXIMAL_RECONVERGENCE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR"/>
+                <type name="VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR"/>
             </require>
         </extension>
         <extension name="VK_EXT_application_parameters" number="436" type="instance" author="EXT" contact="Daniel Koch @dgkoch" supported="vulkansc">
@@ -21283,7 +22789,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_SEC_extension_439&quot;"          name="VK_SEC_EXTENSION_439_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_440" number="440" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+        <extension name="VK_QCOM_extension_440" number="440" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_QCOM_EXTENSION_440_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_extension_440&quot;"         name="VK_QCOM_EXTENSION_440_EXTENSION_NAME"/>
@@ -21291,7 +22797,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="1" extends="VkDeviceQueueCreateFlagBits"  name="VK_DEVICE_QUEUE_CREATE_RESERVED_1_BIT_QCOM"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_image_processing" number="441" type="device" depends="VK_KHR_format_feature_flags2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_image_processing" number="441" type="device" depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_QCOM_IMAGE_PROCESSING_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_image_processing&quot;"      name="VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME"/>
@@ -21307,7 +22813,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceImageProcessingFeaturesQCOM"/>
                 <type name="VkPhysicalDeviceImageProcessingPropertiesQCOM"/>
             </require>
-            <require depends="VK_KHR_format_feature_flags2">
+            <require depends="VK_KHR_format_feature_flags2,VK_VERSION_1_3">
                 <enum bitpos="34" extends="VkFormatFeatureFlagBits2" name="VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM"/>
                 <enum bitpos="35" extends="VkFormatFeatureFlagBits2" name="VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"/>
                 <enum bitpos="36" extends="VkFormatFeatureFlagBits2" name="VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM"/>
@@ -21343,6 +22849,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                             name="VK_COREAVI_EXTENSION_446_SPEC_VERSION"/>
                 <enum value="&quot;VK_COREAVI_extension_446&quot;"          name="VK_COREAVI_EXTENSION_446_EXTENSION_NAME"/>
+                <enum bitpos="24" extends="VkImageUsageFlagBits"            name="VK_IMAGE_USAGE_RESERVED_24_BIT_COREAVI"/>
             </require>
         </extension>
         <extension name="VK_COREAVI_extension_447" number="447" author="COREAVI" contact="Aidan Fabius @afabius" supported="disabled">
@@ -21375,13 +22882,19 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_SEC_extension_451&quot;"          name="VK_SEC_EXTENSION_451_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_452" number="452" author="NV" contact="Piers Daniell @pdaniell-nv" supported="disabled">
+        <extension name="VK_EXT_nested_command_buffer" number="452" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_452_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_452&quot;"           name="VK_NV_EXTENSION_452_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_EXT_NESTED_COMMAND_BUFFER_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_nested_command_buffer&quot;"  name="VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_PROPERTIES_EXT"/>
+                <enum offset="0" extends="VkSubpassContents"            name="VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT"/>
+                <enum bitpos="4" extends="VkRenderingFlagBits"          name="VK_RENDERING_CONTENTS_INLINE_BIT_EXT"/>
+                <type                                                   name="VkPhysicalDeviceNestedCommandBufferFeaturesEXT"/>
+                <type                                                   name="VkPhysicalDeviceNestedCommandBufferPropertiesEXT"/>
             </require>
         </extension>
-        <extension name="VK_ARM_extension_453" number="453" author="Arm" contact="Kevin Petit @kevinpetit" supported="disabled">
+        <extension name="VK_ARM_extension_453" number="453" author="Arm" contact="Kevin Petit @kpet" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_ARM_EXTENSION_453_SPEC_VERSION"/>
                 <enum value="&quot;VK_ARM_extension_453&quot;"          name="VK_ARM_EXTENSION_453_EXTENSION_NAME"/>
@@ -21389,12 +22902,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="43" extends="VkPipelineStageFlagBits2"    name="VK_PIPELINE_STAGE_2_RESERVED_43_BIT_ARM"/>
                 <enum bitpos="49" extends="VkAccessFlagBits2"           name="VK_ACCESS_2_RESERVED_49_BIT_ARM"/>
                 <enum bitpos="50" extends="VkAccessFlagBits2"           name="VK_ACCESS_2_RESERVED_50_BIT_ARM"/>
+                <enum bitpos="47" extends="VkFormatFeatureFlagBits2"    name="VK_FORMAT_FEATURE_2_RESERVED_47_BIT_ARM" />
             </require>
         </extension>
-        <extension name="VK_GOOGLE_extension_454" number="454" author="GOOGLE" contact="Lina Versace @versalinyaa" supported="disabled">
+        <extension name="VK_EXT_external_memory_acquire_unmodified" number="454" type="device" depends="VK_KHR_external_memory,VK_VERSION_1_1" author="EXT" contact="Lina Versace @versalinyaa" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                                         name="VK_GOOGLE_EXTENSION_454_SPEC_VERSION"/>
-                <enum value="&quot;VK_GOOGLE_extension_454&quot;"       name="VK_GOOGLE_EXTENSION_454_EXTENSION_NAME"/>
+                <enum value="1"                                                         name="VK_EXT_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_external_memory_acquire_unmodified&quot;"     name="VK_EXT_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                              name="VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_EXT"/>
+                <type name="VkExternalMemoryAcquireUnmodifiedEXT"/>
             </require>
         </extension>
         <extension name="VK_GOOGLE_extension_455" number="455" author="GOOGLE" contact="Lina Versace @versalinyaa" supported="disabled">
@@ -21403,13 +22919,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_GOOGLE_extension_455&quot;"       name="VK_GOOGLE_EXTENSION_455_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extended_dynamic_state3" number="456" type="device" depends="VK_KHR_get_physical_device_properties2" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+        <extension name="VK_EXT_extended_dynamic_state3" number="456" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="2"                                              name="VK_EXT_EXTENDED_DYNAMIC_STATE_3_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extended_dynamic_state3&quot;"     name="VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT"/>
                 <enum offset="1" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT"/>
-                <enum offset="2" extends="VkDynamicState"                    name="VK_DYNAMIC_STATE_TESSELLATION_DOMAIN_ORIGIN_EXT"/>
                 <enum offset="3" extends="VkDynamicState"                    name="VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT"/>
                 <enum offset="4" extends="VkDynamicState"                    name="VK_DYNAMIC_STATE_POLYGON_MODE_EXT"/>
                 <enum offset="5" extends="VkDynamicState"                    name="VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT"/>
@@ -21420,31 +22935,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="10" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT"/>
                 <enum offset="11" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT"/>
                 <enum offset="12" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT"/>
-                <enum offset="13" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT"/>
-                <enum offset="14" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT"/>
-                <enum offset="15" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_EXTRA_PRIMITIVE_OVERESTIMATION_SIZE_EXT"/>
-                <enum offset="16" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_DEPTH_CLIP_ENABLE_EXT"/>
-                <enum offset="17" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT"/>
-                <enum offset="18" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT"/>
-                <enum offset="19" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_PROVOKING_VERTEX_MODE_EXT"/>
-                <enum offset="20" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT"/>
-                <enum offset="21" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT"/>
-                <enum offset="22" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_DEPTH_CLIP_NEGATIVE_ONE_TO_ONE_EXT"/>
-                <enum offset="23" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_ENABLE_NV"/>
-                <enum offset="24" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_VIEWPORT_SWIZZLE_NV"/>
-                <enum offset="25" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_TO_COLOR_ENABLE_NV"/>
-                <enum offset="26" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_TO_COLOR_LOCATION_NV"/>
-                <enum offset="27" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_MODULATION_MODE_NV"/>
-                <enum offset="28" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_ENABLE_NV"/>
-                <enum offset="29" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_NV"/>
-                <enum offset="30" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_SHADING_RATE_IMAGE_ENABLE_NV"/>
-                <enum offset="31" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_REPRESENTATIVE_FRAGMENT_TEST_ENABLE_NV"/>
-                <enum offset="32" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_REDUCTION_MODE_NV"/>
                 <type name="VkPhysicalDeviceExtendedDynamicState3FeaturesEXT"/>
                 <type name="VkPhysicalDeviceExtendedDynamicState3PropertiesEXT"/>
                 <type name="VkColorBlendEquationEXT"/>
                 <type name="VkColorBlendAdvancedEXT"/>
-                <command name="vkCmdSetTessellationDomainOriginEXT"/>
                 <command name="vkCmdSetDepthClampEnableEXT"/>
                 <command name="vkCmdSetPolygonModeEXT"/>
                 <command name="vkCmdSetRasterizationSamplesEXT"/>
@@ -21455,25 +22949,79 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetColorBlendEnableEXT"/>
                 <command name="vkCmdSetColorBlendEquationEXT"/>
                 <command name="vkCmdSetColorWriteMaskEXT"/>
+            </require>
+            <require depends="VK_KHR_maintenance2,VK_VERSION_1_1">
+                <enum offset="2" extends="VkDynamicState"                    name="VK_DYNAMIC_STATE_TESSELLATION_DOMAIN_ORIGIN_EXT"/>
+                <command name="vkCmdSetTessellationDomainOriginEXT"/>
+            </require>
+            <require depends="VK_EXT_transform_feedback">
+                <enum offset="13" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT"/>
                 <command name="vkCmdSetRasterizationStreamEXT"/>
+            </require>
+            <require depends="VK_EXT_conservative_rasterization">
+                <enum offset="14" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT"/>
+                <enum offset="15" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_EXTRA_PRIMITIVE_OVERESTIMATION_SIZE_EXT"/>
                 <command name="vkCmdSetConservativeRasterizationModeEXT"/>
                 <command name="vkCmdSetExtraPrimitiveOverestimationSizeEXT"/>
+            </require>
+            <require depends="VK_EXT_depth_clip_enable">
+                <enum offset="16" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_DEPTH_CLIP_ENABLE_EXT"/>
                 <command name="vkCmdSetDepthClipEnableEXT"/>
+            </require>
+            <require depends="VK_EXT_sample_locations">
+                <enum offset="17" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT"/>
                 <command name="vkCmdSetSampleLocationsEnableEXT"/>
+            </require>
+            <require depends="VK_EXT_blend_operation_advanced">
+                <enum offset="18" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT"/>
                 <command name="vkCmdSetColorBlendAdvancedEXT"/>
+            </require>
+            <require depends="VK_EXT_provoking_vertex">
+                <enum offset="19" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_PROVOKING_VERTEX_MODE_EXT"/>
                 <command name="vkCmdSetProvokingVertexModeEXT"/>
+            </require>
+            <require depends="VK_EXT_line_rasterization">
+                <enum offset="20" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT"/>
+                <enum offset="21" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT"/>
                 <command name="vkCmdSetLineRasterizationModeEXT"/>
                 <command name="vkCmdSetLineStippleEnableEXT"/>
+            </require>
+            <require depends="VK_EXT_depth_clip_control">
+                <enum offset="22" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_DEPTH_CLIP_NEGATIVE_ONE_TO_ONE_EXT"/>
                 <command name="vkCmdSetDepthClipNegativeOneToOneEXT"/>
+            </require>
+            <require depends="VK_NV_clip_space_w_scaling">
+                <enum offset="23" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_ENABLE_NV"/>
                 <command name="vkCmdSetViewportWScalingEnableNV"/>
+            </require>
+            <require depends="VK_NV_viewport_swizzle">
+                <enum offset="24" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_VIEWPORT_SWIZZLE_NV"/>
                 <command name="vkCmdSetViewportSwizzleNV"/>
+            </require>
+            <require depends="VK_NV_fragment_coverage_to_color">
+                <enum offset="25" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_TO_COLOR_ENABLE_NV"/>
+                <enum offset="26" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_TO_COLOR_LOCATION_NV"/>
                 <command name="vkCmdSetCoverageToColorEnableNV"/>
                 <command name="vkCmdSetCoverageToColorLocationNV"/>
+            </require>
+            <require depends="VK_NV_framebuffer_mixed_samples">
+                <enum offset="27" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_MODULATION_MODE_NV"/>
+                <enum offset="28" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_ENABLE_NV"/>
+                <enum offset="29" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_NV"/>
                 <command name="vkCmdSetCoverageModulationModeNV"/>
                 <command name="vkCmdSetCoverageModulationTableEnableNV"/>
                 <command name="vkCmdSetCoverageModulationTableNV"/>
+            </require>
+            <require depends="VK_NV_shading_rate_image">
+                <enum offset="30" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_SHADING_RATE_IMAGE_ENABLE_NV"/>
                 <command name="vkCmdSetShadingRateImageEnableNV"/>
+            </require>
+            <require depends="VK_NV_representative_fragment_test">
+                <enum offset="31" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_REPRESENTATIVE_FRAGMENT_TEST_ENABLE_NV"/>
                 <command name="vkCmdSetRepresentativeFragmentTestEnableNV"/>
+            </require>
+            <require depends="VK_NV_coverage_reduction_mode">
+                <enum offset="32" extends="VkDynamicState"                   name="VK_DYNAMIC_STATE_COVERAGE_REDUCTION_MODE_NV"/>
                 <command name="vkCmdSetCoverageReductionModeNV"/>
             </require>
         </extension>
@@ -21489,7 +23037,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_458&quot;"          name="VK_EXT_EXTENSION_458_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_subpass_merge_feedback" number="459" type="device" author="EXT" contact="Ting Wei @catweiting" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_EXT_subpass_merge_feedback" number="459" type="device" author="EXT" contact="Ting Wei @catweiting" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="2"                                              name="VK_EXT_SUBPASS_MERGE_FEEDBACK_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_subpass_merge_feedback&quot;"      name="VK_EXT_SUBPASS_MERGE_FEEDBACK_EXTENSION_NAME"/>
@@ -21519,7 +23067,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="PFN_vkGetInstanceProcAddrLUNARG"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_461" number="461" author="EXT" contact="Kevin Petit @kevinpetit" supported="disabled">
+        <extension name="VK_EXT_extension_461" number="461" author="EXT" contact="Kevin Petit @kpet" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_EXT_EXTENSION_461_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_461&quot;"          name="VK_EXT_EXTENSION_461_EXTENSION_NAME"/>
@@ -21533,7 +23081,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_462&quot;"          name="VK_EXT_EXTENSION_462_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_shader_module_identifier" number="463" type="device" depends="VK_KHR_get_physical_device_properties2+VK_EXT_pipeline_creation_cache_control" author="EXT" contact="Hans-Kristian Arntzen @HansKristian-Work" supported="vulkan">
+        <extension name="VK_EXT_shader_module_identifier" number="463" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_EXT_pipeline_creation_cache_control),VK_VERSION_1_3" author="EXT" contact="Hans-Kristian Arntzen @HansKristian-Work" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_SHADER_MODULE_IDENTIFIER_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_shader_module_identifier&quot;"   name="VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME"/>
@@ -21550,7 +23098,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkGetShaderModuleCreateInfoIdentifierEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_rasterization_order_attachment_access" number="464" type="device" depends="VK_KHR_get_physical_device_properties2" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
+        <extension name="VK_EXT_rasterization_order_attachment_access" number="464" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="ARM" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="vulkan">
             <require>
                 <enum value="1"                                                        name="VK_EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_rasterization_order_attachment_access&quot;" name="VK_EXT_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXTENSION_NAME"/>
@@ -21566,7 +23114,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="6" extends="VkSubpassDescriptionFlagBits"              name="VK_SUBPASS_DESCRIPTION_RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_NV_optical_flow" number="465" depends="VK_KHR_get_physical_device_properties2+VK_KHR_format_feature_flags2+VK_KHR_synchronization2" type="device" author="NV" contact="Carsten Rohde @crohde" supported="vulkan">
+        <extension name="VK_NV_optical_flow" number="465" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_format_feature_flags2+VK_KHR_synchronization2),VK_VERSION_1_3" type="device" author="NV" contact="Carsten Rohde @crohde" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_NV_OPTICAL_FLOW_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_optical_flow&quot;"                name="VK_NV_OPTICAL_FLOW_EXTENSION_NAME"/>
@@ -21611,7 +23159,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdOpticalFlowExecuteNV"/>
             </require>
         </extension>
-        <extension name="VK_EXT_legacy_dithering" number="466" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
+        <extension name="VK_EXT_legacy_dithering" number="466" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" specialuse="glemulation">
             <require>
                 <enum value="1"                                         name="VK_EXT_LEGACY_DITHERING_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_legacy_dithering&quot;"       name="VK_EXT_LEGACY_DITHERING_EXTENSION_NAME"/>
@@ -21619,14 +23167,11 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="7" extends="VkSubpassDescriptionFlagBits" name="VK_SUBPASS_DESCRIPTION_ENABLE_LEGACY_DITHERING_BIT_EXT"/>
                 <type name="VkPhysicalDeviceLegacyDitheringFeaturesEXT"/>
             </require>
-            <require depends="VK_VERSION_1_3">
-                <enum bitpos="3" extends="VkRenderingFlagBits"          name="VK_RENDERING_ENABLE_LEGACY_DITHERING_BIT_EXT"/>
-            </require>
-            <require depends="VK_KHR_dynamic_rendering">
+            <require depends="VK_KHR_dynamic_rendering,VK_VERSION_1_3">
                 <enum bitpos="3" extends="VkRenderingFlagBits"          name="VK_RENDERING_ENABLE_LEGACY_DITHERING_BIT_EXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_pipeline_protected_access" number="467" type="device" depends="VK_KHR_get_physical_device_properties2" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
+        <extension name="VK_EXT_pipeline_protected_access" number="467" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="vulkan">
             <require>
                 <enum value="1"                                             name="VK_EXT_PIPELINE_PROTECTED_ACCESS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_pipeline_protected_access&quot;"  name="VK_EXT_PIPELINE_PROTECTED_ACCESS_EXTENSION_NAME"/>
@@ -21640,13 +23185,22 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                         name="VK_EXT_EXTENSION_468_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_468&quot;"          name="VK_EXT_EXTENSION_468_EXTENSION_NAME"/>
+                <enum bitpos="34" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RESERVED_34_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_ANDROID_extension_469" number="469" type="device" platform="android" author="ANDROID" contact="Chris Forbes @chrisforbes" supported="disabled">
+        <extension name="VK_ANDROID_external_format_resolve" number="469" type="device" depends="VK_ANDROID_external_memory_android_hardware_buffer" platform="android" author="ANDROID" contact="Chris Forbes @chrisforbes" specialuse="glemulation" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_ANDROID_EXTENSION_469_SPEC_VERSION"/>
-                <enum value="&quot;VK_ANDROID_extension_469&quot;"      name="VK_ANDROID_EXTENSION_469_EXTENSION_NAME"/>
-                <enum bitpos="4" extends="VkResolveModeFlagBits"        name="VK_RESOLVE_MODE_EXTENSION_469_FLAG_0_BIT"/>
+                <enum value="1"                                             name="VK_ANDROID_EXTERNAL_FORMAT_RESOLVE_SPEC_VERSION"/>
+                <enum value="&quot;VK_ANDROID_external_format_resolve&quot;"  name="VK_ANDROID_EXTERNAL_FORMAT_RESOLVE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_PROPERTIES_ANDROID"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_RESOLVE_PROPERTIES_ANDROID"/>
+                <type name="VkPhysicalDeviceExternalFormatResolveFeaturesANDROID"/>
+                <type name="VkPhysicalDeviceExternalFormatResolvePropertiesANDROID"/>
+                <type name="VkAndroidHardwareBufferFormatResolvePropertiesANDROID"/>
+            </require>
+            <require depends="VK_KHR_dynamic_rendering,VK_VERSION_1_3">
+                <enum bitpos="4" extends="VkResolveModeFlagBits"            name="VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID"/>
             </require>
         </extension>
         <extension name="VK_AMD_extension_470" number="470" author="AMD" contact="Stu Smith" supported="disabled">
@@ -21655,10 +23209,135 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_AMD_extension_470&quot;"          name="VK_AMD_EXTENSION_470_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_AMD_extension_471" number="471" author="AMD" contact="Stu Smith" supported="disabled">
+        <extension name="VK_KHR_maintenance5" number="471" type="device" depends="(VK_VERSION_1_1+VK_KHR_dynamic_rendering),VK_VERSION_1_3" author="KHR" contact="Stu Smith @stu-s" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_AMD_EXTENSION_471_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_extension_471&quot;"          name="VK_AMD_EXTENSION_471_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_MAINTENANCE_5_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_maintenance5&quot;"           name="VK_KHR_MAINTENANCE_5_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_RENDERING_AREA_INFO_KHR"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_IMAGE_SUBRESOURCE_INFO_KHR"/>
+                <type name="VkPhysicalDeviceMaintenance5FeaturesKHR"/>
+                <type name="VkPhysicalDeviceMaintenance5PropertiesKHR"/>
+                <enum offset="0" extends="VkFormat"                     name="VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR"/>
+                <enum offset="1" extends="VkFormat"                     name="VK_FORMAT_A8_UNORM_KHR"/>
+                <command name="vkCmdBindIndexBuffer2KHR"/>
+                <command name="vkGetRenderingAreaGranularityKHR"/>
+                <type name="VkRenderingAreaInfoKHR"/>
+                <command name="vkGetDeviceImageSubresourceLayoutKHR"/>
+                <command name="vkGetImageSubresourceLayout2KHR"/>
+                <type name="VkDeviceImageSubresourceInfoKHR"/>
+                <type name="VkImageSubresource2KHR"/>
+                <type name="VkSubresourceLayout2KHR"/>
+                <enum offset="2" extends="VkStructureType" extnumber="339" name="VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR"/>
+                <enum offset="3" extends="VkStructureType" extnumber="339" name="VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR"/>
+            </require>
+            <require comment="Split off new 64-bit flags separately, for the moment">
+                <type name="VkPipelineCreateFlags2KHR"/>
+                <type name="VkPipelineCreateFlagBits2KHR"/>
+                <type name="VkPipelineCreateFlags2CreateInfoKHR"/>
+                <type name="VkBufferUsageFlags2KHR"/>
+                <type name="VkBufferUsageFlagBits2KHR"/>
+                <type name="VkBufferUsageFlags2CreateInfoKHR"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO_KHR"/>
+                <enum offset="6" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR"/>
+            </require>
+            <require depends="VK_VERSION_1_1,VK_KHR_device_group">
+                <enum bitpos="3"  extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_VIEW_INDEX_FROM_DEVICE_INDEX_BIT_KHR"/>
+                <enum bitpos="4"  extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_DISPATCH_BASE_BIT_KHR"/>
+            </require>
+            <require depends="VK_NV_ray_tracing">
+                <enum bitpos="5"  extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_DEFER_COMPILE_BIT_NV"/>
+            </require>
+            <require depends="VK_KHR_pipeline_executable_properties">
+                <enum bitpos="6"  extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_CAPTURE_STATISTICS_BIT_KHR"/>
+                <enum bitpos="7"  extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR"/>
+            </require>
+            <require depends="VK_VERSION_1_3,VK_EXT_pipeline_creation_cache_control">
+                <enum bitpos="8"  extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_KHR"/>
+                <enum bitpos="9"  extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT_KHR"/>
+            </require>
+            <require depends="VK_EXT_graphics_pipeline_library">
+                <enum bitpos="10" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_LINK_TIME_OPTIMIZATION_BIT_EXT"/>
+                <enum bitpos="23" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT"/>
+            </require>
+            <require depends="VK_KHR_pipeline_library">
+                <enum bitpos="11" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR"/>
+            </require>
+            <require depends="VK_KHR_ray_tracing_pipeline">
+                <enum bitpos="12" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR"/>
+                <enum bitpos="13" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_AABBS_BIT_KHR"/>
+                <enum bitpos="14" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR"/>
+                <enum bitpos="15" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR"/>
+                <enum bitpos="16" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR"/>
+                <enum bitpos="17" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR"/>
+                <enum bitpos="19" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR"/>
+            </require>
+            <require depends="VK_NV_device_generated_commands">
+                <enum bitpos="18" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_NV"/>
+            </require>
+            <require depends="VK_NV_ray_tracing_motion_blur">
+                <enum bitpos="20" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_MOTION_BIT_NV"/>
+            </require>
+            <require depends="(VK_KHR_dynamic_rendering,VK_VERSION_1_3)+VK_KHR_fragment_shading_rate">
+                <enum bitpos="21" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
+            </require>
+            <require depends="(VK_KHR_dynamic_rendering,VK_VERSION_1_3)+VK_EXT_fragment_density_map">
+                <enum bitpos="22" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT"/>
+            </require>
+            <require depends="VK_EXT_opacity_micromap">
+                <enum bitpos="24" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT"/>
+            </require>
+            <require depends="VK_EXT_attachment_feedback_loop_layout">
+                <enum bitpos="25" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT"/>
+                <enum bitpos="26" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT"/>
+            </require>
+            <require depends="VK_EXT_pipeline_protected_access">
+                <enum bitpos="27" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT_EXT"/>
+                <enum bitpos="30" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT_EXT"/>
+            </require>
+            <require depends="VK_NV_displacement_micromap">
+                <enum bitpos="28" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RAY_TRACING_DISPLACEMENT_MICROMAP_BIT_NV"/>
+            </require>
+            <require depends="VK_EXT_descriptor_buffer">
+                <enum bitpos="29" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT"/>
+            </require>
+            <require depends="VK_EXT_conditional_rendering">
+                <enum bitpos="9"  extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_CONDITIONAL_RENDERING_BIT_EXT"/>
+            </require>
+            <require depends="VK_KHR_ray_tracing_pipeline">
+                <enum bitpos="10" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR"/>
+            </require>
+            <require depends="VK_NV_ray_tracing">
+                <enum extends="VkBufferUsageFlagBits2KHR"                name="VK_BUFFER_USAGE_2_RAY_TRACING_BIT_NV" alias="VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR"/>
+            </require>
+            <require depends="VK_EXT_transform_feedback">
+                <enum bitpos="11" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT"/>
+                <enum bitpos="12" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT"/>
+            </require>
+            <require depends="VK_KHR_video_decode_queue">
+                <enum bitpos="13" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_VIDEO_DECODE_SRC_BIT_KHR"/>
+                <enum bitpos="14" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_VIDEO_DECODE_DST_BIT_KHR"/>
+            </require>
+            <require depends="VK_KHR_video_encode_queue">
+                <enum bitpos="15" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_VIDEO_ENCODE_DST_BIT_KHR"/>
+                <enum bitpos="16" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_VIDEO_ENCODE_SRC_BIT_KHR"/>
+            </require>
+            <require depends="VK_VERSION_1_2,VK_KHR_buffer_device_address,VK_EXT_buffer_device_address">
+                <enum bitpos="17" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR"/>
+            </require>
+            <require depends="VK_KHR_acceleration_structure">
+                <enum bitpos="19" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR"/>
+                <enum bitpos="20" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR"/>
+            </require>
+            <require depends="VK_EXT_descriptor_buffer">
+                <enum bitpos="21" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT"/>
+                <enum bitpos="22" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT"/>
+                <enum bitpos="26" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT"/>
+            </require>
+            <require depends="VK_EXT_opacity_micromap">
+                <enum bitpos="23" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT"/>
+                <enum bitpos="24" extends="VkBufferUsageFlagBits2KHR"    name="VK_BUFFER_USAGE_2_MICROMAP_STORAGE_BIT_EXT"/>
             </require>
         </extension>
         <extension name="VK_AMD_extension_472" number="472" author="AMD" contact="Stu Smith" supported="disabled">
@@ -21707,6 +23386,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                         name="VK_AMD_EXTENSION_479_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_extension_479&quot;"          name="VK_AMD_EXTENSION_479_EXTENSION_NAME"/>
+                <enum bitpos="32" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RESERVED_32_BIT_KHR"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_480" number="480" author="EXT" contact="Daniel Stone" supported="disabled">
@@ -21730,7 +23410,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_shader_object" number="483" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+(VK_KHR_dynamic_rendering,VK_VERSION_1_3)" type="device" author="EXT" contact="Daniel Story @daniel-story" supported="vulkan" ratified="vulkan">
+        <extension name="VK_EXT_shader_object" number="483" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_dynamic_rendering),VK_VERSION_1_3" type="device" author="EXT" contact="Daniel Story @daniel-story" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                            name="VK_EXT_SHADER_OBJECT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_shader_object&quot;"             name="VK_EXT_SHADER_OBJECT_EXTENSION_NAME"/>
@@ -21741,7 +23421,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum extnumber="353" offset="2" extends="VkStructureType" name="VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT"/>
                 <enum extends="VkStructureType"                            name="VK_STRUCTURE_TYPE_SHADER_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT" alias="VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO"/>
                 <enum offset="0" extends="VkObjectType"                    name="VK_OBJECT_TYPE_SHADER_EXT"/>
-                <enum offset="0" extends="VkResult"                        name="VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT"/>
+                <enum offset="0" extends="VkResult"                        name="VK_INCOMPATIBLE_SHADER_BINARY_EXT"/>
+                <enum            extends="VkResult"                        name="VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT" alias="VK_INCOMPATIBLE_SHADER_BINARY_EXT" deprecated="aliased"/>
                 <type name="VkShaderEXT"/>
                 <type name="VkShaderCreateFlagBitsEXT"/>
                 <type name="VkShaderCreateFlagsEXT"/>
@@ -21787,26 +23468,32 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetColorBlendEnableEXT"/>
                 <command name="vkCmdSetColorBlendEquationEXT"/>
                 <command name="vkCmdSetColorWriteMaskEXT"/>
+            </require>
+            <require depends="VK_EXT_transform_feedback">
                 <command name="vkCmdSetRasterizationStreamEXT"/>
+            </require>
+            <require depends="VK_EXT_conservative_rasterization">
                 <command name="vkCmdSetConservativeRasterizationModeEXT"/>
                 <command name="vkCmdSetExtraPrimitiveOverestimationSizeEXT"/>
+            </require>
+            <require depends="VK_EXT_depth_clip_enable">
                 <command name="vkCmdSetDepthClipEnableEXT"/>
+            </require>
+            <require depends="VK_EXT_sample_locations">
                 <command name="vkCmdSetSampleLocationsEnableEXT"/>
+            </require>
+            <require depends="VK_EXT_blend_operation_advanced">
                 <command name="vkCmdSetColorBlendAdvancedEXT"/>
+            </require>
+            <require depends="VK_EXT_provoking_vertex">
                 <command name="vkCmdSetProvokingVertexModeEXT"/>
+            </require>
+            <require depends="VK_EXT_line_rasterization">
                 <command name="vkCmdSetLineRasterizationModeEXT"/>
                 <command name="vkCmdSetLineStippleEnableEXT"/>
+            </require>
+            <require depends="VK_EXT_depth_clip_control">
                 <command name="vkCmdSetDepthClipNegativeOneToOneEXT"/>
-                <command name="vkCmdSetViewportWScalingEnableNV"/>
-                <command name="vkCmdSetViewportSwizzleNV"/>
-                <command name="vkCmdSetCoverageToColorEnableNV"/>
-                <command name="vkCmdSetCoverageToColorLocationNV"/>
-                <command name="vkCmdSetCoverageModulationModeNV"/>
-                <command name="vkCmdSetCoverageModulationTableEnableNV"/>
-                <command name="vkCmdSetCoverageModulationTableNV"/>
-                <command name="vkCmdSetShadingRateImageEnableNV"/>
-                <command name="vkCmdSetRepresentativeFragmentTestEnableNV"/>
-                <command name="vkCmdSetCoverageReductionModeNV"/>
             </require>
             <require depends="VK_EXT_subgroup_size_control,VK_VERSION_1_3">
                 <enum bitpos="1" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT"/>
@@ -21824,14 +23511,39 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require depends="VK_EXT_fragment_density_map">
                 <enum bitpos="6" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT"/>
             </require>
+            <require depends="VK_NV_clip_space_w_scaling">
+                <command name="vkCmdSetViewportWScalingEnableNV"/>
+            </require>
+            <require depends="VK_NV_viewport_swizzle">
+                <command name="vkCmdSetViewportSwizzleNV"/>
+            </require>
+            <require depends="VK_NV_fragment_coverage_to_color">
+                <command name="vkCmdSetCoverageToColorEnableNV"/>
+                <command name="vkCmdSetCoverageToColorLocationNV"/>
+            </require>
+            <require depends="VK_NV_framebuffer_mixed_samples">
+                <command name="vkCmdSetCoverageModulationModeNV"/>
+                <command name="vkCmdSetCoverageModulationTableEnableNV"/>
+                <command name="vkCmdSetCoverageModulationTableNV"/>
+            </require>
+            <require depends="VK_NV_shading_rate_image">
+                <command name="vkCmdSetShadingRateImageEnableNV"/>
+            </require>
+            <require depends="VK_NV_representative_fragment_test">
+                <command name="vkCmdSetRepresentativeFragmentTestEnableNV"/>
+            </require>
+            <require depends="VK_NV_coverage_reduction_mode">
+                <command name="vkCmdSetCoverageReductionModeNV"/>
+            </require>
         </extension>
         <extension name="VK_EXT_extension_484" number="484" author="KHR" contact="Chris Glover @cdglove" supported="disabled">
             <require>
-                <enum value="0"                                         name="VK_EXT_EXTENSION_484_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_484&quot;"          name="VK_EXT_EXTENSION_484_EXTENSION_NAME"/>
+                <enum value="0"                                          name="VK_EXT_EXTENSION_484_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_484&quot;"           name="VK_EXT_EXTENSION_484_EXTENSION_NAME"/>
+                <enum bitpos="31" extends="VkPipelineCreateFlagBits2KHR" name="VK_PIPELINE_CREATE_2_RESERVED_31_BIT_KHR"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_tile_properties" number="485" type="device" depends="VK_KHR_get_physical_device_properties2" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_tile_properties" number="485" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="1"                                               name="VK_QCOM_TILE_PROPERTIES_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_tile_properties&quot;"             name="VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME"/>
@@ -21841,10 +23553,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum offset="1" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM"/>
                 <type name="VkPhysicalDeviceTilePropertiesFeaturesQCOM"/>
                 <type name="VkTilePropertiesQCOM"/>
+            </require>
+            <require depends="VK_KHR_dynamic_rendering,VK_VERSION_1_3">
                 <type name="VkRenderingInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_SEC_amigo_profiling" number="486" type="device" depends="VK_KHR_get_physical_device_properties2" author="SEC" contact="Ralph Potter gitlab:@r_potter" supported="vulkan">
+        <extension name="VK_SEC_amigo_profiling" number="486" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="SEC" contact="Ralph Potter gitlab:@r_potter" supported="vulkan">
             <require>
                 <enum value="1"                                               name="VK_SEC_AMIGO_PROFILING_SPEC_VERSION"/>
                 <enum value="&quot;VK_SEC_amigo_profiling&quot;"              name="VK_SEC_AMIGO_PROFILING_EXTENSION_NAME"/>
@@ -21866,7 +23580,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_488&quot;"          name="VK_EXT_EXTENSION_488_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_multiview_per_view_viewports" number="489" type="device" author="QCOM" contact="Jeff Leger @jackohound" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_QCOM_multiview_per_view_viewports" number="489" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="1"                                                name="VK_QCOM_MULTIVIEW_PER_VIEW_VIEWPORTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_multiview_per_view_viewports&quot;" name="VK_QCOM_MULTIVIEW_PER_VIEW_VIEWPORTS_EXTENSION_NAME"/>
@@ -21928,12 +23642,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                         name="VK_NV_EXTENSION_492_SPEC_VERSION"/>
                 <enum value="&quot;VK_NV_extension_492&quot;"           name="VK_NV_EXTENSION_492_EXTENSION_NAME"/>
+                <enum bitpos="44" extends="VkPipelineStageFlagBits2"    name="VK_PIPELINE_STAGE_2_RESERVED_44_BIT_NV"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_493" number="493" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+        <extension name="VK_NV_extended_sparse_address_space" number="493" type="device" author="NV" contact="Russell Chou @russellcnv" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_NV_EXTENSION_493_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_493&quot;"           name="VK_NV_EXTENSION_493_EXTENSION_NAME"/>
+                <enum value="1"                                               name="VK_NV_EXTENDED_SPARSE_ADDRESS_SPACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extended_sparse_address_space&quot;" name="VK_NV_EXTENDED_SPARSE_ADDRESS_SPACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV"/>
+                <enum offset="1" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV"/>
+                <type name="VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV"/>
+                <type name="VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV"/>
             </require>
         </extension>
         <extension name="VK_NV_extension_494" number="494" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
@@ -21962,13 +23681,17 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_496&quot;"              name="VK_EXT_EXTENSION_496_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_497" number="497" author="EXT" contact="Christophe Riccio @christophe" type="device" supported="disabled">
+        <extension name="VK_EXT_layer_settings" number="497" author="EXT" contact="Christophe Riccio @christophe" type="instance" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_497_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_497&quot;"              name="VK_EXT_EXTENSION_497_EXTENSION_NAME"/>
+                <enum value="2"                                             name="VK_EXT_LAYER_SETTINGS_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_layer_settings&quot;"              name="VK_EXT_LAYER_SETTINGS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT"/>
+                <type name="VkLayerSettingsCreateInfoEXT"/>
+                <type name="VkLayerSettingEXT"/>
+                <type name="VkLayerSettingTypeEXT"/>
             </require>
         </extension>
-        <extension name="VK_ARM_shader_core_builtins" number="498" author="ARM" contact="Kevin Petit @kevinpetit" type="device" depends="VK_KHR_get_physical_device_properties2" supported="vulkan">
+        <extension name="VK_ARM_shader_core_builtins" number="498" author="ARM" contact="Kevin Petit @kpet" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" supported="vulkan">
             <require>
                 <enum value="2"                                         name="VK_ARM_SHADER_CORE_BUILTINS_SPEC_VERSION"/>
                 <enum value="&quot;VK_ARM_shader_core_builtins&quot;"   name="VK_ARM_SHADER_CORE_BUILTINS_EXTENSION_NAME"/>
@@ -21986,7 +23709,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_dynamic_rendering_unused_attachments" number="500" author="EXT" contact="Piers Daniell @pdaniell-nv" type="device" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+(VK_KHR_dynamic_rendering,VK_VERSION_1_3)" supported="vulkan" ratified="vulkan">
+        <extension name="VK_EXT_dynamic_rendering_unused_attachments" number="500" author="EXT" contact="Piers Daniell @pdaniell-nv" type="device" depends="((VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_KHR_dynamic_rendering),VK_VERSION_1_3" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                                        name="VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_dynamic_rendering_unused_attachments&quot;"  name="VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME"/>
@@ -22024,19 +23747,53 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_505&quot;"              name="VK_EXT_EXTENSION_505_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NV_extension_506" number="506" author="NV" contact="Charles Hansen @cshansen" type="device" supported="disabled">
+        <extension name="VK_NV_low_latency2" number="506" author="NV" depends="VK_VERSION_1_2,VK_KHR_timeline_semaphore" contact="Charles Hansen @cshansen" type="device" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_NV_EXTENSION_506_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_extension_506&quot;"               name="VK_NV_EXTENSION_506_EXTENSION_NAME"/>
+                <enum value="2"                                             name="VK_NV_LOW_LATENCY_2_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_low_latency2&quot;"                name="VK_NV_LOW_LATENCY_2_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV"/>
+                <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV"/>
+                <enum offset="4" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_LATENCY_TIMINGS_FRAME_REPORT_NV"/>
+                <enum offset="5" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV"/>
+                <enum offset="6" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_OUT_OF_BAND_QUEUE_TYPE_INFO_NV"/>
+                <enum offset="7" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SWAPCHAIN_LATENCY_CREATE_INFO_NV"/>
+                <enum offset="8" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_LATENCY_SURFACE_CAPABILITIES_NV"/>
+                <type name="VkLatencySleepModeInfoNV"/>
+                <type name="VkLatencySleepInfoNV"/>
+                <type name="VkSetLatencyMarkerInfoNV"/>
+                <type name="VkGetLatencyMarkerInfoNV"/>
+                <type name="VkLatencyTimingsFrameReportNV"/>
+                <type name="VkLatencyMarkerNV"/>
+                <type name="VkLatencySubmissionPresentIdNV"/>
+                <type name="VkSwapchainLatencyCreateInfoNV"/>
+                <type name="VkOutOfBandQueueTypeInfoNV"/>
+                <type name="VkOutOfBandQueueTypeNV"/>
+                <type name="VkLatencySurfaceCapabilitiesNV"/>
+                <command name="vkSetLatencySleepModeNV"/>
+                <command name="vkLatencySleepNV"/>
+                <command name="vkSetLatencyMarkerNV"/>
+                <command name="vkGetLatencyTimingsNV"/>
+                <command name="vkQueueNotifyOutOfBandNV"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_507" number="507" author="KHR" contact="Kevin Petit @kevinpetit" type="device" supported="disabled">
+        <extension name="VK_KHR_cooperative_matrix" number="507" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Kevin Petit @kpet" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_KHR_EXTENSION_507_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_507&quot;"              name="VK_KHR_EXTENSION_507_EXTENSION_NAME"/>
+                <enum value="2"                                              name="VK_KHR_COOPERATIVE_MATRIX_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_cooperative_matrix&quot;"          name="VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR"/>
+                <enum offset="1" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR"/>
+                <enum offset="2" extends="VkStructureType"                   name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_KHR"/>
+                <type name="VkCooperativeMatrixPropertiesKHR"/>
+                <type name="VkScopeKHR"/>
+                <type name="VkComponentTypeKHR"/>
+                <type name="VkPhysicalDeviceCooperativeMatrixFeaturesKHR"/>
+                <type name="VkPhysicalDeviceCooperativeMatrixPropertiesKHR"/>
+                <command name="vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_508" number="508" author="EXT" contact="Kevin Petit @kevinpetit" type="device" supported="disabled">
+        <extension name="VK_EXT_extension_508" number="508" author="EXT" contact="Kevin Petit @kpet" type="device" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_EXT_EXTENSION_508_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_508&quot;"              name="VK_EXT_EXTENSION_508_EXTENSION_NAME"/>
@@ -22044,9 +23801,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="42" extends="VkPipelineStageFlagBits2"        name="VK_PIPELINE_STAGE_2_RESERVED_42_BIT_EXT" />
                 <enum bitpos="47" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_RESERVED_47_BIT_EXT" />
                 <enum bitpos="48" extends="VkAccessFlagBits2"               name="VK_ACCESS_2_RESERVED_48_BIT_EXT" />
+                <enum bitpos="48" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_RESERVED_48_BIT_EXT" />
             </require>
         </extension>
-        <extension name="VK_EXT_extension_509" number="509" author="EXT" contact="Kevin Petit @kevinpetit" type="device" supported="disabled">
+        <extension name="VK_EXT_extension_509" number="509" author="EXT" contact="Kevin Petit @kpet" type="device" supported="disabled">
             <require>
                 <enum value="0"                                             name="VK_EXT_EXTENSION_509_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_509&quot;"              name="VK_EXT_EXTENSION_509_EXTENSION_NAME"/>
@@ -22058,7 +23816,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_MESA_extension_510&quot;"             name="VK_MESA_EXTENSION_510_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_multiview_per_view_render_areas" number="511" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="vulkan">
+        <extension name="VK_QCOM_multiview_per_view_render_areas" number="511" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
                 <enum value="1"                                                   name="VK_QCOM_MULTIVIEW_PER_VIEW_RENDER_AREAS_SPEC_VERSION"/>
                 <enum value="&quot;VK_QCOM_multiview_per_view_render_areas&quot;" name="VK_QCOM_MULTIVIEW_PER_VIEW_RENDER_AREAS_EXTENSION_NAME"/>
@@ -22074,10 +23832,22 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_512&quot;"              name="VK_EXT_EXTENSION_512_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_513" number="513" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
+        <extension name="VK_KHR_video_decode_av1" number="513" author="KHR" depends="VK_KHR_video_decode_queue" contact="Daniel Rakos @aqnuep" type="device" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_KHR_EXTENSION_513_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_513&quot;"              name="VK_KHR_EXTENSION_513_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_KHR_VIDEO_DECODE_AV1_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_video_decode_av1&quot;"           name="VK_KHR_VIDEO_DECODE_AV1_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_CAPABILITIES_KHR"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PICTURE_INFO_KHR"/>
+                <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PROFILE_INFO_KHR"/>
+                <enum offset="4" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_SESSION_PARAMETERS_CREATE_INFO_KHR"/>
+                <enum offset="5" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_DPB_SLOT_INFO_KHR"/>
+                <enum bitpos="2" extends="VkVideoCodecOperationFlagBitsKHR" name="VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR"/>
+                <enum name="VK_MAX_VIDEO_AV1_REFERENCES_PER_FRAME_KHR"/>
+                <type name="VkVideoDecodeAV1ProfileInfoKHR"/>
+                <type name="VkVideoDecodeAV1CapabilitiesKHR"/>
+                <type name="VkVideoDecodeAV1SessionParametersCreateInfoKHR"/>
+                <type name="VkVideoDecodeAV1PictureInfoKHR"/>
+                <type name="VkVideoDecodeAV1DpbSlotInfoKHR"/>
             </require>
         </extension>
         <extension name="VK_KHR_extension_514" number="514" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
@@ -22092,19 +23862,26 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_KHR_extension_515&quot;"              name="VK_KHR_EXTENSION_515_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_516" number="516" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
+        <extension name="VK_KHR_video_maintenance1" number="516" author="KHR" contact="Daniel Rakos @aqnuep" type="device" depends="VK_KHR_video_queue" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                             name="VK_KHR_EXTENSION_516_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_516&quot;"              name="VK_KHR_EXTENSION_516_EXTENSION_NAME"/>
-                <enum bitpos="20" extends="VkImageCreateFlagBits"           name="VK_IMAGE_CREATE_RESERVED_20_BIT_KHR"/>
-                <enum bitpos="6" extends="VkBufferCreateFlagBits"           name="VK_BUFFER_CREATE_RESERVED_6_BIT_KHR"/>
+                <enum value="1"                                             name="VK_KHR_VIDEO_MAINTENANCE_1_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_video_maintenance1&quot;"         name="VK_KHR_VIDEO_MAINTENANCE_1_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_1_FEATURES_KHR"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_VIDEO_INLINE_QUERY_INFO_KHR"/>
+                <enum bitpos="20" extends="VkImageCreateFlagBits"           name="VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR"/>
+                <enum bitpos="6" extends="VkBufferCreateFlagBits"           name="VK_BUFFER_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR"/>
+                <enum bitpos="2" extends="VkVideoSessionCreateFlagBitsKHR"  name="VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR"/>
+                <type name="VkPhysicalDeviceVideoMaintenance1FeaturesKHR"/>
+                <type name="VkVideoInlineQueryInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_517" number="517" author="EXT" contact="Daniel Story" supported="disabled">
+        <extension name="VK_NV_per_stage_descriptor_set" number="517" depends="VK_KHR_maintenance6" type="device" author="NV" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
             <require>
-                <enum value="0"                                                name="VK_EXT_EXTENSION_517_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_517&quot;"                 name="VK_EXT_EXTENSION_517_EXTENSION_NAME"/>
-                <enum bitpos="6" extends="VkDescriptorSetLayoutCreateFlagBits" name="VK_DESCRIPTOR_SET_LAYOUT_CREATE_RESERVED_6_BIT_EXT"/>
+                <enum value="1"                                                name="VK_NV_PER_STAGE_DESCRIPTOR_SET_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_per_stage_descriptor_set&quot;"       name="VK_NV_PER_STAGE_DESCRIPTOR_SET_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                     name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PER_STAGE_DESCRIPTOR_SET_FEATURES_NV"/>
+                <enum bitpos="6" extends="VkDescriptorSetLayoutCreateFlagBits" name="VK_DESCRIPTOR_SET_LAYOUT_CREATE_PER_STAGE_BIT_NV"/>
+                <type name="VkPhysicalDevicePerStageDescriptorSetFeaturesNV"/>
             </require>
         </extension>
         <extension name="VK_MESA_extension_518" number="518" author="MESA" contact="Dave Airlie @airlied" type="device" supported="disabled">
@@ -22113,31 +23890,52 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_MESA_extension_518&quot;"             name="VK_MESA_EXTENSION_518_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_519" number="519" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+        <extension name="VK_QCOM_image_processing2" number="519" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan" depends="VK_QCOM_image_processing">
             <require>
-                <enum value="0"                                                   name="VK_QCOM_EXTENSION_519_SPEC_VERSION"/>
-                <enum value="&quot;VK_QCOM_extension_519&quot;"                   name="VK_QCOM_EXTENSION_519_EXTENSION_NAME"/>
+                <enum value="1"                                                   name="VK_QCOM_IMAGE_PROCESSING_2_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_image_processing2&quot;"               name="VK_QCOM_IMAGE_PROCESSING_2_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                        name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM"/>
+                <enum offset="1" extends="VkStructureType"                        name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_PROPERTIES_QCOM"/>
+                <enum offset="2" extends="VkStructureType"                        name="VK_STRUCTURE_TYPE_SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM"/>
+                <type name="VkPhysicalDeviceImageProcessing2FeaturesQCOM"/>
+                <type name="VkPhysicalDeviceImageProcessing2PropertiesQCOM"/>
+                <type name="VkSamplerBlockMatchWindowCreateInfoQCOM"/>
+                <type name="VkBlockMatchWindowCompareModeQCOM"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_520" number="520" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+        <extension name="VK_QCOM_filter_cubic_weights" number="520" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan" depends="VK_EXT_filter_cubic">
             <require>
-                <enum value="0"                                                   name="VK_QCOM_EXTENSION_520_SPEC_VERSION"/>
-                <enum value="&quot;VK_QCOM_extension_520&quot;"                   name="VK_QCOM_EXTENSION_520_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_QCOM_FILTER_CUBIC_WEIGHTS_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_filter_cubic_weights&quot;"      name="VK_QCOM_FILTER_CUBIC_WEIGHTS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_BLIT_IMAGE_CUBIC_WEIGHTS_INFO_QCOM"/>
+                <type name="VkPhysicalDeviceCubicWeightsFeaturesQCOM"/>
+                <type name="VkSamplerCubicWeightsCreateInfoQCOM"/>
+                <type name="VkBlitImageCubicWeightsInfoQCOM"/>
+                <type name="VkCubicFilterWeightsQCOM"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_521" number="521" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+        <extension name="VK_QCOM_ycbcr_degamma" number="521" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
-                <enum value="0"                                                   name="VK_QCOM_EXTENSION_521_SPEC_VERSION"/>
-                <enum value="&quot;VK_QCOM_extension_521&quot;"                   name="VK_QCOM_EXTENSION_521_EXTENSION_NAME"/>
+                <enum value="1"                                                   name="VK_QCOM_YCBCR_DEGAMMA_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_ycbcr_degamma&quot;"                   name="VK_QCOM_YCBCR_DEGAMMA_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                        name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM"/>
+                <enum offset="1" extends="VkStructureType"                        name="VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_YCBCR_DEGAMMA_CREATE_INFO_QCOM"/>
+                <type name="VkPhysicalDeviceYcbcrDegammaFeaturesQCOM"/>
+                <type name="VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM"/>
             </require>
         </extension>
-        <extension name="VK_QCOM_extension_522" number="522" type="device" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+        <extension name="VK_QCOM_filter_cubic_clamp" number="522" type="device" author="QCOM" depends="(VK_EXT_filter_cubic)+(VK_VERSION_1_2,VK_EXT_sampler_filter_minmax)" contact="Matthew Netsch @mnetsch" supported="vulkan">
             <require>
-                <enum value="0"                                                   name="VK_QCOM_EXTENSION_522_SPEC_VERSION"/>
-                <enum value="&quot;VK_QCOM_extension_522&quot;"                   name="VK_QCOM_EXTENSION_522_EXTENSION_NAME"/>
+                <enum value="1"                                                   name="VK_QCOM_FILTER_CUBIC_CLAMP_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_filter_cubic_clamp&quot;"              name="VK_QCOM_FILTER_CUBIC_CLAMP_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                        name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM"/>
+                <enum offset="0" extends="VkSamplerReductionMode"                 name="VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE_RANGECLAMP_QCOM"/>
+                <type name="VkPhysicalDeviceCubicClampFeaturesQCOM"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_523" number="523" author="EXT" contact="Kevin Petit @kevinpetit" supported="disabled">
+        <extension name="VK_EXT_extension_523" number="523" author="EXT" contact="Kevin Petit @kpet" supported="disabled">
             <require>
                 <enum value="0"                                                name="VK_EXT_EXTENSION_523_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_523&quot;"                 name="VK_EXT_EXTENSION_523_EXTENSION_NAME"/>
@@ -22149,7 +23947,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_524&quot;"                 name="VK_EXT_EXTENSION_524_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_attachment_feedback_loop_dynamic_state" number="525" type="device" author="EXT" depends="VK_KHR_get_physical_device_properties2+VK_EXT_attachment_feedback_loop_layout" contact="Mike Blumenkrantz @zmike" supported="vulkan">
+        <extension name="VK_EXT_attachment_feedback_loop_dynamic_state" number="525" type="device" author="EXT" depends="(VK_KHR_get_physical_device_properties2,VK_VERSION_1_1)+VK_EXT_attachment_feedback_loop_layout" contact="Mike Blumenkrantz @zmike" supported="vulkan" ratified="vulkan">
             <require>
                 <enum value="1"                                                                name="VK_EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_attachment_feedback_loop_dynamic_state&quot;" name="VK_EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_EXTENSION_NAME"/>
@@ -22159,16 +23957,25 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <command name="vkCmdSetAttachmentFeedbackLoopEnableEXT"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_526" number="526" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="disabled">
+        <extension name="VK_KHR_vertex_attribute_divisor" number="526" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_EXT_EXTENSION_526_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_526&quot;"          name="VK_EXT_EXTENSION_526_EXTENSION_NAME"/>
+                <enum value="1"                                            name="VK_KHR_VERTEX_ATTRIBUTE_DIVISOR_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_vertex_attribute_divisor&quot;"  name="VK_KHR_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                 name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_KHR"/>
+                <enum offset="1" extends="VkStructureType" extnumber="191" name="VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType" extnumber="191" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_KHR"/>
+                <type name="VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR"/>
+                <type name="VkVertexInputBindingDivisorDescriptionKHR"/>
+                <type name="VkPipelineVertexInputDivisorStateCreateInfoKHR"/>
+                <type name="VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_527" number="527" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="disabled">
+        <extension name="VK_KHR_load_store_op_none" number="527" author="KHR" type="device" contact="Shahbaz Youssefi @syoussefi" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_EXT_EXTENSION_527_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_527&quot;"          name="VK_EXT_EXTENSION_527_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_LOAD_STORE_OP_NONE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_load_store_op_none&quot;"     name="VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkAttachmentLoadOp" extnumber="401" name="VK_ATTACHMENT_LOAD_OP_NONE_KHR"/>
+                <enum extends="VkAttachmentStoreOp" name="VK_ATTACHMENT_STORE_OP_NONE_KHR" alias="VK_ATTACHMENT_STORE_OP_NONE"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_528" number="528" author="EXT" contact="Shahbaz Youssefi @syoussefi" supported="disabled">
@@ -22177,29 +23984,376 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="&quot;VK_EXT_extension_528&quot;"          name="VK_EXT_EXTENSION_528_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_529" number="529" author="KHR" contact="Graeme Leese @gnl21" supported="disabled">
+        <extension name="VK_KHR_shader_float_controls2" number="529" type="device" depends="VK_VERSION_1_1+VK_KHR_shader_float_controls" author="KHR" contact="Graeme Leese @gnl21" supported="vulkan" ratified="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_529_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_529&quot;"          name="VK_KHR_EXTENSION_529_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_SHADER_FLOAT_CONTROLS_2_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_shader_float_controls2&quot;" name="VK_KHR_SHADER_FLOAT_CONTROLS_2_EXTENSION_NAME"/>
+                <type name="VkPhysicalDeviceShaderFloatControls2FeaturesKHR"/>
+                <enum offset="0" extends="VkStructureType" name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT_CONTROLS_2_FEATURES_KHR"/>
             </require>
         </extension>
-        <extension name="VK_QNX_extension_530" number="530" author="QNX" contact="Mike Gorchak @mgorchak-blackberry" supported="disabled">
+        <extension name="VK_QNX_external_memory_screen_buffer" number="530" type="device" author="QNX" depends="((VK_KHR_sampler_ycbcr_conversion+VK_KHR_external_memory+VK_KHR_dedicated_allocation),VK_VERSION_1_1)+VK_EXT_queue_family_foreign" platform="screen" contact="Mike Gorchak @mgorchak-blackberry, Aaron Ruby @aruby-blackberry" supported="vulkan,vulkansc">
             <require>
-                <enum value="0"                                         name="VK_QNX_EXTENSION_530_SPEC_VERSION"/>
-                <enum value="&quot;VK_QNX_extension_530&quot;"          name="VK_QNX_EXTENSION_530_EXTENSION_NAME"/>
-                <enum bitpos="14" extends="VkExternalMemoryHandleTypeFlagBits" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_530_BIT_QNX"/>
+                <enum value="1"                                             name="VK_QNX_EXTERNAL_MEMORY_SCREEN_BUFFER_SPEC_VERSION"/>
+                <enum value="&quot;VK_QNX_external_memory_screen_buffer&quot;" name="VK_QNX_EXTERNAL_MEMORY_SCREEN_BUFFER_EXTENSION_NAME"/>
+                <enum bitpos="14" extends="VkExternalMemoryHandleTypeFlagBits" name="VK_EXTERNAL_MEMORY_HANDLE_TYPE_SCREEN_BUFFER_BIT_QNX"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SCREEN_BUFFER_PROPERTIES_QNX"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SCREEN_BUFFER_FORMAT_PROPERTIES_QNX"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_IMPORT_SCREEN_BUFFER_INFO_QNX"/>
+                <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX"/>
+                <enum offset="4" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCREEN_BUFFER_FEATURES_QNX"/>
+                <type name="VkScreenBufferPropertiesQNX"/>
+                <type name="VkScreenBufferFormatPropertiesQNX"/>
+                <type name="VkImportScreenBufferInfoQNX"/>
+                <type name="VkExternalFormatQNX"/>
+                <type name="VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX"/>
+                <command name="vkGetScreenBufferPropertiesQNX"/>
             </require>
         </extension>
-        <extension name="VK_MSFT_extension_531" number="531" author="MSFT" contact="Jesse Natalie @jenatali" supported="disabled">
+        <extension name="VK_MSFT_layered_driver" number="531" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="MSFT" contact="Jesse Natalie @jenatali" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_MSFT_EXTENSION_531_SPEC_VERSION"/>
-                <enum value="&quot;VK_MSFT_extension_531&quot;"         name="VK_MSFT_EXTENSION_531_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_MSFT_LAYERED_DRIVER_SPEC_VERSION"/>
+                <enum value="&quot;VK_MSFT_layered_driver&quot;"        name="VK_MSFT_LAYERED_DRIVER_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_DRIVER_PROPERTIES_MSFT"/>
+                <type name="VkLayeredDriverUnderlyingApiMSFT"/>
+                <type name="VkPhysicalDeviceLayeredDriverPropertiesMSFT"/>
             </require>
         </extension>
         <extension name="VK_KHR_extension_532" number="532" author="KHR" contact="Tobias Hector @tobias" supported="disabled">
             <require>
                 <enum value="0"                                         name="VK_KHR_EXTENSION_532_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_extension_532&quot;"         name="VK_KHR_EXTENSION_532_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_533" number="533" author="EXT" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_533_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_533&quot;"          name="VK_EXT_EXTENSION_533_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_index_type_uint8" number="534" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Piers Daniell @pdaniell-nv" supported="vulkan" ratified="vulkan">
+            <require>
+                <enum value="1"                                             name="VK_KHR_INDEX_TYPE_UINT8_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_index_type_uint8&quot;"           name="VK_KHR_INDEX_TYPE_UINT8_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType" extnumber="266"  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_KHR"/>
+                <enum offset="0" extends="VkIndexType" extnumber="266"      name="VK_INDEX_TYPE_UINT8_KHR"/>
+                <type name="VkPhysicalDeviceIndexTypeUint8FeaturesKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_line_rasterization" number="535" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Piers Daniell @pdaniell-nv" supported="vulkan" ratified="vulkan">
+            <require>
+                <enum value="1"                                             name="VK_KHR_LINE_RASTERIZATION_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_line_rasterization&quot;"         name="VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType" extnumber="260"  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_KHR"/>
+                <enum offset="1" extends="VkStructureType" extnumber="260"  name="VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_KHR"/>
+                <enum offset="2" extends="VkStructureType" extnumber="260"  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_KHR"/>
+                <enum offset="0" extends="VkDynamicState"  extnumber="260"  name="VK_DYNAMIC_STATE_LINE_STIPPLE_KHR"/>
+                <type name="VkPhysicalDeviceLineRasterizationFeaturesKHR"/>
+                <type name="VkPhysicalDeviceLineRasterizationPropertiesKHR"/>
+                <type name="VkPipelineRasterizationLineStateCreateInfoKHR"/>
+                <type name="VkLineRasterizationModeKHR"/>
+                <command name="vkCmdSetLineStippleKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_QCOM_extension_536" number="536" type="device" author="QCOM" contact="Matthew Netsch @mnetsch" supported="disabled">
+            <require>
+                <enum value="0"                                                   name="VK_QCOM_EXTENSION_536_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_extension_536&quot;"                   name="VK_QCOM_EXTENSION_536_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_537" number="537" author="EXT" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_537_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_537&quot;"          name="VK_EXT_EXTENSION_537_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_538" number="538" author="EXT" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_538_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_538&quot;"          name="VK_EXT_EXTENSION_538_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_539" number="539" author="EXT" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_539_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_539&quot;"          name="VK_EXT_EXTENSION_539_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_540" number="540" author="EXT" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_540_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_540&quot;"          name="VK_EXT_EXTENSION_540_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_541" number="541" author="EXT" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_541_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_541&quot;"          name="VK_EXT_EXTENSION_541_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_542" number="542" author="EXT" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_542_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_542&quot;"          name="VK_EXT_EXTENSION_542_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_543" number="543" author="EXT" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_EXT_EXTENSION_543_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_543&quot;"          name="VK_EXT_EXTENSION_543_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_calibrated_timestamps" number="544" type="device" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" author="KHR" contact="Daniel Rakos @aqnuep" supported="vulkan" ratified="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_CALIBRATED_TIMESTAMPS_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_calibrated_timestamps&quot;"  name="VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType" extnumber="185" name="VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR"/>
+                <type name="VkTimeDomainKHR"/>
+                <type name="VkCalibratedTimestampInfoKHR"/>
+                <command name="vkGetPhysicalDeviceCalibrateableTimeDomainsKHR"/>
+                <command name="vkGetCalibratedTimestampsKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_shader_expect_assume" number="545" type="device" author="KHR" depends="VK_KHR_get_physical_device_properties2,VK_VERSION_1_1" contact="Kevin Petit @kpet" supported="vulkan" ratified="vulkan">
+            <require>
+                <enum value="1"                                             name="VK_KHR_SHADER_EXPECT_ASSUME_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_shader_expect_assume&quot;"       name="VK_KHR_SHADER_EXPECT_ASSUME_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EXPECT_ASSUME_FEATURES_KHR"/>
+                <type name="VkPhysicalDeviceShaderExpectAssumeFeaturesKHR"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_maintenance6" number="546" type="device" depends="VK_VERSION_1_1" author="KHR" contact="Jon Leech @oddhack" supported="vulkan" ratified="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_MAINTENANCE_6_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_maintenance6&quot;"           name="VK_KHR_MAINTENANCE_6_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BIND_MEMORY_STATUS_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO_KHR"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PUSH_CONSTANTS_INFO_KHR"/>
+                <type name="VkPhysicalDeviceMaintenance6FeaturesKHR"/>
+                <type name="VkPhysicalDeviceMaintenance6PropertiesKHR"/>
+                <type name="VkBindMemoryStatusKHR"/>
+                <type name="VkBindDescriptorSetsInfoKHR"/>
+                <type name="VkPushConstantsInfoKHR"/>
+                <command name="vkCmdBindDescriptorSets2KHR"/>
+                <command name="vkCmdPushConstants2KHR"/>
+            </require>
+            <require depends="VK_KHR_push_descriptor">
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_INFO_KHR"/>
+                <enum offset="6" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_WITH_TEMPLATE_INFO_KHR"/>
+                <type name="VkPushDescriptorSetInfoKHR"/>
+                <type name="VkPushDescriptorSetWithTemplateInfoKHR"/>
+                <command name="vkCmdPushDescriptorSet2KHR"/>
+                <command name="vkCmdPushDescriptorSetWithTemplate2KHR"/>
+            </require>
+            <require depends="VK_EXT_descriptor_buffer">
+                <enum offset="7" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT"/>
+                <enum offset="8" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_BUFFER_EMBEDDED_SAMPLERS_INFO_EXT"/>
+                <type name="VkSetDescriptorBufferOffsetsInfoEXT"/>
+                <type name="VkBindDescriptorBufferEmbeddedSamplersInfoEXT"/>
+                <command name="vkCmdSetDescriptorBufferOffsets2EXT"/>
+                <command name="vkCmdBindDescriptorBufferEmbeddedSamplers2EXT"/>
+            </require>
+            <require comment="Individual APIs with dependencies on specific versions/extensions should get their own require blocks with depends= attribute set appropriately">
+            </require>
+        </extension>
+        <extension name="VK_NV_descriptor_pool_overallocation" number="547" type="device" author="NV" depends="VK_VERSION_1_1" contact="Piers Daniell @pdaniell-nv" supported="vulkan">
+            <require>
+                <enum value="1"                                                 name="VK_NV_DESCRIPTOR_POOL_OVERALLOCATION_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_descriptor_pool_overallocation&quot;"  name="VK_NV_DESCRIPTOR_POOL_OVERALLOCATION_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV"/>
+                <enum bitpos="3" extends="VkDescriptorPoolCreateFlagBits"       name="VK_DESCRIPTOR_POOL_CREATE_ALLOW_OVERALLOCATION_SETS_BIT_NV"/>
+                <enum bitpos="4" extends="VkDescriptorPoolCreateFlagBits"       name="VK_DESCRIPTOR_POOL_CREATE_ALLOW_OVERALLOCATION_POOLS_BIT_NV"/>
+                <type name="VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV"/>
+            </require>
+        </extension>
+        <extension name="VK_QCOM_extension_548" number="548" type="device" author="QCOM" contact="Patrick Boyle @pboyleQCOM" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_QCOM_EXTENSION_548_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_extension_548&quot;"         name="VK_QCOM_EXTENSION_548_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_549" number="549" author="NV" contact="Piers Daniell @pdaniell-nv" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_549_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_549&quot;"           name="VK_NV_EXTENSION_549_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_550" number="550" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_550_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_550&quot;"           name="VK_NV_EXTENSION_550_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_551" number="551" author="NV" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_551_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_551&quot;"           name="VK_NV_EXTENSION_551_EXTENSION_NAME"/>
+                <enum bitpos="45" extends="VkPipelineStageFlagBits2"   name="VK_PIPELINE_STAGE_2_RESERVED_45_BIT_NV"/>
+                <enum bitpos="55" extends="VkAccessFlagBits2"          name="VK_ACCESS_2_RESERVED_55_BIT_NV"/>
+                <enum bitpos="56" extends="VkAccessFlagBits2"          name="VK_ACCESS_2_RESERVED_56_BIT_NV"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_552" number="552" author="NV" contact="Russell Chou @russellcnv" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_552_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_552&quot;"           name="VK_NV_EXTENSION_552_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_553" number="553" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_553_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_553&quot;"              name="VK_KHR_EXTENSION_553_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_554" number="554" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" type="device" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_554_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_554&quot;"              name="VK_KHR_EXTENSION_554_EXTENSION_NAME"/>
+                <enum bitpos="2"  extends="VkVideoEncodeCapabilityFlagBitsKHR" name="VK_VIDEO_ENCODE_CAPABILITY_RESERVED_2_BIT_KHR"/>
+                <enum bitpos="3"  extends="VkVideoEncodeCapabilityFlagBitsKHR" name="VK_VIDEO_ENCODE_CAPABILITY_RESERVED_3_BIT_KHR"/>
+                <enum bitpos="3"  extends="VkVideoSessionCreateFlagBitsKHR" name="VK_VIDEO_SESSION_CREATE_RESERVED_3_BIT_KHR"/>
+                <enum bitpos="4"  extends="VkVideoSessionCreateFlagBitsKHR" name="VK_VIDEO_SESSION_CREATE_RESERVED_4_BIT_KHR"/>
+                <enum bitpos="0"  extends="VkVideoEncodeFlagBitsKHR"        name="VK_VIDEO_ENCODE_RESERVED_0_BIT_KHR"/>
+                <enum bitpos="1"  extends="VkVideoEncodeFlagBitsKHR"        name="VK_VIDEO_ENCODE_RESERVED_1_BIT_KHR"/>
+                <enum bitpos="25" extends="VkImageUsageFlagBits"            name="VK_IMAGE_USAGE_RESERVED_25_BIT_KHR"/>
+                <enum bitpos="26" extends="VkImageUsageFlagBits"            name="VK_IMAGE_USAGE_RESERVED_26_BIT_KHR"/>
+                <enum bitpos="49" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_RESERVED_49_BIT_KHR"/>
+                <enum bitpos="50" extends="VkFormatFeatureFlagBits2"        name="VK_FORMAT_FEATURE_2_RESERVED_50_BIT_KHR"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_555" number="555" author="IMG" contact="Jarred Davies" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_IMG_EXTENSION_555_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_555&quot;"              name="VK_IMG_EXTENSION_555_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_raw_access_chains" number="556" type="device" author="NV" contact="Rodrigo Locatti @rlocatti" supported="vulkan">
+            <require>
+                <enum value="1"                                             name="VK_NV_RAW_ACCESS_CHAINS_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_raw_access_chains&quot;"           name="VK_NV_RAW_ACCESS_CHAINS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV"/>
+                <type name="VkPhysicalDeviceRawAccessChainsFeaturesNV"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_557" number="557" type="device" author="NV" contact="Chris Lentini @clentini" supported="disabled">
+            <require>
+                <enum value="1"                                             name="VK_NV_EXTENSION_557_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_557&quot;"               name="VK_NV_EXTENSION_557_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_558" number="558" type="device" author="KHR" contact="Ahmed Abdelkhalek @aabdelkh" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_558_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_558&quot;"              name="VK_KHR_EXTENSION_558_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_559" number="559" type="device" author="KHR" contact="Nathan Gauër @Keenuts1" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_559_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_559&quot;"              name="VK_KHR_EXTENSION_559_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_560" number="560" author="NV" contact="Lujin Wang @lwnv" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_NV_EXTENSION_560_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_560&quot;"               name="VK_NV_EXTENSION_560_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_561" number="561" author="EXT" contact="Piers Daniell @pdaniell-nv" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_561_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_561&quot;"              name="VK_EXT_EXTENSION_561_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_562" number="562" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_562_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_562&quot;"              name="VK_KHR_EXTENSION_562_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_563" number="563" author="KHR" contact="Jon Leech @oddhack" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_563_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_563&quot;"              name="VK_KHR_EXTENSION_563_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_shader_atomic_float16_vector" number="564" type="device" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+            <require>
+                <enum value="1"                                             name="VK_NV_SHADER_ATOMIC_FLOAT16_VECTOR_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_shader_atomic_float16_vector&quot;" name="VK_NV_SHADER_ATOMIC_FLOAT16_VECTOR_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV"/>
+                <type name="VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_565" number="565" author="EXT" contact="Kevin Petit @kpet" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_565_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_565&quot;"              name="VK_EXT_EXTENSION_565_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_ARM_extension_566" number="566" author="ARM" contact="Kevin Petit @kpet" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_ARM_EXTENSION_566_SPEC_VERSION"/>
+                <enum value="&quot;VK_ARM_extension_566&quot;"              name="VK_ARM_EXTENSION_566_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_ARM_extension_567" number="567" author="ARM" contact="Kevin Petit @kpet" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_ARM_EXTENSION_567_SPEC_VERSION"/>
+                <enum value="&quot;VK_ARM_extension_567&quot;"              name="VK_ARM_EXTENSION_567_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_ARM_extension_568" number="568" author="ARM" contact="Kevin Petit @kpet" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_ARM_EXTENSION_568_SPEC_VERSION"/>
+                <enum value="&quot;VK_ARM_extension_568&quot;"              name="VK_ARM_EXTENSION_568_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_ray_tracing_validation" number="569" type="device" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="vulkan">
+            <require>
+                <enum value="1"                                             name="VK_NV_RAY_TRACING_VALIDATION_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_ray_tracing_validation&quot;"      name="VK_NV_RAY_TRACING_VALIDATION_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV"/>
+                <type name="VkPhysicalDeviceRayTracingValidationFeaturesNV"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_570" number="570" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_570_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_570&quot;"           name="VK_NV_EXTENSION_570_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_571" number="571" author="NV" contact="Vikram Kushwaha @vkushwaha-nv" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_571_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_571&quot;"           name="VK_NV_EXTENSION_571_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_572" number="572" author="NV" contact="Jeff Juliano @jjuliano" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_NV_EXTENSION_572_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_572&quot;"               name="VK_NV_EXTENSION_572_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_573" number="573" author="EXT" contact="Mike Blumenkrantz @zmike" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_EXT_EXTENSION_573_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_573&quot;"               name="VK_EXT_EXTENSION_573_EXTENSION_NAME"/>
+                <enum bitpos="7" extends="VkShaderCreateFlagBitsEXT" name="VK_SHADER_CREATE_EXTENSION_573_BIT_EXT"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_574" number="574" author="KHR" contact="Ralph Potter gitlab:@r_potter" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_574_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_574&quot;"              name="VK_KHR_EXTENSION_574_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_575" number="575" author="KHR" contact="Jon Leech @oddhack" supported="disabled">
+            <require>
+                <enum value="0"                                             name="VK_KHR_EXTENSION_575_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_575&quot;"              name="VK_KHR_EXTENSION_575_EXTENSION_NAME"/>
             </require>
         </extension>
     </extensions>
@@ -22238,8 +24392,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </format>
         <format name="VK_FORMAT_B5G5R5A1_UNORM_PACK16" class="16-bit" blockSize="2" texelsPerBlock="1" packed="16">
             <component name="B" bits="5" numericFormat="UNORM"/>
-            <component name="R" bits="5" numericFormat="UNORM"/>
             <component name="G" bits="5" numericFormat="UNORM"/>
+            <component name="R" bits="5" numericFormat="UNORM"/>
             <component name="A" bits="1" numericFormat="UNORM"/>
         </format>
         <format name="VK_FORMAT_A1R5G5B5_UNORM_PACK16" class="16-bit" blockSize="2" texelsPerBlock="1" packed="16">
@@ -22247,6 +24401,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <component name="R" bits="5" numericFormat="UNORM"/>
             <component name="G" bits="5" numericFormat="UNORM"/>
             <component name="B" bits="5" numericFormat="UNORM"/>
+        </format>
+        <format name="VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR" class="16-bit" blockSize="2" texelsPerBlock="1" packed="16">
+            <component name="A" bits="1" numericFormat="UNORM"/>
+            <component name="B" bits="5" numericFormat="UNORM"/>
+            <component name="G" bits="5" numericFormat="UNORM"/>
+            <component name="R" bits="5" numericFormat="UNORM"/>
+        </format>
+        <format name="VK_FORMAT_A8_UNORM_KHR" class="8-bit alpha" blockSize="1" texelsPerBlock="1">
+            <component name="A" bits="8" numericFormat="UNORM"/>
         </format>
         <format name="VK_FORMAT_R8_UNORM" class="8-bit" blockSize="1" texelsPerBlock="1">
             <component name="R" bits="8" numericFormat="UNORM"/>
@@ -22796,15 +24959,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </format>
         <format name="VK_FORMAT_R64G64_UINT" class="128-bit" blockSize="16" texelsPerBlock="1">
             <component name="R" bits="64" numericFormat="UINT"/>
-            <component name="B" bits="64" numericFormat="UINT"/>
+            <component name="G" bits="64" numericFormat="UINT"/>
         </format>
         <format name="VK_FORMAT_R64G64_SINT" class="128-bit" blockSize="16" texelsPerBlock="1">
             <component name="R" bits="64" numericFormat="SINT"/>
-            <component name="B" bits="64" numericFormat="SINT"/>
+            <component name="G" bits="64" numericFormat="SINT"/>
         </format>
         <format name="VK_FORMAT_R64G64_SFLOAT" class="128-bit" blockSize="16" texelsPerBlock="1">
             <component name="R" bits="64" numericFormat="SFLOAT"/>
-            <component name="B" bits="64" numericFormat="SFLOAT"/>
+            <component name="G" bits="64" numericFormat="SFLOAT"/>
         </format>
         <format name="VK_FORMAT_R64G64B64_UINT" class="192-bit" blockSize="24" texelsPerBlock="1">
             <component name="R" bits="64" numericFormat="UINT"/>
@@ -22842,7 +25005,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <format name="VK_FORMAT_B10G11R11_UFLOAT_PACK32" class="32-bit" blockSize="4" texelsPerBlock="1" packed="32">
             <component name="B" bits="10" numericFormat="UFLOAT"/>
             <component name="G" bits="11" numericFormat="UFLOAT"/>
-            <component name="R" bits="10" numericFormat="UFLOAT"/>
+            <component name="R" bits="11" numericFormat="UFLOAT"/>
             <spirvimageformat name="R11fG11fB10f"/>
         </format>
         <format name="VK_FORMAT_E5B9G9R9_UFLOAT_PACK32" class="32-bit" blockSize="4" texelsPerBlock="1" packed="32">
@@ -22924,15 +25087,15 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <component name="R" bits="compressed" numericFormat="UNORM"/>
         </format>
         <format name="VK_FORMAT_BC4_SNORM_BLOCK" class="BC4" blockSize="8" texelsPerBlock="16" blockExtent="4,4,1" compressed="BC">
-            <component name="R" bits="compressed" numericFormat="SRGB"/>
+            <component name="R" bits="compressed" numericFormat="SNORM"/>
         </format>
         <format name="VK_FORMAT_BC5_UNORM_BLOCK" class="BC5" blockSize="16" texelsPerBlock="16" blockExtent="4,4,1" compressed="BC">
             <component name="R" bits="compressed" numericFormat="UNORM"/>
             <component name="G" bits="compressed" numericFormat="UNORM"/>
         </format>
         <format name="VK_FORMAT_BC5_SNORM_BLOCK" class="BC5" blockSize="16" texelsPerBlock="16" blockExtent="4,4,1" compressed="BC">
-            <component name="R" bits="compressed" numericFormat="SRGB"/>
-            <component name="G" bits="compressed" numericFormat="SRGB"/>
+            <component name="R" bits="compressed" numericFormat="SNORM"/>
+            <component name="G" bits="compressed" numericFormat="SNORM"/>
         </format>
         <format name="VK_FORMAT_BC6H_UFLOAT_BLOCK" class="BC6H" blockSize="16" texelsPerBlock="16" blockExtent="4,4,1" compressed="BC">
             <component name="R" bits="compressed" numericFormat="UFLOAT"/>
@@ -23731,21 +25894,21 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <enable extension="VK_EXT_fragment_shader_interlock"/>
         </spirvextension>
         <spirvextension name="SPV_EXT_demote_to_helper_invocation">
-            <enable version="VK_API_VERSION_1_3"/>
+            <enable version="VK_VERSION_1_3"/>
             <enable extension="VK_EXT_shader_demote_to_helper_invocation"/>
         </spirvextension>
         <spirvextension name="SPV_KHR_fragment_shading_rate">
             <enable extension="VK_KHR_fragment_shading_rate"/>
         </spirvextension>
         <spirvextension name="SPV_KHR_non_semantic_info">
-            <enable version="VK_API_VERSION_1_3"/>
+            <enable version="VK_VERSION_1_3"/>
             <enable extension="VK_KHR_shader_non_semantic_info"/>
         </spirvextension>
         <spirvextension name="SPV_EXT_shader_image_int64">
             <enable extension="VK_EXT_shader_image_atomic_int64"/>
         </spirvextension>
         <spirvextension name="SPV_KHR_terminate_invocation">
-            <enable version="VK_API_VERSION_1_3"/>
+            <enable version="VK_VERSION_1_3"/>
             <enable extension="VK_KHR_shader_terminate_invocation"/>
         </spirvextension>
         <spirvextension name="SPV_KHR_multiview">
@@ -23762,7 +25925,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <enable extension="VK_KHR_fragment_shader_barycentric"/>
         </spirvextension>
         <spirvextension name="SPV_KHR_subgroup_uniform_control_flow">
-            <enable version="VK_API_VERSION_1_3"/>
+            <enable version="VK_VERSION_1_3"/>
             <enable extension="VK_KHR_shader_subgroup_uniform_control_flow"/>
         </spirvextension>
         <spirvextension name="SPV_EXT_shader_atomic_float_min_max">
@@ -23771,22 +25934,28 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <spirvextension name="SPV_EXT_shader_atomic_float16_add">
             <enable extension="VK_EXT_shader_atomic_float2"/>
         </spirvextension>
+        <spirvextension name="SPV_NV_shader_atomic_fp16_vector">
+            <enable extension="VK_NV_shader_atomic_float16_vector"/>
+        </spirvextension>
         <spirvextension name="SPV_EXT_fragment_fully_covered">
             <enable extension="VK_EXT_conservative_rasterization"/>
         </spirvextension>
         <spirvextension name="SPV_KHR_integer_dot_product">
-            <enable version="VK_API_VERSION_1_3"/>
+            <enable version="VK_VERSION_1_3"/>
             <enable extension="VK_KHR_shader_integer_dot_product"/>
         </spirvextension>
         <spirvextension name="SPV_INTEL_shader_integer_functions2">
             <enable extension="VK_INTEL_shader_integer_functions2"/>
         </spirvextension>
         <spirvextension name="SPV_KHR_device_group">
-            <enable version="VK_API_VERSION_1_1"/>
+            <enable version="VK_VERSION_1_1"/>
             <enable extension="VK_KHR_device_group"/>
         </spirvextension>
         <spirvextension name="SPV_QCOM_image_processing">
             <enable extension="VK_QCOM_image_processing"/>
+        </spirvextension>
+        <spirvextension name="SPV_QCOM_image_processing2">
+            <enable extension="VK_QCOM_image_processing2"/>
         </spirvextension>
         <spirvextension name="SPV_EXT_mesh_shader">
             <enable extension="VK_EXT_mesh_shader"/>
@@ -23799,6 +25968,42 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </spirvextension>
         <spirvextension name="SPV_EXT_opacity_micromap">
             <enable extension="VK_EXT_opacity_micromap"/>
+        </spirvextension>
+        <spirvextension name="SPV_KHR_cooperative_matrix">
+            <enable extension="VK_KHR_cooperative_matrix"/>
+        </spirvextension>
+        <spirvextension name="SPV_ARM_core_builtins">
+            <enable extension="VK_ARM_shader_core_builtins"/>
+        </spirvextension>
+        <spirvextension name="SPV_AMDX_shader_enqueue">
+            <enable extension="VK_AMDX_shader_enqueue"/>
+        </spirvextension>
+        <spirvextension name="SPV_HUAWEI_cluster_culling_shader">
+            <enable extension="VK_HUAWEI_cluster_culling_shader"/>
+        </spirvextension>
+        <spirvextension name="SPV_HUAWEI_subpass_shading">
+            <enable extension="VK_HUAWEI_subpass_shading"/>
+        </spirvextension>
+        <spirvextension name="SPV_NV_ray_tracing_motion_blur">
+            <enable extension="VK_NV_ray_tracing_motion_blur"/>
+        </spirvextension>
+        <spirvextension name="SPV_KHR_maximal_reconvergence">
+            <enable extension="VK_KHR_shader_maximal_reconvergence"/>
+        </spirvextension>
+        <spirvextension name="SPV_KHR_subgroup_rotate">
+            <enable extension="VK_KHR_shader_subgroup_rotate"/>
+        </spirvextension>
+        <spirvextension name="SPV_KHR_expect_assume">
+            <enable extension="VK_KHR_shader_expect_assume"/>
+        </spirvextension>
+        <spirvextension name="SPV_KHR_float_controls2">
+            <enable extension="VK_KHR_shader_float_controls2"/>
+        </spirvextension>
+        <spirvextension name="SPV_KHR_quad_control">
+            <enable extension="VK_KHR_shader_quad_control"/>
+        </spirvextension>
+        <spirvextension name="SPV_NV_raw_access_chains">
+            <enable extension="VK_NV_raw_access_chains"/>
         </spirvextension>
     </spirvextensions>
     <spirvcapabilities comment="SPIR-V Capabilities allowed in Vulkan and what is required to use it">
@@ -23872,6 +26077,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <enable struct="VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT" feature="shaderBufferFloat64AtomicMinMax" requires="VK_EXT_shader_atomic_float2"/>
             <enable struct="VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT" feature="shaderSharedFloat64AtomicMinMax" requires="VK_EXT_shader_atomic_float2"/>
         </spirvcapability>
+        <spirvcapability name="AtomicFloat16VectorNV">
+            <enable struct="VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV" feature="shaderFloat16VectorAtomics" requires="VK_NV_shader_atomic_float16_vector"/>
+        </spirvcapability>
         <spirvcapability name="Int64ImageEXT">
             <enable struct="VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT" feature="shaderImageInt64Atomics" requires="VK_EXT_shader_image_atomic_int64"/>
         </spirvcapability>
@@ -23934,12 +26142,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </spirvcapability>
         <spirvcapability name="StorageImageReadWithoutFormat">
             <enable struct="VkPhysicalDeviceFeatures" feature="shaderStorageImageReadWithoutFormat" requires="VK_VERSION_1_0"/>
-            <enable version="VK_API_VERSION_1_3"/>
+            <enable version="VK_VERSION_1_3"/>
             <enable extension="VK_KHR_format_feature_flags2"/>
         </spirvcapability>
         <spirvcapability name="StorageImageWriteWithoutFormat">
             <enable struct="VkPhysicalDeviceFeatures" feature="shaderStorageImageWriteWithoutFormat" requires="VK_VERSION_1_0"/>
-            <enable version="VK_API_VERSION_1_3"/>
+            <enable version="VK_VERSION_1_3"/>
             <enable extension="VK_KHR_format_feature_flags2"/>
         </spirvcapability>
         <spirvcapability name="MultiViewport">
@@ -24259,6 +26467,9 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <spirvcapability name="TextureBlockMatchQCOM">
             <enable struct="VkPhysicalDeviceImageProcessingFeaturesQCOM" feature="textureBlockMatch" requires="VK_QCOM_image_processing"/>
         </spirvcapability>
+        <spirvcapability name="TextureBlockMatch2QCOM">
+            <enable struct="VkPhysicalDeviceImageProcessing2FeaturesQCOM" feature="textureBlockMatch2" requires="VK_QCOM_image_processing2"/>
+        </spirvcapability>
         <spirvcapability name="MeshShadingEXT">
             <enable extension="VK_EXT_mesh_shader"/>
         </spirvcapability>
@@ -24286,5 +26497,364 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <spirvcapability name="TileImageStencilReadAccessEXT">
             <enable struct="VkPhysicalDeviceShaderTileImageFeaturesEXT" feature="shaderTileImageStencilReadAccess" requires="VK_EXT_shader_tile_image"/>
         </spirvcapability>
+        <spirvcapability name="CooperativeMatrixKHR">
+            <enable struct="VkPhysicalDeviceCooperativeMatrixFeaturesKHR" feature="cooperativeMatrix" requires="VK_KHR_cooperative_matrix"/>
+        </spirvcapability>
+        <spirvcapability name="ShaderEnqueueAMDX">
+            <enable struct="VkPhysicalDeviceShaderEnqueueFeaturesAMDX" feature="shaderEnqueue" requires="VK_AMDX_shader_enqueue"/>
+        </spirvcapability>
+        <spirvcapability name="GroupNonUniformRotateKHR">
+            <enable struct="VkPhysicalDeviceShaderSubgroupRotateFeaturesKHR" feature="shaderSubgroupRotate" requires="VK_KHR_shader_subgroup_rotate"/>
+        </spirvcapability>
+        <spirvcapability name="ExpectAssumeKHR">
+            <enable struct="VkPhysicalDeviceShaderExpectAssumeFeaturesKHR" feature="shaderExpectAssume" requires="VK_KHR_shader_expect_assume"/>
+        </spirvcapability>
+        <spirvcapability name="FloatControls2">
+            <enable struct="VkPhysicalDeviceShaderFloatControls2FeaturesKHR" feature="shaderFloatControls2" requires="VK_KHR_shader_float_controls2"/>
+        </spirvcapability>
+        <spirvcapability name="QuadControlKHR">
+            <enable struct="VkPhysicalDeviceShaderQuadControlFeaturesKHR" feature="shaderQuadControl" requires="VK_KHR_shader_quad_control"/>
+        </spirvcapability>
+        <spirvcapability name="MaximallyReconvergesKHR">
+            <enable struct="VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR" feature="shaderMaximalReconvergence" requires="VK_KHR_shader_maximal_reconvergence"/>
+        </spirvcapability>
+        <spirvcapability name="RawAccessChainsNV">
+            <enable struct="VkPhysicalDeviceRawAccessChainsFeaturesNV" feature="shaderRawAccessChains" requires="VK_NV_raw_access_chains"/>
+        </spirvcapability>
     </spirvcapabilities>
+    <sync comment="Machine readable representation of the synchronization objects and their mappings">
+        <syncstage name="VK_PIPELINE_STAGE_2_NONE" alias="VK_PIPELINE_STAGE_NONE">
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT" alias="VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT">
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT" alias="VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT">
+            <syncsupport queues="graphics,compute"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT" alias="VK_PIPELINE_STAGE_VERTEX_INPUT_BIT">
+            <syncsupport queues="graphics"/>
+            <syncequivalent stage="VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT,VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT" alias="VK_PIPELINE_STAGE_VERTEX_SHADER_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT" alias="VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT" alias="VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT" alias="VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT" alias="VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT" alias="VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT" alias="VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT" alias="VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT" alias="VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT">
+            <syncsupport queues="compute"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT" alias="VK_PIPELINE_STAGE_TRANSFER_BIT">
+            <syncsupport queues="graphics,compute,transfer"/>
+            <syncequivalent stage="VK_PIPELINE_STAGE_2_COPY_BIT,VK_PIPELINE_STAGE_2_BLIT_BIT,VK_PIPELINE_STAGE_2_RESOLVE_BIT,VK_PIPELINE_STAGE_2_CLEAR_BIT,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT" alias="VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT">
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_HOST_BIT" alias="VK_PIPELINE_STAGE_HOST_BIT">
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT" alias="VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT">
+            <syncsupport queues="graphics"/>
+            <syncequivalent stage="VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT,VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT,VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT,VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT,VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR,VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT" alias="VK_PIPELINE_STAGE_ALL_COMMANDS_BIT">
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_COPY_BIT">
+            <syncsupport queues="graphics,compute,transfer"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_RESOLVE_BIT">
+            <syncsupport queues="graphics,compute,transfer"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_BLIT_BIT">
+            <syncsupport queues="graphics,compute,transfer"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_CLEAR_BIT">
+            <syncsupport queues="graphics,compute,transfer"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT">
+            <syncsupport queues="graphics"/>
+            <syncequivalent stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR">
+            <syncsupport queues="decode"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR">
+            <syncsupport queues="encode"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT" alias="VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT" alias="VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT">
+            <syncsupport queues="graphics,compute"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV" alias="VK_PIPELINE_STAGE_COMMAND_PREPROCESS_BIT_NV">
+            <syncsupport queues="graphics,compute"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR" alias="VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR" alias="VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR">
+            <syncsupport queues="compute"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR" alias="VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR">
+            <syncsupport queues="compute"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT" alias="VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT" alias="VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT" alias="VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR">
+            <syncsupport queues="graphics,compute,transfer"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT">
+            <syncsupport queues="compute"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI">
+            <syncsupport queues="graphics"/>
+        </syncstage>
+        <syncstage name="VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV">
+            <syncsupport queues="opticalflow"/>
+        </syncstage>
+        <syncaccess name="VK_ACCESS_2_NONE" alias="VK_ACCESS_NONE">
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT" alias="VK_ACCESS_INDIRECT_COMMAND_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_INDEX_READ_BIT" alias="VK_ACCESS_INDEX_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT,VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT" alias="VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT,VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_UNIFORM_READ_BIT" alias="VK_ACCESS_UNIFORM_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT" alias="VK_ACCESS_INPUT_ATTACHMENT_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_SHADER_READ_BIT" alias="VK_ACCESS_SHADER_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT,VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+            <syncequivalent access="VK_ACCESS_2_SHADER_SAMPLED_READ_BIT,VK_ACCESS_2_SHADER_STORAGE_READ_BIT,VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_SHADER_WRITE_BIT" alias="VK_ACCESS_SHADER_WRITE_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+            <syncequivalent access="VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT" alias="VK_ACCESS_COLOR_ATTACHMENT_READ_BIT">
+            <comment>Fragment shader stage is added by the VK_EXT_shader_tile_image extension</comment>
+            <syncsupport stage="VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT" alias="VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT" alias="VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT">
+            <comment>Fragment shader stage is added by the VK_EXT_shader_tile_image extension</comment>
+            <syncsupport stage="VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT,VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT" alias="VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT,VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_TRANSFER_READ_BIT" alias="VK_ACCESS_TRANSFER_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT,VK_PIPELINE_STAGE_2_COPY_BIT,VK_PIPELINE_STAGE_2_RESOLVE_BIT,VK_PIPELINE_STAGE_2_BLIT_BIT,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR,VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_TRANSFER_WRITE_BIT" alias="VK_ACCESS_TRANSFER_WRITE_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT,VK_PIPELINE_STAGE_2_COPY_BIT,VK_PIPELINE_STAGE_2_RESOLVE_BIT,VK_PIPELINE_STAGE_2_BLIT_BIT,VK_PIPELINE_STAGE_2_CLEAR_BIT,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR,VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_HOST_READ_BIT" alias="VK_ACCESS_HOST_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_HOST_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_HOST_WRITE_BIT" alias="VK_ACCESS_HOST_WRITE_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_HOST_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_MEMORY_READ_BIT" alias="VK_ACCESS_MEMORY_READ_BIT">
+            <comment>TODO/Suggestion. Introduce 'synclist' (could be a different name) element
+            that specifies the list of stages, accesses, etc. This list can be used by
+            'syncaccess' or 'syncstage' elements. For example, 'syncsupport' in addition to the
+            'stage' attribute can support 'list' attribute to reference 'synclist'.
+            We can have the lists defined for ALL stages and it can be shared between MEMORY_READ
+            and MEMORY_WRITE accesses. Similarly, ALL shader stages list is often used. This proposal
+            is a way to fix duplication problem. When new stage is added multiple places needs to be
+            updated. It is potential source of bugs. The expectation such setup will produce more
+            robust system and also more simple structure to review and validate.
+            </comment>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_MEMORY_WRITE_BIT" alias="VK_ACCESS_MEMORY_WRITE_BIT">
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_SHADER_SAMPLED_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_SHADER_STORAGE_READ_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_VIDEO_DECODE_READ_BIT_KHR">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_VIDEO_DECODE_WRITE_BIT_KHR">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT" alias="VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT" alias="VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT,VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT" alias="VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_CONDITIONAL_RENDERING_READ_BIT_EXT" alias="VK_ACCESS_CONDITIONAL_RENDERING_READ_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV" alias="VK_ACCESS_COMMAND_PREPROCESS_READ_BIT_NV">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_COMMAND_PREPROCESS_WRITE_BIT_NV" alias="VK_ACCESS_COMMAND_PREPROCESS_WRITE_BIT_NV">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR" alias="VK_ACCESS_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR" alias="VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR" alias="VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_FRAGMENT_DENSITY_MAP_READ_BIT_EXT" alias="VK_ACCESS_FRAGMENT_DENSITY_MAP_READ_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT" alias="VK_ACCESS_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_DESCRIPTOR_BUFFER_READ_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_INVOCATION_MASK_READ_BIT_HUAWEI">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT,VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT,VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT,VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT,VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR,VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT,VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI,VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_MICROMAP_READ_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT,VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_OPTICAL_FLOW_READ_BIT_NV">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV"/>
+        </syncaccess>
+        <syncaccess name="VK_ACCESS_2_OPTICAL_FLOW_WRITE_BIT_NV">
+            <syncsupport stage="VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV"/>
+        </syncaccess>
+        <syncpipeline name="graphics primitive">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR</syncpipelinestage>
+            <syncpipelinestage order="None" before="VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT">VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT</syncpipelinestage>
+            <syncpipelinestage order="None">VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="graphics mesh" depends="VK_NV_mesh_shader,VK_EXT_mesh_shader">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR</syncpipelinestage>
+            <syncpipelinestage order="None" before="VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT">VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT</syncpipelinestage>
+            <syncpipelinestage order="None">VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="compute">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT</syncpipelinestage>
+            <syncpipelinestage order="None">VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="transfer">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_TRANSFER_BIT</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="host">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_HOST_BIT</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="subpass shading" depends="VK_HUAWEI_subpass_shading">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="command preprocessing" depends="VK_NV_device_generated_commands">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="acceleration structure build" depends="VK_KHR_acceleration_structure,VK_NV_ray_tracing">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="acceleration structure copy" depends="VK_KHR_acceleration_structure,VK_NV_ray_tracing">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="opacity micromap" depends="VK_EXT_opacity_micromap">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="ray tracing" depends="VK_KHR_ray_tracing_pipeline,VK_NV_ray_tracing">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT</syncpipelinestage>
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="video decode" depends="VK_KHR_video_decode_queue">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="video encode" depends="VK_KHR_video_encode_queue">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR</syncpipelinestage>
+        </syncpipeline>
+        <syncpipeline name="optical flow" depends="VK_NV_optical_flow">
+            <syncpipelinestage>VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV</syncpipelinestage>
+        </syncpipeline>
+    </sync>
 </registry>


### PR DESCRIPTION
## Overview

Pulls in the vk.xml used in ash 0.38 (https://github.com/KhronosGroup/Vulkan-Headers/blob/38899bf60605f0a2c50f7968e5c4c9826a824683/registry/vk.xml) adding stuff to autogen to get it compiling.

## Merge Order

This is ready to merge. It depends on:

1. https://github.com/vulkano-rs/vulkano/pull/2512
2. https://github.com/vulkano-rs/vulkano/pull/2511
3. https://github.com/vulkano-rs/vulkano/pull/2510

all of which are merged.


## Changelog
```markdown
### Additions
- Update vk.xml to [Vulkan-Headers@38899bf](https://github.com/KhronosGroup/Vulkan-Headers/blob/38899bf60605f0a2c50f7968e5c4c9826a824683/registry/vk.xml) to match version used in ash 0.38
```
