### PR TITLE
Bindless Descriptor fixes and optimizations

### DIFF
--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -191,6 +191,9 @@ impl DescriptorSet {
     ) -> Result<(), Box<ValidationError>> {
         let descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
         let descriptor_copies: SmallVec<[_; 8]> = descriptor_copies.into_iter().collect();
+        if descriptor_writes.is_empty() && descriptor_copies.is_empty() {
+            return Ok(());
+        }
 
         self.inner
             .validate_update(&descriptor_writes, &descriptor_copies)?;
@@ -215,6 +218,9 @@ impl DescriptorSet {
     ) {
         let descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
         let descriptor_copies: SmallVec<[_; 8]> = descriptor_copies.into_iter().collect();
+        if descriptor_writes.is_empty() && descriptor_copies.is_empty() {
+            return;
+        }
 
         Self::update_inner(
             &self.inner,
@@ -236,6 +242,9 @@ impl DescriptorSet {
     ) -> Result<(), Box<ValidationError>> {
         let descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
         let descriptor_copies: SmallVec<[_; 8]> = descriptor_copies.into_iter().collect();
+        if descriptor_writes.is_empty() && descriptor_copies.is_empty() {
+            return Ok(());
+        }
 
         self.inner
             .validate_update(&descriptor_writes, &descriptor_copies)?;
@@ -258,6 +267,9 @@ impl DescriptorSet {
     ) {
         let descriptor_writes: SmallVec<[_; 8]> = descriptor_writes.into_iter().collect();
         let descriptor_copies: SmallVec<[_; 8]> = descriptor_copies.into_iter().collect();
+        if descriptor_writes.is_empty() && descriptor_copies.is_empty() {
+            return;
+        }
 
         Self::update_inner(
             &self.inner,

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -75,16 +75,15 @@ use self::{
 pub use self::{
     collection::DescriptorSetsCollection,
     update::{
-        CopyDescriptorSet, DescriptorBufferInfo, DescriptorImageViewInfo, WriteDescriptorSet,
-        WriteDescriptorSetElements,
+        CopyDescriptorSet, DescriptorBufferInfo, DescriptorImageViewInfo, InvalidateDescriptorSet,
+        WriteDescriptorSet, WriteDescriptorSetElements,
     },
 };
 use crate::{
     acceleration_structure::AccelerationStructure,
     buffer::view::BufferView,
-    descriptor_set::{
-        layout::{DescriptorBindingFlags, DescriptorSetLayoutCreateFlags, DescriptorType},
-        update::InvalidateDescriptorSet,
+    descriptor_set::layout::{
+        DescriptorBindingFlags, DescriptorSetLayoutCreateFlags, DescriptorType,
     },
     device::{Device, DeviceOwned},
     image::{sampler::Sampler, ImageLayout},

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -250,9 +250,10 @@ impl DescriptorPool {
         let allocate_infos = allocate_infos.into_iter();
 
         let (lower_size_bound, _) = allocate_infos.size_hint();
-        let mut layouts_vk = Vec::with_capacity(lower_size_bound);
-        let mut variable_descriptor_counts = Vec::with_capacity(lower_size_bound);
-        let mut layouts = Vec::with_capacity(lower_size_bound);
+        let mut layouts_vk: SmallVec<[_; 1]> = SmallVec::with_capacity(lower_size_bound);
+        let mut variable_descriptor_counts: SmallVec<[_; 1]> =
+            SmallVec::with_capacity(lower_size_bound);
+        let mut layouts: SmallVec<[_; 1]> = SmallVec::with_capacity(lower_size_bound);
 
         for info in allocate_infos {
             let DescriptorSetAllocateInfo {
@@ -266,7 +267,7 @@ impl DescriptorPool {
             layouts.push(layout);
         }
 
-        let mut output = vec![];
+        let mut output: SmallVec<[_; 1]> = SmallVec::new();
 
         if !layouts_vk.is_empty() {
             let variable_desc_count_alloc_info = if (self.device.api_version() >= Version::V1_2

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -86,6 +86,10 @@ impl RawDescriptorSet {
         descriptor_writes: &[WriteDescriptorSet],
         descriptor_copies: &[CopyDescriptorSet],
     ) -> Result<(), Box<ValidationError>> {
+        if descriptor_writes.is_empty() && descriptor_copies.is_empty() {
+            return Ok(());
+        }
+
         self.validate_update(descriptor_writes, descriptor_copies)?;
 
         self.update_unchecked(descriptor_writes, descriptor_copies);
@@ -117,6 +121,10 @@ impl RawDescriptorSet {
         descriptor_writes: &[WriteDescriptorSet],
         descriptor_copies: &[CopyDescriptorSet],
     ) {
+        if descriptor_writes.is_empty() && descriptor_copies.is_empty() {
+            return;
+        }
+
         struct PerDescriptorWrite {
             write_info: DescriptorWriteInfo,
             acceleration_structures: ash::vk::WriteDescriptorSetAccelerationStructureKHR<'static>,

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -1599,6 +1599,8 @@ pub struct CopyDescriptorSet {
     pub dst_binding: u32,
 
     /// The first array element in the destination descriptor set to copy into.
+    ///
+    /// The default value is 0.
     pub dst_first_array_element: u32,
 
     /// The number of descriptors (array elements) to copy.
@@ -1828,6 +1830,96 @@ impl CopyDescriptorSet {
 
         // VUID-VkCopyDescriptorSet-srcSet-00349
         // Ensured as long as copies can only occur during descriptor set construction.
+
+        Ok(())
+    }
+}
+
+/// Invalidates descriptors within a descriptor set. Doesn't actually call into vulkan and only
+/// invalidates the descriptors inside vulkano's resource tracking. Invalidated descriptors are
+/// equivalent to uninitialized descriptors, in that binding a descriptor set to a particular
+/// pipeline requires all shader-accessible descriptors to be valid.
+///
+/// The intended use-case is an update-after-bind or bindless system, where entries in an arrayed
+/// binding have to be invalidated so that the backing resource will be freed, and not stay forever
+/// referenced until overridden by some update.
+pub struct InvalidateDescriptorSet {
+    /// The binding number in the descriptor set to invalidate.
+    ///
+    /// The default value is 0.
+    pub binding: u32,
+
+    /// The first array element in the descriptor set to invalidate.
+    ///
+    /// The default value is 0.
+    pub first_array_element: u32,
+
+    /// The number of descriptors (array elements) to invalidate.
+    ///
+    /// The default value is 1.
+    pub descriptor_count: u32,
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl InvalidateDescriptorSet {
+    pub fn invalidate(binding: u32) -> Self {
+        Self::invalidate_array(binding, 0, 1)
+    }
+
+    pub fn invalidate_array(binding: u32, first_array_element: u32, descriptor_count: u32) -> Self {
+        Self {
+            binding,
+            first_array_element,
+            descriptor_count,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
+    pub(crate) fn validate(
+        &self,
+        layout: &DescriptorSetLayout,
+        variable_descriptor_count: u32,
+    ) -> Result<(), Box<ValidationError>> {
+        let &Self {
+            binding,
+            first_array_element,
+            descriptor_count,
+            ..
+        } = self;
+
+        let layout_binding = match layout.bindings().get(&binding) {
+            Some(layout_binding) => layout_binding,
+            None => {
+                return Err(Box::new(ValidationError {
+                    context: "binding".into(),
+                    problem: "does not exist in the descriptor set layout".into(),
+                    vuids: &["VUID-VkWriteDescriptorSet-dstBinding-00315"],
+                    ..Default::default()
+                }));
+            }
+        };
+
+        debug_assert!(descriptor_count != 0);
+        let max_descriptor_count = if layout_binding
+            .binding_flags
+            .intersects(DescriptorBindingFlags::VARIABLE_DESCRIPTOR_COUNT)
+        {
+            variable_descriptor_count
+        } else {
+            layout_binding.descriptor_count
+        };
+
+        // VUID-VkWriteDescriptorSet-dstArrayElement-00321
+        if first_array_element + descriptor_count > max_descriptor_count {
+            return Err(Box::new(ValidationError {
+                problem: "`first_array_element` + the number of provided elements is greater than \
+                    the number of descriptors in the descriptor set binding"
+                    .into(),
+                vuids: &["VUID-VkWriteDescriptorSet-dstArrayElement-00321"],
+                ..Default::default()
+            }));
+        }
 
         Ok(())
     }


### PR DESCRIPTION
* added `DescriptorSet::invalidate()` to make vulkano forget about resources that bound to a descriptor_set, so they can be freed. As (normal) descriptors are validated when bound, this is entirely safe to do.
* disable validation for individual descriptors if the descriptor set is `UPDATE_AFTER_BIND` or `PARTIALLY_BOUND`, making them actually usable
  * I'm not sure these changes are entirely safe. For it to be, we'd need to validate the descriptor set is properly populated just before flushing any commands to the GPU. And I'm not sure if that's done already, or where it should be added. We could ofc also decide to just leave these two flags as unsafe, somehow.
* some small Descriptor optimizations:
  * More SmallVec use in DescriptorPool to improve variable descriptor count allocation. It only ever allocates one descriptor set at a time, i.e. `allocate_infos` only ever has one entry in that code path. Annoyed me and just had to fix :D
  * Descriptor updates with no writes or copies return early instead of calling into vulkan. Particularly useful when creating a new descriptor, writing nothing, and updating it properly later.

1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [ ] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Additions
* added `DescriptorSet::invalidate()` to make vulkano forget about resources that bound to a descriptor_set, so they can be freed

### Bugs fixed
* fixed descriptor sets with `UPDATE_AFTER_BIND` or `PARTIALLY_BOUND` being wrongly validated on bind
```
