### PR TITLE
Allow memory interface blocks to have offset decorations on first member

### DIFF
--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -844,11 +844,6 @@ impl TypeStruct {
                 if last.offset + last_size > offset {
                     bail!(shader.source, "struct members must not overlap");
                 }
-            } else if offset != 0 {
-                bail!(
-                    shader.source,
-                    "expected struct member at index 0 to have an `Offset` decoration of 0",
-                );
             }
 
             members.push(Member { ident, ty, offset });


### PR DESCRIPTION
fixes https://github.com/vulkano-rs/vulkano/issues/2534

There is likely a better, much more involved solution here.

The offending struct only contains the following decorations per spirv
`[Decorate { target: Id(14), decoration: Block }]`

That doesn't look like an indication that this is a push constant declaration to me, so discriminating against this might mean passing additional data alongside the spirv from source. Since I don't know the spec well enough to know if this is actually useful or valid for non push-constant declarations, this is the best I can offer.
