### PR TITLE
Optimize sequential draws

### DIFF
--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -513,6 +513,7 @@ impl AutoSyncState {
     }
 }
 
+#[derive(Debug)]
 struct MergedCommandInfo<'a> {
     name: &'static str,
     render_pass: RenderPassCommand,
@@ -1697,13 +1698,13 @@ pub(in crate::command_buffer) struct RenderPassStateAttachmentResolveInfo {
     pub(in crate::command_buffer) _image_layout: ImageLayout,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(in crate::command_buffer) struct DescriptorSetState {
     pub(in crate::command_buffer) descriptor_sets: HashMap<u32, SetOrPush>,
     pub(in crate::command_buffer) pipeline_layout: Arc<PipelineLayout>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(in crate::command_buffer) enum SetOrPush {
     Set(DescriptorSetWithOffsets),
     Push(DescriptorSetResources),

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -529,11 +529,16 @@ impl<'a> MergedCommandInfo<'a> {
         } else {
             (None, SmallVec::new())
         };
+        let direct = if value.used_resources.direct.is_empty() {
+            SmallVec::new()
+        } else {
+            SmallVec::from_iter([&value.used_resources.direct])
+        };
         Self {
             name: value.name,
             render_pass: value.render_pass,
             pipeline,
-            direct: SmallVec::from_iter([&value.used_resources.direct]),
+            direct,
             deferred,
         }
     }
@@ -548,6 +553,7 @@ impl<'a> MergedCommandInfo<'a> {
             return Err(b);
         }
 
+        // success
         if self.pipeline == None {
             self.pipeline = b.pipeline;
         }

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -544,10 +544,13 @@ impl<'a> MergedCommandInfo<'a> {
             (RenderPassCommand::None, RenderPassCommand::None) => (),
             _ => return Err(b),
         }
-        if self.pipeline != b.pipeline {
+        if !(self.pipeline == b.pipeline || self.pipeline == None || b.pipeline == None) {
             return Err(b);
         }
 
+        if self.pipeline == None {
+            self.pipeline = b.pipeline;
+        }
         self.direct.append(&mut b.direct);
         // FIXME deferred must be merged together to prevent duplicate resources
         self.deferred.append(&mut b.deferred);

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -299,6 +299,15 @@ pub(in crate::command_buffer) enum PipelineEnum {
     Graphics(Arc<GraphicsPipeline>),
 }
 
+impl Debug for PipelineEnum {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PipelineEnum::Compute(p) => f.debug_tuple("Compute").field(&p.handle()).finish(),
+            PipelineEnum::Graphics(p) => f.debug_tuple("Graphics").field(&p.handle()).finish(),
+        }
+    }
+}
+
 impl UsedResources {
     #[inline]
     pub fn direct(direct: Vec<(ResourceUseRef2, Resource)>) -> Self {

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -4,9 +4,7 @@ use crate::{
     acceleration_structure::AccelerationStructure,
     buffer::{view::BufferView, BufferUsage, Subbuffer},
     command_buffer::{
-        auto::{
-            RenderPassState, RenderPassStateType, Resource, ResourceUseRef2, UsedResourcesDeferred,
-        },
+        auto::{PipelineEnum, RenderPassState, RenderPassStateType, Resource, ResourceUseRef2},
         sys::RawRecordingCommandBuffer,
         DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand,
         DrawMeshTasksIndirectCommand, RecordingCommandBuffer, ResourceInCommand, SubpassContents,
@@ -111,7 +109,7 @@ impl RecordingCommandBuffer {
 
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Compute(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Compute(pipeline.clone()), state));
 
         self.add_command_deferred(
             "dispatch",
@@ -190,7 +188,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Compute(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Compute(pipeline.clone()), state));
         self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
 
         self.add_command_deferred(
@@ -375,7 +373,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
         self.add_vertex_buffers_resources(&mut used_resources, pipeline);
 
         self.add_command_deferred(
@@ -479,7 +477,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
         self.add_vertex_buffers_resources(&mut used_resources, pipeline);
         self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
 
@@ -606,7 +604,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
         self.add_vertex_buffers_resources(&mut used_resources, pipeline);
         self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
         self.add_indirect_buffer_resources(&mut used_resources, count_buffer.as_bytes());
@@ -842,7 +840,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
         self.add_vertex_buffers_resources(&mut used_resources, pipeline);
         self.add_index_buffer_resources(&mut used_resources);
 
@@ -968,7 +966,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
         self.add_vertex_buffers_resources(&mut used_resources, pipeline);
         self.add_index_buffer_resources(&mut used_resources);
         self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
@@ -1110,7 +1108,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
         self.add_vertex_buffers_resources(&mut used_resources, pipeline);
         self.add_index_buffer_resources(&mut used_resources);
         self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
@@ -1303,7 +1301,7 @@ impl RecordingCommandBuffer {
 
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
 
         self.add_command_deferred(
             "draw_mesh_tasks",
@@ -1415,7 +1413,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
         self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
 
         self.add_command_deferred(
@@ -1550,7 +1548,7 @@ impl RecordingCommandBuffer {
         let mut used_resources = Vec::new();
         let deferred = self
             .prepare_descriptor_set_state(pipeline.as_ref())
-            .map(|state| UsedResourcesDeferred::Graphics(pipeline.clone(), state));
+            .map(|state| (PipelineEnum::Graphics(pipeline.clone()), state));
         self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
         self.add_indirect_buffer_resources(&mut used_resources, count_buffer.as_bytes());
 

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -318,7 +318,7 @@ impl Hash for DescriptorSet {
 }
 
 /// The resources that are bound to a descriptor set.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DescriptorSetResources {
     binding_resources: HashMap<u32, DescriptorBindingResources>,
 }
@@ -435,7 +435,7 @@ impl DescriptorSetResources {
 }
 
 /// The resources that are bound to a single descriptor set binding.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DescriptorBindingResources {
     None(Elements<()>),
     Buffer(Elements<DescriptorBufferInfo>),
@@ -623,7 +623,7 @@ impl DescriptorBindingResources {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct DescriptorSetWithOffsets {
     descriptor_set: Arc<DescriptorSet>,
     dynamic_offsets: SmallVec<[u32; 4]>,

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -623,7 +623,7 @@ impl DescriptorBindingResources {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DescriptorSetWithOffsets {
     descriptor_set: Arc<DescriptorSet>,
     dynamic_offsets: SmallVec<[u32; 4]>,

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -1524,7 +1524,7 @@ impl WriteDescriptorSetElements {
 }
 
 /// Parameters to write a buffer reference to a descriptor.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DescriptorBufferInfo {
     /// The buffer to write to the descriptor.
     pub buffer: Subbuffer<[u8]>,
@@ -1541,7 +1541,7 @@ pub struct DescriptorBufferInfo {
 }
 
 /// Parameters to write an image view reference to a descriptor.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DescriptorImageViewInfo {
     /// The image view to write to the descriptor.
     pub image_view: Arc<ImageView>,


### PR DESCRIPTION
1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [ ] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Profiling based on my meshlet demo on sponza. Before at ~40fps and fully CPU limited:
![image](https://github.com/vulkano-rs/vulkano/assets/31222740/2781f0ba-2f0c-4005-bdb1-7546f0a39de6)

With this PR I get ~550fps and am most likely CPU GPU sync limited, due not having a working frame in flight system.
![image](https://github.com/vulkano-rs/vulkano/assets/31222740/80979516-092d-4207-878a-1e065445d681)

And the best part is: It's absolutely free and still safe!*
*(if I didn't mess up)

Current master evaluates all accessed resources (buffers, images) if you call any draw or dispatch immediately. My change defers the evaluation specifically of descriptor sets for their resources to the end of the cmd buffer recording. This allows me to deduplicate draws and dispatches using the same pipeline, merging their resources and descriptor sets together, and then deduplicate the descriptor sets again before evaluating each unique one for their actual resources.

Changelog:
```markdown
### Additions
- Optimized performance of back to back draws/dispatches using the same pipeline significantly
```
