### PR TITLE
added `QueueFamilyIndex` type replacing `u32`

### DIFF
--- a/examples/basic-compute-shader/main.rs
+++ b/examples/basic-compute-shader/main.rs
@@ -16,7 +16,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
@@ -56,7 +56,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/buffer-allocator/main.rs
+++ b/examples/buffer-allocator/main.rs
@@ -16,7 +16,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -79,9 +79,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/clear-attachments/main.rs
+++ b/examples/clear-attachments/main.rs
@@ -7,7 +7,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -59,9 +59,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/debug/main.rs
+++ b/examples/debug/main.rs
@@ -1,6 +1,7 @@
 use vulkano::{
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
+        QueueFamilyIndex,
     },
     instance::{
         debug::{
@@ -126,7 +127,7 @@ fn main() {
         .filter(|p| p.supported_extensions().contains(&device_extensions))
         .map(|p| {
             (!p.queue_family_properties().is_empty())
-                .then_some((p, 0))
+                .then_some((p, QueueFamilyIndex(0)))
                 .expect("couldn't find a queue family")
         })
         .min_by_key(|(p, _)| match p.properties().device_type {

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -28,7 +28,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -82,9 +82,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -17,7 +17,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
@@ -53,7 +53,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/dynamic-local-size/main.rs
+++ b/examples/dynamic-local-size/main.rs
@@ -16,7 +16,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
@@ -59,7 +59,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -29,7 +29,7 @@ mod linux {
         },
         device::{
             physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
-            QueueCreateInfo, QueueFlags,
+            QueueCreateInfo, QueueFamilyIndex, QueueFlags,
         },
         format::Format,
         image::{
@@ -555,9 +555,10 @@ mod linux {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.surface_support(i as u32, &surface).unwrap_or(false)
+                            && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                                .unwrap_or(false)
                     })
-                    .map(|i| (p, i as u32))
+                    .map(|i| (p, QueueFamilyIndex(i as u32)))
             })
             .filter(|(p, _)| p.properties().driver_uuid.unwrap() == display.driver_uuid().unwrap())
             .filter(|(p, _)| {

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -12,7 +12,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{
@@ -84,9 +84,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -10,7 +10,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{
@@ -82,9 +82,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -19,7 +19,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{
@@ -88,9 +88,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -29,7 +29,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -96,9 +96,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -12,7 +12,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -94,9 +94,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -25,7 +25,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceFeatures,
-        QueueCreateInfo, QueueFlags,
+        QueueCreateInfo, QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -115,9 +115,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -62,7 +62,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage, SampleCount},
@@ -109,7 +109,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::GRAPHICS))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/multi-window/main.rs
+++ b/examples/multi-window/main.rs
@@ -16,7 +16,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -99,9 +99,10 @@ fn main() -> Result<(), impl Error> {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.surface_support(i as u32, &surface).unwrap_or(false)
+                            && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                                .unwrap_or(false)
                     })
-                    .map(|i| (p, i as u32))
+                    .map(|i| (p, QueueFamilyIndex(i as u32)))
             })
             .min_by_key(|(p, _)| match p.properties().device_type {
                 PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/multiview/main.rs
+++ b/examples/multiview/main.rs
@@ -13,7 +13,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceFeatures,
-        QueueCreateInfo, QueueFlags,
+        QueueCreateInfo, QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{
@@ -87,7 +87,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::GRAPHICS))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/occlusion-query/main.rs
+++ b/examples/occlusion-query/main.rs
@@ -11,7 +11,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
@@ -77,9 +77,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -9,7 +9,10 @@ use vulkano::{
         CommandBufferUsage, CopyImageToBufferInfo, RecordingCommandBuffer, RenderPassBeginInfo,
         SubpassBeginInfo, SubpassContents,
     },
-    device::{physical::PhysicalDeviceType, Device, DeviceCreateInfo, QueueCreateInfo, QueueFlags},
+    device::{
+        physical::PhysicalDeviceType, Device, DeviceCreateInfo, QueueCreateInfo, QueueFamilyIndex,
+        QueueFlags,
+    },
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -55,7 +58,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::GRAPHICS))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/pipeline-caching/main.rs
+++ b/examples/pipeline-caching/main.rs
@@ -23,7 +23,7 @@ use std::{
 use vulkano::{
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     pipeline::{
@@ -60,7 +60,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/push-constants/main.rs
+++ b/examples/push-constants/main.rs
@@ -15,7 +15,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
@@ -51,7 +51,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -8,7 +8,7 @@ use vulkano::{
     descriptor_set::{layout::DescriptorSetLayoutCreateFlags, WriteDescriptorSet},
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{
@@ -78,9 +78,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -11,7 +11,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceFeatures,
-        QueueCreateInfo, QueueFlags,
+        QueueCreateInfo, QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{
@@ -83,9 +83,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -21,7 +21,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -85,9 +85,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/self-copy-buffer/main.rs
+++ b/examples/self-copy-buffer/main.rs
@@ -14,7 +14,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
@@ -50,7 +50,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/shader-include/main.rs
+++ b/examples/shader-include/main.rs
@@ -14,7 +14,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
@@ -50,7 +50,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/shader-types-sharing/main.rs
+++ b/examples/shader-types-sharing/main.rs
@@ -28,7 +28,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
-        QueueCreateInfo, QueueFlags,
+        QueueCreateInfo, QueueFamilyIndex, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
@@ -64,7 +64,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -15,7 +15,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -96,9 +96,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/specialization-constants/main.rs
+++ b/examples/specialization-constants/main.rs
@@ -12,7 +12,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
@@ -48,7 +48,7 @@ fn main() {
             p.queue_family_properties()
                 .iter()
                 .position(|q| q.queue_flags.intersects(QueueFlags::COMPUTE))
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -18,7 +18,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceOwned,
-        QueueCreateInfo, QueueFlags,
+        QueueCreateInfo, QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{view::ImageView, Image, ImageCreateInfo, ImageType, ImageUsage},
@@ -90,9 +90,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -21,7 +21,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceFeatures,
-        QueueCreateInfo, QueueFlags,
+        QueueCreateInfo, QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -188,9 +188,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -10,7 +10,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     format::Format,
     image::{
@@ -84,9 +84,10 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         .min_by_key(|(p, _)| match p.properties().device_type {
             PhysicalDeviceType::DiscreteGpu => 0,

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -21,7 +21,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceFeatures,
-        QueueCreateInfo, QueueFlags,
+        QueueCreateInfo, QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -133,12 +133,13 @@ fn main() -> Result<(), impl Error> {
                     // a window surface, as we do in this example, we also need to check that
                     // queues in this queue family are capable of presenting images to the surface.
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
                 // The code here searches for the first queue family that is suitable. If none is
                 // found, `None` is returned to `filter_map`, which disqualifies this physical
                 // device.
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         // All the physical devices that pass the filters above are suitable for the application.
         // However, not every device is equal, some are preferred over others. Now, we assign each

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -17,7 +17,7 @@ use vulkano::{
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     image::{view::ImageView, Image, ImageUsage},
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
@@ -123,12 +123,13 @@ fn main() -> Result<(), impl Error> {
                     // a window surface, as we do in this example, we also need to check that
                     // queues in this queue family are capable of presenting images to the surface.
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.surface_support(QueueFamilyIndex(i as u32), &surface)
+                            .unwrap_or(false)
                 })
                 // The code here searches for the first queue family that is suitable. If none is
                 // found, `None` is returned to `filter_map`, which disqualifies this physical
                 // device.
-                .map(|i| (p, i as u32))
+                .map(|i| (p, QueueFamilyIndex(i as u32)))
         })
         // All the physical devices that pass the filters above are suitable for the application.
         // However, not every device is equal, some are preferred over others. Now, we assign each

--- a/vulkano-util/src/context.rs
+++ b/vulkano-util/src/context.rs
@@ -5,7 +5,7 @@ use vulkano::{
     device::{
         physical::{PhysicalDevice, PhysicalDeviceType},
         Device, DeviceCreateInfo, DeviceExtensions, DeviceFeatures, Queue, QueueCreateInfo,
-        QueueFlags,
+        QueueFamilyIndex, QueueFlags,
     },
     instance::{
         debug::{DebugUtilsMessenger, DebugUtilsMessengerCreateInfo},
@@ -202,7 +202,7 @@ impl VulkanoContext {
             .queue_family_properties()
             .iter()
             .enumerate()
-            .map(|(i, q)| (i as u32, q))
+            .map(|(i, q)| (QueueFamilyIndex(i as u32), q))
             .find(|(_i, q)| q.queue_flags.intersects(QueueFlags::GRAPHICS))
             .map(|(i, _)| i)
             .expect("could not find a queue that supports graphics");
@@ -211,7 +211,7 @@ impl VulkanoContext {
             .queue_family_properties()
             .iter()
             .enumerate()
-            .map(|(i, q)| (i as u32, q))
+            .map(|(i, q)| (QueueFamilyIndex(i as u32), q))
             .find(|(i, q)| {
                 q.queue_flags.intersects(QueueFlags::COMPUTE) && *i != queue_family_graphics
             })

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -48,6 +48,7 @@ use std::{
     ops::{Range, RangeInclusive},
     sync::{atomic::AtomicBool, Arc},
 };
+use vulkano::device::QueueFamilyIndex;
 
 /// A command buffer in the recording state.
 ///
@@ -70,7 +71,7 @@ impl RecordingCommandBuffer {
     #[inline]
     pub fn new(
         allocator: Arc<dyn CommandBufferAllocator>,
-        queue_family_index: u32,
+        queue_family_index: QueueFamilyIndex,
         level: CommandBufferLevel,
         begin_info: CommandBufferBeginInfo,
     ) -> Result<RecordingCommandBuffer, Validated<VulkanError>> {
@@ -81,7 +82,7 @@ impl RecordingCommandBuffer {
 
     fn validate_new(
         device: &Device,
-        queue_family_index: u32,
+        queue_family_index: QueueFamilyIndex,
         level: CommandBufferLevel,
         begin_info: &CommandBufferBeginInfo,
     ) -> Result<(), Box<ValidationError>> {
@@ -93,7 +94,7 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn new_unchecked(
         allocator: Arc<dyn CommandBufferAllocator>,
-        queue_family_index: u32,
+        queue_family_index: QueueFamilyIndex,
         level: CommandBufferLevel,
         begin_info: CommandBufferBeginInfo,
     ) -> Result<Self, Validated<VulkanError>> {

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -70,7 +70,7 @@ use super::{
 };
 use crate::{
     buffer::Subbuffer,
-    device::{Device, DeviceOwned},
+    device::{Device, DeviceOwned, QueueFamilyIndex},
     image::{Image, ImageLayout, ImageSubresourceRange},
     sync::PipelineStageAccessFlags,
     DeviceSize, ValidationError, VulkanObject,
@@ -130,7 +130,7 @@ impl CommandBuffer {
 
     /// Returns the queue family index of this command buffer.
     #[inline]
-    pub fn queue_family_index(&self) -> u32 {
+    pub fn queue_family_index(&self) -> QueueFamilyIndex {
         self.inner.queue_family_index()
     }
 
@@ -323,7 +323,7 @@ mod tests {
             },
             DescriptorSet, WriteDescriptorSet,
         },
-        device::{Device, DeviceCreateInfo, QueueCreateInfo},
+        device::{Device, DeviceCreateInfo, QueueCreateInfo, QueueFamilyIndex},
         image::sampler::{Sampler, SamplerCreateInfo},
         memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
         pipeline::{layout::PipelineLayoutCreateInfo, PipelineBindPoint, PipelineLayout},
@@ -366,7 +366,7 @@ mod tests {
             physical_device,
             DeviceCreateInfo {
                 queue_create_infos: vec![QueueCreateInfo {
-                    queue_family_index: 0,
+                    queue_family_index: QueueFamilyIndex(0),
                     ..Default::default()
                 }],
                 ..Default::default()

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use smallvec::SmallVec;
 use std::{fmt::Debug, mem::ManuallyDrop, ptr, sync::Arc};
+use vulkano::device::QueueFamilyIndex;
 
 /// A raw command buffer in the recording state.
 ///
@@ -27,7 +28,7 @@ use std::{fmt::Debug, mem::ManuallyDrop, ptr, sync::Arc};
 pub struct RawRecordingCommandBuffer {
     allocation: ManuallyDrop<CommandBufferAlloc>,
     allocator: Arc<dyn CommandBufferAllocator>,
-    queue_family_index: u32,
+    queue_family_index: QueueFamilyIndex,
     // Must be `None` in a primary command buffer and `Some` in a secondary command buffer.
     inheritance_info: Option<CommandBufferInheritanceInfo>,
     pub(super) usage: CommandBufferUsage,
@@ -38,7 +39,7 @@ impl RawRecordingCommandBuffer {
     #[inline]
     pub fn new(
         allocator: Arc<dyn CommandBufferAllocator>,
-        queue_family_index: u32,
+        queue_family_index: QueueFamilyIndex,
         level: CommandBufferLevel,
         begin_info: CommandBufferBeginInfo,
     ) -> Result<Self, Validated<VulkanError>> {
@@ -49,7 +50,7 @@ impl RawRecordingCommandBuffer {
 
     pub(super) fn validate_new(
         device: &Device,
-        _queue_family_index: u32,
+        _queue_family_index: QueueFamilyIndex,
         level: CommandBufferLevel,
         begin_info: &CommandBufferBeginInfo,
     ) -> Result<(), Box<ValidationError>> {
@@ -76,7 +77,7 @@ impl RawRecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn new_unchecked(
         allocator: Arc<dyn CommandBufferAllocator>,
-        queue_family_index: u32,
+        queue_family_index: QueueFamilyIndex,
         level: CommandBufferLevel,
         begin_info: CommandBufferBeginInfo,
     ) -> Result<Self, Validated<VulkanError>> {
@@ -214,7 +215,7 @@ impl RawRecordingCommandBuffer {
 
     /// Returns the queue family index that this command buffer was created for.
     #[inline]
-    pub fn queue_family_index(&self) -> u32 {
+    pub fn queue_family_index(&self) -> QueueFamilyIndex {
         self.queue_family_index
     }
 
@@ -237,7 +238,8 @@ impl RawRecordingCommandBuffer {
     }
 
     pub(in crate::command_buffer) fn queue_family_properties(&self) -> &QueueFamilyProperties {
-        &self.device().physical_device().queue_family_properties()[self.queue_family_index as usize]
+        &self.device().physical_device().queue_family_properties()
+            [self.queue_family_index.0 as usize]
     }
 }
 
@@ -343,7 +345,7 @@ unsafe impl Sync for RawCommandBuffer {}
 impl RawCommandBuffer {
     /// Returns the queue family index that this command buffer was created for.
     #[inline]
-    pub fn queue_family_index(&self) -> u32 {
+    pub fn queue_family_index(&self) -> QueueFamilyIndex {
         self.inner.queue_family_index
     }
 

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -282,7 +282,7 @@ where
                     // Same remark as `CommandBuffer`.
                     assert!(fence.is_none());
                     debug_assert!(queue.device().physical_device().queue_family_properties()
-                        [queue.queue_family_index() as usize]
+                        [queue.queue_family_index().0 as usize]
                         .queue_flags
                         .intersects(QueueFlags::SPARSE_BINDING));
 

--- a/vulkano/src/sync/mod.rs
+++ b/vulkano/src/sync/mod.rs
@@ -16,7 +16,10 @@ pub use self::{
         MemoryBarrier, PipelineStage, PipelineStages, QueueFamilyOwnershipTransfer,
     },
 };
-use crate::{device::Queue, VulkanError};
+use crate::{
+    device::{Queue, QueueFamilyIndex},
+    VulkanError,
+};
 use std::{
     error::Error,
     fmt::{Display, Formatter},
@@ -40,7 +43,7 @@ pub enum SharingMode {
     /// The resource is used is only one queue family.
     Exclusive,
     /// The resource is used in multiple queue families. Can be slower than `Exclusive`.
-    Concurrent(Vec<u32>), // TODO: Vec is too expensive here
+    Concurrent(Vec<QueueFamilyIndex>), // TODO: Vec is too expensive here
 }
 
 impl<'a> From<&'a Arc<Queue>> for SharingMode {

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -1956,7 +1956,7 @@ pub struct ExternalSemaphoreProperties {
 #[cfg(test)]
 mod tests {
     use crate::{
-        device::{Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo},
+        device::{Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo, QueueFamilyIndex},
         instance::{Instance, InstanceCreateInfo, InstanceExtensions},
         sync::semaphore::{
             ExternalSemaphoreHandleType, ExternalSemaphoreHandleTypes, Semaphore,
@@ -2019,7 +2019,7 @@ mod tests {
             physical_device,
             DeviceCreateInfo {
                 queue_create_infos: vec![QueueCreateInfo {
-                    queue_family_index: 0,
+                    queue_family_index: QueueFamilyIndex(0),
                     ..Default::default()
                 }],
                 enabled_extensions: DeviceExtensions {

--- a/vulkano/src/tests.rs
+++ b/vulkano/src/tests.rs
@@ -27,7 +27,7 @@ macro_rules! gfx_dev_and_queue {
     });
     ($($feature:ident),*; $($extension:ident),*) => ({
         use crate::device::physical::PhysicalDeviceType;
-        use crate::device::{Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo};
+        use crate::device::{Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo, QueueFamilyIndex};
         use crate::device::DeviceFeatures;
 
         let instance = instance!();
@@ -55,7 +55,7 @@ macro_rules! gfx_dev_and_queue {
             .filter_map(|p| {
                 p.queue_family_properties().iter()
                     .position(|q| q.queue_flags.intersects(crate::device::QueueFlags::GRAPHICS))
-                    .map(|i| (p, i as u32))
+                    .map(|i| (p, QueueFamilyIndex(i as u32)))
             })
             .min_by_key(|(p, _)| {
                 match p.properties().device_type {


### PR DESCRIPTION
1. [ ] Update documentation to reflect any user-facing changes - in this repository.

2. [ ] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   Github Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Breaking changes
Changes to `Queue`:
- added `QueueFamilyIndex` type to replace `u32` in API calls.
```
