### PR TITLE
Add `#[inline]` and `#[track_caller]` attributes to `Validated` methods

### DIFF
--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -389,6 +389,7 @@ pub enum Validated<E> {
 impl<E> Validated<E> {
     /// Maps the inner `Error` value using the provided function, or does nothing if the value is
     /// `ValidationError`.
+    #[inline]
     pub fn map<F>(self, f: impl FnOnce(E) -> F) -> Validated<F> {
         match self {
             Self::Error(err) => Validated::Error(f(err)),
@@ -396,6 +397,7 @@ impl<E> Validated<E> {
         }
     }
 
+    #[inline]
     fn map_validation(self, f: impl FnOnce(Box<ValidationError>) -> Box<ValidationError>) -> Self {
         match self {
             Self::Error(err) => Self::Error(err),
@@ -404,6 +406,8 @@ impl<E> Validated<E> {
     }
 
     /// Returns the inner `Error` value, or panics if it contains `ValidationError`.
+    #[inline(always)]
+    #[track_caller]
     pub fn unwrap(self) -> E {
         match self {
             Self::Error(err) => err,


### PR DESCRIPTION
The methods in `Validated` are currently not marked as `#[inline]` even though they should be. This PR adds the attributes in accordance with the convention used by `core`.