### PR TITLE
Task graph [4/10]: compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "rand",
  "vulkano",
  "vulkano-shaders",
+ "vulkano-taskgraph",
  "winit 0.29.15",
 ]
 
@@ -402,7 +403,7 @@ dependencies = [
 [[package]]
 name = "concurrent-slotmap"
 version = "0.1.0"
-source = "git+https://github.com/vulkano-rs/concurrent-slotmap?rev=bf52f0a55713bb29dde3e38bc3497b03473d1628#bf52f0a55713bb29dde3e38bc3497b03473d1628"
+source = "git+https://github.com/vulkano-rs/concurrent-slotmap?rev=fa906d916d8d126d3cc3a2b4ab9a29fa27bee62d#fa906d916d8d126d3cc3a2b4ab9a29fa27bee62d"
 dependencies = [
  "virtual-buffer",
 ]
@@ -1685,12 +1686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rangemap"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,10 +2403,10 @@ dependencies = [
 name = "vulkano-taskgraph"
 version = "0.34.0"
 dependencies = [
+ "ahash",
  "ash",
  "concurrent-slotmap",
  "parking_lot",
- "rangemap",
  "smallvec",
  "thread_local",
  "vulkano",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ path = "vulkano-macros"
 version = "0.34"
 path = "vulkano-shaders"
 
+[workspace.dependencies.vulkano-taskgraph]
+version = "0.34"
+path = "vulkano-taskgraph"
+
 [workspace.dependencies.vulkano-util]
 version = "0.34"
 path = "vulkano-util"
@@ -42,7 +46,7 @@ ahash = "0.8"
 # https://github.com/KhronosGroup/Vulkan-Headers/commits/main/registry/vk.xml
 ash = "0.38.0"
 bytemuck = "1.9"
-concurrent-slotmap = { git = "https://github.com/vulkano-rs/concurrent-slotmap", rev = "bf52f0a55713bb29dde3e38bc3497b03473d1628" }
+concurrent-slotmap = { git = "https://github.com/vulkano-rs/concurrent-slotmap", rev = "fa906d916d8d126d3cc3a2b4ab9a29fa27bee62d" }
 core-graphics-types = "0.1"
 crossbeam-queue = "0.3"
 half = "2.0"

--- a/examples/async-update/Cargo.toml
+++ b/examples/async-update/Cargo.toml
@@ -16,4 +16,5 @@ glam = { workspace = true }
 rand = { workspace = true }
 vulkano = { workspace = true, features = ["macros"]  }
 vulkano-shaders = { workspace = true }
+vulkano-taskgraph = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -30,21 +30,21 @@
 use glam::f32::Mat4;
 use rand::Rng;
 use std::{
+    alloc::Layout,
     error::Error,
-    hint,
+    slice,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
         mpsc, Arc,
     },
     thread,
     time::{SystemTime, UNIX_EPOCH},
 };
 use vulkano::{
-    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
+    buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
-        allocator::StandardCommandBufferAllocator, BufferImageCopy, ClearColorImageInfo,
-        CommandBufferBeginInfo, CommandBufferLevel, CommandBufferUsage, CopyBufferToImageInfo,
-        RecordingCommandBuffer, RenderPassBeginInfo,
+        sys::RawRecordingCommandBuffer, BufferImageCopy, ClearColorImageInfo,
+        CopyBufferToImageInfo, RenderPassBeginInfo,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
@@ -60,7 +60,7 @@ use vulkano::{
         Image, ImageCreateInfo, ImageType, ImageUsage,
     },
     instance::{Instance, InstanceCreateFlags, InstanceCreateInfo},
-    memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
+    memory::allocator::{AllocationCreateInfo, DeviceLayout, MemoryTypeFilter},
     pipeline::{
         graphics::{
             color_blend::{ColorBlendAttachmentState, ColorBlendState},
@@ -76,11 +76,14 @@ use vulkano::{
         PipelineShaderStageCreateInfo,
     },
     render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
-    swapchain::{
-        acquire_next_image, Surface, Swapchain, SwapchainCreateInfo, SwapchainPresentInfo,
-    },
-    sync::{self, GpuFuture},
-    Validated, VulkanError, VulkanLibrary,
+    swapchain::{Surface, Swapchain, SwapchainCreateInfo},
+    sync::Sharing,
+    DeviceSize, Validated, VulkanError, VulkanLibrary,
+};
+use vulkano_taskgraph::{
+    graph::{CompileInfo, ExecuteError, TaskGraph},
+    resource::{AccessType, Flight, HostAccessType, ImageLayoutType, Resources},
+    resource_map, Id, QueueFamilyType, Task, TaskContext, TaskResult,
 };
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -90,6 +93,7 @@ use winit::{
 };
 
 const TRANSFER_GRANULARITY: u32 = 4096;
+const MAX_FRAMES_IN_FLIGHT: u32 = 2;
 
 fn main() -> Result<(), impl Error> {
     let event_loop = EventLoop::new().unwrap();
@@ -190,6 +194,16 @@ fn main() -> Result<(), impl Error> {
                 queue_family_index: transfer_family_index,
                 ..Default::default()
             });
+        } else {
+            let queue_family_properties =
+                &physical_device.queue_family_properties()[graphics_family_index as usize];
+
+            // Even if we can't get an async transfer queue family, it's still better to use
+            // different queues on the same queue family. This way, at least the threads on the
+            // host don't have lock the same queue when submitting.
+            if queue_family_properties.queue_count > 1 {
+                queue_create_infos[0].queues.push(0.5);
+            }
         }
 
         Device::new(
@@ -213,44 +227,41 @@ fn main() -> Result<(), impl Error> {
         {transfer_family_index} for transfers",
     );
 
-    let (mut swapchain, images) = {
+    let resources = Resources::new(device.clone(), Default::default());
+
+    let graphics_flight_id = resources.create_flight(MAX_FRAMES_IN_FLIGHT).unwrap();
+    let transfer_flight_id = resources.create_flight(1).unwrap();
+
+    let swapchain_format = device
+        .physical_device()
+        .surface_formats(&surface, Default::default())
+        .unwrap()[0]
+        .0;
+    let mut swapchain_id = {
         let surface_capabilities = device
             .physical_device()
             .surface_capabilities(&surface, Default::default())
             .unwrap();
-        let image_format = device
-            .physical_device()
-            .surface_formats(&surface, Default::default())
-            .unwrap()[0]
-            .0;
 
-        Swapchain::new(
-            device.clone(),
-            surface,
-            SwapchainCreateInfo {
-                min_image_count: surface_capabilities.min_image_count.max(2),
-                image_format,
-                image_extent: window.inner_size().into(),
-                image_usage: ImageUsage::COLOR_ATTACHMENT,
-                composite_alpha: surface_capabilities
-                    .supported_composite_alpha
-                    .into_iter()
-                    .next()
-                    .unwrap(),
-                ..Default::default()
-            },
-        )
-        .unwrap()
+        resources
+            .create_swapchain(
+                graphics_flight_id,
+                surface,
+                SwapchainCreateInfo {
+                    min_image_count: surface_capabilities.min_image_count.max(3),
+                    image_format: swapchain_format,
+                    image_extent: window.inner_size().into(),
+                    image_usage: ImageUsage::COLOR_ATTACHMENT,
+                    composite_alpha: surface_capabilities
+                        .supported_composite_alpha
+                        .into_iter()
+                        .next()
+                        .unwrap(),
+                    ..Default::default()
+                },
+            )
+            .unwrap()
     };
-
-    let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device.clone()));
-
-    #[derive(BufferContents, Vertex)]
-    #[repr(C)]
-    struct MyVertex {
-        #[format(R32G32_SFLOAT)]
-        position: [f32; 2],
-    }
 
     let vertices = [
         MyVertex {
@@ -266,27 +277,26 @@ fn main() -> Result<(), impl Error> {
             position: [0.5, 0.5],
         },
     ];
-    let vertex_buffer = Buffer::from_iter(
-        memory_allocator.clone(),
-        BufferCreateInfo {
-            usage: BufferUsage::VERTEX_BUFFER,
-            ..Default::default()
-        },
-        AllocationCreateInfo {
-            memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
-                | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
-            ..Default::default()
-        },
-        vertices,
-    )
-    .unwrap();
+    let vertex_buffer_id = resources
+        .create_buffer(
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
+                ..Default::default()
+            },
+            DeviceLayout::from_layout(Layout::for_value(&vertices)).unwrap(),
+        )
+        .unwrap();
 
     // Create a pool of uniform buffers, one per frame in flight. This way we always have an
     // available buffer to write during each frame while reusing them as much as possible.
-    let uniform_buffers = (0..swapchain.image_count())
-        .map(|_| {
-            Buffer::new_sized(
-                memory_allocator.clone(),
+    let uniform_buffer_ids = [(); MAX_FRAMES_IN_FLIGHT as usize].map(|_| {
+        resources
+            .create_buffer(
                 BufferCreateInfo {
                     usage: BufferUsage::UNIFORM_BUFFER,
                     ..Default::default()
@@ -296,121 +306,93 @@ fn main() -> Result<(), impl Error> {
                         | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                     ..Default::default()
                 },
+                DeviceLayout::from_layout(Layout::new::<vs::Data>()).unwrap(),
             )
             .unwrap()
-        })
-        .collect::<Vec<_>>();
+    });
+
+    let texture_create_info = ImageCreateInfo {
+        image_type: ImageType::Dim2d,
+        format: Format::R8G8B8A8_UNORM,
+        extent: [TRANSFER_GRANULARITY * 2, TRANSFER_GRANULARITY * 2, 1],
+        usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
+        sharing: if graphics_family_index != transfer_family_index {
+            Sharing::Concurrent(
+                [graphics_family_index, transfer_family_index]
+                    .into_iter()
+                    .collect(),
+            )
+        } else {
+            Sharing::Exclusive
+        },
+        ..Default::default()
+    };
 
     // Create two textures, where at any point in time one is used exclusively for reading and one
     // is used exclusively for writing, swapping the two after each update.
-    let textures = [(); 2].map(|_| {
-        Image::new(
-            memory_allocator.clone(),
-            ImageCreateInfo {
-                image_type: ImageType::Dim2d,
-                format: Format::R8G8B8A8_UNORM,
-                extent: [TRANSFER_GRANULARITY * 2, TRANSFER_GRANULARITY * 2, 1],
-                usage: ImageUsage::TRANSFER_DST | ImageUsage::SAMPLED,
-                ..Default::default()
-            },
-            AllocationCreateInfo::default(),
-        )
-        .unwrap()
+    let texture_ids = [(); 2].map(|_| {
+        resources
+            .create_image(texture_create_info.clone(), AllocationCreateInfo::default())
+            .unwrap()
     });
 
     // The index of the currently most up-to-date texture. The worker thread swaps the index after
     // every finished write, which is always done to the, at that point in time, unused texture.
     let current_texture_index = Arc::new(AtomicBool::new(false));
 
-    // Current generation, used to notify the worker thread of when a texture is no longer read.
-    let current_generation = Arc::new(AtomicU64::new(0));
+    // Initialize the resources.
+    unsafe {
+        vulkano_taskgraph::execute(
+            graphics_queue.clone(),
+            resources.clone(),
+            graphics_flight_id,
+            |cbf, tcx| {
+                tcx.write_buffer::<[MyVertex]>(vertex_buffer_id, ..)?
+                    .copy_from_slice(&vertices);
 
-    let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(
-        device.clone(),
-        Default::default(),
-    ));
+                for &texture_id in &texture_ids {
+                    let texture = tcx.image(texture_id)?.image();
+                    cbf.clear_color_image(&ClearColorImageInfo::image(texture.clone()))?;
+                }
 
-    // Initialize the textures.
-    {
-        let mut builder = RecordingCommandBuffer::new(
-            command_buffer_allocator.clone(),
-            graphics_queue.queue_family_index(),
-            CommandBufferLevel::Primary,
-            CommandBufferBeginInfo {
-                usage: CommandBufferUsage::OneTimeSubmit,
-                ..Default::default()
+                Ok(())
             },
+            [(vertex_buffer_id, HostAccessType::Write)],
+            [],
+            [
+                (
+                    texture_ids[0],
+                    AccessType::ClearTransferWrite,
+                    ImageLayoutType::Optimal,
+                ),
+                (
+                    texture_ids[1],
+                    AccessType::ClearTransferWrite,
+                    ImageLayoutType::Optimal,
+                ),
+            ],
         )
-        .unwrap();
-        for texture in &textures {
-            builder
-                .clear_color_image(ClearColorImageInfo::image(texture.clone()))
-                .unwrap();
-        }
-        let command_buffer = builder.end().unwrap();
-
-        // This waits for the queue to become idle, which is fine for startup initializations.
-        let _ = command_buffer.execute(graphics_queue.clone()).unwrap();
     }
+    .unwrap();
 
     // Start the worker thread.
     let (channel, receiver) = mpsc::channel();
     run_worker(
         receiver,
         transfer_queue,
-        textures.clone(),
+        resources.clone(),
+        graphics_flight_id,
+        transfer_flight_id,
+        &texture_create_info,
+        texture_ids,
         current_texture_index.clone(),
-        current_generation.clone(),
-        swapchain.image_count(),
-        memory_allocator,
-        command_buffer_allocator.clone(),
     );
-
-    mod vs {
-        vulkano_shaders::shader! {
-            ty: "vertex",
-            src: r"
-                #version 450
-
-                layout(location = 0) in vec2 position;
-                layout(location = 0) out vec2 tex_coords;
-
-                layout(set = 0, binding = 0) uniform Data {
-                    mat4 transform;
-                };
-
-                void main() {
-                    gl_Position = vec4(transform * vec4(position, 0.0, 1.0));
-                    tex_coords = position + vec2(0.5);
-                }
-            ",
-        }
-    }
-
-    mod fs {
-        vulkano_shaders::shader! {
-            ty: "fragment",
-            src: r"
-                #version 450
-
-                layout(location = 0) in vec2 tex_coords;
-                layout(location = 0) out vec4 f_color;
-
-                layout(set = 1, binding = 0) uniform sampler s;
-                layout(set = 1, binding = 1) uniform texture2D tex;
-
-                void main() {
-                    f_color = texture(sampler2D(tex, s), tex_coords);
-                }
-            ",
-        }
-    }
 
     let render_pass = vulkano::single_pass_renderpass!(
         device.clone(),
         attachments: {
             color: {
-                format: swapchain.image_format(),
+                format: swapchain_format,
                 samples: 1,
                 load_op: Clear,
                 store_op: Store,
@@ -476,7 +458,8 @@ fn main() -> Result<(), impl Error> {
         extent: [0.0, 0.0],
         depth_range: 0.0..=1.0,
     };
-    let mut framebuffers = window_size_dependent_setup(&images, render_pass.clone(), &mut viewport);
+    let framebuffers =
+        window_size_dependent_setup(&resources, swapchain_id, &render_pass, &mut viewport);
 
     let descriptor_set_allocator = Arc::new(StandardDescriptorSetAllocator::new(
         device.clone(),
@@ -485,36 +468,91 @@ fn main() -> Result<(), impl Error> {
 
     // A byproduct of always using the same set of uniform buffers is that we can also create one
     // descriptor set for each, reusing them in the same way as the buffers.
-    let uniform_buffer_sets = uniform_buffers
-        .iter()
-        .map(|buffer| {
-            DescriptorSet::new(
-                descriptor_set_allocator.clone(),
-                pipeline.layout().set_layouts()[0].clone(),
-                [WriteDescriptorSet::buffer(0, buffer.clone())],
-                [],
-            )
-            .unwrap()
-        })
-        .collect::<Vec<_>>();
+    let uniform_buffer_sets = uniform_buffer_ids.map(|buffer_id| {
+        let buffer_state = resources.buffer(buffer_id).unwrap();
+        let buffer = buffer_state.buffer();
+
+        DescriptorSet::new(
+            descriptor_set_allocator.clone(),
+            pipeline.layout().set_layouts()[0].clone(),
+            [WriteDescriptorSet::buffer(0, buffer.clone().into())],
+            [],
+        )
+        .unwrap()
+    });
 
     // Create the descriptor sets for sampling the textures.
     let sampler = Sampler::new(device.clone(), SamplerCreateInfo::simple_repeat_linear()).unwrap();
-    let sampler_sets = textures.map(|texture| {
+    let sampler_sets = texture_ids.map(|texture_id| {
+        let texture_state = resources.image(texture_id).unwrap();
+        let texture = texture_state.image();
+
         DescriptorSet::new(
             descriptor_set_allocator.clone(),
             pipeline.layout().set_layouts()[1].clone(),
             [
                 WriteDescriptorSet::sampler(0, sampler.clone()),
-                WriteDescriptorSet::image_view(1, ImageView::new_default(texture).unwrap()),
+                WriteDescriptorSet::image_view(1, ImageView::new_default(texture.clone()).unwrap()),
             ],
             [],
         )
         .unwrap()
     });
 
+    let mut rcx = RenderContext {
+        viewport,
+        framebuffers,
+    };
+
+    let mut task_graph = TaskGraph::new(resources.clone(), 1, 4);
+
+    let virtual_swapchain_id = task_graph.add_swapchain(&SwapchainCreateInfo::default());
+    let virtual_texture_id = task_graph.add_image(&texture_create_info);
+    let virtual_uniform_buffer_id = task_graph.add_buffer(&BufferCreateInfo::default());
+
+    task_graph.add_host_buffer_access(virtual_uniform_buffer_id, HostAccessType::Write);
+
+    task_graph
+        .create_task_node(
+            "Render",
+            QueueFamilyType::Graphics,
+            RenderTask {
+                swapchain_id: virtual_swapchain_id,
+                vertex_buffer_id,
+                current_texture_index: current_texture_index.clone(),
+                pipeline: pipeline.clone(),
+                uniform_buffer_id: virtual_uniform_buffer_id,
+                uniform_buffer_sets: uniform_buffer_sets.clone(),
+                sampler_sets: sampler_sets.clone(),
+            },
+        )
+        .image_access(
+            virtual_swapchain_id.current_image_id(),
+            AccessType::ColorAttachmentWrite,
+            ImageLayoutType::Optimal,
+        )
+        .buffer_access(vertex_buffer_id, AccessType::VertexAttributeRead)
+        .image_access(
+            virtual_texture_id,
+            AccessType::FragmentShaderSampledRead,
+            ImageLayoutType::Optimal,
+        )
+        .buffer_access(
+            virtual_uniform_buffer_id,
+            AccessType::VertexShaderUniformRead,
+        );
+
+    let task_graph = unsafe {
+        task_graph.compile(CompileInfo {
+            queues: vec![graphics_queue.clone()],
+            present_queue: Some(graphics_queue.clone()),
+            flight_id: graphics_flight_id,
+            ..Default::default()
+        })
+    }
+    .unwrap();
+
     let mut recreate_swapchain = false;
-    let mut previous_frame_end = Some(sync::now(device.clone()).boxed());
 
     println!("\nPress space to update part of the texture");
 
@@ -559,178 +597,222 @@ fn main() -> Result<(), impl Error> {
                     return;
                 }
 
+                let flight = resources.flight(graphics_flight_id).unwrap();
+
                 if recreate_swapchain {
-                    let (new_swapchain, new_images) = swapchain
-                        .recreate(SwapchainCreateInfo {
+                    swapchain_id = resources
+                        .recreate_swapchain(swapchain_id, |create_info| SwapchainCreateInfo {
                             image_extent,
-                            ..swapchain.create_info()
+                            ..create_info
                         })
                         .expect("failed to recreate swapchain");
 
-                    swapchain = new_swapchain;
-                    framebuffers = window_size_dependent_setup(
-                        &new_images,
-                        render_pass.clone(),
-                        &mut viewport,
+                    flight.destroy_objects(rcx.framebuffers.drain(..));
+
+                    rcx.framebuffers = window_size_dependent_setup(
+                        &resources,
+                        swapchain_id,
+                        &render_pass,
+                        &mut rcx.viewport,
                     );
+
                     recreate_swapchain = false;
                 }
 
-                let (image_index, suboptimal, acquire_future) =
-                    match acquire_next_image(swapchain.clone(), None).map_err(Validated::unwrap) {
-                        Ok(r) => r,
-                        Err(VulkanError::OutOfDate) => {
-                            recreate_swapchain = true;
-                            return;
-                        }
-                        Err(e) => panic!("failed to acquire next image: {e}"),
-                    };
+                let frame_index = flight.current_frame_index();
+                let texture_index = current_texture_index.load(Ordering::Relaxed);
 
-                if suboptimal {
-                    recreate_swapchain = true;
-                }
-
-                let mut builder = RecordingCommandBuffer::new(
-                    command_buffer_allocator.clone(),
-                    graphics_queue.queue_family_index(),
-                    CommandBufferLevel::Primary,
-                    CommandBufferBeginInfo {
-                        usage: CommandBufferUsage::OneTimeSubmit,
-                        ..Default::default()
-                    },
+                let resource_map = resource_map!(
+                    &task_graph,
+                    virtual_swapchain_id => swapchain_id,
+                    virtual_texture_id => texture_ids[texture_index as usize],
+                    virtual_uniform_buffer_id => uniform_buffer_ids[frame_index as usize],
                 )
                 .unwrap();
 
-                builder
-                    .begin_render_pass(
-                        RenderPassBeginInfo {
-                            clear_values: vec![Some([0.0, 0.0, 0.0, 1.0].into())],
-                            ..RenderPassBeginInfo::framebuffer(
-                                framebuffers[image_index as usize].clone(),
-                            )
-                        },
-                        Default::default(),
-                    )
-                    .unwrap()
-                    .set_viewport(0, [viewport.clone()].into_iter().collect())
-                    .unwrap()
-                    .bind_pipeline_graphics(pipeline.clone())
-                    .unwrap()
-                    .bind_descriptor_sets(
-                        PipelineBindPoint::Graphics,
-                        pipeline.layout().clone(),
-                        0,
-                        (
-                            // Bind the uniform buffer designated for this frame.
-                            uniform_buffer_sets[image_index as usize].clone(),
-                            // Bind the currently most up-to-date texture.
-                            sampler_sets[current_texture_index.load(Ordering::Acquire) as usize]
-                                .clone(),
-                        ),
-                    )
-                    .unwrap()
-                    .bind_vertex_buffers(0, vertex_buffer.clone())
-                    .unwrap();
+                flight.wait(None).unwrap();
 
-                unsafe {
-                    builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
-                }
-
-                builder.end_render_pass(Default::default()).unwrap();
-
-                let command_buffer = builder.end().unwrap();
-                acquire_future.wait(None).unwrap();
-                previous_frame_end.as_mut().unwrap().cleanup_finished();
-
-                // Write to the uniform buffer designated for this frame. This must happen after
-                // waiting for the acquire future and cleaning up, otherwise the buffer is still
-                // going to be marked as in use by the device.
-                *uniform_buffers[image_index as usize].write().unwrap() = vs::Data {
-                    transform: {
-                        const DURATION: f64 = 5.0;
-
-                        let elapsed = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs_f64();
-                        let remainder = elapsed.rem_euclid(DURATION);
-                        let delta = (remainder / DURATION) as f32;
-                        let angle = delta * std::f32::consts::PI * 2.0;
-
-                        Mat4::from_rotation_z(angle).to_cols_array_2d()
-                    },
-                };
-
-                // Increment the generation, signalling that the previous frame has finished. This
-                // must be done after waiting on the acquire future, otherwise the oldest frame
-                // would still be in flight.
-                //
-                // NOTE: We are relying on the fact that this thread is the only one doing stores.
-                current_generation.fetch_add(1, Ordering::Release);
-
-                let future = previous_frame_end
-                    .take()
-                    .unwrap()
-                    .join(acquire_future)
-                    .then_execute(graphics_queue.clone(), command_buffer)
-                    .unwrap()
-                    .then_swapchain_present(
-                        graphics_queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(swapchain.clone(), image_index),
-                    )
-                    .then_signal_fence_and_flush();
-
-                match future.map_err(Validated::unwrap) {
-                    Ok(future) => {
-                        previous_frame_end = Some(future.boxed());
-                    }
-                    Err(VulkanError::OutOfDate) => {
+                match unsafe {
+                    task_graph.execute(resource_map, &rcx, || window.pre_present_notify())
+                } {
+                    Ok(()) => {}
+                    Err(ExecuteError::Swapchain {
+                        error: Validated::Error(VulkanError::OutOfDate),
+                        ..
+                    }) => {
                         recreate_swapchain = true;
-                        previous_frame_end = Some(sync::now(device.clone()).boxed());
                     }
                     Err(e) => {
-                        println!("failed to flush future: {e}");
-                        // previous_frame_end = Some(sync::now(device.clone()).boxed());
+                        panic!("failed to execute next frame: {e:?}");
                     }
                 }
             }
-            Event::AboutToWait => window.request_redraw(),
+            Event::AboutToWait => {
+                window.request_redraw();
+            }
+            Event::LoopExiting => {
+                let flight = resources.flight(graphics_flight_id).unwrap();
+                flight.destroy_object(pipeline.clone());
+                flight.destroy_objects(rcx.framebuffers.drain(..));
+                flight.destroy_objects(uniform_buffer_sets.clone());
+                flight.destroy_objects(sampler_sets.clone());
+            }
             _ => (),
         }
     })
+}
+
+#[derive(Clone, Copy, BufferContents, Vertex)]
+#[repr(C)]
+struct MyVertex {
+    #[format(R32G32_SFLOAT)]
+    position: [f32; 2],
+}
+
+mod vs {
+    vulkano_shaders::shader! {
+        ty: "vertex",
+        src: r"
+            #version 450
+
+            layout(location = 0) in vec2 position;
+            layout(location = 0) out vec2 tex_coords;
+
+            layout(set = 0, binding = 0) uniform Data {
+                mat4 transform;
+            };
+
+            void main() {
+                gl_Position = vec4(transform * vec4(position, 0.0, 1.0));
+                tex_coords = position + vec2(0.5);
+            }
+        ",
+    }
+}
+
+mod fs {
+    vulkano_shaders::shader! {
+        ty: "fragment",
+        src: r"
+            #version 450
+
+            layout(location = 0) in vec2 tex_coords;
+            layout(location = 0) out vec4 f_color;
+
+            layout(set = 1, binding = 0) uniform sampler s;
+            layout(set = 1, binding = 1) uniform texture2D tex;
+
+            void main() {
+                f_color = texture(sampler2D(tex, s), tex_coords);
+            }
+        ",
+    }
+}
+
+struct RenderContext {
+    viewport: Viewport,
+    framebuffers: Vec<Arc<Framebuffer>>,
+}
+
+struct RenderTask {
+    swapchain_id: Id<Swapchain>,
+    vertex_buffer_id: Id<Buffer>,
+    current_texture_index: Arc<AtomicBool>,
+    pipeline: Arc<GraphicsPipeline>,
+    uniform_buffer_id: Id<Buffer>,
+    uniform_buffer_sets: [Arc<DescriptorSet>; MAX_FRAMES_IN_FLIGHT as usize],
+    sampler_sets: [Arc<DescriptorSet>; 2],
+}
+
+impl Task for RenderTask {
+    type World = RenderContext;
+
+    unsafe fn execute(
+        &self,
+        cbf: &mut RawRecordingCommandBuffer,
+        tcx: &mut TaskContext<'_>,
+        rcx: &Self::World,
+    ) -> TaskResult {
+        let frame_index = tcx.current_frame_index();
+        let swapchain_state = tcx.swapchain(self.swapchain_id)?;
+        let image_index = swapchain_state.current_image_index().unwrap();
+        let vertex_buffer = Subbuffer::from(tcx.buffer(self.vertex_buffer_id)?.buffer().clone());
+
+        // Write to the uniform buffer designated for this frame.
+        *tcx.write_buffer(self.uniform_buffer_id, ..)? = vs::Data {
+            transform: {
+                const DURATION: f64 = 5.0;
+
+                let elapsed = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs_f64();
+                let remainder = elapsed.rem_euclid(DURATION);
+                let delta = (remainder / DURATION) as f32;
+                let angle = delta * std::f32::consts::PI * 2.0;
+
+                Mat4::from_rotation_z(angle).to_cols_array_2d()
+            },
+        };
+
+        cbf.begin_render_pass(
+            &RenderPassBeginInfo {
+                clear_values: vec![Some([0.0, 0.0, 0.0, 1.0].into())],
+                ..RenderPassBeginInfo::framebuffer(rcx.framebuffers[image_index as usize].clone())
+            },
+            &Default::default(),
+        )?
+        .set_viewport(0, slice::from_ref(&rcx.viewport))?
+        .bind_pipeline_graphics(&self.pipeline)?
+        .bind_descriptor_sets(
+            PipelineBindPoint::Graphics,
+            self.pipeline.layout(),
+            0,
+            &[
+                // Bind the uniform buffer designated for this frame.
+                self.uniform_buffer_sets[frame_index as usize]
+                    .clone()
+                    .into(),
+                // Bind the currently most up-to-date texture.
+                self.sampler_sets[self.current_texture_index.load(Ordering::Relaxed) as usize]
+                    .clone()
+                    .into(),
+            ],
+        )?
+        .bind_vertex_buffers(0, slice::from_ref(&vertex_buffer))?;
+
+        let vertex_count = vertex_buffer.reinterpret_ref::<[MyVertex]>().len();
+        unsafe { cbf.draw(vertex_count as u32, 1, 0, 0) }?;
+
+        cbf.end_render_pass(&Default::default())?;
+
+        Ok(())
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
 fn run_worker(
     channel: mpsc::Receiver<()>,
     transfer_queue: Arc<Queue>,
-    textures: [Arc<Image>; 2],
+    resources: Arc<Resources>,
+    graphics_flight_id: Id<Flight>,
+    transfer_flight_id: Id<Flight>,
+    texture_create_info: &ImageCreateInfo,
+    texture_ids: [Id<Image>; 2],
     current_texture_index: Arc<AtomicBool>,
-    current_generation: Arc<AtomicU64>,
-    swapchain_image_count: u32,
-    memory_allocator: Arc<StandardMemoryAllocator>,
-    command_buffer_allocator: Arc<StandardCommandBufferAllocator>,
 ) {
-    thread::spawn(move || {
-        const CORNER_OFFSETS: [[u32; 3]; 4] = [
-            [0, 0, 0],
-            [TRANSFER_GRANULARITY, 0, 0],
-            [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 0],
-            [0, TRANSFER_GRANULARITY, 0],
-        ];
-
-        // We are going to be updating one of 4 corners of the texture at any point in time. For
-        // that, we will use a staging buffer and initiate a copy. However, since our texture is
-        // eventually consistent and there are 2 replicas, that means that every time we update one
-        // of the replicas the other replica is going to be behind by one update. Therefore we
-        // actually need 2 staging buffers as well: one for the update that happened to the
-        // currently up-to-date texture (at `current_index`) and one for the update that is about
-        // to happen to the currently out-of-date texture (at `!current_index`), so that we can
-        // apply both the current and the upcoming update to the out-of-date texture. Then the
-        // out-of-date texture is the current up-to-date texture and vice-versa, cycle repeating.
-        let staging_buffers = [(); 2].map(|_| {
-            Buffer::from_iter(
-                memory_allocator.clone(),
+    // We are going to be updating one of 4 corners of the texture at any point in time. For that,
+    // we will use a staging buffer and initiate a copy. However, since our texture is eventually
+    // consistent and there are 2 replicas, that means that every time we update one of the
+    // replicas the other replica is going to be behind by one update. Therefore we actually need 2
+    // staging buffers as well: one for the update that happened to the currently up-to-date
+    // texture (at `current_index`) and one for the update that is about to happen to the currently
+    // out-of-date texture (at `!current_index`), so that we can apply both the current and the
+    // upcoming update to the out-of-date texture. Then the out-of-date texture is the current
+    // up-to-date texture and vice-versa, cycle repeating.
+    let staging_buffer_ids = [(); 2].map(|_| {
+        resources
+            .create_buffer(
                 BufferCreateInfo {
                     usage: BufferUsage::TRANSFER_SRC,
                     ..Default::default()
@@ -740,77 +822,62 @@ fn run_worker(
                         | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                     ..Default::default()
                 },
-                (0..TRANSFER_GRANULARITY * TRANSFER_GRANULARITY).map(|_| [0u8; 4]),
+                DeviceLayout::from_size_alignment(
+                    TRANSFER_GRANULARITY as DeviceSize * TRANSFER_GRANULARITY as DeviceSize * 4,
+                    1,
+                )
+                .unwrap(),
             )
             .unwrap()
-        });
+    });
 
+    let mut task_graph = TaskGraph::new(resources.clone(), 1, 3);
+
+    let virtual_front_staging_buffer_id = task_graph.add_buffer(&BufferCreateInfo::default());
+    let virtual_back_staging_buffer_id = task_graph.add_buffer(&BufferCreateInfo::default());
+    let virtual_texture_id = task_graph.add_image(texture_create_info);
+
+    task_graph.add_host_buffer_access(virtual_front_staging_buffer_id, HostAccessType::Write);
+
+    task_graph
+        .create_task_node(
+            "Image Upload",
+            QueueFamilyType::Transfer,
+            UploadTask {
+                front_staging_buffer_id: virtual_front_staging_buffer_id,
+                back_staging_buffer_id: virtual_back_staging_buffer_id,
+                texture_id: virtual_texture_id,
+            },
+        )
+        .buffer_access(
+            virtual_front_staging_buffer_id,
+            AccessType::CopyTransferRead,
+        )
+        .buffer_access(virtual_back_staging_buffer_id, AccessType::CopyTransferRead)
+        .image_access(
+            virtual_texture_id,
+            AccessType::CopyTransferWrite,
+            ImageLayoutType::Optimal,
+        );
+
+    let task_graph = unsafe {
+        task_graph.compile(CompileInfo {
+            queues: vec![transfer_queue],
+            flight_id: transfer_flight_id,
+            ..Default::default()
+        })
+    }
+    .unwrap();
+
+    thread::spawn(move || {
         let mut current_corner = 0;
-        let mut rng = rand::thread_rng();
-        let mut last_generation = 0;
+        let mut last_frame = 0;
 
         // The worker thread is awakened by sending a signal through the channel. In a real program
         // you would likely send some actual data over the channel, instructing the worker what to
         // do, but our work is hard-coded.
         while let Ok(()) = channel.recv() {
-            let current_index = current_texture_index.load(Ordering::Acquire);
-
-            // We simulate some work for the worker to indulge in. In a real program this would
-            // likely be some kind of I/O, for example reading from disk (think loading the next
-            // level in a level-based game, loading the next chunk of terrain in an open-world
-            // game, etc.) or downloading images or other data from the internet.
-            //
-            // NOTE: The size of these textures is exceedingly large on purpose, so that you can
-            // feel that the update is in fact asynchronous due to the latency of the updates while
-            // the rendering continues without any.
-            let color = [rng.gen(), rng.gen(), rng.gen(), u8::MAX];
-            for texel in &mut *staging_buffers[!current_index as usize].write().unwrap() {
-                *texel = color;
-            }
-
-            // Write to the texture that's currently not in use for rendering.
-            let texture = textures[!current_index as usize].clone();
-
-            let mut builder = RecordingCommandBuffer::new(
-                command_buffer_allocator.clone(),
-                transfer_queue.queue_family_index(),
-                CommandBufferLevel::Primary,
-                CommandBufferBeginInfo {
-                    usage: CommandBufferUsage::OneTimeSubmit,
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-            builder
-                .copy_buffer_to_image(CopyBufferToImageInfo {
-                    regions: [BufferImageCopy {
-                        image_subresource: texture.subresource_layers(),
-                        image_offset: CORNER_OFFSETS[current_corner % 4],
-                        image_extent: [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 1],
-                        ..Default::default()
-                    }]
-                    .into(),
-                    ..CopyBufferToImageInfo::buffer_image(
-                        staging_buffers[current_index as usize].clone(),
-                        texture.clone(),
-                    )
-                })
-                .unwrap()
-                .copy_buffer_to_image(CopyBufferToImageInfo {
-                    regions: [BufferImageCopy {
-                        image_subresource: texture.subresource_layers(),
-                        image_offset: CORNER_OFFSETS[(current_corner + 1) % 4],
-                        image_extent: [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 1],
-                        ..Default::default()
-                    }]
-                    .into(),
-                    ..CopyBufferToImageInfo::buffer_image(
-                        staging_buffers[!current_index as usize].clone(),
-                        texture,
-                    )
-                })
-                .unwrap();
-            let command_buffer = builder.end().unwrap();
+            let graphics_flight = resources.flight(graphics_flight_id).unwrap();
 
             // We swap the texture index to use after a write, but there is no guarantee that other
             // tasks have actually moved on to using the new texture. What could happen then, if
@@ -822,56 +889,135 @@ fn run_worker(
             // 3. Task B writes texture 0, swapping the index
             // 4. Task A stops reading texture 0
             //
-            // This is known as the A/B/A problem. In this case it results in a race condition,
-            // since task A (rendering, in our case) is still reading texture 0 while task B (our
-            // worker) has already started writing the very same texture.
+            // This is known as the A/B/A problem. In this case it results in a data race, since
+            // task A (rendering, in our case) is still reading texture 0 while task B (our worker)
+            // has already started writing the very same texture.
             //
-            // The most common way to solve this issue is using *generations*, also known as
-            // *epochs*. A generation is simply a monotonically increasing integer. What exactly
-            // one generation represents depends on the application. In our case, one generation
-            // passed represents one frame that finished rendering. Knowing this, we can keep track
-            // of the generation at the time of swapping the texture index, and ensure that any
-            // further write only happens after a generation was reached which makes it impossible
-            // for any readers to be stuck on the old index. Here we are simply spinning.
-            //
-            // NOTE: You could also use the thread for other things in the meantime. Since frames
-            // are typically very short though, it would make no sense to do that in this case.
-            while current_generation.load(Ordering::Acquire) - last_generation
-                < swapchain_image_count as u64
-            {
-                hint::spin_loop();
-            }
+            // To solve this issue, we keep track of the frame counter before swapping the texture
+            // index and ensure that any further write only happens after a frame was reached which
+            // makes it impossible for any readers to be stuck on the old index, by waiting on the
+            // frame to finish on the rendering thread.
+            graphics_flight.wait_for_frame(last_frame, None).unwrap();
 
-            // Execute the transfer, blocking the thread until it finishes.
-            //
-            // NOTE: You could also use the thread for other things in the meantime.
-            command_buffer
-                .execute(transfer_queue.clone())
-                .unwrap()
-                .then_signal_fence_and_flush()
+            let current_index = current_texture_index.load(Ordering::Relaxed);
+
+            let resource_map = resource_map!(
+                &task_graph,
+                virtual_front_staging_buffer_id => staging_buffer_ids[current_index as usize],
+                virtual_back_staging_buffer_id => staging_buffer_ids[!current_index as usize],
+                // Write to the texture that's currently not in use for rendering.
+                virtual_texture_id => texture_ids[!current_index as usize],
+            )
+            .unwrap();
+
+            unsafe { task_graph.execute(resource_map, &current_corner, || {}) }.unwrap();
+
+            // Block the thread until the transfer finishes.
+            resources
+                .flight(transfer_flight_id)
                 .unwrap()
                 .wait(None)
                 .unwrap();
 
-            // Remember the latest generation.
-            last_generation = current_generation.load(Ordering::Acquire);
+            last_frame = graphics_flight.current_frame();
 
             // Swap the texture used for rendering to the newly updated one.
             //
             // NOTE: We are relying on the fact that this thread is the only one doing stores.
-            current_texture_index.store(!current_index, Ordering::Release);
+            current_texture_index.store(!current_index, Ordering::Relaxed);
 
             current_corner += 1;
         }
     });
 }
 
+struct UploadTask {
+    front_staging_buffer_id: Id<Buffer>,
+    back_staging_buffer_id: Id<Buffer>,
+    texture_id: Id<Image>,
+}
+
+impl Task for UploadTask {
+    type World = usize;
+
+    unsafe fn execute(
+        &self,
+        cbf: &mut RawRecordingCommandBuffer,
+        tcx: &mut TaskContext<'_>,
+        &current_corner: &Self::World,
+    ) -> TaskResult {
+        const CORNER_OFFSETS: [[u32; 3]; 4] = [
+            [0, 0, 0],
+            [TRANSFER_GRANULARITY, 0, 0],
+            [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 0],
+            [0, TRANSFER_GRANULARITY, 0],
+        ];
+
+        let mut rng = rand::thread_rng();
+
+        // We simulate some work for the worker to indulge in. In a real program this would likely
+        // be some kind of I/O, for example reading from disk (think loading the next level in a
+        // level-based game, loading the next chunk of terrain in an open-world game, etc.) or
+        // downloading images or other data from the internet.
+        //
+        // NOTE: The size of these textures is exceedingly large on purpose, so that you can feel
+        // that the update is in fact asynchronous due to the latency of the updates while the
+        // rendering continues without any.
+        let color = [rng.gen(), rng.gen(), rng.gen(), u8::MAX];
+        tcx.write_buffer::<[_]>(self.front_staging_buffer_id, ..)?
+            .fill(color);
+
+        let texture = tcx.image(self.texture_id)?.image();
+
+        cbf.copy_buffer_to_image(&CopyBufferToImageInfo {
+            regions: [BufferImageCopy {
+                image_subresource: texture.subresource_layers(),
+                image_offset: CORNER_OFFSETS[current_corner % 4],
+                image_extent: [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 1],
+                ..Default::default()
+            }]
+            .into(),
+            ..CopyBufferToImageInfo::buffer_image(
+                tcx.buffer(self.front_staging_buffer_id)?
+                    .buffer()
+                    .clone()
+                    .into(),
+                texture.clone(),
+            )
+        })?;
+
+        if current_corner > 0 {
+            cbf.copy_buffer_to_image(&CopyBufferToImageInfo {
+                regions: [BufferImageCopy {
+                    image_subresource: texture.subresource_layers(),
+                    image_offset: CORNER_OFFSETS[(current_corner - 1) % 4],
+                    image_extent: [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 1],
+                    ..Default::default()
+                }]
+                .into(),
+                ..CopyBufferToImageInfo::buffer_image(
+                    tcx.buffer(self.back_staging_buffer_id)?
+                        .buffer()
+                        .clone()
+                        .into(),
+                    texture.clone(),
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+}
+
 /// This function is called once during initialization, then again whenever the window is resized.
 fn window_size_dependent_setup(
-    images: &[Arc<Image>],
-    render_pass: Arc<RenderPass>,
+    resources: &Resources,
+    swapchain_id: Id<Swapchain>,
+    render_pass: &Arc<RenderPass>,
     viewport: &mut Viewport,
 ) -> Vec<Arc<Framebuffer>> {
+    let swapchain_state = resources.swapchain(swapchain_id).unwrap();
+    let images = swapchain_state.images();
     let extent = images[0].extent();
     viewport.extent = [extent[0] as f32, extent[1] as f32];
 

--- a/vulkano-taskgraph/Cargo.toml
+++ b/vulkano-taskgraph/Cargo.toml
@@ -14,10 +14,10 @@ keywords = { workspace = true }
 categories = { workspace = true }
 
 [dependencies]
+ahash = { workspace = true }
 ash = { workspace = true }
 concurrent-slotmap = { workspace = true }
 parking_lot = { workspace = true }
-rangemap = { workspace = true }
 smallvec = { workspace = true }
 thread_local = { workspace = true }
 vulkano = { workspace = true }

--- a/vulkano-taskgraph/src/graph/compile.rs
+++ b/vulkano-taskgraph/src/graph/compile.rs
@@ -1,0 +1,2622 @@
+// FIXME: host read barriers
+
+use self::linear_map::LinearMap;
+use super::{
+    BarrierIndex, ExecutableTaskGraph, Instruction, NodeIndex, NodeInner, ResourceAccess,
+    SemaphoreIndex, Submission, TaskGraph,
+};
+use crate::{resource::Flight, Id, ObjectType, QueueFamilyType};
+use ash::vk;
+use smallvec::{smallvec, SmallVec};
+use std::{cell::RefCell, cmp, error::Error, fmt, mem, ops::Range, sync::Arc};
+use vulkano::{
+    device::{Device, DeviceOwned, Queue, QueueFlags},
+    image::{Image, ImageLayout},
+    swapchain::Swapchain,
+    sync::{semaphore::Semaphore, AccessFlags, PipelineStages},
+    VulkanError,
+};
+
+impl<W: ?Sized> TaskGraph<W> {
+    /// Compiles the task graph into an executable form.
+    ///
+    /// # Safety
+    ///
+    /// - There must be no conflicting device accesses in task nodes with no path between them.
+    /// - There must be no accesses that are incompatible with the queue family type of the task
+    ///   node.
+    /// - There must be no accesses that are unsupported by the device.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `compile_info.queues` is empty.
+    /// - Panics if the device of any queue in `compile_info.queues` or
+    ///   `compile_info.present_queue` is not the same as that of `self`.
+    /// - Panics if `compile_info.queues` contains duplicate queue families.
+    /// - Panics if `compile_info.present_queue` is `None` and the task graph uses any swapchains.
+    ///
+    /// # Errors
+    ///
+    /// In order to get a successful compilation, the graph must satisfy the following conditions:
+    /// - It must be [weakly connected]: every node must be able to reach every other node when
+    ///   disregarding the direction of the edges.
+    /// - It must have no [directed cycles]: if you were to walk starting from any node following
+    ///   the direction of the edges, there must be no way to end up at the node you started at.
+    ///
+    /// [weakly connected]: https://en.wikipedia.org/wiki/Connectivity_(graph_theory)#Connected_vertices_and_graphs
+    /// [directed cycles]: https://en.wikipedia.org/wiki/Cycle_(graph_theory)#Directed_circuit_and_directed_cycle
+    pub unsafe fn compile(
+        mut self,
+        compile_info: CompileInfo,
+    ) -> Result<ExecutableTaskGraph<W>, CompileError<W>> {
+        let CompileInfo {
+            queues,
+            present_queue,
+            flight_id,
+            _ne: _,
+        } = compile_info;
+
+        assert_ne!(queues.len(), 0, "expected to be given at least one queue");
+
+        let device = &self.device().clone();
+
+        for queue in &queues {
+            assert_eq!(queue.device(), device);
+            assert_eq!(
+                queues
+                    .iter()
+                    .filter(|q| q.queue_family_index() == queue.queue_family_index())
+                    .count(),
+                1,
+                "expected each queue in `compile_info.queues` to be from a unique queue family",
+            );
+        }
+
+        if let Some(present_queue) = &present_queue {
+            assert_eq!(present_queue.device(), device);
+        }
+
+        if !self.is_weakly_connected() {
+            return Err(CompileError::new(self, CompileErrorKind::Unconnected));
+        }
+
+        let topological_order = match self.topological_sort() {
+            Ok(topological_order) => topological_order,
+            Err(kind) => return Err(CompileError::new(self, kind)),
+        };
+        unsafe { self.dependency_levels(&topological_order) };
+        let queue_family_indices =
+            match unsafe { self.queue_family_indices(device, &queues, &topological_order) } {
+                Ok(queue_family_indices) => queue_family_indices,
+                Err(kind) => return Err(CompileError::new(self, kind)),
+            };
+        let mut queues_by_queue_family_index: SmallVec<[_; 8]> =
+            smallvec![None; *queue_family_indices.iter().max().unwrap() as usize + 1];
+
+        for queue in &queues {
+            if let Some(x) =
+                queues_by_queue_family_index.get_mut(queue.queue_family_index() as usize)
+            {
+                *x = Some(queue);
+            }
+        }
+
+        let mut prev_accesses = vec![ResourceAccess::default(); self.resources.capacity() as usize];
+        let mut barrier_stages = vec![BarrierStage::Stage0; self.resources.capacity() as usize];
+
+        let (node_meta, semaphore_count, last_swapchain_accesses) = unsafe {
+            self.node_metadata(&topological_order, &mut prev_accesses, &mut barrier_stages)
+        };
+
+        prev_accesses.fill(ResourceAccess::default());
+        barrier_stages.fill(BarrierStage::Stage0);
+
+        let mut state = CompileState::new(&mut prev_accesses, present_queue);
+        let mut prev_submission_end = 0;
+
+        while prev_submission_end < topological_order.len() {
+            // First per-submission pass: compute the initial barriers for the submission.
+            for (i, &node_index) in
+                (prev_submission_end..).zip(&topological_order[prev_submission_end..])
+            {
+                let node = unsafe { self.nodes.node_unchecked(node_index) };
+                let NodeInner::Task(task_node) = &node.inner else {
+                    unreachable!();
+                };
+
+                for (id, access) in task_node.accesses.iter() {
+                    let access = ResourceAccess {
+                        queue_family_index: task_node.queue_family_index,
+                        ..*access
+                    };
+
+                    let barrier_stage = &mut barrier_stages[id.index() as usize];
+
+                    if *barrier_stage == BarrierStage::Stage0 {
+                        if !id.is::<Swapchain>() {
+                            if id.is::<Image>() {
+                                state.transition_image(id, access);
+                            } else if access.access_mask.contains_reads() {
+                                state.memory_barrier(id, access);
+                            } else {
+                                state.execution_barrier(id, access);
+                            }
+                        }
+
+                        *barrier_stage = BarrierStage::Stage1;
+                    }
+                }
+
+                let should_submit = if let Some(&next_node_index) = topological_order.get(i + 1) {
+                    let next_node = unsafe { self.nodes.node_unchecked(next_node_index) };
+                    let NodeInner::Task(next_task_node) = &next_node.inner else {
+                        unreachable!()
+                    };
+
+                    next_task_node.queue_family_index != task_node.queue_family_index
+                } else {
+                    true
+                };
+
+                if should_submit {
+                    break;
+                }
+            }
+
+            state.flush_initial_barriers();
+
+            // Second per-submission pass: add instructions and barriers for the submission.
+            for (i, &node_index) in
+                (prev_submission_end..).zip(&topological_order[prev_submission_end..])
+            {
+                let node = unsafe { self.nodes.node_unchecked(node_index) };
+                let NodeInner::Task(task_node) = &node.inner else {
+                    unreachable!();
+                };
+
+                for &semaphore_index in &node_meta[node_index as usize].wait_semaphores {
+                    state.wait_semaphore(semaphore_index);
+                }
+
+                for (id, access) in task_node.accesses.iter() {
+                    let prev_access = state.prev_accesses[id.index() as usize];
+                    let access = ResourceAccess {
+                        queue_family_index: task_node.queue_family_index,
+                        ..*access
+                    };
+
+                    let barrier_stage = &mut barrier_stages[id.index() as usize];
+
+                    if *barrier_stage == BarrierStage::Stage1 {
+                        if id.is::<Swapchain>() {
+                            state.wait_acquire(unsafe { id.parametrize() }, access);
+                        }
+
+                        *barrier_stage = BarrierStage::Stage2;
+                    } else if prev_access.queue_family_index != access.queue_family_index {
+                        let prev_access = &mut state.prev_accesses[id.index() as usize];
+                        prev_access.stage_mask = PipelineStages::empty();
+                        prev_access.access_mask = AccessFlags::empty();
+
+                        if id.is_exclusive() {
+                            state.acquire_queue_family_ownership(id, access);
+                        } else if prev_access.image_layout != access.image_layout {
+                            state.transition_image(id, access);
+                        } else {
+                            state.prev_accesses[id.index() as usize] = access;
+                        }
+                    } else if prev_access.image_layout != access.image_layout {
+                        state.transition_image(id, access);
+                    } else if prev_access.access_mask.contains_writes()
+                        && access.access_mask.contains_reads()
+                    {
+                        state.memory_barrier(id, access);
+                    } else if access.access_mask.contains_writes() {
+                        state.execution_barrier(id, access);
+                    } else {
+                        // TODO: Could there be use cases for read-after-read execution barriers?
+                        let prev_access = &mut state.prev_accesses[id.index() as usize];
+                        prev_access.stage_mask |= access.stage_mask;
+                        prev_access.access_mask |= access.access_mask;
+                    }
+                }
+
+                state.execute_task(node_index);
+
+                for (id, _) in task_node.accesses.iter() {
+                    if let Some((_, next_access)) = node_meta[node_index as usize]
+                        .release_queue_family_ownership
+                        .iter()
+                        .find(|(x, _)| *x == id)
+                    {
+                        state.release_queue_family_ownership(id, *next_access);
+                    }
+                }
+
+                for &semaphore_index in &node_meta[node_index as usize].signal_semaphores {
+                    state.signal_semaphore(semaphore_index);
+                }
+
+                for (&swapchain_id, _) in last_swapchain_accesses
+                    .iter()
+                    .filter(|(_, &i)| i == node_index)
+                {
+                    state.signal_present(swapchain_id);
+                }
+
+                let should_submit = if let Some(&next_node_index) = topological_order.get(i + 1) {
+                    let next_node = unsafe { self.nodes.node_unchecked(next_node_index) };
+                    let NodeInner::Task(next_task_node) = &next_node.inner else {
+                        unreachable!()
+                    };
+
+                    next_task_node.queue_family_index != task_node.queue_family_index
+                } else {
+                    true
+                };
+
+                if state.should_flush_submit || should_submit {
+                    state.flush_submit();
+                }
+
+                if should_submit {
+                    let queue = queues_by_queue_family_index[task_node.queue_family_index as usize]
+                        .unwrap();
+                    state.submit(queue.clone());
+                    prev_submission_end = i + 1;
+                    break;
+                }
+            }
+        }
+
+        if !state
+            .pre_present_queue_family_ownership_transfers
+            .is_empty()
+        {
+            for swapchain_id in mem::take(&mut state.pre_present_queue_family_ownership_transfers) {
+                state.pre_present_acquire_queue_family_ownership(swapchain_id);
+            }
+
+            state.flush_submit();
+            state.submit(state.present_queue.clone().unwrap());
+        }
+
+        let semaphores = match (0..semaphore_count)
+            .map(|_| {
+                // SAFETY: The parameters are valid.
+                unsafe { Semaphore::new_unchecked(device.clone(), Default::default()) }
+                    .map(Arc::new)
+            })
+            .collect::<Result<_, _>>()
+        {
+            Ok(semaphores) => semaphores,
+            Err(err) => return Err(CompileError::new(self, CompileErrorKind::VulkanError(err))),
+        };
+
+        let swapchains = last_swapchain_accesses.iter().map(|(&id, _)| id).collect();
+
+        Ok(ExecutableTaskGraph {
+            graph: self,
+            flight_id,
+            instructions: state.instructions,
+            submissions: state.submissions,
+            buffer_barriers: state.buffer_barriers,
+            image_barriers: state.image_barriers,
+            semaphores: RefCell::new(semaphores),
+            swapchains,
+            present_queue: state.present_queue,
+            last_accesses: prev_accesses,
+        })
+    }
+
+    /// Performs [depth-first search] on the equivalent undirected graph to determine if every node
+    /// is visited, meaning the undirected graph is [connected]. If it is, then the directed graph
+    /// is [weakly connected]. This property is required because otherwise it could happen that we
+    /// end up with a submit that is in no way synchronized with the host.
+    ///
+    /// [depth-first search]: https://en.wikipedia.org/wiki/Depth-first_search
+    /// [connected]: https://en.wikipedia.org/wiki/Connectivity_(graph_theory)#Connected_vertices_and_graphs
+    /// [weakly connected]: https://en.wikipedia.org/wiki/Connectivity_(graph_theory)#Connected_vertices_and_graphs
+    fn is_weakly_connected(&self) -> bool {
+        unsafe fn dfs<W: ?Sized>(
+            graph: &TaskGraph<W>,
+            node_index: NodeIndex,
+            visited: &mut [bool],
+            visited_count: &mut u32,
+        ) {
+            let is_visited = &mut visited[node_index as usize];
+
+            if *is_visited {
+                return;
+            }
+
+            *is_visited = true;
+            *visited_count += 1;
+
+            let node = unsafe { graph.nodes.node_unchecked(node_index) };
+
+            for &node_index in node.in_edges.iter().chain(&node.out_edges) {
+                unsafe { dfs(graph, node_index, visited, visited_count) };
+            }
+        }
+
+        let mut visited = vec![false; self.nodes.capacity() as usize];
+        let mut visited_count = 0;
+
+        if let Some((id, _)) = self.nodes.nodes().next() {
+            unsafe { dfs(self, id.index(), &mut visited, &mut visited_count) };
+        }
+
+        visited_count == self.nodes.len()
+    }
+
+    /// Performs [topological sort using depth-first search]. Returns a vector of node indices in
+    /// topological order.
+    ///
+    /// [topological sort using depth-first search]: https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
+    fn topological_sort(&self) -> Result<Vec<NodeIndex>, CompileErrorKind> {
+        type NodeState = u8;
+
+        const VISITED_BIT: NodeState = 1 << 0;
+        const ON_STACK_BIT: NodeState = 1 << 1;
+
+        unsafe fn dfs<W: ?Sized>(
+            graph: &TaskGraph<W>,
+            node_index: NodeIndex,
+            state: &mut [NodeState],
+            output: &mut [NodeIndex],
+            mut output_index: u32,
+        ) -> Result<u32, CompileErrorKind> {
+            let node_state = &mut state[node_index as usize];
+
+            if *node_state == VISITED_BIT {
+                return Ok(output_index);
+            }
+
+            if *node_state == ON_STACK_BIT {
+                return Err(CompileErrorKind::Cycle);
+            }
+
+            *node_state = ON_STACK_BIT;
+
+            let node = unsafe { graph.nodes.node_unchecked(node_index) };
+
+            for &node_index in &node.out_edges {
+                output_index = unsafe { dfs(graph, node_index, state, output, output_index) }?;
+            }
+
+            state[node_index as usize] = VISITED_BIT;
+            output[output_index as usize] = node_index;
+
+            Ok(output_index.wrapping_sub(1))
+        }
+
+        let mut state = vec![0; self.nodes.capacity() as usize];
+        let mut output = vec![0; self.nodes.len() as usize];
+        let mut output_index = self.nodes.len().wrapping_sub(1);
+
+        for (id, _) in self.nodes.nodes() {
+            output_index = unsafe { dfs(self, id.index(), &mut state, &mut output, output_index) }?;
+        }
+
+        debug_assert_eq!(output_index, u32::MAX);
+
+        Ok(output)
+    }
+
+    /// Performs [longest path search] to assign the dependency level index to each task node.
+    /// Tasks in the same dependency level don't depend on eachother and can therefore be run in
+    /// parallel. Returns a vector of dependency levels in topological order indexed by the node's
+    /// dependency level index.
+    ///
+    /// [longest path search]: https://en.wikipedia.org/wiki/Longest_path_problem#Acyclic_graphs
+    unsafe fn dependency_levels(&mut self, topological_order: &[NodeIndex]) -> Vec<Vec<NodeIndex>> {
+        let mut distances = vec![0; self.nodes.capacity() as usize];
+        let mut max_level = 0;
+
+        for &node_index in topological_order {
+            let node = unsafe { self.nodes.node_unchecked(node_index) };
+
+            for &out_node_index in &node.out_edges {
+                let new_distance = distances[node_index as usize] + 1;
+
+                if distances[out_node_index as usize] < new_distance {
+                    distances[out_node_index as usize] = new_distance;
+                    max_level = cmp::max(max_level, new_distance);
+                }
+            }
+        }
+
+        let mut levels = vec![Vec::new(); max_level as usize + 1];
+
+        for (id, node) in self.nodes.nodes_mut() {
+            let NodeInner::Task(task_node) = &mut node.inner else {
+                unreachable!();
+            };
+
+            let level_index = distances[id.index() as usize];
+            levels[level_index as usize].push(id.index());
+            task_node.dependency_level_index = level_index;
+        }
+
+        levels
+    }
+
+    /// Assigns a queue family index to each task node. Returns a vector of the used queue family
+    /// indices in topological order.
+    unsafe fn queue_family_indices(
+        &mut self,
+        device: &Device,
+        queues: &[Arc<Queue>],
+        topological_order: &[NodeIndex],
+    ) -> Result<SmallVec<[u32; 3]>, CompileErrorKind> {
+        let queue_family_properties = device.physical_device().queue_family_properties();
+        let graphics_queue_family_index = queues
+            .iter()
+            .find(|q| {
+                queue_family_properties[q.queue_family_index() as usize]
+                    .queue_flags
+                    .contains(QueueFlags::GRAPHICS)
+            })
+            .map(|q| q.queue_family_index());
+        let compute_queue_family_index = queues
+            .iter()
+            .filter(|q| {
+                queue_family_properties[q.queue_family_index() as usize]
+                    .queue_flags
+                    .contains(QueueFlags::COMPUTE)
+            })
+            .min_by_key(|q| {
+                queue_family_properties[q.queue_family_index() as usize]
+                    .queue_flags
+                    .count()
+            })
+            .map(|q| q.queue_family_index());
+        let transfer_queue_family_index = queues
+            .iter()
+            .filter(|q| {
+                queue_family_properties[q.queue_family_index() as usize]
+                    .queue_flags
+                    .contains(QueueFlags::TRANSFER)
+            })
+            .min_by_key(|q| {
+                queue_family_properties[q.queue_family_index() as usize]
+                    .queue_flags
+                    .count()
+            })
+            .map(|q| q.queue_family_index())
+            .or(compute_queue_family_index)
+            .or(graphics_queue_family_index);
+
+        let mut queue_family_indices = SmallVec::new();
+
+        for &node_index in topological_order {
+            let node = unsafe { self.nodes.node_unchecked_mut(node_index) };
+            let NodeInner::Task(task_node) = &mut node.inner else {
+                unreachable!();
+            };
+
+            let queue_family_index = match task_node.queue_family_type() {
+                QueueFamilyType::Graphics => graphics_queue_family_index,
+                QueueFamilyType::Compute => compute_queue_family_index,
+                QueueFamilyType::Transfer => transfer_queue_family_index,
+                QueueFamilyType::Specific { index } => queues
+                    .iter()
+                    .any(|q| q.queue_family_index() == index)
+                    .then_some(index),
+            }
+            .ok_or(CompileErrorKind::InsufficientQueues)?;
+
+            task_node.queue_family_index = queue_family_index;
+
+            if !queue_family_indices.contains(&queue_family_index) {
+                queue_family_indices.push(queue_family_index);
+            }
+        }
+
+        Ok(queue_family_indices)
+    }
+
+    /// Does a preliminary pass over all nodes in the graph to collect information needed before
+    /// the actual compilation pass. Returns a vector of metadata indexed by the node index, the
+    /// current semaphore count, and a map from the swapchain ID to the last node that accessed the
+    /// swapchain.
+    // TODO: Cull redundant semaphores.
+    unsafe fn node_metadata(
+        &self,
+        topological_order: &[NodeIndex],
+        prev_accesses: &mut [ResourceAccess],
+        barrier_stages: &mut [BarrierStage],
+    ) -> (Vec<NodeMeta>, usize, LinearMap<Id<Swapchain>, NodeIndex, 1>) {
+        let mut node_meta = vec![NodeMeta::default(); self.nodes.capacity() as usize];
+        let mut prev_node_indices = vec![0; self.resources.capacity() as usize];
+        let mut semaphore_count = 0;
+        let mut last_swapchain_accesses = LinearMap::new();
+
+        for &node_index in topological_order {
+            let node = unsafe { self.nodes.node_unchecked(node_index) };
+            let NodeInner::Task(task_node) = &node.inner else {
+                unreachable!();
+            };
+
+            for &out_node_index in &node.out_edges {
+                let out_node = unsafe { self.nodes.node_unchecked(out_node_index) };
+                let NodeInner::Task(out_task_node) = &out_node.inner else {
+                    unreachable!();
+                };
+
+                if task_node.queue_family_index != out_task_node.queue_family_index {
+                    let semaphore_index = semaphore_count;
+                    node_meta[node_index as usize]
+                        .signal_semaphores
+                        .push(semaphore_index);
+                    node_meta[out_node_index as usize]
+                        .wait_semaphores
+                        .push(semaphore_index);
+                    semaphore_count += 1;
+                }
+            }
+
+            for (id, access) in task_node.accesses.iter() {
+                let prev_access = &mut prev_accesses[id.index() as usize];
+                let access = ResourceAccess {
+                    queue_family_index: task_node.queue_family_index,
+                    ..*access
+                };
+                let prev_node_index = &mut prev_node_indices[id.index() as usize];
+
+                let barrier_stage = &mut barrier_stages[id.index() as usize];
+
+                if *barrier_stage == BarrierStage::Stage0 {
+                    *prev_access = access;
+                    *prev_node_index = node_index;
+                    *barrier_stage = BarrierStage::Stage1;
+                } else {
+                    if id.is_exclusive()
+                        && prev_access.queue_family_index != access.queue_family_index
+                    {
+                        node_meta[*prev_node_index as usize]
+                            .release_queue_family_ownership
+                            .push((id, access));
+                    }
+
+                    if prev_access.queue_family_index != access.queue_family_index
+                        || prev_access.image_layout != access.image_layout
+                        || prev_access.access_mask.contains_writes()
+                        || access.access_mask.contains_writes()
+                    {
+                        *prev_access = access;
+                    } else {
+                        prev_access.stage_mask |= access.stage_mask;
+                        prev_access.access_mask |= access.access_mask;
+                    }
+
+                    *prev_node_index = node_index;
+                }
+
+                if id.is::<Swapchain>() {
+                    *last_swapchain_accesses
+                        .get_or_insert(unsafe { id.parametrize() }, node_index) = node_index;
+                }
+            }
+        }
+
+        (node_meta, semaphore_count, last_swapchain_accesses)
+    }
+}
+
+#[derive(Clone, Default)]
+struct NodeMeta {
+    wait_semaphores: Vec<SemaphoreIndex>,
+    signal_semaphores: Vec<SemaphoreIndex>,
+    release_queue_family_ownership: Vec<(Id, ResourceAccess)>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BarrierStage {
+    Stage0,
+    Stage1,
+    Stage2,
+}
+
+struct CompileState<'a> {
+    prev_accesses: &'a mut [ResourceAccess],
+    instructions: Vec<Instruction>,
+    submissions: Vec<Submission>,
+    buffer_barriers: Vec<super::BufferMemoryBarrier>,
+    image_barriers: Vec<super::ImageMemoryBarrier>,
+    present_queue: Option<Arc<Queue>>,
+    initial_buffer_barrier_range: Range<BarrierIndex>,
+    initial_image_barrier_range: Range<BarrierIndex>,
+    has_flushed_submit: bool,
+    should_flush_submit: bool,
+    prev_buffer_barrier_index: usize,
+    prev_image_barrier_index: usize,
+    pre_present_queue_family_ownership_transfers: Vec<Id<Swapchain>>,
+}
+
+impl<'a> CompileState<'a> {
+    fn new(prev_accesses: &'a mut [ResourceAccess], present_queue: Option<Arc<Queue>>) -> Self {
+        CompileState {
+            prev_accesses,
+            instructions: Vec::new(),
+            submissions: Vec::new(),
+            buffer_barriers: Vec::new(),
+            image_barriers: Vec::new(),
+            present_queue,
+            initial_buffer_barrier_range: 0..0,
+            initial_image_barrier_range: 0..0,
+            has_flushed_submit: true,
+            should_flush_submit: false,
+            prev_buffer_barrier_index: 0,
+            prev_image_barrier_index: 0,
+            pre_present_queue_family_ownership_transfers: Vec::new(),
+        }
+    }
+
+    fn release_queue_family_ownership(&mut self, id: Id, access: ResourceAccess) {
+        debug_assert!(id.is_exclusive());
+
+        let prev_access = &mut self.prev_accesses[id.index() as usize];
+        let mut src = *prev_access;
+        let dst = ResourceAccess {
+            stage_mask: PipelineStages::empty(),
+            access_mask: AccessFlags::empty(),
+            ..access
+        };
+
+        if !prev_access.access_mask.contains_writes() {
+            src.access_mask = AccessFlags::empty();
+        }
+
+        debug_assert_ne!(src.queue_family_index, dst.queue_family_index);
+
+        self.memory_barrier_inner(id, src, dst);
+    }
+
+    fn acquire_queue_family_ownership(&mut self, id: Id, access: ResourceAccess) {
+        debug_assert!(id.is_exclusive());
+
+        let prev_access = &mut self.prev_accesses[id.index() as usize];
+        let src = ResourceAccess {
+            stage_mask: PipelineStages::empty(),
+            access_mask: AccessFlags::empty(),
+            ..*prev_access
+        };
+        let dst = access;
+
+        debug_assert_ne!(src.queue_family_index, dst.queue_family_index);
+
+        *prev_access = access;
+
+        self.memory_barrier_inner(id, src, dst);
+    }
+
+    fn transition_image(&mut self, id: Id, access: ResourceAccess) {
+        debug_assert_ne!(
+            self.prev_accesses[id.index() as usize].image_layout,
+            access.image_layout,
+        );
+
+        self.memory_barrier(id, access);
+    }
+
+    fn memory_barrier(&mut self, id: Id, access: ResourceAccess) {
+        let prev_access = &mut self.prev_accesses[id.index() as usize];
+        let src = ResourceAccess {
+            queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            ..*prev_access
+        };
+        let dst = ResourceAccess {
+            queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            ..access
+        };
+
+        *prev_access = access;
+
+        self.memory_barrier_inner(id, src, dst);
+    }
+
+    fn execution_barrier(&mut self, id: Id, access: ResourceAccess) {
+        let prev_access = &mut self.prev_accesses[id.index() as usize];
+        let src = ResourceAccess {
+            access_mask: AccessFlags::empty(),
+            queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            ..*prev_access
+        };
+        let dst = ResourceAccess {
+            access_mask: AccessFlags::empty(),
+            queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            ..access
+        };
+
+        debug_assert_eq!(prev_access.image_layout, access.image_layout);
+
+        *prev_access = access;
+
+        self.memory_barrier_inner(id, src, dst);
+    }
+
+    fn memory_barrier_inner(&mut self, id: Id, src: ResourceAccess, dst: ResourceAccess) {
+        match id.object_type() {
+            ObjectType::Buffer => {
+                self.buffer_barriers.push(super::BufferMemoryBarrier {
+                    src_stage_mask: src.stage_mask,
+                    src_access_mask: src.access_mask,
+                    dst_stage_mask: dst.stage_mask,
+                    dst_access_mask: dst.access_mask,
+                    src_queue_family_index: src.queue_family_index,
+                    dst_queue_family_index: dst.queue_family_index,
+                    buffer: unsafe { id.parametrize() },
+                });
+            }
+            ObjectType::Image | ObjectType::Swapchain => {
+                self.image_barriers.push(super::ImageMemoryBarrier {
+                    src_stage_mask: src.stage_mask,
+                    src_access_mask: src.access_mask,
+                    dst_stage_mask: dst.stage_mask,
+                    dst_access_mask: dst.access_mask,
+                    old_layout: src.image_layout,
+                    new_layout: dst.image_layout,
+                    src_queue_family_index: src.queue_family_index,
+                    dst_queue_family_index: dst.queue_family_index,
+                    image: id,
+                });
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn flush_initial_barriers(&mut self) {
+        self.initial_buffer_barrier_range = self.prev_buffer_barrier_index as BarrierIndex
+            ..self.buffer_barriers.len() as BarrierIndex;
+        self.initial_image_barrier_range = self.prev_image_barrier_index as BarrierIndex
+            ..self.image_barriers.len() as BarrierIndex;
+        self.prev_buffer_barrier_index = self.buffer_barriers.len();
+        self.prev_image_barrier_index = self.image_barriers.len();
+    }
+
+    fn wait_acquire(&mut self, swapchain_id: Id<Swapchain>, access: ResourceAccess) {
+        if !self.has_flushed_submit {
+            self.flush_submit();
+        }
+
+        self.image_barriers.push(super::ImageMemoryBarrier {
+            src_stage_mask: access.stage_mask,
+            src_access_mask: AccessFlags::empty(),
+            dst_stage_mask: access.stage_mask,
+            dst_access_mask: access.access_mask,
+            old_layout: ImageLayout::Undefined,
+            new_layout: access.image_layout,
+            src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            image: swapchain_id.erase(),
+        });
+
+        self.prev_accesses[swapchain_id.index() as usize] = access;
+
+        self.instructions.push(Instruction::WaitAcquire {
+            swapchain_id,
+            stage_mask: access.stage_mask,
+        });
+    }
+
+    fn wait_semaphore(&mut self, semaphore_index: SemaphoreIndex) {
+        if !self.has_flushed_submit {
+            self.flush_submit();
+        }
+
+        self.instructions.push(Instruction::WaitSemaphore {
+            semaphore_index,
+            stage_mask: PipelineStages::ALL_COMMANDS,
+        });
+    }
+
+    fn execute_task(&mut self, node_index: NodeIndex) {
+        self.flush_barriers();
+
+        self.instructions
+            .push(Instruction::ExecuteTask { node_index });
+
+        self.has_flushed_submit = false;
+    }
+
+    fn signal_semaphore(&mut self, semaphore_index: SemaphoreIndex) {
+        self.instructions.push(Instruction::SignalSemaphore {
+            semaphore_index,
+            stage_mask: PipelineStages::ALL_COMMANDS,
+        });
+
+        self.should_flush_submit = true;
+    }
+
+    fn signal_present(&mut self, swapchain_id: Id<Swapchain>) {
+        let present_queue = self
+            .present_queue
+            .as_ref()
+            .expect("expected to be given a present queue");
+
+        let prev_access = self.prev_accesses[swapchain_id.index() as usize];
+
+        if prev_access.queue_family_index == present_queue.queue_family_index()
+            || !swapchain_id.is_exclusive()
+        {
+            self.memory_barrier(
+                swapchain_id.erase(),
+                ResourceAccess {
+                    stage_mask: PipelineStages::empty(),
+                    access_mask: AccessFlags::empty(),
+                    image_layout: ImageLayout::PresentSrc,
+                    queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+                },
+            );
+
+            self.instructions.push(Instruction::SignalPresent {
+                swapchain_id,
+                stage_mask: prev_access.stage_mask,
+            });
+        } else {
+            self.pre_present_release_queue_family_ownership(swapchain_id);
+        }
+
+        self.should_flush_submit = true;
+    }
+
+    fn pre_present_release_queue_family_ownership(&mut self, swapchain_id: Id<Swapchain>) {
+        let prev_access = self.prev_accesses[swapchain_id.index() as usize];
+
+        self.release_queue_family_ownership(
+            swapchain_id.erase(),
+            ResourceAccess {
+                stage_mask: PipelineStages::empty(),
+                access_mask: AccessFlags::empty(),
+                image_layout: ImageLayout::PresentSrc,
+                queue_family_index: self.present_queue.as_ref().unwrap().queue_family_index(),
+            },
+        );
+
+        self.instructions.push(Instruction::SignalPrePresent {
+            swapchain_id,
+            stage_mask: prev_access.stage_mask,
+        });
+
+        self.pre_present_queue_family_ownership_transfers
+            .push(swapchain_id);
+    }
+
+    fn pre_present_acquire_queue_family_ownership(&mut self, swapchain_id: Id<Swapchain>) {
+        if !self.has_flushed_submit {
+            self.flush_submit();
+        }
+
+        self.instructions.push(Instruction::WaitPrePresent {
+            swapchain_id,
+            stage_mask: PipelineStages::ALL_COMMANDS,
+        });
+
+        self.acquire_queue_family_ownership(
+            swapchain_id.erase(),
+            ResourceAccess {
+                stage_mask: PipelineStages::empty(),
+                access_mask: AccessFlags::empty(),
+                image_layout: ImageLayout::PresentSrc,
+                queue_family_index: self.present_queue.as_ref().unwrap().queue_family_index(),
+            },
+        );
+
+        self.instructions.push(Instruction::SignalPresent {
+            swapchain_id,
+            stage_mask: PipelineStages::ALL_COMMANDS,
+        });
+    }
+
+    fn flush_barriers(&mut self) {
+        if self.prev_buffer_barrier_index != self.buffer_barriers.len()
+            || self.prev_image_barrier_index != self.image_barriers.len()
+        {
+            self.instructions.push(Instruction::PipelineBarrier {
+                buffer_barrier_range: self.prev_buffer_barrier_index as BarrierIndex
+                    ..self.buffer_barriers.len() as BarrierIndex,
+                image_barrier_range: self.prev_image_barrier_index as BarrierIndex
+                    ..self.image_barriers.len() as BarrierIndex,
+            });
+            self.prev_buffer_barrier_index = self.buffer_barriers.len();
+            self.prev_image_barrier_index = self.image_barriers.len();
+        }
+    }
+
+    fn flush_submit(&mut self) {
+        self.flush_barriers();
+        self.instructions.push(Instruction::FlushSubmit);
+        self.has_flushed_submit = true;
+        self.should_flush_submit = false;
+    }
+
+    fn submit(&mut self, queue: Arc<Queue>) {
+        self.instructions.push(Instruction::Submit);
+
+        let prev_instruction_range_end = self
+            .submissions
+            .last()
+            .map(|s| s.instruction_range.end)
+            .unwrap_or(0);
+        self.submissions.push(Submission {
+            queue,
+            initial_buffer_barrier_range: self.initial_buffer_barrier_range.clone(),
+            initial_image_barrier_range: self.initial_image_barrier_range.clone(),
+            instruction_range: prev_instruction_range_end..self.instructions.len(),
+        });
+    }
+}
+
+impl<W: ?Sized> ExecutableTaskGraph<W> {
+    /// Decompiles the graph back into a modifiable form.
+    #[inline]
+    pub fn decompile(self) -> TaskGraph<W> {
+        self.graph
+    }
+}
+
+/// Parameters to [compile] a [`TaskGraph`].
+///
+/// [compile]: TaskGraph::compile
+#[derive(Clone, Debug)]
+pub struct CompileInfo {
+    /// The queues to work with.
+    ///
+    /// You must supply at least one queue and all queues must be from unique queue families.
+    ///
+    /// The default value is empty, which must be overridden.
+    pub queues: Vec<Arc<Queue>>,
+
+    /// The queue to use for swapchain presentation, if any.
+    ///
+    /// You must supply this queue if the task graph uses any swapchains. It can be the same queue
+    /// as one in the [`queues`] field, or a different one.
+    ///
+    /// The default value is `None`.
+    ///
+    /// [`queues`]: Self::queues
+    pub present_queue: Option<Arc<Queue>>,
+
+    /// The flight which will be executed.
+    ///
+    /// The default value is `Id::INVALID`, which must be overridden.
+    pub flight_id: Id<Flight>,
+
+    pub _ne: vulkano::NonExhaustive,
+}
+
+impl Default for CompileInfo {
+    #[inline]
+    fn default() -> Self {
+        CompileInfo {
+            queues: Vec::new(),
+            present_queue: None,
+            flight_id: Id::INVALID,
+            _ne: crate::NE,
+        }
+    }
+}
+
+/// Error that can happen when [compiling] a [`TaskGraph`].
+///
+/// [compiling]: TaskGraph::compile
+pub struct CompileError<W: ?Sized> {
+    pub graph: TaskGraph<W>,
+    pub kind: CompileErrorKind,
+}
+
+/// The kind of [`CompileError`] that occurred.
+#[derive(Debug)]
+pub enum CompileErrorKind {
+    Unconnected,
+    Cycle,
+    InsufficientQueues,
+    VulkanError(VulkanError),
+}
+
+impl<W: ?Sized> CompileError<W> {
+    fn new(graph: TaskGraph<W>, kind: CompileErrorKind) -> Self {
+        CompileError { graph, kind }
+    }
+}
+
+impl<W: ?Sized> fmt::Debug for CompileError<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.kind, f)
+    }
+}
+
+impl<W: ?Sized> fmt::Display for CompileError<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            CompileErrorKind::Unconnected => f.write_str("the graph is not weakly connected"),
+            CompileErrorKind::Cycle => f.write_str("the graph contains a directed cycle"),
+            CompileErrorKind::InsufficientQueues => {
+                f.write_str("the given queues are not sufficient for the requirements of a task")
+            }
+            CompileErrorKind::VulkanError(_) => f.write_str("a runtime error occurred"),
+        }
+    }
+}
+
+impl<W: ?Sized> Error for CompileError<W> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.kind {
+            CompileErrorKind::VulkanError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+mod linear_map {
+    use smallvec::{Array, SmallVec};
+
+    pub struct LinearMap<K, V, const N: usize>
+    where
+        [(K, V); N]: Array<Item = (K, V)>,
+    {
+        inner: SmallVec<[(K, V); N]>,
+    }
+
+    impl<K, V, const N: usize> LinearMap<K, V, N>
+    where
+        [(K, V); N]: Array<Item = (K, V)>,
+    {
+        #[inline]
+        pub fn new() -> Self {
+            LinearMap {
+                inner: SmallVec::new(),
+            }
+        }
+
+        #[inline]
+        pub fn get_or_insert(&mut self, key: K, value: V) -> &mut V
+        where
+            K: Eq,
+        {
+            let index = if let Some(index) = self.inner.iter().position(|(k, _)| k == &key) {
+                index
+            } else {
+                let index = self.inner.len();
+                self.inner.push((key, value));
+
+                index
+            };
+
+            &mut unsafe { self.inner.get_unchecked_mut(index) }.1
+        }
+
+        #[inline]
+        pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+            self.inner.iter().map(|(k, v)| (k, v))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        resource::{AccessType, ImageLayoutType},
+        tests::test_queues,
+    };
+    use std::marker::PhantomData;
+    use vulkano::{
+        buffer::BufferCreateInfo, image::ImageCreateInfo, swapchain::SwapchainCreateInfo,
+        sync::Sharing,
+    };
+
+    #[test]
+    fn unconnected() {
+        let (resources, queues) = test_queues!();
+        let compile_info = CompileInfo {
+            queues,
+            ..Default::default()
+        };
+
+        {
+            // ┌───┐
+            // │ A │
+            // └───┘
+            // ┄┄┄┄┄
+            // ┌───┐
+            // │ B │
+            // └───┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 0);
+            graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            graph
+                .create_task_node("B", QueueFamilyType::Compute, PhantomData)
+                .build();
+
+            assert!(matches!(
+                unsafe { graph.compile(compile_info.clone()) },
+                Err(CompileError {
+                    kind: CompileErrorKind::Unconnected,
+                    ..
+                }),
+            ));
+        }
+
+        {
+            // ┌───┐
+            // │ A ├─┐
+            // └───┘ │
+            // ┌───┐ │
+            // │ B ├┐│
+            // └───┘││
+            // ┄┄┄┄┄││┄┄┄┄┄┄
+            //      ││ ┌───┐
+            //      │└►│ C │
+            //      │  └───┘
+            //      │  ┌───┐
+            //      └─►│ D │
+            //         └───┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 0);
+            let a = graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let b = graph
+                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let c = graph
+                .create_task_node("C", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let d = graph
+                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+                .build();
+            graph.add_edge(a, c).unwrap();
+            graph.add_edge(b, d).unwrap();
+
+            assert!(matches!(
+                unsafe { graph.compile(compile_info.clone()) },
+                Err(CompileError {
+                    kind: CompileErrorKind::Unconnected,
+                    ..
+                }),
+            ));
+        }
+
+        {
+            // ┌───┐  ┌───┐  ┌───┐
+            // │ A ├─►│ B ├─►│ C │
+            // └───┘  └───┘  └───┘
+            // ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+            // ┌───┐  ┌───┐  ┌───┐   ┌───┐
+            // │ D ├┬►│ E ├┬►│ F ├──►│   │
+            // └───┘│ └───┘│ └───┘┌─►│ G │
+            //      │      └──────┘┌►│   │
+            //      └──────────────┘ └───┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 0);
+            let a = graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let b = graph
+                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let c = graph
+                .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            graph.add_edge(a, b).unwrap();
+            graph.add_edge(b, c).unwrap();
+            let d = graph
+                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let e = graph
+                .create_task_node("E", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let f = graph
+                .create_task_node("F", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let g = graph
+                .create_task_node("G", QueueFamilyType::Compute, PhantomData)
+                .build();
+            graph.add_edge(d, e).unwrap();
+            graph.add_edge(d, g).unwrap();
+            graph.add_edge(e, f).unwrap();
+            graph.add_edge(e, g).unwrap();
+            graph.add_edge(f, g).unwrap();
+
+            assert!(matches!(
+                unsafe { graph.compile(compile_info) },
+                Err(CompileError {
+                    kind: CompileErrorKind::Unconnected,
+                    ..
+                }),
+            ));
+        }
+    }
+
+    #[test]
+    fn cycle() {
+        let (resources, queues) = test_queues!();
+        let compile_info = CompileInfo {
+            queues,
+            ..Default::default()
+        };
+
+        {
+            //   ┌───┐  ┌───┐  ┌───┐
+            // ┌►│ A ├─►│ B ├─►│ C ├┐
+            // │ └───┘  └───┘  └───┘│
+            // └────────────────────┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 0);
+            let a = graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let b = graph
+                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let c = graph
+                .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            graph.add_edge(a, b).unwrap();
+            graph.add_edge(b, c).unwrap();
+            graph.add_edge(c, a).unwrap();
+
+            assert!(matches!(
+                unsafe { graph.compile(compile_info.clone()) },
+                Err(CompileError {
+                    kind: CompileErrorKind::Cycle,
+                    ..
+                }),
+            ));
+        }
+
+        {
+            //   ┌───┐  ┌───┐  ┌───┐
+            // ┌►│ A ├┬►│ B ├─►│ C ├┐
+            // │ └───┘│ └───┘  └───┘│
+            // │┄┄┄┄┄┄│┄┄┄┄┄┄┄┄┄┄┄┄┄│┄┄┄┄┄┄┄
+            // │      │ ┌───┐  ┌───┐│ ┌───┐
+            // │      └►│ D ├─►│ E ├┴►│ F ├┐
+            // │        └───┘  └───┘  └───┘│
+            // └───────────────────────────┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 0);
+            let a = graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let b = graph
+                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let c = graph
+                .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let d = graph
+                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let e = graph
+                .create_task_node("E", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let f = graph
+                .create_task_node("F", QueueFamilyType::Compute, PhantomData)
+                .build();
+            graph.add_edge(a, b).unwrap();
+            graph.add_edge(a, d).unwrap();
+            graph.add_edge(b, c).unwrap();
+            graph.add_edge(c, f).unwrap();
+            graph.add_edge(d, e).unwrap();
+            graph.add_edge(e, f).unwrap();
+            graph.add_edge(f, a).unwrap();
+
+            assert!(matches!(
+                unsafe { graph.compile(compile_info.clone()) },
+                Err(CompileError {
+                    kind: CompileErrorKind::Cycle,
+                    ..
+                }),
+            ));
+        }
+
+        {
+            // ┌─────┐
+            // │┌───┐└►┌───┐  ┌───┐
+            // ││ A ├┬►│ B ├─►│ C ├┬──────┐
+            // │└───┘│ └───┘┌►└───┘│      │
+            // │┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄
+            // │     │ ┌───┐│ ┌───┐│ ┌───┐│
+            // │     └►│ D ├┴►│ E │└►│ F ├│┐
+            // │     ┌►└───┘  └───┘  └───┘││
+            // │     └────────────────────┘│
+            // └───────────────────────────┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 0);
+            let a = graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let b = graph
+                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let c = graph
+                .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let d = graph
+                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let e = graph
+                .create_task_node("E", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let f = graph
+                .create_task_node("F", QueueFamilyType::Compute, PhantomData)
+                .build();
+            graph.add_edge(a, b).unwrap();
+            graph.add_edge(a, d).unwrap();
+            graph.add_edge(b, c).unwrap();
+            graph.add_edge(c, d).unwrap();
+            graph.add_edge(c, f).unwrap();
+            graph.add_edge(d, c).unwrap();
+            graph.add_edge(d, e).unwrap();
+            graph.add_edge(f, b).unwrap();
+
+            assert!(matches!(
+                unsafe { graph.compile(compile_info) },
+                Err(CompileError {
+                    kind: CompileErrorKind::Cycle,
+                    ..
+                }),
+            ));
+        }
+    }
+
+    #[test]
+    fn initial_pipeline_barrier() {
+        let (resources, queues) = test_queues!();
+        let compile_info = CompileInfo {
+            queues,
+            ..Default::default()
+        };
+
+        {
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 10);
+            let buffer = graph.add_buffer(&BufferCreateInfo::default());
+            let image = graph.add_image(&ImageCreateInfo::default());
+            let node = graph
+                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+                .buffer_access(buffer, AccessType::VertexShaderUniformRead)
+                .image_access(
+                    image,
+                    AccessType::FragmentShaderSampledRead,
+                    ImageLayoutType::Optimal,
+                )
+                .build();
+
+            let graph = unsafe { graph.compile(compile_info.clone()) }.unwrap();
+
+            assert_matches_instructions!(
+                graph,
+                InitialPipelineBarrier {
+                    buffer_barriers: [
+                        {
+                            dst_stage_mask: VERTEX_SHADER,
+                            dst_access_mask: UNIFORM_READ,
+                            buffer: buffer,
+                        },
+                    ],
+                    image_barriers: [
+                        {
+                            dst_stage_mask: FRAGMENT_SHADER,
+                            dst_access_mask: SHADER_SAMPLED_READ,
+                            new_layout: ShaderReadOnlyOptimal,
+                            image: image,
+                        },
+                    ],
+                },
+                ExecuteTask { node: node },
+                FlushSubmit,
+                Submit,
+            );
+        }
+    }
+
+    #[test]
+    fn semaphore() {
+        let (resources, queues) = test_queues!();
+
+        let queue_family_properties = resources
+            .device()
+            .physical_device()
+            .queue_family_properties();
+        let has_compute_only_queue = queues.iter().any(|q| {
+            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
+
+            queue_flags.contains(QueueFlags::COMPUTE) && !queue_flags.contains(QueueFlags::GRAPHICS)
+        });
+
+        if !has_compute_only_queue {
+            return;
+        }
+
+        let compile_info = CompileInfo {
+            queues,
+            ..Default::default()
+        };
+
+        {
+            // ┌───┐
+            // │ A ├─┐
+            // └───┘ │
+            // ┌───┐ │
+            // │ B ├┐│
+            // └───┘││
+            // ┄┄┄┄┄││┄┄┄┄┄┄
+            //      │└►┌───┐
+            //      └─►│ C │
+            //         └───┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 10);
+            let a = graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let b = graph
+                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let c = graph
+                .create_task_node("C", QueueFamilyType::Compute, PhantomData)
+                .build();
+            graph.add_edge(a, c).unwrap();
+            graph.add_edge(b, c).unwrap();
+
+            let graph = unsafe { graph.compile(compile_info.clone()) }.unwrap();
+
+            assert_matches_instructions!(
+                graph,
+                ExecuteTask { node: b },
+                // TODO: This semaphore is redundant.
+                SignalSemaphore {
+                    semaphore_index: semaphore1,
+                    stage_mask: ALL_COMMANDS,
+                },
+                FlushSubmit,
+                ExecuteTask { node: a },
+                SignalSemaphore {
+                    semaphore_index: semaphore2,
+                    stage_mask: ALL_COMMANDS,
+                },
+                FlushSubmit,
+                Submit,
+                WaitSemaphore {
+                    semaphore_index: semaphore1,
+                    stage_mask: ALL_COMMANDS,
+                },
+                WaitSemaphore {
+                    semaphore_index: semaphore2,
+                    stage_mask: ALL_COMMANDS,
+                },
+                ExecuteTask { node: c },
+                FlushSubmit,
+                Submit,
+            );
+        }
+
+        {
+            // ┌───┐
+            // │ A ├┐
+            // └───┘│
+            // ┄┄┄┄┄│┄┄┄┄┄┄
+            //      │ ┌───┐
+            //      ├►│ B │
+            //      │ └───┘
+            //      │ ┌───┐
+            //      └►│ C │
+            //        └───┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 10);
+            let a = graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let b = graph
+                .create_task_node("B", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let c = graph
+                .create_task_node("C", QueueFamilyType::Compute, PhantomData)
+                .build();
+            graph.add_edge(a, b).unwrap();
+            graph.add_edge(a, c).unwrap();
+
+            let graph = unsafe { graph.compile(compile_info.clone()) }.unwrap();
+
+            assert_matches_instructions!(
+                graph,
+                ExecuteTask { node: a },
+                // TODO: This semaphore is redundant.
+                SignalSemaphore {
+                    semaphore_index: semaphore1,
+                    stage_mask: ALL_COMMANDS,
+                },
+                SignalSemaphore {
+                    semaphore_index: semaphore2,
+                    stage_mask: ALL_COMMANDS,
+                },
+                FlushSubmit,
+                Submit,
+                WaitSemaphore {
+                    semaphore_index: semaphore2,
+                    stage_mask: ALL_COMMANDS,
+                },
+                ExecuteTask { node: c },
+                FlushSubmit,
+                WaitSemaphore {
+                    semaphore_index: semaphore1,
+                    stage_mask: ALL_COMMANDS,
+                },
+                ExecuteTask { node: b },
+                FlushSubmit,
+                Submit,
+            );
+        }
+
+        {
+            // ┌───┐                ┌───┐
+            // │ A ├───────┬───────►│ E │
+            // └───┘       │      ┌►└───┘
+            // ┌───┐       │      │
+            // │ B ├┐      │      │
+            // └───┘│      │      │
+            // ┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄┄
+            //      │ ┌───┐└►┌───┐│
+            //      └►│ C ├─►│ D ├┘
+            //        └───┘  └───┘
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 10);
+            let a = graph
+                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let b = graph
+                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            let c = graph
+                .create_task_node("C", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let d = graph
+                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+                .build();
+            let e = graph
+                .create_task_node("E", QueueFamilyType::Graphics, PhantomData)
+                .build();
+            graph.add_edge(a, d).unwrap();
+            graph.add_edge(a, e).unwrap();
+            graph.add_edge(b, c).unwrap();
+            graph.add_edge(c, d).unwrap();
+            graph.add_edge(d, e).unwrap();
+
+            let graph = unsafe { graph.compile(compile_info.clone()) }.unwrap();
+
+            // TODO: This could be brought down to 3 submissions with task reordering.
+            assert_matches_instructions!(
+                graph,
+                ExecuteTask { node: b },
+                SignalSemaphore {
+                    semaphore_index: semaphore1,
+                    stage_mask: ALL_COMMANDS,
+                },
+                FlushSubmit,
+                Submit,
+                WaitSemaphore {
+                    semaphore_index: semaphore1,
+                    stage_mask: ALL_COMMANDS,
+                },
+                ExecuteTask { node: c },
+                FlushSubmit,
+                Submit,
+                ExecuteTask { node: a },
+                SignalSemaphore {
+                    semaphore_index: semaphore2,
+                    stage_mask: ALL_COMMANDS,
+                },
+                FlushSubmit,
+                Submit,
+                WaitSemaphore {
+                    semaphore_index: semaphore2,
+                    stage_mask: ALL_COMMANDS,
+                },
+                ExecuteTask { node: d },
+                SignalSemaphore {
+                    semaphore_index: semaphore3,
+                    stage_mask: ALL_COMMANDS,
+                },
+                FlushSubmit,
+                Submit,
+                WaitSemaphore {
+                    semaphore_index: semaphore3,
+                    stage_mask: ALL_COMMANDS,
+                },
+                ExecuteTask { node: e },
+                FlushSubmit,
+                Submit,
+            );
+        }
+    }
+
+    #[test]
+    fn queue_family_ownership_transfer() {
+        let (resources, queues) = test_queues!();
+
+        let queue_family_properties = resources
+            .device()
+            .physical_device()
+            .queue_family_properties();
+        let has_compute_only_queue = queues.iter().any(|q| {
+            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
+
+            queue_flags.contains(QueueFlags::COMPUTE) && !queue_flags.contains(QueueFlags::GRAPHICS)
+        });
+
+        if !has_compute_only_queue {
+            return;
+        }
+
+        let compile_info = CompileInfo {
+            queues,
+            ..Default::default()
+        };
+
+        {
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 10);
+            let buffer1 = graph.add_buffer(&BufferCreateInfo::default());
+            let buffer2 = graph.add_buffer(&BufferCreateInfo::default());
+            let image1 = graph.add_image(&ImageCreateInfo::default());
+            let image2 = graph.add_image(&ImageCreateInfo::default());
+            let compute_node = graph
+                .create_task_node("", QueueFamilyType::Compute, PhantomData)
+                .buffer_access(buffer1, AccessType::ComputeShaderStorageWrite)
+                .buffer_access(buffer2, AccessType::ComputeShaderStorageRead)
+                .image_access(
+                    image1,
+                    AccessType::ComputeShaderStorageWrite,
+                    ImageLayoutType::Optimal,
+                )
+                .image_access(
+                    image2,
+                    AccessType::ComputeShaderSampledRead,
+                    ImageLayoutType::Optimal,
+                )
+                .build();
+            let graphics_node = graph
+                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+                .buffer_access(buffer1, AccessType::IndexRead)
+                .buffer_access(buffer2, AccessType::VertexShaderSampledRead)
+                .image_access(
+                    image1,
+                    AccessType::VertexShaderSampledRead,
+                    ImageLayoutType::General,
+                )
+                .image_access(
+                    image2,
+                    AccessType::FragmentShaderSampledRead,
+                    ImageLayoutType::General,
+                )
+                .build();
+            graph.add_edge(compute_node, graphics_node).unwrap();
+
+            let graph = unsafe { graph.compile(compile_info.clone()) }.unwrap();
+
+            assert_matches_instructions!(
+                graph,
+                ExecuteTask {
+                    node: compute_node,
+                },
+                SignalSemaphore {
+                    semaphore_index: semaphore,
+                    stage_mask: ALL_COMMANDS,
+                },
+                PipelineBarrier {
+                    buffer_barriers: [
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: SHADER_STORAGE_WRITE,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            buffer: buffer1,
+                        },
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: ,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            buffer: buffer2,
+                        },
+                    ],
+                    image_barriers: [
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: SHADER_STORAGE_WRITE,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: General,
+                            new_layout: General,
+                            image: image1,
+                        },
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: ,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: ShaderReadOnlyOptimal,
+                            new_layout: General,
+                            image: image2,
+                        },
+                    ],
+                },
+                FlushSubmit,
+                Submit,
+                WaitSemaphore {
+                    semaphore_index: semaphore,
+                    stage_mask: ALL_COMMANDS,
+                },
+                PipelineBarrier {
+                    buffer_barriers: [
+                        {
+                            src_stage_mask: ,
+                            src_access_mask: ,
+                            dst_stage_mask: INDEX_INPUT,
+                            dst_access_mask: INDEX_READ,
+                            buffer: buffer1,
+                        },
+                        {
+                            src_stage_mask: ,
+                            src_access_mask: ,
+                            dst_stage_mask: VERTEX_SHADER,
+                            dst_access_mask: SHADER_SAMPLED_READ,
+                            buffer: buffer2,
+                        },
+                    ],
+                    image_barriers: [
+                        {
+                            src_stage_mask: ,
+                            src_access_mask: ,
+                            dst_stage_mask: VERTEX_SHADER,
+                            dst_access_mask: SHADER_SAMPLED_READ,
+                            old_layout: General,
+                            new_layout: General,
+                            image: image1,
+                        },
+                        {
+                            src_stage_mask: ,
+                            src_access_mask: ,
+                            dst_stage_mask: FRAGMENT_SHADER,
+                            dst_access_mask: SHADER_SAMPLED_READ,
+                            old_layout: ShaderReadOnlyOptimal,
+                            new_layout: General,
+                            image: image2,
+                        },
+                    ],
+                },
+                ExecuteTask {
+                    node: graphics_node,
+                },
+                FlushSubmit,
+                Submit,
+            );
+        }
+
+        {
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 10);
+            let sharing = Sharing::Concurrent(
+                compile_info
+                    .queues
+                    .iter()
+                    .map(|q| q.queue_family_index())
+                    .collect(),
+            );
+            let buffer1 = graph.add_buffer(&BufferCreateInfo {
+                sharing: sharing.clone(),
+                ..Default::default()
+            });
+            let buffer2 = graph.add_buffer(&BufferCreateInfo {
+                sharing: sharing.clone(),
+                ..Default::default()
+            });
+            let image1 = graph.add_image(&ImageCreateInfo {
+                sharing: sharing.clone(),
+                ..Default::default()
+            });
+            let image2 = graph.add_image(&ImageCreateInfo {
+                sharing: sharing.clone(),
+                ..Default::default()
+            });
+            let compute_node = graph
+                .create_task_node("", QueueFamilyType::Compute, PhantomData)
+                .buffer_access(buffer1, AccessType::ComputeShaderStorageWrite)
+                .buffer_access(buffer2, AccessType::ComputeShaderStorageRead)
+                .image_access(
+                    image1,
+                    AccessType::ComputeShaderStorageWrite,
+                    ImageLayoutType::Optimal,
+                )
+                .image_access(
+                    image2,
+                    AccessType::ComputeShaderSampledRead,
+                    ImageLayoutType::Optimal,
+                )
+                .build();
+            let graphics_node = graph
+                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+                .buffer_access(buffer1, AccessType::IndexRead)
+                .buffer_access(buffer2, AccessType::VertexShaderSampledRead)
+                .image_access(
+                    image1,
+                    AccessType::VertexShaderSampledRead,
+                    ImageLayoutType::General,
+                )
+                .image_access(
+                    image2,
+                    AccessType::FragmentShaderSampledRead,
+                    ImageLayoutType::General,
+                )
+                .build();
+            graph.add_edge(compute_node, graphics_node).unwrap();
+
+            let graph = unsafe { graph.compile(compile_info.clone()) }.unwrap();
+
+            assert_matches_instructions!(
+                graph,
+                ExecuteTask {
+                    node: compute_node,
+                },
+                SignalSemaphore {
+                    semaphore_index: semaphore,
+                    stage_mask: ALL_COMMANDS,
+                },
+                FlushSubmit,
+                Submit,
+                WaitSemaphore {
+                    semaphore_index: semaphore,
+                    stage_mask: ALL_COMMANDS,
+                },
+                PipelineBarrier {
+                    buffer_barriers: [],
+                    image_barriers: [
+                        {
+                            src_stage_mask: ,
+                            src_access_mask: ,
+                            dst_stage_mask: FRAGMENT_SHADER,
+                            dst_access_mask: SHADER_SAMPLED_READ,
+                            old_layout: ShaderReadOnlyOptimal,
+                            new_layout: General,
+                            image: image2,
+                        },
+                    ],
+                },
+                ExecuteTask {
+                    node: graphics_node,
+                },
+                FlushSubmit,
+                Submit,
+            );
+        }
+    }
+
+    #[test]
+    fn swapchain() {
+        let (resources, queues) = test_queues!();
+
+        let queue_family_properties = resources
+            .device()
+            .physical_device()
+            .queue_family_properties();
+
+        let present_queue = queues.iter().find(|q| {
+            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
+
+            queue_flags.contains(QueueFlags::GRAPHICS)
+        });
+        let compile_info = CompileInfo {
+            queues: queues.clone(),
+            present_queue: Some(present_queue.unwrap().clone()),
+            ..Default::default()
+        };
+
+        {
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 10);
+            let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo::default());
+            let swapchain2 = graph.add_swapchain(&SwapchainCreateInfo::default());
+            let node = graph
+                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+                .image_access(
+                    swapchain1.current_image_id(),
+                    AccessType::ColorAttachmentWrite,
+                    ImageLayoutType::Optimal,
+                )
+                .image_access(
+                    swapchain2.current_image_id(),
+                    AccessType::ComputeShaderStorageWrite,
+                    ImageLayoutType::Optimal,
+                )
+                .build();
+
+            let graph = unsafe { graph.compile(compile_info.clone()) }.unwrap();
+
+            assert_matches_instructions!(
+                graph,
+                WaitAcquire {
+                    swapchain_id: swapchain1,
+                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                },
+                WaitAcquire {
+                    swapchain_id: swapchain2,
+                    stage_mask: COMPUTE_SHADER,
+                },
+                PipelineBarrier {
+                    buffer_barriers: [],
+                    image_barriers: [
+                        {
+                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            src_access_mask: ,
+                            dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                            old_layout: Undefined,
+                            new_layout: ColorAttachmentOptimal,
+                            image: swapchain1,
+                        },
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: ,
+                            dst_stage_mask: COMPUTE_SHADER,
+                            dst_access_mask: SHADER_STORAGE_WRITE,
+                            old_layout: Undefined,
+                            new_layout: General,
+                            image: swapchain2,
+                        },
+                    ],
+                },
+                ExecuteTask { node: node },
+                SignalPresent {
+                    swapchain_id: swapchain1,
+                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                },
+                SignalPresent {
+                    swapchain_id: swapchain2,
+                    stage_mask: COMPUTE_SHADER,
+                },
+                PipelineBarrier {
+                    buffer_barriers: [],
+                    image_barriers: [
+                        {
+                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            src_access_mask: COLOR_ATTACHMENT_WRITE,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: ColorAttachmentOptimal,
+                            new_layout: PresentSrc,
+                            image: swapchain1,
+                        },
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: SHADER_STORAGE_WRITE,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: General,
+                            new_layout: PresentSrc,
+                            image: swapchain2,
+                        },
+                    ],
+                },
+                FlushSubmit,
+                Submit,
+            );
+        }
+
+        let present_queue = queues.iter().find(|q| {
+            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
+
+            queue_flags.contains(QueueFlags::COMPUTE) && !queue_flags.contains(QueueFlags::GRAPHICS)
+        });
+
+        if !present_queue.is_some() {
+            return;
+        }
+
+        let compile_info = CompileInfo {
+            queues: queues.clone(),
+            present_queue: Some(present_queue.unwrap().clone()),
+            ..Default::default()
+        };
+
+        {
+            let mut graph = TaskGraph::<()>::new(resources.clone(), 10, 10);
+            let concurrent_sharing = Sharing::Concurrent(
+                compile_info
+                    .queues
+                    .iter()
+                    .map(|q| q.queue_family_index())
+                    .collect(),
+            );
+            let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo::default());
+            let swapchain2 = graph.add_swapchain(&SwapchainCreateInfo {
+                image_sharing: concurrent_sharing.clone(),
+                ..Default::default()
+            });
+            let swapchain3 = graph.add_swapchain(&SwapchainCreateInfo::default());
+            let swapchain4 = graph.add_swapchain(&SwapchainCreateInfo {
+                image_sharing: concurrent_sharing.clone(),
+                ..Default::default()
+            });
+            let node = graph
+                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+                .image_access(
+                    swapchain1.current_image_id(),
+                    AccessType::ColorAttachmentWrite,
+                    ImageLayoutType::Optimal,
+                )
+                .image_access(
+                    swapchain2.current_image_id(),
+                    AccessType::ColorAttachmentWrite,
+                    ImageLayoutType::Optimal,
+                )
+                .image_access(
+                    swapchain3.current_image_id(),
+                    AccessType::ComputeShaderStorageWrite,
+                    ImageLayoutType::Optimal,
+                )
+                .image_access(
+                    swapchain4.current_image_id(),
+                    AccessType::ComputeShaderStorageWrite,
+                    ImageLayoutType::Optimal,
+                )
+                .build();
+
+            let graph = unsafe { graph.compile(compile_info.clone()) }.unwrap();
+
+            assert_matches_instructions!(
+                graph,
+                WaitAcquire {
+                    swapchain_id: swapchain1,
+                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                },
+                WaitAcquire {
+                    swapchain_id: swapchain2,
+                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                },
+                WaitAcquire {
+                    swapchain_id: swapchain3,
+                    stage_mask: COMPUTE_SHADER,
+                },
+                WaitAcquire {
+                    swapchain_id: swapchain4,
+                    stage_mask: COMPUTE_SHADER,
+                },
+                PipelineBarrier {
+                    buffer_barriers: [],
+                    image_barriers: [
+                        {
+                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            src_access_mask: ,
+                            dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                            old_layout: Undefined,
+                            new_layout: ColorAttachmentOptimal,
+                            image: swapchain1,
+                        },
+                        {
+                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            src_access_mask: ,
+                            dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                            old_layout: Undefined,
+                            new_layout: ColorAttachmentOptimal,
+                            image: swapchain2,
+                        },
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: ,
+                            dst_stage_mask: COMPUTE_SHADER,
+                            dst_access_mask: SHADER_STORAGE_WRITE,
+                            old_layout: Undefined,
+                            new_layout: General,
+                            image: swapchain3,
+                        },
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: ,
+                            dst_stage_mask: COMPUTE_SHADER,
+                            dst_access_mask: SHADER_STORAGE_WRITE,
+                            old_layout: Undefined,
+                            new_layout: General,
+                            image: swapchain4,
+                        },
+                    ],
+                },
+                ExecuteTask { node: node },
+                SignalPrePresent {
+                    swapchain_id: swapchain1,
+                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                },
+                SignalPresent {
+                    swapchain_id: swapchain2,
+                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                },
+                SignalPrePresent {
+                    swapchain_id: swapchain3,
+                    stage_mask: COMPUTE_SHADER,
+                },
+                SignalPresent {
+                    swapchain_id: swapchain4,
+                    stage_mask: COMPUTE_SHADER,
+                },
+                PipelineBarrier {
+                    buffer_barriers: [],
+                    image_barriers: [
+                        {
+                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            src_access_mask: COLOR_ATTACHMENT_WRITE,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: ColorAttachmentOptimal,
+                            new_layout: PresentSrc,
+                            image: swapchain1,
+                        },
+                        {
+                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                            src_access_mask: COLOR_ATTACHMENT_WRITE,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: ColorAttachmentOptimal,
+                            new_layout: PresentSrc,
+                            image: swapchain2,
+                        },
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: SHADER_STORAGE_WRITE,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: General,
+                            new_layout: PresentSrc,
+                            image: swapchain3,
+                        },
+                        {
+                            src_stage_mask: COMPUTE_SHADER,
+                            src_access_mask: SHADER_STORAGE_WRITE,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: General,
+                            new_layout: PresentSrc,
+                            image: swapchain4,
+                        },
+                    ],
+                },
+                FlushSubmit,
+                Submit,
+                WaitPrePresent {
+                    swapchain_id: swapchain1,
+                    stage_mask: ALL_COMMANDS,
+                },
+                SignalPresent {
+                    swapchain_id: swapchain1,
+                    stage_mask: ALL_COMMANDS,
+                },
+                WaitPrePresent {
+                    swapchain_id: swapchain3,
+                    stage_mask: ALL_COMMANDS,
+                },
+                SignalPresent {
+                    swapchain_id: swapchain3,
+                    stage_mask: ALL_COMMANDS,
+                },
+                PipelineBarrier {
+                    buffer_barriers: [],
+                    image_barriers: [
+                        {
+                            src_stage_mask: ,
+                            src_access_mask: ,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: ColorAttachmentOptimal,
+                            new_layout: PresentSrc,
+                            image: swapchain1,
+                        },
+                        {
+                            src_stage_mask: ,
+                            src_access_mask: ,
+                            dst_stage_mask: ,
+                            dst_access_mask: ,
+                            old_layout: General,
+                            new_layout: PresentSrc,
+                            image: swapchain3,
+                        },
+                    ],
+                },
+                FlushSubmit,
+                Submit,
+            );
+        }
+    }
+
+    struct MatchingState {
+        submission_index: usize,
+        instruction_index: usize,
+        semaphores: ahash::HashMap<&'static str, SemaphoreIndex>,
+    }
+
+    macro_rules! assert_matches_instructions {
+        (
+            $graph:ident,
+            $($arg:tt)+
+        ) => {
+            let mut state = MatchingState {
+                submission_index: 0,
+                instruction_index: 0,
+                semaphores: Default::default(),
+            };
+            assert_matches_instructions!(@ $graph, state, $($arg)+);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            InitialPipelineBarrier {
+                buffer_barriers: [
+                    $({
+                        dst_stage_mask: $($buffer_dst_stage:ident)|*,
+                        dst_access_mask: $($buffer_dst_access:ident)|*,
+                        buffer: $buffer:ident,
+                    },)*
+                ],
+                image_barriers: [
+                    $({
+                        dst_stage_mask: $($image_dst_stage:ident)|*,
+                        dst_access_mask: $($image_dst_access:ident)|*,
+                        new_layout: $image_new_layout:ident,
+                        image: $image:ident,
+                    },)*
+                ],
+            },
+            $($arg:tt)*
+        ) => {
+            let submission = &$graph.submissions[$state.submission_index];
+            let buffer_barrier_range = &submission.initial_buffer_barrier_range;
+            let image_barrier_range = &submission.initial_image_barrier_range;
+
+            let buffer_barrier_range =
+                buffer_barrier_range.start as usize..buffer_barrier_range.end as usize;
+            let buffer_barriers = &$graph.buffer_barriers[buffer_barrier_range];
+            #[allow(unused_mut)]
+            let mut buffer_barrier_count = 0;
+            $(
+                let barrier = buffer_barriers
+                    .iter()
+                    .find(|barrier| barrier.buffer == $buffer)
+                    .unwrap();
+                assert_eq!(barrier.src_stage_mask, PipelineStages::empty());
+                assert_eq!(barrier.src_access_mask, AccessFlags::empty());
+                assert_eq!(
+                    barrier.dst_stage_mask,
+                    PipelineStages::empty() $(| PipelineStages::$buffer_dst_stage)*,
+                );
+                assert_eq!(
+                    barrier.dst_access_mask,
+                    AccessFlags::empty() $(| AccessFlags::$buffer_dst_access)*,
+                );
+                buffer_barrier_count += 1;
+            )*
+            assert_eq!(buffer_barriers.len(), buffer_barrier_count);
+
+            let image_barrier_range =
+                image_barrier_range.start as usize..image_barrier_range.end as usize;
+            let image_barriers = &$graph.image_barriers[image_barrier_range];
+            #[allow(unused_mut)]
+            let mut image_barrier_count = 0;
+            $(
+                let barrier = image_barriers
+                    .iter()
+                    .find(|barrier| barrier.image == $image.erase())
+                    .unwrap();
+                assert_eq!(barrier.src_stage_mask, PipelineStages::empty());
+                assert_eq!(barrier.src_access_mask, AccessFlags::empty());
+                assert_eq!(
+                    barrier.dst_stage_mask,
+                    PipelineStages::empty() $(| PipelineStages::$image_dst_stage)*,
+                );
+                assert_eq!(
+                    barrier.dst_access_mask,
+                    AccessFlags::empty() $(| AccessFlags::$image_dst_access)*,
+                );
+                assert_eq!(barrier.old_layout, ImageLayout::Undefined);
+                assert_eq!(barrier.new_layout, ImageLayout::$image_new_layout);
+                image_barrier_count += 1;
+            )*
+            assert_eq!(image_barriers.len(), image_barrier_count);
+
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            WaitAcquire {
+                swapchain_id: $swapchain_id:expr,
+                stage_mask: $($stage:ident)|*,
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::WaitAcquire {
+                    swapchain_id,
+                    stage_mask,
+                } if swapchain_id == $swapchain_id
+                    && stage_mask == PipelineStages::empty() $(| PipelineStages::$stage)*,
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            WaitSemaphore {
+                semaphore_index: $semaphore_index:ident,
+                stage_mask: $($stage:ident)|*,
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::WaitSemaphore {
+                    stage_mask,
+                    ..
+                } if stage_mask == PipelineStages::empty() $(| PipelineStages::$stage)*,
+            ));
+            let Instruction::WaitSemaphore { semaphore_index, .. } =
+                &$graph.instructions[$state.instruction_index]
+            else {
+                unreachable!();
+            };
+
+            assert_eq!(
+                semaphore_index,
+                $state.semaphores.get(stringify!($semaphore_index)).unwrap(),
+            );
+
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            ExecuteTask {
+                node: $node:expr $(,)?
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::ExecuteTask { node_index } if node_index == $node.index(),
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            PipelineBarrier {
+                buffer_barriers: [
+                    $({
+                        src_stage_mask: $($buffer_src_stage:ident)|*,
+                        src_access_mask: $($buffer_src_access:ident)|*,
+                        dst_stage_mask: $($buffer_dst_stage:ident)|*,
+                        dst_access_mask: $($buffer_dst_access:ident)|*,
+                        buffer: $buffer:ident,
+                    },)*
+                ],
+                image_barriers: [
+                    $({
+                        src_stage_mask: $($image_src_stage:ident)|*,
+                        src_access_mask: $($image_src_access:ident)|*,
+                        dst_stage_mask: $($image_dst_stage:ident)|*,
+                        dst_access_mask: $($image_dst_access:ident)|*,
+                        old_layout: $image_old_layout:ident,
+                        new_layout: $image_new_layout:ident,
+                        image: $image:ident,
+                    },)*
+                ],
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::PipelineBarrier { .. },
+            ));
+            let Instruction::PipelineBarrier { buffer_barrier_range, image_barrier_range } =
+                &$graph.instructions[$state.instruction_index]
+            else {
+                unreachable!();
+            };
+
+            let buffer_barrier_range =
+                buffer_barrier_range.start as usize..buffer_barrier_range.end as usize;
+            let buffer_barriers = &$graph.buffer_barriers[buffer_barrier_range];
+            #[allow(unused_mut)]
+            let mut buffer_barrier_count = 0;
+            $(
+                let barrier = buffer_barriers
+                    .iter()
+                    .find(|barrier| barrier.buffer == $buffer)
+                    .unwrap();
+                assert_eq!(
+                    barrier.src_stage_mask,
+                    PipelineStages::empty() $(| PipelineStages::$buffer_src_stage)*,
+                );
+                assert_eq!(
+                    barrier.src_access_mask,
+                    AccessFlags::empty() $(| AccessFlags::$buffer_src_access)*,
+                );
+                assert_eq!(
+                    barrier.dst_stage_mask,
+                    PipelineStages::empty() $(| PipelineStages::$buffer_dst_stage)*,
+                );
+                assert_eq!(
+                    barrier.dst_access_mask,
+                    AccessFlags::empty() $(| AccessFlags::$buffer_dst_access)*,
+                );
+                buffer_barrier_count += 1;
+            )*
+            assert_eq!(buffer_barriers.len(), buffer_barrier_count);
+
+            let image_barrier_range =
+                image_barrier_range.start as usize..image_barrier_range.end as usize;
+            let image_barriers = &$graph.image_barriers[image_barrier_range];
+            #[allow(unused_mut)]
+            let mut image_barrier_count = 0;
+            $(
+                let barrier = image_barriers
+                    .iter()
+                    .find(|barrier| barrier.image == $image.erase())
+                    .unwrap();
+                assert_eq!(
+                    barrier.src_stage_mask,
+                    PipelineStages::empty() $(| PipelineStages::$image_src_stage)*,
+                );
+                assert_eq!(
+                    barrier.src_access_mask,
+                    AccessFlags::empty() $(| AccessFlags::$image_src_access)*,
+                );
+                assert_eq!(
+                    barrier.dst_stage_mask,
+                    PipelineStages::empty() $(| PipelineStages::$image_dst_stage)*,
+                );
+                assert_eq!(
+                    barrier.dst_access_mask,
+                    AccessFlags::empty() $(| AccessFlags::$image_dst_access)*,
+                );
+                assert_eq!(barrier.old_layout, ImageLayout::$image_old_layout);
+                assert_eq!(barrier.new_layout, ImageLayout::$image_new_layout);
+                image_barrier_count += 1;
+            )*
+            assert_eq!(image_barriers.len(), image_barrier_count);
+
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            SignalSemaphore {
+                semaphore_index: $semaphore_index:ident,
+                stage_mask: $($stage:ident)|*,
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::SignalSemaphore {
+                    stage_mask,
+                    ..
+                } if stage_mask == PipelineStages::empty() $(| PipelineStages::$stage)*,
+            ));
+            let Instruction::SignalSemaphore { semaphore_index, .. } =
+                &$graph.instructions[$state.instruction_index]
+            else {
+                unreachable!();
+            };
+
+            assert!($state.semaphores.get(&stringify!($semaphore_index)).is_none());
+            $state.semaphores.insert(stringify!($semaphore_index), *semaphore_index);
+
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            SignalPrePresent {
+                swapchain_id: $swapchain_id:expr,
+                stage_mask: $($stage:ident)|*,
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::SignalPrePresent {
+                    swapchain_id,
+                    stage_mask,
+                } if swapchain_id == $swapchain_id
+                    && stage_mask == PipelineStages::empty() $(| PipelineStages::$stage)*,
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            WaitPrePresent {
+                swapchain_id: $swapchain_id:expr,
+                stage_mask: $($stage:ident)|*,
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::WaitPrePresent {
+                    swapchain_id,
+                    stage_mask,
+                } if swapchain_id == $swapchain_id
+                    && stage_mask == PipelineStages::empty() $(| PipelineStages::$stage)*,
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            SignalPresent {
+                swapchain_id: $swapchain_id:expr,
+                stage_mask: $($stage:ident)|*,
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::SignalPresent {
+                    swapchain_id,
+                    stage_mask,
+                } if swapchain_id == $swapchain_id
+                    && stage_mask == PipelineStages::empty() $(| PipelineStages::$stage)*,
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            FlushSubmit,
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::FlushSubmit,
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            Submit,
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::Submit,
+            ));
+            $state.submission_index += 1;
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+        ) => {
+            assert_eq!($graph.submissions.len(), $state.submission_index);
+            assert_eq!($graph.instructions.len(), $state.instruction_index);
+        };
+    }
+    use assert_matches_instructions;
+}

--- a/vulkano-taskgraph/src/graph/mod.rs
+++ b/vulkano-taskgraph/src/graph/mod.rs
@@ -1,32 +1,30 @@
 //! The task graph data structure and associated types.
 
-pub use self::execute::{ExecuteError, ResourceMap};
-use crate::{
-    resource::{AccessType, BufferRange, ImageLayoutType},
-    Id, InvalidSlotError, QueueFamilyType, Task, BUFFER_TAG, IMAGE_TAG, SWAPCHAIN_TAG,
+pub use self::{
+    compile::{CompileError, CompileErrorKind, CompileInfo},
+    execute::{ExecuteError, ResourceMap},
 };
+use crate::{
+    resource::{self, AccessType, Flight, HostAccessType, ImageLayoutType},
+    Id, InvalidSlotError, Object, ObjectType, QueueFamilyType, Task,
+};
+use ahash::HashMap;
+use ash::vk;
 use concurrent_slotmap::{IterMut, IterUnprotected, SlotId, SlotMap};
 use smallvec::SmallVec;
 use std::{
-    borrow::Cow, cell::RefCell, error::Error, fmt, hint, iter::FusedIterator, ops::Range, slice,
-    sync::Arc,
+    borrow::Cow, cell::RefCell, error::Error, fmt, hint, iter::FusedIterator, ops::Range, sync::Arc,
 };
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo},
     device::{Device, DeviceOwned, Queue},
-    format::Format,
-    image::{
-        Image, ImageAspects, ImageCreateFlags, ImageCreateInfo, ImageLayout, ImageSubresourceRange,
-    },
+    image::{Image, ImageCreateInfo, ImageLayout},
     swapchain::{Swapchain, SwapchainCreateInfo},
     sync::{semaphore::Semaphore, AccessFlags, PipelineStages},
-    DeviceSize,
 };
 
+mod compile;
 mod execute;
-
-const EXCLUSIVE_BIT: u32 = 1 << 6;
-const VIRTUAL_BIT: u32 = 1 << 7;
 
 /// The task graph is a [directed acyclic graph] consisting of [`Task`] nodes, with edges
 /// representing happens-before relations.
@@ -42,6 +40,8 @@ struct Nodes<W: ?Sized> {
 }
 
 struct Node<W: ?Sized> {
+    // TODO:
+    #[allow(unused)]
     name: Cow<'static, str>,
     inner: NodeInner<W>,
     in_edges: Vec<NodeIndex>,
@@ -51,53 +51,41 @@ struct Node<W: ?Sized> {
 enum NodeInner<W: ?Sized> {
     Task(TaskNode<W>),
     // TODO:
+    #[allow(unused)]
     Semaphore,
 }
 
 type NodeIndex = u32;
 
-struct Resources {
-    inner: SlotMap<ResourceInfo>,
-}
-
-#[derive(Clone, Copy)]
-enum ResourceInfo {
-    Buffer(BufferInfo),
-    Image(ImageInfo),
-    Swapchain(SwapchainInfo),
-}
-
-#[derive(Clone, Copy)]
-struct BufferInfo {
-    size: DeviceSize,
-}
-
-#[derive(Clone, Copy)]
-struct ImageInfo {
-    flags: ImageCreateFlags,
-    format: Format,
-    array_layers: u32,
-    mip_levels: u32,
-}
-
-#[derive(Clone, Copy)]
-struct SwapchainInfo {
-    image_array_layers: u32,
+pub(crate) struct Resources {
+    inner: SlotMap<()>,
+    physical_resources: Arc<resource::Resources>,
+    physical_map: HashMap<Id, Id>,
+    host_reads: Vec<Id<Buffer>>,
+    host_writes: Vec<Id<Buffer>>,
 }
 
 impl<W: ?Sized> TaskGraph<W> {
     /// Creates a new `TaskGraph`.
     ///
     /// `max_nodes` is the maximum number of nodes the graph can ever have. `max_resources` is the
-    /// maximum number of resources the graph can ever have.
+    /// maximum number of virtual resources the graph can ever have.
     #[must_use]
-    pub fn new(max_nodes: u32, max_resources: u32) -> Self {
+    pub fn new(
+        physical_resources: Arc<resource::Resources>,
+        max_nodes: u32,
+        max_resources: u32,
+    ) -> Self {
         TaskGraph {
             nodes: Nodes {
                 inner: SlotMap::new(max_nodes),
             },
             resources: Resources {
                 inner: SlotMap::new(max_resources),
+                physical_resources,
+                physical_map: HashMap::default(),
+                host_reads: Vec::new(),
+                host_writes: Vec::new(),
             },
         }
     }
@@ -124,7 +112,7 @@ impl<W: ?Sized> TaskGraph<W> {
         TaskNodeBuilder {
             id,
             task_node,
-            resources: &self.resources,
+            resources: &mut self.resources,
         }
     }
 
@@ -220,6 +208,15 @@ impl<W: ?Sized> TaskGraph<W> {
     #[must_use]
     pub fn add_swapchain(&mut self, create_info: &SwapchainCreateInfo) -> Id<Swapchain> {
         self.resources.add_swapchain(create_info)
+    }
+
+    /// Adds a host buffer access to this task graph.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
+    pub fn add_host_buffer_access(&mut self, id: Id<Buffer>, access_type: HostAccessType) {
+        self.resources.add_host_buffer_access(id, access_type)
     }
 }
 
@@ -363,47 +360,108 @@ impl<W: ?Sized> Nodes<W> {
 
 impl Resources {
     fn add_buffer(&mut self, create_info: &BufferCreateInfo) -> Id<Buffer> {
-        let resource_info = ResourceInfo::Buffer(BufferInfo {
-            size: create_info.size,
-        });
-        let mut tag = BUFFER_TAG | VIRTUAL_BIT;
+        let mut tag = Buffer::TAG | Id::VIRTUAL_BIT;
 
         if create_info.sharing.is_exclusive() {
-            tag |= EXCLUSIVE_BIT;
+            tag |= Id::EXCLUSIVE_BIT;
         }
 
-        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
+        let slot = self.inner.insert_with_tag_mut((), tag);
 
-        Id::new(slot)
+        unsafe { Id::new(slot) }
     }
 
     fn add_image(&mut self, create_info: &ImageCreateInfo) -> Id<Image> {
-        let resource_info = ResourceInfo::Image(ImageInfo {
-            flags: create_info.flags,
-            format: create_info.format,
-            array_layers: create_info.array_layers,
-            mip_levels: create_info.mip_levels,
-        });
-        let mut tag = IMAGE_TAG | VIRTUAL_BIT;
+        let mut tag = Image::TAG | Id::VIRTUAL_BIT;
 
         if create_info.sharing.is_exclusive() {
-            tag |= EXCLUSIVE_BIT;
+            tag |= Id::EXCLUSIVE_BIT;
         }
 
-        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
+        let slot = self.inner.insert_with_tag_mut((), tag);
 
-        Id::new(slot)
+        unsafe { Id::new(slot) }
     }
 
     fn add_swapchain(&mut self, create_info: &SwapchainCreateInfo) -> Id<Swapchain> {
-        let resource_info = ResourceInfo::Swapchain(SwapchainInfo {
-            image_array_layers: create_info.image_array_layers,
+        let mut tag = Swapchain::TAG | Id::VIRTUAL_BIT;
+
+        if create_info.image_sharing.is_exclusive() {
+            tag |= Id::EXCLUSIVE_BIT;
+        }
+
+        let slot = self.inner.insert_with_tag_mut((), tag);
+
+        unsafe { Id::new(slot) }
+    }
+
+    fn add_physical_buffer(
+        &mut self,
+        physical_id: Id<Buffer>,
+    ) -> Result<Id<Buffer>, InvalidSlotError> {
+        let physical_resources = self.physical_resources.clone();
+        let buffer_state = physical_resources.buffer(physical_id)?;
+        let buffer = buffer_state.buffer();
+        let virtual_id = self.add_buffer(&BufferCreateInfo {
+            sharing: buffer.sharing().clone(),
+            ..Default::default()
         });
-        let tag = SWAPCHAIN_TAG | VIRTUAL_BIT;
+        self.physical_map
+            .insert(physical_id.erase(), virtual_id.erase());
 
-        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
+        Ok(virtual_id)
+    }
 
-        Id::new(slot)
+    fn add_physical_image(
+        &mut self,
+        physical_id: Id<Image>,
+    ) -> Result<Id<Image>, InvalidSlotError> {
+        let physical_resources = self.physical_resources.clone();
+        let image_state = physical_resources.image(physical_id)?;
+        let image = image_state.image();
+        let virtual_id = self.add_image(&ImageCreateInfo {
+            sharing: image.sharing().clone(),
+            ..Default::default()
+        });
+        self.physical_map
+            .insert(physical_id.erase(), virtual_id.erase());
+
+        Ok(virtual_id)
+    }
+
+    fn add_physical_swapchain(
+        &mut self,
+        id: Id<Swapchain>,
+    ) -> Result<Id<Swapchain>, InvalidSlotError> {
+        let physical_resources = self.physical_resources.clone();
+        let swapchain_state = physical_resources.swapchain(id)?;
+        let swapchain = swapchain_state.swapchain();
+        let virtual_id = self.add_swapchain(&SwapchainCreateInfo {
+            image_sharing: swapchain.image_sharing().clone(),
+            ..Default::default()
+        });
+        self.physical_map.insert(id.erase(), virtual_id.erase());
+
+        Ok(virtual_id)
+    }
+
+    fn add_host_buffer_access(&mut self, mut id: Id<Buffer>, access_type: HostAccessType) {
+        if id.is_virtual() {
+            self.get(id.erase()).expect("invalid buffer");
+        } else if let Some(&virtual_id) = self.physical_map.get(&id.erase()) {
+            id = unsafe { virtual_id.parametrize() };
+        } else {
+            id = self.add_physical_buffer(id).expect("invalid buffer");
+        }
+
+        let host_accesses = match access_type {
+            HostAccessType::Read => &mut self.host_reads,
+            HostAccessType::Write => &mut self.host_writes,
+        };
+
+        if !host_accesses.contains(&id) {
+            host_accesses.push(id);
+        }
     }
 
     fn capacity(&self) -> u32 {
@@ -414,96 +472,49 @@ impl Resources {
         self.inner.len()
     }
 
-    fn buffer(&self, id: Id<Buffer>) -> Result<&BufferInfo, InvalidSlotError> {
+    fn get(&self, id: Id) -> Result<&(), InvalidSlotError> {
         // SAFETY: We never modify the map concurrently.
-        let resource_info =
-            unsafe { self.inner.get_unprotected(id.slot) }.ok_or(InvalidSlotError::new(id))?;
-
-        if let ResourceInfo::Buffer(buffer) = resource_info {
-            Ok(buffer)
-        } else {
-            // SAFETY: The `get_unprotected` call above already successfully compared the tag, so
-            // there is no need to check it again. We always ensure that buffer IDs get tagged with
-            // the `BUFFER_TAG`.
-            unsafe { hint::unreachable_unchecked() }
-        }
+        unsafe { self.inner.get_unprotected(id.slot) }.ok_or(InvalidSlotError::new(id))
     }
 
-    unsafe fn buffer_unchecked(&self, id: Id<Buffer>) -> &BufferInfo {
-        // SAFETY:
-        // * The caller must ensure that the `id` is valid.
-        // * We never modify the map concurrently.
-        let resource_info = unsafe { self.inner.index_unchecked_unprotected(id.index()) };
-
-        if let ResourceInfo::Buffer(buffer) = resource_info {
-            buffer
-        } else {
-            // SAFETY: The caller must ensure that the `id` is valid.
-            unsafe { hint::unreachable_unchecked() }
-        }
-    }
-
-    fn image(&self, id: Id<Image>) -> Result<&ImageInfo, InvalidSlotError> {
+    fn iter(&self) -> impl Iterator<Item = (Id, &())> {
         // SAFETY: We never modify the map concurrently.
-        let resource_info =
-            unsafe { self.inner.get_unprotected(id.slot) }.ok_or(InvalidSlotError::new(id))?;
-
-        if let ResourceInfo::Image(image) = resource_info {
-            Ok(image)
-        } else {
-            // SAFETY: The `get_unprotected` call above already successfully compared the tag, so
-            // there is no need to check it again. We always ensure that image IDs get tagged with
-            // the `IMAGE_TAG`.
-            unsafe { hint::unreachable_unchecked() }
-        }
+        unsafe { self.inner.iter_unprotected() }.map(|(slot, v)| (unsafe { Id::new(slot) }, v))
     }
 
-    unsafe fn image_unchecked(&self, id: Id<Image>) -> &ImageInfo {
-        // SAFETY:
-        // * The caller must ensure that the `index` is valid.
-        // * We never modify the map concurrently.
-        let resource_info = unsafe { self.inner.index_unchecked_unprotected(id.index()) };
-
-        if let ResourceInfo::Image(image) = resource_info {
-            image
-        } else {
-            // SAFETY: The caller must ensure that the `id` is valid.
-            unsafe { hint::unreachable_unchecked() }
+    pub(crate) fn contains_host_buffer_access(
+        &self,
+        mut id: Id<Buffer>,
+        access_type: HostAccessType,
+    ) -> bool {
+        if !id.is_virtual() {
+            if let Some(&virtual_id) = self.physical_map.get(&id.erase()) {
+                id = unsafe { virtual_id.parametrize() };
+            } else {
+                return false;
+            }
         }
+
+        let host_accesses = match access_type {
+            HostAccessType::Read => &self.host_reads,
+            HostAccessType::Write => &self.host_writes,
+        };
+
+        host_accesses.contains(&id)
     }
+}
 
-    fn swapchain(&self, id: Id<Swapchain>) -> Result<&SwapchainInfo, InvalidSlotError> {
-        // SAFETY: We never modify the map concurrently.
-        let resource_info =
-            unsafe { self.inner.get_unprotected(id.slot) }.ok_or(InvalidSlotError::new(id))?;
-
-        if let ResourceInfo::Swapchain(swapchain) = resource_info {
-            Ok(swapchain)
-        } else {
-            // SAFETY: The `get_unprotected` call above already successfully compared the tag, so
-            // there is no need to check it again. We always ensure that swapchain IDs get tagged
-            // with the `SWAPCHAIN_TAG`.
-            unsafe { hint::unreachable_unchecked() }
-        }
+impl<W: ?Sized> fmt::Debug for TaskGraph<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // FIXME:
+        f.debug_struct("TaskGraph").finish_non_exhaustive()
     }
+}
 
-    unsafe fn swapchain_unchecked(&self, id: Id<Swapchain>) -> &SwapchainInfo {
-        // SAFETY:
-        // * The caller must ensure that the `index` is valid.
-        // * We never modify the map concurrently.
-        let resource_info = unsafe { self.inner.index_unchecked_unprotected(id.index()) };
-
-        if let ResourceInfo::Swapchain(swapchain) = resource_info {
-            swapchain
-        } else {
-            // SAFETY: The caller must ensure that the `id` is valid.
-            unsafe { hint::unreachable_unchecked() }
-        }
-    }
-
-    fn iter(&self) -> IterUnprotected<'_, ResourceInfo> {
-        // SAFETY: We never modify the map concurrently.
-        unsafe { self.inner.iter_unprotected() }
+unsafe impl<W: ?Sized> DeviceOwned for TaskGraph<W> {
+    #[inline]
+    fn device(&self) -> &Arc<Device> {
+        self.resources.physical_resources.device()
     }
 }
 
@@ -540,38 +551,15 @@ pub struct TaskNode<W: ?Sized> {
 }
 
 pub(crate) struct ResourceAccesses {
-    inner: Vec<ResourceAccess>,
+    inner: Vec<(Id, ResourceAccess)>,
 }
 
-// TODO: Literally anything else
-#[derive(Clone)]
-enum ResourceAccess {
-    Buffer(BufferAccess),
-    Image(ImageAccess),
-    Swapchain(SwapchainAccess),
-}
-
-#[derive(Clone)]
-struct BufferAccess {
-    id: Id<Buffer>,
-    range: BufferRange,
-    access_type: AccessType,
-}
-
-#[derive(Clone)]
-struct ImageAccess {
-    id: Id<Image>,
-    subresource_range: ImageSubresourceRange,
-    access_type: AccessType,
-    layout_type: ImageLayoutType,
-}
-
-#[derive(Clone)]
-struct SwapchainAccess {
-    id: Id<Swapchain>,
-    array_layers: Range<u32>,
-    access_type: AccessType,
-    layout_type: ImageLayoutType,
+#[derive(Clone, Copy, Default)]
+struct ResourceAccess {
+    stage_mask: PipelineStages,
+    access_mask: AccessFlags,
+    image_layout: ImageLayout,
+    queue_family_index: u32,
 }
 
 impl<W: ?Sized> TaskNode<W> {
@@ -605,113 +593,46 @@ impl<W: ?Sized> TaskNode<W> {
     pub fn task_mut(&mut self) -> &mut dyn Task<World = W> {
         &mut *self.task
     }
-
-    /// Returns `true` if the task node has access of the given `access_type` to the buffer
-    /// corresponding to `id` where the given `range` is contained within the access's range.
-    #[inline]
-    #[must_use]
-    pub fn contains_buffer_access(
-        &self,
-        id: Id<Buffer>,
-        range: BufferRange,
-        access_type: AccessType,
-    ) -> bool {
-        self.accesses.contains_buffer_access(id, range, access_type)
-    }
-
-    /// Returns `true` if the task node has access of the given `access_type` and `layout_type` to
-    /// the image corresponding to `id` where the given `subresource_range` is contained within
-    /// the access's subresource range.
-    #[inline]
-    #[must_use]
-    pub fn contains_image_access(
-        &self,
-        id: Id<Image>,
-        subresource_range: ImageSubresourceRange,
-        access_type: AccessType,
-        layout_type: ImageLayoutType,
-    ) -> bool {
-        self.accesses
-            .contains_image_access(id, subresource_range, access_type, layout_type)
-    }
-
-    /// Returns `true` if the task node has access of the given `access_type` and `layout_type` to
-    /// the swapchain corresponding to `id` where the given `array_layers` are contained within
-    /// the access's array layers.
-    #[inline]
-    #[must_use]
-    pub fn contains_swapchain_access(
-        &self,
-        id: Id<Swapchain>,
-        array_layers: Range<u32>,
-        access_type: AccessType,
-        layout_type: ImageLayoutType,
-    ) -> bool {
-        self.accesses
-            .contains_swapchain_access(id, array_layers, access_type, layout_type)
-    }
 }
 
 impl ResourceAccesses {
-    fn iter(&self) -> slice::Iter<'_, ResourceAccess> {
-        self.inner.iter()
+    fn get_mut(
+        &mut self,
+        resources: &mut Resources,
+        mut id: Id,
+    ) -> Result<(Id, Option<&mut ResourceAccess>), InvalidSlotError> {
+        if id.is_virtual() {
+            resources.get(id)?;
+        } else if let Some(&virtual_id) = resources.physical_map.get(&id) {
+            id = virtual_id;
+        } else {
+            id = match id.object_type() {
+                ObjectType::Buffer => resources
+                    .add_physical_buffer(unsafe { id.parametrize() })?
+                    .erase(),
+                ObjectType::Image => resources
+                    .add_physical_image(unsafe { id.parametrize() })?
+                    .erase(),
+                ObjectType::Swapchain => resources
+                    .add_physical_swapchain(unsafe { id.parametrize() })?
+                    .erase(),
+                _ => unreachable!(),
+            };
+        }
+
+        let access = self
+            .iter_mut()
+            .find_map(|(x, access)| (x == id).then_some(access));
+
+        Ok((id, access))
     }
 
-    pub(crate) fn contains_buffer_access(
-        &self,
-        id: Id<Buffer>,
-        range: BufferRange,
-        access_type: AccessType,
-    ) -> bool {
-        debug_assert!(!range.is_empty());
-
-        self.iter().any(|resource_access| {
-            matches!(resource_access, ResourceAccess::Buffer(a) if a.id == id
-                && a.access_type == access_type
-                && a.range.start <= range.start
-                && range.end <= a.range.end)
-        })
+    fn iter(&self) -> impl Iterator<Item = (Id, &ResourceAccess)> {
+        self.inner.iter().map(|(id, access)| (*id, access))
     }
 
-    pub(crate) fn contains_image_access(
-        &self,
-        id: Id<Image>,
-        subresource_range: ImageSubresourceRange,
-        access_type: AccessType,
-        layout_type: ImageLayoutType,
-    ) -> bool {
-        debug_assert!(!subresource_range.aspects.is_empty());
-        debug_assert!(!subresource_range.mip_levels.is_empty());
-        debug_assert!(!subresource_range.array_layers.is_empty());
-
-        self.iter().any(|resource_access| {
-            matches!(resource_access, ResourceAccess::Image(a) if a.id == id
-                && a.access_type == access_type
-                && a.layout_type == layout_type
-                && a.subresource_range.aspects.contains(subresource_range.aspects)
-                && a.subresource_range.mip_levels.start <= subresource_range.mip_levels.start
-                && subresource_range.mip_levels.end <= a.subresource_range.mip_levels.end
-                && a.subresource_range.array_layers.start <= subresource_range.array_layers.start
-                && subresource_range.array_layers.end <= a.subresource_range.array_layers.end)
-        })
-    }
-
-    pub(crate) fn contains_swapchain_access(
-        &self,
-        id: Id<Swapchain>,
-        array_layers: Range<u32>,
-        access_type: AccessType,
-        layout_type: ImageLayoutType,
-    ) -> bool {
-        debug_assert!(!array_layers.is_empty());
-
-        self.iter().any(|resource_access| {
-            matches!(resource_access, ResourceAccess::Swapchain(a) if a.id == id
-                && a.access_type == access_type
-                && a.layout_type == layout_type
-                && a.array_layers.start <= array_layers.start
-                && array_layers.end <= a.array_layers.end)
-        })
+    fn iter_mut(&mut self) -> impl Iterator<Item = (Id, &mut ResourceAccess)> {
+        self.inner.iter_mut().map(|(id, access)| (*id, access))
     }
 }
 
@@ -719,7 +640,7 @@ impl ResourceAccesses {
 pub struct TaskNodeBuilder<'a, W: ?Sized> {
     id: NodeId,
     task_node: &'a mut TaskNode<W>,
-    resources: &'a Resources,
+    resources: &'a mut Resources,
 }
 
 impl<W: ?Sized> TaskNodeBuilder<'_, W> {
@@ -727,48 +648,27 @@ impl<W: ?Sized> TaskNodeBuilder<'_, W> {
     ///
     /// # Panics
     ///
-    /// - Panics if `id` is not a valid virtual resource ID.
-    /// - Panics if `range` doesn't denote a valid range of the buffer.
+    /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
     /// - Panics if `access_type` isn't a valid buffer access type.
-    pub fn buffer_access(
-        &mut self,
-        id: Id<Buffer>,
-        range: BufferRange,
-        access_type: AccessType,
-    ) -> &mut Self {
-        let buffer = self.resources.buffer(id).expect("invalid buffer");
-
-        assert!(range.end <= buffer.size);
-        assert!(!range.is_empty());
+    pub fn buffer_access(&mut self, id: Id<Buffer>, access_type: AccessType) -> &mut Self {
+        let (id, access) = self.access_mut(id.erase()).expect("invalid buffer");
 
         assert!(access_type.is_valid_buffer_access_type());
 
-        // SAFETY: We checked the safety preconditions above.
-        unsafe { self.buffer_access_unchecked(id, range, access_type) }
-    }
-
-    /// Adds a buffer access to this task node without doing any checks.
-    ///
-    /// # Safety
-    ///
-    /// - `id` must be a valid virtual resource ID.
-    /// - `range` must denote a valid range of the buffer.
-    /// - `access_type` must be a valid buffer access type.
-    #[inline]
-    pub unsafe fn buffer_access_unchecked(
-        &mut self,
-        id: Id<Buffer>,
-        range: BufferRange,
-        access_type: AccessType,
-    ) -> &mut Self {
-        self.task_node
-            .accesses
-            .inner
-            .push(ResourceAccess::Buffer(BufferAccess {
-                id,
-                range,
-                access_type,
-            }));
+        if let Some(access) = access {
+            access.stage_mask |= access_type.stage_mask();
+            access.access_mask |= access_type.access_mask();
+        } else {
+            self.task_node.accesses.inner.push((
+                id.erase(),
+                ResourceAccess {
+                    stage_mask: access_type.stage_mask(),
+                    access_mask: access_type.access_mask(),
+                    image_layout: ImageLayout::Undefined,
+                    queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+                },
+            ));
+        }
 
         self
     }
@@ -777,136 +677,52 @@ impl<W: ?Sized> TaskNodeBuilder<'_, W> {
     ///
     /// # Panics
     ///
-    /// - Panics if `id` is not a valid virtual resource ID.
-    /// - Panics if `subresource_range` doesn't denote a valid subresource range of the image.
+    /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
     /// - Panics if `access_type` isn't a valid image access type.
+    /// - Panics if an access for `id` was already added and its image layout doesn't equal
+    ///   `access_type.image_layout(layout_type)`.
     pub fn image_access(
         &mut self,
         id: Id<Image>,
-        mut subresource_range: ImageSubresourceRange,
         access_type: AccessType,
         layout_type: ImageLayoutType,
     ) -> &mut Self {
-        let image = self.resources.image(id).expect("invalid image");
-
-        if image.flags.contains(ImageCreateFlags::DISJOINT) {
-            subresource_range.aspects -= ImageAspects::COLOR;
-            subresource_range.aspects |= match image.format.planes().len() {
-                2 => ImageAspects::PLANE_0 | ImageAspects::PLANE_1,
-                3 => ImageAspects::PLANE_0 | ImageAspects::PLANE_1 | ImageAspects::PLANE_2,
-                _ => unreachable!(),
-            };
-        }
-
-        assert!(image.format.aspects().contains(subresource_range.aspects));
-        assert!(subresource_range.mip_levels.end <= image.mip_levels);
-        assert!(subresource_range.array_layers.end <= image.array_layers);
-        assert!(!subresource_range.aspects.is_empty());
-        assert!(!subresource_range.mip_levels.is_empty());
-        assert!(!subresource_range.array_layers.is_empty());
+        let (id, access) = self.access_mut(id.erase()).expect("invalid image");
 
         assert!(access_type.is_valid_image_access_type());
 
-        // SAFETY: We checked the safety preconditions above.
-        unsafe { self.image_access_unchecked(id, subresource_range, access_type, layout_type) }
-    }
+        let image_layout = access_type.image_layout(layout_type);
 
-    /// Adds an image access to this task node without doing any checks.
-    ///
-    /// # Safety
-    ///
-    /// - `id` must be a valid virtual resource ID.
-    /// - `subresource_range` must denote a valid subresource range of the image. If the image
-    ///   flags contain `ImageCreateFlags::DISJOINT`, then the color aspect is not considered
-    ///   valid.
-    /// - `access_type` must be a valid image access type.
-    #[inline]
-    pub unsafe fn image_access_unchecked(
-        &mut self,
-        id: Id<Image>,
-        subresource_range: ImageSubresourceRange,
-        access_type: AccessType,
-        mut layout_type: ImageLayoutType,
-    ) -> &mut Self {
-        // Normalize the layout type so that comparisons of accesses are predictable.
-        if access_type.image_layout() == ImageLayout::General {
-            layout_type = ImageLayoutType::Optimal;
+        if let Some(access) = access {
+            assert_eq!(access.image_layout, image_layout);
+
+            access.stage_mask |= access_type.stage_mask();
+            access.access_mask |= access_type.access_mask();
+        } else {
+            self.task_node.accesses.inner.push((
+                id.erase(),
+                ResourceAccess {
+                    stage_mask: access_type.stage_mask(),
+                    access_mask: access_type.access_mask(),
+                    image_layout,
+                    queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+                },
+            ));
         }
-
-        self.task_node
-            .accesses
-            .inner
-            .push(ResourceAccess::Image(ImageAccess {
-                id,
-                subresource_range,
-                access_type,
-                layout_type,
-            }));
 
         self
     }
 
-    /// Adds a swapchain image access to this task node.
-    ///
-    /// # Panics
-    ///
-    /// - Panics if `id` is not a valid virtual resource ID.
-    /// - Panics if `array_layers` doesn't denote a valid range of array layers of the swapchain.
-    /// - Panics if `access_type` isn't a valid image access type.
-    pub fn swapchain_access(
+    fn access_mut(
         &mut self,
-        id: Id<Swapchain>,
-        array_layers: Range<u32>,
-        access_type: AccessType,
-        layout_type: ImageLayoutType,
-    ) -> &mut Self {
-        let swapchain = self.resources.swapchain(id).expect("invalid swapchain");
-
-        assert!(array_layers.end <= swapchain.image_array_layers);
-        assert!(!array_layers.is_empty());
-
-        assert!(access_type.is_valid_image_access_type());
-
-        // SAFETY: We checked the safety preconditions above.
-        unsafe { self.swapchain_access_unchecked(id, array_layers, access_type, layout_type) }
-    }
-
-    /// Adds a swapchain image access to this task node without doing any checks.
-    ///
-    /// # Safety
-    ///
-    /// - `id` must be a valid virtual resource ID.
-    /// - `array_layers` must denote a valid range of array layers of the swapchain.
-    /// - `access_type` must be a valid image access type.
-    #[inline]
-    pub unsafe fn swapchain_access_unchecked(
-        &mut self,
-        id: Id<Swapchain>,
-        array_layers: Range<u32>,
-        access_type: AccessType,
-        mut layout_type: ImageLayoutType,
-    ) -> &mut Self {
-        // Normalize the layout type so that comparisons of accesses are predictable.
-        if access_type.image_layout() == ImageLayout::General {
-            layout_type = ImageLayoutType::Optimal;
-        }
-
-        self.task_node
-            .accesses
-            .inner
-            .push(ResourceAccess::Swapchain(SwapchainAccess {
-                id,
-                access_type,
-                layout_type,
-                array_layers,
-            }));
-
-        self
+        id: Id,
+    ) -> Result<(Id, Option<&mut ResourceAccess>), InvalidSlotError> {
+        self.task_node.accesses.get_mut(self.resources, id)
     }
 
     /// Finishes building the task node and returns the ID of the built node.
     #[inline]
-    pub fn build(self) -> NodeId {
+    pub fn build(&mut self) -> NodeId {
         self.id
     }
 }
@@ -914,16 +730,19 @@ impl<W: ?Sized> TaskNodeBuilder<'_, W> {
 /// A [`TaskGraph`] that has been compiled into an executable form.
 pub struct ExecutableTaskGraph<W: ?Sized> {
     graph: TaskGraph<W>,
+    flight_id: Id<Flight>,
     instructions: Vec<Instruction>,
     submissions: Vec<Submission>,
     buffer_barriers: Vec<BufferMemoryBarrier>,
     image_barriers: Vec<ImageMemoryBarrier>,
-    semaphores: RefCell<Vec<Semaphore>>,
+    semaphores: RefCell<Vec<Arc<Semaphore>>>,
     swapchains: SmallVec<[Id<Swapchain>; 1]>,
     present_queue: Option<Arc<Queue>>,
+    last_accesses: Vec<ResourceAccess>,
 }
 
 // FIXME: Initial queue family ownership transfers
+#[derive(Debug)]
 struct Submission {
     queue: Arc<Queue>,
     initial_buffer_barrier_range: Range<BarrierIndex>,
@@ -933,7 +752,7 @@ struct Submission {
 
 type InstructionIndex = usize;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum Instruction {
     WaitAcquire {
         swapchain_id: Id<Swapchain>,
@@ -965,6 +784,14 @@ enum Instruction {
         semaphore_index: SemaphoreIndex,
         stage_mask: PipelineStages,
     },
+    SignalPrePresent {
+        swapchain_id: Id<Swapchain>,
+        stage_mask: PipelineStages,
+    },
+    WaitPrePresent {
+        swapchain_id: Id<Swapchain>,
+        stage_mask: PipelineStages,
+    },
     SignalPresent {
         swapchain_id: Id<Swapchain>,
         stage_mask: PipelineStages,
@@ -977,6 +804,7 @@ type SemaphoreIndex = usize;
 
 type BarrierIndex = u32;
 
+#[derive(Clone, Debug)]
 struct BufferMemoryBarrier {
     src_stage_mask: PipelineStages,
     src_access_mask: AccessFlags,
@@ -985,9 +813,9 @@ struct BufferMemoryBarrier {
     src_queue_family_index: u32,
     dst_queue_family_index: u32,
     buffer: Id<Buffer>,
-    range: BufferRange,
 }
 
+#[derive(Clone, Debug)]
 struct ImageMemoryBarrier {
     src_stage_mask: PipelineStages,
     src_access_mask: AccessFlags,
@@ -997,15 +825,7 @@ struct ImageMemoryBarrier {
     new_layout: ImageLayout,
     src_queue_family_index: u32,
     dst_queue_family_index: u32,
-    image: ImageReference,
-    subresource_range: ImageSubresourceRange,
-}
-
-// TODO: This really ought not to be necessary.
-#[derive(Clone, Copy)]
-enum ImageReference {
-    Normal(Id<Image>),
-    Swapchain(Id<Swapchain>),
+    image: Id,
 }
 
 impl<W: ?Sized> ExecutableTaskGraph<W> {
@@ -1032,12 +852,36 @@ impl<W: ?Sized> ExecutableTaskGraph<W> {
     pub fn task_nodes_mut(&mut self) -> TaskNodesMut<'_, W> {
         self.graph.task_nodes_mut()
     }
+
+    /// Returns the flight ID that the task graph was compiled with.
+    #[inline]
+    pub fn flight_id(&self) -> Id<Flight> {
+        self.flight_id
+    }
+}
+
+impl<W: ?Sized> fmt::Debug for ExecutableTaskGraph<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("ExecutableTaskGraph");
+
+        debug
+            .field("graph", &self.graph)
+            .field("flight_id", &self.flight_id)
+            .field("instructions", &self.instructions)
+            .field("submissions", &self.submissions)
+            .field("buffer_barriers", &self.buffer_barriers)
+            .field("image_barriers", &self.image_barriers)
+            .field("semaphores", &self.semaphores)
+            .field("swapchains", &self.swapchains)
+            .field("present_queue", &self.present_queue)
+            .finish_non_exhaustive()
+    }
 }
 
 unsafe impl<W: ?Sized> DeviceOwned for ExecutableTaskGraph<W> {
     #[inline]
     fn device(&self) -> &Arc<Device> {
-        self.submissions[0].queue.device()
+        self.graph.device()
     }
 }
 
@@ -1172,27 +1016,19 @@ impl Error for TaskGraphError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{TaskContext, TaskResult};
-
-    struct DummyTask;
-
-    impl Task for DummyTask {
-        type World = ();
-
-        unsafe fn execute(&self, _tcx: &mut TaskContext<'_>, _world: &Self::World) -> TaskResult {
-            Ok(())
-        }
-    }
+    use crate::tests::test_queues;
+    use std::marker::PhantomData;
 
     #[test]
     fn basic_usage1() {
-        let mut graph = TaskGraph::new(10, 0);
+        let (resources, _) = test_queues!();
+        let mut graph = TaskGraph::<()>::new(resources, 10, 0);
 
         let x = graph
-            .create_task_node("", QueueFamilyType::Graphics, DummyTask)
+            .create_task_node("X", QueueFamilyType::Graphics, PhantomData)
             .build();
         let y = graph
-            .create_task_node("", QueueFamilyType::Graphics, DummyTask)
+            .create_task_node("Y", QueueFamilyType::Graphics, PhantomData)
             .build();
 
         graph.add_edge(x, y).unwrap();
@@ -1220,16 +1056,17 @@ mod tests {
 
     #[test]
     fn basic_usage2() {
-        let mut graph = TaskGraph::new(10, 0);
+        let (resources, _) = test_queues!();
+        let mut graph = TaskGraph::<()>::new(resources, 10, 0);
 
         let x = graph
-            .create_task_node("", QueueFamilyType::Graphics, DummyTask)
+            .create_task_node("X", QueueFamilyType::Graphics, PhantomData)
             .build();
         let y = graph
-            .create_task_node("", QueueFamilyType::Graphics, DummyTask)
+            .create_task_node("Y", QueueFamilyType::Graphics, PhantomData)
             .build();
         let z = graph
-            .create_task_node("", QueueFamilyType::Graphics, DummyTask)
+            .create_task_node("Z", QueueFamilyType::Graphics, PhantomData)
             .build();
 
         assert!(graph.task_node(x).is_ok());
@@ -1256,10 +1093,11 @@ mod tests {
 
     #[test]
     fn self_referential_node() {
-        let mut graph = TaskGraph::new(10, 0);
+        let (resources, _) = test_queues!();
+        let mut graph = TaskGraph::<()>::new(resources, 10, 0);
 
         let x = graph
-            .create_task_node("", QueueFamilyType::Graphics, DummyTask)
+            .create_task_node("X", QueueFamilyType::Graphics, PhantomData)
             .build();
 
         assert_eq!(graph.add_edge(x, x), Err(TaskGraphError::InvalidNode));

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -512,33 +512,33 @@ vulkan_bitflags! {
 
     /// A set of memory access types that are included in a memory dependency.
     AccessFlags impl {
-        // TODO: use the Vulkano associated constants once | becomes const for custom types.
-        const WRITES: AccessFlags = AccessFlags(
-            ash::vk::AccessFlags2::SHADER_WRITE.as_raw()
-            | ash::vk::AccessFlags2::COLOR_ATTACHMENT_WRITE.as_raw()
-            | ash::vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE.as_raw()
-            | ash::vk::AccessFlags2::TRANSFER_WRITE.as_raw()
-            | ash::vk::AccessFlags2::HOST_WRITE.as_raw()
-            | ash::vk::AccessFlags2::MEMORY_WRITE.as_raw()
-            | ash::vk::AccessFlags2::SHADER_STORAGE_WRITE.as_raw()
-            | ash::vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR.as_raw()
-            | ash::vk::AccessFlags2::VIDEO_ENCODE_WRITE_KHR.as_raw()
-            | ash::vk::AccessFlags2::TRANSFORM_FEEDBACK_WRITE_EXT.as_raw()
-            | ash::vk::AccessFlags2::TRANSFORM_FEEDBACK_COUNTER_WRITE_EXT.as_raw()
-            | ash::vk::AccessFlags2::COMMAND_PREPROCESS_WRITE_NV.as_raw()
-            | ash::vk::AccessFlags2::ACCELERATION_STRUCTURE_WRITE_KHR.as_raw()
-        );
+        const WRITES: AccessFlags = AccessFlags::SHADER_WRITE
+            .union(AccessFlags::COLOR_ATTACHMENT_WRITE)
+            .union(AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE)
+            .union(AccessFlags::TRANSFER_WRITE)
+            .union(AccessFlags::HOST_WRITE)
+            .union(AccessFlags::MEMORY_WRITE)
+            .union(AccessFlags::SHADER_STORAGE_WRITE)
+            .union(AccessFlags::VIDEO_DECODE_WRITE)
+            .union(AccessFlags::VIDEO_ENCODE_WRITE)
+            .union(AccessFlags::TRANSFORM_FEEDBACK_WRITE)
+            .union(AccessFlags::TRANSFORM_FEEDBACK_COUNTER_WRITE)
+            .union(AccessFlags::COMMAND_PREPROCESS_WRITE)
+            .union(AccessFlags::ACCELERATION_STRUCTURE_WRITE);
 
-        pub(crate) fn contains_reads(self) -> bool {
-            !(self - Self::WRITES).is_empty()
+        /// Returns whether `self` contains any read flags.
+        #[inline]
+        pub const fn contains_reads(self) -> bool {
+            !self.difference(Self::WRITES).is_empty()
         }
 
-        pub(crate) fn contains_writes(self) -> bool {
+        /// Returns whether `self` contains any write flags.
+        #[inline]
+        pub const fn contains_writes(self) -> bool {
             self.intersects(Self::WRITES)
         }
 
-        /// Returns whether `self` contains stages that are only available in
-        /// `VkAccessFlagBits2`.
+        /// Returns whether `self` contains flags that are only available in `VkAccessFlagBits2`.
         pub(crate) fn contains_flags2(self) -> bool {
             !(self
                 - (AccessFlags::INDIRECT_COMMAND_READ


### PR DESCRIPTION
Follow-up to #2548, implementing the task graph compiler.

I gave up on subresource-granularity sync because it was making everything complicated and I just didn't want to deal with it anymore. The only reason I did it in the first place was because the old sync did it. But that's also what we're trying to replace, so maybe it was just not meant to be. Few things come to mind that couldn't be worked around with whole-resource-granularity sync anyway. A nice side-effect is that this is a whole lot faster both when compiling and executing the task graph.

I converted the async-update example as a very very very (very) early test. Mainly because the kind of syncronization it does was the biggest thorn in my ass.

Changelog:
```markdown
### Additions
- Added `AccessFlags::{contains_reads,contains_writes}`.
```
