### PR TITLE
Add `PhysicalDevice::presentation_support`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,8 @@ dependencies = [
  "thread_local",
  "vk-parse",
  "vulkano-macros",
+ "x11-dl",
+ "x11rb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ syn = "2.0"
 thread_local = "1.1"
 vk-parse = "0.12"
 winit = { version = "0.29", default-features = false }
+x11-dl = "2.0"
+x11rb = "0.13"
 
 # Only used in examples
 glam = "0.25"

--- a/examples/async-update/Cargo.toml
+++ b/examples/async-update/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 [dependencies]
 glam = { workspace = true }
 rand = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 vulkano-taskgraph = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -110,9 +110,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -127,7 +124,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -231,6 +228,9 @@ fn main() -> Result<(), impl Error> {
 
     let graphics_flight_id = resources.create_flight(MAX_FRAMES_IN_FLIGHT).unwrap();
     let transfer_flight_id = resources.create_flight(1).unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let swapchain_format = device
         .physical_device()

--- a/examples/basic-compute-shader/Cargo.toml
+++ b/examples/basic-compute-shader/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/buffer-allocator/Cargo.toml
+++ b/examples/buffer-allocator/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/buffer-allocator/main.rs
+++ b/examples/buffer-allocator/main.rs
@@ -62,9 +62,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -79,7 +76,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -113,6 +110,9 @@ fn main() -> Result<(), impl Error> {
     .unwrap();
 
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/clear-attachments/Cargo.toml
+++ b/examples/clear-attachments/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, default-features = true }
 winit = { workspace = true, default-features = true }

--- a/examples/clear-attachments/main.rs
+++ b/examples/clear-attachments/main.rs
@@ -42,9 +42,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -59,7 +56,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -92,6 +89,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/debug/Cargo.toml
+++ b/examples/debug/Cargo.toml
@@ -12,4 +12,4 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, default-features = true }

--- a/examples/deferred/Cargo.toml
+++ b/examples/deferred/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 glam = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -65,9 +65,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -82,7 +79,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -115,6 +112,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, mut images) = {
         let surface_capabilities = device

--- a/examples/dynamic-buffers/Cargo.toml
+++ b/examples/dynamic-buffers/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/dynamic-local-size/Cargo.toml
+++ b/examples/dynamic-local-size/Cargo.toml
@@ -13,5 +13,5 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/gl-interop/Cargo.toml
+++ b/examples/gl-interop/Cargo.toml
@@ -13,7 +13,7 @@ doc = false
 
 [dependencies]
 glium = "0.32.1"
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }
 # Glium has still not been updated to the latest winit version

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -531,9 +531,6 @@ mod linux {
             .unwrap()
         };
 
-        let window = Arc::new(WindowBuilder::new().build(event_loop).unwrap());
-        let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
         let device_extensions = DeviceExtensions {
             khr_external_semaphore: true,
             khr_external_semaphore_fd: true,
@@ -555,7 +552,7 @@ mod linux {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.surface_support(i as u32, &surface).unwrap_or(false)
+                            && p.presentation_support(i as u32, &event_loop).unwrap()
                     })
                     .map(|i| (p, i as u32))
             })
@@ -596,6 +593,9 @@ mod linux {
         .unwrap();
 
         let queue = queues.next().unwrap();
+
+        let window = Arc::new(WindowBuilder::new().build(event_loop).unwrap());
+        let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
         let (swapchain, images) = {
             let surface_capabilities = device

--- a/examples/image-self-copy-blit/Cargo.toml
+++ b/examples/image-self-copy-blit/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -67,9 +67,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -84,7 +81,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -117,6 +114,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/image/Cargo.toml
+++ b/examples/image/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -65,9 +65,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -82,7 +79,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -115,6 +112,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/immutable-sampler/Cargo.toml
+++ b/examples/immutable-sampler/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -71,9 +71,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -88,7 +85,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -121,6 +118,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/indirect/Cargo.toml
+++ b/examples/indirect/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -78,9 +78,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         khr_storage_buffer_storage_class: true,
@@ -96,7 +93,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -130,6 +127,9 @@ fn main() -> Result<(), impl Error> {
     .unwrap();
 
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/instancing/Cargo.toml
+++ b/examples/instancing/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -77,9 +77,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -94,7 +91,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -128,6 +125,9 @@ fn main() -> Result<(), impl Error> {
     .unwrap();
 
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/interactive-fractal/Cargo.toml
+++ b/examples/interactive-fractal/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 [dependencies]
 glam = { workspace = true }
 rand = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 vulkano-util = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/mesh-shader/Cargo.toml
+++ b/examples/mesh-shader/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"] }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -97,9 +97,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ext_mesh_shader: true,
@@ -115,7 +112,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -153,6 +150,9 @@ fn main() -> Result<(), impl Error> {
     .unwrap();
 
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/msaa-renderpass/Cargo.toml
+++ b/examples/msaa-renderpass/Cargo.toml
@@ -13,5 +13,5 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/multi-window-game-of-life/Cargo.toml
+++ b/examples/multi-window-game-of-life/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 [dependencies]
 glam = { workspace = true }
 rand = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 vulkano-util = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/multi-window/Cargo.toml
+++ b/examples/multi-window/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/multiview/Cargo.toml
+++ b/examples/multiview/Cargo.toml
@@ -13,5 +13,5 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/occlusion-query/Cargo.toml
+++ b/examples/occlusion-query/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/occlusion-query/main.rs
+++ b/examples/occlusion-query/main.rs
@@ -60,9 +60,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -77,7 +74,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -110,6 +107,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/offscreen/Cargo.toml
+++ b/examples/offscreen/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/pipeline-caching/Cargo.toml
+++ b/examples/pipeline-caching/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/push-constants/Cargo.toml
+++ b/examples/push-constants/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/push-descriptors/Cargo.toml
+++ b/examples/push-descriptors/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -60,9 +60,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         khr_push_descriptor: true,
@@ -78,7 +75,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -111,6 +108,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/runtime-array/Cargo.toml
+++ b/examples/runtime-array/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -66,9 +66,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -83,7 +80,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -123,6 +120,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/runtime-shader/Cargo.toml
+++ b/examples/runtime-shader/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true }
+vulkano = { workspace = true, default-features = true }
 winit = { workspace = true, default-features = true }

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -68,9 +68,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -85,7 +82,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -118,6 +115,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/self-copy-buffer/Cargo.toml
+++ b/examples/self-copy-buffer/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/shader-include/Cargo.toml
+++ b/examples/shader-include/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/shader-types-derive/Cargo.toml
+++ b/examples/shader-types-derive/Cargo.toml
@@ -14,6 +14,6 @@ doc = false
 [dependencies]
 ron = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-vulkano = { workspace = true, features = ["serde", "macros"] }
+vulkano = { workspace = true, default-features = true, features = ["serde"] }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/shader-types-sharing/Cargo.toml
+++ b/examples/shader-types-sharing/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/simple-particles/Cargo.toml
+++ b/examples/simple-particles/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -71,17 +71,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(
-        WindowBuilder::new()
-            // For simplicity, we are going to assert that the window size is static.
-            .with_resizable(false)
-            .with_title("simple particles")
-            .with_inner_size(winit::dpi::PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT))
-            .build(&event_loop)
-            .unwrap(),
-    );
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -96,7 +85,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -129,6 +118,17 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(
+        WindowBuilder::new()
+            // For simplicity, we are going to assert that the window size is static.
+            .with_resizable(false)
+            .with_title("simple particles")
+            .with_inner_size(winit::dpi::PhysicalSize::new(WINDOW_WIDTH, WINDOW_HEIGHT))
+            .build(&event_loop)
+            .unwrap(),
+    );
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (swapchain, images) = {
         let surface_capabilities = device

--- a/examples/specialization-constants/Cargo.toml
+++ b/examples/specialization-constants/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }

--- a/examples/teapot/Cargo.toml
+++ b/examples/teapot/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 glam = { workspace = true }
-vulkano = { workspace = true, features = ["macros"] }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -73,9 +73,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -90,7 +87,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -124,6 +121,9 @@ fn main() -> Result<(), impl Error> {
     .unwrap();
 
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/tessellation/Cargo.toml
+++ b/examples/tessellation/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"] }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -165,9 +165,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -188,7 +185,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -222,6 +219,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/texture-array/Cargo.toml
+++ b/examples/texture-array/Cargo.toml
@@ -13,6 +13,6 @@ doc = false
 
 [dependencies]
 png = { workspace = true }
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -67,9 +67,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     let device_extensions = DeviceExtensions {
         khr_swapchain: true,
         ..DeviceExtensions::empty()
@@ -84,7 +81,7 @@ fn main() -> Result<(), impl Error> {
                 .enumerate()
                 .position(|(i, q)| {
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 .map(|i| (p, i as u32))
         })
@@ -117,6 +114,9 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
     let queue = queues.next().unwrap();
+
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     let (mut swapchain, images) = {
         let surface_capabilities = device

--- a/examples/triangle-util/Cargo.toml
+++ b/examples/triangle-util/Cargo.toml
@@ -13,7 +13,7 @@ doc = false
 
 [dependencies]
 # The `vulkano` crate is the main crate that you must use to use Vulkan.
-vulkano = { workspace = true, features = ["macros"] }
+vulkano = { workspace = true, default-features = true }
 # Provides the `shader!` macro that is used to generate code for using shaders.
 vulkano-shaders = { workspace = true }
 # Contains the utility functions that make life easier.

--- a/examples/triangle-v1_3/Cargo.toml
+++ b/examples/triangle-v1_3/Cargo.toml
@@ -12,6 +12,6 @@ bench = false
 doc = false
 
 [dependencies]
-vulkano = { workspace = true, features = ["macros"]  }
+vulkano = { workspace = true, default-features = true }
 vulkano-shaders = { workspace = true }
 winit = { workspace = true, default-features = true }

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -80,15 +80,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    // The objective of this example is to draw a triangle on a window. To do so, we first need to
-    // create the window. We use the `WindowBuilder` from the `winit` crate to do that here.
-    //
-    // Before we can render to a window, we must first create a `vulkano::swapchain::Surface`
-    // object from it, which represents the drawable surface of a window. For that we must wrap the
-    // `winit::window::Window` in an `Arc`.
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     // Choose device extensions that we're going to use. In order to present images to a surface,
     // we need a `Swapchain`, which is provided by the `khr_swapchain` extension.
     let mut device_extensions = DeviceExtensions {
@@ -133,7 +124,7 @@ fn main() -> Result<(), impl Error> {
                     // a window surface, as we do in this example, we also need to check that
                     // queues in this queue family are capable of presenting images to the surface.
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 // The code here searches for the first queue family that is suitable. If none is
                 // found, `None` is returned to `filter_map`, which disqualifies this physical
@@ -216,6 +207,15 @@ fn main() -> Result<(), impl Error> {
     // use one queue in this example, so we just retrieve the first and only element of the
     // iterator.
     let queue = queues.next().unwrap();
+
+    // The objective of this example is to draw a triangle on a window. To do so, we first need to
+    // create the window. We use the `WindowBuilder` from the `winit` crate to do that here.
+    //
+    // Before we can render to a window, we must first create a `vulkano::swapchain::Surface`
+    // object from it, which represents the drawable surface of a window. For that we must wrap the
+    // `winit::window::Window` in an `Arc`.
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     // Before we can draw on the surface, we have to create what is called a swapchain. Creating a
     // swapchain allocates the color buffers that will contain the image that will ultimately be

--- a/examples/triangle/Cargo.toml
+++ b/examples/triangle/Cargo.toml
@@ -13,7 +13,7 @@ doc = false
 
 [dependencies]
 # The `vulkano` crate is the main crate that you must use to use Vulkan.
-vulkano = { workspace = true, features = ["macros"] }
+vulkano = { workspace = true, default-features = true }
 # Provides the `shader!` macro that is used to generate code for using shaders.
 vulkano-shaders = { workspace = true }
 # The Vulkan library doesn't provide any functionality to create and handle windows, as

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -75,15 +75,6 @@ fn main() -> Result<(), impl Error> {
     )
     .unwrap();
 
-    // The objective of this example is to draw a triangle on a window. To do so, we first need to
-    // create the window. We use the `WindowBuilder` from the `winit` crate to do that here.
-    //
-    // Before we can render to a window, we must first create a `vulkano::swapchain::Surface`
-    // object from it, which represents the drawable surface of a window. For that we must wrap the
-    // `winit::window::Window` in an `Arc`.
-    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
-    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
-
     // Choose device extensions that we're going to use. In order to present images to a surface,
     // we need a `Swapchain`, which is provided by the `khr_swapchain` extension.
     let device_extensions = DeviceExtensions {
@@ -123,7 +114,7 @@ fn main() -> Result<(), impl Error> {
                     // a window surface, as we do in this example, we also need to check that
                     // queues in this queue family are capable of presenting images to the surface.
                     q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                        && p.surface_support(i as u32, &surface).unwrap_or(false)
+                        && p.presentation_support(i as u32, &event_loop).unwrap()
                 })
                 // The code here searches for the first queue family that is suitable. If none is
                 // found, `None` is returned to `filter_map`, which disqualifies this physical
@@ -186,6 +177,15 @@ fn main() -> Result<(), impl Error> {
     // use one queue in this example, so we just retrieve the first and only element of the
     // iterator.
     let queue = queues.next().unwrap();
+
+    // The objective of this example is to draw a triangle on a window. To do so, we first need to
+    // create the window. We use the `WindowBuilder` from the `winit` crate to do that here.
+    //
+    // Before we can render to a window, we must first create a `vulkano::swapchain::Surface`
+    // object from it, which represents the drawable surface of a window. For that we must wrap the
+    // `winit::window::Window` in an `Arc`.
+    let window = Arc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let surface = Surface::from_window(instance.clone(), window.clone()).unwrap();
 
     // Before we can draw on the surface, we have to create what is called a swapchain. Creating a
     // swapchain allocates the color buffers that will contain the image that will ultimately be

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -34,6 +34,10 @@ vulkano-macros = { workspace = true, optional = true }
 objc = { workspace = true }
 core-graphics-types = { workspace = true }
 
+[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "hurd", target_os = "illumos", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
+x11-dl = { workspace = true, optional = true }
+x11rb = { workspace = true, features = ["allow-unsafe-code"], optional = true }
+
 [build-dependencies]
 ahash = { workspace = true }
 heck = { workspace = true }
@@ -50,9 +54,10 @@ vk-parse = { workspace = true }
 libc = "0.2.153"
 
 [features]
-default = ["macros"]
-macros = ["dep:vulkano-macros"]
+default = ["macros", "x11"]
 document_unchecked = []
+macros = ["dep:vulkano-macros"]
+x11 = ["dep:x11-dl", "dep:x11rb"]
 
 [lints]
 workspace = true

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -93,6 +93,7 @@
 //! | Feature              | Description                                                    |
 //! |----------------------|----------------------------------------------------------------|
 //! | `macros`             | Include reexports from [`vulkano-macros`]. Enabled by default. |
+//! | `x11`                | Support for X11 platforms. Enabled by default.                 |
 //! | `document_unchecked` | Include `_unchecked` functions in the generated documentation. |
 //! | `serde`              | Enables (de)serialization of certain types using [`serde`].    |
 //!


### PR DESCRIPTION
This adds a function that abstracts away the platform-specific presentation support calls akin to `Surface::from_window`, allowing you to determine presentation support to the surface of any window of a given event loop. This addresses two issues:
- There are cases where you don't have a window to test for support with. For instance, ever since winit 0.30 you can only create a surface in the `Resumed` callback, which makes people think that you have to create the whole device in that callback, when that's not the case. This addition is going to make updating to winit 0.30 easier.
- There are cases where you have multiple windows, or you could be creating additional windows at the user's request. This too is impractical with `PhysicalDevice::surface_support`. This also fixes the issues that the multi-window example was having.

`PhysicalDevice::surface_support` is essentially only usable if you have a window since right after the creation of the event loop and when the window exists for the app's lifetime. Therefore, I replaced all `PhysicalDevice::surface_support` calls in the examples with `PhysicalDevice::presentation_support` to promote the better alternative (and for the future when we update to winit 0.30).

Unfortunately, this function was not implementable without adding dependencies for X11 libraries on X11 platforms. I added a default feature same as winit does, so the user can disable the dependencies if they e.g. only support Wayland.

Changelog:
```markdown
### Additions
- Added `PhysicalDevice::presentation_support` for determining presentation support to the surface of any window of a given event loop.
```
