### PR TITLE
Add support for `khr_fragment_shading_rate`

### DIFF
--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -19,6 +19,7 @@ use crate::{
         graphics::{
             color_blend::LogicOp,
             depth_stencil::{CompareOp, StencilOps},
+            fragment_shading_rate::FragmentShadingRateState,
             input_assembly::PrimitiveTopology,
             rasterization::{
                 ConservativeRasterizationMode, CullMode, DepthBiasState, FrontFace, LineStipple,
@@ -1212,6 +1213,7 @@ pub(in crate::command_buffer) struct CommandBufferBuilderState {
     pub(in crate::command_buffer) conservative_rasterization_mode:
         Option<ConservativeRasterizationMode>,
     pub(in crate::command_buffer) extra_primitive_overestimation_size: Option<f32>,
+    pub(in crate::command_buffer) fragment_shading_rate: Option<FragmentShadingRateState>,
 
     // Active queries
     pub(in crate::command_buffer) queries: HashMap<QueryType, QueryState>,
@@ -1243,7 +1245,7 @@ impl CommandBufferBuilderState {
                 DynamicState::DepthWriteEnable => self.depth_write_enable = None,
                 DynamicState::DiscardRectangle => self.discard_rectangle.clear(),
                 // DynamicState::ExclusiveScissor => todo!(),
-                // DynamicState::FragmentShadingRate => todo!(),
+                DynamicState::FragmentShadingRate => self.fragment_shading_rate = None,
                 DynamicState::FrontFace => self.front_face = None,
                 DynamicState::LineStipple => self.line_stipple = None,
                 DynamicState::LineWidth => self.line_width = None,

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -5,6 +5,7 @@ use crate::{
         graphics::{
             color_blend::LogicOp,
             depth_stencil::{CompareOp, StencilFaces, StencilOp, StencilOps},
+            fragment_shading_rate::{FragmentShadingRateCombinerOp, FragmentShadingRateState},
             input_assembly::PrimitiveTopology,
             rasterization::{
                 ConservativeRasterizationMode, CullMode, DepthBiasState, FrontFace, LineStipple,
@@ -1275,6 +1276,49 @@ impl RecordingCommandBuffer {
                 out.set_extra_primitive_overestimation_size_unchecked(
                     extra_primitive_overestimation_size,
                 );
+            },
+        );
+
+        self
+    }
+
+    /// Sets the dynamic fragment shading rate for future draw calls.
+    #[inline]
+    pub fn set_fragment_shading_rate(
+        &mut self,
+        fragment_size: [u32; 2],
+        combiner_ops: [FragmentShadingRateCombinerOp; 2],
+    ) -> Result<&mut Self, Box<ValidationError>> {
+        self.validate_set_fragment_shading_rate()?;
+
+        unsafe { Ok(self.set_fragment_shading_rate_unchecked(fragment_size, combiner_ops)) }
+    }
+
+    fn validate_set_fragment_shading_rate(&self) -> Result<(), Box<ValidationError>> {
+        // self.inner.validate_set_conservative_rasterization_mode()?;
+
+        self.validate_graphics_pipeline_fixed_state(DynamicState::FragmentShadingRate)?;
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_fragment_shading_rate_unchecked(
+        &mut self,
+        fragment_size: [u32; 2],
+        combiner_ops: [FragmentShadingRateCombinerOp; 2],
+    ) -> &mut Self {
+        self.builder_state.fragment_shading_rate = Some(FragmentShadingRateState {
+            fragment_size,
+            combiner_ops,
+            ..FragmentShadingRateState::default()
+        });
+
+        self.add_command(
+            "set_fragment_shading_rate",
+            Default::default(),
+            move |out: &mut RawRecordingCommandBuffer| {
+                out.set_fragment_shading_rate_unchecked(fragment_size, combiner_ops);
             },
         );
 
@@ -3377,6 +3421,31 @@ impl RawRecordingCommandBuffer {
             .cmd_set_extra_primitive_overestimation_size_ext)(
             self.handle(),
             extra_primitive_overestimation_size,
+        );
+
+        self
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn set_fragment_shading_rate_unchecked(
+        &mut self,
+        fragment_size: [u32; 2],
+        combiner_ops: [FragmentShadingRateCombinerOp; 2],
+    ) -> &mut Self {
+        let fns = self.device().fns();
+
+        let fragment_size = ash::vk::Extent2D {
+            width: fragment_size[0],
+            height: fragment_size[1],
+        };
+        let combiner_ops: [ash::vk::FragmentShadingRateCombinerOpKHR; 2] =
+            [combiner_ops[0].into(), combiner_ops[1].into()];
+
+        (fns.khr_fragment_shading_rate
+            .cmd_set_fragment_shading_rate_khr)(
+            self.handle(),
+            &fragment_size,
+            combiner_ops.as_ptr().cast(),
         );
 
         self

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -2633,7 +2633,25 @@ impl RecordingCommandBuffer {
                     }
                 }
                 // DynamicState::ExclusiveScissor => todo!(),
-                // DynamicState::FragmentShadingRate => todo!(),
+                DynamicState::FragmentShadingRate => {
+                    if self.builder_state.fragment_shading_rate.is_none() {
+                        return Err(Box::new(ValidationError {
+                            problem: format!(
+                                "the currently bound graphics pipeline requires the \
+                                `DynamicState::{:?}` dynamic state, but \
+                                this state was either not set, or it was overwritten by a \
+                                more recent `bind_pipeline_graphics` command",
+                                dynamic_state
+                            )
+                            .into(),
+                            vuids: vuids!(
+                                vuid_type,
+                                "VUID-vkCmdDrawIndexed-pipelineFragmentShadingRate-09238"
+                            ),
+                            ..Default::default()
+                        }));
+                    }
+                }
                 DynamicState::FrontFace => {
                     if self.builder_state.front_face.is_none() {
                         return Err(Box::new(ValidationError {

--- a/vulkano/src/pipeline/graphics/fragment_shading_rate.rs
+++ b/vulkano/src/pipeline/graphics/fragment_shading_rate.rs
@@ -1,0 +1,201 @@
+use crate::{device::Device, macros::vulkan_enum, ValidationError};
+use ash::vk;
+
+/// The state in a graphics pipeline describing the fragment shading rate.
+#[derive(Clone, Debug)]
+pub struct FragmentShadingRateState {
+    /// The pipeline fragment shading rate.
+    ///
+    /// The default value is `[1, 1]`.
+    pub fragment_size: [u32; 2],
+
+    /// Determines how the pipeline, primitive, and attachment shading rates are combined for
+    /// fragments generated.
+    ///
+    /// The default value is `[FragmentShadingRateCombinerOp::Keep; 2]`.
+    pub combiner_ops: [FragmentShadingRateCombinerOp; 2],
+
+    pub _ne: crate::NonExhaustive,
+}
+
+impl Default for FragmentShadingRateState {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            fragment_size: [1, 1],
+            combiner_ops: [FragmentShadingRateCombinerOp::Keep; 2],
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+}
+
+impl FragmentShadingRateState {
+    pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
+        let &Self {
+            fragment_size,
+            combiner_ops,
+            _ne: _,
+        } = self;
+
+        let properties = device.physical_device().properties();
+        let features = device.enabled_features();
+
+        if fragment_size[0] == 0 {
+            return Err(Box::new(ValidationError {
+                context: "fragment_size[0]".into(),
+                problem: "fragment_size[0] must be greater than or equal to 1".into(),
+                vuids: &["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04494"],
+                ..Default::default()
+            }));
+        }
+
+        if fragment_size[1] == 0 {
+            return Err(Box::new(ValidationError {
+                context: "fragment_size[1]".into(),
+                problem: "fragment_size[1] must be greater than or equal to 1".into(),
+                vuids: &["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04495"],
+                ..Default::default()
+            }));
+        }
+
+        if !fragment_size[0].is_power_of_two() {
+            return Err(Box::new(ValidationError {
+                context: "fragment_size[0]".into(),
+                problem: "fragment_size[0] must be a power of two".into(),
+                vuids: &["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04496"],
+                ..Default::default()
+            }));
+        }
+
+        if !fragment_size[1].is_power_of_two() {
+            return Err(Box::new(ValidationError {
+                context: "fragment_size[1]".into(),
+                problem: "fragment_size[1] must be a power of two".into(),
+                vuids: &["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04497"],
+                ..Default::default()
+            }));
+        }
+
+        if fragment_size[0] > 4 {
+            return Err(Box::new(ValidationError {
+                context: "fragment_size[0]".into(),
+                problem: "fragment_size[0] must be less than or equal to 4".into(),
+                vuids: &["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04498"],
+                ..Default::default()
+            }));
+        }
+
+        if fragment_size[1] > 4 {
+            return Err(Box::new(ValidationError {
+                context: "fragment_size[1]".into(),
+                problem: "fragment_size[1] must be less than or equal to 4".into(),
+                vuids: &["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04499"],
+                ..Default::default()
+            }));
+        }
+
+        if !features.pipeline_fragment_shading_rate {
+            return Err(Box::new(ValidationError {
+                context: "features.pipeline_fragment_shading_rate".into(),
+                problem: "the pipeline_fragment_shading_rate feature must be enabled".into(),
+                vuids: &["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04500"],
+                ..Default::default()
+            }));
+        }
+
+        combiner_ops[0].validate_device(device).map_err(|err| {
+            err.add_context("combiner_ops[0]")
+                .set_vuids(&["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-06567"])
+        })?;
+        combiner_ops[1].validate_device(device).map_err(|err| {
+            err.add_context("combiner_ops[1]")
+                .set_vuids(&["VUID-VkGraphicsPipelineCreateInfo-pDynamicState-06568"])
+        })?;
+
+        if !features.primitive_fragment_shading_rate
+            && combiner_ops[0] != FragmentShadingRateCombinerOp::Keep
+        {
+            return Err(Box::new(ValidationError {
+                context: "combiner_ops[0]".into(),
+                problem: "the primitive_fragment_shading_rate feature must be enabled if combiner_ops[0] is not Keep".into(),
+                vuids: &[
+                    "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04501",
+                ],
+                ..Default::default()
+            }));
+        }
+
+        if !features.attachment_fragment_shading_rate
+            && combiner_ops[1] != FragmentShadingRateCombinerOp::Keep
+        {
+            return Err(Box::new(ValidationError {
+                context: "combiner_ops[1]".into(),
+                problem: "the attachment_fragment_shading_rate feature must be enabled if combiner_ops[1] is not Keep".into(),
+                vuids: &[
+                    "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04502",
+                ],
+                ..Default::default()
+            }));
+        }
+
+        if !properties.fragment_shading_rate_non_trivial_combiner_ops.unwrap() && // TODO: Is this unwrap OK?
+        (
+            !(combiner_ops[0] == FragmentShadingRateCombinerOp::Keep || combiner_ops[0] == FragmentShadingRateCombinerOp::Replace) ||
+            !(combiner_ops[1] == FragmentShadingRateCombinerOp::Keep || combiner_ops[1] == FragmentShadingRateCombinerOp::Replace)
+        ) {
+            return Err(Box::new(ValidationError {
+                context: "combiner_ops[0]".into(),
+                problem: "the fragment_shading_rate_non_trivial_combiner_ops feature must be enabled if combiner_ops[0] or combiner_ops[1] is not Keep or Replace".into(),
+                vuids: &[
+                    "VUID-VkGraphicsPipelineCreateInfo-fragmentShadingRateNonTrivialCombinerOps-04506",
+                ],
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn to_vk<'a>(&self) -> ash::vk::PipelineFragmentShadingRateStateCreateInfoKHR<'a> {
+        let fragment_size = vk::Extent2D {
+            width: self.fragment_size[0],
+            height: self.fragment_size[1],
+        };
+        let combiner_ops: [ash::vk::FragmentShadingRateCombinerOpKHR; 2] =
+            [self.combiner_ops[0].into(), self.combiner_ops[1].into()];
+
+        ash::vk::PipelineFragmentShadingRateStateCreateInfoKHR::default()
+            .fragment_size(fragment_size)
+            .combiner_ops(combiner_ops)
+    }
+}
+
+vulkan_enum! {
+    #[non_exhaustive]
+
+    /// Control how fragment shading rates are combined.
+    FragmentShadingRateCombinerOp = FragmentShadingRateCombinerOpKHR(i32);
+
+    /// Specifies a combiner operation of combine(Axy,Bxy) = Axy.
+    Keep = KEEP,
+
+    /// Specifies a combiner operation of combine(Axy,Bxy) = Bxy.
+    Replace = REPLACE,
+
+    /// Specifies a combiner operation of combine(Axy,Bxy) = min(Axy,Bxy).
+    Min = MIN,
+
+    /// Specifies a combiner operation of combine(Axy,Bxy) = max(Axy,Bxy).
+    Max = MAX,
+
+    /// Specifies a combiner operation of combine(Axy,Bxy) = Axy * Bxy.
+    ///
+    /// See the vulkan specification for more information on how this operation is performed if `fragmentShadingRateStrictMultiplyCombiner` is `false`.
+    Mul = MUL,
+}
+
+impl Default for FragmentShadingRateCombinerOp {
+    fn default() -> Self {
+        Self::Keep
+    }
+}

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -588,12 +588,15 @@ vulkan_enum! {
         RequiresAllOf([DeviceExtension(nv_scissor_exclusive)]),
     ]), */
 
-    /* TODO: enable
-    // TODO: document
+    /// The value of
+    /// [`FragmentShadingRateState`](crate::pipeline::graphics::fragment_shading_rate::FragmentShadingRateState).
+    ///
+    /// Set with
+    /// [`set_fragment_shading_rate`](crate::command_buffer::RecordingCommandBuffer::set_fragment_shading_rate).
     FragmentShadingRate = FRAGMENT_SHADING_RATE_KHR
     RequiresOneOf([
         RequiresAllOf([DeviceExtension(khr_fragment_shading_rate)]),
-    ]), */
+    ]),
 
     /// The value of
     /// [`RasterizationState::line_stipple`](crate::pipeline::graphics::rasterization::RasterizationState::line_stipple).


### PR DESCRIPTION
This is a work in progress for supporting the `khr_fragment_shading_rate` extension.

This is my first potential contribution to `vulkano`. I'd appreciate feedback before I proceed any further. Thanks!

TODO:
- [x] `FragmentShadingRateState` for `GraphicsPipeline`
- [x] `DynamicState::FragmentShadingRate` and `set_fragment_shading_rate`
- [ ] Per-region support `VkFragmentShadingRateAttachmentInfoKHR`
- [ ] Combine parameters for `set_fragment_shading_rate`  as `FragmentShadingRateStateDynamic`?
- [ ] taskgraph support?

Changelog:
```markdown
### Additions
- Support for the `khr_fragment_shading_rate` extension.
```
