### PR TITLE
Fix SPIR-V validation of image ops with offsets

### DIFF
--- a/vulkano/src/pipeline/shader/validate_runtime.rs
+++ b/vulkano/src/pipeline/shader/validate_runtime.rs
@@ -6,8 +6,9 @@ use crate::{
     },
     shader::{
         reflect::{
-            get_constant, get_constant_composite, get_constant_composite_composite,
-            get_constant_float_composite, get_constant_maybe_composite, size_of_type,
+            get_constant, get_constant_composite, get_constant_float_composite,
+            get_constant_signed_composite_composite, get_constant_signed_maybe_composite,
+            size_of_type,
         },
         spirv::{
             Capability, Decoration, Dim, ExecutionMode, ExecutionModel, FunctionInfo, Id,
@@ -2468,7 +2469,7 @@ impl<'a> RuntimeValidator<'a> {
                     if let Some(components) = image_operands
                         .const_offset
                         .or(image_operands.offset)
-                        .and_then(|offset| get_constant_maybe_composite(self.spirv, offset))
+                        .and_then(|offset| get_constant_signed_maybe_composite(self.spirv, offset))
                     {
                         for offset in components {
                             if offset < properties.min_texel_gather_offset as i64 {
@@ -2497,7 +2498,7 @@ impl<'a> RuntimeValidator<'a> {
                         }
                     } else if let Some(elements) = image_operands
                         .const_offsets
-                        .and_then(|id| get_constant_composite_composite(self.spirv, id))
+                        .and_then(|id| get_constant_signed_composite_composite(self.spirv, id))
                     {
                         for components in elements {
                             for offset in components {
@@ -2534,7 +2535,7 @@ impl<'a> RuntimeValidator<'a> {
                 if let Some(image_operands) = instruction.image_operands() {
                     if let Some(components) = image_operands
                         .const_offset
-                        .and_then(|offset| get_constant_maybe_composite(self.spirv, offset))
+                        .and_then(|offset| get_constant_signed_maybe_composite(self.spirv, offset))
                     {
                         for offset in components {
                             if offset < properties.min_texel_offset as i64 {

--- a/vulkano/src/shader/reflect.rs
+++ b/vulkano/src/shader/reflect.rs
@@ -1242,7 +1242,10 @@ fn integer_constant_to_i64(spirv: &Spirv, value: &[u32], result_type_id: Id) -> 
     }
 }
 
-pub(crate) fn get_constant_maybe_composite(spirv: &Spirv, id: Id) -> Option<SmallVec<[i64; 4]>> {
+pub(crate) fn get_constant_signed_maybe_composite(
+    spirv: &Spirv,
+    id: Id,
+) -> Option<SmallVec<[i64; 4]>> {
     match spirv.id(id).instruction() {
         Instruction::Constant {
             value,
@@ -1270,7 +1273,7 @@ pub(crate) fn get_constant_maybe_composite(spirv: &Spirv, id: Id) -> Option<Smal
     }
 }
 
-pub(crate) fn get_constant_composite_composite(
+pub(crate) fn get_constant_signed_composite_composite(
     spirv: &Spirv,
     id: Id,
 ) -> Option<SmallVec<[SmallVec<[i64; 4]>; 4]>> {


### PR DESCRIPTION
Shader functions like `textureLodOffset` would incorrectly fail validation.

Checks like this would always evaluate to true (and fail validation) because the property wraps:
https://github.com/vulkano-rs/vulkano/blob/a2704689603bd614186edd17c73779fd1f401548/vulkano/src/pipeline/shader/validate_runtime.rs#L2540

Changelog:
```markdown
### Bugs fixed
- Fix SPIR-V validation of image ops with offsets
```
