### PR TITLE
Fix broken doc links

### DIFF
--- a/vulkano/src/memory/allocator/suballocator/buddy.rs
+++ b/vulkano/src/memory/allocator/suballocator/buddy.rs
@@ -55,8 +55,10 @@ use std::cmp;
 /// [suballocator]: Suballocator
 /// [internal fragmentation]: super#internal-fragmentation
 /// [external fragmentation]: super#external-fragmentation
+/// [`FreeListAllocator`]: super::FreeListAllocator
 /// [the `Suballocator` implementation]: Suballocator#impl-Suballocator-for-Arc<BuddyAllocator>
 /// [region]: Suballocator#regions
+/// [`BumpAllocator`]: super::BumpAllocator
 #[derive(Debug)]
 pub struct BuddyAllocator {
     region_offset: DeviceSize,

--- a/vulkano/src/memory/allocator/suballocator/bump.rs
+++ b/vulkano/src/memory/allocator/suballocator/bump.rs
@@ -45,6 +45,7 @@ use std::iter::FusedIterator;
 /// Allocation is *O*(1), and so is resetting the allocator (freeing all allocations).
 ///
 /// [suballocator]: Suballocator
+/// [`FreeListAllocator`]: super::FreeListAllocator
 /// [the `Suballocator` implementation]: Suballocator#impl-Suballocator-for-Arc<BumpAllocator>
 /// [region]: Suballocator#regions
 /// [free-list]: Suballocator#free-lists

--- a/vulkano/src/memory/allocator/suballocator/free_list.rs
+++ b/vulkano/src/memory/allocator/suballocator/free_list.rs
@@ -55,6 +55,8 @@ use std::{cmp, iter::FusedIterator, marker::PhantomData, ptr::NonNull};
 /// [suballocator]: Suballocator
 /// [free-list]: Suballocator#free-lists
 /// [external fragmentation]: super#external-fragmentation
+/// [`BuddyAllocator`]: super::BuddyAllocator
+/// [`BumpAllocator`]: super::BumpAllocator
 /// [the `Suballocator` implementation]: Suballocator#impl-Suballocator-for-Arc<FreeListAllocator>
 /// [internal fragmentation]: super#internal-fragmentation
 /// [alignment requirements]: super#alignment

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -153,6 +153,8 @@ impl ResourceMemory {
     ///
     /// - Two resources must not alias each other, and if they do, you must ensure correct
     ///   synchronization yourself.
+    ///
+    /// [`new_dedicated`]: Self::new_dedicated
     pub unsafe fn new_dedicated_unchecked(device_memory: Arc<DeviceMemory>) -> Self {
         let size = device_memory.allocation_size();
 
@@ -166,9 +168,9 @@ impl ResourceMemory {
     ///
     /// # Safety
     ///
-    /// - Two resources must not alias each other (as returned by [`Buffer::memory_requirements`]
-    ///   or [`Image::memory_requirements`]), and if they do, you must ensure correct
-    ///   synchronization yourself.
+    /// - Two resources must not alias each other (as returned by
+    ///   [`RawBuffer::memory_requirements`] or [`RawImage::memory_requirements`]), and if they do,
+    ///   you must ensure correct synchronization yourself.
     ///
     /// # Panics
     ///

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -731,7 +731,7 @@ vulkan_enum! {
     ]), */
 
     /// The value of
-    /// [`ConservativeRasterizationState::mode`](crate::pipeline::graphics::conservative_rasterization::ConservativeRasterizationState::mode)
+    /// [`ConservativeRasterizationState::mode`](crate::pipeline::graphics::rasterization::RasterizationConservativeState::mode)
     ///
     /// Set with
     /// [`set_conservative_rasterization_mode`](crate::command_buffer::RecordingCommandBuffer::set_conservative_rasterization_mode).
@@ -741,7 +741,7 @@ vulkan_enum! {
     ]),
 
     /// The value of
-    /// [`ConservativeRasterizationState::overestimation_size`](crate::pipeline::graphics::conservative_rasterization::ConservativeRasterizationState::overestimation_size)
+    /// [`ConservativeRasterizationState::overestimation_size`](crate::pipeline::graphics::rasterization::RasterizationConservativeState::overestimation_size)
     ///
     /// Set with
     /// [`set_extra_primitive_overestimation_size`](crate::command_buffer::RecordingCommandBuffer::set_extra_primitive_overestimation_size).

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -296,7 +296,7 @@ impl QueryPool {
     /// - There must be no calls to `reset*` or `get_results*` executing concurrently on another
     ///   thread.
     ///
-    /// [`host_query_reset`]: Features::host_query_reset
+    /// [`host_query_reset`]: crate::device::DeviceFeatures::host_query_reset
     #[inline]
     pub unsafe fn reset(&self, range: Range<u32>) -> Result<(), Box<ValidationError>> {
         self.validate_reset(range.clone())?;

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -224,7 +224,7 @@
 //! ## Mesh shading
 //!
 //! - If the shader declares the `OutputPoints` execution mode with a value greater than 0, and the
-//!   [`maintenance5`](Features::maintenance5) feature is not enabled on the device, then the
+//!   [`maintenance5`](DeviceFeatures::maintenance5) feature is not enabled on the device, then the
 //!   shader must write to a variable decorated with `PointSize` for each output point.
 //!   <sup>[\[09218\]]</sup>
 //!


### PR DESCRIPTION
There's one more broken link:
```ansi
warning: unresolved link to `Format::A8_UNORM`
   --> vulkano/src/shader/mod.rs:167:26
    |
167 | //!   view's format is [`Format::A8_UNORM`], then the type of the `Texel` operand must have four
    |                          ^^^^^^^^^^^^^^^^ the enum `Format` has no variant or associated item named `A8_UNORM`
```
It seems to me like the intention was for the format to generate as `A8_UNORM`, whereas it generates as `A8_UNORM_KHR`.