### PR TITLE
Fix 2583.

### DIFF
--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -352,8 +352,9 @@ impl ApplicationHandler for App {
                 // Begin rendering by acquiring the gpu future from the window renderer.
                 let previous_frame_end = window_renderer
                     .acquire(Some(Duration::from_millis(1000)), |swapchain_images| {
-                        // Whenever the swapchain gets recreated, we need to recreate everything dependent upon it.
-                        // In this example, that is only the framebuffers.
+                        // Whenever the swapchain gets recreated, we need to recreate everything
+                        // dependent upon it. In this example, that is only
+                        // the framebuffers.
                         rcx.framebuffers =
                             window_size_dependent_setup(swapchain_images, &rcx.render_pass);
                     })
@@ -403,10 +404,15 @@ impl ApplicationHandler for App {
                     // We are now inside the first subpass of the render pass.
                     //
                     // TODO: Document state setting and how it affects subsequent draw commands.
-                    .set_viewport(0, [Viewport {
-                        extent: window_size.into(),
-                        ..Default::default()
-                    }].into_iter().collect())
+                    .set_viewport(
+                        0,
+                        [Viewport {
+                            extent: window_size.into(),
+                            ..Default::default()
+                        }]
+                        .into_iter()
+                        .collect(),
+                    )
                     .unwrap()
                     .bind_pipeline_graphics(rcx.pipeline.clone())
                     .unwrap()

--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -62,7 +62,6 @@ struct RenderContext {
     render_pass: Arc<RenderPass>,
     framebuffers: Vec<Arc<Framebuffer>>,
     pipeline: Arc<GraphicsPipeline>,
-    viewport: Viewport,
 }
 
 impl App {
@@ -133,7 +132,6 @@ impl ApplicationHandler for App {
         self.windows
             .create_window(event_loop, &self.context, &Default::default(), |_| {});
         let window_renderer = self.windows.get_primary_renderer_mut().unwrap();
-        let window_size = window_renderer.window().inner_size();
 
         // The next step is to create the shaders.
         //
@@ -315,14 +313,6 @@ impl ApplicationHandler for App {
             .unwrap()
         };
 
-        // Dynamic viewports allow us to recreate just the viewport when the window is resized.
-        // Otherwise we would have to recreate the whole pipeline.
-        let viewport = Viewport {
-            offset: [0.0, 0.0],
-            extent: window_size.into(),
-            depth_range: 0.0..=1.0,
-        };
-
         // In the `window_event` handler below we are going to submit commands to the GPU.
         // Submitting a command produces an object that implements the `GpuFuture` trait, which
         // holds the resources for as long as they are in use by the GPU.
@@ -331,7 +321,6 @@ impl ApplicationHandler for App {
             render_pass,
             framebuffers,
             pipeline,
-            viewport,
         });
     }
 
@@ -363,10 +352,8 @@ impl ApplicationHandler for App {
                 // Begin rendering by acquiring the gpu future from the window renderer.
                 let previous_frame_end = window_renderer
                     .acquire(Some(Duration::from_millis(1000)), |swapchain_images| {
-                        // Whenever the window resizes we need to recreate everything dependent
-                        // on the window size. In this example that
-                        // includes the swapchain, the framebuffers
-                        // and the dynamic state viewport.
+                        // Whenever the swapchain gets recreated, we need to recreate everything dependent upon it.
+                        // In this example, that is only the framebuffers.
                         rcx.framebuffers =
                             window_size_dependent_setup(swapchain_images, &rcx.render_pass);
                     })
@@ -416,7 +403,10 @@ impl ApplicationHandler for App {
                     // We are now inside the first subpass of the render pass.
                     //
                     // TODO: Document state setting and how it affects subsequent draw commands.
-                    .set_viewport(0, [rcx.viewport.clone()].into_iter().collect())
+                    .set_viewport(0, [Viewport {
+                        extent: window_size.into(),
+                        ..Default::default()
+                    }].into_iter().collect())
                     .unwrap()
                     .bind_pipeline_graphics(rcx.pipeline.clone())
                     .unwrap()

--- a/vulkano/src/pipeline/graphics/viewport.rs
+++ b/vulkano/src/pipeline/graphics/viewport.rs
@@ -281,8 +281,7 @@ pub struct Viewport {
 
     /// Dimensions in pixels of the viewport.
     ///
-    /// The default value is `[1.0; 2]`, which you probably want to override if you are not
-    /// using dynamic state.
+    /// The default value is `[1.0; 2]`, which you probably want to override.
     pub extent: [f32; 2],
 
     /// Minimum and maximum values of the depth.


### PR DESCRIPTION
Fixes [2583](https://github.com/vulkano-rs/vulkano/issues/2583). It seems that triangle-util is the only example that fell into this trap, but there are a lot of examples, so I can't say for certain.
