### PR TITLE
Fix panic in `BufferContents` derive expansion and wrong safety docs

### DIFF
--- a/vulkano-macros/src/derive_buffer_contents.rs
+++ b/vulkano-macros/src/derive_buffer_contents.rs
@@ -95,8 +95,6 @@ pub fn derive_buffer_contents(crate_ident: &Ident, mut ast: DeriveInput) -> Resu
             };
 
             ptr_from_slice = quote! {
-                debug_assert_eq!(slice.len(), ::std::mem::size_of::<Self>());
-
                 <*mut [u8]>::cast::<Self>(slice.as_ptr())
             };
         }

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -839,9 +839,7 @@ pub unsafe trait BufferContents: Send + Sync + 'static {
     ///
     /// # Safety
     ///
-    /// - If `Self` is sized, then `slice.len()` must match the size exactly.
-    /// - If `Self` is unsized, then `slice.len()` minus the size of the head (sized part) of the
-    ///   DST must be evenly divisible by the size of the element type.
+    /// - `slice` must be a pointer that's valid for reads and writes of the entire slice.
     #[doc(hidden)]
     unsafe fn ptr_from_slice(slice: NonNull<[u8]>) -> *mut Self;
 }
@@ -854,8 +852,6 @@ where
 
     #[inline(always)]
     unsafe fn ptr_from_slice(slice: NonNull<[u8]>) -> *mut Self {
-        debug_assert_eq!(slice.len(), size_of::<T>());
-
         <*mut [u8]>::cast::<T>(slice.as_ptr())
     }
 }

--- a/vulkano/src/padded.rs
+++ b/vulkano/src/padded.rs
@@ -8,7 +8,7 @@ use std::{
     cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
-    mem::{size_of, MaybeUninit},
+    mem::MaybeUninit,
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
@@ -290,8 +290,6 @@ where
     const LAYOUT: BufferContentsLayout = BufferContentsLayout::from_sized(Layout::new::<Self>());
 
     unsafe fn ptr_from_slice(slice: NonNull<[u8]>) -> *mut Self {
-        debug_assert_eq!(slice.len(), size_of::<Padded<T, N>>());
-
         <*mut [u8]>::cast::<Padded<T, N>>(slice.as_ptr())
     }
 }


### PR DESCRIPTION
This debug assert was checking a safety precondition that's too strong, while at the same time the documented safety preconditions were too weak (the pointer must have valid provenance since #2563).