### PR TITLE
Clean up `BufferContents` derive macro expansion further

### DIFF
--- a/vulkano-macros/src/derive_buffer_contents.rs
+++ b/vulkano-macros/src/derive_buffer_contents.rs
@@ -167,16 +167,10 @@ pub fn derive_buffer_contents(crate_ident: &Ident, mut ast: DeriveInput) -> Resu
 
     let bounds = bound_types.into_iter().map(|ty| {
         quote_spanned! { ty.span() =>
-            const _: () = {
-                // HACK: This works around Rust issue #48214, which makes it impossible to put
-                // these bounds in the where clause of the trait implementation where they actually
-                // belong until that is resolved.
-                #[allow(unused)]
-                fn bound #impl_generics () #where_clause {
-                    fn assert_impl<T: ::#crate_ident::buffer::BufferContents + ?Sized>() {}
-                    assert_impl::<#ty>();
-                }
-            };
+            // HACK: This works around Rust issue #48214, which makes it impossible to put these
+            // bounds in the where clause of the trait implementation where they actually belong
+            // until that is resolved.
+            let _: ::vulkano::buffer::AssertParamIsBufferContents<#ty>;
         }
     });
 
@@ -189,11 +183,11 @@ pub fn derive_buffer_contents(crate_ident: &Ident, mut ast: DeriveInput) -> Resu
 
             #[inline(always)]
             unsafe fn ptr_from_slice(slice: ::std::ptr::NonNull<[u8]>) -> *mut Self {
+                #( #bounds )*
+
                 #ptr_from_slice
             }
         }
-
-        #( #bounds )*
     })
 }
 

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -92,6 +92,7 @@ use std::{
     error::Error,
     fmt::{Display, Formatter},
     hash::{Hash, Hasher},
+    marker::PhantomData,
     ops::Range,
     sync::Arc,
 };
@@ -1066,3 +1067,7 @@ impl From<Subbuffer<[u32]>> for IndexBuffer {
         Self::U32(value)
     }
 }
+
+/// This is intended for use by the `BufferContents` derive macro only.
+#[doc(hidden)]
+pub struct AssertParamIsBufferContents<T: BufferContents + ?Sized>(PhantomData<T>);


### PR DESCRIPTION
This is taking inspiration from Rust's expansion of `derive(Clone, Copy)`, where each bound only takes up one line (instead of the 7 we had before), making it easier to look at the expansion.