### PR TITLE
Ignore `vk.xml` and `spirv.core.grammar.json` from editor search results

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+vulkano/spirv.core.grammar.json
+vulkano/vk.xml


### PR DESCRIPTION
Having these files be searched when one is doing a project-wide search is rather counter-productive. This fixes that for any editor that uses ripgrep e.g. vscode, Helix and Neovim with the Telescope plugin.