### PR TITLE
Minimise `unsafe` block size, in examples

### DIFF
--- a/examples/basic-compute-shader/main.rs
+++ b/examples/basic-compute-shader/main.rs
@@ -217,11 +217,9 @@ fn main() {
         )
         .unwrap();
 
-    unsafe {
-        // The command buffer only does one thing: execute the compute pipeline. This is called a
-        // *dispatch* operation.
-        builder.dispatch([1024, 1, 1]).unwrap();
-    }
+    // The command buffer only does one thing: execute the compute pipeline. This is called a
+    // *dispatch* operation.
+    unsafe { builder.dispatch([1024, 1, 1]) }.unwrap();
 
     // Finish building the command buffer by calling `build`.
     let command_buffer = builder.build().unwrap();

--- a/examples/buffer-allocator/main.rs
+++ b/examples/buffer-allocator/main.rs
@@ -445,9 +445,7 @@ impl ApplicationHandler for App {
                     .bind_vertex_buffers(0, buffer)
                     .unwrap();
 
-                unsafe {
-                    builder.draw(num_vertices, 1, 0, 0).unwrap();
-                }
+                unsafe { builder.draw(num_vertices, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/debug/main.rs
+++ b/examples/debug/main.rs
@@ -113,8 +113,8 @@ fn main() {
                 ))
             },
         )
-        .ok()
-    };
+    }
+    .ok();
 
     // Create Vulkan objects in the same way as the other examples.
     let device_extensions = DeviceExtensions {

--- a/examples/deferred/frame/ambient_lighting_system.rs
+++ b/examples/deferred/frame/ambient_lighting_system.rs
@@ -204,12 +204,7 @@ impl AmbientLightingSystem {
             .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
             .unwrap();
-
-        unsafe {
-            builder
-                .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                .unwrap();
-        }
+        unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
         builder.build().unwrap()
     }

--- a/examples/deferred/frame/directional_lighting_system.rs
+++ b/examples/deferred/frame/directional_lighting_system.rs
@@ -218,12 +218,7 @@ impl DirectionalLightingSystem {
             .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
             .unwrap();
-
-        unsafe {
-            builder
-                .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                .unwrap();
-        }
+        unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
         builder.build().unwrap()
     }

--- a/examples/deferred/frame/point_lighting_system.rs
+++ b/examples/deferred/frame/point_lighting_system.rs
@@ -231,12 +231,7 @@ impl PointLightingSystem {
             .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
             .unwrap();
-
-        unsafe {
-            builder
-                .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                .unwrap();
-        }
+        unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
         builder.build().unwrap()
     }

--- a/examples/deferred/triangle_draw_system.rs
+++ b/examples/deferred/triangle_draw_system.rs
@@ -153,12 +153,7 @@ impl TriangleDrawSystem {
             .unwrap()
             .bind_vertex_buffers(0, self.vertex_buffer.clone())
             .unwrap();
-
-        unsafe {
-            builder
-                .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                .unwrap();
-        }
+        unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
         builder.build().unwrap()
     }

--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -255,10 +255,7 @@ fn main() {
                 set.clone().offsets([index * align as u32]),
             )
             .unwrap();
-
-        unsafe {
-            builder.dispatch([12, 1, 1]).unwrap();
-        }
+        unsafe { builder.dispatch([12, 1, 1]) }.unwrap();
     }
 
     let command_buffer = builder.build().unwrap();

--- a/examples/dynamic-local-size/main.rs
+++ b/examples/dynamic-local-size/main.rs
@@ -267,12 +267,8 @@ fn main() {
         )
         .unwrap();
 
-    unsafe {
-        // Note that dispatch dimensions must be proportional to the local size.
-        builder
-            .dispatch([1024 / local_size_x, 1024 / local_size_y, 1])
-            .unwrap();
-    }
+    // Note that dispatch dimensions must be proportional to the local size.
+    unsafe { builder.dispatch([1024 / local_size_x, 1024 / local_size_y, 1]) }.unwrap();
 
     builder
         .copy_image_to_buffer(CopyImageToBufferInfo::image_buffer(image, buf.clone()))

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -178,8 +178,8 @@ mod linux {
                         },
                     )),
                 )
-                .unwrap()
-            };
+            }
+            .unwrap();
 
             let device_extensions = DeviceExtensions {
                 khr_external_semaphore: true,
@@ -326,12 +326,11 @@ mod linux {
                 .unwrap();
 
             // SAFETY: we just created this raw image and hasn't bound any memory to it.
-            let image = Arc::new(unsafe {
-                raw_image
-                    .bind_memory([ResourceMemory::new_dedicated(image_memory)])
+            let image = Arc::new(
+                unsafe { raw_image.bind_memory([ResourceMemory::new_dedicated(image_memory)]) }
                     .map_err(|(err, _, _)| err)
-                    .unwrap()
-            });
+                    .unwrap(),
+            );
 
             let image_view = ImageView::new_default(image).unwrap();
 
@@ -370,16 +369,10 @@ mod linux {
                 .unwrap(),
             );
 
-            let acquire_fd = unsafe {
-                acquire_sem
-                    .export_fd(ExternalSemaphoreHandleType::OpaqueFd)
-                    .unwrap()
-            };
-            let release_fd = unsafe {
-                release_sem
-                    .export_fd(ExternalSemaphoreHandleType::OpaqueFd)
-                    .unwrap()
-            };
+            let acquire_fd =
+                unsafe { acquire_sem.export_fd(ExternalSemaphoreHandleType::OpaqueFd) }.unwrap();
+            let release_fd =
+                unsafe { release_sem.export_fd(ExternalSemaphoreHandleType::OpaqueFd) }.unwrap();
 
             let barrier_clone = barrier.clone();
             let barrier_2_clone = barrier_2.clone();
@@ -407,13 +400,12 @@ mod linux {
 
                 let gl_acquire_sem = unsafe {
                     glium::semaphore::Semaphore::new_from_fd(gl_display.as_ref(), acquire_fd)
-                        .unwrap()
-                };
-
+                }
+                .unwrap();
                 let gl_release_sem = unsafe {
                     glium::semaphore::Semaphore::new_from_fd(gl_display.as_ref(), release_fd)
-                        .unwrap()
-                };
+                }
+                .unwrap();
 
                 let rotation_start = Instant::now();
 
@@ -733,12 +725,7 @@ mod linux {
                         .unwrap()
                         .bind_vertex_buffers(0, self.vertex_buffer.clone())
                         .unwrap();
-
-                    unsafe {
-                        builder
-                            .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                            .unwrap();
-                    }
+                    unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                     builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -554,12 +554,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -498,12 +498,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -517,12 +517,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -541,10 +541,7 @@ impl ApplicationHandler for App {
                         cs_descriptor_set,
                     )
                     .unwrap();
-
-                unsafe {
-                    builder.dispatch([1, 1, 1]).unwrap();
-                }
+                unsafe { builder.dispatch([1, 1, 1]) }.unwrap();
 
                 builder
                     .begin_render_pass(
@@ -564,11 +561,9 @@ impl ApplicationHandler for App {
                     .bind_vertex_buffers(0, vertices)
                     .unwrap();
 
-                unsafe {
-                    // The indirect draw call is placed in the command buffer with a reference to
-                    // the buffer that will contain the arguments for the draw.
-                    builder.draw_indirect(indirect_buffer).unwrap();
-                }
+                // The indirect draw call is placed in the command buffer with a reference to
+                // the buffer that will contain the arguments for the draw.
+                unsafe { builder.draw_indirect(indirect_buffer) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -470,17 +470,15 @@ impl ApplicationHandler for App {
                         (self.vertex_buffer.clone(), self.instance_buffer.clone()),
                     )
                     .unwrap();
-
                 unsafe {
-                    builder
-                        .draw(
-                            self.vertex_buffer.len() as u32,
-                            self.instance_buffer.len() as u32,
-                            0,
-                            0,
-                        )
-                        .unwrap();
+                    builder.draw(
+                        self.vertex_buffer.len() as u32,
+                        self.instance_buffer.len() as u32,
+                        0,
+                        0,
+                    )
                 }
+                .unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/interactive-fractal/fractal_compute_pipeline.rs
+++ b/examples/interactive-fractal/fractal_compute_pipeline.rs
@@ -175,12 +175,7 @@ impl FractalComputePipeline {
             .unwrap()
             .push_constants(self.pipeline.layout().clone(), 0, push_constants)
             .unwrap();
-
-        unsafe {
-            builder
-                .dispatch([image_extent[0] / 8, image_extent[1] / 8, 1])
-                .unwrap();
-        }
+        unsafe { builder.dispatch([image_extent[0] / 8, image_extent[1] / 8, 1]) }.unwrap();
 
         let command_buffer = builder.build().unwrap();
         let finished = command_buffer.execute(self.queue.clone()).unwrap();

--- a/examples/interactive-fractal/pixels_draw_pipeline.rs
+++ b/examples/interactive-fractal/pixels_draw_pipeline.rs
@@ -162,10 +162,7 @@ impl PixelsDrawPipeline {
                 self.create_descriptor_set(image),
             )
             .unwrap();
-
-        unsafe {
-            builder.draw(6, 1, 0, 0).unwrap();
-        }
+        unsafe { builder.draw(6, 1, 0, 0) }.unwrap();
 
         builder.build().unwrap()
     }

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -476,10 +476,7 @@ impl ApplicationHandler for App {
                         rcx.descriptor_set.clone(),
                     )
                     .unwrap();
-
-                unsafe {
-                    builder.draw_mesh_tasks([self.cols, self.rows, 1]).unwrap();
-                }
+                unsafe { builder.draw_mesh_tasks([self.cols, self.rows, 1]) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -401,10 +401,7 @@ fn main() {
         .unwrap()
         .bind_vertex_buffers(0, vertex_buffer.clone())
         .unwrap();
-
-    unsafe {
-        builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
-    }
+    unsafe { builder.draw(vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
     builder
         .end_render_pass(Default::default())

--- a/examples/multi-window-game-of-life/game_of_life.rs
+++ b/examples/multi-window-game-of-life/game_of_life.rs
@@ -205,12 +205,7 @@ impl GameOfLifeComputePipeline {
                 push_constants,
             )
             .unwrap();
-
-        unsafe {
-            builder
-                .dispatch([image_extent[0] / 8, image_extent[1] / 8, 1])
-                .unwrap();
-        }
+        unsafe { builder.dispatch([image_extent[0] / 8, image_extent[1] / 8, 1]) }.unwrap();
     }
 }
 

--- a/examples/multi-window-game-of-life/pixels_draw.rs
+++ b/examples/multi-window-game-of-life/pixels_draw.rs
@@ -158,10 +158,7 @@ impl PixelsDrawPipeline {
                 self.create_image_sampler_nearest(image),
             )
             .unwrap();
-
-        unsafe {
-            builder.draw(6, 1, 0, 0).unwrap();
-        }
+        unsafe { builder.draw(6, 1, 0, 0) }.unwrap();
 
         builder.build().unwrap()
     }

--- a/examples/multi-window/main.rs
+++ b/examples/multi-window/main.rs
@@ -450,12 +450,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/multiview/main.rs
+++ b/examples/multiview/main.rs
@@ -349,12 +349,10 @@ fn main() {
         .bind_vertex_buffers(0, vertex_buffer.clone())
         .unwrap();
 
-    unsafe {
-        // Drawing commands are broadcast to each view in the view mask of the active renderpass
-        // which means only a single draw call is needed to draw to multiple layers of the
-        // framebuffer.
-        builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
-    }
+    // Drawing commands are broadcast to each view in the view mask of the active renderpass
+    // which means only a single draw call is needed to draw to multiple layers of the
+    // framebuffer.
+    unsafe { builder.draw(vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
     builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -297,10 +297,7 @@ fn main() {
         .unwrap()
         .bind_vertex_buffers(0, vertex_buffer.clone())
         .unwrap();
-
-    unsafe {
-        builder.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
-    }
+    unsafe { builder.draw(vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
     builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/pipeline-caching/main.rs
+++ b/examples/pipeline-caching/main.rs
@@ -93,7 +93,7 @@ fn main() {
     .unwrap();
 
     // We are creating an empty PipelineCache to start somewhere.
-    let pipeline_cache = unsafe { PipelineCache::new(device.clone(), Default::default()).unwrap() };
+    let pipeline_cache = unsafe { PipelineCache::new(device.clone(), Default::default()) }.unwrap();
 
     // We need to create the compute pipeline that describes our operation. We are using the shader
     // from the basic-compute-shader example.
@@ -192,8 +192,8 @@ fn main() {
                 ..Default::default()
             },
         )
-        .unwrap()
-    };
+    }
+    .unwrap();
 
     // As the `PipelineCache` of the Vulkan implementation saves an opaque blob of data, there is
     // no real way to know if the data is correct. There might be differences in the byte blob

--- a/examples/push-constants/main.rs
+++ b/examples/push-constants/main.rs
@@ -199,10 +199,7 @@ fn main() {
         .unwrap()
         .push_constants(pipeline.layout().clone(), 0, push_constants)
         .unwrap();
-
-    unsafe {
-        builder.dispatch([1024, 1, 1]).unwrap();
-    }
+    unsafe { builder.dispatch([1024, 1, 1]) }.unwrap();
 
     let command_buffer = builder.build().unwrap();
 

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -490,12 +490,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -625,12 +625,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -258,8 +258,8 @@ impl ApplicationHandler for App {
                 // NOTE: You will have to verify correctness of the data by yourself!
                 let module = unsafe {
                     ShaderModule::new(self.device.clone(), ShaderModuleCreateInfo::new(&code))
-                        .unwrap()
-                };
+                }
+                .unwrap();
                 module.entry_point("main").unwrap()
             };
 
@@ -268,8 +268,8 @@ impl ApplicationHandler for App {
 
                 let module = unsafe {
                     ShaderModule::new(self.device.clone(), ShaderModuleCreateInfo::new(&code))
-                        .unwrap()
-                };
+                }
+                .unwrap();
                 module.entry_point("main").unwrap()
             };
 
@@ -414,12 +414,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/self-copy-buffer/main.rs
+++ b/examples/self-copy-buffer/main.rs
@@ -192,10 +192,7 @@ fn main() {
             set,
         )
         .unwrap();
-
-    unsafe {
-        builder.dispatch([1024, 1, 1]).unwrap();
-    }
+    unsafe { builder.dispatch([1024, 1, 1]) }.unwrap();
 
     let command_buffer = builder.build().unwrap();
 

--- a/examples/shader-include/main.rs
+++ b/examples/shader-include/main.rs
@@ -183,10 +183,7 @@ fn main() {
             set,
         )
         .unwrap();
-
-    unsafe {
-        builder.dispatch([1024, 1, 1]).unwrap();
-    }
+    unsafe { builder.dispatch([1024, 1, 1]) }.unwrap();
 
     let command_buffer = builder.build().unwrap();
     let future = sync::now(device)

--- a/examples/shader-types-sharing/main.rs
+++ b/examples/shader-types-sharing/main.rs
@@ -211,10 +211,7 @@ fn main() {
             .unwrap()
             .push_constants(pipeline.layout().clone(), 0, parameters)
             .unwrap();
-
-        unsafe {
-            builder.dispatch([1024, 1, 1]).unwrap();
-        }
+        unsafe { builder.dispatch([1024, 1, 1]) }.unwrap();
 
         let command_buffer = builder.build().unwrap();
         let future = sync::now(queue.device().clone())

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -559,12 +559,7 @@ impl ApplicationHandler for App {
                         self.descriptor_set.clone(),
                     )
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .dispatch([PARTICLE_COUNT as u32 / 128, 1, 1])
-                        .unwrap();
-                }
+                unsafe { builder.dispatch([PARTICLE_COUNT as u32 / 128, 1, 1]) }.unwrap();
 
                 // Use render-pass to draw particles to swapchain.
                 builder
@@ -582,10 +577,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder.draw(PARTICLE_COUNT as u32, 1, 0, 0).unwrap();
-                }
+                unsafe { builder.draw(PARTICLE_COUNT as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/specialization-constants/main.rs
+++ b/examples/specialization-constants/main.rs
@@ -186,10 +186,7 @@ fn main() {
             descriptor_set,
         )
         .unwrap();
-
-    unsafe {
-        builder.dispatch([1024, 1, 1]).unwrap();
-    }
+    unsafe { builder.dispatch([1024, 1, 1]) }.unwrap();
 
     let command_buffer = builder.build().unwrap();
 

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -481,12 +481,8 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_index_buffer(self.index_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw_indexed(self.index_buffer.len() as u32, 1, 0, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw_indexed(self.index_buffer.len() as u32, 1, 0, 0, 0) }
+                    .unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -441,12 +441,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -511,12 +511,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
-
-                unsafe {
-                    builder
-                        .draw(self.vertex_buffer.len() as u32, 3, 0, 0)
-                        .unwrap();
-                }
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 3, 0, 0) }.unwrap();
 
                 builder.end_render_pass(Default::default()).unwrap();
 

--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -424,12 +424,8 @@ impl ApplicationHandler for App {
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
 
-                unsafe {
-                    builder
-                        // We add a draw command.
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                // We add a draw command.
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder
                     // We leave the render pass. Note that if we had multiple subpasses we could

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -690,12 +690,8 @@ impl ApplicationHandler for App {
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
 
-                unsafe {
-                    builder
-                        // We add a draw command.
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                // We add a draw command.
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder
                     // We leave the render pass.

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -690,12 +690,8 @@ impl ApplicationHandler for App {
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())
                     .unwrap();
 
-                unsafe {
-                    builder
-                        // We add a draw command.
-                        .draw(self.vertex_buffer.len() as u32, 1, 0, 0)
-                        .unwrap();
-                }
+                // We add a draw command.
+                unsafe { builder.draw(self.vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 
                 builder
                     // We leave the render pass. Note that if we had multiple subpasses we could


### PR DESCRIPTION
Trying to minimise the size of `unsafe` blocks to contain only the unsafe operation and nothing else. I believe this is the preferred practice in Rust, and I notice that @marc0246 does it that way too.

This is for the examples, the rest will follow later.