### PR TITLE
Minimise unsafe block size, in library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,11 +83,12 @@ rand = "0.8"
 ron = "0.8"
 
 [workspace.lints]
-rust.missing_docs = "allow"            # TODO: warn eventually
+rust.missing_docs = "allow"                                       # TODO: warn eventually
 rust.rust_2018_idioms = { level = "warn", priority = -1 }
 rust.rust_2024_compatibility = { level = "allow", priority = -1 } # TODO: warn eventually
 clippy.borrow_as_ptr = "warn"
-clippy.missing_safety_doc = "allow"    # TODO: warn eventually
+clippy.missing_safety_doc = "allow"                               # TODO: warn eventually
+clippy.multiple_unsafe_ops_per_block = "warn"
 clippy.ptr_as_ptr = "warn"
 clippy.ptr_cast_constness = "warn"
 # clippy.ref_as_ptr = "warn"                 # TODO: enable once it's stable

--- a/vulkano-taskgraph/src/graph/execute.rs
+++ b/vulkano-taskgraph/src/graph/execute.rs
@@ -566,7 +566,8 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
                 ObjectType::Buffer => {
                     // SAFETY: The caller must ensure that `resource_map` maps the virtual IDs
                     // exhaustively.
-                    let state = unsafe { resource_map.buffer_unchecked(id.parametrize()) };
+                    let id_p = unsafe { id.parametrize() };
+                    let state = unsafe { resource_map.buffer_unchecked(id_p) };
                     let access = BufferAccess::from_masks(
                         access.stage_mask,
                         access.access_mask,
@@ -577,7 +578,8 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
                 ObjectType::Image => {
                     // SAFETY: The caller must ensure that `resource_map` maps the virtual IDs
                     // exhaustively.
-                    let state = unsafe { resource_map.image_unchecked(id.parametrize()) };
+                    let id_p = unsafe { id.parametrize() };
+                    let state = unsafe { resource_map.image_unchecked(id_p) };
                     let access = ImageAccess::from_masks(
                         access.stage_mask,
                         access.access_mask,
@@ -589,7 +591,8 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
                 ObjectType::Swapchain => {
                     // SAFETY: The caller must ensure that `resource_map` maps the virtual IDs
                     // exhaustively.
-                    let state = unsafe { resource_map.swapchain_unchecked(id.parametrize()) };
+                    let id_p = unsafe { id.parametrize() };
+                    let state = unsafe { resource_map.swapchain_unchecked(id_p) };
                     let access = ImageAccess::from_masks(
                         access.stage_mask,
                         access.access_mask,
@@ -1670,17 +1673,26 @@ impl<'a> ResourceMap<'a> {
 
             *slot = match physical_id.object_type() {
                 // SAFETY: We own an `epoch::Guard`.
-                ObjectType::Buffer => <*const _>::cast(unsafe {
-                    physical_resources.buffer_unprotected(physical_id.parametrize())
-                }?),
+                ObjectType::Buffer => {
+                    let physical_id_p = unsafe { physical_id.parametrize() };
+                    <*const _>::cast(unsafe {
+                        physical_resources.buffer_unprotected(physical_id_p)
+                    }?)
+                }
                 // SAFETY: We own an `epoch::Guard`.
-                ObjectType::Image => <*const _>::cast(unsafe {
-                    physical_resources.image_unprotected(physical_id.parametrize())
-                }?),
+                ObjectType::Image => {
+                    let physical_id_p = unsafe { physical_id.parametrize() };
+                    <*const _>::cast(unsafe {
+                        physical_resources.image_unprotected(physical_id_p)
+                    }?)
+                }
                 // SAFETY: We own an `epoch::Guard`.
-                ObjectType::Swapchain => <*const _>::cast(unsafe {
-                    physical_resources.swapchain_unprotected(physical_id.parametrize())
-                }?),
+                ObjectType::Swapchain => {
+                    let physical_id_p = unsafe { physical_id.parametrize() };
+                    <*const _>::cast(unsafe {
+                        physical_resources.swapchain_unprotected(physical_id_p)
+                    }?)
+                }
                 _ => unreachable!(),
             };
         }

--- a/vulkano-taskgraph/src/lib.rs
+++ b/vulkano-taskgraph/src/lib.rs
@@ -389,7 +389,8 @@ impl<'a> TaskContext<'a> {
         let mapped_slice = subbuffer.mapped_slice().unwrap();
 
         // SAFETY: The caller must ensure that access to the data is synchronized.
-        let data = unsafe { &*T::ptr_from_slice(mapped_slice) };
+        let data_ptr = unsafe { T::ptr_from_slice(mapped_slice) };
+        let data = unsafe { &*data_ptr };
 
         Ok(data)
     }
@@ -492,7 +493,8 @@ impl<'a> TaskContext<'a> {
         let mapped_slice = subbuffer.mapped_slice().unwrap();
 
         // SAFETY: The caller must ensure that access to the data is synchronized.
-        let data = unsafe { &mut *T::ptr_from_slice(mapped_slice) };
+        let data_ptr = unsafe { T::ptr_from_slice(mapped_slice) };
+        let data = unsafe { &mut *data_ptr };
 
         Ok(data)
     }

--- a/vulkano/src/buffer/allocator.rs
+++ b/vulkano/src/buffer/allocator.rs
@@ -182,7 +182,8 @@ where
     /// The next time you allocate a subbuffer, a new arena will be allocated with the new size,
     /// and all subsequently allocated arenas will also share the new size.
     pub fn set_arena_size(&self, size: DeviceSize) {
-        let state = unsafe { &mut *self.state.get() };
+        let state_ptr = self.state.get();
+        let state = unsafe { &mut *state_ptr };
         state.arena_size = size;
         state.arena = None;
         state.reserve = None;
@@ -195,7 +196,8 @@ where
     /// this has no effect.
     pub fn reserve(&self, size: DeviceSize) -> Result<(), MemoryAllocatorError> {
         if size > self.arena_size() {
-            let state = unsafe { &mut *self.state.get() };
+            let state_ptr = self.state.get();
+            let state = unsafe { &mut *state_ptr };
             state.arena_size = size;
             state.reserve = None;
             state.arena = Some(state.next_arena()?);
@@ -211,7 +213,9 @@ where
     {
         let layout = T::LAYOUT.unwrap_sized();
 
-        unsafe { &mut *self.state.get() }
+        let state_ptr = self.state.get();
+        let state = unsafe { &mut *state_ptr };
+        state
             .allocate(layout)
             .map(|subbuffer| unsafe { subbuffer.reinterpret_unchecked() })
     }

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -405,12 +405,10 @@ impl Buffer {
         let allocation = unsafe { ResourceMemory::from_allocation(allocator, allocation) };
 
         // SAFETY: we just created this raw buffer and hasn't bound any memory to it.
-        let buffer = unsafe {
-            raw_buffer.bind_memory(allocation).map_err(|(err, _, _)| {
-                err.map(AllocateBufferError::BindMemory)
-                    .map_validation(|err| err.add_context("RawBuffer::bind_memory"))
-            })?
-        };
+        let buffer = unsafe { raw_buffer.bind_memory(allocation) }.map_err(|(err, _, _)| {
+            err.map(AllocateBufferError::BindMemory)
+                .map_validation(|err| err.add_context("RawBuffer::bind_memory"))
+        })?;
 
         Ok(Arc::new(buffer))
     }
@@ -472,7 +470,7 @@ impl Buffer {
     pub fn device_address(&self) -> Result<NonNullDeviceAddress, Box<ValidationError>> {
         self.validate_device_address()?;
 
-        unsafe { Ok(self.device_address_unchecked()) }
+        Ok(unsafe { self.device_address_unchecked() })
     }
 
     fn validate_device_address(&self) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -377,7 +377,8 @@ where
         }
 
         // SAFETY: `Subbuffer` guarantees that its contents are laid out correctly for `T`.
-        let data = unsafe { &*T::ptr_from_slice(mapped_slice) };
+        let data_ptr = unsafe { T::ptr_from_slice(mapped_slice) };
+        let data = unsafe { &*data_ptr };
 
         Ok(BufferReadGuard {
             subbuffer: self,
@@ -464,7 +465,8 @@ where
         }
 
         // SAFETY: `Subbuffer` guarantees that its contents are laid out correctly for `T`.
-        let data = unsafe { &mut *T::ptr_from_slice(mapped_slice) };
+        let data_ptr = unsafe { T::ptr_from_slice(mapped_slice) };
+        let data = unsafe { &mut *data_ptr };
 
         Ok(BufferWriteGuard {
             subbuffer: self,
@@ -710,7 +712,7 @@ impl<T: ?Sized> Drop for BufferWriteGuard<'_, T> {
                 _ne: crate::NonExhaustive(()),
             };
 
-            unsafe { allocation.flush_range_unchecked(memory_range).unwrap() };
+            unsafe { allocation.flush_range_unchecked(memory_range) }.unwrap();
         }
 
         let mut state = self.subbuffer.buffer().state();

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -216,7 +216,9 @@ impl StandardCommandBufferAllocator {
         queue_family_index: u32,
         flags: CommandPoolResetFlags,
     ) -> Result<(), Validated<ResetCommandPoolError>> {
-        if let Some(entry) = unsafe { &mut *self.entry(queue_family_index) }.as_mut() {
+        let entry_ptr = self.entry(queue_family_index);
+
+        if let Some(entry) = unsafe { &mut *entry_ptr }.as_mut() {
             entry.try_reset_pool(flags)
         } else {
             Ok(())
@@ -234,7 +236,8 @@ impl StandardCommandBufferAllocator {
     /// - Panics if `queue_family_index` is not less than the number of queue families.
     #[inline]
     pub fn clear(&self, queue_family_index: u32) {
-        unsafe { *self.entry(queue_family_index) = None };
+        let entry_ptr = self.entry(queue_family_index);
+        unsafe { *entry_ptr = None };
     }
 
     fn entry(&self, queue_family_index: u32) -> *mut Option<Entry> {
@@ -271,7 +274,8 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
             }))?;
         }
 
-        let entry = unsafe { &mut *self.entry(queue_family_index) };
+        let entry_ptr = self.entry(queue_family_index);
+        let entry = unsafe { &mut *entry_ptr };
 
         if entry.is_none() {
             *entry = Some(Entry::new(

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -117,7 +117,7 @@ impl AutoCommandBufferBuilder<PrimaryAutoCommandBuffer> {
     pub fn build(self) -> Result<Arc<PrimaryAutoCommandBuffer>, Validated<VulkanError>> {
         self.validate_end()?;
 
-        let (inner, keep_alive_objects, resources_usage, _) = unsafe { self.end_unchecked()? };
+        let (inner, keep_alive_objects, resources_usage, _) = unsafe { self.end_unchecked() }?;
 
         Ok(Arc::new(PrimaryAutoCommandBuffer {
             inner,
@@ -177,7 +177,7 @@ impl AutoCommandBufferBuilder<SecondaryAutoCommandBuffer> {
     pub fn build(self) -> Result<Arc<SecondaryAutoCommandBuffer>, Validated<VulkanError>> {
         self.validate_end()?;
 
-        let (inner, keep_alive_objects, _, resources_usage) = unsafe { self.end_unchecked()? };
+        let (inner, keep_alive_objects, _, resources_usage) = unsafe { self.end_unchecked() }?;
 
         let submit_state = match inner.usage() {
             CommandBufferUsage::MultipleSubmit => SubmitState::ExclusiveUse {
@@ -331,15 +331,14 @@ impl<L> AutoCommandBufferBuilder<L> {
         for (command_index, (_, record_func)) in self.commands.iter().enumerate() {
             if let Some(barriers) = barriers.remove(&command_index) {
                 for dependency_info in barriers {
-                    unsafe {
-                        #[cfg(debug_assertions)]
-                        self.inner
-                            .pipeline_barrier(&dependency_info)
-                            .expect("bug in Vulkano");
+                    #[cfg(debug_assertions)]
+                    unsafe { self.inner.pipeline_barrier(&dependency_info) }
+                        .expect("bug in Vulkano");
 
-                        #[cfg(not(debug_assertions))]
-                        self.inner.pipeline_barrier_unchecked(&dependency_info);
-                    }
+                    #[cfg(not(debug_assertions))]
+                    unsafe {
+                        self.inner.pipeline_barrier_unchecked(&dependency_info)
+                    };
                 }
             }
 
@@ -349,15 +348,13 @@ impl<L> AutoCommandBufferBuilder<L> {
         // Record final barriers
         if let Some(final_barriers) = barriers.remove(&final_barrier_index) {
             for dependency_info in final_barriers {
-                unsafe {
-                    #[cfg(debug_assertions)]
-                    self.inner
-                        .pipeline_barrier(&dependency_info)
-                        .expect("bug in Vulkano");
+                #[cfg(debug_assertions)]
+                unsafe { self.inner.pipeline_barrier(&dependency_info) }.expect("bug in Vulkano");
 
-                    #[cfg(not(debug_assertions))]
-                    self.inner.pipeline_barrier_unchecked(&dependency_info);
-                }
+                #[cfg(not(debug_assertions))]
+                unsafe {
+                    self.inner.pipeline_barrier_unchecked(&dependency_info)
+                };
             }
         }
 

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -644,67 +644,51 @@ mod tests {
 
     #[test]
     fn secondary_conflicting_writes() {
-        unsafe {
-            let (device, queue) = gfx_dev_and_queue!();
+        let (device, queue) = gfx_dev_and_queue!();
 
-            let cb_allocator = Arc::new(StandardCommandBufferAllocator::new(
-                device.clone(),
-                StandardCommandBufferAllocatorCreateInfo {
-                    secondary_buffer_count: 1,
-                    ..Default::default()
-                },
-            ));
-            let cbb = AutoCommandBufferBuilder::primary(
-                cb_allocator.clone(),
-                queue.queue_family_index(),
-                CommandBufferUsage::OneTimeSubmit,
-            )
+        let cb_allocator = Arc::new(StandardCommandBufferAllocator::new(
+            device.clone(),
+            StandardCommandBufferAllocatorCreateInfo {
+                secondary_buffer_count: 1,
+                ..Default::default()
+            },
+        ));
+        let cbb = AutoCommandBufferBuilder::primary(
+            cb_allocator.clone(),
+            queue.queue_family_index(),
+            CommandBufferUsage::OneTimeSubmit,
+        )
+        .unwrap();
+
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
+        // Create a tiny test buffer
+        let buffer = Buffer::from_data(
+            memory_allocator,
+            BufferCreateInfo {
+                usage: BufferUsage::TRANSFER_DST,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
+                ..Default::default()
+            },
+            0u32,
+        )
+        .unwrap();
+
+        cbb.build()
+            .unwrap()
+            .execute(queue.clone())
+            .unwrap()
+            .then_signal_fence_and_flush()
+            .unwrap()
+            .wait(None)
             .unwrap();
 
-            let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
-            // Create a tiny test buffer
-            let buffer = Buffer::from_data(
-                memory_allocator,
-                BufferCreateInfo {
-                    usage: BufferUsage::TRANSFER_DST,
-                    ..Default::default()
-                },
-                AllocationCreateInfo {
-                    memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
-                        | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
-                    ..Default::default()
-                },
-                0u32,
-            )
-            .unwrap();
-
-            cbb.build()
-                .unwrap()
-                .execute(queue.clone())
-                .unwrap()
-                .then_signal_fence_and_flush()
-                .unwrap()
-                .wait(None)
-                .unwrap();
-
-            // Two secondary command buffers that both write to the buffer
-            let secondary = (0..2)
-                .map(|_| {
-                    let mut builder = AutoCommandBufferBuilder::secondary(
-                        cb_allocator.clone(),
-                        queue.queue_family_index(),
-                        CommandBufferUsage::SimultaneousUse,
-                        Default::default(),
-                    )
-                    .unwrap();
-                    builder
-                        .fill_buffer(buffer.clone().into_slice(), 42)
-                        .unwrap();
-                    builder.build().unwrap()
-                })
-                .collect::<Vec<_>>();
-
-            {
+        // Two secondary command buffers that both write to the buffer
+        let secondary = (0..2)
+            .map(|_| {
                 let mut builder = AutoCommandBufferBuilder::secondary(
                     cb_allocator.clone(),
                     queue.queue_family_index(),
@@ -712,224 +696,243 @@ mod tests {
                     Default::default(),
                 )
                 .unwrap();
+                builder
+                    .fill_buffer(buffer.clone().into_slice(), 42)
+                    .unwrap();
+                builder.build().unwrap()
+            })
+            .collect::<Vec<_>>();
 
-                // Add both secondary command buffers using separate execute_commands calls.
-                secondary.iter().cloned().for_each(|secondary| {
-                    builder.execute_commands_unchecked([secondary as _].into_iter().collect());
-                });
+        {
+            let mut builder = AutoCommandBufferBuilder::secondary(
+                cb_allocator.clone(),
+                queue.queue_family_index(),
+                CommandBufferUsage::SimultaneousUse,
+                Default::default(),
+            )
+            .unwrap();
 
-                let _primary = builder.build().unwrap();
-                /*
-                let names = primary._commands.iter().map(|c| c.name).collect::<Vec<_>>();
+            // Add both secondary command buffers using separate execute_commands calls.
+            secondary.iter().cloned().for_each(|secondary| {
+                unsafe {
+                    builder.execute_commands_unchecked([secondary as _].into_iter().collect())
+                };
+            });
 
-                // Ensure that the builder added a barrier between the two writes
-                assert_eq!(&names, &["execute_commands", "execute_commands"]);
-                assert_eq!(&primary._barriers, &[0, 1]);
-                 */
-            }
+            let _primary = builder.build().unwrap();
+            /*
+            let names = primary._commands.iter().map(|c| c.name).collect::<Vec<_>>();
 
-            {
-                let mut builder = AutoCommandBufferBuilder::secondary(
-                    cb_allocator,
-                    queue.queue_family_index(),
-                    CommandBufferUsage::SimultaneousUse,
-                    Default::default(),
-                )
-                .unwrap();
+            // Ensure that the builder added a barrier between the two writes
+            assert_eq!(&names, &["execute_commands", "execute_commands"]);
+            assert_eq!(&primary._barriers, &[0, 1]);
+             */
+        }
 
-                // Add a single execute_commands for all secondary command buffers at once
+        {
+            let mut builder = AutoCommandBufferBuilder::secondary(
+                cb_allocator,
+                queue.queue_family_index(),
+                CommandBufferUsage::SimultaneousUse,
+                Default::default(),
+            )
+            .unwrap();
+
+            // Add a single execute_commands for all secondary command buffers at once
+            unsafe {
                 builder.execute_commands_unchecked(
                     secondary
                         .into_iter()
                         .map(|secondary| secondary as _)
                         .collect(),
-                );
-            }
+                )
+            };
         }
     }
 
     #[test]
     fn vertex_buffer_binding() {
-        unsafe {
-            let (device, queue) = gfx_dev_and_queue!();
+        let (device, queue) = gfx_dev_and_queue!();
 
-            let cb_allocator = Arc::new(StandardCommandBufferAllocator::new(
-                device.clone(),
-                Default::default(),
-            ));
-            let mut sync = AutoCommandBufferBuilder::primary(
-                cb_allocator,
-                queue.queue_family_index(),
-                CommandBufferUsage::MultipleSubmit,
-            )
-            .unwrap();
+        let cb_allocator = Arc::new(StandardCommandBufferAllocator::new(
+            device.clone(),
+            Default::default(),
+        ));
+        let mut sync = AutoCommandBufferBuilder::primary(
+            cb_allocator,
+            queue.queue_family_index(),
+            CommandBufferUsage::MultipleSubmit,
+        )
+        .unwrap();
 
-            let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
-            let buf = Buffer::from_data(
-                memory_allocator,
-                BufferCreateInfo {
-                    usage: BufferUsage::VERTEX_BUFFER,
-                    ..Default::default()
-                },
-                AllocationCreateInfo {
-                    memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
-                        | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
-                    ..Default::default()
-                },
-                0u32,
-            )
-            .unwrap();
-            sync.bind_vertex_buffers_unchecked(1, buf);
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new_default(device));
+        let buf = Buffer::from_data(
+            memory_allocator,
+            BufferCreateInfo {
+                usage: BufferUsage::VERTEX_BUFFER,
+                ..Default::default()
+            },
+            AllocationCreateInfo {
+                memory_type_filter: MemoryTypeFilter::PREFER_DEVICE
+                    | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
+                ..Default::default()
+            },
+            0u32,
+        )
+        .unwrap();
+        unsafe { sync.bind_vertex_buffers_unchecked(1, buf) };
 
-            assert!(!sync.builder_state.vertex_buffers.contains_key(&0));
-            assert!(sync.builder_state.vertex_buffers.contains_key(&1));
-            assert!(!sync.builder_state.vertex_buffers.contains_key(&2));
-        }
+        assert!(!sync.builder_state.vertex_buffers.contains_key(&0));
+        assert!(sync.builder_state.vertex_buffers.contains_key(&1));
+        assert!(!sync.builder_state.vertex_buffers.contains_key(&2));
     }
 
     #[test]
     fn descriptor_set_binding() {
-        unsafe {
-            let (device, queue) = gfx_dev_and_queue!();
+        let (device, queue) = gfx_dev_and_queue!();
 
-            let cb_allocator = Arc::new(StandardCommandBufferAllocator::new(
-                device.clone(),
-                Default::default(),
-            ));
-            let mut sync = AutoCommandBufferBuilder::primary(
-                cb_allocator,
-                queue.queue_family_index(),
-                CommandBufferUsage::MultipleSubmit,
-            )
-            .unwrap();
-            let set_layout = DescriptorSetLayout::new(
-                device.clone(),
-                DescriptorSetLayoutCreateInfo {
-                    bindings: [(
-                        0,
-                        DescriptorSetLayoutBinding {
-                            stages: ShaderStages::all_graphics(),
-                            ..DescriptorSetLayoutBinding::descriptor_type(DescriptorType::Sampler)
-                        },
-                    )]
-                    .into(),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-            let pipeline_layout = PipelineLayout::new(
-                device.clone(),
-                PipelineLayoutCreateInfo {
-                    set_layouts: [set_layout.clone(), set_layout.clone()].into(),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-
-            let ds_allocator = Arc::new(StandardDescriptorSetAllocator::new(
-                device.clone(),
-                Default::default(),
-            ));
-
-            let set = DescriptorSet::new(
-                ds_allocator.clone(),
-                set_layout.clone(),
-                [WriteDescriptorSet::sampler(
+        let cb_allocator = Arc::new(StandardCommandBufferAllocator::new(
+            device.clone(),
+            Default::default(),
+        ));
+        let mut sync = AutoCommandBufferBuilder::primary(
+            cb_allocator,
+            queue.queue_family_index(),
+            CommandBufferUsage::MultipleSubmit,
+        )
+        .unwrap();
+        let set_layout = DescriptorSetLayout::new(
+            device.clone(),
+            DescriptorSetLayoutCreateInfo {
+                bindings: [(
                     0,
-                    Sampler::new(device.clone(), SamplerCreateInfo::simple_repeat_linear())
-                        .unwrap(),
-                )],
-                [],
-            )
-            .unwrap();
+                    DescriptorSetLayoutBinding {
+                        stages: ShaderStages::all_graphics(),
+                        ..DescriptorSetLayoutBinding::descriptor_type(DescriptorType::Sampler)
+                    },
+                )]
+                .into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let pipeline_layout = PipelineLayout::new(
+            device.clone(),
+            PipelineLayoutCreateInfo {
+                set_layouts: [set_layout.clone(), set_layout.clone()].into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
+        let ds_allocator = Arc::new(StandardDescriptorSetAllocator::new(
+            device.clone(),
+            Default::default(),
+        ));
+
+        let set = DescriptorSet::new(
+            ds_allocator.clone(),
+            set_layout.clone(),
+            [WriteDescriptorSet::sampler(
+                0,
+                Sampler::new(device.clone(), SamplerCreateInfo::simple_repeat_linear()).unwrap(),
+            )],
+            [],
+        )
+        .unwrap();
+
+        unsafe {
             sync.bind_descriptor_sets_unchecked(
                 PipelineBindPoint::Graphics,
                 pipeline_layout.clone(),
                 1,
                 set.clone(),
-            );
+            )
+        };
 
-            assert!(!sync
-                .builder_state
-                .descriptor_sets
-                .get(&PipelineBindPoint::Compute)
-                .map_or(false, |state| state.descriptor_sets.contains_key(&0)));
-            assert!(!sync
-                .builder_state
-                .descriptor_sets
-                .get(&PipelineBindPoint::Graphics)
-                .map_or(false, |state| state.descriptor_sets.contains_key(&0)));
-            assert!(sync
-                .builder_state
-                .descriptor_sets
-                .get(&PipelineBindPoint::Graphics)
-                .map_or(false, |state| state.descriptor_sets.contains_key(&1)));
-            assert!(!sync
-                .builder_state
-                .descriptor_sets
-                .get(&PipelineBindPoint::Graphics)
-                .map_or(false, |state| state.descriptor_sets.contains_key(&2)));
+        assert!(!sync
+            .builder_state
+            .descriptor_sets
+            .get(&PipelineBindPoint::Compute)
+            .map_or(false, |state| state.descriptor_sets.contains_key(&0)));
+        assert!(!sync
+            .builder_state
+            .descriptor_sets
+            .get(&PipelineBindPoint::Graphics)
+            .map_or(false, |state| state.descriptor_sets.contains_key(&0)));
+        assert!(sync
+            .builder_state
+            .descriptor_sets
+            .get(&PipelineBindPoint::Graphics)
+            .map_or(false, |state| state.descriptor_sets.contains_key(&1)));
+        assert!(!sync
+            .builder_state
+            .descriptor_sets
+            .get(&PipelineBindPoint::Graphics)
+            .map_or(false, |state| state.descriptor_sets.contains_key(&2)));
 
+        unsafe {
             sync.bind_descriptor_sets_unchecked(
                 PipelineBindPoint::Graphics,
                 pipeline_layout,
                 0,
                 set,
-            );
-
-            assert!(sync
-                .builder_state
-                .descriptor_sets
-                .get(&PipelineBindPoint::Graphics)
-                .map_or(false, |state| state.descriptor_sets.contains_key(&0)));
-            assert!(sync
-                .builder_state
-                .descriptor_sets
-                .get(&PipelineBindPoint::Graphics)
-                .map_or(false, |state| state.descriptor_sets.contains_key(&1)));
-
-            let pipeline_layout = PipelineLayout::new(
-                device.clone(),
-                PipelineLayoutCreateInfo {
-                    set_layouts: [
-                        DescriptorSetLayout::new(device.clone(), Default::default()).unwrap(),
-                        set_layout.clone(),
-                    ]
-                    .into(),
-                    ..Default::default()
-                },
             )
-            .unwrap();
+        };
 
-            let set = DescriptorSet::new(
-                ds_allocator,
-                set_layout,
-                [WriteDescriptorSet::sampler(
-                    0,
-                    Sampler::new(device, SamplerCreateInfo::simple_repeat_linear()).unwrap(),
-                )],
-                [],
-            )
-            .unwrap();
+        assert!(sync
+            .builder_state
+            .descriptor_sets
+            .get(&PipelineBindPoint::Graphics)
+            .map_or(false, |state| state.descriptor_sets.contains_key(&0)));
+        assert!(sync
+            .builder_state
+            .descriptor_sets
+            .get(&PipelineBindPoint::Graphics)
+            .map_or(false, |state| state.descriptor_sets.contains_key(&1)));
 
+        let pipeline_layout = PipelineLayout::new(
+            device.clone(),
+            PipelineLayoutCreateInfo {
+                set_layouts: [
+                    DescriptorSetLayout::new(device.clone(), Default::default()).unwrap(),
+                    set_layout.clone(),
+                ]
+                .into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let set = DescriptorSet::new(
+            ds_allocator,
+            set_layout,
+            [WriteDescriptorSet::sampler(
+                0,
+                Sampler::new(device, SamplerCreateInfo::simple_repeat_linear()).unwrap(),
+            )],
+            [],
+        )
+        .unwrap();
+
+        unsafe {
             sync.bind_descriptor_sets_unchecked(
                 PipelineBindPoint::Graphics,
                 pipeline_layout,
                 1,
                 set,
-            );
+            )
+        };
 
-            assert!(!sync
-                .builder_state
-                .descriptor_sets
-                .get(&PipelineBindPoint::Graphics)
-                .map_or(false, |state| state.descriptor_sets.contains_key(&0)));
-            assert!(sync
-                .builder_state
-                .descriptor_sets
-                .get(&PipelineBindPoint::Graphics)
-                .map_or(false, |state| state.descriptor_sets.contains_key(&1)));
-        }
+        assert!(!sync
+            .builder_state
+            .descriptor_sets
+            .get(&PipelineBindPoint::Graphics)
+            .map_or(false, |state| state.descriptor_sets.contains_key(&0)));
+        assert!(sync
+            .builder_state
+            .descriptor_sets
+            .get(&PipelineBindPoint::Graphics)
+            .map_or(false, |state| state.descriptor_sets.contains_key(&1)));
     }
 }

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -38,14 +38,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             &descriptor_sets,
         )?;
 
-        unsafe {
-            Ok(self.bind_descriptor_sets_unchecked(
+        Ok(unsafe {
+            self.bind_descriptor_sets_unchecked(
                 pipeline_bind_point,
                 pipeline_layout,
                 first_set,
                 descriptor_sets,
-            ))
-        }
+            )
+        })
     }
 
     // TODO: The validation here is somewhat duplicated because of how different the parameters are
@@ -269,7 +269,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         let index_buffer = index_buffer.into();
         self.validate_bind_index_buffer(&index_buffer)?;
 
-        unsafe { Ok(self.bind_index_buffer_unchecked(index_buffer)) }
+        Ok(unsafe { self.bind_index_buffer_unchecked(index_buffer) })
     }
 
     fn validate_bind_index_buffer(
@@ -306,7 +306,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_bind_pipeline_compute(&pipeline)?;
 
-        unsafe { Ok(self.bind_pipeline_compute_unchecked(pipeline)) }
+        Ok(unsafe { self.bind_pipeline_compute_unchecked(pipeline) })
     }
 
     fn validate_bind_pipeline_compute(
@@ -342,7 +342,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_bind_pipeline_graphics(&pipeline)?;
 
-        unsafe { Ok(self.bind_pipeline_graphics_unchecked(pipeline)) }
+        Ok(unsafe { self.bind_pipeline_graphics_unchecked(pipeline) })
     }
 
     fn validate_bind_pipeline_graphics(
@@ -387,7 +387,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         let vertex_buffers = vertex_buffers.into_vec();
         self.validate_bind_vertex_buffers(first_binding, &vertex_buffers)?;
 
-        unsafe { Ok(self.bind_vertex_buffers_unchecked(first_binding, vertex_buffers)) }
+        Ok(unsafe { self.bind_vertex_buffers_unchecked(first_binding, vertex_buffers) })
     }
 
     fn validate_bind_vertex_buffers(
@@ -444,7 +444,7 @@ impl<L> AutoCommandBufferBuilder<L> {
 
         self.validate_push_constants(&pipeline_layout, offset, &push_constants)?;
 
-        unsafe { Ok(self.push_constants_unchecked(pipeline_layout, offset, push_constants)) }
+        Ok(unsafe { self.push_constants_unchecked(pipeline_layout, offset, push_constants) })
     }
 
     fn validate_push_constants<Pc: BufferContents>(
@@ -505,14 +505,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             &descriptor_writes,
         )?;
 
-        unsafe {
-            Ok(self.push_descriptor_set_unchecked(
+        Ok(unsafe {
+            self.push_descriptor_set_unchecked(
                 pipeline_bind_point,
                 pipeline_layout,
                 set_num,
                 descriptor_writes,
-            ))
-        }
+            )
+        })
     }
 
     fn validate_push_descriptor_set(

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -22,7 +22,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_clear_color_image(&clear_info)?;
 
-        unsafe { Ok(self.clear_color_image_unchecked(clear_info)) }
+        Ok(unsafe { self.clear_color_image_unchecked(clear_info) })
     }
 
     fn validate_clear_color_image(
@@ -88,7 +88,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_clear_depth_stencil_image(&clear_info)?;
 
-        unsafe { Ok(self.clear_depth_stencil_image_unchecked(clear_info)) }
+        Ok(unsafe { self.clear_depth_stencil_image_unchecked(clear_info) })
     }
 
     fn validate_clear_depth_stencil_image(
@@ -158,7 +158,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_fill_buffer(&dst_buffer, data)?;
 
-        unsafe { Ok(self.fill_buffer_unchecked(dst_buffer, data)) }
+        Ok(unsafe { self.fill_buffer_unchecked(dst_buffer, data) })
     }
 
     fn validate_fill_buffer(
@@ -220,7 +220,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             size_of_val(data.deref()) as DeviceSize,
         )?;
 
-        unsafe { Ok(self.update_buffer_unchecked(dst_buffer, data)) }
+        Ok(unsafe { self.update_buffer_unchecked(dst_buffer, data) })
     }
 
     fn validate_update_buffer(

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -33,7 +33,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         let copy_buffer_info = copy_buffer_info.into();
         self.validate_copy_buffer(&copy_buffer_info)?;
 
-        unsafe { Ok(self.copy_buffer_unchecked(copy_buffer_info)) }
+        Ok(unsafe { self.copy_buffer_unchecked(copy_buffer_info) })
     }
 
     fn validate_copy_buffer(
@@ -131,7 +131,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_image(&copy_image_info)?;
 
-        unsafe { Ok(self.copy_image_unchecked(copy_image_info)) }
+        Ok(unsafe { self.copy_image_unchecked(copy_image_info) })
     }
 
     fn validate_copy_image(
@@ -215,7 +215,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_buffer_to_image(&copy_buffer_to_image_info)?;
 
-        unsafe { Ok(self.copy_buffer_to_image_unchecked(copy_buffer_to_image_info)) }
+        Ok(unsafe { self.copy_buffer_to_image_unchecked(copy_buffer_to_image_info) })
     }
 
     fn validate_copy_buffer_to_image(
@@ -302,7 +302,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_image_to_buffer(&copy_image_to_buffer_info)?;
 
-        unsafe { Ok(self.copy_image_to_buffer_unchecked(copy_image_to_buffer_info)) }
+        Ok(unsafe { self.copy_image_to_buffer_unchecked(copy_image_to_buffer_info) })
     }
 
     fn validate_copy_image_to_buffer(
@@ -418,7 +418,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_blit_image(&blit_image_info)?;
 
-        unsafe { Ok(self.blit_image_unchecked(blit_image_info)) }
+        Ok(unsafe { self.blit_image_unchecked(blit_image_info) })
     }
 
     fn validate_blit_image(
@@ -506,7 +506,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_resolve_image(&resolve_image_info)?;
 
-        unsafe { Ok(self.resolve_image_unchecked(resolve_image_info)) }
+        Ok(unsafe { self.resolve_image_unchecked(resolve_image_info) })
     }
 
     fn validate_resolve_image(

--- a/vulkano/src/command_buffer/commands/debug.rs
+++ b/vulkano/src/command_buffer/commands/debug.rs
@@ -18,7 +18,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_begin_debug_utils_label(&label_info)?;
 
-        unsafe { Ok(self.begin_debug_utils_label_unchecked(label_info)) }
+        Ok(unsafe { self.begin_debug_utils_label_unchecked(label_info) })
     }
 
     fn validate_begin_debug_utils_label(
@@ -89,7 +89,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_insert_debug_utils_label(&label_info)?;
 
-        unsafe { Ok(self.insert_debug_utils_label_unchecked(label_info)) }
+        Ok(unsafe { self.insert_debug_utils_label_unchecked(label_info) })
     }
 
     fn validate_insert_debug_utils_label(

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -54,7 +54,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_blend_constants(constants)?;
 
-        unsafe { Ok(self.set_blend_constants_unchecked(constants)) }
+        Ok(unsafe { self.set_blend_constants_unchecked(constants) })
     }
 
     fn validate_set_blend_constants(
@@ -90,7 +90,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_color_write_enable(&enables)?;
 
-        unsafe { Ok(self.set_color_write_enable_unchecked(enables)) }
+        Ok(unsafe { self.set_color_write_enable_unchecked(enables) })
     }
 
     fn validate_set_color_write_enable(
@@ -146,7 +146,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_cull_mode(cull_mode)?;
 
-        unsafe { Ok(self.set_cull_mode_unchecked(cull_mode)) }
+        Ok(unsafe { self.set_cull_mode_unchecked(cull_mode) })
     }
 
     fn validate_set_cull_mode(&self, cull_mode: CullMode) -> Result<(), Box<ValidationError>> {
@@ -180,7 +180,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_bias(constant_factor, clamp, slope_factor)?;
 
-        unsafe { Ok(self.set_depth_bias_unchecked(constant_factor, clamp, slope_factor)) }
+        Ok(unsafe { self.set_depth_bias_unchecked(constant_factor, clamp, slope_factor) })
     }
 
     fn validate_set_depth_bias(
@@ -227,7 +227,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_bias_enable(enable)?;
 
-        unsafe { Ok(self.set_depth_bias_enable_unchecked(enable)) }
+        Ok(unsafe { self.set_depth_bias_enable_unchecked(enable) })
     }
 
     fn validate_set_depth_bias_enable(&self, enable: bool) -> Result<(), Box<ValidationError>> {
@@ -259,7 +259,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_bounds(bounds.clone())?;
 
-        unsafe { Ok(self.set_depth_bounds_unchecked(bounds)) }
+        Ok(unsafe { self.set_depth_bounds_unchecked(bounds) })
     }
 
     fn validate_set_depth_bounds(
@@ -294,7 +294,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_bounds_test_enable(enable)?;
 
-        unsafe { Ok(self.set_depth_bounds_test_enable_unchecked(enable)) }
+        Ok(unsafe { self.set_depth_bounds_test_enable_unchecked(enable) })
     }
 
     fn validate_set_depth_bounds_test_enable(
@@ -329,7 +329,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_compare_op(compare_op)?;
 
-        unsafe { Ok(self.set_depth_compare_op_unchecked(compare_op)) }
+        Ok(unsafe { self.set_depth_compare_op_unchecked(compare_op) })
     }
 
     fn validate_set_depth_compare_op(
@@ -364,7 +364,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_test_enable(enable)?;
 
-        unsafe { Ok(self.set_depth_test_enable_unchecked(enable)) }
+        Ok(unsafe { self.set_depth_test_enable_unchecked(enable) })
     }
 
     fn validate_set_depth_test_enable(&self, enable: bool) -> Result<(), Box<ValidationError>> {
@@ -396,7 +396,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_write_enable(enable)?;
 
-        unsafe { Ok(self.set_depth_write_enable_unchecked(enable)) }
+        Ok(unsafe { self.set_depth_write_enable_unchecked(enable) })
     }
 
     fn validate_set_depth_write_enable(&self, enable: bool) -> Result<(), Box<ValidationError>> {
@@ -429,7 +429,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_discard_rectangle(first_rectangle, &rectangles)?;
 
-        unsafe { Ok(self.set_discard_rectangle_unchecked(first_rectangle, rectangles)) }
+        Ok(unsafe { self.set_discard_rectangle_unchecked(first_rectangle, rectangles) })
     }
 
     fn validate_set_discard_rectangle(
@@ -471,7 +471,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     pub fn set_front_face(&mut self, face: FrontFace) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_front_face(face)?;
 
-        unsafe { Ok(self.set_front_face_unchecked(face)) }
+        Ok(unsafe { self.set_front_face_unchecked(face) })
     }
 
     fn validate_set_front_face(&self, face: FrontFace) -> Result<(), Box<ValidationError>> {
@@ -504,7 +504,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_line_stipple(factor, pattern)?;
 
-        unsafe { Ok(self.set_line_stipple_unchecked(factor, pattern)) }
+        Ok(unsafe { self.set_line_stipple_unchecked(factor, pattern) })
     }
 
     fn validate_set_line_stipple(
@@ -537,7 +537,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     pub fn set_line_width(&mut self, line_width: f32) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_line_width(line_width)?;
 
-        unsafe { Ok(self.set_line_width_unchecked(line_width)) }
+        Ok(unsafe { self.set_line_width_unchecked(line_width) })
     }
 
     fn validate_set_line_width(&self, line_width: f32) -> Result<(), Box<ValidationError>> {
@@ -566,7 +566,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     pub fn set_logic_op(&mut self, logic_op: LogicOp) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_logic_op(logic_op)?;
 
-        unsafe { Ok(self.set_logic_op_unchecked(logic_op)) }
+        Ok(unsafe { self.set_logic_op_unchecked(logic_op) })
     }
 
     fn validate_set_logic_op(&self, logic_op: LogicOp) -> Result<(), Box<ValidationError>> {
@@ -598,7 +598,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_patch_control_points(num)?;
 
-        unsafe { Ok(self.set_patch_control_points_unchecked(num)) }
+        Ok(unsafe { self.set_patch_control_points_unchecked(num) })
     }
 
     fn validate_set_patch_control_points(&self, num: u32) -> Result<(), Box<ValidationError>> {
@@ -630,7 +630,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_primitive_restart_enable(enable)?;
 
-        unsafe { Ok(self.set_primitive_restart_enable_unchecked(enable)) }
+        Ok(unsafe { self.set_primitive_restart_enable_unchecked(enable) })
     }
 
     fn validate_set_primitive_restart_enable(
@@ -665,7 +665,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_primitive_topology(topology)?;
 
-        unsafe { Ok(self.set_primitive_topology_unchecked(topology)) }
+        Ok(unsafe { self.set_primitive_topology_unchecked(topology) })
     }
 
     fn validate_set_primitive_topology(
@@ -703,7 +703,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_rasterizer_discard_enable(enable)?;
 
-        unsafe { Ok(self.set_rasterizer_discard_enable_unchecked(enable)) }
+        Ok(unsafe { self.set_rasterizer_discard_enable_unchecked(enable) })
     }
 
     fn validate_set_rasterizer_discard_enable(
@@ -739,7 +739,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_scissor(first_scissor, &scissors)?;
 
-        unsafe { Ok(self.set_scissor_unchecked(first_scissor, scissors)) }
+        Ok(unsafe { self.set_scissor_unchecked(first_scissor, scissors) })
     }
 
     fn validate_set_scissor(
@@ -785,7 +785,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_scissor_with_count(&scissors)?;
 
-        unsafe { Ok(self.set_scissor_with_count_unchecked(scissors)) }
+        Ok(unsafe { self.set_scissor_with_count_unchecked(scissors) })
     }
 
     fn validate_set_scissor_with_count(
@@ -824,7 +824,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_compare_mask(faces, compare_mask)?;
 
-        unsafe { Ok(self.set_stencil_compare_mask_unchecked(faces, compare_mask)) }
+        Ok(unsafe { self.set_stencil_compare_mask_unchecked(faces, compare_mask) })
     }
 
     fn validate_set_stencil_compare_mask(
@@ -878,9 +878,9 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_op(faces, fail_op, pass_op, depth_fail_op, compare_op)?;
 
-        unsafe {
-            Ok(self.set_stencil_op_unchecked(faces, fail_op, pass_op, depth_fail_op, compare_op))
-        }
+        Ok(unsafe {
+            self.set_stencil_op_unchecked(faces, fail_op, pass_op, depth_fail_op, compare_op)
+        })
     }
 
     fn validate_set_stencil_op(
@@ -947,7 +947,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_reference(faces, reference)?;
 
-        unsafe { Ok(self.set_stencil_reference_unchecked(faces, reference)) }
+        Ok(unsafe { self.set_stencil_reference_unchecked(faces, reference) })
     }
 
     fn validate_set_stencil_reference(
@@ -997,7 +997,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_test_enable(enable)?;
 
-        unsafe { Ok(self.set_stencil_test_enable_unchecked(enable)) }
+        Ok(unsafe { self.set_stencil_test_enable_unchecked(enable) })
     }
 
     fn validate_set_stencil_test_enable(&self, enable: bool) -> Result<(), Box<ValidationError>> {
@@ -1030,7 +1030,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_write_mask(faces, write_mask)?;
 
-        unsafe { Ok(self.set_stencil_write_mask_unchecked(faces, write_mask)) }
+        Ok(unsafe { self.set_stencil_write_mask_unchecked(faces, write_mask) })
     }
 
     fn validate_set_stencil_write_mask(
@@ -1081,7 +1081,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_vertex_input(&vertex_input_state)?;
 
-        unsafe { Ok(self.set_vertex_input_unchecked(vertex_input_state)) }
+        Ok(unsafe { self.set_vertex_input_unchecked(vertex_input_state) })
     }
 
     fn validate_set_vertex_input(
@@ -1121,7 +1121,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_viewport(first_viewport, &viewports)?;
 
-        unsafe { Ok(self.set_viewport_unchecked(first_viewport, viewports)) }
+        Ok(unsafe { self.set_viewport_unchecked(first_viewport, viewports) })
     }
 
     fn validate_set_viewport(
@@ -1166,7 +1166,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_viewport_with_count(&viewports)?;
 
-        unsafe { Ok(self.set_viewport_with_count_unchecked(viewports)) }
+        Ok(unsafe { self.set_viewport_with_count_unchecked(viewports) })
     }
 
     fn validate_set_viewport_with_count(
@@ -1205,9 +1205,9 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_conservative_rasterization_mode()?;
 
-        unsafe {
-            Ok(self.set_conservative_rasterization_mode_unchecked(conservative_rasterization_mode))
-        }
+        Ok(unsafe {
+            self.set_conservative_rasterization_mode_unchecked(conservative_rasterization_mode)
+        })
     }
 
     fn validate_set_conservative_rasterization_mode(&self) -> Result<(), Box<ValidationError>> {
@@ -1244,11 +1244,11 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_extra_primitive_overestimation_size()?;
 
-        unsafe {
-            Ok(self.set_extra_primitive_overestimation_size_unchecked(
+        Ok(unsafe {
+            self.set_extra_primitive_overestimation_size_unchecked(
                 extra_primitive_overestimation_size,
-            ))
-        }
+            )
+        })
     }
 
     fn validate_set_extra_primitive_overestimation_size(&self) -> Result<(), Box<ValidationError>> {
@@ -1291,7 +1291,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_fragment_shading_rate(fragment_size, combiner_ops)?;
 
-        unsafe { Ok(self.set_fragment_shading_rate_unchecked(fragment_size, combiner_ops)) }
+        Ok(unsafe { self.set_fragment_shading_rate_unchecked(fragment_size, combiner_ops) })
     }
 
     fn validate_set_fragment_shading_rate(

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -68,7 +68,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_dispatch(group_counts)?;
 
-        unsafe { Ok(self.dispatch_unchecked(group_counts)) }
+        Ok(unsafe { self.dispatch_unchecked(group_counts) })
     }
 
     fn validate_dispatch(&self, group_counts: [u32; 3]) -> Result<(), Box<ValidationError>> {
@@ -143,7 +143,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_dispatch_indirect(indirect_buffer.as_bytes())?;
 
-        unsafe { Ok(self.dispatch_indirect_unchecked(indirect_buffer)) }
+        Ok(unsafe { self.dispatch_indirect_unchecked(indirect_buffer) })
     }
 
     fn validate_dispatch_indirect(
@@ -231,9 +231,9 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_draw(vertex_count, instance_count, first_vertex, first_instance)?;
 
-        unsafe {
-            Ok(self.draw_unchecked(vertex_count, instance_count, first_vertex, first_instance))
-        }
+        Ok(unsafe {
+            self.draw_unchecked(vertex_count, instance_count, first_vertex, first_instance)
+        })
     }
 
     fn validate_draw(
@@ -422,7 +422,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         let stride = size_of::<DrawIndirectCommand>() as u32;
         self.validate_draw_indirect(indirect_buffer.as_bytes(), draw_count, stride)?;
 
-        unsafe { Ok(self.draw_indirect_unchecked(indirect_buffer, draw_count, stride)) }
+        Ok(unsafe { self.draw_indirect_unchecked(indirect_buffer, draw_count, stride) })
     }
 
     fn validate_draw_indirect(
@@ -538,14 +538,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             stride,
         )?;
 
-        unsafe {
-            Ok(self.draw_indirect_count_unchecked(
+        Ok(unsafe {
+            self.draw_indirect_count_unchecked(
                 indirect_buffer,
                 count_buffer,
                 max_draw_count,
                 stride,
-            ))
-        }
+            )
+        })
     }
 
     fn validate_draw_indirect_count(
@@ -681,15 +681,15 @@ impl<L> AutoCommandBufferBuilder<L> {
             first_instance,
         )?;
 
-        unsafe {
-            Ok(self.draw_indexed_unchecked(
+        Ok(unsafe {
+            self.draw_indexed_unchecked(
                 index_count,
                 instance_count,
                 first_index,
                 vertex_offset,
                 first_instance,
-            ))
-        }
+            )
+        })
     }
 
     fn validate_draw_indexed(
@@ -909,7 +909,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         let stride = size_of::<DrawIndexedIndirectCommand>() as u32;
         self.validate_draw_indexed_indirect(indirect_buffer.as_bytes(), draw_count, stride)?;
 
-        unsafe { Ok(self.draw_indexed_indirect_unchecked(indirect_buffer, draw_count, stride)) }
+        Ok(unsafe { self.draw_indexed_indirect_unchecked(indirect_buffer, draw_count, stride) })
     }
 
     fn validate_draw_indexed_indirect(
@@ -1040,14 +1040,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             stride,
         )?;
 
-        unsafe {
-            Ok(self.draw_indexed_indirect_count_unchecked(
+        Ok(unsafe {
+            self.draw_indexed_indirect_count_unchecked(
                 indirect_buffer,
                 count_buffer,
                 max_draw_count,
                 stride,
-            ))
-        }
+            )
+        })
     }
 
     fn validate_draw_indexed_indirect_count(
@@ -1163,7 +1163,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_draw_mesh_tasks(group_counts)?;
 
-        unsafe { Ok(self.draw_mesh_tasks_unchecked(group_counts)) }
+        Ok(unsafe { self.draw_mesh_tasks_unchecked(group_counts) })
     }
 
     fn validate_draw_mesh_tasks(&self, group_counts: [u32; 3]) -> Result<(), Box<ValidationError>> {
@@ -1361,7 +1361,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         let stride = size_of::<DrawMeshTasksIndirectCommand>() as u32;
         self.validate_draw_mesh_tasks_indirect(indirect_buffer.as_bytes(), draw_count, stride)?;
 
-        unsafe { Ok(self.draw_mesh_tasks_indirect_unchecked(indirect_buffer, draw_count, stride)) }
+        Ok(unsafe { self.draw_mesh_tasks_indirect_unchecked(indirect_buffer, draw_count, stride) })
     }
 
     fn validate_draw_mesh_tasks_indirect(
@@ -1485,14 +1485,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             stride,
         )?;
 
-        unsafe {
-            Ok(self.draw_mesh_tasks_indirect_count_unchecked(
+        Ok(unsafe {
+            self.draw_mesh_tasks_indirect_count_unchecked(
                 indirect_buffer,
                 count_buffer,
                 max_draw_count,
                 stride,
-            ))
-        }
+            )
+        })
     }
 
     fn validate_draw_mesh_tasks_indirect_count(

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -113,7 +113,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_end_query(&query_pool, query)?;
 
-        unsafe { Ok(self.end_query_unchecked(query_pool, query)) }
+        Ok(unsafe { self.end_query_unchecked(query_pool, query) })
     }
 
     fn validate_end_query(
@@ -265,9 +265,9 @@ impl<L> AutoCommandBufferBuilder<L> {
     {
         self.validate_copy_query_pool_results(&query_pool, queries.clone(), &destination, flags)?;
 
-        unsafe {
-            Ok(self.copy_query_pool_results_unchecked(query_pool, queries, destination, flags))
-        }
+        Ok(unsafe {
+            self.copy_query_pool_results_unchecked(query_pool, queries, destination, flags)
+        })
     }
 
     fn validate_copy_query_pool_results<T>(

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -38,7 +38,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_begin_render_pass(&render_pass_begin_info, &subpass_begin_info)?;
 
-        unsafe { Ok(self.begin_render_pass_unchecked(render_pass_begin_info, subpass_begin_info)) }
+        Ok(unsafe { self.begin_render_pass_unchecked(render_pass_begin_info, subpass_begin_info) })
     }
 
     fn validate_begin_render_pass(
@@ -154,7 +154,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_next_subpass(&subpass_end_info, &subpass_begin_info)?;
 
-        unsafe { Ok(self.next_subpass_unchecked(subpass_end_info, subpass_begin_info)) }
+        Ok(unsafe { self.next_subpass_unchecked(subpass_end_info, subpass_begin_info) })
     }
 
     fn validate_next_subpass(
@@ -257,7 +257,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_end_render_pass(&subpass_end_info)?;
 
-        unsafe { Ok(self.end_render_pass_unchecked(subpass_end_info)) }
+        Ok(unsafe { self.end_render_pass_unchecked(subpass_end_info) })
     }
 
     fn validate_end_render_pass(
@@ -343,7 +343,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         rendering_info.set_auto_extent_layers();
         self.validate_begin_rendering(&rendering_info)?;
 
-        unsafe { Ok(self.begin_rendering_unchecked(rendering_info)) }
+        Ok(unsafe { self.begin_rendering_unchecked(rendering_info) })
     }
 
     fn validate_begin_rendering(
@@ -573,7 +573,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     pub fn end_rendering(&mut self) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_end_rendering()?;
 
-        unsafe { Ok(self.end_rendering_unchecked()) }
+        Ok(unsafe { self.end_rendering_unchecked() })
     }
 
     fn validate_end_rendering(&self) -> Result<(), Box<ValidationError>> {
@@ -656,7 +656,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_clear_attachments(&attachments, &rects)?;
 
-        unsafe { Ok(self.clear_attachments_unchecked(attachments, rects)) }
+        Ok(unsafe { self.clear_attachments_unchecked(attachments, rects) })
     }
 
     fn validate_clear_attachments(

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -30,7 +30,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         let command_buffer = DropUnlockCommandBuffer::new(command_buffer)?;
         self.validate_execute_commands(iter::once(&**command_buffer))?;
 
-        unsafe { Ok(self.execute_commands_locked(smallvec![command_buffer])) }
+        Ok(unsafe { self.execute_commands_locked(smallvec![command_buffer]) })
     }
 
     /// Executes multiple secondary command buffers in a vector.
@@ -50,7 +50,7 @@ impl<L> AutoCommandBufferBuilder<L> {
 
         self.validate_execute_commands(command_buffers.iter().map(|cb| &***cb))?;
 
-        unsafe { Ok(self.execute_commands_locked(command_buffers)) }
+        Ok(unsafe { self.execute_commands_locked(command_buffers) })
     }
 
     fn validate_execute_commands<'a>(

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -74,10 +74,7 @@
 //!     .unwrap()
 //!     .bind_vertex_buffers(0, vertex_buffer.clone())
 //!     .unwrap();
-//!
-//! unsafe {
-//!     cb.draw(vertex_buffer.len() as u32, 1, 0, 0).unwrap();
-//! }
+//! unsafe { cb.draw(vertex_buffer.len() as u32, 1, 0, 0) }.unwrap();
 //!
 //! cb.end_render_pass(Default::default()).unwrap();
 //!
@@ -704,12 +701,9 @@ impl CommandBufferInheritanceRenderingInfo {
                 }));
             }
 
-            let potential_format_features = unsafe {
-                device
-                    .physical_device()
-                    .format_properties_unchecked(format)
-                    .potential_format_features()
-            };
+            let format_properties =
+                unsafe { device.physical_device().format_properties_unchecked(format) };
+            let potential_format_features = format_properties.potential_format_features();
 
             if !potential_format_features.intersects(FormatFeatures::COLOR_ATTACHMENT) {
                 return Err(Box::new(ValidationError {
@@ -748,12 +742,9 @@ impl CommandBufferInheritanceRenderingInfo {
                 }));
             }
 
-            let potential_format_features = unsafe {
-                device
-                    .physical_device()
-                    .format_properties_unchecked(format)
-                    .potential_format_features()
-            };
+            let format_properties =
+                unsafe { device.physical_device().format_properties_unchecked(format) };
+            let potential_format_features = format_properties.potential_format_features();
 
             if !potential_format_features.intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT) {
                 return Err(Box::new(ValidationError {
@@ -793,12 +784,9 @@ impl CommandBufferInheritanceRenderingInfo {
                 }));
             }
 
-            let potential_format_features = unsafe {
-                device
-                    .physical_device()
-                    .format_properties_unchecked(format)
-                    .potential_format_features()
-            };
+            let format_properties =
+                unsafe { device.physical_device().format_properties_unchecked(format) };
+            let potential_format_features = format_properties.potential_format_features();
 
             if !potential_format_features.intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT) {
                 return Err(Box::new(ValidationError {

--- a/vulkano/src/deferred.rs
+++ b/vulkano/src/deferred.rs
@@ -34,7 +34,7 @@ impl DeferredOperation {
     pub fn new(device: Arc<Device>) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_new(&device)?;
 
-        unsafe { Ok(Self::new_unchecked(device)?) }
+        Ok(unsafe { Self::new_unchecked(device) }?)
     }
 
     fn validate_new(device: &Device) -> Result<(), Box<ValidationError>> {
@@ -85,8 +85,8 @@ impl DeferredOperation {
 
     /// Executes a portion of the operation on the current thread.
     pub fn join(&self) -> Result<DeferredOperationJoinStatus, VulkanError> {
+        let fns = self.device.fns();
         let result = unsafe {
-            let fns = self.device.fns();
             (fns.khr_deferred_host_operations.deferred_operation_join_khr)(
                 self.device.handle(),
                 self.handle,
@@ -103,8 +103,8 @@ impl DeferredOperation {
 
     /// Returns the result of the operation, or `None` if the operation is not yet complete.
     pub fn result(&self) -> Option<Result<(), VulkanError>> {
+        let fns = self.device.fns();
         let result = unsafe {
-            let fns = self.device.fns();
             (fns.khr_deferred_host_operations
                 .get_deferred_operation_result_khr)(self.device.handle(), self.handle)
         };
@@ -149,8 +149,8 @@ impl DeferredOperation {
     ///
     /// Returns `None` if no exact number of threads can be calculated.
     pub fn max_concurrency(&self) -> Option<u32> {
+        let fns = self.device.fns();
         let result = unsafe {
-            let fns = self.device.fns();
             (fns.khr_deferred_host_operations
                 .get_deferred_operation_max_concurrency_khr)(
                 self.device.handle(), self.handle
@@ -166,13 +166,13 @@ impl Drop for DeferredOperation {
     fn drop(&mut self) {
         let _ = self.wait(); // Ignore errors
 
+        let fns = self.device.fns();
         unsafe {
-            let fns = self.device.fns();
             (fns.khr_deferred_host_operations
                 .destroy_deferred_operation_khr)(
                 self.device.handle(), self.handle, ptr::null()
-            );
-        }
+            )
+        };
     }
 }
 

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -211,7 +211,8 @@ impl StandardDescriptorSetAllocator {
     /// This has no effect if the entry was not initialized yet.
     #[inline]
     pub fn clear(&self, layout: &Arc<DescriptorSetLayout>) {
-        unsafe { &mut *self.pools.get_or(Default::default).get() }.remove(layout.id())
+        let entry_ptr = self.pools.get_or(Default::default).get();
+        unsafe { &mut *entry_ptr }.remove(layout.id())
     }
 
     /// Clears all entries for the current thread. This does not mean that the pools are dropped
@@ -220,7 +221,8 @@ impl StandardDescriptorSetAllocator {
     /// This has no effect if no entries were initialized yet.
     #[inline]
     pub fn clear_all(&self) {
-        unsafe { *self.pools.get_or(Default::default).get() = SortedMap::default() };
+        let entry_ptr = self.pools.get_or(Default::default).get();
+        unsafe { *entry_ptr = SortedMap::default() };
     }
 }
 
@@ -234,7 +236,8 @@ unsafe impl DescriptorSetAllocator for StandardDescriptorSetAllocator {
         let is_fixed = layout.variable_descriptor_count() == 0;
         let pools = self.pools.get_or_default();
 
-        let entry = unsafe { &mut *pools.get() }.get_or_try_insert(layout.id(), || {
+        let entry_ptr = pools.get();
+        let entry = unsafe { &mut *entry_ptr }.get_or_try_insert(layout.id(), || {
             if is_fixed {
                 FixedEntry::new(layout, &self.create_info).map(Entry::Fixed)
             } else {

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -37,7 +37,7 @@ impl DescriptorSetLayout {
     ) -> Result<Arc<DescriptorSetLayout>, Validated<VulkanError>> {
         Self::validate_new(&device, &create_info)?;
 
-        unsafe { Ok(Self::new_unchecked(device, create_info)?) }
+        Ok(unsafe { Self::new_unchecked(device, create_info) }?)
     }
 
     fn validate_new(
@@ -63,11 +63,7 @@ impl DescriptorSetLayout {
             // Safety: create_info is validated, and we only enter here if the
             // max_per_set_descriptors property exists (which means this function exists too).
             if total_descriptor_count > max_per_set_descriptors
-                && unsafe {
-                    device
-                        .descriptor_set_layout_support_unchecked(create_info)
-                        .is_none()
-                }
+                && unsafe { device.descriptor_set_layout_support_unchecked(create_info) }.is_none()
             {
                 return Err(Box::new(ValidationError {
                     problem: "the total number of descriptors across all bindings is greater than \
@@ -201,14 +197,10 @@ impl DescriptorSetLayout {
 impl Drop for DescriptorSetLayout {
     #[inline]
     fn drop(&mut self) {
+        let fns = self.device.fns();
         unsafe {
-            let fns = self.device.fns();
-            (fns.v1_0.destroy_descriptor_set_layout)(
-                self.device.handle(),
-                self.handle,
-                ptr::null(),
-            );
-        }
+            (fns.v1_0.destroy_descriptor_set_layout)(self.device.handle(), self.handle, ptr::null())
+        };
     }
 }
 

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -209,8 +209,8 @@ impl DescriptorSet {
                 self.resources.get_mut(),
                 &descriptor_writes,
                 &descriptor_copies,
-            );
-        }
+            )
+        };
 
         Ok(())
     }

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -179,7 +179,7 @@ impl Device {
     {
         Self::validate_new(&physical_device, &create_info)?;
 
-        unsafe { Ok(Self::new_unchecked(physical_device, create_info)?) }
+        Ok(unsafe { Self::new_unchecked(physical_device, create_info) }?)
     }
 
     fn validate_new(
@@ -363,19 +363,20 @@ impl Device {
             let create_info_vk =
                 create_info.to_vk(&create_info_fields1_vk, &mut create_info_extensions);
 
+            let fns = physical_device.instance().fns();
+
+            let mut output = MaybeUninit::uninit();
             unsafe {
-                let fns = physical_device.instance().fns();
-                let mut output = MaybeUninit::uninit();
                 (fns.v1_0.create_device)(
                     physical_device.handle(),
                     &create_info_vk,
                     ptr::null(),
                     output.as_mut_ptr(),
                 )
-                .result()
-                .map_err(VulkanError::from)?;
-                output.assume_init()
             }
+            .result()
+            .map_err(VulkanError::from)?;
+            unsafe { output.assume_init() }
         };
 
         Ok(Self::from_handle(physical_device, handle, create_info))
@@ -402,9 +403,11 @@ impl Device {
         } = create_info;
 
         let api_version = physical_device.api_version();
-        let fns = DeviceFunctions::load(|name| unsafe {
-            (physical_device.instance().fns().v1_0.get_device_proc_addr)(handle, name.as_ptr())
-                .map_or(ptr::null(), |func| func as _)
+        let fns = DeviceFunctions::load(|name| {
+            unsafe {
+                (physical_device.instance().fns().v1_0.get_device_proc_addr)(handle, name.as_ptr())
+            }
+            .map_or(ptr::null(), |func| func as _)
         });
 
         let mut active_queue_family_indices: SmallVec<[_; 2]> =
@@ -577,13 +580,13 @@ impl Device {
             max_primitive_counts,
         )?;
 
-        unsafe {
-            Ok(self.acceleration_structure_build_sizes_unchecked(
+        Ok(unsafe {
+            self.acceleration_structure_build_sizes_unchecked(
                 build_type,
                 build_info,
                 max_primitive_counts,
-            ))
-        }
+            )
+        })
     }
 
     fn validate_acceleration_structure_build_sizes(
@@ -728,7 +731,7 @@ impl Device {
     ) -> Result<bool, Box<ValidationError>> {
         self.validate_acceleration_structure_is_compatible(version_data)?;
 
-        unsafe { Ok(self.acceleration_structure_is_compatible_unchecked(version_data)) }
+        Ok(unsafe { self.acceleration_structure_is_compatible_unchecked(version_data) })
     }
 
     fn validate_acceleration_structure_is_compatible(
@@ -797,7 +800,7 @@ impl Device {
     ) -> Result<Option<DescriptorSetLayoutSupport>, Box<ValidationError>> {
         self.validate_descriptor_set_layout_support(create_info)?;
 
-        unsafe { Ok(self.descriptor_set_layout_support_unchecked(create_info)) }
+        Ok(unsafe { self.descriptor_set_layout_support_unchecked(create_info) })
     }
 
     fn validate_descriptor_set_layout_support(
@@ -875,7 +878,7 @@ impl Device {
     ) -> Result<MemoryRequirements, Box<ValidationError>> {
         self.validate_buffer_memory_requirements(&create_info)?;
 
-        unsafe { Ok(self.buffer_memory_requirements_unchecked(create_info)) }
+        Ok(unsafe { self.buffer_memory_requirements_unchecked(create_info) })
     }
 
     fn validate_buffer_memory_requirements(
@@ -915,24 +918,26 @@ impl Device {
         let mut memory_requirements2_vk =
             MemoryRequirements::to_mut_vk2(&mut memory_requirements2_extensions_vk);
 
-        unsafe {
-            let fns = self.fns();
+        let fns = self.fns();
 
-            if self.api_version() >= Version::V1_3 {
+        if self.api_version() >= Version::V1_3 {
+            unsafe {
                 (fns.v1_3.get_device_buffer_memory_requirements)(
                     self.handle(),
                     &info_vk,
                     &mut memory_requirements2_vk,
-                );
-            } else {
-                debug_assert!(self.enabled_extensions().khr_maintenance4);
+                )
+            };
+        } else {
+            debug_assert!(self.enabled_extensions().khr_maintenance4);
+            unsafe {
                 (fns.khr_maintenance4
                     .get_device_buffer_memory_requirements_khr)(
                     self.handle(),
                     &info_vk,
                     &mut memory_requirements2_vk,
-                );
-            }
+                )
+            };
         }
 
         // Unborrow
@@ -966,7 +971,7 @@ impl Device {
     ) -> Result<MemoryRequirements, Box<ValidationError>> {
         self.validate_image_memory_requirements(&create_info, plane)?;
 
-        unsafe { Ok(self.image_memory_requirements_unchecked(create_info, plane)) }
+        Ok(unsafe { self.image_memory_requirements_unchecked(create_info, plane) })
     }
 
     fn validate_image_memory_requirements(
@@ -1130,24 +1135,26 @@ impl Device {
         let mut memory_requirements2_vk =
             MemoryRequirements::to_mut_vk2(&mut memory_requirements2_extensions_vk);
 
-        unsafe {
-            let fns = self.fns();
+        let fns = self.fns();
 
-            if self.api_version() >= Version::V1_3 {
+        if self.api_version() >= Version::V1_3 {
+            unsafe {
                 (fns.v1_3.get_device_image_memory_requirements)(
                     self.handle(),
                     &info_vk,
                     &mut memory_requirements2_vk,
-                );
-            } else {
-                debug_assert!(self.enabled_extensions().khr_maintenance4);
+                )
+            };
+        } else {
+            debug_assert!(self.enabled_extensions().khr_maintenance4);
+            unsafe {
                 (fns.khr_maintenance4
                     .get_device_image_memory_requirements_khr)(
                     self.handle(),
                     &info_vk,
                     &mut memory_requirements2_vk,
-                );
-            }
+                )
+            };
         }
 
         // Unborrow
@@ -1270,12 +1277,10 @@ impl Device {
             info_vk = info_vk.object_name(object_name_vk);
         }
 
-        unsafe {
-            let fns = self.fns();
-            (fns.ext_debug_utils.set_debug_utils_object_name_ext)(self.handle, &info_vk)
-                .result()
-                .map_err(VulkanError::from)?;
-        }
+        let fns = self.fns();
+        unsafe { (fns.ext_debug_utils.set_debug_utils_object_name_ext)(self.handle, &info_vk) }
+            .result()
+            .map_err(VulkanError::from)?;
 
         Ok(())
     }
@@ -1342,18 +1347,19 @@ impl Drop for Device {
     fn drop(&mut self) {
         let fns = self.fns();
 
-        unsafe {
-            for &raw_fence in self.fence_pool.lock().iter() {
-                (fns.v1_0.destroy_fence)(self.handle, raw_fence, ptr::null());
-            }
-            for &raw_sem in self.semaphore_pool.lock().iter() {
-                (fns.v1_0.destroy_semaphore)(self.handle, raw_sem, ptr::null());
-            }
-            for &raw_event in self.event_pool.lock().iter() {
-                (fns.v1_0.destroy_event)(self.handle, raw_event, ptr::null());
-            }
-            (fns.v1_0.destroy_device)(self.handle, ptr::null());
+        for &raw_fence in self.fence_pool.lock().iter() {
+            unsafe { (fns.v1_0.destroy_fence)(self.handle, raw_fence, ptr::null()) };
         }
+
+        for &raw_sem in self.semaphore_pool.lock().iter() {
+            unsafe { (fns.v1_0.destroy_semaphore)(self.handle, raw_sem, ptr::null()) };
+        }
+
+        for &raw_event in self.event_pool.lock().iter() {
+            unsafe { (fns.v1_0.destroy_event)(self.handle, raw_event, ptr::null()) };
+        }
+
+        unsafe { (fns.v1_0.destroy_device)(self.handle, ptr::null()) };
     }
 }
 

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -427,7 +427,7 @@ impl PhysicalDevice {
     ) -> Result<Vec<Arc<Display>>, Validated<VulkanError>> {
         self.validate_display_properties()?;
 
-        unsafe { Ok(self.display_properties_unchecked()?) }
+        Ok(unsafe { self.display_properties_unchecked() }?)
     }
 
     fn validate_display_properties(&self) -> Result<(), Box<ValidationError>> {
@@ -454,35 +454,36 @@ impl PhysicalDevice {
             .enabled_extensions()
             .khr_get_display_properties2
         {
-            let properties_vk = unsafe {
-                loop {
-                    let mut count = 0;
+            let properties_vk = loop {
+                let mut count = 0;
+                unsafe {
                     (fns.khr_get_display_properties2
                         .get_physical_device_display_properties2_khr)(
                         self.handle,
                         &mut count,
                         ptr::null_mut(),
                     )
-                    .result()
-                    .map_err(VulkanError::from)?;
+                }
+                .result()
+                .map_err(VulkanError::from)?;
 
-                    let mut properties_vk = vec![DisplayProperties::to_mut_vk2(); count as usize];
-                    let result = (fns
-                        .khr_get_display_properties2
+                let mut properties_vk = vec![DisplayProperties::to_mut_vk2(); count as usize];
+                let result = unsafe {
+                    (fns.khr_get_display_properties2
                         .get_physical_device_display_properties2_khr)(
                         self.handle,
                         &mut count,
                         properties_vk.as_mut_ptr(),
-                    );
+                    )
+                };
 
-                    match result {
-                        ash::vk::Result::SUCCESS => {
-                            properties_vk.set_len(count as usize);
-                            break properties_vk;
-                        }
-                        ash::vk::Result::INCOMPLETE => (),
-                        err => return Err(VulkanError::from(err)),
+                match result {
+                    ash::vk::Result::SUCCESS => {
+                        unsafe { properties_vk.set_len(count as usize) };
+                        break properties_vk;
                     }
+                    ash::vk::Result::INCOMPLETE => (),
+                    err => return Err(VulkanError::from(err)),
                 }
             };
 
@@ -501,32 +502,34 @@ impl PhysicalDevice {
                 })
                 .collect())
         } else {
-            let properties_vk = unsafe {
-                loop {
-                    let mut count = 0;
+            let properties_vk = loop {
+                let mut count = 0;
+                unsafe {
                     (fns.khr_display.get_physical_device_display_properties_khr)(
                         self.handle,
                         &mut count,
                         ptr::null_mut(),
                     )
-                    .result()
-                    .map_err(VulkanError::from)?;
+                }
+                .result()
+                .map_err(VulkanError::from)?;
 
-                    let mut properties_vk = Vec::with_capacity(count as usize);
-                    let result = (fns.khr_display.get_physical_device_display_properties_khr)(
+                let mut properties_vk = Vec::with_capacity(count as usize);
+                let result = unsafe {
+                    (fns.khr_display.get_physical_device_display_properties_khr)(
                         self.handle,
                         &mut count,
                         properties_vk.as_mut_ptr(),
-                    );
+                    )
+                };
 
-                    match result {
-                        ash::vk::Result::SUCCESS => {
-                            properties_vk.set_len(count as usize);
-                            break properties_vk;
-                        }
-                        ash::vk::Result::INCOMPLETE => (),
-                        err => return Err(VulkanError::from(err)),
+                match result {
+                    ash::vk::Result::SUCCESS => {
+                        unsafe { properties_vk.set_len(count as usize) };
+                        break properties_vk;
                     }
+                    ash::vk::Result::INCOMPLETE => (),
+                    err => return Err(VulkanError::from(err)),
                 }
             };
 
@@ -553,7 +556,7 @@ impl PhysicalDevice {
     ) -> Result<Vec<DisplayPlaneProperties>, Validated<VulkanError>> {
         self.validate_display_plane_properties()?;
 
-        unsafe { Ok(self.display_plane_properties_unchecked()?) }
+        Ok(unsafe { self.display_plane_properties_unchecked() }?)
     }
 
     fn validate_display_plane_properties(&self) -> Result<(), Box<ValidationError>> {
@@ -625,36 +628,36 @@ impl PhysicalDevice {
             .enabled_extensions()
             .khr_get_display_properties2
         {
-            let properties_vk = unsafe {
-                loop {
-                    let mut count = 0;
+            let properties_vk = loop {
+                let mut count = 0;
+                unsafe {
                     (fns.khr_get_display_properties2
                         .get_physical_device_display_plane_properties2_khr)(
                         self.handle,
                         &mut count,
                         ptr::null_mut(),
                     )
-                    .result()
-                    .map_err(VulkanError::from)?;
+                }
+                .result()
+                .map_err(VulkanError::from)?;
 
-                    let mut properties =
-                        vec![DisplayPlanePropertiesRaw::to_mut_vk2(); count as usize];
-                    let result = (fns
-                        .khr_get_display_properties2
+                let mut properties = vec![DisplayPlanePropertiesRaw::to_mut_vk2(); count as usize];
+                let result = unsafe {
+                    (fns.khr_get_display_properties2
                         .get_physical_device_display_plane_properties2_khr)(
                         self.handle,
                         &mut count,
                         properties.as_mut_ptr(),
-                    );
+                    )
+                };
 
-                    match result {
-                        ash::vk::Result::SUCCESS => {
-                            properties.set_len(count as usize);
-                            break properties;
-                        }
-                        ash::vk::Result::INCOMPLETE => (),
-                        err => return Err(VulkanError::from(err)),
+                match result {
+                    ash::vk::Result::SUCCESS => {
+                        unsafe { properties.set_len(count as usize) };
+                        break properties;
                     }
+                    ash::vk::Result::INCOMPLETE => (),
+                    err => return Err(VulkanError::from(err)),
                 }
             };
 
@@ -666,35 +669,36 @@ impl PhysicalDevice {
                 })
                 .collect()
         } else {
-            let properties_vk = unsafe {
-                loop {
-                    let mut count = 0;
+            let properties_vk = loop {
+                let mut count = 0;
+                unsafe {
                     (fns.khr_display
                         .get_physical_device_display_plane_properties_khr)(
                         self.handle,
                         &mut count,
                         ptr::null_mut(),
                     )
-                    .result()
-                    .map_err(VulkanError::from)?;
+                }
+                .result()
+                .map_err(VulkanError::from)?;
 
-                    let mut properties = Vec::with_capacity(count as usize);
-                    let result = (fns
-                        .khr_display
+                let mut properties = Vec::with_capacity(count as usize);
+                let result = unsafe {
+                    (fns.khr_display
                         .get_physical_device_display_plane_properties_khr)(
                         self.handle,
                         &mut count,
                         properties.as_mut_ptr(),
-                    );
+                    )
+                };
 
-                    match result {
-                        ash::vk::Result::SUCCESS => {
-                            properties.set_len(count as usize);
-                            break properties;
-                        }
-                        ash::vk::Result::INCOMPLETE => (),
-                        err => return Err(VulkanError::from(err)),
+                match result {
+                    ash::vk::Result::SUCCESS => {
+                        unsafe { properties.set_len(count as usize) };
+                        break properties;
                     }
+                    ash::vk::Result::INCOMPLETE => (),
+                    err => return Err(VulkanError::from(err)),
                 }
             };
 
@@ -722,7 +726,7 @@ impl PhysicalDevice {
     ) -> Result<Vec<Arc<Display>>, Validated<VulkanError>> {
         self.validate_display_plane_supported_displays(plane_index)?;
 
-        unsafe { Ok(self.display_plane_supported_displays_unchecked(plane_index)?) }
+        Ok(unsafe { self.display_plane_supported_displays_unchecked(plane_index) }?)
     }
 
     fn validate_display_plane_supported_displays(
@@ -738,16 +742,15 @@ impl PhysicalDevice {
             }));
         }
 
-        let display_plane_properties_raw = unsafe {
-            self.display_plane_properties_raw().map_err(|_err| {
+        let display_plane_properties_raw =
+            unsafe { self.display_plane_properties_raw() }.map_err(|_err| {
                 Box::new(ValidationError {
                     problem: "`PhysicalDevice::display_plane_properties` \
                         returned an error"
                         .into(),
                     ..Default::default()
                 })
-            })?
-        };
+            })?;
 
         if plane_index as usize >= display_plane_properties_raw.len() {
             return Err(Box::new(ValidationError {
@@ -769,34 +772,36 @@ impl PhysicalDevice {
     ) -> Result<Vec<Arc<Display>>, VulkanError> {
         let fns = self.instance.fns();
 
-        let displays_vk = unsafe {
-            loop {
-                let mut count = 0;
+        let displays_vk = loop {
+            let mut count = 0;
+            unsafe {
                 (fns.khr_display.get_display_plane_supported_displays_khr)(
                     self.handle,
                     plane_index,
                     &mut count,
                     ptr::null_mut(),
                 )
-                .result()
-                .map_err(VulkanError::from)?;
+            }
+            .result()
+            .map_err(VulkanError::from)?;
 
-                let mut displays = Vec::with_capacity(count as usize);
-                let result = (fns.khr_display.get_display_plane_supported_displays_khr)(
+            let mut displays = Vec::with_capacity(count as usize);
+            let result = unsafe {
+                (fns.khr_display.get_display_plane_supported_displays_khr)(
                     self.handle,
                     plane_index,
                     &mut count,
                     displays.as_mut_ptr(),
-                );
+                )
+            };
 
-                match result {
-                    ash::vk::Result::SUCCESS => {
-                        displays.set_len(count as usize);
-                        break displays;
-                    }
-                    ash::vk::Result::INCOMPLETE => (),
-                    err => return Err(VulkanError::from(err)),
+            match result {
+                ash::vk::Result::SUCCESS => {
+                    unsafe { displays.set_len(count as usize) };
+                    break displays;
                 }
+                ash::vk::Result::INCOMPLETE => (),
+                err => return Err(VulkanError::from(err)),
             }
         };
 
@@ -833,7 +838,7 @@ impl PhysicalDevice {
     ) -> Result<ExternalBufferProperties, Box<ValidationError>> {
         self.validate_external_buffer_properties(&info)?;
 
-        unsafe { Ok(self.external_buffer_properties_unchecked(info)) }
+        Ok(unsafe { self.external_buffer_properties_unchecked(info) })
     }
 
     fn validate_external_buffer_properties(
@@ -917,7 +922,7 @@ impl PhysicalDevice {
     ) -> Result<ExternalFenceProperties, Box<ValidationError>> {
         self.validate_external_fence_properties(&info)?;
 
-        unsafe { Ok(self.external_fence_properties_unchecked(info)) }
+        Ok(unsafe { self.external_fence_properties_unchecked(info) })
     }
 
     fn validate_external_fence_properties(
@@ -1001,7 +1006,7 @@ impl PhysicalDevice {
     ) -> Result<ExternalSemaphoreProperties, Box<ValidationError>> {
         self.validate_external_semaphore_properties(&info)?;
 
-        unsafe { Ok(self.external_semaphore_properties_unchecked(info)) }
+        Ok(unsafe { self.external_semaphore_properties_unchecked(info) })
     }
 
     fn validate_external_semaphore_properties(
@@ -1081,7 +1086,7 @@ impl PhysicalDevice {
     ) -> Result<FormatProperties, Box<ValidationError>> {
         self.validate_format_properties(format)?;
 
-        unsafe { Ok(self.format_properties_unchecked(format)) }
+        Ok(unsafe { self.format_properties_unchecked(format) })
     }
 
     fn validate_format_properties(&self, format: Format) -> Result<(), Box<ValidationError>> {
@@ -1176,7 +1181,7 @@ impl PhysicalDevice {
     ) -> Result<Option<ImageFormatProperties>, Validated<VulkanError>> {
         self.validate_image_format_properties(&image_format_info)?;
 
-        unsafe { Ok(self.image_format_properties_unchecked(image_format_info)?) }
+        Ok(unsafe { self.image_format_properties_unchecked(image_format_info) }?)
     }
 
     fn validate_image_format_properties(
@@ -1290,7 +1295,7 @@ impl PhysicalDevice {
     ) -> Result<Vec<SparseImageFormatProperties>, Box<ValidationError>> {
         self.validate_sparse_image_format_properties(&format_info)?;
 
-        unsafe { Ok(self.sparse_image_format_properties_unchecked(format_info)) }
+        Ok(unsafe { self.sparse_image_format_properties_unchecked(format_info) })
     }
 
     fn validate_sparse_image_format_properties(
@@ -1422,7 +1427,7 @@ impl PhysicalDevice {
     ) -> Result<SurfaceCapabilities, Validated<VulkanError>> {
         self.validate_surface_capabilities(surface, &surface_info)?;
 
-        unsafe { Ok(self.surface_capabilities_unchecked(surface, surface_info)?) }
+        Ok(unsafe { self.surface_capabilities_unchecked(surface, surface_info) }?)
     }
 
     fn validate_surface_capabilities(
@@ -1448,9 +1453,8 @@ impl PhysicalDevice {
         // VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-commonparent
         assert_eq!(self.instance(), surface.instance());
 
-        if !(0..self.queue_family_properties.len() as u32).any(|index| unsafe {
-            self.surface_support_unchecked(index, surface)
-                .unwrap_or_default()
+        if !(0..self.queue_family_properties.len() as u32).any(|index| {
+            unsafe { self.surface_support_unchecked(index, surface) }.unwrap_or_default()
         }) {
             return Err(Box::new(ValidationError {
                 context: "surface".into(),
@@ -1480,15 +1484,15 @@ impl PhysicalDevice {
                         ..surface_info.clone()
                     },
                 )
-                .map_err(|_err| {
-                    Box::new(ValidationError {
-                        problem: "`PhysicalDevice::surface_present_modes` \
+            }
+            .map_err(|_err| {
+                Box::new(ValidationError {
+                    problem: "`PhysicalDevice::surface_present_modes` \
                                 returned an error"
-                            .into(),
-                        ..Default::default()
-                    })
-                })?
-            };
+                        .into(),
+                    ..Default::default()
+                })
+            })?;
 
             if !present_modes.into_iter().any(|mode| mode == present_mode) {
                 return Err(Box::new(ValidationError {
@@ -1607,7 +1611,7 @@ impl PhysicalDevice {
     ) -> Result<Vec<(Format, ColorSpace)>, Validated<VulkanError>> {
         self.validate_surface_formats(surface, &surface_info)?;
 
-        unsafe { Ok(self.surface_formats_unchecked(surface, surface_info)?) }
+        Ok(unsafe { self.surface_formats_unchecked(surface, surface_info) }?)
     }
 
     fn validate_surface_formats(
@@ -1633,9 +1637,8 @@ impl PhysicalDevice {
         // VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-commonparent
         assert_eq!(self.instance(), surface.instance());
 
-        if !(0..self.queue_family_properties.len() as u32).any(|index| unsafe {
-            self.surface_support_unchecked(index, surface)
-                .unwrap_or_default()
+        if !(0..self.queue_family_properties.len() as u32).any(|index| {
+            unsafe { self.surface_support_unchecked(index, surface) }.unwrap_or_default()
         }) {
             return Err(Box::new(ValidationError {
                 context: "surface".into(),
@@ -1665,15 +1668,15 @@ impl PhysicalDevice {
                         ..surface_info.clone()
                     },
                 )
-                .map_err(|_err| {
-                    Box::new(ValidationError {
-                        problem: "`PhysicalDevice::surface_present_modes` \
+            }
+            .map_err(|_err| {
+                Box::new(ValidationError {
+                    problem: "`PhysicalDevice::surface_present_modes` \
                                 returned an error"
-                            .into(),
-                        ..Default::default()
-                    })
-                })?
-            };
+                        .into(),
+                    ..Default::default()
+                })
+            })?;
 
             if !present_modes.into_iter().any(|mode| mode == present_mode) {
                 return Err(Box::new(ValidationError {
@@ -1872,7 +1875,7 @@ impl PhysicalDevice {
     ) -> Result<Vec<PresentMode>, Validated<VulkanError>> {
         self.validate_surface_present_modes(surface, &surface_info)?;
 
-        unsafe { Ok(self.surface_present_modes_unchecked(surface, surface_info)?) }
+        Ok(unsafe { self.surface_present_modes_unchecked(surface, surface_info) }?)
     }
 
     fn validate_surface_present_modes(
@@ -1892,9 +1895,8 @@ impl PhysicalDevice {
         // VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-commonparent
         assert_eq!(self.instance(), surface.instance());
 
-        if !(0..self.queue_family_properties.len() as u32).any(|index| unsafe {
-            self.surface_support_unchecked(index, surface)
-                .unwrap_or_default()
+        if !(0..self.queue_family_properties.len() as u32).any(|index| {
+            unsafe { self.surface_support_unchecked(index, surface) }.unwrap_or_default()
         }) {
             return Err(Box::new(ValidationError {
                 context: "surface".into(),
@@ -2095,7 +2097,7 @@ impl PhysicalDevice {
     ) -> Result<bool, Validated<VulkanError>> {
         self.validate_surface_support(queue_family_index, surface)?;
 
-        unsafe { Ok(self.surface_support_unchecked(queue_family_index, surface)?) }
+        Ok(unsafe { self.surface_support_unchecked(queue_family_index, surface) }?)
     }
 
     fn validate_surface_support(
@@ -2162,7 +2164,7 @@ impl PhysicalDevice {
     pub fn tool_properties(&self) -> Result<Vec<ToolProperties>, Validated<VulkanError>> {
         self.validate_tool_properties()?;
 
-        unsafe { Ok(self.tool_properties_unchecked()?) }
+        Ok(unsafe { self.tool_properties_unchecked() }?)
     }
 
     fn validate_tool_properties(&self) -> Result<(), Box<ValidationError>> {
@@ -2265,7 +2267,6 @@ impl PhysicalDevice {
             RawDisplayHandle::AppKit(_) => true,
             RawDisplayHandle::Wayland(display) => {
                 let display = display.display.as_ptr();
-
                 unsafe { self.wayland_presentation_support(queue_family_index, display.cast()) }?
             }
             RawDisplayHandle::Windows(_display) => {
@@ -2412,7 +2413,7 @@ impl PhysicalDevice {
     ) -> Result<bool, Box<ValidationError>> {
         self.validate_win32_presentation_support(queue_family_index)?;
 
-        unsafe { Ok(self.win32_presentation_support_unchecked(queue_family_index)) }
+        Ok(unsafe { self.win32_presentation_support_unchecked(queue_family_index) })
     }
 
     fn validate_win32_presentation_support(

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -166,12 +166,10 @@ impl Image {
         let allocation = unsafe { ResourceMemory::from_allocation(allocator, allocation) };
 
         // SAFETY: we just created this raw image and hasn't bound any memory to it.
-        let image = unsafe {
-            raw_image.bind_memory([allocation]).map_err(|(err, _, _)| {
-                err.map(AllocateImageError::BindMemory)
-                    .map_validation(|err| err.add_context("RawImage::bind_memory"))
-            })?
-        };
+        let image = unsafe { raw_image.bind_memory([allocation]) }.map_err(|(err, _, _)| {
+            err.map(AllocateImageError::BindMemory)
+                .map_validation(|err| err.add_context("RawImage::bind_memory"))
+        })?;
 
         Ok(Arc::new(image))
     }

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -82,7 +82,7 @@ impl RawImage {
     ) -> Result<RawImage, Validated<VulkanError>> {
         Self::validate_new(&device, &create_info)?;
 
-        unsafe { Ok(RawImage::new_unchecked(device, create_info)?) }
+        Ok(unsafe { RawImage::new_unchecked(device, create_info) }?)
     }
 
     fn validate_new(
@@ -306,33 +306,37 @@ impl RawImage {
         let mut memory_requirements2_vk =
             MemoryRequirements::to_mut_vk2(&mut memory_requirements2_extensions_vk);
 
-        unsafe {
-            let fns = device.fns();
+        let fns = device.fns();
 
-            if device.api_version() >= Version::V1_1
-                || device.enabled_extensions().khr_get_memory_requirements2
-            {
-                if device.api_version() >= Version::V1_1 {
+        if device.api_version() >= Version::V1_1
+            || device.enabled_extensions().khr_get_memory_requirements2
+        {
+            if device.api_version() >= Version::V1_1 {
+                unsafe {
                     (fns.v1_1.get_image_memory_requirements2)(
                         device.handle(),
                         &info_vk,
                         &mut memory_requirements2_vk,
-                    );
-                } else {
+                    )
+                };
+            } else {
+                unsafe {
                     (fns.khr_get_memory_requirements2
                         .get_image_memory_requirements2_khr)(
                         device.handle(),
                         &info_vk,
                         &mut memory_requirements2_vk,
-                    );
-                }
-            } else {
+                    )
+                };
+            }
+        } else {
+            unsafe {
                 (fns.v1_0.get_image_memory_requirements)(
                     device.handle(),
                     handle,
                     &mut memory_requirements2_vk.memory_requirements,
-                );
-            }
+                )
+            };
         }
 
         // Unborrow
@@ -350,88 +354,95 @@ impl RawImage {
     #[allow(dead_code)] // Remove when sparse memory is implemented
     fn get_sparse_memory_requirements(&self) -> Vec<SparseImageMemoryRequirements> {
         let device = &self.device;
+        let fns = self.device.fns();
 
-        unsafe {
-            let fns = self.device.fns();
+        if device.api_version() >= Version::V1_1
+            || device.enabled_extensions().khr_get_memory_requirements2
+        {
+            let info2_vk =
+                ash::vk::ImageSparseMemoryRequirementsInfo2::default().image(self.handle);
 
-            if device.api_version() >= Version::V1_1
-                || device.enabled_extensions().khr_get_memory_requirements2
-            {
-                let info2_vk =
-                    ash::vk::ImageSparseMemoryRequirementsInfo2::default().image(self.handle);
+            let mut count = 0;
 
-                let mut count = 0;
-
-                if device.api_version() >= Version::V1_1 {
+            if device.api_version() >= Version::V1_1 {
+                unsafe {
                     (fns.v1_1.get_image_sparse_memory_requirements2)(
                         device.handle(),
                         &info2_vk,
                         &mut count,
                         ptr::null_mut(),
-                    );
-                } else {
-                    (fns.khr_get_memory_requirements2
-                        .get_image_sparse_memory_requirements2_khr)(
-                        device.handle(),
-                        &info2_vk,
-                        &mut count,
-                        ptr::null_mut(),
-                    );
-                }
-
-                let mut requirements2_vk =
-                    vec![SparseImageMemoryRequirements::to_mut_vk2(); count as usize];
-
-                if device.api_version() >= Version::V1_1 {
-                    (fns.v1_1.get_image_sparse_memory_requirements2)(
-                        self.device.handle(),
-                        &info2_vk,
-                        &mut count,
-                        requirements2_vk.as_mut_ptr(),
-                    );
-                } else {
-                    (fns.khr_get_memory_requirements2
-                        .get_image_sparse_memory_requirements2_khr)(
-                        self.device.handle(),
-                        &info2_vk,
-                        &mut count,
-                        requirements2_vk.as_mut_ptr(),
-                    );
-                }
-
-                requirements2_vk.set_len(count as usize);
-
-                requirements2_vk
-                    .iter()
-                    .map(SparseImageMemoryRequirements::from_vk2)
-                    .collect()
+                    )
+                };
             } else {
-                let mut count = 0;
+                unsafe {
+                    (fns.khr_get_memory_requirements2
+                        .get_image_sparse_memory_requirements2_khr)(
+                        device.handle(),
+                        &info2_vk,
+                        &mut count,
+                        ptr::null_mut(),
+                    )
+                };
+            }
 
+            let mut requirements2_vk =
+                vec![SparseImageMemoryRequirements::to_mut_vk2(); count as usize];
+
+            if device.api_version() >= Version::V1_1 {
+                unsafe {
+                    (fns.v1_1.get_image_sparse_memory_requirements2)(
+                        self.device.handle(),
+                        &info2_vk,
+                        &mut count,
+                        requirements2_vk.as_mut_ptr(),
+                    )
+                };
+            } else {
+                unsafe {
+                    (fns.khr_get_memory_requirements2
+                        .get_image_sparse_memory_requirements2_khr)(
+                        self.device.handle(),
+                        &info2_vk,
+                        &mut count,
+                        requirements2_vk.as_mut_ptr(),
+                    )
+                };
+            }
+
+            unsafe { requirements2_vk.set_len(count as usize) };
+            requirements2_vk
+                .iter()
+                .map(SparseImageMemoryRequirements::from_vk2)
+                .collect()
+        } else {
+            let mut count = 0;
+
+            unsafe {
                 (fns.v1_0.get_image_sparse_memory_requirements)(
                     device.handle(),
                     self.handle,
                     &mut count,
                     ptr::null_mut(),
-                );
+                )
+            };
 
-                let mut requirements_vk =
-                    vec![SparseImageMemoryRequirements::to_mut_vk(); count as usize];
+            let mut requirements_vk =
+                vec![SparseImageMemoryRequirements::to_mut_vk(); count as usize];
 
+            unsafe {
                 (fns.v1_0.get_image_sparse_memory_requirements)(
                     device.handle(),
                     self.handle,
                     &mut count,
                     requirements_vk.as_mut_ptr(),
-                );
+                )
+            };
 
-                requirements_vk.set_len(count as usize);
-
-                requirements_vk
-                    .iter()
-                    .map(SparseImageMemoryRequirements::from_vk)
-                    .collect()
-            }
+            unsafe { requirements_vk.set_len(count as usize) };
+            requirements_vk
+                .iter()
+                .map(SparseImageMemoryRequirements::from_vk)
+                .collect()
         }
     }
 
@@ -1159,7 +1170,7 @@ impl RawImage {
     ) -> Result<SubresourceLayout, Box<ValidationError>> {
         self.validate_subresource_layout(aspect, mip_level, array_layer)?;
 
-        unsafe { Ok(self.subresource_layout_unchecked(aspect, mip_level, array_layer)) }
+        Ok(unsafe { self.subresource_layout_unchecked(aspect, mip_level, array_layer) })
     }
 
     fn validate_subresource_layout(
@@ -1417,10 +1428,8 @@ impl Drop for RawImage {
             return;
         }
 
-        unsafe {
-            let fns = self.device.fns();
-            (fns.v1_0.destroy_image)(self.device.handle(), self.handle, ptr::null());
-        }
+        let fns = self.device.fns();
+        unsafe { (fns.v1_0.destroy_image)(self.device.handle(), self.handle, ptr::null()) };
     }
 }
 
@@ -2606,33 +2615,32 @@ impl ImageCreateInfo {
         for drm_format_modifier in iter_or_none(drm_format_modifiers.iter().copied()) {
             for external_memory_handle_type in iter_or_none(external_memory_handle_types) {
                 let image_format_properties = unsafe {
-                    physical_device
-                        .image_format_properties_unchecked(ImageFormatInfo {
-                            flags,
-                            format,
-                            image_type,
-                            tiling,
-                            usage,
-                            stencil_usage,
-                            external_memory_handle_type,
-                            drm_format_modifier_info: drm_format_modifier.map(
-                                |drm_format_modifier| ImageDrmFormatModifierInfo {
-                                    drm_format_modifier,
-                                    sharing: sharing.clone(),
-                                    ..Default::default()
-                                },
-                            ),
-                            ..Default::default()
-                        })
-                        .map_err(|_err| {
-                            Box::new(ValidationError {
-                                problem: "`PhysicalDevice::image_format_properties` \
-                                    returned an error"
-                                    .into(),
+                    physical_device.image_format_properties_unchecked(ImageFormatInfo {
+                        flags,
+                        format,
+                        image_type,
+                        tiling,
+                        usage,
+                        stencil_usage,
+                        external_memory_handle_type,
+                        drm_format_modifier_info: drm_format_modifier.map(|drm_format_modifier| {
+                            ImageDrmFormatModifierInfo {
+                                drm_format_modifier,
+                                sharing: sharing.clone(),
                                 ..Default::default()
-                            })
-                        })?
-                };
+                            }
+                        }),
+                        ..Default::default()
+                    })
+                }
+                .map_err(|_err| {
+                    Box::new(ValidationError {
+                        problem: "`PhysicalDevice::image_format_properties` \
+                                    returned an error"
+                            .into(),
+                        ..Default::default()
+                    })
+                })?;
 
                 let image_format_properties = image_format_properties.ok_or_else(|| Box::new(ValidationError {
                     problem: "the combination of parameters of this image is not \

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -55,7 +55,7 @@ impl ImageView {
     ) -> Result<Arc<ImageView>, Validated<VulkanError>> {
         Self::validate_new(&image, &create_info)?;
 
-        unsafe { Ok(Self::new_unchecked(image, create_info)?) }
+        Ok(unsafe { Self::new_unchecked(image, create_info) }?)
     }
 
     fn validate_new(
@@ -729,11 +729,9 @@ impl ImageView {
 impl Drop for ImageView {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            let device = self.device();
-            let fns = device.fns();
-            (fns.v1_0.destroy_image_view)(device.handle(), self.handle, ptr::null());
-        }
+        let device = self.device();
+        let fns = device.fns();
+        unsafe { (fns.v1_0.destroy_image_view)(device.handle(), self.handle, ptr::null()) };
     }
 }
 

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1099,8 +1099,8 @@ impl<S> GenericMemoryAllocator<S> {
                     offset: 0,
                     size: memory.allocation_size(),
                     _ne: crate::NonExhaustive(()),
-                })?;
-            }
+                })
+            }?;
         }
 
         Ok(Arc::new(memory))

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -59,7 +59,7 @@ impl ComputePipeline {
     ) -> Result<Arc<ComputePipeline>, Validated<VulkanError>> {
         Self::validate_new(&device, cache.as_ref().map(AsRef::as_ref), &create_info)?;
 
-        unsafe { Ok(Self::new_unchecked(device, cache, create_info)?) }
+        Ok(unsafe { Self::new_unchecked(device, cache, create_info) }?)
     }
 
     fn validate_new(
@@ -213,10 +213,8 @@ unsafe impl DeviceOwned for ComputePipeline {
 impl Drop for ComputePipeline {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            let fns = self.device.fns();
-            (fns.v1_0.destroy_pipeline)(self.device.handle(), self.handle, ptr::null());
-        }
+        let fns = self.device.fns();
+        unsafe { (fns.v1_0.destroy_pipeline)(self.device.handle(), self.handle, ptr::null()) };
     }
 }
 
@@ -460,7 +458,7 @@ mod tests {
 
         let (device, queue) = gfx_dev_and_queue!();
 
-        let cs = unsafe {
+        let cs = {
             /*
             #version 450
 
@@ -487,7 +485,8 @@ mod tests {
                 4, 0, 3, 131320, 5, 327745, 12, 13, 9, 10, 196670, 13, 11, 65789, 65592,
             ];
             let module =
-                ShaderModule::new(device.clone(), ShaderModuleCreateInfo::new(&MODULE)).unwrap();
+                unsafe { ShaderModule::new(device.clone(), ShaderModuleCreateInfo::new(&MODULE)) }
+                    .unwrap();
             module
                 .specialize([(83, 0x12345678i32.into())].into_iter().collect())
                 .unwrap()
@@ -560,10 +559,7 @@ mod tests {
                 set,
             )
             .unwrap();
-
-        unsafe {
-            cbb.dispatch([1, 1, 1]).unwrap();
-        }
+        unsafe { cbb.dispatch([1, 1, 1]) }.unwrap();
 
         let cb = cbb.build().unwrap();
 
@@ -596,7 +592,7 @@ mod tests {
             return;
         }
 
-        let cs = unsafe {
+        let cs = {
             /*
             #version 450
 
@@ -636,7 +632,8 @@ mod tests {
                 131321, 17, 131320, 17, 65789, 65592,
             ];
             let module =
-                ShaderModule::new(device.clone(), ShaderModuleCreateInfo::new(&MODULE)).unwrap();
+                unsafe { ShaderModule::new(device.clone(), ShaderModuleCreateInfo::new(&MODULE)) }
+                    .unwrap();
             module.entry_point("main").unwrap()
         };
 
@@ -711,10 +708,7 @@ mod tests {
                 set,
             )
             .unwrap();
-
-        unsafe {
-            cbb.dispatch([128, 1, 1]).unwrap();
-        }
+        unsafe { cbb.dispatch([128, 1, 1]) }.unwrap();
 
         let cb = cbb.build().unwrap();
 

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -180,7 +180,7 @@ impl GraphicsPipeline {
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_new(&device, cache.as_ref().map(AsRef::as_ref), &create_info)?;
 
-        unsafe { Ok(Self::new_unchecked(device, cache, create_info)?) }
+        Ok(unsafe { Self::new_unchecked(device, cache, create_info) }?)
     }
 
     fn validate_new(
@@ -611,10 +611,8 @@ unsafe impl VulkanObject for GraphicsPipeline {
 impl Drop for GraphicsPipeline {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            let fns = self.device.fns();
-            (fns.v1_0.destroy_pipeline)(self.device.handle(), self.handle, ptr::null());
-        }
+        let fns = self.device.fns();
+        unsafe { (fns.v1_0.destroy_pipeline)(self.device.handle(), self.handle, ptr::null()) };
     }
 }
 
@@ -2307,10 +2305,10 @@ impl GraphicsPipelineCreateInfo {
                         }
                     };
 
-                    if !attachment_format.map_or(false, |format| unsafe {
-                        device
-                            .physical_device()
-                            .format_properties_unchecked(format)
+                    if !attachment_format.map_or(false, |format| {
+                        let format_properties =
+                            unsafe { device.physical_device().format_properties_unchecked(format) };
+                        format_properties
                             .potential_format_features()
                             .intersects(FormatFeatures::COLOR_ATTACHMENT_BLEND)
                     }) {

--- a/vulkano/src/pipeline/graphics/subpass.rs
+++ b/vulkano/src/pipeline/graphics/subpass.rs
@@ -225,7 +225,10 @@ impl PipelineRenderingCreateInfo {
                 }));
             }
 
-            if !unsafe { device.physical_device().format_properties_unchecked(format) }
+            let format_properties =
+                unsafe { device.physical_device().format_properties_unchecked(format) };
+
+            if !format_properties
                 .potential_format_features()
                 .intersects(FormatFeatures::COLOR_ATTACHMENT)
             {
@@ -254,7 +257,10 @@ impl PipelineRenderingCreateInfo {
                 }));
             }
 
-            if !unsafe { device.physical_device().format_properties_unchecked(format) }
+            let format_properties =
+                unsafe { device.physical_device().format_properties_unchecked(format) };
+
+            if !format_properties
                 .potential_format_features()
                 .intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT)
             {
@@ -292,7 +298,10 @@ impl PipelineRenderingCreateInfo {
                 }));
             }
 
-            if !unsafe { device.physical_device().format_properties_unchecked(format) }
+            let format_properties =
+                unsafe { device.physical_device().format_properties_unchecked(format) };
+
+            if !format_properties
                 .potential_format_features()
                 .intersects(FormatFeatures::DEPTH_STENCIL_ATTACHMENT)
             {

--- a/vulkano/src/pipeline/graphics/vertex_input/mod.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/mod.rs
@@ -795,12 +795,9 @@ impl VertexInputAttributeDescription {
             }));
         }
 
-        let format_features = unsafe {
-            device
-                .physical_device()
-                .format_properties_unchecked(format)
-                .buffer_features
-        };
+        let format_properties =
+            unsafe { device.physical_device().format_properties_unchecked(format) };
+        let format_features = format_properties.buffer_features;
 
         if !format_features.intersects(FormatFeatures::VERTEX_BUFFER) {
             return Err(Box::new(ValidationError {

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -103,7 +103,7 @@ impl PipelineLayout {
     ) -> Result<Arc<PipelineLayout>, Validated<VulkanError>> {
         Self::validate_new(&device, &create_info)?;
 
-        unsafe { Ok(Self::new_unchecked(device, create_info)?) }
+        Ok(unsafe { Self::new_unchecked(device, create_info) }?)
     }
 
     fn validate_new(
@@ -353,10 +353,10 @@ impl PipelineLayout {
 impl Drop for PipelineLayout {
     #[inline]
     fn drop(&mut self) {
+        let fns = self.device.fns();
         unsafe {
-            let fns = self.device.fns();
-            (fns.v1_0.destroy_pipeline_layout)(self.device.handle(), self.handle, ptr::null());
-        }
+            (fns.v1_0.destroy_pipeline_layout)(self.device.handle(), self.handle, ptr::null())
+        };
     }
 }
 

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -641,10 +641,7 @@ impl ShaderModule {
     /// [`specialize`]: Self::specialize
     #[inline]
     pub fn entry_point(self: &Arc<Self>, name: &str) -> Option<EntryPoint> {
-        unsafe {
-            self.specialize_unchecked(HashMap::default())
-                .entry_point(name)
-        }
+        unsafe { self.specialize_unchecked(HashMap::default()) }.entry_point(name)
     }
 
     /// Equivalent to calling [`specialize`] with empty specialization info,
@@ -657,10 +654,8 @@ impl ShaderModule {
         name: &str,
         execution: ExecutionModel,
     ) -> Option<EntryPoint> {
-        unsafe {
-            self.specialize_unchecked(HashMap::default())
-                .entry_point_with_execution(name, execution)
-        }
+        unsafe { self.specialize_unchecked(HashMap::default()) }
+            .entry_point_with_execution(name, execution)
     }
 
     /// Equivalent to calling [`specialize`] with empty specialization info,
@@ -669,10 +664,7 @@ impl ShaderModule {
     /// [`specialize`]: Self::specialize
     #[inline]
     pub fn single_entry_point(self: &Arc<Self>) -> Option<EntryPoint> {
-        unsafe {
-            self.specialize_unchecked(HashMap::default())
-                .single_entry_point()
-        }
+        unsafe { self.specialize_unchecked(HashMap::default()) }.single_entry_point()
     }
 
     /// Equivalent to calling [`specialize`] with empty specialization info,
@@ -684,20 +676,16 @@ impl ShaderModule {
         self: &Arc<Self>,
         execution: ExecutionModel,
     ) -> Option<EntryPoint> {
-        unsafe {
-            self.specialize_unchecked(HashMap::default())
-                .single_entry_point_with_execution(execution)
-        }
+        unsafe { self.specialize_unchecked(HashMap::default()) }
+            .single_entry_point_with_execution(execution)
     }
 }
 
 impl Drop for ShaderModule {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            let fns = self.device.fns();
-            (fns.v1_0.destroy_shader_module)(self.device.handle(), self.handle, ptr::null());
-        }
+        let fns = self.device.fns();
+        unsafe { (fns.v1_0.destroy_shader_module)(self.device.handle(), self.handle, ptr::null()) };
     }
 }
 
@@ -996,7 +984,7 @@ impl SpecializedShaderModule {
     ) -> Result<Arc<Self>, Box<ValidationError>> {
         Self::validate_new(&base_module, &specialization_info)?;
 
-        unsafe { Ok(Self::new_unchecked(base_module, specialization_info)) }
+        Ok(unsafe { Self::new_unchecked(base_module, specialization_info) })
     }
 
     fn validate_new(

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -188,7 +188,7 @@ impl Surface {
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_headless(&instance)?;
 
-        unsafe { Ok(Self::headless_unchecked(instance, object)?) }
+        Ok(unsafe { Self::headless_unchecked(instance, object) }?)
     }
 
     fn validate_headless(instance: &Instance) -> Result<(), Box<ValidationError>> {
@@ -242,12 +242,7 @@ impl Surface {
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_from_display_plane(&display_mode, &create_info)?;
 
-        unsafe {
-            Ok(Self::from_display_plane_unchecked(
-                display_mode,
-                create_info,
-            )?)
-        }
+        Ok(unsafe { Self::from_display_plane_unchecked(display_mode, create_info) }?)
     }
 
     fn validate_from_display_plane(
@@ -283,15 +278,15 @@ impl Surface {
                 .display()
                 .physical_device()
                 .display_plane_properties_raw()
-                .map_err(|_err| {
-                    Box::new(ValidationError {
-                        problem: "`PhysicalDevice::display_plane_properties` \
+        }
+        .map_err(|_err| {
+            Box::new(ValidationError {
+                problem: "`PhysicalDevice::display_plane_properties` \
                             returned an error"
-                            .into(),
-                        ..Default::default()
-                    })
-                })?
-        };
+                    .into(),
+                ..Default::default()
+            })
+        })?;
 
         if display_mode.display().plane_reorder_possible() {
             if plane_stack_index as usize >= display_plane_properties_raw.len() {
@@ -318,18 +313,17 @@ impl Surface {
             }
         }
 
-        let display_plane_capabilities = unsafe {
-            display_mode
-                .display_plane_capabilities_unchecked(plane_index)
-                .map_err(|_err| {
+        let display_plane_capabilities =
+            unsafe { display_mode.display_plane_capabilities_unchecked(plane_index) }.map_err(
+                |_err| {
                     Box::new(ValidationError {
                         problem: "`DisplayMode::display_plane_capabilities` \
                             returned an error"
                             .into(),
                         ..Default::default()
                     })
-                })?
-        };
+                },
+            )?;
 
         if !display_plane_capabilities
             .supported_alpha
@@ -1393,10 +1387,10 @@ impl Surface {
 impl Drop for Surface {
     #[inline]
     fn drop(&mut self) {
+        let fns = self.instance.fns();
         unsafe {
-            let fns = self.instance.fns();
-            (fns.khr_surface.destroy_surface_khr)(self.instance.handle(), self.handle, ptr::null());
-        }
+            (fns.khr_surface.destroy_surface_khr)(self.instance.handle(), self.handle, ptr::null())
+        };
     }
 }
 
@@ -1525,18 +1519,15 @@ impl DisplaySurfaceCreateInfo {
                     .set_vuids(&["VUID-VkDisplaySurfaceCreateInfoKHR-alphaMode-parameter"])
             })?;
 
-        let display_plane_properties_raw = unsafe {
-            physical_device
-                .display_plane_properties_raw()
-                .map_err(|_err| {
-                    Box::new(ValidationError {
-                        problem: "`PhysicalDevice::display_plane_properties` \
+        let display_plane_properties_raw =
+            unsafe { physical_device.display_plane_properties_raw() }.map_err(|_err| {
+                Box::new(ValidationError {
+                    problem: "`PhysicalDevice::display_plane_properties` \
                             returned an error"
-                            .into(),
-                        ..Default::default()
-                    })
-                })?
-        };
+                        .into(),
+                    ..Default::default()
+                })
+            })?;
 
         if plane_index as usize >= display_plane_properties_raw.len() {
             return Err(Box::new(ValidationError {

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -54,7 +54,7 @@ impl Event {
     ) -> Result<Event, Validated<VulkanError>> {
         Self::validate_new(&device, &create_info)?;
 
-        unsafe { Ok(Self::new_unchecked(device, create_info)?) }
+        Ok(unsafe { Self::new_unchecked(device, create_info) }?)
     }
 
     fn validate_new(
@@ -86,18 +86,20 @@ impl Event {
     ) -> Result<Event, VulkanError> {
         let create_info_vk = create_info.to_vk();
 
-        let handle = unsafe {
+        let handle = {
             let mut output = MaybeUninit::uninit();
             let fns = device.fns();
-            (fns.v1_0.create_event)(
-                device.handle(),
-                &create_info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.v1_0.create_event)(
+                    device.handle(),
+                    &create_info_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
         Ok(Self::from_handle(device, handle, create_info))
@@ -114,13 +116,14 @@ impl Event {
         let handle = device.event_pool().lock().pop();
         let event = match handle {
             Some(handle) => {
+                // Make sure the event isn't signaled
+                let fns = device.fns();
                 unsafe {
-                    // Make sure the event isn't signaled
-                    let fns = device.fns();
                     (fns.v1_0.reset_event)(device.handle(), handle)
                         .result()
-                        .map_err(VulkanError::from)?;
-                }
+                        .map_err(VulkanError::from)
+                }?;
+
                 Event {
                     handle,
                     device: InstanceOwnedDebugWrapper(device),
@@ -132,7 +135,7 @@ impl Event {
             }
             None => {
                 // Pool is empty, alloc new event
-                let mut event = unsafe { Event::new_unchecked(device, Default::default())? };
+                let mut event = unsafe { Event::new_unchecked(device, Default::default()) }?;
                 event.must_put_in_pool = true;
                 event
             }
@@ -175,7 +178,7 @@ impl Event {
     pub fn is_signaled(&self) -> Result<bool, Validated<VulkanError>> {
         self.validate_is_signaled()?;
 
-        unsafe { Ok(self.is_signaled_unchecked()?) }
+        Ok(unsafe { self.is_signaled_unchecked() }?)
     }
 
     fn validate_is_signaled(&self) -> Result<(), Box<ValidationError>> {
@@ -185,14 +188,12 @@ impl Event {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     #[inline]
     pub unsafe fn is_signaled_unchecked(&self) -> Result<bool, VulkanError> {
-        unsafe {
-            let fns = self.device.fns();
-            let result = (fns.v1_0.get_event_status)(self.device.handle(), self.handle);
-            match result {
-                ash::vk::Result::EVENT_SET => Ok(true),
-                ash::vk::Result::EVENT_RESET => Ok(false),
-                err => Err(VulkanError::from(err)),
-            }
+        let fns = self.device.fns();
+        let result = unsafe { (fns.v1_0.get_event_status)(self.device.handle(), self.handle) };
+        match result {
+            ash::vk::Result::EVENT_SET => Ok(true),
+            ash::vk::Result::EVENT_RESET => Ok(false),
+            err => Err(VulkanError::from(err)),
         }
     }
 
@@ -202,7 +203,7 @@ impl Event {
     pub fn set(&mut self) -> Result<(), Validated<VulkanError>> {
         self.validate_set()?;
 
-        unsafe { Ok(self.set_unchecked()?) }
+        Ok(unsafe { self.set_unchecked() }?)
     }
 
     fn validate_set(&mut self) -> Result<(), Box<ValidationError>> {
@@ -212,13 +213,11 @@ impl Event {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     #[inline]
     pub unsafe fn set_unchecked(&mut self) -> Result<(), VulkanError> {
-        unsafe {
-            let fns = self.device.fns();
-            (fns.v1_0.set_event)(self.device.handle(), self.handle)
-                .result()
-                .map_err(VulkanError::from)?;
-            Ok(())
-        }
+        let fns = self.device.fns();
+        unsafe { (fns.v1_0.set_event)(self.device.handle(), self.handle) }
+            .result()
+            .map_err(VulkanError::from)?;
+        Ok(())
     }
 
     /// Changes the `Event` to the unsignaled state.
@@ -247,27 +246,23 @@ impl Event {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     #[inline]
     pub unsafe fn reset_unchecked(&mut self) -> Result<(), VulkanError> {
-        unsafe {
-            let fns = self.device.fns();
-            (fns.v1_0.reset_event)(self.device.handle(), self.handle)
-                .result()
-                .map_err(VulkanError::from)?;
-            Ok(())
-        }
+        let fns = self.device.fns();
+        unsafe { (fns.v1_0.reset_event)(self.device.handle(), self.handle) }
+            .result()
+            .map_err(VulkanError::from)?;
+        Ok(())
     }
 }
 
 impl Drop for Event {
     #[inline]
     fn drop(&mut self) {
-        unsafe {
-            if self.must_put_in_pool {
-                let raw_event = self.handle;
-                self.device.event_pool().lock().push(raw_event);
-            } else {
-                let fns = self.device.fns();
-                (fns.v1_0.destroy_event)(self.device.handle(), self.handle, ptr::null());
-            }
+        if self.must_put_in_pool {
+            let raw_event = self.handle;
+            self.device.event_pool().lock().push(raw_event);
+        } else {
+            let fns = self.device.fns();
+            unsafe { (fns.v1_0.destroy_event)(self.device.handle(), self.handle, ptr::null()) };
         }
     }
 }


### PR DESCRIPTION
Same as previously, but for the Vulkano library itself. I've also enabled the `clippy.multiple_unsafe_ops_per_block` lint.