### PR TITLE
Revert making `Raw{Buffer,Image}::bind_memory` unsafe

### DIFF
--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -325,9 +325,9 @@ mod linux {
                 .export_fd(ExternalMemoryHandleType::OpaqueFd)
                 .unwrap();
 
-            // SAFETY: we just created this raw image and hasn't bound any memory to it.
             let image = Arc::new(
-                unsafe { raw_image.bind_memory([ResourceMemory::new_dedicated(image_memory)]) }
+                raw_image
+                    .bind_memory([ResourceMemory::new_dedicated(image_memory)])
                     .map_err(|(err, _, _)| err)
                     .unwrap(),
             );

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -404,8 +404,7 @@ impl Buffer {
             .map_err(AllocateBufferError::AllocateMemory)?;
         let allocation = unsafe { ResourceMemory::from_allocation(allocator, allocation) };
 
-        // SAFETY: we just created this raw buffer and hasn't bound any memory to it.
-        let buffer = unsafe { raw_buffer.bind_memory(allocation) }.map_err(|(err, _, _)| {
+        let buffer = raw_buffer.bind_memory(allocation).map_err(|(err, _, _)| {
             err.map(AllocateBufferError::BindMemory)
                 .map_validation(|err| err.add_context("RawBuffer::bind_memory"))
         })?;

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -166,7 +166,7 @@ impl Image {
         let allocation = unsafe { ResourceMemory::from_allocation(allocator, allocation) };
 
         // SAFETY: we just created this raw image and hasn't bound any memory to it.
-        let image = unsafe { raw_image.bind_memory([allocation]) }.map_err(|(err, _, _)| {
+        let image = raw_image.bind_memory([allocation]).map_err(|(err, _, _)| {
             err.map(AllocateImageError::BindMemory)
                 .map_validation(|err| err.add_context("RawImage::bind_memory"))
         })?;


### PR DESCRIPTION
This reverts the making unsafe of the `bind_memory` methods that was done in #2413, as it's a bit silly to make code that was safe before unsafe because of a niche use case which already comes with unsafe code.

Changelog:
Remove these lines:
```markdown
### Breaking changes
Changes to buffers:
- `RawBuffer::bind_memory` is now marked unsafe.

Changes to images:
- `RawImage::bind_memory` is now marked unsafe.
```
