### PR TITLE
Improve `DeviceLayout` convenience

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -30,7 +30,6 @@
 use glam::f32::Mat4;
 use rand::Rng;
 use std::{
-    alloc::Layout,
     error::Error,
     slice,
     sync::{
@@ -293,7 +292,7 @@ impl App {
                         | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                     ..Default::default()
                 },
-                DeviceLayout::from_layout(Layout::for_value(&vertices)).unwrap(),
+                DeviceLayout::for_value(vertices.as_slice()).unwrap(),
             )
             .unwrap();
 
@@ -311,7 +310,7 @@ impl App {
                             | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                         ..Default::default()
                     },
-                    DeviceLayout::from_layout(Layout::new::<vs::Data>()).unwrap(),
+                    DeviceLayout::new_sized::<vs::Data>(),
                 )
                 .unwrap()
         });

--- a/examples/bloom/scene.rs
+++ b/examples/bloom/scene.rs
@@ -1,5 +1,5 @@
 use crate::{App, RenderContext};
-use std::{alloc::Layout, slice, sync::Arc};
+use std::{slice, sync::Arc};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::RenderPassBeginInfo,
@@ -122,7 +122,7 @@ impl SceneTask {
                         | MemoryTypeFilter::HOST_SEQUENTIAL_WRITE,
                     ..Default::default()
                 },
-                DeviceLayout::from_layout(Layout::for_value(&vertices)).unwrap(),
+                DeviceLayout::for_value(vertices.as_slice()).unwrap(),
             )
             .unwrap();
 

--- a/vulkano/src/buffer/allocator.rs
+++ b/vulkano/src/buffer/allocator.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         DeviceAlignment,
     },
-    DeviceSize, NonZeroDeviceSize, Validated,
+    DeviceSize, Validated,
 };
 use crossbeam_queue::ArrayQueue;
 use std::{
@@ -241,7 +241,6 @@ where
     where
         T: BufferContents + ?Sized,
     {
-        let len = NonZeroDeviceSize::new(len).expect("empty slices are not valid buffer contents");
         let layout = T::LAYOUT.layout_for_len(len).unwrap();
 
         unsafe { &mut *self.state.get() }

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -83,8 +83,8 @@ use crate::{
     },
     range_map::RangeMap,
     sync::{future::AccessError, AccessConflict, CurrentAccess, Sharing},
-    DeviceSize, NonNullDeviceAddress, NonZeroDeviceSize, Requires, RequiresAllOf, RequiresOneOf,
-    Validated, ValidationError, Version, VulkanError, VulkanObject,
+    DeviceSize, NonNullDeviceAddress, Requires, RequiresAllOf, RequiresOneOf, Validated,
+    ValidationError, Version, VulkanError, VulkanObject,
 };
 use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
@@ -352,7 +352,6 @@ impl Buffer {
     where
         T: BufferContents + ?Sized,
     {
-        let len = NonZeroDeviceSize::new(len).expect("empty slices are not valid buffer contents");
         let layout = T::LAYOUT.layout_for_len(len).unwrap();
         let buffer = Subbuffer::new(Buffer::new(
             allocator,

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -944,10 +944,10 @@ impl BufferContentsLayout {
         }
     }
 
-    /// Returns the [`DeviceLayout`] for the data for the given `len`, or returns [`None`] on
-    /// arithmetic overflow or if the total size would exceed [`DeviceLayout::MAX_SIZE`].
+    /// Returns the [`DeviceLayout`] for the data for the given `len`, or returns [`None`] if `len`
+    /// is zero or if the total size would exceed [`DeviceLayout::MAX_SIZE`].
     #[inline]
-    pub const fn layout_for_len(&self, len: NonZeroDeviceSize) -> Option<DeviceLayout> {
+    pub const fn layout_for_len(&self, len: DeviceSize) -> Option<DeviceLayout> {
         match &self.0 {
             BufferContentsLayoutInner::Sized(sized) => Some(*sized),
             BufferContentsLayoutInner::Unsized {
@@ -977,7 +977,7 @@ impl BufferContentsLayout {
             "types with alignments above 64 are not valid buffer contents",
         );
 
-        if let Ok(sized) = DeviceLayout::from_layout(sized) {
+        if let Some(sized) = DeviceLayout::from_layout(sized) {
             Self(BufferContentsLayoutInner::Sized(sized))
         } else {
             unreachable!()
@@ -994,7 +994,7 @@ impl BufferContentsLayout {
             "types with alignments above 64 are not valid buffer contents",
         );
 
-        if let Ok(element_layout) = DeviceLayout::from_layout(element_layout) {
+        if let Some(element_layout) = DeviceLayout::from_layout(element_layout) {
             Self(BufferContentsLayoutInner::Unsized {
                 head_layout: None,
                 element_layout,
@@ -1021,11 +1021,11 @@ impl BufferContentsLayout {
 
         while i < field_layouts.len() {
             head_layout = match DeviceLayout::from_layout(field_layouts[i]) {
-                Ok(field_layout) => Some(match head_layout {
+                Some(field_layout) => Some(match head_layout {
                     Some(layout) => extend(layout, field_layout),
                     None => field_layout,
                 }),
-                Err(_) => unreachable!(),
+                None => unreachable!(),
             };
 
             i += 1;
@@ -1133,7 +1133,7 @@ impl BufferContentsLayout {
         )
     }
 
-    pub(super) const fn unwrap_sized(self) -> DeviceLayout {
+    pub(crate) const fn unwrap_sized(self) -> DeviceLayout {
         match self.0 {
             BufferContentsLayoutInner::Sized(sized) => sized,
             BufferContentsLayoutInner::Unsized { .. } => {


### PR DESCRIPTION
This greatly improves ergonomics of working with `DeviceLayout`, which is important considering I would like `DeviceLayout` to be the one shared way of specifying a layout for all allocation, like buffers and suballocations thereof. `DeviceLayout::repeat` et al. taking `NonZeroDeviceSize` was a mistake as that adds way too much boilerplate for little benefit. The added constructors bring us with line with std's `Layout` such that users don't have to import and create a `Layout` just to create a `DeviceLayout`.

Changelog:
```markdown
### Breaking changes
Changes to memory allocation:
- `DeviceLayout::repeat` and `BufferContentsLayout::layout_for_len` now take `DeviceSize` as argument.
- `DeviceLayout::{from_layout,into_layout}` return an `Option` now.

### Additions
- Added `DeviceLayout::{new_sized,new_unsized,for_value}` for improved ergonomics when (sub)allocating buffers.
- Added `DeviceAlignment::of_val`.
```
