### PR TITLE
Revert #2419

### DIFF
--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -4,7 +4,7 @@ use vulkano::{
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, BlitImageInfo,
         BufferImageCopy, ClearColorImageInfo, CommandBufferUsage, CopyBufferToImageInfo,
-        CopyImageInfo, ImageBlit, ImageCopy, RenderPassBeginInfo,
+        CopyImageInfo, ImageBlit, ImageCopy, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -3,7 +3,7 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyBufferToImageInfo, RenderPassBeginInfo,
+        CopyBufferToImageInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -12,7 +12,7 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyBufferToImageInfo, RenderPassBeginInfo,
+        CopyBufferToImageInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,

--- a/examples/interactive-fractal/fractal_compute_pipeline.rs
+++ b/examples/interactive-fractal/fractal_compute_pipeline.rs
@@ -5,6 +5,7 @@ use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
+        PrimaryCommandBufferAbstract,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -58,7 +58,7 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyImageToBufferInfo, RenderPassBeginInfo,
+        CopyImageToBufferInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -6,7 +6,8 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyImageToBufferInfo, RenderPassBeginInfo, SubpassBeginInfo, SubpassContents,
+        CopyImageToBufferInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo, SubpassBeginInfo,
+        SubpassContents,
     },
     device::{physical::PhysicalDeviceType, Device, DeviceCreateInfo, QueueCreateInfo, QueueFlags},
     format::Format,

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -3,7 +3,7 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyBufferToImageInfo, RenderPassBeginInfo,
+        CopyBufferToImageInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{layout::DescriptorSetLayoutCreateFlags, WriteDescriptorSet},
     device::{

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -3,7 +3,7 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyBufferToImageInfo, RenderPassBeginInfo,
+        CopyBufferToImageInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, layout::DescriptorBindingFlags, DescriptorSet,

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -8,7 +8,7 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyBufferInfo, RenderPassBeginInfo,
+        CopyBufferInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -3,7 +3,7 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage, Subbuffer},
     command_buffer::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
-        CopyBufferToImageInfo, RenderPassBeginInfo,
+        CopyBufferToImageInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,

--- a/vulkano/src/buffer/allocator.rs
+++ b/vulkano/src/buffer/allocator.rs
@@ -78,7 +78,9 @@ const MAX_ARENAS: usize = 32;
 ///         allocator::{SubbufferAllocator, SubbufferAllocatorCreateInfo},
 ///         BufferUsage,
 ///     },
-///     command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage},
+///     command_buffer::{
+///         AutoCommandBufferBuilder, CommandBufferUsage, PrimaryCommandBufferAbstract,
+///     },
 ///     memory::allocator::MemoryTypeFilter,
 ///     sync::GpuFuture,
 /// };

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -121,7 +121,10 @@ pub mod view;
 /// ```
 /// use vulkano::{
 ///     buffer::{BufferUsage, Buffer, BufferCreateInfo},
-///     command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage, CopyBufferInfo},
+///     command_buffer::{
+///         AutoCommandBufferBuilder, CommandBufferUsage, CopyBufferInfo,
+///         PrimaryCommandBufferAbstract,
+///     },
 ///     memory::allocator::{AllocationCreateInfo, MemoryTypeFilter},
 ///     sync::GpuFuture,
 ///     DeviceSize,

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -3,7 +3,7 @@ use crate::{
         auto::{RenderPassStateType, Resource, ResourceUseRef2},
         sys::{CommandBuffer, RecordingCommandBuffer},
         AutoCommandBufferBuilder, CommandBufferInheritanceRenderPassType, CommandBufferLevel,
-        ResourceInCommand, SecondaryAutoCommandBuffer, SecondaryCommandBufferBufferUsage,
+        ResourceInCommand, SecondaryCommandBufferAbstract, SecondaryCommandBufferBufferUsage,
         SecondaryCommandBufferImageUsage, SecondaryCommandBufferResourcesUsage, SubpassContents,
     },
     device::{DeviceOwned, QueueFlags},
@@ -25,7 +25,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     /// with `Flags::OneTimeSubmit` will set `self`'s flags to `Flags::OneTimeSubmit` also.
     pub fn execute_commands(
         &mut self,
-        command_buffer: Arc<SecondaryAutoCommandBuffer>,
+        command_buffer: Arc<dyn SecondaryCommandBufferAbstract>,
     ) -> Result<&mut Self, Box<ValidationError>> {
         let command_buffer = DropUnlockCommandBuffer::new(command_buffer)?;
         self.validate_execute_commands(iter::once(&**command_buffer))?;
@@ -41,7 +41,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     // TODO ^ would be nice if this just worked without errors
     pub fn execute_commands_from_vec(
         &mut self,
-        command_buffers: Vec<Arc<SecondaryAutoCommandBuffer>>,
+        command_buffers: Vec<Arc<dyn SecondaryCommandBufferAbstract>>,
     ) -> Result<&mut Self, Box<ValidationError>> {
         let command_buffers: SmallVec<[_; 4]> = command_buffers
             .into_iter()
@@ -55,10 +55,10 @@ impl<L> AutoCommandBufferBuilder<L> {
 
     fn validate_execute_commands<'a>(
         &self,
-        command_buffers: impl Iterator<Item = &'a SecondaryAutoCommandBuffer> + Clone,
+        command_buffers: impl Iterator<Item = &'a dyn SecondaryCommandBufferAbstract> + Clone,
     ) -> Result<(), Box<ValidationError>> {
         self.inner
-            .validate_execute_commands(command_buffers.clone().map(|cb| cb.inner()))?;
+            .validate_execute_commands(command_buffers.clone().map(|cb| cb.as_raw()))?;
 
         if let Some(render_pass_state) = &self.builder_state.render_pass {
             if render_pass_state.contents != SubpassContents::SecondaryCommandBuffers {
@@ -459,7 +459,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn execute_commands_unchecked(
         &mut self,
-        command_buffers: SmallVec<[Arc<SecondaryAutoCommandBuffer>; 4]>,
+        command_buffers: SmallVec<[Arc<dyn SecondaryCommandBufferAbstract>; 4]>,
     ) -> &mut Self {
         self.execute_commands_locked(
             command_buffers
@@ -670,17 +670,19 @@ impl RecordingCommandBuffer {
     }
 }
 
-struct DropUnlockCommandBuffer(Arc<SecondaryAutoCommandBuffer>);
+struct DropUnlockCommandBuffer(Arc<dyn SecondaryCommandBufferAbstract>);
 
 impl DropUnlockCommandBuffer {
-    fn new(command_buffer: Arc<SecondaryAutoCommandBuffer>) -> Result<Self, Box<ValidationError>> {
+    fn new(
+        command_buffer: Arc<dyn SecondaryCommandBufferAbstract>,
+    ) -> Result<Self, Box<ValidationError>> {
         command_buffer.lock_record()?;
         Ok(Self(command_buffer))
     }
 }
 
 impl std::ops::Deref for DropUnlockCommandBuffer {
-    type Target = Arc<SecondaryAutoCommandBuffer>;
+    type Target = Arc<dyn SecondaryCommandBufferAbstract>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -52,7 +52,10 @@
 //! on the GPU.
 //!
 //! ```
-//! use vulkano::command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage, SubpassContents};
+//! use vulkano::command_buffer::{
+//!     AutoCommandBufferBuilder, CommandBufferUsage, PrimaryCommandBufferAbstract,
+//!     SubpassContents,
+//! };
 //!
 //! # let device: std::sync::Arc<vulkano::device::Device> = return;
 //! # let queue: std::sync::Arc<vulkano::device::Queue> = return;
@@ -97,7 +100,10 @@ pub use self::commands::{
 pub use self::{
     auto::{AutoCommandBufferBuilder, PrimaryAutoCommandBuffer, SecondaryAutoCommandBuffer},
     sys::{CommandBuffer, CommandBufferBeginInfo, RecordingCommandBuffer},
-    traits::{CommandBufferExecError, CommandBufferExecFuture},
+    traits::{
+        CommandBufferExecError, CommandBufferExecFuture, PrimaryCommandBufferAbstract,
+        SecondaryCommandBufferAbstract,
+    },
 };
 use crate::{
     buffer::{Buffer, Subbuffer},
@@ -1185,7 +1191,7 @@ pub struct CommandBufferSubmitInfo {
     /// The command buffer to execute.
     ///
     /// There is no default value.
-    pub command_buffer: Arc<PrimaryAutoCommandBuffer>,
+    pub command_buffer: Arc<dyn PrimaryCommandBufferAbstract>,
 
     pub _ne: crate::NonExhaustive,
 }
@@ -1193,7 +1199,7 @@ pub struct CommandBufferSubmitInfo {
 impl CommandBufferSubmitInfo {
     /// Returns a `CommandBufferSubmitInfo` with the specified `command_buffer`.
     #[inline]
-    pub fn new(command_buffer: Arc<PrimaryAutoCommandBuffer>) -> Self {
+    pub fn new(command_buffer: Arc<dyn PrimaryCommandBufferAbstract>) -> Self {
         Self {
             command_buffer,
             _ne: crate::NonExhaustive(()),

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -92,8 +92,8 @@ use crate::{
     buffer::{Buffer, BufferState},
     command_buffer::{
         CommandBufferExecError, CommandBufferExecFuture, CommandBufferResourcesUsage,
-        CommandBufferState, CommandBufferSubmitInfo, CommandBufferUsage, PrimaryAutoCommandBuffer,
-        SubmitInfo,
+        CommandBufferState, CommandBufferSubmitInfo, CommandBufferUsage,
+        PrimaryCommandBufferAbstract, SubmitInfo,
     },
     device::{DeviceOwned, Queue},
     image::{Image, ImageLayout, ImageState},
@@ -242,7 +242,7 @@ pub unsafe trait GpuFuture: DeviceOwned {
     fn then_execute(
         self,
         queue: Arc<Queue>,
-        command_buffer: Arc<PrimaryAutoCommandBuffer>,
+        command_buffer: Arc<impl PrimaryCommandBufferAbstract + 'static>,
     ) -> Result<CommandBufferExecFuture<Self>, CommandBufferExecError>
     where
         Self: Sized,
@@ -256,7 +256,7 @@ pub unsafe trait GpuFuture: DeviceOwned {
     /// > `CommandBuffer` trait.
     fn then_execute_same_queue(
         self,
-        command_buffer: Arc<PrimaryAutoCommandBuffer>,
+        command_buffer: Arc<impl PrimaryCommandBufferAbstract + 'static>,
     ) -> Result<CommandBufferExecFuture<Self>, CommandBufferExecError>
     where
         Self: Sized,


### PR DESCRIPTION
This reverts #2419; see #2576 for rationale.

Changelog:
Remove this line:
```markdown
### Breaking changes
Changes to command buffers:
- The `PrimaryCommandBufferAbstract` and `SecondaryCommandBufferAbstract` traits were removed.
```