### PR TITLE
Fix incorrect buffer in acceleration structure check

### DIFF
--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -1100,7 +1100,7 @@ impl RecordingCommandBuffer {
                         if primitive_offset as DeviceSize
                             + 3 * primitive_count as DeviceSize
                                 * index_data.index_type().size() as DeviceSize
-                            > vertex_data.size()
+                            > index_data.as_bytes().size()
                         {
                             return Err(Box::new(ValidationError {
                                 problem: format!(


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- [#2607](https://github.com/vulkano-rs/vulkano/issues/2607): Incorrect buffer used in acceleration structure build validation.
```

Fixes #2607.