### PR TITLE
Replace ahash with foldhash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,10 +1804,10 @@ dependencies = [
 name = "vulkano"
 version = "0.34.0"
 dependencies = [
- "ahash",
  "ash",
  "bytemuck",
  "crossbeam-queue",
+ "foldhash",
  "half",
  "heck",
  "indexmap",
@@ -1839,7 +1845,7 @@ dependencies = [
 name = "vulkano-shaders"
 version = "0.34.0"
 dependencies = [
- "ahash",
+ "foldhash",
  "heck",
  "proc-macro2",
  "quote",
@@ -1852,9 +1858,9 @@ dependencies = [
 name = "vulkano-taskgraph"
 version = "0.34.0"
 dependencies = [
- "ahash",
  "ash",
  "concurrent-slotmap",
+ "foldhash",
  "parking_lot",
  "smallvec",
  "thread_local",
@@ -1865,7 +1871,7 @@ dependencies = [
 name = "vulkano-util"
 version = "0.34.0"
 dependencies = [
- "ahash",
+ "foldhash",
  "vulkano",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ version = "0.34"
 path = "vulkano-util"
 
 [workspace.dependencies]
-ahash = "0.8"
 # When updating Ash, also update vk.xml to the same Vulkan patch version that Ash uses.
 # All versions of vk.xml can be found at:
 # https://github.com/KhronosGroup/Vulkan-Headers/commits/main/registry/vk.xml
@@ -51,6 +50,7 @@ ash = "0.38.0"
 bytemuck = "1.9"
 concurrent-slotmap = "0.1.0-alpha.1"
 crossbeam-queue = "0.3"
+foldhash = "0.1"
 half = "2.0"
 heck = "0.4"
 indexmap = "2.0"

--- a/vulkano-shaders/Cargo.toml
+++ b/vulkano-shaders/Cargo.toml
@@ -17,7 +17,7 @@ categories = { workspace = true }
 proc-macro = true
 
 [dependencies]
-ahash = { workspace = true }
+foldhash = { workspace = true }
 heck = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -227,7 +227,7 @@
 #![recursion_limit = "1024"]
 
 use crate::codegen::ShaderKind;
-use ahash::HashMap;
+use foldhash::HashMap;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use shaderc::{EnvVersion, SpirvVersion};

--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -1,5 +1,5 @@
 use crate::{bail, codegen::Shader, LinAlgType, MacroInput};
-use ahash::HashMap;
+use foldhash::HashMap;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens, TokenStreamExt};
 use std::{cmp::Ordering, num::NonZeroUsize};

--- a/vulkano-taskgraph/Cargo.toml
+++ b/vulkano-taskgraph/Cargo.toml
@@ -14,9 +14,9 @@ keywords = { workspace = true }
 categories = { workspace = true }
 
 [dependencies]
-ahash = { workspace = true }
 ash = { workspace = true }
 concurrent-slotmap = { workspace = true }
+foldhash = { workspace = true }
 parking_lot = { workspace = true }
 smallvec = { workspace = true }
 thread_local = { workspace = true }

--- a/vulkano-taskgraph/src/graph/compile.rs
+++ b/vulkano-taskgraph/src/graph/compile.rs
@@ -2223,7 +2223,7 @@ mod tests {
     struct MatchingState {
         submission_index: usize,
         instruction_index: usize,
-        semaphores: ahash::HashMap<&'static str, SemaphoreIndex>,
+        semaphores: foldhash::HashMap<&'static str, SemaphoreIndex>,
     }
 
     macro_rules! assert_matches_instructions {

--- a/vulkano-taskgraph/src/graph/mod.rs
+++ b/vulkano-taskgraph/src/graph/mod.rs
@@ -8,9 +8,9 @@ use crate::{
     resource::{self, AccessType, Flight, HostAccessType, ImageLayoutType},
     Id, InvalidSlotError, Object, ObjectType, QueueFamilyType, Task,
 };
-use ahash::HashMap;
 use ash::vk;
 use concurrent_slotmap::{IterMut, IterUnprotected, SlotId, SlotMap};
+use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::{
     borrow::Cow, cell::RefCell, error::Error, fmt, hint, iter::FusedIterator, ops::Range, sync::Arc,

--- a/vulkano-util/Cargo.toml
+++ b/vulkano-util/Cargo.toml
@@ -14,7 +14,7 @@ keywords = { workspace = true }
 categories = { workspace = true }
 
 [dependencies]
-ahash = { workspace = true }
+foldhash = { workspace = true }
 vulkano = { workspace = true }
 winit = { workspace = true }
 

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -1,5 +1,5 @@
 use crate::{context::VulkanoContext, window::WindowDescriptor};
-use ahash::HashMap;
+use foldhash::HashMap;
 use std::{sync::Arc, time::Duration};
 use vulkano::{
     device::{Device, Queue},

--- a/vulkano-util/src/window.rs
+++ b/vulkano-util/src/window.rs
@@ -3,7 +3,7 @@
 // https://github.com/bevyengine/bevy/blob/main/LICENSE-APACHE
 
 use crate::{context::VulkanoContext, renderer::VulkanoWindowRenderer};
-use ahash::HashMap;
+use foldhash::HashMap;
 use std::collections::hash_map::{Iter, IterMut};
 use vulkano::swapchain::{PresentMode, SwapchainCreateInfo};
 use winit::{

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -15,10 +15,10 @@ keywords = { workspace = true }
 categories = { workspace = true }
 
 [dependencies]
-ahash = { workspace = true }
 ash = { workspace = true }
 bytemuck = { workspace = true, features = ["min_const_generics"] }
 crossbeam-queue = { workspace = true }
+foldhash = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 libloading = { workspace = true }
 once_cell = { workspace = true }
@@ -38,7 +38,7 @@ x11-dl = { workspace = true, optional = true }
 x11rb = { workspace = true, features = ["allow-unsafe-code"], optional = true }
 
 [build-dependencies]
-ahash = { workspace = true }
+foldhash = { workspace = true }
 heck = { workspace = true }
 indexmap = { workspace = true }
 nom = { workspace = true }

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -1,5 +1,5 @@
 use super::{write_file, IndexMap, VkRegistryData};
-use ahash::HashMap;
+use foldhash::HashMap;
 use heck::ToSnakeCase;
 use nom::{bytes::complete::tag, character::complete::digit1, combinator::eof, sequence::tuple};
 use proc_macro2::{Ident, TokenStream};

--- a/vulkano/autogen/mod.rs
+++ b/vulkano/autogen/mod.rs
@@ -1,5 +1,5 @@
 use self::spirv_grammar::SpirvGrammar;
-use ahash::HashMap;
+use foldhash::HashMap;
 use nom::{
     bytes::complete::{tag, take_until},
     character::complete::{self, multispace0, multispace1},
@@ -34,7 +34,7 @@ mod spirv_parse;
 mod spirv_reqs;
 mod version;
 
-pub type IndexMap<K, V> = indexmap::IndexMap<K, V, ahash::RandomState>;
+pub type IndexMap<K, V> = indexmap::IndexMap<K, V, foldhash::fast::RandomState>;
 
 pub fn autogen() {
     let registry = get_vk_registry("vk.xml");

--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -1,5 +1,5 @@
 use super::{write_file, IndexMap, VkRegistryData};
-use ahash::{HashMap, HashSet};
+use foldhash::{HashMap, HashSet};
 use heck::ToSnakeCase;
 use nom::{
     bytes::complete::{tag, take_until, take_while1},

--- a/vulkano/autogen/spirv_parse.rs
+++ b/vulkano/autogen/spirv_parse.rs
@@ -1,5 +1,5 @@
 use super::{write_file, SpirvGrammar};
-use ahash::{HashMap, HashSet};
+use foldhash::{HashMap, HashSet};
 use heck::ToSnakeCase;
 use once_cell::sync::Lazy;
 use proc_macro2::{Ident, TokenStream};

--- a/vulkano/src/cache.rs
+++ b/vulkano/src/cache.rs
@@ -1,4 +1,4 @@
-use ahash::HashMap;
+use foldhash::HashMap;
 use parking_lot::RwLock;
 use std::{
     collections::hash_map::Entry,

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -41,7 +41,7 @@ use crate::{
     },
     DeviceSize, Validated, ValidationError, VulkanError,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use parking_lot::{Mutex, RwLockReadGuard};
 use smallvec::SmallVec;
 use std::{

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -125,8 +125,8 @@ use crate::{
     device::{DeviceFeatures, DeviceProperties},
     pipeline::graphics::vertex_input::VertexInputRate,
 };
-use ahash::HashMap;
 use bytemuck::{Pod, Zeroable};
+use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::{ops::Range, sync::Arc};
 

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -11,7 +11,7 @@ use crate::{
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,
     VulkanObject,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::{collections::BTreeMap, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
 
@@ -1396,7 +1396,7 @@ mod tests {
         },
         shader::ShaderStages,
     };
-    use ahash::HashMap;
+    use foldhash::HashMap;
 
     #[test]
     fn empty() {

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -88,7 +88,7 @@ use crate::{
     image::{sampler::Sampler, ImageLayout},
     Validated, ValidationError, VulkanError, VulkanObject,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use parking_lot::{RwLock, RwLockReadGuard};
 use smallvec::{smallvec, SmallVec};
 use std::{

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -9,7 +9,7 @@ use crate::{
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,
     VulkanObject,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::{cell::Cell, marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
 

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -25,7 +25,7 @@ use crate::{
     shader::{spirv::ExecutionModel, DescriptorBindingRequirements},
     Validated, ValidationError, VulkanError, VulkanObject,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use std::{fmt::Debug, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
 
 /// A pipeline object that describes to the Vulkan implementation how it should perform compute

--- a/vulkano/src/pipeline/graphics/color_blend.rs
+++ b/vulkano/src/pipeline/graphics/color_blend.rs
@@ -20,7 +20,7 @@ use crate::{
     pipeline::inout_interface::{ShaderInterfaceLocationInfo, ShaderInterfaceLocationWidth},
     Requires, RequiresAllOf, RequiresOneOf, ValidationError,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::iter;
 

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -113,7 +113,7 @@ use crate::{
     },
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, VulkanError, VulkanObject,
 };
-use ahash::{HashMap, HashSet};
+use foldhash::{HashMap, HashSet};
 use fragment_shading_rate::FragmentShadingRateState;
 use smallvec::SmallVec;
 use std::{

--- a/vulkano/src/pipeline/graphics/vertex_input/definition.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/definition.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     ValidationError,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use std::{borrow::Cow, collections::hash_map::Entry};
 
 /// Trait for types that can create a [`VertexInputState`] from an [`EntryPoint`].

--- a/vulkano/src/pipeline/graphics/vertex_input/mod.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/mod.rs
@@ -104,7 +104,7 @@ use crate::{
     pipeline::inout_interface::{ShaderInterfaceLocationInfo, ShaderInterfaceLocationWidth},
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use smallvec::SmallVec;
 
 mod buffers;

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -67,7 +67,7 @@ use crate::{
     shader::{DescriptorBindingRequirements, ShaderStage, ShaderStages},
     Validated, ValidationError, VulkanError, VulkanObject,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::{
     array,

--- a/vulkano/src/pipeline/mod.rs
+++ b/vulkano/src/pipeline/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     macros::{vulkan_bitflags, vulkan_enum},
     shader::DescriptorBindingRequirements,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use std::sync::Arc;
 
 pub mod cache;

--- a/vulkano/src/pipeline/shader/inout_interface.rs
+++ b/vulkano/src/pipeline/shader/inout_interface.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     ValidationError,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use std::{collections::hash_map::Entry, convert::Infallible};
 
 pub(crate) fn validate_interfaces_compatible(

--- a/vulkano/src/pipeline/shader/validate_runtime.rs
+++ b/vulkano/src/pipeline/shader/validate_runtime.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use std::{cmp::max, convert::Infallible};
 
 pub(crate) fn validate_runtime(

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,
     VulkanObject,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::{
     cmp::max,

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -427,8 +427,8 @@ use crate::{
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version, VulkanError,
     VulkanObject,
 };
-use ahash::{HashMap, HashSet};
 use bytemuck::bytes_of;
+use foldhash::{HashMap, HashSet};
 use half::f16;
 use smallvec::SmallVec;
 use spirv::ExecutionModel;

--- a/vulkano/src/shader/reflect.rs
+++ b/vulkano/src/shader/reflect.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     DeviceSize, Version,
 };
-use ahash::{HashMap, HashSet};
+use foldhash::{HashMap, HashSet};
 use half::f16;
 use smallvec::{smallvec, SmallVec};
 

--- a/vulkano/src/shader/spirv/mod.rs
+++ b/vulkano/src/shader/spirv/mod.rs
@@ -7,7 +7,7 @@
 //! [SPIR-V specification](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html).
 
 use crate::{shader::SpecializationConstant, Version};
-use ahash::{HashMap, HashSet};
+use foldhash::{HashMap, HashSet};
 use smallvec::{smallvec, SmallVec};
 use std::{
     borrow::Cow,

--- a/vulkano/src/shader/spirv/specialization.rs
+++ b/vulkano/src/shader/spirv/specialization.rs
@@ -2,7 +2,7 @@ use crate::shader::{
     spirv::{Decoration, Id, IdInfo, Instruction, SpecConstantInstruction},
     SpecializationConstant,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use half::f16;
 use smallvec::{smallvec, SmallVec};
 

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -101,7 +101,7 @@ use crate::{
     swapchain::{self, PresentFuture, PresentInfo, Swapchain, SwapchainPresentInfo},
     DeviceSize, Validated, ValidationError, VulkanError, VulkanObject,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use parking_lot::MutexGuard;
 use smallvec::{smallvec, SmallVec};
 use std::{

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -9,7 +9,7 @@ use crate::{
     shader::ShaderStages,
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
-use ahash::HashMap;
+use foldhash::HashMap;
 use once_cell::sync::Lazy;
 use smallvec::SmallVec;
 use std::{ops::Range, sync::Arc};


### PR DESCRIPTION
foldhash is faster than ahash without needing any special hardware support (and arguably more importantly, without relying on static target feature detection like ahash) while still having very good collision resistance unlike e.g. fxhash. Many crates are moving to foldhash including e.g. hashbrown (and soon Bevy and other downstream crates).