### PR TITLE
Fix `shader!` using `bytes` not getting recompiled when the file changes

### DIFF
--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -348,7 +348,9 @@ fn shader_inner(mut input: MacroInput) -> Result<TokenStream> {
                 let words = vulkano::shader::spirv::bytes_to_words(&bytes)
                     .or_else(|err| bail!(path, "failed to read source `{full_path:?}`: {err}"))?;
 
-                codegen::reflect(&input, path, name, &words, Vec::new(), &mut type_registry)?
+                let includes = vec![full_path.into_os_string().into_string().unwrap()];
+
+                codegen::reflect(&input, path, name, &words, includes, &mut type_registry)?
             }
         };
 


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- Vulkano-shaders: Fixed `shader!` invocations using the `bytes` option not getting recompiled automatically when the source file changes.
```
