### PR TITLE
Task graph [6/10]: render passes

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -41,7 +41,6 @@ use std::{
 };
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
-    command_buffer::RenderPassBeginInfo,
     descriptor_set::{
         allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
     },
@@ -71,7 +70,6 @@ use vulkano::{
         DynamicState, GraphicsPipeline, Pipeline, PipelineBindPoint, PipelineLayout,
         PipelineShaderStageCreateInfo,
     },
-    render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
     swapchain::{Surface, Swapchain, SwapchainCreateInfo},
     sync::Sharing,
     DeviceSize, Validated, VulkanError, VulkanLibrary,
@@ -81,7 +79,7 @@ use vulkano_taskgraph::{
         BufferImageCopy, ClearColorImageInfo, CopyBufferToImageInfo, RecordingCommandBuffer,
     },
     graph::{CompileInfo, ExecutableTaskGraph, ExecuteError, TaskGraph},
-    resource::{AccessType, Flight, HostAccessType, ImageLayoutType, Resources},
+    resource::{AccessTypes, Flight, HostAccessType, ImageLayoutType, Resources},
     resource_map, Id, QueueFamilyType, Task, TaskContext, TaskResult,
 };
 use winit::{
@@ -123,8 +121,6 @@ struct App {
 struct RenderContext {
     window: Arc<Window>,
     swapchain_id: Id<Swapchain>,
-    render_pass: Arc<RenderPass>,
-    framebuffers: Vec<Arc<Framebuffer>>,
     viewport: Viewport,
     recreate_swapchain: bool,
     task_graph: ExecutableTaskGraph<Self>,
@@ -370,12 +366,12 @@ impl App {
                 [
                     (
                         texture_ids[0],
-                        AccessType::ClearTransferWrite,
+                        AccessTypes::CLEAR_TRANSFER_WRITE,
                         ImageLayoutType::Optimal,
                     ),
                     (
                         texture_ids[1],
-                        AccessType::ClearTransferWrite,
+                        AccessTypes::CLEAR_TRANSFER_WRITE,
                         ImageLayoutType::Optimal,
                     ),
                 ],
@@ -458,72 +454,26 @@ impl ApplicationHandler for App {
                 .unwrap()
         };
 
-        let render_pass = vulkano::single_pass_renderpass!(
+        let vs = vs::load(self.device.clone())
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
+        let fs = fs::load(self.device.clone())
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
+        let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
+        let stages = [
+            PipelineShaderStageCreateInfo::new(vs),
+            PipelineShaderStageCreateInfo::new(fs),
+        ];
+        let layout = PipelineLayout::new(
             self.device.clone(),
-            attachments: {
-                color: {
-                    format: swapchain_format,
-                    samples: 1,
-                    load_op: Clear,
-                    store_op: Store,
-                },
-            },
-            pass: {
-                color: [color],
-                depth_stencil: {},
-            },
+            PipelineDescriptorSetLayoutCreateInfo::from_stages(&stages)
+                .into_pipeline_layout_create_info(self.device.clone())
+                .unwrap(),
         )
         .unwrap();
-
-        let framebuffers = window_size_dependent_setup(&self.resources, swapchain_id, &render_pass);
-
-        let pipeline = {
-            let vs = vs::load(self.device.clone())
-                .unwrap()
-                .entry_point("main")
-                .unwrap();
-            let fs = fs::load(self.device.clone())
-                .unwrap()
-                .entry_point("main")
-                .unwrap();
-            let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
-            let stages = [
-                PipelineShaderStageCreateInfo::new(vs),
-                PipelineShaderStageCreateInfo::new(fs),
-            ];
-            let layout = PipelineLayout::new(
-                self.device.clone(),
-                PipelineDescriptorSetLayoutCreateInfo::from_stages(&stages)
-                    .into_pipeline_layout_create_info(self.device.clone())
-                    .unwrap(),
-            )
-            .unwrap();
-            let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
-
-            GraphicsPipeline::new(
-                self.device.clone(),
-                None,
-                GraphicsPipelineCreateInfo {
-                    stages: stages.into_iter().collect(),
-                    vertex_input_state: Some(vertex_input_state),
-                    input_assembly_state: Some(InputAssemblyState {
-                        topology: PrimitiveTopology::TriangleStrip,
-                        ..Default::default()
-                    }),
-                    viewport_state: Some(ViewportState::default()),
-                    rasterization_state: Some(RasterizationState::default()),
-                    multisample_state: Some(MultisampleState::default()),
-                    color_blend_state: Some(ColorBlendState::with_attachment_states(
-                        subpass.num_color_attachments(),
-                        ColorBlendAttachmentState::default(),
-                    )),
-                    dynamic_state: [DynamicState::Viewport].into_iter().collect(),
-                    subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
-                },
-            )
-            .unwrap()
-        };
 
         let viewport = Viewport {
             offset: [0.0, 0.0],
@@ -544,7 +494,7 @@ impl ApplicationHandler for App {
 
             DescriptorSet::new(
                 descriptor_set_allocator.clone(),
-                pipeline.layout().set_layouts()[0].clone(),
+                layout.set_layouts()[0].clone(),
                 [WriteDescriptorSet::buffer(0, buffer.clone().into())],
                 [],
             )
@@ -563,7 +513,7 @@ impl ApplicationHandler for App {
 
             DescriptorSet::new(
                 descriptor_set_allocator.clone(),
-                pipeline.layout().set_layouts()[1].clone(),
+                layout.set_layouts()[1].clone(),
                 [
                     WriteDescriptorSet::sampler(0, sampler.clone()),
                     WriteDescriptorSet::image_view(
@@ -578,7 +528,10 @@ impl ApplicationHandler for App {
 
         let mut task_graph = TaskGraph::new(&self.resources, 1, 4);
 
-        let virtual_swapchain_id = task_graph.add_swapchain(&SwapchainCreateInfo::default());
+        let virtual_swapchain_id = task_graph.add_swapchain(&SwapchainCreateInfo {
+            image_format: swapchain_format,
+            ..Default::default()
+        });
         let virtual_texture_id = task_graph.add_image(&ImageCreateInfo {
             sharing: if self.graphics_family_index != self.transfer_family_index {
                 Sharing::Concurrent(
@@ -592,40 +545,43 @@ impl ApplicationHandler for App {
             ..Default::default()
         });
         let virtual_uniform_buffer_id = task_graph.add_buffer(&BufferCreateInfo::default());
+        let virtual_framebuffer_id = task_graph.add_framebuffer();
 
         task_graph.add_host_buffer_access(virtual_uniform_buffer_id, HostAccessType::Write);
 
-        task_graph
+        let render_node_id = task_graph
             .create_task_node(
                 "Render",
                 QueueFamilyType::Graphics,
                 RenderTask {
-                    swapchain_id: virtual_swapchain_id,
                     vertex_buffer_id: self.vertex_buffer_id,
                     current_texture_index: self.current_texture_index.clone(),
-                    pipeline,
+                    pipeline: None,
                     uniform_buffer_id: virtual_uniform_buffer_id,
                     uniform_buffer_sets,
                     sampler_sets,
                 },
             )
-            .image_access(
+            .framebuffer(virtual_framebuffer_id)
+            .color_attachment(
                 virtual_swapchain_id.current_image_id(),
-                AccessType::ColorAttachmentWrite,
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
                 ImageLayoutType::Optimal,
+                &Default::default(),
             )
-            .buffer_access(self.vertex_buffer_id, AccessType::VertexAttributeRead)
+            .buffer_access(self.vertex_buffer_id, AccessTypes::VERTEX_ATTRIBUTE_READ)
             .image_access(
                 virtual_texture_id,
-                AccessType::FragmentShaderSampledRead,
+                AccessTypes::FRAGMENT_SHADER_SAMPLED_READ,
                 ImageLayoutType::Optimal,
             )
             .buffer_access(
                 virtual_uniform_buffer_id,
-                AccessType::VertexShaderUniformRead,
-            );
+                AccessTypes::VERTEX_SHADER_UNIFORM_READ,
+            )
+            .build();
 
-        let task_graph = unsafe {
+        let mut task_graph = unsafe {
             task_graph.compile(&CompileInfo {
                 queues: &[&self.graphics_queue],
                 present_queue: Some(&self.graphics_queue),
@@ -635,11 +591,44 @@ impl ApplicationHandler for App {
         }
         .unwrap();
 
+        let node = task_graph.task_node(render_node_id).unwrap();
+        let subpass = node.subpass().unwrap().clone();
+
+        let pipeline = GraphicsPipeline::new(
+            self.device.clone(),
+            None,
+            GraphicsPipelineCreateInfo {
+                stages: stages.into_iter().collect(),
+                vertex_input_state: Some(vertex_input_state),
+                input_assembly_state: Some(InputAssemblyState {
+                    topology: PrimitiveTopology::TriangleStrip,
+                    ..Default::default()
+                }),
+                viewport_state: Some(ViewportState::default()),
+                rasterization_state: Some(RasterizationState::default()),
+                multisample_state: Some(MultisampleState::default()),
+                color_blend_state: Some(ColorBlendState::with_attachment_states(
+                    subpass.num_color_attachments(),
+                    ColorBlendAttachmentState::default(),
+                )),
+                dynamic_state: [DynamicState::Viewport].into_iter().collect(),
+                subpass: Some(subpass.into()),
+                ..GraphicsPipelineCreateInfo::layout(layout)
+            },
+        )
+        .unwrap();
+
+        task_graph
+            .task_node_mut(render_node_id)
+            .unwrap()
+            .task_mut()
+            .downcast_mut::<RenderTask>()
+            .unwrap()
+            .pipeline = Some(pipeline);
+
         self.rcx = Some(RenderContext {
             window,
             swapchain_id,
-            render_pass,
-            framebuffers,
             viewport,
             recreate_swapchain: false,
             task_graph,
@@ -692,11 +681,6 @@ impl ApplicationHandler for App {
                             ..create_info
                         })
                         .expect("failed to recreate swapchain");
-                    rcx.framebuffers = window_size_dependent_setup(
-                        &self.resources,
-                        rcx.swapchain_id,
-                        &rcx.render_pass,
-                    );
                     rcx.viewport.extent = window_size.into();
                     rcx.recreate_swapchain = false;
                 }
@@ -788,10 +772,9 @@ mod fs {
 }
 
 struct RenderTask {
-    swapchain_id: Id<Swapchain>,
     vertex_buffer_id: Id<Buffer>,
     current_texture_index: Arc<AtomicBool>,
-    pipeline: Arc<GraphicsPipeline>,
+    pipeline: Option<Arc<GraphicsPipeline>>,
     uniform_buffer_id: Id<Buffer>,
     uniform_buffer_sets: [Arc<DescriptorSet>; MAX_FRAMES_IN_FLIGHT as usize],
     sampler_sets: [Arc<DescriptorSet>; 2],
@@ -807,8 +790,6 @@ impl Task for RenderTask {
         rcx: &Self::World,
     ) -> TaskResult {
         let frame_index = tcx.current_frame_index();
-        let swapchain_state = tcx.swapchain(self.swapchain_id)?;
-        let image_index = swapchain_state.current_image_index().unwrap();
 
         // Write to the uniform buffer designated for this frame.
         *tcx.write_buffer(self.uniform_buffer_id, ..)? = vs::Data {
@@ -827,18 +808,13 @@ impl Task for RenderTask {
             },
         };
 
-        cbf.as_raw().begin_render_pass(
-            &RenderPassBeginInfo {
-                clear_values: vec![Some([0.0, 0.0, 0.0, 1.0].into())],
-                ..RenderPassBeginInfo::framebuffer(rcx.framebuffers[image_index as usize].clone())
-            },
-            &Default::default(),
-        )?;
+        let pipeline = self.pipeline.as_ref().unwrap();
+
         cbf.set_viewport(0, slice::from_ref(&rcx.viewport))?;
-        cbf.bind_pipeline_graphics(&self.pipeline)?;
+        cbf.bind_pipeline_graphics(pipeline)?;
         cbf.as_raw().bind_descriptor_sets(
             PipelineBindPoint::Graphics,
-            self.pipeline.layout(),
+            pipeline.layout(),
             0,
             &[
                 // Bind the uniform buffer designated for this frame.
@@ -853,9 +829,6 @@ impl Task for RenderTask {
 
         unsafe { cbf.draw(4, 1, 0, 0) }?;
 
-        cbf.as_raw().end_render_pass(&Default::default())?;
-
-        cbf.destroy_objects(rcx.framebuffers.iter().cloned());
         cbf.destroy_objects(self.uniform_buffer_sets.iter().cloned());
         cbf.destroy_objects(self.sampler_sets.iter().cloned());
 
@@ -936,12 +909,15 @@ fn run_worker(
         )
         .buffer_access(
             virtual_front_staging_buffer_id,
-            AccessType::CopyTransferRead,
+            AccessTypes::COPY_TRANSFER_READ,
         )
-        .buffer_access(virtual_back_staging_buffer_id, AccessType::CopyTransferRead)
+        .buffer_access(
+            virtual_back_staging_buffer_id,
+            AccessTypes::COPY_TRANSFER_READ,
+        )
         .image_access(
             virtual_texture_id,
-            AccessType::CopyTransferWrite,
+            AccessTypes::COPY_TRANSFER_WRITE,
             ImageLayoutType::Optimal,
         );
 
@@ -1088,30 +1064,4 @@ impl Task for UploadTask {
 
         Ok(())
     }
-}
-
-/// This function is called once during initialization, then again whenever the window is resized.
-fn window_size_dependent_setup(
-    resources: &Resources,
-    swapchain_id: Id<Swapchain>,
-    render_pass: &Arc<RenderPass>,
-) -> Vec<Arc<Framebuffer>> {
-    let swapchain_state = resources.swapchain(swapchain_id).unwrap();
-    let images = swapchain_state.images();
-
-    images
-        .iter()
-        .map(|image| {
-            let view = ImageView::new_default(image.clone()).unwrap();
-
-            Framebuffer::new(
-                render_pass.clone(),
-                FramebufferCreateInfo {
-                    attachments: vec![view],
-                    ..Default::default()
-                },
-            )
-            .unwrap()
-        })
-        .collect::<Vec<_>>()
 }

--- a/examples/bloom/bloom.rs
+++ b/examples/bloom/bloom.rs
@@ -80,7 +80,7 @@ impl Task for BloomTask {
             PipelineBindPoint::Compute,
             &rcx.pipeline_layout,
             0,
-            &[&rcx.descriptor_set],
+            &[rcx.descriptor_set.as_raw()],
             &[],
         )?;
 

--- a/examples/bloom/scene.rs
+++ b/examples/bloom/scene.rs
@@ -2,12 +2,8 @@ use crate::{App, RenderContext};
 use std::{slice, sync::Arc};
 use vulkano::{
     buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
-    command_buffer::RenderPassBeginInfo,
-    format::Format,
-    image::{
-        view::{ImageView, ImageViewCreateInfo},
-        Image, ImageAspects, ImageSubresourceRange, ImageUsage,
-    },
+    device::DeviceOwned,
+    image::Image,
     memory::allocator::{AllocationCreateInfo, DeviceLayout, MemoryTypeFilter},
     pipeline::{
         graphics::{
@@ -21,84 +17,21 @@ use vulkano::{
         },
         DynamicState, GraphicsPipeline, PipelineLayout, PipelineShaderStageCreateInfo,
     },
-    render_pass::{Framebuffer, FramebufferCreateInfo, RenderPass, Subpass},
+    render_pass::Subpass,
 };
 use vulkano_taskgraph::{
-    command_buffer::RecordingCommandBuffer,
-    resource::{HostAccessType, Resources},
-    Id, Task, TaskContext, TaskResult,
+    command_buffer::RecordingCommandBuffer, resource::HostAccessType, ClearValues, Id, Task,
+    TaskContext, TaskResult,
 };
 
 pub struct SceneTask {
-    render_pass: Arc<RenderPass>,
-    pipeline: Arc<GraphicsPipeline>,
-    framebuffer: Arc<Framebuffer>,
+    pipeline: Option<Arc<GraphicsPipeline>>,
     vertex_buffer_id: Id<Buffer>,
+    bloom_image_id: Id<Image>,
 }
 
 impl SceneTask {
-    pub fn new(
-        app: &App,
-        pipeline_layout: &Arc<PipelineLayout>,
-        bloom_image_id: Id<Image>,
-    ) -> Self {
-        let render_pass = vulkano::single_pass_renderpass!(
-            app.device.clone(),
-            attachments: {
-                color: {
-                    format: Format::R32_UINT,
-                    samples: 1,
-                    load_op: Clear,
-                    store_op: Store,
-                },
-            },
-            pass: {
-                color: [color],
-                depth_stencil: {},
-            },
-        )
-        .unwrap();
-
-        let pipeline = {
-            let vs = vs::load(app.device.clone())
-                .unwrap()
-                .entry_point("main")
-                .unwrap();
-            let fs = fs::load(app.device.clone())
-                .unwrap()
-                .entry_point("main")
-                .unwrap();
-            let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
-            let stages = [
-                PipelineShaderStageCreateInfo::new(vs),
-                PipelineShaderStageCreateInfo::new(fs),
-            ];
-            let subpass = Subpass::from(render_pass.clone(), 0).unwrap();
-
-            GraphicsPipeline::new(
-                app.device.clone(),
-                None,
-                GraphicsPipelineCreateInfo {
-                    stages: stages.into_iter().collect(),
-                    vertex_input_state: Some(vertex_input_state),
-                    input_assembly_state: Some(InputAssemblyState::default()),
-                    viewport_state: Some(ViewportState::default()),
-                    rasterization_state: Some(RasterizationState::default()),
-                    multisample_state: Some(MultisampleState::default()),
-                    color_blend_state: Some(ColorBlendState::with_attachment_states(
-                        subpass.num_color_attachments(),
-                        ColorBlendAttachmentState::default(),
-                    )),
-                    dynamic_state: [DynamicState::Viewport].into_iter().collect(),
-                    subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(pipeline_layout.clone())
-                },
-            )
-            .unwrap()
-        };
-
-        let framebuffer = window_size_dependent_setup(&app.resources, bloom_image_id, &render_pass);
-
+    pub fn new(app: &App, virtual_bloom_image_id: Id<Image>) -> Self {
         let vertices = [
             MyVertex {
                 position: [-0.5, 0.5],
@@ -145,21 +78,60 @@ impl SceneTask {
         .unwrap();
 
         SceneTask {
-            render_pass,
-            pipeline,
-            framebuffer,
+            pipeline: None,
             vertex_buffer_id,
+            bloom_image_id: virtual_bloom_image_id,
         }
     }
 
-    pub fn handle_resize(&mut self, resources: &Resources, bloom_image_id: Id<Image>) {
-        self.framebuffer =
-            window_size_dependent_setup(resources, bloom_image_id, &self.render_pass);
+    pub fn create_pipeline(&mut self, pipeline_layout: &Arc<PipelineLayout>, subpass: Subpass) {
+        let pipeline = {
+            let vs = vs::load(pipeline_layout.device().clone())
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = fs::load(pipeline_layout.device().clone())
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
+            let stages = [
+                PipelineShaderStageCreateInfo::new(vs),
+                PipelineShaderStageCreateInfo::new(fs),
+            ];
+
+            GraphicsPipeline::new(
+                pipeline_layout.device().clone(),
+                None,
+                GraphicsPipelineCreateInfo {
+                    stages: stages.into_iter().collect(),
+                    vertex_input_state: Some(vertex_input_state),
+                    input_assembly_state: Some(InputAssemblyState::default()),
+                    viewport_state: Some(ViewportState::default()),
+                    rasterization_state: Some(RasterizationState::default()),
+                    multisample_state: Some(MultisampleState::default()),
+                    color_blend_state: Some(ColorBlendState::with_attachment_states(
+                        subpass.num_color_attachments(),
+                        ColorBlendAttachmentState::default(),
+                    )),
+                    dynamic_state: [DynamicState::Viewport].into_iter().collect(),
+                    subpass: Some(subpass.into()),
+                    ..GraphicsPipelineCreateInfo::layout(pipeline_layout.clone())
+                },
+            )
+            .unwrap()
+        };
+
+        self.pipeline = Some(pipeline);
     }
 }
 
 impl Task for SceneTask {
     type World = RenderContext;
+
+    fn clear_values(&self, clear_values: &mut ClearValues<'_>) {
+        clear_values.set(self.bloom_image_id, [0.0; 4]);
+    }
 
     unsafe fn execute(
         &self,
@@ -167,22 +139,11 @@ impl Task for SceneTask {
         _tcx: &mut TaskContext<'_>,
         rcx: &Self::World,
     ) -> TaskResult {
-        cbf.as_raw().begin_render_pass(
-            &RenderPassBeginInfo {
-                clear_values: vec![Some([0u32; 4].into())],
-                ..RenderPassBeginInfo::framebuffer(self.framebuffer.clone())
-            },
-            &Default::default(),
-        )?;
         cbf.set_viewport(0, slice::from_ref(&rcx.viewport))?;
-        cbf.bind_pipeline_graphics(&self.pipeline)?;
+        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap())?;
         cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
 
         unsafe { cbf.draw(3, 1, 0, 0) }?;
-
-        cbf.as_raw().end_render_pass(&Default::default())?;
-
-        cbf.destroy_object(self.framebuffer.clone());
 
         Ok(())
     }
@@ -193,38 +154,6 @@ impl Task for SceneTask {
 struct MyVertex {
     #[format(R32G32_SFLOAT)]
     position: [f32; 2],
-}
-
-fn window_size_dependent_setup(
-    resources: &Resources,
-    bloom_image_id: Id<Image>,
-    render_pass: &Arc<RenderPass>,
-) -> Arc<Framebuffer> {
-    let image_state = resources.image(bloom_image_id).unwrap();
-    let image = image_state.image();
-    let view = ImageView::new(
-        image.clone(),
-        ImageViewCreateInfo {
-            format: Format::R32_UINT,
-            subresource_range: ImageSubresourceRange {
-                aspects: ImageAspects::COLOR,
-                mip_levels: 0..1,
-                array_layers: 0..1,
-            },
-            usage: ImageUsage::COLOR_ATTACHMENT,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    Framebuffer::new(
-        render_pass.clone(),
-        FramebufferCreateInfo {
-            attachments: vec![view],
-            ..Default::default()
-        },
-    )
-    .unwrap()
 }
 
 mod vs {

--- a/examples/ray-tracing/main.rs
+++ b/examples/ray-tracing/main.rs
@@ -25,7 +25,7 @@ use vulkano::{
 };
 use vulkano_taskgraph::{
     graph::{CompileInfo, ExecutableTaskGraph, ExecuteError, NodeId, TaskGraph},
-    resource::{AccessType, Flight, ImageLayoutType, Resources},
+    resource::{AccessTypes, Flight, ImageLayoutType, Resources},
     resource_map, Id, QueueFamilyType,
 };
 use winit::{
@@ -309,7 +309,7 @@ impl ApplicationHandler for App {
             )
             .image_access(
                 virtual_swapchain_id.current_image_id(),
-                AccessType::RayTracingShaderStorageWrite,
+                AccessTypes::RAY_TRACING_SHADER_STORAGE_WRITE,
                 ImageLayoutType::General,
             )
             .build();

--- a/vulkano-taskgraph/src/command_buffer/commands/clear.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/clear.rs
@@ -1,6 +1,6 @@
 use crate::{
     command_buffer::{RecordingCommandBuffer, Result},
-    resource::{AccessType, ImageLayoutType},
+    resource::{AccessTypes, ImageLayoutType},
     Id,
 };
 use smallvec::SmallVec;
@@ -36,7 +36,7 @@ impl RecordingCommandBuffer<'_> {
         } = clear_info;
 
         let image = unsafe { self.accesses.image_unchecked(image) };
-        let image_layout = AccessType::ClearTransferWrite.image_layout(image_layout);
+        let image_layout = AccessTypes::CLEAR_TRANSFER_WRITE.image_layout(image_layout);
 
         let fns = self.device().fns();
         let cmd_clear_color_image = fns.v1_0.cmd_clear_color_image;
@@ -96,7 +96,7 @@ impl RecordingCommandBuffer<'_> {
         } = clear_info;
 
         let image = unsafe { self.accesses.image_unchecked(image) };
-        let image_layout = AccessType::ClearTransferWrite.image_layout(image_layout);
+        let image_layout = AccessTypes::CLEAR_TRANSFER_WRITE.image_layout(image_layout);
 
         let fns = self.device().fns();
         let cmd_clear_depth_stencil_image = fns.v1_0.cmd_clear_depth_stencil_image;

--- a/vulkano-taskgraph/src/command_buffer/commands/copy.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/copy.rs
@@ -1,6 +1,6 @@
 use crate::{
     command_buffer::{RecordingCommandBuffer, Result},
-    resource::{AccessType, ImageLayoutType},
+    resource::{AccessTypes, ImageLayoutType},
     Id,
 };
 use ash::vk;
@@ -171,9 +171,9 @@ impl RecordingCommandBuffer<'_> {
         } = copy_image_info;
 
         let src_image = unsafe { self.accesses.image_unchecked(src_image) };
-        let src_image_layout = AccessType::CopyTransferRead.image_layout(src_image_layout);
+        let src_image_layout = AccessTypes::COPY_TRANSFER_READ.image_layout(src_image_layout);
         let dst_image = unsafe { self.accesses.image_unchecked(dst_image) };
-        let dst_image_layout = AccessType::CopyTransferWrite.image_layout(dst_image_layout);
+        let dst_image_layout = AccessTypes::COPY_TRANSFER_WRITE.image_layout(dst_image_layout);
 
         let fns = self.device().fns();
 
@@ -352,7 +352,7 @@ impl RecordingCommandBuffer<'_> {
 
         let src_buffer = unsafe { self.accesses.buffer_unchecked(src_buffer) };
         let dst_image = unsafe { self.accesses.image_unchecked(dst_image) };
-        let dst_image_layout = AccessType::CopyTransferWrite.image_layout(dst_image_layout);
+        let dst_image_layout = AccessTypes::COPY_TRANSFER_WRITE.image_layout(dst_image_layout);
 
         let fns = self.device().fns();
 
@@ -498,7 +498,7 @@ impl RecordingCommandBuffer<'_> {
         } = copy_image_to_buffer_info;
 
         let src_image = unsafe { self.accesses.image_unchecked(src_image) };
-        let src_image_layout = AccessType::CopyTransferRead.image_layout(src_image_layout);
+        let src_image_layout = AccessTypes::COPY_TRANSFER_READ.image_layout(src_image_layout);
         let dst_buffer = unsafe { self.accesses.buffer_unchecked(dst_buffer) };
 
         let fns = self.device().fns();
@@ -669,9 +669,9 @@ impl RecordingCommandBuffer<'_> {
         } = blit_image_info;
 
         let src_image = unsafe { self.accesses.image_unchecked(src_image) };
-        let src_image_layout = AccessType::BlitTransferRead.image_layout(src_image_layout);
+        let src_image_layout = AccessTypes::BLIT_TRANSFER_READ.image_layout(src_image_layout);
         let dst_image = unsafe { self.accesses.image_unchecked(dst_image) };
-        let dst_image_layout = AccessType::BlitTransferWrite.image_layout(dst_image_layout);
+        let dst_image_layout = AccessTypes::BLIT_TRANSFER_WRITE.image_layout(dst_image_layout);
 
         let fns = self.device().fns();
 
@@ -836,9 +836,9 @@ impl RecordingCommandBuffer<'_> {
         } = resolve_image_info;
 
         let src_image = unsafe { self.accesses.image_unchecked(src_image) };
-        let src_image_layout = AccessType::ResolveTransferRead.image_layout(src_image_layout);
+        let src_image_layout = AccessTypes::RESOLVE_TRANSFER_READ.image_layout(src_image_layout);
         let dst_image = unsafe { self.accesses.image_unchecked(dst_image) };
-        let dst_image_layout = AccessType::ResolveTransferRead.image_layout(dst_image_layout);
+        let dst_image_layout = AccessTypes::RESOLVE_TRANSFER_WRITE.image_layout(dst_image_layout);
 
         let fns = self.device().fns();
 

--- a/vulkano-taskgraph/src/command_buffer/commands/mod.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/mod.rs
@@ -3,4 +3,5 @@ pub(super) mod clear;
 pub(super) mod copy;
 pub(super) mod dynamic_state;
 pub(super) mod pipeline;
+pub(super) mod render_pass;
 pub(super) mod sync;

--- a/vulkano-taskgraph/src/command_buffer/commands/render_pass.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/render_pass.rs
@@ -1,0 +1,34 @@
+use crate::command_buffer::{RecordingCommandBuffer, Result};
+use vulkano::command_buffer::{ClearAttachment, ClearRect};
+
+/// # Commands for render passes
+///
+/// These commands require a graphics queue.
+impl RecordingCommandBuffer<'_> {
+    /// Clears specific regions of specific attachments of the framebuffer.
+    ///
+    /// `attachments` specify the types of attachments and their clear values. `rects` specify the
+    /// regions to clear.
+    ///
+    /// If the render pass instance this is recorded in uses multiview then
+    /// [`ClearRect::base_array_layer`] must be zero and [`ClearRect::layer_count`] must be one.
+    ///
+    /// The rectangle area must be inside the render area ranges.
+    pub unsafe fn clear_attachments(
+        &mut self,
+        attachments: &[ClearAttachment],
+        rects: &[ClearRect],
+    ) -> Result<&mut Self> {
+        Ok(unsafe { self.clear_attachments_unchecked(attachments, rects) })
+    }
+
+    pub unsafe fn clear_attachments_unchecked(
+        &mut self,
+        attachments: &[ClearAttachment],
+        rects: &[ClearRect],
+    ) -> &mut Self {
+        unsafe { self.inner.clear_attachments_unchecked(attachments, rects) };
+
+        self
+    }
+}

--- a/vulkano-taskgraph/src/graph/compile.rs
+++ b/vulkano-taskgraph/src/graph/compile.rs
@@ -1,20 +1,24 @@
 // FIXME: host read barriers
 
-use self::linear_map::LinearMap;
 use super::{
-    BarrierIndex, ExecutableTaskGraph, Instruction, NodeIndex, NodeInner, ResourceAccess,
-    SemaphoreIndex, Submission, TaskGraph,
+    Attachments, BarrierIndex, ExecutableTaskGraph, Instruction, NodeIndex, NodeInner,
+    RenderPassIndex, ResourceAccess, ResourceAccesses, SemaphoreIndex, Submission, TaskGraph,
 };
-use crate::{resource::Flight, Id, ObjectType, QueueFamilyType};
+use crate::{linear_map::LinearMap, resource::Flight, Id, QueueFamilyType};
 use ash::vk;
 use smallvec::{smallvec, SmallVec};
-use std::{cell::RefCell, cmp, error::Error, fmt, mem, ops::Range, sync::Arc};
+use std::{cell::RefCell, cmp, error::Error, fmt, ops::Range, sync::Arc};
 use vulkano::{
     device::{Device, DeviceOwned, Queue, QueueFlags},
-    image::{Image, ImageLayout},
+    format::Format,
+    image::{sampler::ComponentMapping, Image, ImageLayout, ImageUsage},
+    render_pass::{
+        AttachmentDescription, AttachmentLoadOp, AttachmentReference, AttachmentStoreOp,
+        Framebuffer, RenderPass, RenderPassCreateInfo, SubpassDependency, SubpassDescription,
+    },
     swapchain::Swapchain,
-    sync::{semaphore::Semaphore, AccessFlags, PipelineStages},
-    VulkanError,
+    sync::{semaphore::Semaphore, AccessFlags, DependencyFlags, PipelineStages},
+    Validated, VulkanError,
 };
 
 impl<W: ?Sized> TaskGraph<W> {
@@ -101,184 +105,154 @@ impl<W: ?Sized> TaskGraph<W> {
             }
         }
 
-        let mut prev_accesses = vec![ResourceAccess::default(); self.resources.capacity() as usize];
-        let mut barrier_stages = vec![BarrierStage::Stage0; self.resources.capacity() as usize];
-
-        let (node_meta, semaphore_count, last_swapchain_accesses) = unsafe {
-            self.node_metadata(&topological_order, &mut prev_accesses, &mut barrier_stages)
+        let (
+            IntermediateRepresentationBuilder {
+                prev_accesses: last_accesses,
+                submissions,
+                nodes,
+                semaphore_count,
+                render_passes,
+                pre_present_queue_family_ownership_transfers,
+                ..
+            },
+            last_swapchain_accesses,
+        ) = match unsafe { self.lower(present_queue, &topological_order) } {
+            Ok(x) => x,
+            Err(kind) => return Err(CompileError::new(self, kind)),
         };
 
-        prev_accesses.fill(ResourceAccess::default());
-        barrier_stages.fill(BarrierStage::Stage0);
-
-        let mut state = CompileState::new(&mut prev_accesses, present_queue);
+        let mut builder = FinalRepresentationBuilder::new(present_queue);
         let mut prev_submission_end = 0;
+        let mut submission_index = 0;
 
         while prev_submission_end < topological_order.len() {
-            // First per-submission pass: compute the initial barriers for the submission.
+            let submission_state = &submissions[submission_index];
+            builder.initial_pipeline_barrier(&submission_state.initial_barriers);
+
             for (i, &node_index) in
                 (prev_submission_end..).zip(&topological_order[prev_submission_end..])
             {
-                let node = unsafe { self.nodes.node_unchecked(node_index) };
-                let NodeInner::Task(task_node) = &node.inner else {
+                let node = unsafe { self.nodes.node_unchecked_mut(node_index) };
+                let NodeInner::Task(task_node) = &mut node.inner else {
                     unreachable!();
                 };
+                let queue_family_index = task_node.queue_family_index;
+                let node_state = &nodes[node_index as usize];
 
-                for (id, access) in task_node.accesses.iter() {
-                    let access = ResourceAccess {
-                        queue_family_index: task_node.queue_family_index,
-                        ..*access
-                    };
+                for &(swapchain_id, stage_mask) in &node_state.wait_acquire {
+                    builder.wait_acquire(swapchain_id, stage_mask);
+                }
 
-                    let barrier_stage = &mut barrier_stages[id.index() as usize];
+                for &semaphore_index in &node_state.wait_semaphores {
+                    builder.wait_semaphore(semaphore_index);
+                }
 
-                    if *barrier_stage == BarrierStage::Stage0 {
-                        if !id.is::<Swapchain>() {
-                            if id.is::<Image>() {
-                                state.transition_image(id, access);
-                            } else if access.access_mask.contains_reads() {
-                                state.memory_barrier(id, access);
-                            } else {
-                                state.execution_barrier(id, access);
-                            }
-                        }
+                builder.pipeline_barrier(&node_state.start_barriers);
 
-                        *barrier_stage = BarrierStage::Stage1;
+                if let Some(subpass) = node_state.subpass {
+                    let render_pass_state = &render_passes[subpass.render_pass_index];
+
+                    if node_index == render_pass_state.first_node_index {
+                        builder.begin_render_pass(subpass.render_pass_index);
                     }
+
+                    builder.next_subpass(subpass.subpass_index);
+
+                    if !node_state.clear_attachments.is_empty() {
+                        builder.clear_attachments(
+                            node_index,
+                            subpass.render_pass_index,
+                            &node_state.clear_attachments,
+                        );
+                    }
+                }
+
+                builder.execute_task(node_index);
+
+                if let Some(subpass) = node_state.subpass {
+                    let render_pass_state = &render_passes[subpass.render_pass_index];
+
+                    if node_index == render_pass_state.last_node_index {
+                        builder.end_render_pass();
+                    }
+                }
+
+                builder.pipeline_barrier(&node_state.end_barriers);
+
+                for &semaphore_index in &node_state.signal_semaphores {
+                    builder.signal_semaphore(semaphore_index);
+                }
+
+                for &(swapchain_id, stage_mask) in &node_state.signal_pre_present {
+                    builder.signal_pre_present(swapchain_id, stage_mask);
+                }
+
+                for &(swapchain_id, stage_mask) in &node_state.signal_present {
+                    builder.signal_present(swapchain_id, stage_mask);
                 }
 
                 let should_submit = if let Some(&next_node_index) = topological_order.get(i + 1) {
                     let next_node = unsafe { self.nodes.node_unchecked(next_node_index) };
                     let NodeInner::Task(next_task_node) = &next_node.inner else {
-                        unreachable!()
+                        unreachable!();
                     };
 
-                    next_task_node.queue_family_index != task_node.queue_family_index
+                    next_task_node.queue_family_index != queue_family_index
                 } else {
                     true
                 };
 
-                if should_submit {
-                    break;
-                }
-            }
-
-            state.flush_initial_barriers();
-
-            // Second per-submission pass: add instructions and barriers for the submission.
-            for (i, &node_index) in
-                (prev_submission_end..).zip(&topological_order[prev_submission_end..])
-            {
-                let node = unsafe { self.nodes.node_unchecked(node_index) };
-                let NodeInner::Task(task_node) = &node.inner else {
-                    unreachable!();
-                };
-
-                for &semaphore_index in &node_meta[node_index as usize].wait_semaphores {
-                    state.wait_semaphore(semaphore_index);
-                }
-
-                for (id, access) in task_node.accesses.iter() {
-                    let prev_access = state.prev_accesses[id.index() as usize];
-                    let access = ResourceAccess {
-                        queue_family_index: task_node.queue_family_index,
-                        ..*access
-                    };
-
-                    let barrier_stage = &mut barrier_stages[id.index() as usize];
-
-                    if *barrier_stage == BarrierStage::Stage1 {
-                        if id.is::<Swapchain>() {
-                            state.wait_acquire(unsafe { id.parametrize() }, access);
-                        }
-
-                        *barrier_stage = BarrierStage::Stage2;
-                    } else if prev_access.queue_family_index != access.queue_family_index {
-                        let prev_access = &mut state.prev_accesses[id.index() as usize];
-                        prev_access.stage_mask = PipelineStages::empty();
-                        prev_access.access_mask = AccessFlags::empty();
-
-                        if id.is_exclusive() {
-                            state.acquire_queue_family_ownership(id, access);
-                        } else if prev_access.image_layout != access.image_layout {
-                            state.transition_image(id, access);
-                        } else {
-                            state.prev_accesses[id.index() as usize] = access;
-                        }
-                    } else if prev_access.image_layout != access.image_layout {
-                        state.transition_image(id, access);
-                    } else if prev_access.access_mask.contains_writes()
-                        && access.access_mask.contains_reads()
-                    {
-                        state.memory_barrier(id, access);
-                    } else if access.access_mask.contains_writes() {
-                        state.execution_barrier(id, access);
-                    } else {
-                        // TODO: Could there be use cases for read-after-read execution barriers?
-                        let prev_access = &mut state.prev_accesses[id.index() as usize];
-                        prev_access.stage_mask |= access.stage_mask;
-                        prev_access.access_mask |= access.access_mask;
-                    }
-                }
-
-                state.execute_task(node_index);
-
-                for (id, _) in task_node.accesses.iter() {
-                    if let Some((_, next_access)) = node_meta[node_index as usize]
-                        .release_queue_family_ownership
-                        .iter()
-                        .find(|(x, _)| *x == id)
-                    {
-                        state.release_queue_family_ownership(id, *next_access);
-                    }
-                }
-
-                for &semaphore_index in &node_meta[node_index as usize].signal_semaphores {
-                    state.signal_semaphore(semaphore_index);
-                }
-
-                for (&swapchain_id, _) in last_swapchain_accesses
-                    .iter()
-                    .filter(|(_, &i)| i == node_index)
-                {
-                    state.signal_present(swapchain_id);
-                }
-
-                let should_submit = if let Some(&next_node_index) = topological_order.get(i + 1) {
-                    let next_node = unsafe { self.nodes.node_unchecked(next_node_index) };
-                    let NodeInner::Task(next_task_node) = &next_node.inner else {
-                        unreachable!()
-                    };
-
-                    next_task_node.queue_family_index != task_node.queue_family_index
-                } else {
-                    true
-                };
-
-                if state.should_flush_submit || should_submit {
-                    state.flush_submit();
+                if builder.should_flush_submit || should_submit {
+                    builder.flush_submit();
                 }
 
                 if should_submit {
-                    let queue = queues_by_queue_family_index[task_node.queue_family_index as usize]
-                        .unwrap();
-                    state.submit(queue);
+                    let queue = queues_by_queue_family_index[queue_family_index as usize]
+                        .unwrap()
+                        .clone();
+                    builder.submit(queue);
                     prev_submission_end = i + 1;
+                    submission_index += 1;
                     break;
                 }
             }
         }
 
-        if !state
-            .pre_present_queue_family_ownership_transfers
-            .is_empty()
-        {
-            for swapchain_id in mem::take(&mut state.pre_present_queue_family_ownership_transfers) {
-                state.pre_present_acquire_queue_family_ownership(swapchain_id);
+        if !pre_present_queue_family_ownership_transfers.is_empty() {
+            for swapchain_id in pre_present_queue_family_ownership_transfers {
+                builder.pre_present_acquire_queue_family_ownership(&last_accesses, swapchain_id);
             }
 
-            state.flush_submit();
-            state.submit(state.present_queue.unwrap());
+            builder.flush_submit();
+            builder.submit(present_queue.unwrap().clone());
+        }
+
+        let render_passes = match render_passes
+            .into_iter()
+            .map(|render_pass_state| create_render_pass(&self.resources, render_pass_state))
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(render_passes) => render_passes,
+            Err(kind) => return Err(CompileError::new(self, kind)),
+        };
+
+        if !render_passes.is_empty() {
+            for (id, node) in self.nodes.nodes_mut() {
+                let NodeInner::Task(task_node) = &mut node.inner else {
+                    unreachable!();
+                };
+
+                if let Some(subpass) = nodes[id.index() as usize].subpass {
+                    let render_pass = &render_passes[subpass.render_pass_index].render_pass;
+                    task_node.subpass = Some(
+                        vulkano::render_pass::Subpass::from(
+                            render_pass.clone(),
+                            subpass.subpass_index as u32,
+                        )
+                        .unwrap(),
+                    );
+                }
+            }
         }
 
         let semaphores = match (0..semaphore_count)
@@ -293,19 +267,20 @@ impl<W: ?Sized> TaskGraph<W> {
             Err(err) => return Err(CompileError::new(self, CompileErrorKind::VulkanError(err))),
         };
 
-        let swapchains = last_swapchain_accesses.iter().map(|(&id, _)| id).collect();
+        let swapchains = last_swapchain_accesses.keys().copied().collect();
 
         Ok(ExecutableTaskGraph {
             graph: self,
             flight_id,
-            instructions: state.instructions,
-            submissions: state.submissions,
-            buffer_barriers: state.buffer_barriers,
-            image_barriers: state.image_barriers,
+            instructions: builder.instructions,
+            submissions: builder.submissions,
+            barriers: builder.barriers,
+            render_passes: RefCell::new(render_passes),
+            clear_attachments: builder.clear_attachments,
             semaphores: RefCell::new(semaphores),
             swapchains,
-            present_queue: state.present_queue.cloned(),
-            last_accesses: prev_accesses,
+            present_queue: present_queue.cloned(),
+            last_accesses,
         })
     }
 
@@ -517,20 +492,24 @@ impl<W: ?Sized> TaskGraph<W> {
         Ok(queue_family_indices)
     }
 
-    /// Does a preliminary pass over all nodes in the graph to collect information needed before
-    /// the actual compilation pass. Returns a vector of metadata indexed by the node index, the
-    /// current semaphore count, and a map from the swapchain ID to the last node that accessed the
-    /// swapchain.
+    /// Lowers the task graph to the intermediate representation.
     // TODO: Cull redundant semaphores.
-    unsafe fn node_metadata(
-        &self,
+    unsafe fn lower(
+        &mut self,
+        present_queue: Option<&Arc<Queue>>,
         topological_order: &[NodeIndex],
-        prev_accesses: &mut [ResourceAccess],
-        barrier_stages: &mut [BarrierStage],
-    ) -> (Vec<NodeMeta>, usize, LinearMap<Id<Swapchain>, NodeIndex, 1>) {
-        let mut node_meta = vec![NodeMeta::default(); self.nodes.capacity() as usize];
-        let mut prev_node_indices = vec![0; self.resources.capacity() as usize];
-        let mut semaphore_count = 0;
+    ) -> Result<
+        (
+            IntermediateRepresentationBuilder,
+            LinearMap<Id<Swapchain>, NodeIndex>,
+        ),
+        CompileErrorKind,
+    > {
+        let mut builder = IntermediateRepresentationBuilder::new(
+            self.nodes.capacity(),
+            self.resources.capacity(),
+        );
+        let mut prev_queue_family_index = vk::QUEUE_FAMILY_IGNORED;
         let mut last_swapchain_accesses = LinearMap::new();
 
         for &node_index in topological_order {
@@ -538,6 +517,7 @@ impl<W: ?Sized> TaskGraph<W> {
             let NodeInner::Task(task_node) = &node.inner else {
                 unreachable!();
             };
+            let queue_family_index = task_node.queue_family_index;
 
             for &out_node_index in &node.out_edges {
                 let out_node = unsafe { self.nodes.node_unchecked(out_node_index) };
@@ -545,116 +525,346 @@ impl<W: ?Sized> TaskGraph<W> {
                     unreachable!();
                 };
 
-                if task_node.queue_family_index != out_task_node.queue_family_index {
-                    let semaphore_index = semaphore_count;
-                    node_meta[node_index as usize]
+                if queue_family_index != out_task_node.queue_family_index {
+                    let semaphore_index = builder.semaphore_count;
+                    builder.nodes[node_index as usize]
                         .signal_semaphores
                         .push(semaphore_index);
-                    node_meta[out_node_index as usize]
+                    builder.nodes[out_node_index as usize]
                         .wait_semaphores
                         .push(semaphore_index);
-                    semaphore_count += 1;
+                    builder.semaphore_count += 1;
                 }
             }
 
+            if prev_queue_family_index != queue_family_index {
+                builder.submissions.push(SubmissionState::new(node_index));
+                builder.is_render_pass_instance_active = false;
+            }
+
+            let submission_index = builder.submissions.len() - 1;
+            builder.nodes[node_index as usize].submission_index = submission_index;
+
+            if let Some(attachments) = &task_node.attachments {
+                builder.subpass(node_index, &task_node.accesses, attachments);
+                builder.is_render_pass_instance_active = true;
+            } else {
+                builder.is_render_pass_instance_active = false;
+            }
+
             for (id, access) in task_node.accesses.iter() {
-                let prev_access = &mut prev_accesses[id.index() as usize];
                 let access = ResourceAccess {
-                    queue_family_index: task_node.queue_family_index,
+                    queue_family_index,
                     ..*access
                 };
-                let prev_node_index = &mut prev_node_indices[id.index() as usize];
-
-                let barrier_stage = &mut barrier_stages[id.index() as usize];
-
-                if *barrier_stage == BarrierStage::Stage0 {
-                    *prev_access = access;
-                    *prev_node_index = node_index;
-                    *barrier_stage = BarrierStage::Stage1;
-                } else {
-                    if id.is_exclusive()
-                        && prev_access.queue_family_index != access.queue_family_index
-                    {
-                        node_meta[*prev_node_index as usize]
-                            .release_queue_family_ownership
-                            .push((id, access));
-                    }
-
-                    if prev_access.queue_family_index != access.queue_family_index
-                        || prev_access.image_layout != access.image_layout
-                        || prev_access.access_mask.contains_writes()
-                        || access.access_mask.contains_writes()
-                    {
-                        *prev_access = access;
-                    } else {
-                        prev_access.stage_mask |= access.stage_mask;
-                        prev_access.access_mask |= access.access_mask;
-                    }
-
-                    *prev_node_index = node_index;
-                }
+                builder.resource_access(node_index, id, access);
 
                 if id.is::<Swapchain>() {
                     *last_swapchain_accesses
                         .get_or_insert(unsafe { id.parametrize() }, node_index) = node_index;
                 }
             }
+
+            builder.submissions.last_mut().unwrap().last_node_index = node_index;
+
+            prev_queue_family_index = queue_family_index;
         }
 
-        (node_meta, semaphore_count, last_swapchain_accesses)
+        if !last_swapchain_accesses.is_empty() {
+            let present_queue = present_queue.expect("expected to be given a present queue");
+
+            for (&swapchain_id, &node_index) in last_swapchain_accesses.iter() {
+                builder.swapchain_present(node_index, swapchain_id, present_queue);
+            }
+        }
+
+        Ok((builder, last_swapchain_accesses))
     }
 }
 
-#[derive(Clone, Default)]
-struct NodeMeta {
-    wait_semaphores: Vec<SemaphoreIndex>,
-    signal_semaphores: Vec<SemaphoreIndex>,
-    release_queue_family_ownership: Vec<(Id, ResourceAccess)>,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum BarrierStage {
-    Stage0,
-    Stage1,
-    Stage2,
-}
-
-struct CompileState<'a> {
-    prev_accesses: &'a mut [ResourceAccess],
-    instructions: Vec<Instruction>,
-    submissions: Vec<Submission>,
-    buffer_barriers: Vec<super::BufferMemoryBarrier>,
-    image_barriers: Vec<super::ImageMemoryBarrier>,
-    present_queue: Option<&'a Arc<Queue>>,
-    initial_buffer_barrier_range: Range<BarrierIndex>,
-    initial_image_barrier_range: Range<BarrierIndex>,
-    has_flushed_submit: bool,
-    should_flush_submit: bool,
-    prev_buffer_barrier_index: usize,
-    prev_image_barrier_index: usize,
+struct IntermediateRepresentationBuilder {
+    submissions: Vec<SubmissionState>,
+    nodes: Vec<NodeState>,
+    prev_accesses: Vec<ResourceAccess>,
+    prev_node_indices: Vec<NodeIndex>,
+    semaphore_count: usize,
+    render_passes: Vec<RenderPassState>,
+    is_render_pass_instance_active: bool,
     pre_present_queue_family_ownership_transfers: Vec<Id<Swapchain>>,
 }
 
-impl<'a> CompileState<'a> {
-    fn new(prev_accesses: &'a mut [ResourceAccess], present_queue: Option<&'a Arc<Queue>>) -> Self {
-        CompileState {
-            prev_accesses,
-            instructions: Vec::new(),
+struct SubmissionState {
+    initial_barriers: Vec<super::MemoryBarrier>,
+    first_node_index: NodeIndex,
+    last_node_index: NodeIndex,
+}
+
+#[derive(Clone, Default)]
+struct NodeState {
+    submission_index: usize,
+    wait_acquire: Vec<(Id<Swapchain>, PipelineStages)>,
+    wait_semaphores: Vec<SemaphoreIndex>,
+    start_barriers: Vec<super::MemoryBarrier>,
+    subpass: Option<Subpass>,
+    clear_attachments: Vec<Id>,
+    end_barriers: Vec<super::MemoryBarrier>,
+    signal_semaphores: Vec<SemaphoreIndex>,
+    signal_pre_present: Vec<(Id<Swapchain>, PipelineStages)>,
+    signal_present: Vec<(Id<Swapchain>, PipelineStages)>,
+}
+
+#[derive(Clone, Copy)]
+struct Subpass {
+    render_pass_index: RenderPassIndex,
+    subpass_index: usize,
+}
+
+struct RenderPassState {
+    framebuffer_id: Id<Framebuffer>,
+    attachments: LinearMap<Id, AttachmentState>,
+    subpasses: Vec<SubpassState>,
+    first_node_index: NodeIndex,
+    last_node_index: NodeIndex,
+    clear_node_indices: Vec<NodeIndex>,
+}
+
+struct AttachmentState {
+    first_node_index: NodeIndex,
+    first_access: ResourceAccess,
+    last_access: ResourceAccess,
+    has_reads: bool,
+    index: u32,
+    clear: bool,
+    format: Format,
+    component_mapping: ComponentMapping,
+    mip_level: u32,
+    base_array_layer: u32,
+}
+
+struct SubpassState {
+    input_attachments: LinearMap<Id, (u32, ImageLayout)>,
+    color_attachments: LinearMap<Id, (u32, ImageLayout)>,
+    depth_stencil_attachment: Option<(Id, ImageLayout)>,
+    accesses: LinearMap<Id, ResourceAccess>,
+}
+
+impl IntermediateRepresentationBuilder {
+    fn new(node_capacity: u32, resource_capacity: u32) -> Self {
+        IntermediateRepresentationBuilder {
             submissions: Vec::new(),
-            buffer_barriers: Vec::new(),
-            image_barriers: Vec::new(),
-            present_queue,
-            initial_buffer_barrier_range: 0..0,
-            initial_image_barrier_range: 0..0,
-            has_flushed_submit: true,
-            should_flush_submit: false,
-            prev_buffer_barrier_index: 0,
-            prev_image_barrier_index: 0,
+            nodes: vec![NodeState::default(); node_capacity as usize],
+            prev_accesses: vec![ResourceAccess::default(); resource_capacity as usize],
+            prev_node_indices: vec![0; resource_capacity as usize],
+            semaphore_count: 0,
+            render_passes: Vec::new(),
+            is_render_pass_instance_active: false,
             pre_present_queue_family_ownership_transfers: Vec::new(),
         }
     }
 
-    fn release_queue_family_ownership(&mut self, id: Id, access: ResourceAccess) {
+    fn subpass(
+        &mut self,
+        node_index: NodeIndex,
+        accesses: &ResourceAccesses,
+        attachments: &Attachments,
+    ) {
+        let is_same_render_pass = self.is_render_pass_instance_active
+            && is_render_pass_mergeable(self.render_passes.last().unwrap(), accesses, attachments);
+
+        if !is_same_render_pass {
+            self.render_passes
+                .push(RenderPassState::new(attachments.framebuffer_id, node_index));
+        }
+
+        let render_pass_state = self.render_passes.last_mut().unwrap();
+
+        let is_same_subpass = render_pass_state
+            .subpasses
+            .last()
+            .is_some_and(|subpass_state| {
+                is_subpass_mergeable(subpass_state, accesses, attachments)
+            });
+
+        if !is_same_subpass {
+            render_pass_state
+                .subpasses
+                .push(SubpassState::from_task_node(accesses, attachments));
+        }
+
+        let subpass_state = render_pass_state.subpasses.last_mut().unwrap();
+
+        for (id, access) in accesses.iter() {
+            let current_access = subpass_state
+                .accesses
+                .get_or_insert_with(id, Default::default);
+            current_access.stage_mask |= access.stage_mask;
+            current_access.access_mask |= access.access_mask;
+        }
+
+        for (&id, attachment_info) in attachments.iter() {
+            let access = *accesses.get(id.erase()).unwrap();
+            let attachment_state =
+                render_pass_state
+                    .attachments
+                    .get_or_insert_with(id, || AttachmentState {
+                        first_node_index: node_index,
+                        first_access: access,
+                        last_access: ResourceAccess::default(),
+                        has_reads: false,
+                        index: attachment_info.index,
+                        clear: attachment_info.clear,
+                        format: attachment_info.format,
+                        component_mapping: attachment_info.component_mapping,
+                        mip_level: attachment_info.mip_level,
+                        base_array_layer: attachment_info.base_array_layer,
+                    });
+            attachment_state.last_access = access;
+            attachment_state.has_reads |= access.access_mask.contains_reads();
+
+            if attachment_info.clear {
+                // If we are the first node in the render pass to clear this attachment, we can
+                // make use of `AttachmentLoadOp::Clear`. Otherwise, we have to use the
+                // `clear_attachments` command.
+                if attachment_state.first_node_index == node_index {
+                    if !render_pass_state.clear_node_indices.contains(&node_index) {
+                        render_pass_state.clear_node_indices.push(node_index);
+                    }
+                } else {
+                    let node_state = &mut self.nodes[node_index as usize];
+
+                    if !node_state.clear_attachments.contains(&id) {
+                        node_state.clear_attachments.push(id);
+                    }
+                }
+            }
+        }
+
+        render_pass_state.last_node_index = node_index;
+
+        self.nodes[node_index as usize].subpass = Some(Subpass {
+            subpass_index: render_pass_state.subpasses.len() - 1,
+            render_pass_index: self.render_passes.len() - 1,
+        });
+    }
+
+    fn resource_access(&mut self, node_index: NodeIndex, id: Id, access: ResourceAccess) {
+        let prev_access = self.prev_accesses[id.index() as usize];
+        let prev_node_index = self.prev_node_indices[id.index() as usize];
+        let mut barriered = true;
+
+        if prev_access.stage_mask.is_empty() {
+            if id.is::<Swapchain>() {
+                self.swapchain_acquire(node_index, unsafe { id.parametrize() }, access);
+            } else if id.is::<Image>() {
+                self.initial_image_layout_transition(id, access);
+            } else if access.access_mask.contains_reads() {
+                self.initial_memory_barrier(id, access);
+            }
+        } else if prev_access.queue_family_index != access.queue_family_index {
+            if id.is_exclusive() {
+                self.queue_family_ownership_release(prev_node_index, id, access);
+                self.queue_family_ownership_acquire(node_index, id, access);
+            } else {
+                let prev_access = &mut self.prev_accesses[id.index() as usize];
+                prev_access.stage_mask = PipelineStages::empty();
+                prev_access.access_mask = AccessFlags::empty();
+
+                if prev_access.image_layout != access.image_layout {
+                    self.image_layout_transition(node_index, id, access);
+                }
+            }
+        } else if self.is_render_pass_instance_active
+            && self.nodes[prev_node_index as usize]
+                .subpass
+                .is_some_and(|subpass| subpass.render_pass_index == self.render_passes.len() - 1)
+        {
+            // Dependencies within a render pass instance are handled using subpass dependencies.
+        } else if prev_access.image_layout != access.image_layout {
+            self.image_layout_transition(node_index, id, access);
+        } else if prev_access.access_mask.contains_writes() {
+            self.memory_barrier(node_index, id, access);
+        } else if access.access_mask.contains_writes() {
+            self.execution_barrier(node_index, id, access);
+        } else {
+            barriered = false;
+        }
+
+        let prev_access = &mut self.prev_accesses[id.index() as usize];
+        let prev_node_index = &mut self.prev_node_indices[id.index() as usize];
+
+        if barriered {
+            *prev_access = access;
+            *prev_node_index = node_index;
+        } else {
+            prev_access.stage_mask |= access.stage_mask;
+            prev_access.access_mask |= access.access_mask;
+
+            let prev_barrier = self.nodes[*prev_node_index as usize]
+                .start_barriers
+                .iter_mut()
+                .find(|barrier| barrier.resource == id)
+                .unwrap();
+            prev_barrier.dst_stage_mask |= access.stage_mask;
+            prev_barrier.dst_access_mask |= access.access_mask;
+        }
+    }
+
+    fn swapchain_acquire(
+        &mut self,
+        node_index: NodeIndex,
+        swapchain_id: Id<Swapchain>,
+        access: ResourceAccess,
+    ) {
+        let src = ResourceAccess {
+            stage_mask: access.stage_mask,
+            access_mask: AccessFlags::empty(),
+            image_layout: ImageLayout::Undefined,
+            queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+        };
+        let dst = ResourceAccess {
+            stage_mask: access.stage_mask,
+            access_mask: access.access_mask,
+            image_layout: access.image_layout,
+            queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+        };
+
+        self.memory_barrier_inner(node_index, swapchain_id.erase(), src, dst, false);
+
+        let submission_state = self.submissions.last().unwrap();
+
+        self.nodes[submission_state.first_node_index as usize]
+            .wait_acquire
+            .push((swapchain_id, access.stage_mask));
+    }
+
+    fn initial_image_layout_transition(&mut self, id: Id, access: ResourceAccess) {
+        self.initial_memory_barrier(id, access);
+    }
+
+    fn initial_memory_barrier(&mut self, id: Id, access: ResourceAccess) {
+        let submission_state = self.submissions.last_mut().unwrap();
+
+        submission_state
+            .initial_barriers
+            .push(super::MemoryBarrier {
+                src_stage_mask: PipelineStages::empty(),
+                src_access_mask: AccessFlags::empty(),
+                dst_stage_mask: access.stage_mask,
+                dst_access_mask: access.access_mask,
+                old_layout: ImageLayout::Undefined,
+                new_layout: access.image_layout,
+                src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+                dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+                resource: id,
+            });
+    }
+
+    fn queue_family_ownership_release(
+        &mut self,
+        node_index: NodeIndex,
+        id: Id,
+        access: ResourceAccess,
+    ) {
         debug_assert!(id.is_exclusive());
 
         let prev_access = &mut self.prev_accesses[id.index() as usize];
@@ -671,58 +881,59 @@ impl<'a> CompileState<'a> {
 
         debug_assert_ne!(src.queue_family_index, dst.queue_family_index);
 
-        self.memory_barrier_inner(id, src, dst);
+        self.memory_barrier_inner(node_index, id, src, dst, true);
     }
 
-    fn acquire_queue_family_ownership(&mut self, id: Id, access: ResourceAccess) {
+    fn queue_family_ownership_acquire(
+        &mut self,
+        node_index: NodeIndex,
+        id: Id,
+        access: ResourceAccess,
+    ) {
         debug_assert!(id.is_exclusive());
 
-        let prev_access = &mut self.prev_accesses[id.index() as usize];
+        let prev_access = self.prev_accesses[id.index() as usize];
         let src = ResourceAccess {
             stage_mask: PipelineStages::empty(),
             access_mask: AccessFlags::empty(),
-            ..*prev_access
+            ..prev_access
         };
         let dst = access;
 
         debug_assert_ne!(src.queue_family_index, dst.queue_family_index);
 
-        *prev_access = access;
-
-        self.memory_barrier_inner(id, src, dst);
+        self.memory_barrier_inner(node_index, id, src, dst, false);
     }
 
-    fn transition_image(&mut self, id: Id, access: ResourceAccess) {
+    fn image_layout_transition(&mut self, node_index: NodeIndex, id: Id, access: ResourceAccess) {
         debug_assert_ne!(
             self.prev_accesses[id.index() as usize].image_layout,
             access.image_layout,
         );
 
-        self.memory_barrier(id, access);
+        self.memory_barrier(node_index, id, access);
     }
 
-    fn memory_barrier(&mut self, id: Id, access: ResourceAccess) {
-        let prev_access = &mut self.prev_accesses[id.index() as usize];
+    fn memory_barrier(&mut self, node_index: NodeIndex, id: Id, access: ResourceAccess) {
+        let prev_access = self.prev_accesses[id.index() as usize];
         let src = ResourceAccess {
             queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-            ..*prev_access
+            ..prev_access
         };
         let dst = ResourceAccess {
             queue_family_index: vk::QUEUE_FAMILY_IGNORED,
             ..access
         };
 
-        *prev_access = access;
-
-        self.memory_barrier_inner(id, src, dst);
+        self.memory_barrier_inner(node_index, id, src, dst, false);
     }
 
-    fn execution_barrier(&mut self, id: Id, access: ResourceAccess) {
-        let prev_access = &mut self.prev_accesses[id.index() as usize];
+    fn execution_barrier(&mut self, node_index: NodeIndex, id: Id, access: ResourceAccess) {
+        let prev_access = self.prev_accesses[id.index() as usize];
         let src = ResourceAccess {
             access_mask: AccessFlags::empty(),
             queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-            ..*prev_access
+            ..prev_access
         };
         let dst = ResourceAccess {
             access_mask: AccessFlags::empty(),
@@ -732,72 +943,554 @@ impl<'a> CompileState<'a> {
 
         debug_assert_eq!(prev_access.image_layout, access.image_layout);
 
-        *prev_access = access;
-
-        self.memory_barrier_inner(id, src, dst);
+        self.memory_barrier_inner(node_index, id, src, dst, false);
     }
 
-    fn memory_barrier_inner(&mut self, id: Id, src: ResourceAccess, dst: ResourceAccess) {
-        match id.object_type() {
-            ObjectType::Buffer => {
-                self.buffer_barriers.push(super::BufferMemoryBarrier {
-                    src_stage_mask: src.stage_mask,
-                    src_access_mask: src.access_mask,
-                    dst_stage_mask: dst.stage_mask,
-                    dst_access_mask: dst.access_mask,
-                    src_queue_family_index: src.queue_family_index,
-                    dst_queue_family_index: dst.queue_family_index,
-                    buffer: unsafe { id.parametrize() },
-                });
-            }
-            ObjectType::Image | ObjectType::Swapchain => {
-                self.image_barriers.push(super::ImageMemoryBarrier {
-                    src_stage_mask: src.stage_mask,
-                    src_access_mask: src.access_mask,
-                    dst_stage_mask: dst.stage_mask,
-                    dst_access_mask: dst.access_mask,
-                    old_layout: src.image_layout,
-                    new_layout: dst.image_layout,
-                    src_queue_family_index: src.queue_family_index,
-                    dst_queue_family_index: dst.queue_family_index,
-                    image: id,
-                });
-            }
-            _ => unreachable!(),
+    fn memory_barrier_inner(
+        &mut self,
+        node_index: NodeIndex,
+        id: Id,
+        src: ResourceAccess,
+        dst: ResourceAccess,
+        is_end_barrier: bool,
+    ) {
+        let mut node_state = &mut self.nodes[node_index as usize];
+
+        // Regular pipeline barriers are not permitted during a render pass instance, so we need to
+        // move them before/after the render pass instance. This works because dependencies between
+        // subpasses are handled with subpass dependencies and the only pipeline barriers that
+        // could be needed are image layout transitions and/or queue family ownership transfers on
+        // first/last use of a resource used during the render pass instance.
+        if let Some(subpass) = node_state.subpass {
+            let render_pass_state = &self.render_passes[subpass.render_pass_index];
+            let moved_node_index = if is_end_barrier {
+                render_pass_state.last_node_index
+            } else {
+                render_pass_state.first_node_index
+            };
+            node_state = &mut self.nodes[moved_node_index as usize];
+        }
+
+        let barriers = if is_end_barrier {
+            &mut node_state.end_barriers
+        } else {
+            &mut node_state.start_barriers
+        };
+
+        barriers.push(super::MemoryBarrier {
+            src_stage_mask: src.stage_mask,
+            src_access_mask: src.access_mask,
+            dst_stage_mask: dst.stage_mask,
+            dst_access_mask: dst.access_mask,
+            old_layout: src.image_layout,
+            new_layout: dst.image_layout,
+            src_queue_family_index: src.queue_family_index,
+            dst_queue_family_index: dst.queue_family_index,
+            resource: id,
+        });
+    }
+
+    fn swapchain_present(
+        &mut self,
+        node_index: NodeIndex,
+        swapchain_id: Id<Swapchain>,
+        present_queue: &Queue,
+    ) {
+        let prev_access = self.prev_accesses[swapchain_id.index() as usize];
+        let src = ResourceAccess {
+            queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            ..prev_access
+        };
+
+        let needs_queue_family_ownership_transfer = prev_access.queue_family_index
+            != present_queue.queue_family_index()
+            && swapchain_id.is_exclusive();
+
+        if needs_queue_family_ownership_transfer {
+            self.queue_family_ownership_release(
+                node_index,
+                swapchain_id.erase(),
+                ResourceAccess {
+                    stage_mask: PipelineStages::empty(),
+                    access_mask: AccessFlags::empty(),
+                    image_layout: ImageLayout::PresentSrc,
+                    queue_family_index: present_queue.queue_family_index(),
+                },
+            );
+        } else {
+            self.memory_barrier_inner(
+                node_index,
+                swapchain_id.erase(),
+                src,
+                ResourceAccess {
+                    stage_mask: PipelineStages::empty(),
+                    access_mask: AccessFlags::empty(),
+                    image_layout: ImageLayout::PresentSrc,
+                    queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+                },
+                true,
+            );
+        }
+
+        let node_state = &self.nodes[node_index as usize];
+        let submission_state = &self.submissions[node_state.submission_index];
+
+        if needs_queue_family_ownership_transfer {
+            self.nodes[submission_state.last_node_index as usize]
+                .signal_pre_present
+                .push((swapchain_id, prev_access.stage_mask));
+            self.pre_present_queue_family_ownership_transfers
+                .push(swapchain_id);
+        } else {
+            self.nodes[submission_state.last_node_index as usize]
+                .signal_present
+                .push((swapchain_id, prev_access.stage_mask));
+        }
+    }
+}
+
+impl SubmissionState {
+    fn new(node_index: u32) -> Self {
+        Self {
+            initial_barriers: Vec::new(),
+            first_node_index: node_index,
+            last_node_index: node_index,
+        }
+    }
+}
+
+impl RenderPassState {
+    fn new(framebuffer: Id<Framebuffer>, node_index: NodeIndex) -> Self {
+        RenderPassState {
+            framebuffer_id: framebuffer,
+            attachments: LinearMap::new(),
+            subpasses: Vec::new(),
+            first_node_index: node_index,
+            last_node_index: node_index,
+            clear_node_indices: Vec::new(),
+        }
+    }
+}
+
+impl SubpassState {
+    fn from_task_node(accesses: &ResourceAccesses, attachments: &Attachments) -> Self {
+        SubpassState {
+            input_attachments: attachments
+                .input_attachments
+                .iter()
+                .map(|(id, attachment_info)| {
+                    let input_attachment_index = attachment_info.index;
+                    let image_layout = accesses.get(id.erase()).unwrap().image_layout;
+
+                    (*id, (input_attachment_index, image_layout))
+                })
+                .collect(),
+            color_attachments: attachments
+                .color_attachments
+                .iter()
+                .map(|(id, attachment_info)| {
+                    let location = attachment_info.index;
+                    let image_layout = accesses.get(id.erase()).unwrap().image_layout;
+
+                    (*id, (location, image_layout))
+                })
+                .collect(),
+            depth_stencil_attachment: attachments.depth_stencil_attachment.as_ref().map(
+                |(id, _)| {
+                    let image_layout = accesses.get(id.erase()).unwrap().image_layout;
+
+                    (*id, image_layout)
+                },
+            ),
+            accesses: accesses.inner.clone(),
+        }
+    }
+}
+
+fn is_render_pass_mergeable(
+    render_pass_state: &RenderPassState,
+    accesses: &ResourceAccesses,
+    attachments: &Attachments,
+) -> bool {
+    const ATTACHMENT_ACCESSES: AccessFlags = AccessFlags::INPUT_ATTACHMENT_READ
+        .union(AccessFlags::COLOR_ATTACHMENT_READ)
+        .union(AccessFlags::COLOR_ATTACHMENT_WRITE)
+        .union(AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ)
+        .union(AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE);
+
+    // Different framebuffers may have different dimensions so we can't merge them.
+    if render_pass_state.framebuffer_id != attachments.framebuffer_id {
+        return false;
+    }
+
+    // We can't merge with a task node that accesses one of our attachments as anything other
+    // than an attachment, as render passes don't allow this.
+    if render_pass_state.attachments.keys().any(|id| {
+        accesses
+            .get(id.erase())
+            .is_some_and(|access| !ATTACHMENT_ACCESSES.contains(access.access_mask))
+    }) {
+        return false;
+    }
+
+    // We can't merge with a task node that has an attachment which we access as anything other
+    // than an attachment, as render passes don't allow this.
+    if attachments.keys().any(|id| {
+        render_pass_state.subpasses.iter().any(|subpass_state| {
+            subpass_state
+                .accesses
+                .get(&id.erase())
+                .is_some_and(|access| !ATTACHMENT_ACCESSES.contains(access.access_mask))
+        })
+    }) {
+        return false;
+    }
+
+    true
+}
+
+fn is_subpass_mergeable(
+    subpass_state: &SubpassState,
+    accesses: &ResourceAccesses,
+    attachments: &Attachments,
+) -> bool {
+    // We can only merge with a task node that has the exact same attachments. Keep in mind that
+    // being here, `is_render_pass_mergeable` must have returned `true`, which rules out the other
+    // incompatibilities.
+
+    // Early nope-out to avoid the expense below.
+    if subpass_state.color_attachments.len() != attachments.color_attachments.len()
+        || subpass_state.input_attachments.len() != attachments.input_attachments.len()
+        || subpass_state.depth_stencil_attachment.is_some()
+            != attachments.depth_stencil_attachment.is_some()
+    {
+        return false;
+    }
+
+    for (id, &(location, image_layout)) in subpass_state.color_attachments.iter() {
+        if !attachments
+            .color_attachments
+            .get(id)
+            .is_some_and(|attachment_info| attachment_info.index == location)
+            || accesses.get(id.erase()).unwrap().image_layout != image_layout
+        {
+            return false;
         }
     }
 
-    fn flush_initial_barriers(&mut self) {
-        self.initial_buffer_barrier_range = self.prev_buffer_barrier_index as BarrierIndex
-            ..self.buffer_barriers.len() as BarrierIndex;
-        self.initial_image_barrier_range = self.prev_image_barrier_index as BarrierIndex
-            ..self.image_barriers.len() as BarrierIndex;
-        self.prev_buffer_barrier_index = self.buffer_barriers.len();
-        self.prev_image_barrier_index = self.image_barriers.len();
+    for (id, &(input_attachment_index, image_layout)) in subpass_state.input_attachments.iter() {
+        if !attachments
+            .input_attachments
+            .get(id)
+            .is_some_and(|attachment_info| attachment_info.index == input_attachment_index)
+            || accesses.get(id.erase()).unwrap().image_layout != image_layout
+        {
+            return false;
+        }
     }
 
-    fn wait_acquire(&mut self, swapchain_id: Id<Swapchain>, access: ResourceAccess) {
+    if subpass_state.depth_stencil_attachment
+        != attachments
+            .depth_stencil_attachment
+            .as_ref()
+            .map(|(id, _)| (*id, accesses.get(id.erase()).unwrap().image_layout))
+    {
+        return false;
+    }
+
+    true
+}
+
+fn create_render_pass(
+    resources: &super::Resources,
+    render_pass_state: RenderPassState,
+) -> Result<super::RenderPassState, CompileErrorKind> {
+    const FRAMEBUFFER_SPACE_ACCESS_FLAGS: AccessFlags = AccessFlags::INPUT_ATTACHMENT_READ
+        .union(AccessFlags::COLOR_ATTACHMENT_READ)
+        .union(AccessFlags::COLOR_ATTACHMENT_WRITE)
+        .union(AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ)
+        .union(AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE);
+
+    let attachments = render_pass_state
+        .attachments
+        .iter()
+        .map(|(&id, attachment_state)| {
+            let resource_info = resources.get(id.erase()).unwrap();
+            let is_resident = !resource_info
+                .usage
+                .contains(ImageUsage::TRANSIENT_ATTACHMENT);
+
+            AttachmentDescription {
+                format: attachment_state.format,
+                samples: resource_info.samples,
+                load_op: if attachment_state.clear {
+                    AttachmentLoadOp::Clear
+                } else if attachment_state.has_reads && is_resident {
+                    AttachmentLoadOp::Load
+                } else {
+                    AttachmentLoadOp::DontCare
+                },
+                store_op: if is_resident {
+                    AttachmentStoreOp::Store
+                } else {
+                    AttachmentStoreOp::DontCare
+                },
+                initial_layout: attachment_state.first_access.image_layout,
+                final_layout: attachment_state.last_access.image_layout,
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    let subpasses = render_pass_state
+        .subpasses
+        .iter()
+        .map(|subpass_state| SubpassDescription {
+            // FIXME:
+            view_mask: 0,
+            input_attachments: convert_attachments(
+                &render_pass_state,
+                &subpass_state.input_attachments,
+            ),
+            color_attachments: convert_attachments(
+                &render_pass_state,
+                &subpass_state.color_attachments,
+            ),
+            depth_stencil_attachment: subpass_state.depth_stencil_attachment.map(|(id, layout)| {
+                AttachmentReference {
+                    attachment: render_pass_state.attachments.index_of(&id).unwrap() as u32,
+                    layout,
+                    ..Default::default()
+                }
+            }),
+            preserve_attachments: render_pass_state
+                .attachments
+                .keys()
+                .enumerate()
+                .filter_map(|(attachment, &id)| {
+                    (!subpass_state.input_attachments.contains_key(&id)
+                        && !subpass_state.color_attachments.contains_key(&id)
+                        && !subpass_state
+                            .depth_stencil_attachment
+                            .is_some_and(|(x, _)| x == id))
+                    .then_some(attachment as u32)
+                })
+                .collect(),
+            ..Default::default()
+        })
+        .collect();
+
+    let mut dependencies = Vec::<SubpassDependency>::new();
+
+    // FIXME: subpass dependency chains
+    for (src_subpass_index, src_subpass_state) in render_pass_state.subpasses.iter().enumerate() {
+        let src_subpass = src_subpass_index as u32;
+
+        for (dst_subpass_index, dst_subpass_state) in render_pass_state
+            .subpasses
+            .iter()
+            .enumerate()
+            .skip(src_subpass_index + 1)
+        {
+            let dst_subpass = dst_subpass_index as u32;
+
+            for (id, src_access) in src_subpass_state.accesses.iter() {
+                let Some(dst_access) = dst_subpass_state.accesses.get(id) else {
+                    continue;
+                };
+                let src_access_mask;
+                let dst_access_mask;
+
+                if src_access.access_mask.contains_writes() {
+                    src_access_mask = src_access.access_mask;
+                    dst_access_mask = dst_access.access_mask;
+                } else if dst_access.access_mask.contains_writes() {
+                    src_access_mask = AccessFlags::empty();
+                    dst_access_mask = AccessFlags::empty();
+                } else {
+                    continue;
+                }
+
+                let dependency =
+                    get_or_insert_subpass_dependency(&mut dependencies, src_subpass, dst_subpass);
+                dependency.src_stages |= src_access.stage_mask;
+                dependency.src_access |= src_access_mask;
+                dependency.dst_stages |= dst_access.stage_mask;
+                dependency.dst_access |= dst_access_mask;
+
+                // Attachments can only have framebuffer-space accesses, for which
+                // `DependencyFlags::BY_REGION` is always sound. For resources other than
+                // attachments, it could be sound, but we have no way of knowing. There should be
+                // no reason for this in the first place, or at least be really uncommon.
+                if !FRAMEBUFFER_SPACE_ACCESS_FLAGS.contains(src_access_mask) {
+                    dependency.dependency_flags = DependencyFlags::empty();
+                }
+            }
+        }
+    }
+
+    // TODO: What do we do about non-framebuffer-space subpass self-dependencies?
+    for (subpass_index, subpass_state) in render_pass_state.subpasses.iter().enumerate() {
+        let subpass = subpass_index as u32;
+
+        for access in subpass_state.accesses.values() {
+            let access_mask = access.access_mask;
+
+            if access_mask.contains(AccessFlags::INPUT_ATTACHMENT_READ) {
+                if access_mask.contains(AccessFlags::COLOR_ATTACHMENT_WRITE) {
+                    let dependency =
+                        get_or_insert_subpass_dependency(&mut dependencies, subpass, subpass);
+                    dependency.src_stages |= PipelineStages::COLOR_ATTACHMENT_OUTPUT;
+                    dependency.dst_stages |= PipelineStages::FRAGMENT_SHADER;
+                    dependency.src_access |= AccessFlags::COLOR_ATTACHMENT_WRITE;
+                    dependency.dst_access |= AccessFlags::INPUT_ATTACHMENT_READ;
+                } else if access_mask.contains(AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE) {
+                    let dependency =
+                        get_or_insert_subpass_dependency(&mut dependencies, subpass, subpass);
+                    dependency.src_stages |=
+                        PipelineStages::EARLY_FRAGMENT_TESTS | PipelineStages::LATE_FRAGMENT_TESTS;
+                    dependency.dst_stages |= PipelineStages::FRAGMENT_SHADER;
+                    dependency.src_access |= AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE;
+                    dependency.dst_access |= AccessFlags::INPUT_ATTACHMENT_READ;
+                }
+            }
+        }
+    }
+
+    let render_pass = RenderPass::new(
+        resources.physical_resources.device().clone(),
+        RenderPassCreateInfo {
+            attachments,
+            subpasses,
+            dependencies,
+            ..Default::default()
+        },
+    )
+    // FIXME:
+    .map_err(Validated::unwrap)
+    .map_err(CompileErrorKind::VulkanError)?;
+
+    let attachments = render_pass_state
+        .attachments
+        .iter()
+        .map(|(&id, attachment_state)| {
+            let attachment = super::AttachmentState {
+                index: attachment_state.index,
+                format: attachment_state.format,
+                component_mapping: attachment_state.component_mapping,
+                mip_level: attachment_state.mip_level,
+                base_array_layer: attachment_state.base_array_layer,
+            };
+
+            (id, attachment)
+        })
+        .collect();
+
+    Ok(super::RenderPassState {
+        render_pass,
+        attachments,
+        framebuffers: Vec::new(),
+        clear_node_indices: render_pass_state.clear_node_indices,
+    })
+}
+
+fn convert_attachments(
+    render_pass_state: &RenderPassState,
+    attachments: &LinearMap<Id, (u32, ImageLayout)>,
+) -> Vec<Option<AttachmentReference>> {
+    let len = attachments.values().map(|(i, _)| *i + 1).max().unwrap_or(0);
+    let mut attachments_out = vec![None; len as usize];
+
+    for (&id, &(index, layout)) in attachments.iter() {
+        let attachment = &mut attachments_out[index as usize];
+
+        debug_assert!(attachment.is_none());
+
+        *attachment = Some(AttachmentReference {
+            attachment: render_pass_state.attachments.index_of(&id).unwrap() as u32,
+            layout,
+            ..Default::default()
+        });
+    }
+
+    attachments_out
+}
+
+fn get_or_insert_subpass_dependency(
+    dependencies: &mut Vec<SubpassDependency>,
+    src_subpass: u32,
+    dst_subpass: u32,
+) -> &mut SubpassDependency {
+    let dependency_index = dependencies
+        .iter_mut()
+        .position(|dependency| {
+            dependency.src_subpass == Some(src_subpass)
+                && dependency.dst_subpass == Some(dst_subpass)
+        })
+        .unwrap_or_else(|| {
+            let index = dependencies.len();
+
+            dependencies.push(SubpassDependency {
+                src_subpass: Some(src_subpass),
+                dst_subpass: Some(dst_subpass),
+                dependency_flags: DependencyFlags::BY_REGION,
+                ..Default::default()
+            });
+
+            index
+        });
+
+    &mut dependencies[dependency_index]
+}
+
+struct FinalRepresentationBuilder {
+    instructions: Vec<Instruction>,
+    submissions: Vec<Submission>,
+    barriers: Vec<super::MemoryBarrier>,
+    clear_attachments: Vec<Id>,
+    present_queue: Option<Arc<Queue>>,
+    initial_barrier_range: Range<BarrierIndex>,
+    has_flushed_submit: bool,
+    should_flush_submit: bool,
+    prev_barrier_index: usize,
+    prev_subpass_index: usize,
+}
+
+impl FinalRepresentationBuilder {
+    fn new(present_queue: Option<&Arc<Queue>>) -> Self {
+        FinalRepresentationBuilder {
+            instructions: Vec::new(),
+            submissions: Vec::new(),
+            barriers: Vec::new(),
+            clear_attachments: Vec::new(),
+            present_queue: present_queue.cloned(),
+            initial_barrier_range: 0..0,
+            has_flushed_submit: true,
+            should_flush_submit: false,
+            prev_barrier_index: 0,
+            prev_subpass_index: 0,
+        }
+    }
+
+    fn initial_pipeline_barrier(&mut self, barriers: &[super::MemoryBarrier]) {
+        self.barriers.extend_from_slice(barriers);
+        self.initial_barrier_range =
+            self.prev_barrier_index as BarrierIndex..self.barriers.len() as BarrierIndex;
+        self.prev_barrier_index = self.barriers.len();
+    }
+
+    fn pipeline_barrier(&mut self, barriers: &[super::MemoryBarrier]) {
+        self.barriers.extend_from_slice(barriers);
+    }
+
+    fn wait_acquire(&mut self, swapchain_id: Id<Swapchain>, stage_mask: PipelineStages) {
         if !self.has_flushed_submit {
             self.flush_submit();
         }
 
-        self.image_barriers.push(super::ImageMemoryBarrier {
-            src_stage_mask: access.stage_mask,
-            src_access_mask: AccessFlags::empty(),
-            dst_stage_mask: access.stage_mask,
-            dst_access_mask: access.access_mask,
-            old_layout: ImageLayout::Undefined,
-            new_layout: access.image_layout,
-            src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-            dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-            image: swapchain_id.erase(),
-        });
-
-        self.prev_accesses[swapchain_id.index() as usize] = access;
-
         self.instructions.push(Instruction::WaitAcquire {
             swapchain_id,
-            stage_mask: access.stage_mask,
+            stage_mask,
         });
     }
 
@@ -812,6 +1505,22 @@ impl<'a> CompileState<'a> {
         });
     }
 
+    fn begin_render_pass(&mut self, render_pass_index: RenderPassIndex) {
+        self.flush_barriers();
+
+        self.instructions
+            .push(Instruction::BeginRenderPass { render_pass_index });
+
+        self.prev_subpass_index = 0;
+    }
+
+    fn next_subpass(&mut self, subpass_index: usize) {
+        if self.prev_subpass_index != subpass_index {
+            self.instructions.push(Instruction::NextSubpass);
+            self.prev_subpass_index = subpass_index;
+        }
+    }
+
     fn execute_task(&mut self, node_index: NodeIndex) {
         self.flush_barriers();
 
@@ -819,6 +1528,27 @@ impl<'a> CompileState<'a> {
             .push(Instruction::ExecuteTask { node_index });
 
         self.has_flushed_submit = false;
+    }
+
+    fn end_render_pass(&mut self) {
+        self.instructions.push(Instruction::EndRenderPass);
+    }
+
+    fn clear_attachments(
+        &mut self,
+        node_index: NodeIndex,
+        render_pass_index: RenderPassIndex,
+        clear_attachments: &[Id],
+    ) {
+        self.flush_barriers();
+
+        let clear_attachment_range_start = self.clear_attachments.len();
+        self.clear_attachments.extend_from_slice(clear_attachments);
+        self.instructions.push(Instruction::ClearAttachments {
+            node_index,
+            render_pass_index,
+            clear_attachment_range: clear_attachment_range_start..self.clear_attachments.len(),
+        });
     }
 
     fn signal_semaphore(&mut self, semaphore_index: SemaphoreIndex) {
@@ -830,61 +1560,29 @@ impl<'a> CompileState<'a> {
         self.should_flush_submit = true;
     }
 
-    fn signal_present(&mut self, swapchain_id: Id<Swapchain>) {
-        let present_queue = self
-            .present_queue
-            .as_ref()
-            .expect("expected to be given a present queue");
-
-        let prev_access = self.prev_accesses[swapchain_id.index() as usize];
-
-        if prev_access.queue_family_index == present_queue.queue_family_index()
-            || !swapchain_id.is_exclusive()
-        {
-            self.memory_barrier(
-                swapchain_id.erase(),
-                ResourceAccess {
-                    stage_mask: PipelineStages::empty(),
-                    access_mask: AccessFlags::empty(),
-                    image_layout: ImageLayout::PresentSrc,
-                    queue_family_index: vk::QUEUE_FAMILY_IGNORED,
-                },
-            );
-
-            self.instructions.push(Instruction::SignalPresent {
-                swapchain_id,
-                stage_mask: prev_access.stage_mask,
-            });
-        } else {
-            self.pre_present_release_queue_family_ownership(swapchain_id);
-        }
+    fn signal_present(&mut self, swapchain_id: Id<Swapchain>, stage_mask: PipelineStages) {
+        self.instructions.push(Instruction::SignalPresent {
+            swapchain_id,
+            stage_mask,
+        });
 
         self.should_flush_submit = true;
     }
 
-    fn pre_present_release_queue_family_ownership(&mut self, swapchain_id: Id<Swapchain>) {
-        let prev_access = self.prev_accesses[swapchain_id.index() as usize];
-
-        self.release_queue_family_ownership(
-            swapchain_id.erase(),
-            ResourceAccess {
-                stage_mask: PipelineStages::empty(),
-                access_mask: AccessFlags::empty(),
-                image_layout: ImageLayout::PresentSrc,
-                queue_family_index: self.present_queue.as_ref().unwrap().queue_family_index(),
-            },
-        );
-
+    fn signal_pre_present(&mut self, swapchain_id: Id<Swapchain>, stage_mask: PipelineStages) {
         self.instructions.push(Instruction::SignalPrePresent {
             swapchain_id,
-            stage_mask: prev_access.stage_mask,
+            stage_mask,
         });
 
-        self.pre_present_queue_family_ownership_transfers
-            .push(swapchain_id);
+        self.should_flush_submit = true;
     }
 
-    fn pre_present_acquire_queue_family_ownership(&mut self, swapchain_id: Id<Swapchain>) {
+    fn pre_present_acquire_queue_family_ownership(
+        &mut self,
+        last_accesses: &[ResourceAccess],
+        swapchain_id: Id<Swapchain>,
+    ) {
         if !self.has_flushed_submit {
             self.flush_submit();
         }
@@ -894,15 +1592,19 @@ impl<'a> CompileState<'a> {
             stage_mask: PipelineStages::ALL_COMMANDS,
         });
 
-        self.acquire_queue_family_ownership(
-            swapchain_id.erase(),
-            ResourceAccess {
-                stage_mask: PipelineStages::empty(),
-                access_mask: AccessFlags::empty(),
-                image_layout: ImageLayout::PresentSrc,
-                queue_family_index: self.present_queue.as_ref().unwrap().queue_family_index(),
-            },
-        );
+        let last_access = last_accesses[swapchain_id.index() as usize];
+
+        self.barriers.push(super::MemoryBarrier {
+            src_stage_mask: PipelineStages::empty(),
+            src_access_mask: AccessFlags::empty(),
+            dst_stage_mask: PipelineStages::empty(),
+            dst_access_mask: AccessFlags::empty(),
+            old_layout: last_access.image_layout,
+            new_layout: ImageLayout::PresentSrc,
+            src_queue_family_index: last_access.queue_family_index,
+            dst_queue_family_index: self.present_queue.as_ref().unwrap().queue_family_index(),
+            resource: swapchain_id.erase(),
+        });
 
         self.instructions.push(Instruction::SignalPresent {
             swapchain_id,
@@ -911,17 +1613,12 @@ impl<'a> CompileState<'a> {
     }
 
     fn flush_barriers(&mut self) {
-        if self.prev_buffer_barrier_index != self.buffer_barriers.len()
-            || self.prev_image_barrier_index != self.image_barriers.len()
-        {
+        if self.prev_barrier_index != self.barriers.len() {
             self.instructions.push(Instruction::PipelineBarrier {
-                buffer_barrier_range: self.prev_buffer_barrier_index as BarrierIndex
-                    ..self.buffer_barriers.len() as BarrierIndex,
-                image_barrier_range: self.prev_image_barrier_index as BarrierIndex
-                    ..self.image_barriers.len() as BarrierIndex,
+                barrier_range: self.prev_barrier_index as BarrierIndex
+                    ..self.barriers.len() as BarrierIndex,
             });
-            self.prev_buffer_barrier_index = self.buffer_barriers.len();
-            self.prev_image_barrier_index = self.image_barriers.len();
+            self.prev_barrier_index = self.barriers.len();
         }
     }
 
@@ -932,7 +1629,7 @@ impl<'a> CompileState<'a> {
         self.should_flush_submit = false;
     }
 
-    fn submit(&mut self, queue: &Arc<Queue>) {
+    fn submit(&mut self, queue: Arc<Queue>) {
         self.instructions.push(Instruction::Submit);
 
         let prev_instruction_range_end = self
@@ -941,9 +1638,8 @@ impl<'a> CompileState<'a> {
             .map(|s| s.instruction_range.end)
             .unwrap_or(0);
         self.submissions.push(Submission {
-            queue: queue.clone(),
-            initial_buffer_barrier_range: self.initial_buffer_barrier_range.clone(),
-            initial_image_barrier_range: self.initial_image_barrier_range.clone(),
+            queue,
+            initial_barrier_range: self.initial_barrier_range.clone(),
             instruction_range: prev_instruction_range_end..self.instructions.len(),
         });
     }
@@ -1008,7 +1704,7 @@ pub struct CompileError<W: ?Sized> {
 }
 
 /// The kind of [`CompileError`] that occurred.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CompileErrorKind {
     Unconnected,
     Cycle,
@@ -1050,56 +1746,12 @@ impl<W: ?Sized> Error for CompileError<W> {
     }
 }
 
-mod linear_map {
-    use smallvec::{Array, SmallVec};
-
-    pub struct LinearMap<K, V, const N: usize>
-    where
-        [(K, V); N]: Array<Item = (K, V)>,
-    {
-        inner: SmallVec<[(K, V); N]>,
-    }
-
-    impl<K, V, const N: usize> LinearMap<K, V, N>
-    where
-        [(K, V); N]: Array<Item = (K, V)>,
-    {
-        #[inline]
-        pub fn new() -> Self {
-            LinearMap {
-                inner: SmallVec::new(),
-            }
-        }
-
-        #[inline]
-        pub fn get_or_insert(&mut self, key: K, value: V) -> &mut V
-        where
-            K: Eq,
-        {
-            let index = if let Some(index) = self.inner.iter().position(|(k, _)| k == &key) {
-                index
-            } else {
-                let index = self.inner.len();
-                self.inner.push((key, value));
-
-                index
-            };
-
-            &mut unsafe { self.inner.get_unchecked_mut(index) }.1
-        }
-
-        #[inline]
-        pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
-            self.inner.iter().map(|(k, v)| (k, v))
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        resource::{AccessType, ImageLayoutType},
+        graph::AttachmentInfo,
+        resource::{AccessTypes, ImageLayoutType},
         tests::test_queues,
     };
     use std::marker::PhantomData;
@@ -1109,784 +1761,1574 @@ mod tests {
     };
 
     #[test]
-    fn unconnected() {
+    fn unconnected1() {
         let (resources, queues) = test_queues!();
-        let compile_info = CompileInfo {
-            queues: &queues.iter().collect::<Vec<_>>(),
-            ..Default::default()
-        };
 
-        {
-            // ┌───┐
-            // │ A │
-            // └───┘
-            // ┄┄┄┄┄
-            // ┌───┐
-            // │ B │
-            // └───┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
-            graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            graph
-                .create_task_node("B", QueueFamilyType::Compute, PhantomData)
-                .build();
+        // ┌───┐
+        // │ A │
+        // └───┘
+        // ┄┄┄┄┄
+        // ┌───┐
+        // │ B │
+        // └───┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        graph
+            .create_task_node("B", QueueFamilyType::Compute, PhantomData)
+            .build();
 
-            assert!(matches!(
-                unsafe { graph.compile(&compile_info) },
-                Err(CompileError {
-                    kind: CompileErrorKind::Unconnected,
-                    ..
-                }),
-            ));
+        let err = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
         }
+        .unwrap_err();
 
-        {
-            // ┌───┐
-            // │ A ├─┐
-            // └───┘ │
-            // ┌───┐ │
-            // │ B ├┐│
-            // └───┘││
-            // ┄┄┄┄┄││┄┄┄┄┄┄
-            //      ││ ┌───┐
-            //      │└►│ C │
-            //      │  └───┘
-            //      │  ┌───┐
-            //      └─►│ D │
-            //         └───┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
-            let a = graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let b = graph
-                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let c = graph
-                .create_task_node("C", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let d = graph
-                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
-                .build();
-            graph.add_edge(a, c).unwrap();
-            graph.add_edge(b, d).unwrap();
-
-            assert!(matches!(
-                unsafe { graph.compile(&compile_info) },
-                Err(CompileError {
-                    kind: CompileErrorKind::Unconnected,
-                    ..
-                }),
-            ));
-        }
-
-        {
-            // ┌───┐  ┌───┐  ┌───┐
-            // │ A ├─►│ B ├─►│ C │
-            // └───┘  └───┘  └───┘
-            // ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
-            // ┌───┐  ┌───┐  ┌───┐   ┌───┐
-            // │ D ├┬►│ E ├┬►│ F ├──►│   │
-            // └───┘│ └───┘│ └───┘┌─►│ G │
-            //      │      └──────┘┌►│   │
-            //      └──────────────┘ └───┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
-            let a = graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let b = graph
-                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let c = graph
-                .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            graph.add_edge(a, b).unwrap();
-            graph.add_edge(b, c).unwrap();
-            let d = graph
-                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let e = graph
-                .create_task_node("E", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let f = graph
-                .create_task_node("F", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let g = graph
-                .create_task_node("G", QueueFamilyType::Compute, PhantomData)
-                .build();
-            graph.add_edge(d, e).unwrap();
-            graph.add_edge(d, g).unwrap();
-            graph.add_edge(e, f).unwrap();
-            graph.add_edge(e, g).unwrap();
-            graph.add_edge(f, g).unwrap();
-
-            assert!(matches!(
-                unsafe { graph.compile(&compile_info) },
-                Err(CompileError {
-                    kind: CompileErrorKind::Unconnected,
-                    ..
-                }),
-            ));
-        }
+        assert_eq!(err.kind, CompileErrorKind::Unconnected);
     }
 
     #[test]
-    fn cycle() {
+    fn unconnected2() {
         let (resources, queues) = test_queues!();
-        let compile_info = CompileInfo {
-            queues: &queues.iter().collect::<Vec<_>>(),
-            ..Default::default()
-        };
 
-        {
-            //   ┌───┐  ┌───┐  ┌───┐
-            // ┌►│ A ├─►│ B ├─►│ C ├┐
-            // │ └───┘  └───┘  └───┘│
-            // └────────────────────┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
-            let a = graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let b = graph
-                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let c = graph
-                .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            graph.add_edge(a, b).unwrap();
-            graph.add_edge(b, c).unwrap();
-            graph.add_edge(c, a).unwrap();
+        // ┌───┐
+        // │ A ├─┐
+        // └───┘ │
+        // ┌───┐ │
+        // │ B ├┐│
+        // └───┘││
+        // ┄┄┄┄┄││┄┄┄┄┄┄
+        //      ││ ┌───┐
+        //      │└►│ C │
+        //      │  └───┘
+        //      │  ┌───┐
+        //      └─►│ D │
+        //         └───┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let a = graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let b = graph
+            .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let c = graph
+            .create_task_node("C", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let d = graph
+            .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+            .build();
+        graph.add_edge(a, c).unwrap();
+        graph.add_edge(b, d).unwrap();
 
-            assert!(matches!(
-                unsafe { graph.compile(&compile_info) },
-                Err(CompileError {
-                    kind: CompileErrorKind::Cycle,
-                    ..
-                }),
-            ));
+        let err = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
         }
+        .unwrap_err();
 
-        {
-            //   ┌───┐  ┌───┐  ┌───┐
-            // ┌►│ A ├┬►│ B ├─►│ C ├┐
-            // │ └───┘│ └───┘  └───┘│
-            // │┄┄┄┄┄┄│┄┄┄┄┄┄┄┄┄┄┄┄┄│┄┄┄┄┄┄┄
-            // │      │ ┌───┐  ┌───┐│ ┌───┐
-            // │      └►│ D ├─►│ E ├┴►│ F ├┐
-            // │        └───┘  └───┘  └───┘│
-            // └───────────────────────────┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
-            let a = graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let b = graph
-                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let c = graph
-                .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let d = graph
-                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let e = graph
-                .create_task_node("E", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let f = graph
-                .create_task_node("F", QueueFamilyType::Compute, PhantomData)
-                .build();
-            graph.add_edge(a, b).unwrap();
-            graph.add_edge(a, d).unwrap();
-            graph.add_edge(b, c).unwrap();
-            graph.add_edge(c, f).unwrap();
-            graph.add_edge(d, e).unwrap();
-            graph.add_edge(e, f).unwrap();
-            graph.add_edge(f, a).unwrap();
+        assert_eq!(err.kind, CompileErrorKind::Unconnected);
+    }
 
-            assert!(matches!(
-                unsafe { graph.compile(&compile_info) },
-                Err(CompileError {
-                    kind: CompileErrorKind::Cycle,
-                    ..
-                }),
-            ));
+    #[test]
+    fn unconnected3() {
+        let (resources, queues) = test_queues!();
+
+        // ┌───┐  ┌───┐  ┌───┐
+        // │ A ├─►│ B ├─►│ C │
+        // └───┘  └───┘  └───┘
+        // ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+        // ┌───┐  ┌───┐  ┌───┐   ┌───┐
+        // │ D ├┬►│ E ├┬►│ F ├──►│   │
+        // └───┘│ └───┘│ └───┘┌─►│ G │
+        //      │      └──────┘┌►│   │
+        //      └──────────────┘ └───┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let a = graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let b = graph
+            .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let c = graph
+            .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        graph.add_edge(a, b).unwrap();
+        graph.add_edge(b, c).unwrap();
+        let d = graph
+            .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let e = graph
+            .create_task_node("E", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let f = graph
+            .create_task_node("F", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let g = graph
+            .create_task_node("G", QueueFamilyType::Compute, PhantomData)
+            .build();
+        graph.add_edge(d, e).unwrap();
+        graph.add_edge(d, g).unwrap();
+        graph.add_edge(e, f).unwrap();
+        graph.add_edge(e, g).unwrap();
+        graph.add_edge(f, g).unwrap();
+
+        let err = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
         }
+        .unwrap_err();
 
-        {
-            // ┌─────┐
-            // │┌───┐└►┌───┐  ┌───┐
-            // ││ A ├┬►│ B ├─►│ C ├┬──────┐
-            // │└───┘│ └───┘┌►└───┘│      │
-            // │┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄
-            // │     │ ┌───┐│ ┌───┐│ ┌───┐│
-            // │     └►│ D ├┴►│ E │└►│ F ├│┐
-            // │     ┌►└───┘  └───┘  └───┘││
-            // │     └────────────────────┘│
-            // └───────────────────────────┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
-            let a = graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let b = graph
-                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let c = graph
-                .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let d = graph
-                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let e = graph
-                .create_task_node("E", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let f = graph
-                .create_task_node("F", QueueFamilyType::Compute, PhantomData)
-                .build();
-            graph.add_edge(a, b).unwrap();
-            graph.add_edge(a, d).unwrap();
-            graph.add_edge(b, c).unwrap();
-            graph.add_edge(c, d).unwrap();
-            graph.add_edge(c, f).unwrap();
-            graph.add_edge(d, c).unwrap();
-            graph.add_edge(d, e).unwrap();
-            graph.add_edge(f, b).unwrap();
+        assert_eq!(err.kind, CompileErrorKind::Unconnected);
+    }
 
-            assert!(matches!(
-                unsafe { graph.compile(&compile_info) },
-                Err(CompileError {
-                    kind: CompileErrorKind::Cycle,
-                    ..
-                }),
-            ));
+    #[test]
+    fn cycle1() {
+        let (resources, queues) = test_queues!();
+
+        //   ┌───┐  ┌───┐  ┌───┐
+        // ┌►│ A ├─►│ B ├─►│ C ├┐
+        // │ └───┘  └───┘  └───┘│
+        // └────────────────────┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let a = graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let b = graph
+            .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let c = graph
+            .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        graph.add_edge(a, b).unwrap();
+        graph.add_edge(b, c).unwrap();
+        graph.add_edge(c, a).unwrap();
+
+        let err = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
         }
+        .unwrap_err();
+
+        assert_eq!(err.kind, CompileErrorKind::Cycle);
+    }
+
+    #[test]
+    fn cycle2() {
+        let (resources, queues) = test_queues!();
+
+        //   ┌───┐  ┌───┐  ┌───┐
+        // ┌►│ A ├┬►│ B ├─►│ C ├┐
+        // │ └───┘│ └───┘  └───┘│
+        // │┄┄┄┄┄┄│┄┄┄┄┄┄┄┄┄┄┄┄┄│┄┄┄┄┄┄┄
+        // │      │ ┌───┐  ┌───┐│ ┌───┐
+        // │      └►│ D ├─►│ E ├┴►│ F ├┐
+        // │        └───┘  └───┘  └───┘│
+        // └───────────────────────────┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let a = graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let b = graph
+            .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let c = graph
+            .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let d = graph
+            .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let e = graph
+            .create_task_node("E", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let f = graph
+            .create_task_node("F", QueueFamilyType::Compute, PhantomData)
+            .build();
+        graph.add_edge(a, b).unwrap();
+        graph.add_edge(a, d).unwrap();
+        graph.add_edge(b, c).unwrap();
+        graph.add_edge(c, f).unwrap();
+        graph.add_edge(d, e).unwrap();
+        graph.add_edge(e, f).unwrap();
+        graph.add_edge(f, a).unwrap();
+
+        let err = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap_err();
+
+        assert_eq!(err.kind, CompileErrorKind::Cycle);
+    }
+
+    #[test]
+    fn cycle3() {
+        let (resources, queues) = test_queues!();
+
+        // ┌─────┐
+        // │┌───┐└►┌───┐  ┌───┐
+        // ││ A ├┬►│ B ├─►│ C ├┬──────┐
+        // │└───┘│ └───┘┌►└───┘│      │
+        // │┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄
+        // │     │ ┌───┐│ ┌───┐│ ┌───┐│
+        // │     └►│ D ├┴►│ E │└►│ F ├│┐
+        // │     ┌►└───┘  └───┘  └───┘││
+        // │     └────────────────────┘│
+        // └───────────────────────────┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let a = graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let b = graph
+            .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let c = graph
+            .create_task_node("C", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let d = graph
+            .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let e = graph
+            .create_task_node("E", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let f = graph
+            .create_task_node("F", QueueFamilyType::Compute, PhantomData)
+            .build();
+        graph.add_edge(a, b).unwrap();
+        graph.add_edge(a, d).unwrap();
+        graph.add_edge(b, c).unwrap();
+        graph.add_edge(c, d).unwrap();
+        graph.add_edge(c, f).unwrap();
+        graph.add_edge(d, c).unwrap();
+        graph.add_edge(d, e).unwrap();
+        graph.add_edge(f, b).unwrap();
+
+        let err = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap_err();
+
+        assert_eq!(err.kind, CompileErrorKind::Cycle);
     }
 
     #[test]
     fn initial_pipeline_barrier() {
         let (resources, queues) = test_queues!();
-        let compile_info = CompileInfo {
-            queues: &queues.iter().collect::<Vec<_>>(),
-            ..Default::default()
-        };
 
-        {
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
-            let buffer = graph.add_buffer(&BufferCreateInfo::default());
-            let image = graph.add_image(&ImageCreateInfo::default());
-            let node = graph
-                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
-                .buffer_access(buffer, AccessType::VertexShaderUniformRead)
-                .image_access(
-                    image,
-                    AccessType::FragmentShaderSampledRead,
-                    ImageLayoutType::Optimal,
-                )
-                .build();
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let buffer = graph.add_buffer(&BufferCreateInfo::default());
+        let image = graph.add_image(&ImageCreateInfo::default());
+        let node = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .buffer_access(buffer, AccessTypes::VERTEX_SHADER_UNIFORM_READ)
+            .image_access(
+                image,
+                AccessTypes::FRAGMENT_SHADER_SAMPLED_READ,
+                ImageLayoutType::Optimal,
+            )
+            .build();
 
-            let graph = unsafe { graph.compile(&compile_info) }.unwrap();
-
-            assert_matches_instructions!(
-                graph,
-                InitialPipelineBarrier {
-                    buffer_barriers: [
-                        {
-                            dst_stage_mask: VERTEX_SHADER,
-                            dst_access_mask: UNIFORM_READ,
-                            buffer: buffer,
-                        },
-                    ],
-                    image_barriers: [
-                        {
-                            dst_stage_mask: FRAGMENT_SHADER,
-                            dst_access_mask: SHADER_SAMPLED_READ,
-                            new_layout: ShaderReadOnlyOptimal,
-                            image: image,
-                        },
-                    ],
-                },
-                ExecuteTask { node: node },
-                FlushSubmit,
-                Submit,
-            );
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
         }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            InitialPipelineBarrier {
+                barriers: [
+                    {
+                        dst_stage_mask: VERTEX_SHADER,
+                        dst_access_mask: UNIFORM_READ,
+                        new_layout: Undefined,
+                        resource: buffer,
+                    },
+                    {
+                        dst_stage_mask: FRAGMENT_SHADER,
+                        dst_access_mask: SHADER_SAMPLED_READ,
+                        new_layout: ShaderReadOnlyOptimal,
+                        resource: image,
+                    },
+                ],
+            },
+            ExecuteTask { node: node },
+            FlushSubmit,
+            Submit,
+        );
     }
 
     #[test]
-    fn semaphore() {
+    fn barrier1() {
         let (resources, queues) = test_queues!();
 
-        let queue_family_properties = resources
-            .device()
-            .physical_device()
-            .queue_family_properties();
-        let has_compute_only_queue = queues.iter().any(|q| {
-            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let buffer = graph.add_buffer(&BufferCreateInfo::default());
+        let image = graph.add_image(&ImageCreateInfo::default());
+        let node1 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .buffer_access(buffer, AccessTypes::FRAGMENT_SHADER_STORAGE_WRITE)
+            .image_access(
+                image,
+                AccessTypes::FRAGMENT_SHADER_STORAGE_WRITE,
+                ImageLayoutType::General,
+            )
+            .build();
+        let node2 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .buffer_access(buffer, AccessTypes::INDIRECT_COMMAND_READ)
+            .image_access(
+                image,
+                AccessTypes::FRAGMENT_SHADER_COLOR_INPUT_ATTACHMENT_READ,
+                ImageLayoutType::General,
+            )
+            .build();
+        let node3 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .buffer_access(buffer, AccessTypes::RAY_TRACING_SHADER_STORAGE_READ)
+            .image_access(
+                image,
+                AccessTypes::RAY_TRACING_SHADER_COLOR_INPUT_ATTACHMENT_READ,
+                ImageLayoutType::General,
+            )
+            .build();
+        graph.add_edge(node1, node2).unwrap();
+        graph.add_edge(node2, node3).unwrap();
 
-            queue_flags.contains(QueueFlags::COMPUTE) && !queue_flags.contains(QueueFlags::GRAPHICS)
-        });
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
 
-        if !has_compute_only_queue {
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask { node: node1 },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: FRAGMENT_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: DRAW_INDIRECT | RAY_TRACING_SHADER,
+                        dst_access_mask: INDIRECT_COMMAND_READ | SHADER_STORAGE_READ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer,
+                    },
+                    {
+                        src_stage_mask: FRAGMENT_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: FRAGMENT_SHADER | RAY_TRACING_SHADER,
+                        dst_access_mask: INPUT_ATTACHMENT_READ,
+                        old_layout: General,
+                        new_layout: General,
+                        resource: image,
+                    },
+                ],
+            },
+            ExecuteTask { node: node2 },
+            ExecuteTask { node: node3 },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn barrier2() {
+        let (resources, queues) = test_queues!();
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let buffer = graph.add_buffer(&BufferCreateInfo::default());
+        let image = graph.add_image(&ImageCreateInfo::default());
+        let node1 = graph
+            .create_task_node("", QueueFamilyType::Compute, PhantomData)
+            .buffer_access(buffer, AccessTypes::COMPUTE_SHADER_STORAGE_WRITE)
+            .image_access(
+                image,
+                AccessTypes::COPY_TRANSFER_WRITE,
+                ImageLayoutType::General,
+            )
+            .build();
+        let node2 = graph
+            .create_task_node("", QueueFamilyType::Compute, PhantomData)
+            .buffer_access(buffer, AccessTypes::COPY_TRANSFER_WRITE)
+            .image_access(
+                image,
+                AccessTypes::COMPUTE_SHADER_STORAGE_WRITE,
+                ImageLayoutType::General,
+            )
+            .build();
+        let node3 = graph
+            .create_task_node("", QueueFamilyType::Compute, PhantomData)
+            .buffer_access(buffer, AccessTypes::INDIRECT_COMMAND_READ)
+            .image_access(
+                image,
+                AccessTypes::COMPUTE_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .build();
+        graph.add_edge(node1, node2).unwrap();
+        graph.add_edge(node2, node3).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask { node: node1 },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: COPY,
+                        dst_access_mask: TRANSFER_WRITE,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer,
+                    },
+                    {
+                        src_stage_mask: COPY,
+                        src_access_mask: TRANSFER_WRITE,
+                        dst_stage_mask: COMPUTE_SHADER,
+                        dst_access_mask: SHADER_STORAGE_WRITE,
+                        old_layout: General,
+                        new_layout: General,
+                        resource: image,
+                    },
+                ],
+            },
+            ExecuteTask { node: node2 },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COPY,
+                        src_access_mask: TRANSFER_WRITE,
+                        dst_stage_mask: DRAW_INDIRECT,
+                        dst_access_mask: INDIRECT_COMMAND_READ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: COMPUTE_SHADER,
+                        dst_access_mask: SHADER_SAMPLED_READ,
+                        old_layout: General,
+                        new_layout: General,
+                        resource: image,
+                    },
+                ],
+            },
+            ExecuteTask { node: node3 },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn semaphore1() {
+        let (resources, queues) = test_queues!();
+
+        if !has_compute_only_queue(&queues) {
             return;
         }
 
-        let compile_info = CompileInfo {
-            queues: &queues.iter().collect::<Vec<_>>(),
-            ..Default::default()
-        };
+        // ┌───┐
+        // │ A ├─┐
+        // └───┘ │
+        // ┌───┐ │
+        // │ B ├┐│
+        // └───┘││
+        // ┄┄┄┄┄││┄┄┄┄┄┄
+        //      │└►┌───┐
+        //      └─►│ C │
+        //         └───┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let a = graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let b = graph
+            .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let c = graph
+            .create_task_node("C", QueueFamilyType::Compute, PhantomData)
+            .build();
+        graph.add_edge(a, c).unwrap();
+        graph.add_edge(b, c).unwrap();
 
-        {
-            // ┌───┐
-            // │ A ├─┐
-            // └───┘ │
-            // ┌───┐ │
-            // │ B ├┐│
-            // └───┘││
-            // ┄┄┄┄┄││┄┄┄┄┄┄
-            //      │└►┌───┐
-            //      └─►│ C │
-            //         └───┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
-            let a = graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let b = graph
-                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let c = graph
-                .create_task_node("C", QueueFamilyType::Compute, PhantomData)
-                .build();
-            graph.add_edge(a, c).unwrap();
-            graph.add_edge(b, c).unwrap();
-
-            let graph = unsafe { graph.compile(&compile_info) }.unwrap();
-
-            assert_matches_instructions!(
-                graph,
-                ExecuteTask { node: b },
-                // TODO: This semaphore is redundant.
-                SignalSemaphore {
-                    semaphore_index: semaphore1,
-                    stage_mask: ALL_COMMANDS,
-                },
-                FlushSubmit,
-                ExecuteTask { node: a },
-                SignalSemaphore {
-                    semaphore_index: semaphore2,
-                    stage_mask: ALL_COMMANDS,
-                },
-                FlushSubmit,
-                Submit,
-                WaitSemaphore {
-                    semaphore_index: semaphore1,
-                    stage_mask: ALL_COMMANDS,
-                },
-                WaitSemaphore {
-                    semaphore_index: semaphore2,
-                    stage_mask: ALL_COMMANDS,
-                },
-                ExecuteTask { node: c },
-                FlushSubmit,
-                Submit,
-            );
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
         }
+        .unwrap();
 
-        {
-            // ┌───┐
-            // │ A ├┐
-            // └───┘│
-            // ┄┄┄┄┄│┄┄┄┄┄┄
-            //      │ ┌───┐
-            //      ├►│ B │
-            //      │ └───┘
-            //      │ ┌───┐
-            //      └►│ C │
-            //        └───┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
-            let a = graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let b = graph
-                .create_task_node("B", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let c = graph
-                .create_task_node("C", QueueFamilyType::Compute, PhantomData)
-                .build();
-            graph.add_edge(a, b).unwrap();
-            graph.add_edge(a, c).unwrap();
-
-            let graph = unsafe { graph.compile(&compile_info) }.unwrap();
-
-            assert_matches_instructions!(
-                graph,
-                ExecuteTask { node: a },
-                // TODO: This semaphore is redundant.
-                SignalSemaphore {
-                    semaphore_index: semaphore1,
-                    stage_mask: ALL_COMMANDS,
-                },
-                SignalSemaphore {
-                    semaphore_index: semaphore2,
-                    stage_mask: ALL_COMMANDS,
-                },
-                FlushSubmit,
-                Submit,
-                WaitSemaphore {
-                    semaphore_index: semaphore2,
-                    stage_mask: ALL_COMMANDS,
-                },
-                ExecuteTask { node: c },
-                FlushSubmit,
-                WaitSemaphore {
-                    semaphore_index: semaphore1,
-                    stage_mask: ALL_COMMANDS,
-                },
-                ExecuteTask { node: b },
-                FlushSubmit,
-                Submit,
-            );
-        }
-
-        {
-            // ┌───┐                ┌───┐
-            // │ A ├───────┬───────►│ E │
-            // └───┘       │      ┌►└───┘
-            // ┌───┐       │      │
-            // │ B ├┐      │      │
-            // └───┘│      │      │
-            // ┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄┄
-            //      │ ┌───┐└►┌───┐│
-            //      └►│ C ├─►│ D ├┘
-            //        └───┘  └───┘
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
-            let a = graph
-                .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let b = graph
-                .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            let c = graph
-                .create_task_node("C", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let d = graph
-                .create_task_node("D", QueueFamilyType::Compute, PhantomData)
-                .build();
-            let e = graph
-                .create_task_node("E", QueueFamilyType::Graphics, PhantomData)
-                .build();
-            graph.add_edge(a, d).unwrap();
-            graph.add_edge(a, e).unwrap();
-            graph.add_edge(b, c).unwrap();
-            graph.add_edge(c, d).unwrap();
-            graph.add_edge(d, e).unwrap();
-
-            let graph = unsafe { graph.compile(&compile_info) }.unwrap();
-
-            // TODO: This could be brought down to 3 submissions with task reordering.
-            assert_matches_instructions!(
-                graph,
-                ExecuteTask { node: b },
-                SignalSemaphore {
-                    semaphore_index: semaphore1,
-                    stage_mask: ALL_COMMANDS,
-                },
-                FlushSubmit,
-                Submit,
-                WaitSemaphore {
-                    semaphore_index: semaphore1,
-                    stage_mask: ALL_COMMANDS,
-                },
-                ExecuteTask { node: c },
-                FlushSubmit,
-                Submit,
-                ExecuteTask { node: a },
-                SignalSemaphore {
-                    semaphore_index: semaphore2,
-                    stage_mask: ALL_COMMANDS,
-                },
-                FlushSubmit,
-                Submit,
-                WaitSemaphore {
-                    semaphore_index: semaphore2,
-                    stage_mask: ALL_COMMANDS,
-                },
-                ExecuteTask { node: d },
-                SignalSemaphore {
-                    semaphore_index: semaphore3,
-                    stage_mask: ALL_COMMANDS,
-                },
-                FlushSubmit,
-                Submit,
-                WaitSemaphore {
-                    semaphore_index: semaphore3,
-                    stage_mask: ALL_COMMANDS,
-                },
-                ExecuteTask { node: e },
-                FlushSubmit,
-                Submit,
-            );
-        }
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask { node: b },
+            // TODO: This semaphore is redundant.
+            SignalSemaphore {
+                semaphore_index: semaphore1,
+                stage_mask: ALL_COMMANDS,
+            },
+            FlushSubmit,
+            ExecuteTask { node: a },
+            SignalSemaphore {
+                semaphore_index: semaphore2,
+                stage_mask: ALL_COMMANDS,
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore1,
+                stage_mask: ALL_COMMANDS,
+            },
+            WaitSemaphore {
+                semaphore_index: semaphore2,
+                stage_mask: ALL_COMMANDS,
+            },
+            ExecuteTask { node: c },
+            FlushSubmit,
+            Submit,
+        );
     }
 
     #[test]
-    fn queue_family_ownership_transfer() {
+    fn semaphore2() {
         let (resources, queues) = test_queues!();
 
-        let queue_family_properties = resources
-            .device()
-            .physical_device()
-            .queue_family_properties();
-        let has_compute_only_queue = queues.iter().any(|q| {
-            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
-
-            queue_flags.contains(QueueFlags::COMPUTE) && !queue_flags.contains(QueueFlags::GRAPHICS)
-        });
-
-        if !has_compute_only_queue {
+        if !has_compute_only_queue(&queues) {
             return;
         }
 
-        let compile_info = CompileInfo {
-            queues: &queues.iter().collect::<Vec<_>>(),
-            ..Default::default()
-        };
+        // ┌───┐
+        // │ A ├┐
+        // └───┘│
+        // ┄┄┄┄┄│┄┄┄┄┄┄
+        //      │ ┌───┐
+        //      ├►│ B │
+        //      │ └───┘
+        //      │ ┌───┐
+        //      └►│ C │
+        //        └───┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let a = graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let b = graph
+            .create_task_node("B", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let c = graph
+            .create_task_node("C", QueueFamilyType::Compute, PhantomData)
+            .build();
+        graph.add_edge(a, b).unwrap();
+        graph.add_edge(a, c).unwrap();
 
-        {
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
-            let buffer1 = graph.add_buffer(&BufferCreateInfo::default());
-            let buffer2 = graph.add_buffer(&BufferCreateInfo::default());
-            let image1 = graph.add_image(&ImageCreateInfo::default());
-            let image2 = graph.add_image(&ImageCreateInfo::default());
-            let compute_node = graph
-                .create_task_node("", QueueFamilyType::Compute, PhantomData)
-                .buffer_access(buffer1, AccessType::ComputeShaderStorageWrite)
-                .buffer_access(buffer2, AccessType::ComputeShaderStorageRead)
-                .image_access(
-                    image1,
-                    AccessType::ComputeShaderStorageWrite,
-                    ImageLayoutType::Optimal,
-                )
-                .image_access(
-                    image2,
-                    AccessType::ComputeShaderSampledRead,
-                    ImageLayoutType::Optimal,
-                )
-                .build();
-            let graphics_node = graph
-                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
-                .buffer_access(buffer1, AccessType::IndexRead)
-                .buffer_access(buffer2, AccessType::VertexShaderSampledRead)
-                .image_access(
-                    image1,
-                    AccessType::VertexShaderSampledRead,
-                    ImageLayoutType::General,
-                )
-                .image_access(
-                    image2,
-                    AccessType::FragmentShaderSampledRead,
-                    ImageLayoutType::General,
-                )
-                .build();
-            graph.add_edge(compute_node, graphics_node).unwrap();
-
-            let graph = unsafe { graph.compile(&compile_info) }.unwrap();
-
-            assert_matches_instructions!(
-                graph,
-                ExecuteTask {
-                    node: compute_node,
-                },
-                SignalSemaphore {
-                    semaphore_index: semaphore,
-                    stage_mask: ALL_COMMANDS,
-                },
-                PipelineBarrier {
-                    buffer_barriers: [
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: SHADER_STORAGE_WRITE,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            buffer: buffer1,
-                        },
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: ,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            buffer: buffer2,
-                        },
-                    ],
-                    image_barriers: [
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: SHADER_STORAGE_WRITE,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: General,
-                            new_layout: General,
-                            image: image1,
-                        },
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: ,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: ShaderReadOnlyOptimal,
-                            new_layout: General,
-                            image: image2,
-                        },
-                    ],
-                },
-                FlushSubmit,
-                Submit,
-                WaitSemaphore {
-                    semaphore_index: semaphore,
-                    stage_mask: ALL_COMMANDS,
-                },
-                PipelineBarrier {
-                    buffer_barriers: [
-                        {
-                            src_stage_mask: ,
-                            src_access_mask: ,
-                            dst_stage_mask: INDEX_INPUT,
-                            dst_access_mask: INDEX_READ,
-                            buffer: buffer1,
-                        },
-                        {
-                            src_stage_mask: ,
-                            src_access_mask: ,
-                            dst_stage_mask: VERTEX_SHADER,
-                            dst_access_mask: SHADER_SAMPLED_READ,
-                            buffer: buffer2,
-                        },
-                    ],
-                    image_barriers: [
-                        {
-                            src_stage_mask: ,
-                            src_access_mask: ,
-                            dst_stage_mask: VERTEX_SHADER,
-                            dst_access_mask: SHADER_SAMPLED_READ,
-                            old_layout: General,
-                            new_layout: General,
-                            image: image1,
-                        },
-                        {
-                            src_stage_mask: ,
-                            src_access_mask: ,
-                            dst_stage_mask: FRAGMENT_SHADER,
-                            dst_access_mask: SHADER_SAMPLED_READ,
-                            old_layout: ShaderReadOnlyOptimal,
-                            new_layout: General,
-                            image: image2,
-                        },
-                    ],
-                },
-                ExecuteTask {
-                    node: graphics_node,
-                },
-                FlushSubmit,
-                Submit,
-            );
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
         }
+        .unwrap();
 
-        {
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
-            let sharing = Sharing::Concurrent(
-                compile_info
-                    .queues
-                    .iter()
-                    .map(|q| q.queue_family_index())
-                    .collect(),
-            );
-            let buffer1 = graph.add_buffer(&BufferCreateInfo {
-                sharing: sharing.clone(),
-                ..Default::default()
-            });
-            let buffer2 = graph.add_buffer(&BufferCreateInfo {
-                sharing: sharing.clone(),
-                ..Default::default()
-            });
-            let image1 = graph.add_image(&ImageCreateInfo {
-                sharing: sharing.clone(),
-                ..Default::default()
-            });
-            let image2 = graph.add_image(&ImageCreateInfo {
-                sharing: sharing.clone(),
-                ..Default::default()
-            });
-            let compute_node = graph
-                .create_task_node("", QueueFamilyType::Compute, PhantomData)
-                .buffer_access(buffer1, AccessType::ComputeShaderStorageWrite)
-                .buffer_access(buffer2, AccessType::ComputeShaderStorageRead)
-                .image_access(
-                    image1,
-                    AccessType::ComputeShaderStorageWrite,
-                    ImageLayoutType::Optimal,
-                )
-                .image_access(
-                    image2,
-                    AccessType::ComputeShaderSampledRead,
-                    ImageLayoutType::Optimal,
-                )
-                .build();
-            let graphics_node = graph
-                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
-                .buffer_access(buffer1, AccessType::IndexRead)
-                .buffer_access(buffer2, AccessType::VertexShaderSampledRead)
-                .image_access(
-                    image1,
-                    AccessType::VertexShaderSampledRead,
-                    ImageLayoutType::General,
-                )
-                .image_access(
-                    image2,
-                    AccessType::FragmentShaderSampledRead,
-                    ImageLayoutType::General,
-                )
-                .build();
-            graph.add_edge(compute_node, graphics_node).unwrap();
-
-            let graph = unsafe { graph.compile(&compile_info) }.unwrap();
-
-            assert_matches_instructions!(
-                graph,
-                ExecuteTask {
-                    node: compute_node,
-                },
-                SignalSemaphore {
-                    semaphore_index: semaphore,
-                    stage_mask: ALL_COMMANDS,
-                },
-                FlushSubmit,
-                Submit,
-                WaitSemaphore {
-                    semaphore_index: semaphore,
-                    stage_mask: ALL_COMMANDS,
-                },
-                PipelineBarrier {
-                    buffer_barriers: [],
-                    image_barriers: [
-                        {
-                            src_stage_mask: ,
-                            src_access_mask: ,
-                            dst_stage_mask: FRAGMENT_SHADER,
-                            dst_access_mask: SHADER_SAMPLED_READ,
-                            old_layout: ShaderReadOnlyOptimal,
-                            new_layout: General,
-                            image: image2,
-                        },
-                    ],
-                },
-                ExecuteTask {
-                    node: graphics_node,
-                },
-                FlushSubmit,
-                Submit,
-            );
-        }
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask { node: a },
+            // TODO: This semaphore is redundant.
+            SignalSemaphore {
+                semaphore_index: semaphore1,
+                stage_mask: ALL_COMMANDS,
+            },
+            SignalSemaphore {
+                semaphore_index: semaphore2,
+                stage_mask: ALL_COMMANDS,
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore2,
+                stage_mask: ALL_COMMANDS,
+            },
+            ExecuteTask { node: c },
+            FlushSubmit,
+            WaitSemaphore {
+                semaphore_index: semaphore1,
+                stage_mask: ALL_COMMANDS,
+            },
+            ExecuteTask { node: b },
+            FlushSubmit,
+            Submit,
+        );
     }
 
     #[test]
-    fn swapchain() {
+    fn semaphore3() {
+        let (resources, queues) = test_queues!();
+
+        if !has_compute_only_queue(&queues) {
+            return;
+        }
+
+        // ┌───┐                ┌───┐
+        // │ A ├───────┬───────►│ E │
+        // └───┘       │      ┌►└───┘
+        // ┌───┐       │      │
+        // │ B ├┐      │      │
+        // └───┘│      │      │
+        // ┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄│┄┄┄┄┄┄
+        //      │ ┌───┐└►┌───┐│
+        //      └►│ C ├─►│ D ├┘
+        //        └───┘  └───┘
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let a = graph
+            .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let b = graph
+            .create_task_node("B", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        let c = graph
+            .create_task_node("C", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let d = graph
+            .create_task_node("D", QueueFamilyType::Compute, PhantomData)
+            .build();
+        let e = graph
+            .create_task_node("E", QueueFamilyType::Graphics, PhantomData)
+            .build();
+        graph.add_edge(a, d).unwrap();
+        graph.add_edge(a, e).unwrap();
+        graph.add_edge(b, c).unwrap();
+        graph.add_edge(c, d).unwrap();
+        graph.add_edge(d, e).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        // TODO: This could be brought down to 3 submissions with task reordering.
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask { node: b },
+            SignalSemaphore {
+                semaphore_index: semaphore1,
+                stage_mask: ALL_COMMANDS,
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore1,
+                stage_mask: ALL_COMMANDS,
+            },
+            ExecuteTask { node: c },
+            FlushSubmit,
+            Submit,
+            ExecuteTask { node: a },
+            SignalSemaphore {
+                semaphore_index: semaphore2,
+                stage_mask: ALL_COMMANDS,
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore2,
+                stage_mask: ALL_COMMANDS,
+            },
+            ExecuteTask { node: d },
+            SignalSemaphore {
+                semaphore_index: semaphore3,
+                stage_mask: ALL_COMMANDS,
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore3,
+                stage_mask: ALL_COMMANDS,
+            },
+            ExecuteTask { node: e },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn render_pass1() {
+        let (resources, queues) = test_queues!();
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let color_image = graph.add_image(&ImageCreateInfo {
+            format: Format::R8G8B8A8_UNORM,
+            ..Default::default()
+        });
+        let depth_image = graph.add_image(&ImageCreateInfo {
+            format: Format::D16_UNORM,
+            ..Default::default()
+        });
+        let framebuffer = graph.add_framebuffer();
+        let node1 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_READ | AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .build();
+        let node2 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_READ,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .build();
+        graph.add_edge(node1, node2).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            BeginRenderPass,
+            ExecuteTask { node: node1 },
+            NextSubpass,
+            ExecuteTask { node: node2 },
+            EndRenderPass,
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn render_pass2() {
+        let (resources, queues) = test_queues!();
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let color_image = graph.add_image(&ImageCreateInfo {
+            format: Format::R8G8B8A8_UNORM,
+            ..Default::default()
+        });
+        let depth_image = graph.add_image(&ImageCreateInfo {
+            format: Format::D16_UNORM,
+            ..Default::default()
+        });
+        let framebuffer = graph.add_framebuffer();
+        let node1 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_READ | AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_READ
+                    | AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .build();
+        let node2 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .input_attachment(
+                color_image,
+                AccessTypes::FRAGMENT_SHADER_COLOR_INPUT_ATTACHMENT_READ,
+                ImageLayoutType::General,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::General,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_READ,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .build();
+        graph.add_edge(node1, node2).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            BeginRenderPass,
+            ExecuteTask { node: node1 },
+            NextSubpass,
+            ClearAttachments {
+                node: node2,
+                attachments: [color_image, depth_image],
+            },
+            ExecuteTask { node: node2 },
+            EndRenderPass,
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn render_pass3() {
+        let (resources, queues) = test_queues!();
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let color_image = graph.add_image(&ImageCreateInfo {
+            format: Format::R8G8B8A8_UNORM,
+            ..Default::default()
+        });
+        let depth_image = graph.add_image(&ImageCreateInfo {
+            format: Format::D16_UNORM,
+            ..Default::default()
+        });
+        let framebuffer = graph.add_framebuffer();
+        let node1 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_READ | AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_READ
+                    | AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .build();
+        let node2 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_READ,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    clear: true,
+                    ..Default::default()
+                },
+            )
+            .build();
+        let node3 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .input_attachment(
+                color_image,
+                AccessTypes::FRAGMENT_SHADER_COLOR_INPUT_ATTACHMENT_READ,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        graph.add_edge(node1, node2).unwrap();
+        graph.add_edge(node2, node3).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            BeginRenderPass,
+            ExecuteTask { node: node1 },
+            ClearAttachments {
+                node: node2,
+                attachments: [color_image, depth_image],
+            },
+            ExecuteTask { node: node2 },
+            NextSubpass,
+            ExecuteTask { node: node3 },
+            EndRenderPass,
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn queue_family_ownership_transfer1() {
+        let (resources, queues) = test_queues!();
+
+        if !has_compute_only_queue(&queues) {
+            return;
+        }
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let buffer1 = graph.add_buffer(&BufferCreateInfo::default());
+        let buffer2 = graph.add_buffer(&BufferCreateInfo::default());
+        let image1 = graph.add_image(&ImageCreateInfo::default());
+        let image2 = graph.add_image(&ImageCreateInfo::default());
+        let compute_node = graph
+            .create_task_node("", QueueFamilyType::Compute, PhantomData)
+            .buffer_access(buffer1, AccessTypes::COMPUTE_SHADER_STORAGE_WRITE)
+            .buffer_access(buffer2, AccessTypes::COMPUTE_SHADER_STORAGE_READ)
+            .image_access(
+                image1,
+                AccessTypes::COMPUTE_SHADER_STORAGE_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .image_access(
+                image2,
+                AccessTypes::COMPUTE_SHADER_SAMPLED_READ,
+                ImageLayoutType::Optimal,
+            )
+            .build();
+        let graphics_node = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .buffer_access(buffer1, AccessTypes::INDEX_READ)
+            .buffer_access(buffer2, AccessTypes::VERTEX_SHADER_UNIFORM_READ)
+            .image_access(
+                image1,
+                AccessTypes::VERTEX_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .image_access(
+                image2,
+                AccessTypes::FRAGMENT_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .build();
+        graph.add_edge(compute_node, graphics_node).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask { node: compute_node },
+            SignalSemaphore {
+                semaphore_index: semaphore,
+                stage_mask: ALL_COMMANDS,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer1,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: ,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer2,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: General,
+                        new_layout: General,
+                        resource: image1,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: ,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ShaderReadOnlyOptimal,
+                        new_layout: General,
+                        resource: image2,
+                    },
+                ],
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore,
+                stage_mask: ALL_COMMANDS,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: INDEX_INPUT,
+                        dst_access_mask: INDEX_READ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer1,
+                    },
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: VERTEX_SHADER,
+                        dst_access_mask: UNIFORM_READ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer2,
+                    },
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: VERTEX_SHADER,
+                        dst_access_mask: SHADER_SAMPLED_READ,
+                        old_layout: General,
+                        new_layout: General,
+                        resource: image1,
+                    },
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: FRAGMENT_SHADER,
+                        dst_access_mask: SHADER_SAMPLED_READ,
+                        old_layout: ShaderReadOnlyOptimal,
+                        new_layout: General,
+                        resource: image2,
+                    },
+                ],
+            },
+            ExecuteTask { node: graphics_node },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn queue_family_ownership_transfer2() {
+        let (resources, queues) = test_queues!();
+
+        if !has_compute_only_queue(&queues) {
+            return;
+        }
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let sharing = Sharing::Concurrent(queues.iter().map(|q| q.queue_family_index()).collect());
+        let buffer1 = graph.add_buffer(&BufferCreateInfo {
+            sharing: sharing.clone(),
+            ..Default::default()
+        });
+        let buffer2 = graph.add_buffer(&BufferCreateInfo {
+            sharing: sharing.clone(),
+            ..Default::default()
+        });
+        let image1 = graph.add_image(&ImageCreateInfo {
+            sharing: sharing.clone(),
+            ..Default::default()
+        });
+        let image2 = graph.add_image(&ImageCreateInfo {
+            sharing: sharing.clone(),
+            ..Default::default()
+        });
+        let compute_node = graph
+            .create_task_node("", QueueFamilyType::Compute, PhantomData)
+            .buffer_access(buffer1, AccessTypes::COMPUTE_SHADER_STORAGE_WRITE)
+            .buffer_access(buffer2, AccessTypes::COMPUTE_SHADER_STORAGE_READ)
+            .image_access(
+                image1,
+                AccessTypes::COMPUTE_SHADER_STORAGE_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .image_access(
+                image2,
+                AccessTypes::COMPUTE_SHADER_SAMPLED_READ,
+                ImageLayoutType::Optimal,
+            )
+            .build();
+        let graphics_node = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .buffer_access(buffer1, AccessTypes::INDEX_READ)
+            .buffer_access(buffer2, AccessTypes::VERTEX_SHADER_UNIFORM_READ)
+            .image_access(
+                image1,
+                AccessTypes::VERTEX_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .image_access(
+                image2,
+                AccessTypes::FRAGMENT_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .build();
+        graph.add_edge(compute_node, graphics_node).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask { node: compute_node },
+            SignalSemaphore {
+                semaphore_index: semaphore,
+                stage_mask: ALL_COMMANDS,
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore,
+                stage_mask: ALL_COMMANDS,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: FRAGMENT_SHADER,
+                        dst_access_mask: SHADER_SAMPLED_READ,
+                        old_layout: ShaderReadOnlyOptimal,
+                        new_layout: General,
+                        resource: image2,
+                    },
+                ],
+            },
+            ExecuteTask { node: graphics_node },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn queue_family_ownership_transfer3() {
+        let (resources, queues) = test_queues!();
+
+        if !has_compute_only_queue(&queues) {
+            return;
+        }
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let buffer1 = graph.add_buffer(&BufferCreateInfo::default());
+        let buffer2 = graph.add_buffer(&BufferCreateInfo::default());
+        let image1 = graph.add_image(&ImageCreateInfo::default());
+        let image2 = graph.add_image(&ImageCreateInfo::default());
+        let color_image = graph.add_image(&ImageCreateInfo {
+            format: Format::R8G8B8A8_UNORM,
+            ..Default::default()
+        });
+        let depth_image = graph.add_image(&ImageCreateInfo {
+            format: Format::D16_UNORM,
+            ..Default::default()
+        });
+        let framebuffer = graph.add_framebuffer();
+        let compute_node = graph
+            .create_task_node("", QueueFamilyType::Compute, PhantomData)
+            .buffer_access(buffer1, AccessTypes::COMPUTE_SHADER_STORAGE_WRITE)
+            .buffer_access(buffer2, AccessTypes::COMPUTE_SHADER_STORAGE_READ)
+            .image_access(
+                image1,
+                AccessTypes::COMPUTE_SHADER_STORAGE_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .image_access(
+                image2,
+                AccessTypes::COMPUTE_SHADER_SAMPLED_READ,
+                ImageLayoutType::Optimal,
+            )
+            .build();
+        let graphics_node1 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        let graphics_node2 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .input_attachment(
+                depth_image,
+                AccessTypes::FRAGMENT_SHADER_DEPTH_STENCIL_INPUT_ATTACHMENT_READ,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .buffer_access(buffer1, AccessTypes::INDEX_READ)
+            .buffer_access(buffer2, AccessTypes::VERTEX_SHADER_UNIFORM_READ)
+            .image_access(
+                image1,
+                AccessTypes::VERTEX_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .image_access(
+                image2,
+                AccessTypes::FRAGMENT_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .build();
+        graph.add_edge(compute_node, graphics_node1).unwrap();
+        graph.add_edge(graphics_node1, graphics_node2).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask { node: compute_node },
+            SignalSemaphore {
+                semaphore_index: semaphore,
+                stage_mask: ALL_COMMANDS,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer1,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: ,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer2,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: General,
+                        new_layout: General,
+                        resource: image1,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: ,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ShaderReadOnlyOptimal,
+                        new_layout: General,
+                        resource: image2,
+                    },
+                ],
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore,
+                stage_mask: ALL_COMMANDS,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: INDEX_INPUT,
+                        dst_access_mask: INDEX_READ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer1,
+                    },
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: VERTEX_SHADER,
+                        dst_access_mask: UNIFORM_READ,
+                        old_layout: Undefined,
+                        new_layout: Undefined,
+                        resource: buffer2,
+                    },
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: VERTEX_SHADER,
+                        dst_access_mask: SHADER_SAMPLED_READ,
+                        old_layout: General,
+                        new_layout: General,
+                        resource: image1,
+                    },
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: FRAGMENT_SHADER,
+                        dst_access_mask: SHADER_SAMPLED_READ,
+                        old_layout: ShaderReadOnlyOptimal,
+                        new_layout: General,
+                        resource: image2,
+                    },
+                ],
+            },
+            BeginRenderPass,
+            ExecuteTask { node: graphics_node1 },
+            NextSubpass,
+            ExecuteTask { node: graphics_node2 },
+            EndRenderPass,
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn queue_family_ownership_transfer4() {
+        let (resources, queues) = test_queues!();
+
+        if !has_compute_only_queue(&queues) {
+            return;
+        }
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let sharing = Sharing::Concurrent(queues.iter().map(|q| q.queue_family_index()).collect());
+        let buffer1 = graph.add_buffer(&BufferCreateInfo {
+            sharing: sharing.clone(),
+            ..Default::default()
+        });
+        let buffer2 = graph.add_buffer(&BufferCreateInfo {
+            sharing: sharing.clone(),
+            ..Default::default()
+        });
+        let image1 = graph.add_image(&ImageCreateInfo {
+            sharing: sharing.clone(),
+            ..Default::default()
+        });
+        let image2 = graph.add_image(&ImageCreateInfo {
+            sharing: sharing.clone(),
+            ..Default::default()
+        });
+        let color_image = graph.add_image(&ImageCreateInfo {
+            format: Format::R8G8B8A8_UNORM,
+            ..Default::default()
+        });
+        let depth_image = graph.add_image(&ImageCreateInfo {
+            format: Format::D16_UNORM,
+            ..Default::default()
+        });
+        let framebuffer = graph.add_framebuffer();
+        let compute_node = graph
+            .create_task_node("", QueueFamilyType::Compute, PhantomData)
+            .buffer_access(buffer1, AccessTypes::COMPUTE_SHADER_STORAGE_WRITE)
+            .buffer_access(buffer2, AccessTypes::COMPUTE_SHADER_STORAGE_READ)
+            .image_access(
+                image1,
+                AccessTypes::COMPUTE_SHADER_STORAGE_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .image_access(
+                image2,
+                AccessTypes::COMPUTE_SHADER_SAMPLED_READ,
+                ImageLayoutType::Optimal,
+            )
+            .build();
+        let graphics_node1 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        let graphics_node2 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                color_image,
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .input_attachment(
+                depth_image,
+                AccessTypes::FRAGMENT_SHADER_DEPTH_STENCIL_INPUT_ATTACHMENT_READ,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .buffer_access(buffer1, AccessTypes::INDEX_READ)
+            .buffer_access(buffer2, AccessTypes::VERTEX_SHADER_UNIFORM_READ)
+            .image_access(
+                image1,
+                AccessTypes::VERTEX_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .image_access(
+                image2,
+                AccessTypes::FRAGMENT_SHADER_SAMPLED_READ,
+                ImageLayoutType::General,
+            )
+            .build();
+        graph.add_edge(compute_node, graphics_node1).unwrap();
+        graph.add_edge(graphics_node1, graphics_node2).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            ExecuteTask {
+                node: compute_node,
+            },
+            SignalSemaphore {
+                semaphore_index: semaphore,
+                stage_mask: ALL_COMMANDS,
+            },
+            FlushSubmit,
+            Submit,
+            WaitSemaphore {
+                semaphore_index: semaphore,
+                stage_mask: ALL_COMMANDS,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: FRAGMENT_SHADER,
+                        dst_access_mask: SHADER_SAMPLED_READ,
+                        old_layout: ShaderReadOnlyOptimal,
+                        new_layout: General,
+                        resource: image2,
+                    },
+                ],
+            },
+            BeginRenderPass,
+            ExecuteTask { node: graphics_node1 },
+            NextSubpass,
+            ExecuteTask { node: graphics_node2 },
+            EndRenderPass,
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn swapchain1() {
         let (resources, queues) = test_queues!();
 
         let queue_family_properties = resources
@@ -1899,101 +3341,109 @@ mod tests {
 
             queue_flags.contains(QueueFlags::GRAPHICS)
         });
-        let compile_info = CompileInfo {
-            queues: &queues.iter().collect::<Vec<_>>(),
-            present_queue: Some(present_queue.unwrap()),
-            ..Default::default()
-        };
 
-        {
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
-            let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo::default());
-            let swapchain2 = graph.add_swapchain(&SwapchainCreateInfo::default());
-            let node = graph
-                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
-                .image_access(
-                    swapchain1.current_image_id(),
-                    AccessType::ColorAttachmentWrite,
-                    ImageLayoutType::Optimal,
-                )
-                .image_access(
-                    swapchain2.current_image_id(),
-                    AccessType::ComputeShaderStorageWrite,
-                    ImageLayoutType::Optimal,
-                )
-                .build();
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo::default());
+        let swapchain2 = graph.add_swapchain(&SwapchainCreateInfo::default());
+        let node = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .image_access(
+                swapchain1.current_image_id(),
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .image_access(
+                swapchain2.current_image_id(),
+                AccessTypes::COMPUTE_SHADER_STORAGE_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .build();
 
-            let graph = unsafe { graph.compile(&compile_info) }.unwrap();
-
-            assert_matches_instructions!(
-                graph,
-                WaitAcquire {
-                    swapchain_id: swapchain1,
-                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                },
-                WaitAcquire {
-                    swapchain_id: swapchain2,
-                    stage_mask: COMPUTE_SHADER,
-                },
-                PipelineBarrier {
-                    buffer_barriers: [],
-                    image_barriers: [
-                        {
-                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            src_access_mask: ,
-                            dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            dst_access_mask: COLOR_ATTACHMENT_WRITE,
-                            old_layout: Undefined,
-                            new_layout: ColorAttachmentOptimal,
-                            image: swapchain1,
-                        },
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: ,
-                            dst_stage_mask: COMPUTE_SHADER,
-                            dst_access_mask: SHADER_STORAGE_WRITE,
-                            old_layout: Undefined,
-                            new_layout: General,
-                            image: swapchain2,
-                        },
-                    ],
-                },
-                ExecuteTask { node: node },
-                SignalPresent {
-                    swapchain_id: swapchain1,
-                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                },
-                SignalPresent {
-                    swapchain_id: swapchain2,
-                    stage_mask: COMPUTE_SHADER,
-                },
-                PipelineBarrier {
-                    buffer_barriers: [],
-                    image_barriers: [
-                        {
-                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            src_access_mask: COLOR_ATTACHMENT_WRITE,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: ColorAttachmentOptimal,
-                            new_layout: PresentSrc,
-                            image: swapchain1,
-                        },
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: SHADER_STORAGE_WRITE,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: General,
-                            new_layout: PresentSrc,
-                            image: swapchain2,
-                        },
-                    ],
-                },
-                FlushSubmit,
-                Submit,
-            );
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                present_queue: Some(present_queue.unwrap()),
+                ..Default::default()
+            })
         }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            WaitAcquire {
+                swapchain_id: swapchain1,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            WaitAcquire {
+                swapchain_id: swapchain2,
+                stage_mask: COMPUTE_SHADER,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: ,
+                        dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                        old_layout: Undefined,
+                        new_layout: ColorAttachmentOptimal,
+                        resource: swapchain1,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: ,
+                        dst_stage_mask: COMPUTE_SHADER,
+                        dst_access_mask: SHADER_STORAGE_WRITE,
+                        old_layout: Undefined,
+                        new_layout: General,
+                        resource: swapchain2,
+                    },
+                ],
+            },
+            ExecuteTask { node: node },
+            SignalPresent {
+                swapchain_id: swapchain1,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            SignalPresent {
+                swapchain_id: swapchain2,
+                stage_mask: COMPUTE_SHADER,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: COLOR_ATTACHMENT_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ColorAttachmentOptimal,
+                        new_layout: PresentSrc,
+                        resource: swapchain1,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: General,
+                        new_layout: PresentSrc,
+                        resource: swapchain2,
+                    },
+                ],
+            },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn swapchain2() {
+        let (resources, queues) = test_queues!();
+
+        let queue_family_properties = resources
+            .device()
+            .physical_device()
+            .queue_family_properties();
 
         let present_queue = queues.iter().find(|q| {
             let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
@@ -2005,219 +3455,534 @@ mod tests {
             return;
         }
 
-        let compile_info = CompileInfo {
-            queues: &queues.iter().collect::<Vec<_>>(),
-            present_queue: Some(present_queue.unwrap()),
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let concurrent_sharing =
+            Sharing::Concurrent(queues.iter().map(|q| q.queue_family_index()).collect());
+        let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo::default());
+        let swapchain2 = graph.add_swapchain(&SwapchainCreateInfo {
+            image_sharing: concurrent_sharing.clone(),
             ..Default::default()
-        };
+        });
+        let swapchain3 = graph.add_swapchain(&SwapchainCreateInfo::default());
+        let swapchain4 = graph.add_swapchain(&SwapchainCreateInfo {
+            image_sharing: concurrent_sharing.clone(),
+            ..Default::default()
+        });
+        let node = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .image_access(
+                swapchain1.current_image_id(),
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .image_access(
+                swapchain2.current_image_id(),
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .image_access(
+                swapchain3.current_image_id(),
+                AccessTypes::COMPUTE_SHADER_STORAGE_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .image_access(
+                swapchain4.current_image_id(),
+                AccessTypes::COMPUTE_SHADER_STORAGE_WRITE,
+                ImageLayoutType::Optimal,
+            )
+            .build();
 
-        {
-            let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
-            let concurrent_sharing = Sharing::Concurrent(
-                compile_info
-                    .queues
-                    .iter()
-                    .map(|q| q.queue_family_index())
-                    .collect(),
-            );
-            let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo::default());
-            let swapchain2 = graph.add_swapchain(&SwapchainCreateInfo {
-                image_sharing: concurrent_sharing.clone(),
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                present_queue: Some(present_queue.unwrap()),
                 ..Default::default()
-            });
-            let swapchain3 = graph.add_swapchain(&SwapchainCreateInfo::default());
-            let swapchain4 = graph.add_swapchain(&SwapchainCreateInfo {
-                image_sharing: concurrent_sharing.clone(),
-                ..Default::default()
-            });
-            let node = graph
-                .create_task_node("", QueueFamilyType::Graphics, PhantomData)
-                .image_access(
-                    swapchain1.current_image_id(),
-                    AccessType::ColorAttachmentWrite,
-                    ImageLayoutType::Optimal,
-                )
-                .image_access(
-                    swapchain2.current_image_id(),
-                    AccessType::ColorAttachmentWrite,
-                    ImageLayoutType::Optimal,
-                )
-                .image_access(
-                    swapchain3.current_image_id(),
-                    AccessType::ComputeShaderStorageWrite,
-                    ImageLayoutType::Optimal,
-                )
-                .image_access(
-                    swapchain4.current_image_id(),
-                    AccessType::ComputeShaderStorageWrite,
-                    ImageLayoutType::Optimal,
-                )
-                .build();
-
-            let graph = unsafe { graph.compile(&compile_info) }.unwrap();
-
-            assert_matches_instructions!(
-                graph,
-                WaitAcquire {
-                    swapchain_id: swapchain1,
-                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                },
-                WaitAcquire {
-                    swapchain_id: swapchain2,
-                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                },
-                WaitAcquire {
-                    swapchain_id: swapchain3,
-                    stage_mask: COMPUTE_SHADER,
-                },
-                WaitAcquire {
-                    swapchain_id: swapchain4,
-                    stage_mask: COMPUTE_SHADER,
-                },
-                PipelineBarrier {
-                    buffer_barriers: [],
-                    image_barriers: [
-                        {
-                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            src_access_mask: ,
-                            dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            dst_access_mask: COLOR_ATTACHMENT_WRITE,
-                            old_layout: Undefined,
-                            new_layout: ColorAttachmentOptimal,
-                            image: swapchain1,
-                        },
-                        {
-                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            src_access_mask: ,
-                            dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            dst_access_mask: COLOR_ATTACHMENT_WRITE,
-                            old_layout: Undefined,
-                            new_layout: ColorAttachmentOptimal,
-                            image: swapchain2,
-                        },
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: ,
-                            dst_stage_mask: COMPUTE_SHADER,
-                            dst_access_mask: SHADER_STORAGE_WRITE,
-                            old_layout: Undefined,
-                            new_layout: General,
-                            image: swapchain3,
-                        },
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: ,
-                            dst_stage_mask: COMPUTE_SHADER,
-                            dst_access_mask: SHADER_STORAGE_WRITE,
-                            old_layout: Undefined,
-                            new_layout: General,
-                            image: swapchain4,
-                        },
-                    ],
-                },
-                ExecuteTask { node: node },
-                SignalPrePresent {
-                    swapchain_id: swapchain1,
-                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                },
-                SignalPresent {
-                    swapchain_id: swapchain2,
-                    stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                },
-                SignalPrePresent {
-                    swapchain_id: swapchain3,
-                    stage_mask: COMPUTE_SHADER,
-                },
-                SignalPresent {
-                    swapchain_id: swapchain4,
-                    stage_mask: COMPUTE_SHADER,
-                },
-                PipelineBarrier {
-                    buffer_barriers: [],
-                    image_barriers: [
-                        {
-                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            src_access_mask: COLOR_ATTACHMENT_WRITE,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: ColorAttachmentOptimal,
-                            new_layout: PresentSrc,
-                            image: swapchain1,
-                        },
-                        {
-                            src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
-                            src_access_mask: COLOR_ATTACHMENT_WRITE,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: ColorAttachmentOptimal,
-                            new_layout: PresentSrc,
-                            image: swapchain2,
-                        },
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: SHADER_STORAGE_WRITE,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: General,
-                            new_layout: PresentSrc,
-                            image: swapchain3,
-                        },
-                        {
-                            src_stage_mask: COMPUTE_SHADER,
-                            src_access_mask: SHADER_STORAGE_WRITE,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: General,
-                            new_layout: PresentSrc,
-                            image: swapchain4,
-                        },
-                    ],
-                },
-                FlushSubmit,
-                Submit,
-                WaitPrePresent {
-                    swapchain_id: swapchain1,
-                    stage_mask: ALL_COMMANDS,
-                },
-                SignalPresent {
-                    swapchain_id: swapchain1,
-                    stage_mask: ALL_COMMANDS,
-                },
-                WaitPrePresent {
-                    swapchain_id: swapchain3,
-                    stage_mask: ALL_COMMANDS,
-                },
-                SignalPresent {
-                    swapchain_id: swapchain3,
-                    stage_mask: ALL_COMMANDS,
-                },
-                PipelineBarrier {
-                    buffer_barriers: [],
-                    image_barriers: [
-                        {
-                            src_stage_mask: ,
-                            src_access_mask: ,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: ColorAttachmentOptimal,
-                            new_layout: PresentSrc,
-                            image: swapchain1,
-                        },
-                        {
-                            src_stage_mask: ,
-                            src_access_mask: ,
-                            dst_stage_mask: ,
-                            dst_access_mask: ,
-                            old_layout: General,
-                            new_layout: PresentSrc,
-                            image: swapchain3,
-                        },
-                    ],
-                },
-                FlushSubmit,
-                Submit,
-            );
+            })
         }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            WaitAcquire {
+                swapchain_id: swapchain1,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            WaitAcquire {
+                swapchain_id: swapchain2,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            WaitAcquire {
+                swapchain_id: swapchain3,
+                stage_mask: COMPUTE_SHADER,
+            },
+            WaitAcquire {
+                swapchain_id: swapchain4,
+                stage_mask: COMPUTE_SHADER,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: ,
+                        dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                        old_layout: Undefined,
+                        new_layout: ColorAttachmentOptimal,
+                        resource: swapchain1,
+                    },
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: ,
+                        dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                        old_layout: Undefined,
+                        new_layout: ColorAttachmentOptimal,
+                        resource: swapchain2,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: ,
+                        dst_stage_mask: COMPUTE_SHADER,
+                        dst_access_mask: SHADER_STORAGE_WRITE,
+                        old_layout: Undefined,
+                        new_layout: General,
+                        resource: swapchain3,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: ,
+                        dst_stage_mask: COMPUTE_SHADER,
+                        dst_access_mask: SHADER_STORAGE_WRITE,
+                        old_layout: Undefined,
+                        new_layout: General,
+                        resource: swapchain4,
+                    },
+                ],
+            },
+            ExecuteTask { node: node },
+            SignalPrePresent {
+                swapchain_id: swapchain1,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            SignalPrePresent {
+                swapchain_id: swapchain3,
+                stage_mask: COMPUTE_SHADER,
+            },
+            SignalPresent {
+                swapchain_id: swapchain2,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            SignalPresent {
+                swapchain_id: swapchain4,
+                stage_mask: COMPUTE_SHADER,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: COLOR_ATTACHMENT_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ColorAttachmentOptimal,
+                        new_layout: PresentSrc,
+                        resource: swapchain1,
+                    },
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: COLOR_ATTACHMENT_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ColorAttachmentOptimal,
+                        new_layout: PresentSrc,
+                        resource: swapchain2,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: General,
+                        new_layout: PresentSrc,
+                        resource: swapchain3,
+                    },
+                    {
+                        src_stage_mask: COMPUTE_SHADER,
+                        src_access_mask: SHADER_STORAGE_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: General,
+                        new_layout: PresentSrc,
+                        resource: swapchain4,
+                    },
+                ],
+            },
+            FlushSubmit,
+            Submit,
+            WaitPrePresent {
+                swapchain_id: swapchain1,
+                stage_mask: ALL_COMMANDS,
+            },
+            SignalPresent {
+                swapchain_id: swapchain1,
+                stage_mask: ALL_COMMANDS,
+            },
+            WaitPrePresent {
+                swapchain_id: swapchain3,
+                stage_mask: ALL_COMMANDS,
+            },
+            SignalPresent {
+                swapchain_id: swapchain3,
+                stage_mask: ALL_COMMANDS,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ColorAttachmentOptimal,
+                        new_layout: PresentSrc,
+                        resource: swapchain1,
+                    },
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: General,
+                        new_layout: PresentSrc,
+                        resource: swapchain3,
+                    },
+                ],
+            },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn swapchain3() {
+        let (resources, queues) = test_queues!();
+
+        let queue_family_properties = resources
+            .device()
+            .physical_device()
+            .queue_family_properties();
+
+        let present_queue = queues.iter().find(|q| {
+            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
+
+            queue_flags.contains(QueueFlags::GRAPHICS)
+        });
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let swapchain = graph.add_swapchain(&SwapchainCreateInfo {
+            image_format: Format::R8G8B8A8_UNORM,
+            ..Default::default()
+        });
+        let depth_image = graph.add_image(&ImageCreateInfo {
+            format: Format::D16_UNORM,
+            ..Default::default()
+        });
+        let framebuffer = graph.add_framebuffer();
+        let node1 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        let node2 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                swapchain.current_image_id(),
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        let node3 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .input_attachment(
+                depth_image,
+                AccessTypes::FRAGMENT_SHADER_DEPTH_STENCIL_INPUT_ATTACHMENT_READ,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        graph.add_edge(node1, node2).unwrap();
+        graph.add_edge(node2, node3).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                present_queue: Some(present_queue.unwrap()),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            WaitAcquire {
+                swapchain_id: swapchain,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: ,
+                        dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                        old_layout: Undefined,
+                        new_layout: ColorAttachmentOptimal,
+                        resource: swapchain,
+                    },
+                ],
+            },
+            BeginRenderPass,
+            ExecuteTask { node: node1 },
+            NextSubpass,
+            ExecuteTask { node: node2 },
+            NextSubpass,
+            ExecuteTask { node: node3 },
+            EndRenderPass,
+            SignalPresent {
+                swapchain_id: swapchain,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: COLOR_ATTACHMENT_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ColorAttachmentOptimal,
+                        new_layout: PresentSrc,
+                        resource: swapchain,
+                    },
+                ],
+            },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    #[test]
+    fn swapchain4() {
+        let (resources, queues) = test_queues!();
+
+        let queue_family_properties = resources
+            .device()
+            .physical_device()
+            .queue_family_properties();
+
+        let present_queue = queues.iter().find(|q| {
+            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
+
+            queue_flags.contains(QueueFlags::COMPUTE) && !queue_flags.contains(QueueFlags::GRAPHICS)
+        });
+
+        if !present_queue.is_some() {
+            return;
+        }
+
+        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let concurrent_sharing =
+            Sharing::Concurrent(queues.iter().map(|q| q.queue_family_index()).collect());
+        let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo {
+            image_format: Format::R8G8B8A8_UNORM,
+            ..SwapchainCreateInfo::default()
+        });
+        let swapchain2 = graph.add_swapchain(&SwapchainCreateInfo {
+            image_format: Format::R8G8B8A8_UNORM,
+            image_sharing: concurrent_sharing.clone(),
+            ..Default::default()
+        });
+        let depth_image = graph.add_image(&ImageCreateInfo {
+            format: Format::D16_UNORM,
+            ..Default::default()
+        });
+        let framebuffer = graph.add_framebuffer();
+        let node1 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        let node2 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .color_attachment(
+                swapchain1.current_image_id(),
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .color_attachment(
+                swapchain2.current_image_id(),
+                AccessTypes::COLOR_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo {
+                    index: 1,
+                    ..Default::default()
+                },
+            )
+            .depth_stencil_attachment(
+                depth_image,
+                AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        let node3 = graph
+            .create_task_node("", QueueFamilyType::Graphics, PhantomData)
+            .framebuffer(framebuffer)
+            .input_attachment(
+                depth_image,
+                AccessTypes::FRAGMENT_SHADER_DEPTH_STENCIL_INPUT_ATTACHMENT_READ,
+                ImageLayoutType::Optimal,
+                &AttachmentInfo::default(),
+            )
+            .build();
+        graph.add_edge(node1, node2).unwrap();
+        graph.add_edge(node2, node3).unwrap();
+
+        let graph = unsafe {
+            graph.compile(&CompileInfo {
+                queues: &queues.iter().collect::<Vec<_>>(),
+                present_queue: Some(present_queue.unwrap()),
+                ..Default::default()
+            })
+        }
+        .unwrap();
+
+        assert_matches_instructions!(
+            graph,
+            WaitAcquire {
+                swapchain_id: swapchain1,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            WaitAcquire {
+                swapchain_id: swapchain2,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: ,
+                        dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                        old_layout: Undefined,
+                        new_layout: ColorAttachmentOptimal,
+                        resource: swapchain1,
+                    },
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: ,
+                        dst_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        dst_access_mask: COLOR_ATTACHMENT_WRITE,
+                        old_layout: Undefined,
+                        new_layout: ColorAttachmentOptimal,
+                        resource: swapchain2,
+                    },
+                ],
+            },
+            BeginRenderPass,
+            ExecuteTask { node: node1 },
+            NextSubpass,
+            ExecuteTask { node: node2 },
+            NextSubpass,
+            ExecuteTask { node: node3 },
+            EndRenderPass,
+            SignalPrePresent {
+                swapchain_id: swapchain1,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            SignalPresent {
+                swapchain_id: swapchain2,
+                stage_mask: COLOR_ATTACHMENT_OUTPUT,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: COLOR_ATTACHMENT_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ColorAttachmentOptimal,
+                        new_layout: PresentSrc,
+                        resource: swapchain1,
+                    },
+                    {
+                        src_stage_mask: COLOR_ATTACHMENT_OUTPUT,
+                        src_access_mask: COLOR_ATTACHMENT_WRITE,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ColorAttachmentOptimal,
+                        new_layout: PresentSrc,
+                        resource: swapchain2,
+                    },
+                ],
+            },
+            FlushSubmit,
+            Submit,
+            WaitPrePresent {
+                swapchain_id: swapchain1,
+                stage_mask: ALL_COMMANDS,
+            },
+            SignalPresent {
+                swapchain_id: swapchain1,
+                stage_mask: ALL_COMMANDS,
+            },
+            PipelineBarrier {
+                barriers: [
+                    {
+                        src_stage_mask: ,
+                        src_access_mask: ,
+                        dst_stage_mask: ,
+                        dst_access_mask: ,
+                        old_layout: ColorAttachmentOptimal,
+                        new_layout: PresentSrc,
+                        resource: swapchain1,
+                    },
+                ],
+            },
+            FlushSubmit,
+            Submit,
+        );
+    }
+
+    fn has_compute_only_queue(queues: &[Arc<Queue>]) -> bool {
+        let queue_family_properties = queues[0]
+            .device()
+            .physical_device()
+            .queue_family_properties();
+
+        queues.iter().any(|q| {
+            let queue_flags = queue_family_properties[q.queue_family_index() as usize].queue_flags;
+
+            queue_flags.contains(QueueFlags::COMPUTE) && !queue_flags.contains(QueueFlags::GRAPHICS)
+        })
     }
 
     struct MatchingState {
@@ -2243,77 +4008,44 @@ mod tests {
             $graph:ident,
             $state:ident,
             InitialPipelineBarrier {
-                buffer_barriers: [
+                barriers: [
                     $({
-                        dst_stage_mask: $($buffer_dst_stage:ident)|*,
-                        dst_access_mask: $($buffer_dst_access:ident)|*,
-                        buffer: $buffer:ident,
-                    },)*
-                ],
-                image_barriers: [
-                    $({
-                        dst_stage_mask: $($image_dst_stage:ident)|*,
-                        dst_access_mask: $($image_dst_access:ident)|*,
-                        new_layout: $image_new_layout:ident,
-                        image: $image:ident,
+                        dst_stage_mask: $($dst_stage:ident)|*,
+                        dst_access_mask: $($dst_access:ident)|*,
+                        new_layout: $new_layout:ident,
+                        resource: $resource:ident,
                     },)*
                 ],
             },
             $($arg:tt)*
         ) => {
             let submission = &$graph.submissions[$state.submission_index];
-            let buffer_barrier_range = &submission.initial_buffer_barrier_range;
-            let image_barrier_range = &submission.initial_image_barrier_range;
+            let barrier_range = &submission.initial_barrier_range;
+            let barrier_range = barrier_range.start as usize..barrier_range.end as usize;
+            let barriers = &$graph.barriers[barrier_range];
 
-            let buffer_barrier_range =
-                buffer_barrier_range.start as usize..buffer_barrier_range.end as usize;
-            let buffer_barriers = &$graph.buffer_barriers[buffer_barrier_range];
             #[allow(unused_mut)]
-            let mut buffer_barrier_count = 0;
+            let mut barrier_count = 0;
             $(
-                let barrier = buffer_barriers
+                let barrier = barriers
                     .iter()
-                    .find(|barrier| barrier.buffer == $buffer)
+                    .find(|barrier| barrier.resource == $resource.erase())
                     .unwrap();
                 assert_eq!(barrier.src_stage_mask, PipelineStages::empty());
                 assert_eq!(barrier.src_access_mask, AccessFlags::empty());
                 assert_eq!(
                     barrier.dst_stage_mask,
-                    PipelineStages::empty() $(| PipelineStages::$buffer_dst_stage)*,
+                    PipelineStages::empty() $(| PipelineStages::$dst_stage)*,
                 );
                 assert_eq!(
                     barrier.dst_access_mask,
-                    AccessFlags::empty() $(| AccessFlags::$buffer_dst_access)*,
-                );
-                buffer_barrier_count += 1;
-            )*
-            assert_eq!(buffer_barriers.len(), buffer_barrier_count);
-
-            let image_barrier_range =
-                image_barrier_range.start as usize..image_barrier_range.end as usize;
-            let image_barriers = &$graph.image_barriers[image_barrier_range];
-            #[allow(unused_mut)]
-            let mut image_barrier_count = 0;
-            $(
-                let barrier = image_barriers
-                    .iter()
-                    .find(|barrier| barrier.image == $image.erase())
-                    .unwrap();
-                assert_eq!(barrier.src_stage_mask, PipelineStages::empty());
-                assert_eq!(barrier.src_access_mask, AccessFlags::empty());
-                assert_eq!(
-                    barrier.dst_stage_mask,
-                    PipelineStages::empty() $(| PipelineStages::$image_dst_stage)*,
-                );
-                assert_eq!(
-                    barrier.dst_access_mask,
-                    AccessFlags::empty() $(| AccessFlags::$image_dst_access)*,
+                    AccessFlags::empty() $(| AccessFlags::$dst_access)*,
                 );
                 assert_eq!(barrier.old_layout, ImageLayout::Undefined);
-                assert_eq!(barrier.new_layout, ImageLayout::$image_new_layout);
-                image_barrier_count += 1;
+                assert_eq!(barrier.new_layout, ImageLayout::$new_layout);
+                barrier_count += 1;
             )*
-            assert_eq!(image_barriers.len(), image_barrier_count);
+            assert_eq!(barriers.len(), barrier_count);
 
             assert_matches_instructions!(@ $graph, $state, $($arg)*);
         };
@@ -2390,25 +4122,16 @@ mod tests {
             $graph:ident,
             $state:ident,
             PipelineBarrier {
-                buffer_barriers: [
+                barriers: [
                     $({
-                        src_stage_mask: $($buffer_src_stage:ident)|*,
-                        src_access_mask: $($buffer_src_access:ident)|*,
-                        dst_stage_mask: $($buffer_dst_stage:ident)|*,
-                        dst_access_mask: $($buffer_dst_access:ident)|*,
-                        buffer: $buffer:ident,
-                    },)*
-                ],
-                image_barriers: [
-                    $({
-                        src_stage_mask: $($image_src_stage:ident)|*,
-                        src_access_mask: $($image_src_access:ident)|*,
-                        dst_stage_mask: $($image_dst_stage:ident)|*,
-                        dst_access_mask: $($image_dst_access:ident)|*,
-                        old_layout: $image_old_layout:ident,
-                        new_layout: $image_new_layout:ident,
-                        image: $image:ident,
-                    },)*
+                        src_stage_mask: $($src_stage:ident)|*,
+                        src_access_mask: $($src_access:ident)|*,
+                        dst_stage_mask: $($dst_stage:ident)|*,
+                        dst_access_mask: $($dst_access:ident)|*,
+                        old_layout: $old_layout:ident,
+                        new_layout: $new_layout:ident,
+                        resource: $resource:ident,
+                    },)+
                 ],
             },
             $($arg:tt)*
@@ -2417,73 +4140,114 @@ mod tests {
                 $graph.instructions[$state.instruction_index],
                 Instruction::PipelineBarrier { .. },
             ));
-            let Instruction::PipelineBarrier { buffer_barrier_range, image_barrier_range } =
+            let Instruction::PipelineBarrier { barrier_range } =
                 &$graph.instructions[$state.instruction_index]
             else {
                 unreachable!();
             };
+            let barrier_range = barrier_range.start as usize..barrier_range.end as usize;
+            let barriers = &$graph.barriers[barrier_range];
 
-            let buffer_barrier_range =
-                buffer_barrier_range.start as usize..buffer_barrier_range.end as usize;
-            let buffer_barriers = &$graph.buffer_barriers[buffer_barrier_range];
-            #[allow(unused_mut)]
-            let mut buffer_barrier_count = 0;
+            let mut barrier_count = 0;
             $(
-                let barrier = buffer_barriers
+                let barrier = barriers
                     .iter()
-                    .find(|barrier| barrier.buffer == $buffer)
+                    .find(|barrier| barrier.resource == $resource.erase())
                     .unwrap();
                 assert_eq!(
                     barrier.src_stage_mask,
-                    PipelineStages::empty() $(| PipelineStages::$buffer_src_stage)*,
+                    PipelineStages::empty() $(| PipelineStages::$src_stage)*,
                 );
                 assert_eq!(
                     barrier.src_access_mask,
-                    AccessFlags::empty() $(| AccessFlags::$buffer_src_access)*,
+                    AccessFlags::empty() $(| AccessFlags::$src_access)*,
                 );
                 assert_eq!(
                     barrier.dst_stage_mask,
-                    PipelineStages::empty() $(| PipelineStages::$buffer_dst_stage)*,
+                    PipelineStages::empty() $(| PipelineStages::$dst_stage)*,
                 );
                 assert_eq!(
                     barrier.dst_access_mask,
-                    AccessFlags::empty() $(| AccessFlags::$buffer_dst_access)*,
+                    AccessFlags::empty() $(| AccessFlags::$dst_access)*,
                 );
-                buffer_barrier_count += 1;
-            )*
-            assert_eq!(buffer_barriers.len(), buffer_barrier_count);
+                assert_eq!(barrier.old_layout, ImageLayout::$old_layout);
+                assert_eq!(barrier.new_layout, ImageLayout::$new_layout);
+                barrier_count += 1;
+            )+
+            assert_eq!(barriers.len(), barrier_count);
 
-            let image_barrier_range =
-                image_barrier_range.start as usize..image_barrier_range.end as usize;
-            let image_barriers = &$graph.image_barriers[image_barrier_range];
-            #[allow(unused_mut)]
-            let mut image_barrier_count = 0;
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            BeginRenderPass,
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::BeginRenderPass { .. },
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            NextSubpass,
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::NextSubpass,
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            EndRenderPass,
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::EndRenderPass,
+            ));
+            $state.instruction_index += 1;
+            assert_matches_instructions!(@ $graph, $state, $($arg)*);
+        };
+        (
+            @
+            $graph:ident,
+            $state:ident,
+            ClearAttachments {
+                node: $node:ident,
+                attachments: [$($resource:ident),+ $(,)?],
+            },
+            $($arg:tt)*
+        ) => {
+            assert!(matches!(
+                $graph.instructions[$state.instruction_index],
+                Instruction::ClearAttachments { node_index, .. } if node_index == $node.index(),
+            ));
+            let Instruction::ClearAttachments { clear_attachment_range, .. } =
+                &$graph.instructions[$state.instruction_index]
+            else {
+                unreachable!();
+            };
+            let clear_attachments = &$graph.clear_attachments[clear_attachment_range.clone()];
+
+            let mut clear_attachment_count = 0;
             $(
-                let barrier = image_barriers
-                    .iter()
-                    .find(|barrier| barrier.image == $image.erase())
-                    .unwrap();
-                assert_eq!(
-                    barrier.src_stage_mask,
-                    PipelineStages::empty() $(| PipelineStages::$image_src_stage)*,
-                );
-                assert_eq!(
-                    barrier.src_access_mask,
-                    AccessFlags::empty() $(| AccessFlags::$image_src_access)*,
-                );
-                assert_eq!(
-                    barrier.dst_stage_mask,
-                    PipelineStages::empty() $(| PipelineStages::$image_dst_stage)*,
-                );
-                assert_eq!(
-                    barrier.dst_access_mask,
-                    AccessFlags::empty() $(| AccessFlags::$image_dst_access)*,
-                );
-                assert_eq!(barrier.old_layout, ImageLayout::$image_old_layout);
-                assert_eq!(barrier.new_layout, ImageLayout::$image_new_layout);
-                image_barrier_count += 1;
-            )*
-            assert_eq!(image_barriers.len(), image_barrier_count);
+                assert!(clear_attachments.contains(&$resource.erase()));
+                clear_attachment_count += 1;
+            )+
+            assert_eq!(clear_attachments.len(), clear_attachment_count);
 
             $state.instruction_index += 1;
             assert_matches_instructions!(@ $graph, $state, $($arg)*);

--- a/vulkano-taskgraph/src/graph/mod.rs
+++ b/vulkano-taskgraph/src/graph/mod.rs
@@ -5,7 +5,8 @@ pub use self::{
     execute::{ExecuteError, ResourceMap},
 };
 use crate::{
-    resource::{self, AccessType, Flight, HostAccessType, ImageLayoutType},
+    linear_map::LinearMap,
+    resource::{self, AccessTypes, Flight, HostAccessType, ImageLayoutType},
     Id, InvalidSlotError, Object, ObjectType, QueueFamilyType, Task,
 };
 use ash::vk;
@@ -18,7 +19,12 @@ use std::{
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo},
     device::{Device, DeviceOwned, Queue},
-    image::{Image, ImageCreateInfo, ImageLayout},
+    format::Format,
+    image::{
+        sampler::ComponentMapping, Image, ImageAspects, ImageCreateInfo, ImageLayout, ImageUsage,
+        SampleCount,
+    },
+    render_pass::{Framebuffer, RenderPass, Subpass},
     swapchain::{Swapchain, SwapchainCreateInfo},
     sync::{semaphore::Semaphore, AccessFlags, PipelineStages},
 };
@@ -58,11 +64,18 @@ enum NodeInner<W: ?Sized> {
 type NodeIndex = u32;
 
 pub(crate) struct Resources {
-    inner: SlotMap<()>,
+    inner: SlotMap<ResourceInfo>,
     physical_resources: Arc<resource::Resources>,
     physical_map: HashMap<Id, Id>,
     host_reads: Vec<Id<Buffer>>,
     host_writes: Vec<Id<Buffer>>,
+    framebuffers: SlotMap<()>,
+}
+
+struct ResourceInfo {
+    format: Format,
+    samples: SampleCount,
+    usage: ImageUsage,
 }
 
 impl<W: ?Sized> TaskGraph<W> {
@@ -86,6 +99,8 @@ impl<W: ?Sized> TaskGraph<W> {
                 physical_map: HashMap::default(),
                 host_reads: Vec::new(),
                 host_writes: Vec::new(),
+                // FIXME:
+                framebuffers: SlotMap::new(256),
             },
         }
     }
@@ -100,7 +115,7 @@ impl<W: ?Sized> TaskGraph<W> {
         name: impl Into<Cow<'static, str>>,
         queue_family_type: QueueFamilyType,
         task: impl Task<World = W>,
-    ) -> TaskNodeBuilder<'_, W> {
+    ) -> TaskNodeBuilder<'_> {
         let id = self.nodes.add_node(
             name.into(),
             NodeInner::Task(TaskNode::new(queue_family_type, task)),
@@ -111,7 +126,8 @@ impl<W: ?Sized> TaskGraph<W> {
 
         TaskNodeBuilder {
             id,
-            task_node,
+            accesses: &mut task_node.accesses,
+            attachments: &mut task_node.attachments,
             resources: &mut self.resources,
         }
     }
@@ -210,13 +226,19 @@ impl<W: ?Sized> TaskGraph<W> {
         self.resources.add_swapchain(create_info)
     }
 
-    /// Adds a host buffer access to this task graph.
+    /// Adds a host buffer access to the task graph.
     ///
     /// # Panics
     ///
     /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
     pub fn add_host_buffer_access(&mut self, id: Id<Buffer>, access_type: HostAccessType) {
         self.resources.add_host_buffer_access(id, access_type)
+    }
+
+    /// Adds a [virtual framebuffer] to the task graph.
+    #[must_use]
+    pub fn add_framebuffer(&mut self) -> Id<Framebuffer> {
+        self.resources.add_framebuffer()
     }
 }
 
@@ -366,7 +388,13 @@ impl Resources {
             tag |= Id::EXCLUSIVE_BIT;
         }
 
-        let slot = self.inner.insert_with_tag_mut((), tag);
+        let resource_info = ResourceInfo {
+            format: Format::UNDEFINED,
+            samples: SampleCount::Sample1,
+            usage: ImageUsage::empty(),
+        };
+
+        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
 
         unsafe { Id::new(slot) }
     }
@@ -378,7 +406,13 @@ impl Resources {
             tag |= Id::EXCLUSIVE_BIT;
         }
 
-        let slot = self.inner.insert_with_tag_mut((), tag);
+        let resource_info = ResourceInfo {
+            format: create_info.format,
+            samples: create_info.samples,
+            usage: create_info.usage,
+        };
+
+        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
 
         unsafe { Id::new(slot) }
     }
@@ -390,7 +424,13 @@ impl Resources {
             tag |= Id::EXCLUSIVE_BIT;
         }
 
-        let slot = self.inner.insert_with_tag_mut((), tag);
+        let resource_info = ResourceInfo {
+            format: create_info.image_format,
+            samples: SampleCount::Sample1,
+            usage: create_info.image_usage,
+        };
+
+        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
 
         unsafe { Id::new(slot) }
     }
@@ -464,6 +504,13 @@ impl Resources {
         }
     }
 
+    fn add_framebuffer(&mut self) -> Id<Framebuffer> {
+        let tag = Framebuffer::TAG | Id::VIRTUAL_BIT;
+        let slot = self.framebuffers.insert_with_tag_mut((), tag);
+
+        unsafe { Id::new(slot) }
+    }
+
     fn capacity(&self) -> u32 {
         self.inner.capacity()
     }
@@ -472,12 +519,16 @@ impl Resources {
         self.inner.len()
     }
 
-    fn get(&self, id: Id) -> Result<&(), InvalidSlotError> {
+    pub(crate) fn physical_map(&self) -> &HashMap<Id, Id> {
+        &self.physical_map
+    }
+
+    fn get(&self, id: Id) -> Result<&ResourceInfo, InvalidSlotError> {
         // SAFETY: We never modify the map concurrently.
         unsafe { self.inner.get_unprotected(id.slot) }.ok_or(InvalidSlotError::new(id))
     }
 
-    fn iter(&self) -> impl Iterator<Item = (Id, &())> {
+    fn iter(&self) -> impl Iterator<Item = (Id, &ResourceInfo)> {
         // SAFETY: We never modify the map concurrently.
         unsafe { self.inner.iter_unprotected() }.map(|(slot, v)| (unsafe { Id::new(slot) }, v))
     }
@@ -501,6 +552,10 @@ impl Resources {
         };
 
         host_accesses.contains(&id)
+    }
+
+    fn framebuffer_mut(&mut self, id: Id<Framebuffer>) -> Option<&mut ()> {
+        self.framebuffers.get_mut(id.slot)
     }
 }
 
@@ -544,14 +599,16 @@ impl fmt::Debug for NodeId {
 /// accesses.
 pub struct TaskNode<W: ?Sized> {
     accesses: ResourceAccesses,
+    attachments: Option<Attachments>,
     queue_family_type: QueueFamilyType,
     queue_family_index: u32,
     dependency_level_index: u32,
+    subpass: Option<Subpass>,
     task: Box<dyn Task<World = W>>,
 }
 
 pub(crate) struct ResourceAccesses {
-    inner: Vec<(Id, ResourceAccess)>,
+    inner: LinearMap<Id, ResourceAccess>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -562,13 +619,22 @@ struct ResourceAccess {
     queue_family_index: u32,
 }
 
+pub(crate) struct Attachments {
+    framebuffer_id: Id<Framebuffer>,
+    input_attachments: LinearMap<Id, AttachmentInfo<'static>>,
+    color_attachments: LinearMap<Id, AttachmentInfo<'static>>,
+    depth_stencil_attachment: Option<(Id, AttachmentInfo<'static>)>,
+}
+
 impl<W: ?Sized> TaskNode<W> {
     fn new(queue_family_type: QueueFamilyType, task: impl Task<World = W>) -> Self {
         TaskNode {
             accesses: ResourceAccesses::new(),
+            attachments: None,
             queue_family_type,
             queue_family_index: 0,
             dependency_level_index: 0,
+            subpass: None,
             task: Box::new(task),
         }
     }
@@ -593,11 +659,43 @@ impl<W: ?Sized> TaskNode<W> {
     pub fn task_mut(&mut self) -> &mut dyn Task<World = W> {
         &mut *self.task
     }
+
+    /// Returns the subpass that the task node is part of, if any.
+    #[inline]
+    pub fn subpass(&self) -> Option<&Subpass> {
+        self.subpass.as_ref()
+    }
 }
 
 impl ResourceAccesses {
-    pub(crate) const fn new() -> Self {
-        ResourceAccesses { inner: Vec::new() }
+    const fn new() -> Self {
+        ResourceAccesses {
+            inner: LinearMap::new(),
+        }
+    }
+
+    fn get(&self, id: Id) -> Option<&ResourceAccess> {
+        self.inner.get(&id)
+    }
+
+    fn buffer_mut(
+        &mut self,
+        resources: &mut Resources,
+        id: Id<Buffer>,
+    ) -> (Id<Buffer>, Option<&mut ResourceAccess>) {
+        let (id, access) = self.get_mut(resources, id.erase()).expect("invalid buffer");
+
+        (unsafe { id.parametrize() }, access)
+    }
+
+    fn image_mut(
+        &mut self,
+        resources: &mut Resources,
+        id: Id<Image>,
+    ) -> (Id<Image>, Option<&mut ResourceAccess>) {
+        let (id, access) = self.get_mut(resources, id.erase()).expect("invalid image");
+
+        (unsafe { id.parametrize() }, access)
     }
 
     fn get_mut(
@@ -624,9 +722,7 @@ impl ResourceAccesses {
             };
         }
 
-        let access = self
-            .iter_mut()
-            .find_map(|(x, access)| (x == id).then_some(access));
+        let access = self.inner.get_mut(&id);
 
         Ok((id, access))
     }
@@ -634,94 +730,420 @@ impl ResourceAccesses {
     fn iter(&self) -> impl Iterator<Item = (Id, &ResourceAccess)> {
         self.inner.iter().map(|(id, access)| (*id, access))
     }
+}
 
-    fn iter_mut(&mut self) -> impl Iterator<Item = (Id, &mut ResourceAccess)> {
-        self.inner.iter_mut().map(|(id, access)| (*id, access))
+impl Attachments {
+    fn keys(&self) -> impl Iterator<Item = &Id> {
+        self.input_attachments
+            .keys()
+            .chain(self.color_attachments.keys())
+            .chain(self.depth_stencil_attachment.iter().map(|(id, _)| id))
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&Id, &AttachmentInfo<'static>)> {
+        self.input_attachments
+            .iter()
+            .chain(self.color_attachments.iter())
+            .chain(
+                self.depth_stencil_attachment
+                    .iter()
+                    .map(|(id, attachment_state)| (id, attachment_state)),
+            )
     }
 }
 
-/// A builder used to add resource accesses to a [`TaskNode`].
-pub struct TaskNodeBuilder<'a, W: ?Sized> {
+const INPUT_ATTACHMENT_ACCESS_FLAGS: AccessFlags = AccessFlags::INPUT_ATTACHMENT_READ;
+const COLOR_ATTACHMENT_ACCESS_FLAGS: AccessFlags =
+    AccessFlags::COLOR_ATTACHMENT_READ.union(AccessFlags::COLOR_ATTACHMENT_WRITE);
+const DEPTH_STENCIL_ATTACHMENT_ACCESS_FLAGS: AccessFlags =
+    AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ.union(AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE);
+const ATTACHMENT_ACCESS_FLAGS: AccessFlags = INPUT_ATTACHMENT_ACCESS_FLAGS
+    .union(COLOR_ATTACHMENT_ACCESS_FLAGS)
+    .union(DEPTH_STENCIL_ATTACHMENT_ACCESS_FLAGS);
+
+const COLOR_ASPECTS: ImageAspects = ImageAspects::COLOR
+    .union(ImageAspects::PLANE_0)
+    .union(ImageAspects::PLANE_1)
+    .union(ImageAspects::PLANE_2);
+const DEPTH_STENCIL_ASPECTS: ImageAspects = ImageAspects::DEPTH.union(ImageAspects::STENCIL);
+
+/// A builder used to add resource accesses and attachments to a [`TaskNode`].
+pub struct TaskNodeBuilder<'a> {
     id: NodeId,
-    task_node: &'a mut TaskNode<W>,
+    accesses: &'a mut ResourceAccesses,
+    attachments: &'a mut Option<Attachments>,
     resources: &'a mut Resources,
 }
 
-impl<W: ?Sized> TaskNodeBuilder<'_, W> {
-    /// Adds a buffer access to this task node.
+impl TaskNodeBuilder<'_> {
+    /// Adds a buffer access to the task node.
     ///
     /// # Panics
     ///
     /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
-    /// - Panics if `access_type` isn't a valid buffer access type.
-    pub fn buffer_access(&mut self, id: Id<Buffer>, access_type: AccessType) -> &mut Self {
-        let (id, access) = self.access_mut(id.erase()).expect("invalid buffer");
+    /// - Panics if `access_types` contains any access type that's not a valid buffer access type.
+    #[track_caller]
+    pub fn buffer_access(&mut self, id: Id<Buffer>, access_types: AccessTypes) -> &mut Self {
+        assert!(access_types.are_valid_buffer_access_types());
 
-        assert!(access_type.is_valid_buffer_access_type());
+        let (id, access) = self.accesses.buffer_mut(self.resources, id);
 
         if let Some(access) = access {
-            access.stage_mask |= access_type.stage_mask();
-            access.access_mask |= access_type.access_mask();
+            access.stage_mask |= access_types.stage_mask();
+            access.access_mask |= access_types.access_mask();
         } else {
-            self.task_node.accesses.inner.push((
+            self.accesses.inner.insert(
                 id.erase(),
                 ResourceAccess {
-                    stage_mask: access_type.stage_mask(),
-                    access_mask: access_type.access_mask(),
+                    stage_mask: access_types.stage_mask(),
+                    access_mask: access_types.access_mask(),
                     image_layout: ImageLayout::Undefined,
                     queue_family_index: vk::QUEUE_FAMILY_IGNORED,
                 },
-            ));
+            );
         }
 
         self
     }
 
-    /// Adds an image access to this task node.
+    /// Adds an image access to the task node.
     ///
     /// # Panics
     ///
     /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
-    /// - Panics if `access_type` isn't a valid image access type.
+    /// - Panics if `access_types` contains any access type that's not a valid image access type.
+    /// - Panics if `access_types` contains attachment access types as well as other access types.
+    /// - Panics if `access_types` contains both color and depth/stencil access types.
     /// - Panics if an access for `id` was already added and its image layout doesn't equal
-    ///   `access_type.image_layout(layout_type)`.
+    ///   `access_types.image_layout(layout_type)`.
+    #[track_caller]
     pub fn image_access(
         &mut self,
         id: Id<Image>,
-        access_type: AccessType,
+        access_types: AccessTypes,
         layout_type: ImageLayoutType,
     ) -> &mut Self {
-        let (id, access) = self.access_mut(id.erase()).expect("invalid image");
+        assert!(access_types.are_valid_image_access_types());
 
-        assert!(access_type.is_valid_image_access_type());
+        let (id, access) = self.accesses.image_mut(self.resources, id);
 
-        let image_layout = access_type.image_layout(layout_type);
+        let access_mask = access_types.access_mask();
+
+        if access_mask.intersects(ATTACHMENT_ACCESS_FLAGS) {
+            assert!(
+                ATTACHMENT_ACCESS_FLAGS.contains(access_mask),
+                "an image access that contains attachment access types must not contain any other \
+                access types",
+            );
+
+            assert!(
+                !(access_mask.intersects(COLOR_ATTACHMENT_ACCESS_FLAGS)
+                    && access_mask.intersects(DEPTH_STENCIL_ATTACHMENT_ACCESS_FLAGS)),
+                "an image access can't contain both color and depth/stencil attachment access \
+                types",
+            );
+        }
 
         if let Some(access) = access {
-            assert_eq!(access.image_layout, image_layout);
+            assert_eq!(access.image_layout, access_types.image_layout(layout_type));
 
-            access.stage_mask |= access_type.stage_mask();
-            access.access_mask |= access_type.access_mask();
+            access.stage_mask |= access_types.stage_mask();
+            access.access_mask |= access_types.access_mask();
         } else {
-            self.task_node.accesses.inner.push((
+            self.accesses.inner.insert(
                 id.erase(),
                 ResourceAccess {
-                    stage_mask: access_type.stage_mask(),
-                    access_mask: access_type.access_mask(),
-                    image_layout,
+                    stage_mask: access_types.stage_mask(),
+                    access_mask: access_types.access_mask(),
+                    image_layout: access_types.image_layout(layout_type),
                     queue_family_index: vk::QUEUE_FAMILY_IGNORED,
                 },
-            ));
+            );
         }
 
         self
     }
 
-    fn access_mut(
+    /// Sets the framebuffer that the task node's attachments will belong to. You must call this
+    /// method before adding attachments to the task node.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `id` is not a valid framebuffer ID.
+    /// - Panics if the framebuffer was already set.
+    #[track_caller]
+    pub fn framebuffer(&mut self, id: Id<Framebuffer>) -> &mut Self {
+        assert!(self.resources.framebuffer_mut(id).is_some());
+
+        assert!(
+            self.attachments.is_none(),
+            "a task node must use at most one framebuffer",
+        );
+
+        *self.attachments = Some(Attachments {
+            framebuffer_id: id,
+            color_attachments: LinearMap::new(),
+            input_attachments: LinearMap::new(),
+            depth_stencil_attachment: None,
+        });
+
+        self
+    }
+
+    /// Adds an input attachment to the task node.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the framebuffer wasn't set beforehand.
+    /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
+    /// - Panics if `access_types` contains any access type that's not an input attachment access
+    ///   type.
+    /// - Panics if an input attachment for `id` was already added.
+    /// - Panics if an input attachment using the `attachment_info.index` was already added.
+    /// - Panics if a color or depth/stencil attachment using `id` was added but the attachment
+    ///   infos don't match.
+    /// - Panics if an access for `id` was already added and its image layout doesn't equal
+    ///   `access_types.image_layout(layout_type)`.
+    #[track_caller]
+    pub fn input_attachment(
         &mut self,
-        id: Id,
-    ) -> Result<(Id, Option<&mut ResourceAccess>), InvalidSlotError> {
-        self.task_node.accesses.get_mut(self.resources, id)
+        id: Id<Image>,
+        mut access_types: AccessTypes,
+        layout_type: ImageLayoutType,
+        attachment_info: &AttachmentInfo<'_>,
+    ) -> &mut Self {
+        let attachments = self
+            .attachments
+            .as_mut()
+            .expect("the framebuffer must be set before adding attachments");
+
+        let (id, _access) = self.accesses.image_mut(self.resources, id);
+
+        assert!(INPUT_ATTACHMENT_ACCESS_FLAGS.contains(access_types.access_mask()));
+
+        assert!(
+            attachments.input_attachments.get(&id.erase()).is_none(),
+            "a task node must use an image as at most one input attachment",
+        );
+
+        let input_attachment_index = attachment_info.index;
+
+        assert!(
+            !attachments
+                .input_attachments
+                .values()
+                .any(|info| info.index == input_attachment_index),
+            "the task node already has an input attachment that uses the input attachment index \
+            `{input_attachment_index}`",
+        );
+
+        assert!(
+            !attachments
+                .color_attachments
+                .get(&id.erase())
+                .is_some_and(|attachment_info2| attachment_info2 == attachment_info),
+            "the task node also uses the image as a color attachment but the attachment infos \
+            don't match",
+        );
+
+        assert!(
+            !attachments
+                .depth_stencil_attachment
+                .as_ref()
+                .is_some_and(|(_, attachment_info2)| attachment_info2 == attachment_info),
+            "the task node also uses the image as a depth/stencil attachment but the attachment \
+            infos dont' match",
+        );
+
+        let resource_info = self.resources.get(id.erase()).unwrap();
+        let format = if attachment_info.format == Format::UNDEFINED {
+            resource_info.format
+        } else {
+            attachment_info.format
+        };
+
+        // Clear operations (whether using `AttachmentLoadOp::Clear` or the `clear_attachments`
+        // command) are attachment writes.
+        if attachment_info.clear {
+            if format.aspects().intersects(COLOR_ASPECTS) {
+                access_types |= AccessTypes::COLOR_ATTACHMENT_WRITE;
+            } else if format.aspects().intersects(DEPTH_STENCIL_ASPECTS) {
+                access_types |= AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE;
+            } else {
+                unreachable!();
+            }
+        }
+
+        attachments.input_attachments.insert(
+            id.erase(),
+            AttachmentInfo {
+                format,
+                _ne: crate::NE,
+                ..attachment_info.clone()
+            },
+        );
+
+        self.image_access(id, access_types, layout_type)
+    }
+
+    /// Adds a color attachment to the task node.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the framebuffer wasn't set beforehand.
+    /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
+    /// - Panics if `access_types` contains any access type that's not a color attachment access
+    ///   type.
+    /// - Panics if a color attachment using `id` was already added.
+    /// - Panics if a color attachment using the `attachment_info.index` was already added.
+    /// - Panics if an input attachment using `id` was added but the attachment infos don't match.
+    /// - Panics if `attachment_info.format` is not a color format.
+    /// - Panics if an access for `id` was already added and its image layout doesn't equal
+    ///   `access_types.image_layout(layout_type)`.
+    #[track_caller]
+    pub fn color_attachment(
+        &mut self,
+        id: Id<Image>,
+        mut access_types: AccessTypes,
+        layout_type: ImageLayoutType,
+        attachment_info: &AttachmentInfo<'_>,
+    ) -> &mut Self {
+        let attachments = self
+            .attachments
+            .as_mut()
+            .expect("the framebuffer must be set before adding attachments");
+
+        let (id, _access) = self.accesses.image_mut(self.resources, id);
+
+        assert!(COLOR_ATTACHMENT_ACCESS_FLAGS.contains(access_types.access_mask()));
+
+        assert!(
+            attachments.color_attachments.get(&id.erase()).is_none(),
+            "a task node must use an image as at most one color attachment",
+        );
+
+        let location = attachment_info.index;
+
+        assert!(
+            !attachments
+                .color_attachments
+                .values()
+                .any(|info| info.index == location),
+            "the task node already has a color attachment that uses the location `{location}`",
+        );
+
+        assert!(
+            !attachments
+                .input_attachments
+                .get(&id.erase())
+                .is_some_and(|attachment_info2| attachment_info2 == attachment_info),
+            "the task node also uses the image as an input attachment but the attachment infos \
+            don't match",
+        );
+
+        let resource_info = self.resources.get(id.erase()).unwrap();
+        let format = if attachment_info.format == Format::UNDEFINED {
+            resource_info.format
+        } else {
+            attachment_info.format
+        };
+
+        assert!(
+            format.aspects().intersects(COLOR_ASPECTS),
+            "an image can only be used as a color attachment if it has a color format",
+        );
+
+        // Clear operations (whether using `AttachmentLoadOp::Clear` or the `clear_attachments`
+        // command) are attachment writes.
+        if attachment_info.clear {
+            access_types |= AccessTypes::COLOR_ATTACHMENT_WRITE;
+        }
+
+        attachments.color_attachments.insert(
+            id.erase(),
+            AttachmentInfo {
+                format,
+                _ne: crate::NE,
+                ..attachment_info.clone()
+            },
+        );
+
+        self.image_access(id, access_types, layout_type)
+    }
+
+    /// Adds a depth/stencil attachment to the task node.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if the framebuffer wasn't set beforehand.
+    /// - Panics if `id` is not a valid virtual resource ID nor a valid physical ID.
+    /// - Panics if `access_types` contains any access type that's not a depth/stencil attachment
+    ///   access type.
+    /// - Panics if a depth/stencil attachment was already added.
+    /// - Panics if an input attachment using `id` was added but the attachment infos don't match.
+    /// - Panics if `attachment_info.format` is not a depth/stencil format.
+    /// - Panics if an access for `id` was already added and its image layout doesn't equal
+    ///   `access_types.image_layout(layout_type)`.
+    #[track_caller]
+    pub fn depth_stencil_attachment(
+        &mut self,
+        id: Id<Image>,
+        mut access_types: AccessTypes,
+        layout_type: ImageLayoutType,
+        attachment_info: &AttachmentInfo<'_>,
+    ) -> &mut Self {
+        let attachments = self
+            .attachments
+            .as_mut()
+            .expect("the framebuffer must be set before adding attachments");
+
+        let (id, _access) = self.accesses.image_mut(self.resources, id);
+
+        assert!(DEPTH_STENCIL_ATTACHMENT_ACCESS_FLAGS.contains(access_types.access_mask()));
+
+        assert!(
+            attachments.depth_stencil_attachment.is_none(),
+            "a task node must have at most one depth/stencil attachment",
+        );
+
+        assert!(
+            !attachments
+                .input_attachments
+                .get(&id.erase())
+                .is_some_and(|attachment_info2| attachment_info2 == attachment_info),
+            "the task node also uses the image as an input attachment but the attachment infos \
+            don't match",
+        );
+
+        let resource_info = self.resources.get(id.erase()).unwrap();
+        let format = if attachment_info.format == Format::UNDEFINED {
+            resource_info.format
+        } else {
+            attachment_info.format
+        };
+
+        assert!(
+            format.aspects().intersects(DEPTH_STENCIL_ASPECTS),
+            "an image can only be used as a depth/stencil attachment if it has a depth/stencil \
+            format",
+        );
+
+        // Clear operations (whether using `AttachmentLoadOp::Clear` or the `clear_attachments`
+        // command) are attachment writes.
+        if attachment_info.clear {
+            access_types |= AccessTypes::DEPTH_STENCIL_ATTACHMENT_WRITE;
+        }
+
+        attachments.depth_stencil_attachment = Some((
+            id.erase(),
+            AttachmentInfo {
+                format,
+                _ne: crate::NE,
+                ..attachment_info.clone()
+            },
+        ));
+
+        self.image_access(id, access_types, layout_type)
     }
 
     /// Finishes building the task node and returns the ID of the built node.
@@ -731,14 +1153,89 @@ impl<W: ?Sized> TaskNodeBuilder<'_, W> {
     }
 }
 
+/// Parameters describing a rendering attachment.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttachmentInfo<'a> {
+    /// The input attachment index or location to use.
+    ///
+    /// For input attachments, this corresponds to the input attachment index you read from the
+    /// shader. For color attachments, this corresponds to the location you read or write from the
+    /// shader. For depth/stencil attachments, this is ignored.
+    ///
+    /// The default value is `0`.
+    pub index: u32,
+
+    /// If set to `true`, the attachment is cleared before the task is executed. The clear value is
+    /// set by the task in [`Task::clear_values`].
+    ///
+    /// The default value is `false`.
+    pub clear: bool,
+
+    /// The format of the attachment.
+    ///
+    /// If left as the default, the format of the image is used.
+    ///
+    /// If this is set to a format that is different from the image, the image must be created with
+    /// the `MUTABLE_FORMAT` flag.
+    ///
+    /// On [portability subset] devices, if `format` does not have the same number of components
+    /// and bits per component as the parent image's format, the
+    /// [`image_view_format_reinterpretation`] feature must be enabled on the device.
+    ///
+    /// The default value is `Format::UNDEFINED`.
+    ///
+    /// [portability subset]: vulkano::instance#portability-subset-devices-and-the-enumerate_portability-flag
+    /// [`image_view_format_reinterpretation`]: vulkano::device::DeviceFeatures::image_view_format_reinterpretation
+    pub format: Format,
+
+    /// How to map components of each pixel.
+    ///
+    /// On [portability subset] devices, if `component_mapping` is not the identity mapping, the
+    /// [`image_view_format_swizzle`] feature must be enabled on the device.
+    ///
+    /// The default value is [`ComponentMapping::identity()`].
+    ///
+    /// [portability subset]: vulkano::instance#portability-subset-devices-and-the-enumerate_portability-flag
+    /// [`image_view_format_swizzle`]: crate::device::DeviceFeatures::image_view_format_swizzle
+    pub component_mapping: ComponentMapping,
+
+    /// The mip level to render to.
+    ///
+    /// The default value is `0`.
+    pub mip_level: u32,
+
+    /// The base array layer to render to.
+    ///
+    /// The default value is `0`.
+    pub base_array_layer: u32,
+
+    pub _ne: crate::NonExhaustive<'a>,
+}
+
+impl Default for AttachmentInfo<'_> {
+    #[inline]
+    fn default() -> Self {
+        AttachmentInfo {
+            index: 0,
+            clear: false,
+            format: Format::UNDEFINED,
+            component_mapping: ComponentMapping::identity(),
+            mip_level: 0,
+            base_array_layer: 0,
+            _ne: crate::NE,
+        }
+    }
+}
+
 /// A [`TaskGraph`] that has been compiled into an executable form.
 pub struct ExecutableTaskGraph<W: ?Sized> {
     graph: TaskGraph<W>,
     flight_id: Id<Flight>,
     instructions: Vec<Instruction>,
     submissions: Vec<Submission>,
-    buffer_barriers: Vec<BufferMemoryBarrier>,
-    image_barriers: Vec<ImageMemoryBarrier>,
+    barriers: Vec<MemoryBarrier>,
+    render_passes: RefCell<Vec<RenderPassState>>,
+    clear_attachments: Vec<Id>,
     semaphores: RefCell<Vec<Arc<Semaphore>>>,
     swapchains: SmallVec<[Id<Swapchain>; 1]>,
     present_queue: Option<Arc<Queue>>,
@@ -749,8 +1246,7 @@ pub struct ExecutableTaskGraph<W: ?Sized> {
 #[derive(Debug)]
 struct Submission {
     queue: Arc<Queue>,
-    initial_buffer_barrier_range: Range<BarrierIndex>,
-    initial_image_barrier_range: Range<BarrierIndex>,
+    initial_barrier_range: Range<BarrierIndex>,
     instruction_range: Range<InstructionIndex>,
 }
 
@@ -770,20 +1266,27 @@ enum Instruction {
         node_index: NodeIndex,
     },
     PipelineBarrier {
-        buffer_barrier_range: Range<BarrierIndex>,
-        image_barrier_range: Range<BarrierIndex>,
+        barrier_range: Range<BarrierIndex>,
     },
     // TODO:
     // SetEvent {
     //     event_index: EventIndex,
-    //     buffer_barriers: Range<BarrierIndex>,
-    //     image_barriers: Range<BarrierIndex>,
+    //     barrier_range: Range<BarrierIndex>,
     // },
     // WaitEvent {
     //     event_index: EventIndex,
-    //     buffer_barriers: Range<BarrierIndex>,
-    //     image_barriers: Range<BarrierIndex>,
+    //     barrier_range: Range<BarrierIndex>,
     // },
+    BeginRenderPass {
+        render_pass_index: RenderPassIndex,
+    },
+    NextSubpass,
+    EndRenderPass,
+    ClearAttachments {
+        node_index: NodeIndex,
+        render_pass_index: RenderPassIndex,
+        clear_attachment_range: Range<ClearAttachmentIndex>,
+    },
     SignalSemaphore {
         semaphore_index: SemaphoreIndex,
         stage_mask: PipelineStages,
@@ -804,23 +1307,16 @@ enum Instruction {
     Submit,
 }
 
+type RenderPassIndex = usize;
+
 type SemaphoreIndex = usize;
 
 type BarrierIndex = u32;
 
-#[derive(Clone, Debug)]
-struct BufferMemoryBarrier {
-    src_stage_mask: PipelineStages,
-    src_access_mask: AccessFlags,
-    dst_stage_mask: PipelineStages,
-    dst_access_mask: AccessFlags,
-    src_queue_family_index: u32,
-    dst_queue_family_index: u32,
-    buffer: Id<Buffer>,
-}
+type ClearAttachmentIndex = usize;
 
 #[derive(Clone, Debug)]
-struct ImageMemoryBarrier {
+struct MemoryBarrier {
     src_stage_mask: PipelineStages,
     src_access_mask: AccessFlags,
     dst_stage_mask: PipelineStages,
@@ -829,7 +1325,24 @@ struct ImageMemoryBarrier {
     new_layout: ImageLayout,
     src_queue_family_index: u32,
     dst_queue_family_index: u32,
-    image: Id,
+    resource: Id,
+}
+
+#[derive(Debug)]
+struct RenderPassState {
+    render_pass: Arc<RenderPass>,
+    attachments: LinearMap<Id, AttachmentState>,
+    framebuffers: Vec<Arc<Framebuffer>>,
+    clear_node_indices: Vec<NodeIndex>,
+}
+
+#[derive(Debug)]
+struct AttachmentState {
+    index: u32,
+    format: Format,
+    component_mapping: ComponentMapping,
+    mip_level: u32,
+    base_array_layer: u32,
 }
 
 impl<W: ?Sized> ExecutableTaskGraph<W> {
@@ -873,8 +1386,9 @@ impl<W: ?Sized> fmt::Debug for ExecutableTaskGraph<W> {
             .field("flight_id", &self.flight_id)
             .field("instructions", &self.instructions)
             .field("submissions", &self.submissions)
-            .field("buffer_barriers", &self.buffer_barriers)
-            .field("image_barriers", &self.image_barriers)
+            .field("barriers", &self.barriers)
+            .field("render_passes", &self.render_passes)
+            .field("clear_attachments", &self.clear_attachments)
             .field("semaphores", &self.semaphores)
             .field("swapchains", &self.swapchains)
             .field("present_queue", &self.present_queue)

--- a/vulkano-taskgraph/src/lib.rs
+++ b/vulkano-taskgraph/src/lib.rs
@@ -3,8 +3,9 @@
 use command_buffer::RecordingCommandBuffer;
 use concurrent_slotmap::SlotId;
 use graph::{CompileInfo, ExecuteError, ResourceMap, TaskGraph};
+use linear_map::LinearMap;
 use resource::{
-    AccessType, BufferState, Flight, HostAccessType, ImageLayoutType, ImageState, Resources,
+    AccessTypes, BufferState, Flight, HostAccessType, ImageLayoutType, ImageState, Resources,
     SwapchainState,
 };
 use std::{
@@ -23,13 +24,16 @@ use vulkano::{
     buffer::{Buffer, BufferContents, BufferMemory, Subbuffer},
     command_buffer as raw,
     device::Queue,
+    format::ClearValue,
     image::Image,
+    render_pass::Framebuffer,
     swapchain::Swapchain,
     DeviceSize, ValidationError,
 };
 
 pub mod command_buffer;
 pub mod graph;
+mod linear_map;
 pub mod resource;
 
 /// Creates a [`TaskGraph`] with one task node, compiles it, and executes it.
@@ -39,8 +43,8 @@ pub unsafe fn execute(
     flight_id: Id<Flight>,
     task: impl FnOnce(&mut RecordingCommandBuffer<'_>, &mut TaskContext<'_>) -> TaskResult,
     host_buffer_accesses: impl IntoIterator<Item = (Id<Buffer>, HostAccessType)>,
-    buffer_accesses: impl IntoIterator<Item = (Id<Buffer>, AccessType)>,
-    image_accesses: impl IntoIterator<Item = (Id<Image>, AccessType, ImageLayoutType)>,
+    buffer_accesses: impl IntoIterator<Item = (Id<Buffer>, AccessTypes)>,
+    image_accesses: impl IntoIterator<Item = (Id<Image>, AccessTypes, ImageLayoutType)>,
 ) -> Result<(), ExecuteError> {
     #[repr(transparent)]
     struct OnceTask<'a>(
@@ -91,12 +95,12 @@ pub unsafe fn execute(
         unsafe { mem::transmute::<OnceTask<'_>, OnceTask<'static>>(OnceTask(&trampoline)) },
     );
 
-    for (id, access_type) in buffer_accesses {
-        node.buffer_access(id, access_type);
+    for (id, access_types) in buffer_accesses {
+        node.buffer_access(id, access_types);
     }
 
-    for (id, access_type, layout_type) in image_accesses {
-        node.image_access(id, access_type, layout_type);
+    for (id, access_types, layout_type) in image_accesses {
+        node.image_access(id, access_types, layout_type);
     }
 
     // SAFETY:
@@ -125,6 +129,19 @@ pub trait Task: Any + Send + Sync {
 
     // Potentially TODO:
     // fn update(&mut self, ...) {}
+
+    /// If the task node was created with any attachments which were [set to be cleared], this
+    /// method is invoked to allow the task to set clear values for such attachments.
+    ///
+    /// This method is invoked at least once for every attachment to be cleared before every
+    /// execution of the task. It's possible that it is invoked multiple times before the task is
+    /// executed, and it may not be invoked right before [`execute`], just at some point between
+    /// when the task graph has begun execution and when the task is executed.
+    ///
+    /// [set to be cleared]: graph::AttachmentInfo::clear
+    /// [`execute`]: Self::execute
+    #[allow(unused)]
+    fn clear_values(&self, clear_values: &mut ClearValues<'_>) {}
 
     /// Executes the task, which should record its commands using the provided command buffer and
     /// context.
@@ -535,6 +552,45 @@ impl<'a> TaskContext<'a> {
     }
 }
 
+/// Stores the clear value for each attachment that was [set to be cleared] when creating the task
+/// node.
+///
+/// This is used to set the clear values in [`Task::clear_values`].
+///
+/// [set to be cleared]: graph::AttachmentInfo::clear
+pub struct ClearValues<'a> {
+    inner: &'a mut LinearMap<Id, Option<ClearValue>>,
+    resource_map: &'a ResourceMap<'a>,
+}
+
+impl ClearValues<'_> {
+    /// Sets the clear value for the image corresponding to `id`.
+    #[inline]
+    pub fn set(&mut self, id: Id<Image>, clear_value: impl Into<ClearValue>) {
+        self.set_inner(id, clear_value.into());
+    }
+
+    fn set_inner(&mut self, id: Id<Image>, clear_value: ClearValue) {
+        let mut id = id.erase();
+
+        if !id.is_virtual() {
+            let virtual_resources = self.resource_map.virtual_resources();
+
+            if let Some(&virtual_id) = virtual_resources.physical_map().get(&id.erase()) {
+                id = virtual_id;
+            } else {
+                return;
+            }
+        }
+
+        if let Some(value) = self.inner.get_mut(&id) {
+            if value.is_none() {
+                *value = Some(clear_value);
+            }
+        }
+    }
+}
+
 /// The type of result returned by a task.
 pub type TaskResult<T = (), E = TaskError> = ::std::result::Result<T, E>;
 
@@ -725,7 +781,7 @@ impl Id<Swapchain> {
 }
 
 impl Id {
-    const OBJECT_TYPE_MASK: u32 = 0b11;
+    const OBJECT_TYPE_MASK: u32 = 0b111;
 
     const VIRTUAL_BIT: u32 = 1 << 7;
     const EXCLUSIVE_BIT: u32 = 1 << 6;
@@ -835,16 +891,27 @@ impl Object for Flight {
     const TYPE: ObjectType = ObjectType::Flight;
 }
 
+impl Object for Framebuffer {
+    const TYPE: ObjectType = ObjectType::Framebuffer;
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ObjectType {
     Buffer = 0,
     Image = 1,
     Swapchain = 2,
     Flight = 3,
+    Framebuffer = 4,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct NonExhaustive<'a>(PhantomData<&'a ()>);
+
+impl fmt::Debug for NonExhaustive<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("NonExhaustive")
+    }
+}
 
 const NE: NonExhaustive<'static> = NonExhaustive(PhantomData);
 

--- a/vulkano-taskgraph/src/linear_map.rs
+++ b/vulkano-taskgraph/src/linear_map.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+
+/// > **Note**: This map **permits duplicate keys** as an optimization. It is assumed that this
+/// > doesn't happen in the codebase and this is validated with debug assertions on.
+#[derive(Clone)]
+pub struct LinearMap<K, V> {
+    inner: Vec<(K, V)>,
+}
+
+impl<K, V> Default for LinearMap<K, V> {
+    #[inline]
+    fn default() -> Self {
+        LinearMap::new()
+    }
+}
+
+impl<K, V> LinearMap<K, V> {
+    #[inline]
+    pub const fn new() -> Self {
+        LinearMap { inner: Vec::new() }
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        LinearMap {
+            inner: Vec::with_capacity(capacity),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.inner.iter().map(|(k, v)| (k, v))
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut V)> {
+        self.inner.iter_mut().map(|(k, v)| (&*k, v))
+    }
+
+    #[inline]
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.inner.iter().map(|(k, _)| k)
+    }
+
+    #[inline]
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.inner.iter().map(|(_, v)| v)
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl<K: Eq, V> LinearMap<K, V> {
+    #[inline]
+    pub fn insert(&mut self, key: K, value: V) {
+        debug_assert!(!self.keys().any(|k| k == &key));
+
+        self.inner.push((key, value));
+    }
+
+    #[inline]
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.iter().find_map(|(k, v)| (k == key).then_some(v))
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.iter_mut().find_map(|(k, v)| (k == key).then_some(v))
+    }
+
+    #[inline]
+    pub fn get_or_insert(&mut self, key: K, value: V) -> &mut V {
+        self.get_or_insert_with(key, || value)
+    }
+
+    #[inline]
+    pub fn get_or_insert_with(&mut self, key: K, f: impl FnOnce() -> V) -> &mut V {
+        let index;
+
+        if let Some(i) = self.inner.iter().position(|(k, _)| k == &key) {
+            index = i;
+        } else {
+            index = self.inner.len();
+            self.inner.push((key, f()));
+        }
+
+        &mut unsafe { self.inner.get_unchecked_mut(index) }.1
+    }
+
+    #[inline]
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.keys().any(|k| k == key)
+    }
+
+    #[inline]
+    pub fn index_of(&self, key: &K) -> Option<usize> {
+        self.keys().position(|k| k == key)
+    }
+}
+
+impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for LinearMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
+}
+
+impl<K: Eq, V> Extend<(K, V)> for LinearMap<K, V> {
+    #[inline]
+    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+        if cfg!(debug_assertions) {
+            iter.into_iter().for_each(|(k, v)| self.insert(k, v));
+        } else {
+            self.inner.extend(iter);
+        }
+    }
+}
+
+impl<K: Eq, V> FromIterator<(K, V)> for LinearMap<K, V> {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        let mut map = LinearMap::with_capacity(lower);
+        map.extend(iter);
+
+        map
+    }
+}

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -3231,7 +3231,8 @@ impl ClearAttachment {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_vk(&self) -> ash::vk::ClearAttachment {
+    #[doc(hidden)]
+    pub fn to_vk(&self) -> ash::vk::ClearAttachment {
         match *self {
             ClearAttachment::Color {
                 color_attachment,
@@ -3287,7 +3288,8 @@ pub struct ClearRect {
 }
 
 impl ClearRect {
-    pub(crate) fn to_vk(&self) -> ash::vk::ClearRect {
+    #[doc(hidden)]
+    pub fn to_vk(&self) -> ash::vk::ClearRect {
         let &Self {
             offset,
             extent,

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -466,7 +466,8 @@ impl ClearValue {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_vk(&self) -> ash::vk::ClearValue {
+    #[doc(hidden)]
+    pub fn to_vk(&self) -> ash::vk::ClearValue {
         match *self {
             ClearValue::Float(val) => ash::vk::ClearValue {
                 color: ash::vk::ClearColorValue { float32: val },


### PR DESCRIPTION
Follow up to #2567, adding automatic render pass and framebuffer creation and fixing some unsoundness that was found along the way.

Adding the ability to add attachments to task nodes is relatively straight-forward, but there is the question of how we determine if different task nodes can be combined into the same render pass. After all, that's the whole point of render passes. For this we need to know that their attachments all share the same dimensions. I've seen implementations that have you specify the extent of the virtual images and use that to determine mergability. However, this has the downside that you have to recompile the whole thing whenever the dimensions of the images change. I've also seen ideas of "swapchain-relative size." But Vulkan *already has* a concept like this: the framebuffer. What I opted for is a "virtual framebuffer," which you must specify whenever adding attachments to a task node, which has the sole purpose of informing the compiler that those attachments all share the same dimensions. What those dimensions are doesn't matter. A virtual framebuffer doesn't necessarily correspond to a physical one; even if the sizes match, it's always possible that it's unavoidable that some task nodes can't be combined into a render pass for other reasons. In that case there are multiple sets of framebuffers, one for each render pass. These physical framebuffers are created and cached until any of the underlying images change, thereby completely abstracting render passes and framebuffers away.

At some point, I want to add dynamic rendering support too. Reason being that while render passes are abstracted away, you still have to create your graphics pipelines with the specific subpass, and that *is* a very real limitation, as is evident in the examples. When we have dynamic rendering support, this will be the only API difference. Everything else will be completely transparent to the user. This is, in my opinion, really cool. You can then say "I don't want to support mobile" and if that ever changes, all you have to do is flip one bool and change how you create graphics pipelines.