### PR TITLE
Increase MSRV to 1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,6 @@ dependencies = [
  "libc",
  "libloading",
  "nom",
- "once_cell",
  "parking_lot",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 license = "MIT OR Apache-2.0"
 homepage = "https://vulkano.rs"
 keywords = ["vulkan", "bindings", "graphics", "gpu", "rendering"]
@@ -56,7 +56,6 @@ heck = "0.4"
 indexmap = "2.0"
 libloading = "0.8"
 nom = "7.1"
-once_cell = "1.17"
 parking_lot = "0.12"
 proc-macro2 = "1.0"
 proc-macro-crate = "3.0"

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -21,7 +21,6 @@ crossbeam-queue = { workspace = true }
 foldhash = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 libloading = { workspace = true }
-once_cell = { workspace = true }
 parking_lot = { workspace = true, features = ["send_guard"] }
 raw-window-handle = { workspace = true, features = ["std"] }
 serde = { workspace = true, optional = true }
@@ -42,7 +41,6 @@ foldhash = { workspace = true }
 heck = { workspace = true }
 indexmap = { workspace = true }
 nom = { workspace = true }
-once_cell = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/vulkano/autogen/spirv_parse.rs
+++ b/vulkano/autogen/spirv_parse.rs
@@ -1,15 +1,14 @@
 use super::{write_file, SpirvGrammar};
 use foldhash::{HashMap, HashSet};
 use heck::ToSnakeCase;
-use once_cell::sync::Lazy;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::LazyLock};
 
 // From the documentation of the OpSpecConstantOp instruction.
 // The instructions requiring the Kernel capability are not listed,
 // as this capability is not supported by Vulkan.
-static SPEC_CONSTANT_OP: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+static SPEC_CONSTANT_OP: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     HashSet::from_iter([
         "SConvert",
         "UConvert",

--- a/vulkano/src/library.rs
+++ b/vulkano/src/library.rs
@@ -17,7 +17,7 @@ use crate::{
 use libloading::{Error as LibloadingError, Library};
 use std::{
     error::Error,
-    ffi::{CStr, CString},
+    ffi::CString,
     fmt::{Debug, Display, Error as FmtError, Formatter},
     mem::transmute,
     os::raw::c_char,
@@ -113,7 +113,7 @@ impl VulkanLibrary {
         // Vulkan 1.0 implementation. Otherwise, the application can call vkEnumerateInstanceVersion
         // to determine the version of Vulkan.
 
-        let name = CStr::from_bytes_with_nul_unchecked(b"vkEnumerateInstanceVersion\0");
+        let name = c"vkEnumerateInstanceVersion";
         let func = loader.get_instance_proc_addr(ash::vk::Instance::null(), name.as_ptr());
 
         let version = if let Some(func) = func {

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -10,9 +10,11 @@ use crate::{
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
 use foldhash::HashMap;
-use once_cell::sync::Lazy;
 use smallvec::SmallVec;
-use std::{ops::Range, sync::Arc};
+use std::{
+    ops::Range,
+    sync::{Arc, LazyLock},
+};
 
 vulkan_bitflags_enum! {
     #[non_exhaustive]
@@ -1401,9 +1403,9 @@ impl PipelineStageAccess {
         stages_read: ShaderStages,
         stages_write: ShaderStages,
     ) -> impl Iterator<Item = Self> + 'static {
-        static MAP_READ: Lazy<
+        static MAP_READ: LazyLock<
             HashMap<DescriptorType, HashMap<PipelineStage, PipelineStageAccess>>,
-        > = Lazy::new(|| {
+        > = LazyLock::new(|| {
             let uniform_read = [
                 DescriptorType::UniformBuffer,
                 DescriptorType::UniformBufferDynamic,
@@ -1581,9 +1583,9 @@ impl PipelineStageAccess {
                 .chain(input_attachment_read)
                 .collect()
         });
-        static MAP_WRITE: Lazy<
+        static MAP_WRITE: LazyLock<
             HashMap<DescriptorType, HashMap<PipelineStage, PipelineStageAccess>>,
-        > = Lazy::new(|| {
+        > = LazyLock::new(|| {
             let shader_storage_write = [
                 DescriptorType::StorageImage,
                 DescriptorType::StorageTexelBuffer,


### PR DESCRIPTION
Changelog:
```markdown
### Public dependency updates
- Rust version: 1.80.0
```

To be merged after the Vulkano 0.35 release.