### PR TITLE
Enable and fix `unsafe_op_in_unsafe_fn` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ ron = "0.8"
 rust.missing_docs = "allow"                                       # TODO: warn eventually
 rust.rust_2018_idioms = { level = "warn", priority = -1 }
 rust.rust_2024_compatibility = { level = "allow", priority = -1 } # TODO: warn eventually
+rust.unsafe_op_in_unsafe_fn = "warn"
 clippy.borrow_as_ptr = "warn"
 clippy.missing_safety_doc = "allow"                               # TODO: warn eventually
 clippy.multiple_unsafe_ops_per_block = "warn"

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -508,14 +508,14 @@ impl Buffer {
 
         let ptr = {
             let fns = device.fns();
-            let f = if device.api_version() >= Version::V1_2 {
+            let func = if device.api_version() >= Version::V1_2 {
                 fns.v1_2.get_buffer_device_address
             } else if device.enabled_extensions().khr_buffer_device_address {
                 fns.khr_buffer_device_address.get_buffer_device_address_khr
             } else {
                 fns.ext_buffer_device_address.get_buffer_device_address_ext
             };
-            f(device.handle(), &info_vk)
+            unsafe { func(device.handle(), &info_vk) }
         };
 
         NonNullDeviceAddress::new(ptr).unwrap()

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -88,18 +88,20 @@ impl RawBuffer {
         let handle = {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
-            (fns.v1_0.create_buffer)(
-                device.handle(),
-                &create_info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.v1_0.create_buffer)(
+                    device.handle(),
+                    &create_info_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `RawBuffer` from a raw object handle.
@@ -116,7 +118,7 @@ impl RawBuffer {
         handle: ash::vk::Buffer,
         create_info: BufferCreateInfo,
     ) -> Self {
-        Self::from_handle_with_destruction(device, handle, create_info, true)
+        unsafe { Self::from_handle_with_destruction(device, handle, create_info, true) }
     }
 
     /// Creates a new `RawBuffer` from a raw object handle. Unlike `from_handle`, the created
@@ -136,7 +138,7 @@ impl RawBuffer {
         handle: ash::vk::Buffer,
         create_info: BufferCreateInfo,
     ) -> Self {
-        Self::from_handle_with_destruction(device, handle, create_info, false)
+        unsafe { Self::from_handle_with_destruction(device, handle, create_info, false) }
     }
 
     unsafe fn from_handle_with_destruction(
@@ -493,25 +495,31 @@ impl RawBuffer {
             let bind_infos_vk = [bind_info_vk];
 
             if self.device.api_version() >= Version::V1_1 {
-                (fns.v1_1.bind_buffer_memory2)(
-                    self.device.handle(),
-                    bind_infos_vk.len() as u32,
-                    bind_infos_vk.as_ptr(),
-                )
+                unsafe {
+                    (fns.v1_1.bind_buffer_memory2)(
+                        self.device.handle(),
+                        bind_infos_vk.len() as u32,
+                        bind_infos_vk.as_ptr(),
+                    )
+                }
             } else {
-                (fns.khr_bind_memory2.bind_buffer_memory2_khr)(
-                    self.device.handle(),
-                    bind_infos_vk.len() as u32,
-                    bind_infos_vk.as_ptr(),
-                )
+                unsafe {
+                    (fns.khr_bind_memory2.bind_buffer_memory2_khr)(
+                        self.device.handle(),
+                        bind_infos_vk.len() as u32,
+                        bind_infos_vk.as_ptr(),
+                    )
+                }
             }
         } else {
-            (fns.v1_0.bind_buffer_memory)(
-                self.device.handle(),
-                bind_info_vk.buffer,
-                bind_info_vk.memory,
-                bind_info_vk.memory_offset,
-            )
+            unsafe {
+                (fns.v1_0.bind_buffer_memory)(
+                    self.device.handle(),
+                    bind_info_vk.buffer,
+                    bind_info_vk.memory,
+                    bind_info_vk.memory_offset,
+                )
+            }
         }
         .result();
 

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -303,7 +303,7 @@ impl BufferView {
             unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(subbuffer, handle, create_info))
+        Ok(unsafe { Self::from_handle(subbuffer, handle, create_info) })
     }
 
     /// Creates a new `BufferView` from a raw object handle.

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -343,7 +343,7 @@ unsafe impl<T: CommandBufferAllocator> CommandBufferAllocator for Arc<T> {
 
     #[inline]
     unsafe fn deallocate(&self, allocation: CommandBufferAlloc) {
-        (**self).deallocate(allocation)
+        unsafe { (**self).deallocate(allocation) }
     }
 }
 

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -249,12 +249,9 @@ impl<L> AutoCommandBufferBuilder<L> {
             }
         }
 
-        let inner = RecordingCommandBuffer::new_unchecked(
-            allocator,
-            queue_family_index,
-            level,
-            begin_info,
-        )?;
+        let inner = unsafe {
+            RecordingCommandBuffer::new_unchecked(allocator, queue_family_index, level, begin_info)
+        }?;
 
         Ok(AutoCommandBufferBuilder {
             inner,
@@ -362,7 +359,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         debug_assert!(barriers.is_empty());
 
         Ok((
-            self.inner.end()?,
+            unsafe { self.inner.end() }?,
             self.commands
                 .into_iter()
                 .map(|(_, record_func)| record_func)

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -83,7 +83,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_build_acceleration_structure(&info, &build_range_infos)?;
 
-        Ok(self.build_acceleration_structure_unchecked(info, build_range_infos))
+        Ok(unsafe { self.build_acceleration_structure_unchecked(info, build_range_infos) })
     }
 
     fn validate_build_acceleration_structure(
@@ -119,7 +119,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "build_acceleration_structure",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.build_acceleration_structure_unchecked(&info, &build_range_infos);
+                unsafe { out.build_acceleration_structure_unchecked(&info, &build_range_infos) };
             },
         );
 
@@ -198,12 +198,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             &max_primitive_counts,
         )?;
 
-        Ok(self.build_acceleration_structure_indirect_unchecked(
-            info,
-            indirect_buffer,
-            stride,
-            max_primitive_counts,
-        ))
+        Ok(unsafe {
+            self.build_acceleration_structure_indirect_unchecked(
+                info,
+                indirect_buffer,
+                stride,
+                max_primitive_counts,
+            )
+        })
     }
 
     fn validate_build_acceleration_structure_indirect(
@@ -248,12 +250,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             "build_acceleration_structure_indirect",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.build_acceleration_structure_indirect_unchecked(
-                    &info,
-                    &indirect_buffer,
-                    stride,
-                    &max_primitive_counts,
-                );
+                unsafe {
+                    out.build_acceleration_structure_indirect_unchecked(
+                        &info,
+                        &indirect_buffer,
+                        stride,
+                        &max_primitive_counts,
+                    )
+                };
             },
         );
 
@@ -277,7 +281,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_acceleration_structure(&info)?;
 
-        Ok(self.copy_acceleration_structure_unchecked(info))
+        Ok(unsafe { self.copy_acceleration_structure_unchecked(info) })
     }
 
     fn validate_copy_acceleration_structure(
@@ -337,7 +341,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             .into_iter()
             .collect(),
             move |out: &mut RecordingCommandBuffer| {
-                out.copy_acceleration_structure_unchecked(&info);
+                unsafe { out.copy_acceleration_structure_unchecked(&info) };
             },
         );
 
@@ -361,7 +365,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_acceleration_structure_to_memory(&info)?;
 
-        Ok(self.copy_acceleration_structure_to_memory_unchecked(info))
+        Ok(unsafe { self.copy_acceleration_structure_to_memory_unchecked(info) })
     }
 
     fn validate_copy_acceleration_structure_to_memory(
@@ -421,7 +425,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             .into_iter()
             .collect(),
             move |out: &mut RecordingCommandBuffer| {
-                out.copy_acceleration_structure_to_memory_unchecked(&info);
+                unsafe { out.copy_acceleration_structure_to_memory_unchecked(&info) };
             },
         );
 
@@ -448,7 +452,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_memory_to_acceleration_structure(&info)?;
 
-        Ok(self.copy_memory_to_acceleration_structure_unchecked(info))
+        Ok(unsafe { self.copy_memory_to_acceleration_structure_unchecked(info) })
     }
 
     fn validate_copy_memory_to_acceleration_structure(
@@ -508,7 +512,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             .into_iter()
             .collect(),
             move |out: &mut RecordingCommandBuffer| {
-                out.copy_memory_to_acceleration_structure_unchecked(&info);
+                unsafe { out.copy_memory_to_acceleration_structure_unchecked(&info) };
             },
         );
 
@@ -544,11 +548,13 @@ impl<L> AutoCommandBufferBuilder<L> {
             first_query,
         )?;
 
-        Ok(self.write_acceleration_structures_properties_unchecked(
-            acceleration_structures,
-            query_pool,
-            first_query,
-        ))
+        Ok(unsafe {
+            self.write_acceleration_structures_properties_unchecked(
+                acceleration_structures,
+                query_pool,
+                first_query,
+            )
+        })
     }
 
     fn validate_write_acceleration_structures_properties(
@@ -604,11 +610,11 @@ impl<L> AutoCommandBufferBuilder<L> {
                 )
             }).collect(),
             move |out: &mut RecordingCommandBuffer| {
-                out.write_acceleration_structures_properties_unchecked(
+                unsafe { out.write_acceleration_structures_properties_unchecked(
                     &acceleration_structures,
                     &query_pool,
                     first_query,
-                );
+                ) };
             },
         );
 
@@ -799,7 +805,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_build_acceleration_structure(info, build_range_infos)?;
 
-        Ok(self.build_acceleration_structure_unchecked(info, build_range_infos))
+        Ok(unsafe { self.build_acceleration_structure_unchecked(info, build_range_infos) })
     }
 
     fn validate_build_acceleration_structure(
@@ -1552,13 +1558,15 @@ impl RecordingCommandBuffer {
             .collect();
 
         let fns = self.device().fns();
-        (fns.khr_acceleration_structure
-            .cmd_build_acceleration_structures_khr)(
-            self.handle(),
-            1,
-            &info_vk,
-            build_range_info_pointers_vk.as_ptr(),
-        );
+        unsafe {
+            (fns.khr_acceleration_structure
+                .cmd_build_acceleration_structures_khr)(
+                self.handle(),
+                1,
+                &info_vk,
+                build_range_info_pointers_vk.as_ptr(),
+            )
+        };
 
         self
     }
@@ -1578,12 +1586,14 @@ impl RecordingCommandBuffer {
             max_primitive_counts,
         )?;
 
-        Ok(self.build_acceleration_structure_indirect_unchecked(
-            info,
-            indirect_buffer,
-            stride,
-            max_primitive_counts,
-        ))
+        Ok(unsafe {
+            self.build_acceleration_structure_indirect_unchecked(
+                info,
+                indirect_buffer,
+                stride,
+                max_primitive_counts,
+            )
+        })
     }
 
     fn validate_build_acceleration_structure_indirect(
@@ -2168,15 +2178,17 @@ impl RecordingCommandBuffer {
         let info_vk = info.to_vk(&info_fields1_vk);
 
         let fns = self.device().fns();
-        (fns.khr_acceleration_structure
-            .cmd_build_acceleration_structures_indirect_khr)(
-            self.handle(),
-            1,
-            &info_vk,
-            &indirect_buffer.device_address().unwrap().get(),
-            &stride,
-            &max_primitive_counts.as_ptr(),
-        );
+        unsafe {
+            (fns.khr_acceleration_structure
+                .cmd_build_acceleration_structures_indirect_khr)(
+                self.handle(),
+                1,
+                &info_vk,
+                &indirect_buffer.device_address().unwrap().get(),
+                &stride,
+                &max_primitive_counts.as_ptr(),
+            )
+        };
 
         self
     }
@@ -2188,7 +2200,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_acceleration_structure(info)?;
 
-        Ok(self.copy_acceleration_structure_unchecked(info))
+        Ok(unsafe { self.copy_acceleration_structure_unchecked(info) })
     }
 
     fn validate_copy_acceleration_structure(
@@ -2223,8 +2235,10 @@ impl RecordingCommandBuffer {
         let info_vk = info.to_vk();
 
         let fns = self.device().fns();
-        (fns.khr_acceleration_structure
-            .cmd_copy_acceleration_structure_khr)(self.handle(), &info_vk);
+        unsafe {
+            (fns.khr_acceleration_structure
+                .cmd_copy_acceleration_structure_khr)(self.handle(), &info_vk)
+        };
 
         self
     }
@@ -2236,7 +2250,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_acceleration_structure_to_memory(info)?;
 
-        Ok(self.copy_acceleration_structure_to_memory_unchecked(info))
+        Ok(unsafe { self.copy_acceleration_structure_to_memory_unchecked(info) })
     }
 
     fn validate_copy_acceleration_structure_to_memory(
@@ -2280,8 +2294,10 @@ impl RecordingCommandBuffer {
         let info_vk = info.to_vk();
 
         let fns = self.device().fns();
-        (fns.khr_acceleration_structure
-            .cmd_copy_acceleration_structure_to_memory_khr)(self.handle(), &info_vk);
+        unsafe {
+            (fns.khr_acceleration_structure
+                .cmd_copy_acceleration_structure_to_memory_khr)(self.handle(), &info_vk)
+        };
 
         self
     }
@@ -2293,7 +2309,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_memory_to_acceleration_structure(info)?;
 
-        Ok(self.copy_memory_to_acceleration_structure_unchecked(info))
+        Ok(unsafe { self.copy_memory_to_acceleration_structure_unchecked(info) })
     }
 
     fn validate_copy_memory_to_acceleration_structure(
@@ -2337,8 +2353,10 @@ impl RecordingCommandBuffer {
         let info_vk = info.to_vk();
 
         let fns = self.device().fns();
-        (fns.khr_acceleration_structure
-            .cmd_copy_memory_to_acceleration_structure_khr)(self.handle(), &info_vk);
+        unsafe {
+            (fns.khr_acceleration_structure
+                .cmd_copy_memory_to_acceleration_structure_khr)(self.handle(), &info_vk)
+        };
 
         self
     }
@@ -2356,11 +2374,13 @@ impl RecordingCommandBuffer {
             first_query,
         )?;
 
-        Ok(self.write_acceleration_structures_properties_unchecked(
-            acceleration_structures,
-            query_pool,
-            first_query,
-        ))
+        Ok(unsafe {
+            self.write_acceleration_structures_properties_unchecked(
+                acceleration_structures,
+                query_pool,
+                first_query,
+            )
+        })
     }
 
     fn validate_write_acceleration_structures_properties(
@@ -2447,15 +2467,17 @@ impl RecordingCommandBuffer {
             .collect();
 
         let fns = self.device().fns();
-        (fns.khr_acceleration_structure
-            .cmd_write_acceleration_structures_properties_khr)(
-            self.handle(),
-            acceleration_structures_vk.len() as u32,
-            acceleration_structures_vk.as_ptr(),
-            query_pool.query_type().into(),
-            query_pool.handle(),
-            first_query,
-        );
+        unsafe {
+            (fns.khr_acceleration_structure
+                .cmd_write_acceleration_structures_properties_khr)(
+                self.handle(),
+                acceleration_structures_vk.len() as u32,
+                acceleration_structures_vk.as_ptr(),
+                query_pool.query_type().into(),
+                query_pool.handle(),
+                first_query,
+            )
+        };
 
         self
     }

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -74,7 +74,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 })
                 .collect(),
             move |out: &mut RecordingCommandBuffer| {
-                out.clear_color_image_unchecked(&clear_info);
+                unsafe { out.clear_color_image_unchecked(&clear_info) };
             },
         );
 
@@ -140,7 +140,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 })
                 .collect(),
             move |out: &mut RecordingCommandBuffer| {
-                out.clear_depth_stencil_image_unchecked(&clear_info);
+                unsafe { out.clear_depth_stencil_image_unchecked(&clear_info) };
             },
         );
 
@@ -198,7 +198,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             .into_iter()
             .collect(),
             move |out: &mut RecordingCommandBuffer| {
-                out.fill_buffer_unchecked(&dst_buffer, data);
+                unsafe { out.fill_buffer_unchecked(&dst_buffer, data) };
             },
         );
 
@@ -264,7 +264,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             .into_iter()
             .collect(),
             move |out: &mut RecordingCommandBuffer| {
-                out.update_buffer_unchecked(&dst_buffer, &data);
+                unsafe { out.update_buffer_unchecked(&dst_buffer, &data) };
             },
         );
 
@@ -280,7 +280,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_clear_color_image(clear_info)?;
 
-        Ok(self.clear_color_image_unchecked(clear_info))
+        Ok(unsafe { self.clear_color_image_unchecked(clear_info) })
     }
 
     fn validate_clear_color_image(
@@ -321,14 +321,16 @@ impl RecordingCommandBuffer {
         let ranges_vk = clear_info.to_vk_ranges();
 
         let fns = self.device().fns();
-        (fns.v1_0.cmd_clear_color_image)(
-            self.handle(),
-            clear_info_vk.image,
-            clear_info_vk.image_layout,
-            &clear_info_vk.color,
-            ranges_vk.len() as u32,
-            ranges_vk.as_ptr(),
-        );
+        unsafe {
+            (fns.v1_0.cmd_clear_color_image)(
+                self.handle(),
+                clear_info_vk.image,
+                clear_info_vk.image_layout,
+                &clear_info_vk.color,
+                ranges_vk.len() as u32,
+                ranges_vk.as_ptr(),
+            )
+        };
 
         self
     }
@@ -340,7 +342,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_clear_depth_stencil_image(clear_info)?;
 
-        Ok(self.clear_depth_stencil_image_unchecked(clear_info))
+        Ok(unsafe { self.clear_depth_stencil_image_unchecked(clear_info) })
     }
 
     fn validate_clear_depth_stencil_image(
@@ -381,14 +383,16 @@ impl RecordingCommandBuffer {
         let ranges_vk = clear_info.to_vk_ranges();
 
         let fns = self.device().fns();
-        (fns.v1_0.cmd_clear_depth_stencil_image)(
-            self.handle(),
-            clear_info_vk.image,
-            clear_info_vk.image_layout,
-            &clear_info_vk.depth_stencil,
-            ranges_vk.len() as u32,
-            ranges_vk.as_ptr(),
-        );
+        unsafe {
+            (fns.v1_0.cmd_clear_depth_stencil_image)(
+                self.handle(),
+                clear_info_vk.image,
+                clear_info_vk.image_layout,
+                &clear_info_vk.depth_stencil,
+                ranges_vk.len() as u32,
+                ranges_vk.as_ptr(),
+            )
+        };
 
         self
     }
@@ -401,7 +405,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_fill_buffer(dst_buffer, data)?;
 
-        Ok(self.fill_buffer_unchecked(dst_buffer, data))
+        Ok(unsafe { self.fill_buffer_unchecked(dst_buffer, data) })
     }
 
     fn validate_fill_buffer(
@@ -477,13 +481,15 @@ impl RecordingCommandBuffer {
         data: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_fill_buffer)(
-            self.handle(),
-            dst_buffer.buffer().handle(),
-            dst_buffer.offset(),
-            dst_buffer.size(),
-            data,
-        );
+        unsafe {
+            (fns.v1_0.cmd_fill_buffer)(
+                self.handle(),
+                dst_buffer.buffer().handle(),
+                dst_buffer.offset(),
+                dst_buffer.size(),
+                data,
+            )
+        };
 
         self
     }
@@ -503,7 +509,7 @@ impl RecordingCommandBuffer {
 
         self.validate_update_buffer(dst_buffer.as_bytes(), size_of_val(data) as DeviceSize)?;
 
-        Ok(self.update_buffer_unchecked(dst_buffer, data))
+        Ok(unsafe { self.update_buffer_unchecked(dst_buffer, data) })
     }
 
     fn validate_update_buffer(
@@ -601,13 +607,15 @@ impl RecordingCommandBuffer {
         }
 
         let fns = self.device().fns();
-        (fns.v1_0.cmd_update_buffer)(
-            self.handle(),
-            dst_buffer.buffer().handle(),
-            dst_buffer.offset(),
-            size_of_val(data) as DeviceSize,
-            <*const _>::cast(data),
-        );
+        unsafe {
+            (fns.v1_0.cmd_update_buffer)(
+                self.handle(),
+                dst_buffer.buffer().handle(),
+                dst_buffer.offset(),
+                size_of_val(data) as DeviceSize,
+                <*const _>::cast(data),
+            )
+        };
 
         self
     }

--- a/vulkano/src/command_buffer/commands/debug.rs
+++ b/vulkano/src/command_buffer/commands/debug.rs
@@ -39,7 +39,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "begin_debug_utils_label",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.begin_debug_utils_label_unchecked(&label_info);
+                unsafe { out.begin_debug_utils_label_unchecked(&label_info) };
             },
         );
 
@@ -56,7 +56,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     pub unsafe fn end_debug_utils_label(&mut self) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_end_debug_utils_label()?;
 
-        Ok(self.end_debug_utils_label_unchecked())
+        Ok(unsafe { self.end_debug_utils_label_unchecked() })
     }
 
     fn validate_end_debug_utils_label(&self) -> Result<(), Box<ValidationError>> {
@@ -75,7 +75,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "end_debug_utils_label",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.end_debug_utils_label_unchecked();
+                unsafe { out.end_debug_utils_label_unchecked() };
             },
         );
 
@@ -110,7 +110,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "insert_debug_utils_label",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.insert_debug_utils_label_unchecked(&label_info);
+                unsafe { out.insert_debug_utils_label_unchecked(&label_info) };
             },
         );
 
@@ -126,7 +126,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_begin_debug_utils_label(label_info)?;
 
-        Ok(self.begin_debug_utils_label_unchecked(label_info))
+        Ok(unsafe { self.begin_debug_utils_label_unchecked(label_info) })
     }
 
     fn validate_begin_debug_utils_label(
@@ -173,7 +173,9 @@ impl RecordingCommandBuffer {
         let label_info_vk = label_info.to_vk(&label_info_fields1_vk);
 
         let fns = self.device().fns();
-        (fns.ext_debug_utils.cmd_begin_debug_utils_label_ext)(self.handle(), &label_info_vk);
+        unsafe {
+            (fns.ext_debug_utils.cmd_begin_debug_utils_label_ext)(self.handle(), &label_info_vk)
+        };
 
         self
     }
@@ -182,7 +184,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn end_debug_utils_label(&mut self) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_end_debug_utils_label()?;
 
-        Ok(self.end_debug_utils_label_unchecked())
+        Ok(unsafe { self.end_debug_utils_label_unchecked() })
     }
 
     fn validate_end_debug_utils_label(&self) -> Result<(), Box<ValidationError>> {
@@ -220,7 +222,7 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn end_debug_utils_label_unchecked(&mut self) -> &mut Self {
         let fns = self.device().fns();
-        (fns.ext_debug_utils.cmd_end_debug_utils_label_ext)(self.handle());
+        unsafe { (fns.ext_debug_utils.cmd_end_debug_utils_label_ext)(self.handle()) };
 
         self
     }
@@ -232,7 +234,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_insert_debug_utils_label(label_info)?;
 
-        Ok(self.insert_debug_utils_label_unchecked(label_info))
+        Ok(unsafe { self.insert_debug_utils_label_unchecked(label_info) })
     }
 
     fn validate_insert_debug_utils_label(
@@ -279,7 +281,9 @@ impl RecordingCommandBuffer {
         let label_info_vk = label_info.to_vk(&label_info_fields1_vk);
 
         let fns = self.device().fns();
-        (fns.ext_debug_utils.cmd_insert_debug_utils_label_ext)(self.handle(), &label_info_vk);
+        unsafe {
+            (fns.ext_debug_utils.cmd_insert_debug_utils_label_ext)(self.handle(), &label_info_vk)
+        };
 
         self
     }

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -75,7 +75,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_blend_constants",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_blend_constants_unchecked(constants);
+                unsafe { out.set_blend_constants_unchecked(constants) };
             },
         );
 
@@ -132,7 +132,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_color_write_enable",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_color_write_enable_unchecked(&enables);
+                unsafe { out.set_color_write_enable_unchecked(&enables) };
             },
         );
 
@@ -164,7 +164,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_cull_mode",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_cull_mode_unchecked(cull_mode);
+                unsafe { out.set_cull_mode_unchecked(cull_mode) };
             },
         );
 
@@ -213,7 +213,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_depth_bias",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_depth_bias_unchecked(constant_factor, clamp, slope_factor);
+                unsafe { out.set_depth_bias_unchecked(constant_factor, clamp, slope_factor) };
             },
         );
 
@@ -245,7 +245,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_depth_bias_enable",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_depth_bias_enable_unchecked(enable);
+                unsafe { out.set_depth_bias_enable_unchecked(enable) };
             },
         );
 
@@ -280,7 +280,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_depth_bounds",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_depth_bounds_unchecked(bounds.clone());
+                unsafe { out.set_depth_bounds_unchecked(bounds.clone()) };
             },
         );
 
@@ -315,7 +315,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_depth_bounds_test_enable",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_depth_bounds_test_enable_unchecked(enable);
+                unsafe { out.set_depth_bounds_test_enable_unchecked(enable) };
             },
         );
 
@@ -350,7 +350,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_depth_compare_op",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_depth_compare_op_unchecked(compare_op);
+                unsafe { out.set_depth_compare_op_unchecked(compare_op) };
             },
         );
 
@@ -382,7 +382,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_depth_test_enable",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_depth_test_enable_unchecked(enable);
+                unsafe { out.set_depth_test_enable_unchecked(enable) };
             },
         );
 
@@ -414,7 +414,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_depth_write_enable",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_depth_write_enable_unchecked(enable);
+                unsafe { out.set_depth_write_enable_unchecked(enable) };
             },
         );
 
@@ -460,7 +460,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_discard_rectangle",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_discard_rectangle_unchecked(first_rectangle, &rectangles);
+                unsafe { out.set_discard_rectangle_unchecked(first_rectangle, &rectangles) };
             },
         );
 
@@ -489,7 +489,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_front_face",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_front_face_unchecked(face);
+                unsafe { out.set_front_face_unchecked(face) };
             },
         );
 
@@ -526,7 +526,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_line_stipple",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_line_stipple_unchecked(factor, pattern);
+                unsafe { out.set_line_stipple_unchecked(factor, pattern) };
             },
         );
 
@@ -555,7 +555,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_line_width",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_line_width_unchecked(line_width);
+                unsafe { out.set_line_width_unchecked(line_width) };
             },
         );
 
@@ -584,7 +584,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_logic_op",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_logic_op_unchecked(logic_op);
+                unsafe { out.set_logic_op_unchecked(logic_op) };
             },
         );
 
@@ -616,7 +616,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_patch_control_points",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_patch_control_points_unchecked(num);
+                unsafe { out.set_patch_control_points_unchecked(num) };
             },
         );
 
@@ -651,7 +651,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_primitive_restart_enable",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_primitive_restart_enable_unchecked(enable);
+                unsafe { out.set_primitive_restart_enable_unchecked(enable) };
             },
         );
 
@@ -689,7 +689,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_primitive_topology",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_primitive_topology_unchecked(topology);
+                unsafe { out.set_primitive_topology_unchecked(topology) };
             },
         );
 
@@ -724,7 +724,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_rasterizer_discard_enable",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_rasterizer_discard_enable_unchecked(enable);
+                unsafe { out.set_rasterizer_discard_enable_unchecked(enable) };
             },
         );
 
@@ -771,7 +771,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_scissor",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_scissor_unchecked(first_scissor, &scissors);
+                unsafe { out.set_scissor_unchecked(first_scissor, &scissors) };
             },
         );
 
@@ -809,7 +809,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_scissor_with_count",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_scissor_with_count_unchecked(&scissors);
+                unsafe { out.set_scissor_with_count_unchecked(&scissors) };
             },
         );
 
@@ -860,7 +860,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_stencil_compare_mask",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_stencil_compare_mask_unchecked(faces, compare_mask);
+                unsafe { out.set_stencil_compare_mask_unchecked(faces, compare_mask) };
             },
         );
 
@@ -932,7 +932,9 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_stencil_op",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_stencil_op_unchecked(faces, fail_op, pass_op, depth_fail_op, compare_op);
+                unsafe {
+                    out.set_stencil_op_unchecked(faces, fail_op, pass_op, depth_fail_op, compare_op)
+                };
             },
         );
 
@@ -983,7 +985,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_stencil_reference",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_stencil_reference_unchecked(faces, reference);
+                unsafe { out.set_stencil_reference_unchecked(faces, reference) };
             },
         );
 
@@ -1015,7 +1017,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_stencil_test_enable",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_stencil_test_enable_unchecked(enable);
+                unsafe { out.set_stencil_test_enable_unchecked(enable) };
             },
         );
 
@@ -1066,7 +1068,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_stencil_write_mask",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_stencil_write_mask_unchecked(faces, write_mask);
+                unsafe { out.set_stencil_write_mask_unchecked(faces, write_mask) };
             },
         );
 
@@ -1106,7 +1108,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_vertex_input",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_vertex_input_unchecked(&vertex_input_state);
+                unsafe { out.set_vertex_input_unchecked(&vertex_input_state) };
             },
         );
 
@@ -1152,7 +1154,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_viewport",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_viewport_unchecked(first_viewport, &viewports);
+                unsafe { out.set_viewport_unchecked(first_viewport, &viewports) };
             },
         );
 
@@ -1190,7 +1192,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_viewport",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_viewport_with_count_unchecked(&viewports);
+                unsafe { out.set_viewport_with_count_unchecked(&viewports) };
             },
         );
 
@@ -1229,7 +1231,11 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_conservative_rasterization_mode",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_conservative_rasterization_mode_unchecked(conservative_rasterization_mode);
+                unsafe {
+                    out.set_conservative_rasterization_mode_unchecked(
+                        conservative_rasterization_mode,
+                    )
+                };
             },
         );
 
@@ -1273,9 +1279,11 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_extra_primitive_overestimation_size",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_extra_primitive_overestimation_size_unchecked(
-                    extra_primitive_overestimation_size,
-                );
+                unsafe {
+                    out.set_extra_primitive_overestimation_size_unchecked(
+                        extra_primitive_overestimation_size,
+                    )
+                };
             },
         );
 
@@ -1323,7 +1331,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "set_fragment_shading_rate",
             Default::default(),
             move |out: &mut RecordingCommandBuffer| {
-                out.set_fragment_shading_rate_unchecked(fragment_size, combiner_ops);
+                unsafe { out.set_fragment_shading_rate_unchecked(fragment_size, combiner_ops) };
             },
         );
 
@@ -1339,7 +1347,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_blend_constants(constants)?;
 
-        Ok(self.set_blend_constants_unchecked(constants))
+        Ok(unsafe { self.set_blend_constants_unchecked(constants) })
     }
 
     fn validate_set_blend_constants(
@@ -1366,7 +1374,7 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn set_blend_constants_unchecked(&mut self, constants: [f32; 4]) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_blend_constants)(self.handle(), &constants);
+        unsafe { (fns.v1_0.cmd_set_blend_constants)(self.handle(), &constants) };
 
         self
     }
@@ -1378,7 +1386,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_color_write_enable(enables)?;
 
-        Ok(self.set_color_write_enable_unchecked(enables))
+        Ok(unsafe { self.set_color_write_enable_unchecked(enables) })
     }
 
     fn validate_set_color_write_enable(
@@ -1425,11 +1433,13 @@ impl RecordingCommandBuffer {
         }
 
         let fns = self.device().fns();
-        (fns.ext_color_write_enable.cmd_set_color_write_enable_ext)(
-            self.handle(),
-            enables_vk.len() as u32,
-            enables_vk.as_ptr(),
-        );
+        unsafe {
+            (fns.ext_color_write_enable.cmd_set_color_write_enable_ext)(
+                self.handle(),
+                enables_vk.len() as u32,
+                enables_vk.as_ptr(),
+            )
+        };
 
         self
     }
@@ -1441,7 +1451,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_cull_mode(cull_mode)?;
 
-        Ok(self.set_cull_mode_unchecked(cull_mode))
+        Ok(unsafe { self.set_cull_mode_unchecked(cull_mode) })
     }
 
     fn validate_set_cull_mode(&self, cull_mode: CullMode) -> Result<(), Box<ValidationError>> {
@@ -1485,9 +1495,14 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_cull_mode)(self.handle(), cull_mode.into());
+            unsafe { (fns.v1_3.cmd_set_cull_mode)(self.handle(), cull_mode.into()) };
         } else {
-            (fns.ext_extended_dynamic_state.cmd_set_cull_mode_ext)(self.handle(), cull_mode.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state.cmd_set_cull_mode_ext)(
+                    self.handle(),
+                    cull_mode.into(),
+                )
+            };
         }
 
         self
@@ -1502,7 +1517,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_bias(constant_factor, clamp, slope_factor)?;
 
-        Ok(self.set_depth_bias_unchecked(constant_factor, clamp, slope_factor))
+        Ok(unsafe { self.set_depth_bias_unchecked(constant_factor, clamp, slope_factor) })
     }
 
     fn validate_set_depth_bias(
@@ -1547,7 +1562,9 @@ impl RecordingCommandBuffer {
         slope_factor: f32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_depth_bias)(self.handle(), constant_factor, clamp, slope_factor);
+        unsafe {
+            (fns.v1_0.cmd_set_depth_bias)(self.handle(), constant_factor, clamp, slope_factor)
+        };
 
         self
     }
@@ -1559,7 +1576,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_bias_enable(enable)?;
 
-        Ok(self.set_depth_bias_enable_unchecked(enable))
+        Ok(unsafe { self.set_depth_bias_enable_unchecked(enable) })
     }
 
     fn validate_set_depth_bias_enable(&self, _enable: bool) -> Result<(), Box<ValidationError>> {
@@ -1598,10 +1615,12 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_depth_bias_enable)(self.handle(), enable.into());
+            unsafe { (fns.v1_3.cmd_set_depth_bias_enable)(self.handle(), enable.into()) };
         } else {
-            (fns.ext_extended_dynamic_state2
-                .cmd_set_depth_bias_enable_ext)(self.handle(), enable.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state2
+                    .cmd_set_depth_bias_enable_ext)(self.handle(), enable.into())
+            };
         }
 
         self
@@ -1614,7 +1633,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_bounds(bounds.clone())?;
 
-        Ok(self.set_depth_bounds_unchecked(bounds))
+        Ok(unsafe { self.set_depth_bounds_unchecked(bounds) })
     }
 
     fn validate_set_depth_bounds(
@@ -1669,7 +1688,7 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn set_depth_bounds_unchecked(&mut self, bounds: RangeInclusive<f32>) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_depth_bounds)(self.handle(), *bounds.start(), *bounds.end());
+        unsafe { (fns.v1_0.cmd_set_depth_bounds)(self.handle(), *bounds.start(), *bounds.end()) };
 
         self
     }
@@ -1681,7 +1700,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_bounds_test_enable(enable)?;
 
-        Ok(self.set_depth_bounds_test_enable_unchecked(enable))
+        Ok(unsafe { self.set_depth_bounds_test_enable_unchecked(enable) })
     }
 
     fn validate_set_depth_bounds_test_enable(
@@ -1723,10 +1742,14 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_depth_bounds_test_enable)(self.handle(), enable.into());
+            unsafe { (fns.v1_3.cmd_set_depth_bounds_test_enable)(self.handle(), enable.into()) };
         } else {
-            (fns.ext_extended_dynamic_state
-                .cmd_set_depth_bounds_test_enable_ext)(self.handle(), enable.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state
+                    .cmd_set_depth_bounds_test_enable_ext)(
+                    self.handle(), enable.into()
+                )
+            };
         }
 
         self
@@ -1739,7 +1762,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_compare_op(compare_op)?;
 
-        Ok(self.set_depth_compare_op_unchecked(compare_op))
+        Ok(unsafe { self.set_depth_compare_op_unchecked(compare_op) })
     }
 
     fn validate_set_depth_compare_op(
@@ -1786,12 +1809,14 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_depth_compare_op)(self.handle(), compare_op.into());
+            unsafe { (fns.v1_3.cmd_set_depth_compare_op)(self.handle(), compare_op.into()) };
         } else {
-            (fns.ext_extended_dynamic_state.cmd_set_depth_compare_op_ext)(
-                self.handle(),
-                compare_op.into(),
-            );
+            unsafe {
+                (fns.ext_extended_dynamic_state.cmd_set_depth_compare_op_ext)(
+                    self.handle(),
+                    compare_op.into(),
+                )
+            };
         }
 
         self
@@ -1804,7 +1829,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_test_enable(enable)?;
 
-        Ok(self.set_depth_test_enable_unchecked(enable))
+        Ok(unsafe { self.set_depth_test_enable_unchecked(enable) })
     }
 
     fn validate_set_depth_test_enable(&self, _enable: bool) -> Result<(), Box<ValidationError>> {
@@ -1843,12 +1868,14 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_depth_test_enable)(self.handle(), enable.into());
+            unsafe { (fns.v1_3.cmd_set_depth_test_enable)(self.handle(), enable.into()) };
         } else {
-            (fns.ext_extended_dynamic_state.cmd_set_depth_test_enable_ext)(
-                self.handle(),
-                enable.into(),
-            );
+            unsafe {
+                (fns.ext_extended_dynamic_state.cmd_set_depth_test_enable_ext)(
+                    self.handle(),
+                    enable.into(),
+                )
+            };
         }
 
         self
@@ -1861,7 +1888,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_depth_write_enable(enable)?;
 
-        Ok(self.set_depth_write_enable_unchecked(enable))
+        Ok(unsafe { self.set_depth_write_enable_unchecked(enable) })
     }
 
     fn validate_set_depth_write_enable(&self, _enable: bool) -> Result<(), Box<ValidationError>> {
@@ -1900,10 +1927,12 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_depth_write_enable)(self.handle(), enable.into());
+            unsafe { (fns.v1_3.cmd_set_depth_write_enable)(self.handle(), enable.into()) };
         } else {
-            (fns.ext_extended_dynamic_state
-                .cmd_set_depth_write_enable_ext)(self.handle(), enable.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state
+                    .cmd_set_depth_write_enable_ext)(self.handle(), enable.into())
+            };
         }
 
         self
@@ -1917,7 +1946,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_discard_rectangle(first_rectangle, rectangles)?;
 
-        Ok(self.set_discard_rectangle_unchecked(first_rectangle, rectangles))
+        Ok(unsafe { self.set_discard_rectangle_unchecked(first_rectangle, rectangles) })
     }
 
     fn validate_set_discard_rectangle(
@@ -1978,12 +2007,14 @@ impl RecordingCommandBuffer {
         }
 
         let fns = self.device().fns();
-        (fns.ext_discard_rectangles.cmd_set_discard_rectangle_ext)(
-            self.handle(),
-            first_rectangle,
-            rectangles.len() as u32,
-            rectangles.as_ptr(),
-        );
+        unsafe {
+            (fns.ext_discard_rectangles.cmd_set_discard_rectangle_ext)(
+                self.handle(),
+                first_rectangle,
+                rectangles.len() as u32,
+                rectangles.as_ptr(),
+            )
+        };
 
         self
     }
@@ -1995,7 +2026,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_front_face(face)?;
 
-        Ok(self.set_front_face_unchecked(face))
+        Ok(unsafe { self.set_front_face_unchecked(face) })
     }
 
     fn validate_set_front_face(&self, face: FrontFace) -> Result<(), Box<ValidationError>> {
@@ -2039,9 +2070,11 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_front_face)(self.handle(), face.into());
+            unsafe { (fns.v1_3.cmd_set_front_face)(self.handle(), face.into()) };
         } else {
-            (fns.ext_extended_dynamic_state.cmd_set_front_face_ext)(self.handle(), face.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state.cmd_set_front_face_ext)(self.handle(), face.into())
+            };
         }
 
         self
@@ -2055,7 +2088,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_line_stipple(factor, pattern)?;
 
-        Ok(self.set_line_stipple_unchecked(factor, pattern))
+        Ok(unsafe { self.set_line_stipple_unchecked(factor, pattern) })
     }
 
     fn validate_set_line_stipple(
@@ -2101,7 +2134,9 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn set_line_stipple_unchecked(&mut self, factor: u32, pattern: u16) -> &mut Self {
         let fns = self.device().fns();
-        (fns.ext_line_rasterization.cmd_set_line_stipple_ext)(self.handle(), factor, pattern);
+        unsafe {
+            (fns.ext_line_rasterization.cmd_set_line_stipple_ext)(self.handle(), factor, pattern)
+        };
 
         self
     }
@@ -2113,7 +2148,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_line_width(line_width)?;
 
-        Ok(self.set_line_width_unchecked(line_width))
+        Ok(unsafe { self.set_line_width_unchecked(line_width) })
     }
 
     fn validate_set_line_width(&self, line_width: f32) -> Result<(), Box<ValidationError>> {
@@ -2148,7 +2183,7 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn set_line_width_unchecked(&mut self, line_width: f32) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_line_width)(self.handle(), line_width);
+        unsafe { (fns.v1_0.cmd_set_line_width)(self.handle(), line_width) };
 
         self
     }
@@ -2160,7 +2195,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_logic_op(logic_op)?;
 
-        Ok(self.set_logic_op_unchecked(logic_op))
+        Ok(unsafe { self.set_logic_op_unchecked(logic_op) })
     }
 
     fn validate_set_logic_op(&self, logic_op: LogicOp) -> Result<(), Box<ValidationError>> {
@@ -2203,7 +2238,9 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn set_logic_op_unchecked(&mut self, logic_op: LogicOp) -> &mut Self {
         let fns = self.device().fns();
-        (fns.ext_extended_dynamic_state2.cmd_set_logic_op_ext)(self.handle(), logic_op.into());
+        unsafe {
+            (fns.ext_extended_dynamic_state2.cmd_set_logic_op_ext)(self.handle(), logic_op.into())
+        };
 
         self
     }
@@ -2215,7 +2252,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_patch_control_points(num)?;
 
-        Ok(self.set_patch_control_points_unchecked(num))
+        Ok(unsafe { self.set_patch_control_points_unchecked(num) })
     }
 
     fn validate_set_patch_control_points(&self, num: u32) -> Result<(), Box<ValidationError>> {
@@ -2273,8 +2310,10 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn set_patch_control_points_unchecked(&mut self, num: u32) -> &mut Self {
         let fns = self.device().fns();
-        (fns.ext_extended_dynamic_state2
-            .cmd_set_patch_control_points_ext)(self.handle(), num);
+        unsafe {
+            (fns.ext_extended_dynamic_state2
+                .cmd_set_patch_control_points_ext)(self.handle(), num)
+        };
 
         self
     }
@@ -2286,7 +2325,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_primitive_restart_enable(enable)?;
 
-        Ok(self.set_primitive_restart_enable_unchecked(enable))
+        Ok(unsafe { self.set_primitive_restart_enable_unchecked(enable) })
     }
 
     fn validate_set_primitive_restart_enable(
@@ -2328,10 +2367,14 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_primitive_restart_enable)(self.handle(), enable.into());
+            unsafe { (fns.v1_3.cmd_set_primitive_restart_enable)(self.handle(), enable.into()) };
         } else {
-            (fns.ext_extended_dynamic_state2
-                .cmd_set_primitive_restart_enable_ext)(self.handle(), enable.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state2
+                    .cmd_set_primitive_restart_enable_ext)(
+                    self.handle(), enable.into()
+                )
+            };
         }
 
         self
@@ -2344,7 +2387,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_primitive_topology(topology)?;
 
-        Ok(self.set_primitive_topology_unchecked(topology))
+        Ok(unsafe { self.set_primitive_topology_unchecked(topology) })
     }
 
     fn validate_set_primitive_topology(
@@ -2441,10 +2484,12 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_primitive_topology)(self.handle(), topology.into());
+            unsafe { (fns.v1_3.cmd_set_primitive_topology)(self.handle(), topology.into()) };
         } else {
-            (fns.ext_extended_dynamic_state
-                .cmd_set_primitive_topology_ext)(self.handle(), topology.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state
+                    .cmd_set_primitive_topology_ext)(self.handle(), topology.into())
+            };
         }
 
         self
@@ -2457,7 +2502,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_rasterizer_discard_enable(enable)?;
 
-        Ok(self.set_rasterizer_discard_enable_unchecked(enable))
+        Ok(unsafe { self.set_rasterizer_discard_enable_unchecked(enable) })
     }
 
     fn validate_set_rasterizer_discard_enable(
@@ -2499,10 +2544,14 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_rasterizer_discard_enable)(self.handle(), enable.into());
+            unsafe { (fns.v1_3.cmd_set_rasterizer_discard_enable)(self.handle(), enable.into()) };
         } else {
-            (fns.ext_extended_dynamic_state2
-                .cmd_set_rasterizer_discard_enable_ext)(self.handle(), enable.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state2
+                    .cmd_set_rasterizer_discard_enable_ext)(
+                    self.handle(), enable.into()
+                )
+            };
         }
 
         self
@@ -2516,7 +2565,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_scissor(first_scissor, scissors)?;
 
-        Ok(self.set_scissor_unchecked(first_scissor, scissors))
+        Ok(unsafe { self.set_scissor_unchecked(first_scissor, scissors) })
     }
 
     fn validate_set_scissor(
@@ -2591,12 +2640,14 @@ impl RecordingCommandBuffer {
         }
 
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_scissor)(
-            self.handle(),
-            first_scissor,
-            scissors.len() as u32,
-            scissors.as_ptr(),
-        );
+        unsafe {
+            (fns.v1_0.cmd_set_scissor)(
+                self.handle(),
+                first_scissor,
+                scissors.len() as u32,
+                scissors.as_ptr(),
+            )
+        };
 
         self
     }
@@ -2608,7 +2659,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_scissor_with_count(scissors)?;
 
-        Ok(self.set_scissor_with_count_unchecked(scissors))
+        Ok(unsafe { self.set_scissor_with_count_unchecked(scissors) })
     }
 
     fn validate_set_scissor_with_count(
@@ -2679,18 +2730,22 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_scissor_with_count)(
-                self.handle(),
-                scissors.len() as u32,
-                scissors.as_ptr(),
-            );
+            unsafe {
+                (fns.v1_3.cmd_set_scissor_with_count)(
+                    self.handle(),
+                    scissors.len() as u32,
+                    scissors.as_ptr(),
+                )
+            };
         } else {
-            (fns.ext_extended_dynamic_state
-                .cmd_set_scissor_with_count_ext)(
-                self.handle(),
-                scissors.len() as u32,
-                scissors.as_ptr(),
-            );
+            unsafe {
+                (fns.ext_extended_dynamic_state
+                    .cmd_set_scissor_with_count_ext)(
+                    self.handle(),
+                    scissors.len() as u32,
+                    scissors.as_ptr(),
+                )
+            };
         }
 
         self
@@ -2704,7 +2759,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_compare_mask(faces, compare_mask)?;
 
-        Ok(self.set_stencil_compare_mask_unchecked(faces, compare_mask))
+        Ok(unsafe { self.set_stencil_compare_mask_unchecked(faces, compare_mask) })
     }
 
     fn validate_set_stencil_compare_mask(
@@ -2741,7 +2796,9 @@ impl RecordingCommandBuffer {
         compare_mask: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_stencil_compare_mask)(self.handle(), faces.into(), compare_mask);
+        unsafe {
+            (fns.v1_0.cmd_set_stencil_compare_mask)(self.handle(), faces.into(), compare_mask)
+        };
 
         self
     }
@@ -2757,7 +2814,9 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_op(faces, fail_op, pass_op, depth_fail_op, compare_op)?;
 
-        Ok(self.set_stencil_op_unchecked(faces, fail_op, pass_op, depth_fail_op, compare_op))
+        Ok(unsafe {
+            self.set_stencil_op_unchecked(faces, fail_op, pass_op, depth_fail_op, compare_op)
+        })
     }
 
     fn validate_set_stencil_op(
@@ -2837,23 +2896,27 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_stencil_op)(
-                self.handle(),
-                faces.into(),
-                fail_op.into(),
-                pass_op.into(),
-                depth_fail_op.into(),
-                compare_op.into(),
-            );
+            unsafe {
+                (fns.v1_3.cmd_set_stencil_op)(
+                    self.handle(),
+                    faces.into(),
+                    fail_op.into(),
+                    pass_op.into(),
+                    depth_fail_op.into(),
+                    compare_op.into(),
+                )
+            };
         } else {
-            (fns.ext_extended_dynamic_state.cmd_set_stencil_op_ext)(
-                self.handle(),
-                faces.into(),
-                fail_op.into(),
-                pass_op.into(),
-                depth_fail_op.into(),
-                compare_op.into(),
-            );
+            unsafe {
+                (fns.ext_extended_dynamic_state.cmd_set_stencil_op_ext)(
+                    self.handle(),
+                    faces.into(),
+                    fail_op.into(),
+                    pass_op.into(),
+                    depth_fail_op.into(),
+                    compare_op.into(),
+                )
+            };
         }
 
         self
@@ -2867,7 +2930,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_reference(faces, reference)?;
 
-        Ok(self.set_stencil_reference_unchecked(faces, reference))
+        Ok(unsafe { self.set_stencil_reference_unchecked(faces, reference) })
     }
 
     fn validate_set_stencil_reference(
@@ -2904,7 +2967,7 @@ impl RecordingCommandBuffer {
         reference: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_stencil_reference)(self.handle(), faces.into(), reference);
+        unsafe { (fns.v1_0.cmd_set_stencil_reference)(self.handle(), faces.into(), reference) };
 
         self
     }
@@ -2916,7 +2979,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_test_enable(enable)?;
 
-        Ok(self.set_stencil_test_enable_unchecked(enable))
+        Ok(unsafe { self.set_stencil_test_enable_unchecked(enable) })
     }
 
     fn validate_set_stencil_test_enable(&self, _enable: bool) -> Result<(), Box<ValidationError>> {
@@ -2955,10 +3018,12 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_stencil_test_enable)(self.handle(), enable.into());
+            unsafe { (fns.v1_3.cmd_set_stencil_test_enable)(self.handle(), enable.into()) };
         } else {
-            (fns.ext_extended_dynamic_state
-                .cmd_set_stencil_test_enable_ext)(self.handle(), enable.into());
+            unsafe {
+                (fns.ext_extended_dynamic_state
+                    .cmd_set_stencil_test_enable_ext)(self.handle(), enable.into())
+            };
         }
 
         self
@@ -2972,7 +3037,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_stencil_write_mask(faces, write_mask)?;
 
-        Ok(self.set_stencil_write_mask_unchecked(faces, write_mask))
+        Ok(unsafe { self.set_stencil_write_mask_unchecked(faces, write_mask) })
     }
 
     fn validate_set_stencil_write_mask(
@@ -3009,7 +3074,7 @@ impl RecordingCommandBuffer {
         write_mask: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_stencil_write_mask)(self.handle(), faces.into(), write_mask);
+        unsafe { (fns.v1_0.cmd_set_stencil_write_mask)(self.handle(), faces.into(), write_mask) };
 
         self
     }
@@ -3021,7 +3086,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_vertex_input(vertex_input_state)?;
 
-        Ok(self.set_vertex_input_unchecked(vertex_input_state))
+        Ok(unsafe { self.set_vertex_input_unchecked(vertex_input_state) })
     }
 
     fn validate_set_vertex_input(
@@ -3089,13 +3154,15 @@ impl RecordingCommandBuffer {
         );
 
         let fns = self.device().fns();
-        (fns.ext_vertex_input_dynamic_state.cmd_set_vertex_input_ext)(
-            self.handle(),
-            vertex_binding_descriptions_vk.len() as u32,
-            vertex_binding_descriptions_vk.as_ptr(),
-            vertex_attribute_descriptions_vk.len() as u32,
-            vertex_attribute_descriptions_vk.as_ptr(),
-        );
+        unsafe {
+            (fns.ext_vertex_input_dynamic_state.cmd_set_vertex_input_ext)(
+                self.handle(),
+                vertex_binding_descriptions_vk.len() as u32,
+                vertex_binding_descriptions_vk.as_ptr(),
+                vertex_attribute_descriptions_vk.len() as u32,
+                vertex_attribute_descriptions_vk.as_ptr(),
+            )
+        };
 
         self
     }
@@ -3108,7 +3175,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_viewport(first_viewport, viewports)?;
 
-        Ok(self.set_viewport_unchecked(first_viewport, viewports))
+        Ok(unsafe { self.set_viewport_unchecked(first_viewport, viewports) })
     }
 
     fn validate_set_viewport(
@@ -3183,12 +3250,14 @@ impl RecordingCommandBuffer {
         }
 
         let fns = self.device().fns();
-        (fns.v1_0.cmd_set_viewport)(
-            self.handle(),
-            first_viewport,
-            viewports.len() as u32,
-            viewports.as_ptr(),
-        );
+        unsafe {
+            (fns.v1_0.cmd_set_viewport)(
+                self.handle(),
+                first_viewport,
+                viewports.len() as u32,
+                viewports.as_ptr(),
+            )
+        };
 
         self
     }
@@ -3200,7 +3269,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_viewport_with_count(viewports)?;
 
-        Ok(self.set_viewport_with_count_unchecked(viewports))
+        Ok(unsafe { self.set_viewport_with_count_unchecked(viewports) })
     }
 
     fn validate_set_viewport_with_count(
@@ -3274,18 +3343,22 @@ impl RecordingCommandBuffer {
         let fns = self.device().fns();
 
         if self.device().api_version() >= Version::V1_3 {
-            (fns.v1_3.cmd_set_viewport_with_count)(
-                self.handle(),
-                viewports.len() as u32,
-                viewports.as_ptr(),
-            );
+            unsafe {
+                (fns.v1_3.cmd_set_viewport_with_count)(
+                    self.handle(),
+                    viewports.len() as u32,
+                    viewports.as_ptr(),
+                )
+            };
         } else {
-            (fns.ext_extended_dynamic_state
-                .cmd_set_viewport_with_count_ext)(
-                self.handle(),
-                viewports.len() as u32,
-                viewports.as_ptr(),
-            );
+            unsafe {
+                (fns.ext_extended_dynamic_state
+                    .cmd_set_viewport_with_count_ext)(
+                    self.handle(),
+                    viewports.len() as u32,
+                    viewports.as_ptr(),
+                )
+            };
         }
 
         self
@@ -3298,7 +3371,9 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_conservative_rasterization_mode()?;
 
-        Ok(self.set_conservative_rasterization_mode_unchecked(conservative_rasterization_mode))
+        Ok(unsafe {
+            self.set_conservative_rasterization_mode_unchecked(conservative_rasterization_mode)
+        })
     }
 
     fn validate_set_conservative_rasterization_mode(&self) -> Result<(), Box<ValidationError>> {
@@ -3342,11 +3417,13 @@ impl RecordingCommandBuffer {
         conservative_rasterization_mode: ConservativeRasterizationMode,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.ext_extended_dynamic_state3
-            .cmd_set_conservative_rasterization_mode_ext)(
-            self.handle(),
-            conservative_rasterization_mode.into(),
-        );
+        unsafe {
+            (fns.ext_extended_dynamic_state3
+                .cmd_set_conservative_rasterization_mode_ext)(
+                self.handle(),
+                conservative_rasterization_mode.into(),
+            )
+        };
 
         self
     }
@@ -3358,8 +3435,11 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_set_extra_primitive_overestimation_size(extra_primitive_overestimation_size)?;
 
-        Ok(self
-            .set_extra_primitive_overestimation_size_unchecked(extra_primitive_overestimation_size))
+        Ok(unsafe {
+            self.set_extra_primitive_overestimation_size_unchecked(
+                extra_primitive_overestimation_size,
+            )
+        })
     }
 
     fn validate_set_extra_primitive_overestimation_size(
@@ -3422,11 +3502,13 @@ impl RecordingCommandBuffer {
         extra_primitive_overestimation_size: f32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.ext_extended_dynamic_state3
-            .cmd_set_extra_primitive_overestimation_size_ext)(
-            self.handle(),
-            extra_primitive_overestimation_size,
-        );
+        unsafe {
+            (fns.ext_extended_dynamic_state3
+                .cmd_set_extra_primitive_overestimation_size_ext)(
+                self.handle(),
+                extra_primitive_overestimation_size,
+            )
+        };
 
         self
     }
@@ -3461,12 +3543,14 @@ impl RecordingCommandBuffer {
         let combiner_ops: [ash::vk::FragmentShadingRateCombinerOpKHR; 2] =
             [combiner_ops[0].into(), combiner_ops[1].into()];
 
-        (fns.khr_fragment_shading_rate
-            .cmd_set_fragment_shading_rate_khr)(
-            self.handle(),
-            &fragment_size,
-            combiner_ops.as_ptr().cast(),
-        );
+        unsafe {
+            (fns.khr_fragment_shading_rate
+                .cmd_set_fragment_shading_rate_khr)(
+                self.handle(),
+                &fragment_size,
+                combiner_ops.as_ptr().cast(),
+            )
+        };
 
         self
     }

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -119,7 +119,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "dispatch",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.dispatch_unchecked(group_counts);
+                unsafe { out.dispatch_unchecked(group_counts) };
             },
         );
 
@@ -201,7 +201,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "dispatch",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.dispatch_indirect_unchecked(&indirect_buffer);
+                unsafe { out.dispatch_indirect_unchecked(&indirect_buffer) };
             },
         );
 
@@ -388,7 +388,9 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_unchecked(vertex_count, instance_count, first_vertex, first_instance);
+                unsafe {
+                    out.draw_unchecked(vertex_count, instance_count, first_vertex, first_instance)
+                };
             },
         );
 
@@ -495,7 +497,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw_indirect",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_indirect_unchecked(&indirect_buffer, draw_count, stride);
+                unsafe { out.draw_indirect_unchecked(&indirect_buffer, draw_count, stride) };
             },
         );
 
@@ -625,12 +627,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw_indirect_count",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_indirect_count_unchecked(
-                    &indirect_buffer,
-                    &count_buffer,
-                    max_draw_count,
-                    stride,
-                );
+                unsafe {
+                    out.draw_indirect_count_unchecked(
+                        &indirect_buffer,
+                        &count_buffer,
+                        max_draw_count,
+                        stride,
+                    )
+                };
             },
         );
 
@@ -862,13 +866,15 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw_indexed",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_indexed_unchecked(
-                    index_count,
-                    instance_count,
-                    first_index,
-                    vertex_offset,
-                    first_instance,
-                );
+                unsafe {
+                    out.draw_indexed_unchecked(
+                        index_count,
+                        instance_count,
+                        first_index,
+                        vertex_offset,
+                        first_instance,
+                    )
+                };
             },
         );
 
@@ -991,7 +997,9 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw_indexed_indirect",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_indexed_indirect_unchecked(&indirect_buffer, draw_count, stride);
+                unsafe {
+                    out.draw_indexed_indirect_unchecked(&indirect_buffer, draw_count, stride)
+                };
             },
         );
 
@@ -1136,12 +1144,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw_indexed_indirect_count",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_indexed_indirect_count_unchecked(
-                    &indirect_buffer,
-                    &count_buffer,
-                    max_draw_count,
-                    stride,
-                );
+                unsafe {
+                    out.draw_indexed_indirect_count_unchecked(
+                        &indirect_buffer,
+                        &count_buffer,
+                        max_draw_count,
+                        stride,
+                    )
+                };
             },
         );
 
@@ -1328,7 +1338,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw_mesh_tasks",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_mesh_tasks_unchecked(group_counts);
+                unsafe { out.draw_mesh_tasks_unchecked(group_counts) };
             },
         );
 
@@ -1443,7 +1453,9 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw_mesh_tasks_indirect",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_mesh_tasks_indirect_unchecked(&indirect_buffer, draw_count, stride);
+                unsafe {
+                    out.draw_mesh_tasks_indirect_unchecked(&indirect_buffer, draw_count, stride)
+                };
             },
         );
 
@@ -1581,12 +1593,14 @@ impl<L> AutoCommandBufferBuilder<L> {
             "draw_mesh_tasks_indirect_count",
             used_resources,
             move |out: &mut RecordingCommandBuffer| {
-                out.draw_mesh_tasks_indirect_count_unchecked(
-                    &indirect_buffer,
-                    &count_buffer,
-                    max_draw_count,
-                    stride,
-                );
+                unsafe {
+                    out.draw_mesh_tasks_indirect_count_unchecked(
+                        &indirect_buffer,
+                        &count_buffer,
+                        max_draw_count,
+                        stride,
+                    )
+                };
             },
         );
 
@@ -1613,7 +1627,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         self.inner
             .validate_trace_rays(&shader_binding_table_addresses, dimensions)?;
 
-        Ok(self.trace_rays_unchecked(shader_binding_table_addresses, dimensions))
+        Ok(unsafe { self.trace_rays_unchecked(shader_binding_table_addresses, dimensions) })
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
@@ -1628,7 +1642,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         self.add_descriptor_sets_resources(&mut used_resources, pipeline);
 
         self.add_command("trace_rays", used_resources, move |out| {
-            out.trace_rays_unchecked(&shader_binding_table_addresses, dimensions);
+            unsafe { out.trace_rays_unchecked(&shader_binding_table_addresses, dimensions) };
         });
 
         self
@@ -3766,7 +3780,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_dispatch(group_counts)?;
 
-        Ok(self.dispatch_unchecked(group_counts))
+        Ok(unsafe { self.dispatch_unchecked(group_counts) })
     }
 
     fn validate_dispatch(&self, group_counts: [u32; 3]) -> Result<(), Box<ValidationError>> {
@@ -3819,12 +3833,14 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn dispatch_unchecked(&mut self, group_counts: [u32; 3]) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_dispatch)(
-            self.handle(),
-            group_counts[0],
-            group_counts[1],
-            group_counts[2],
-        );
+        unsafe {
+            (fns.v1_0.cmd_dispatch)(
+                self.handle(),
+                group_counts[0],
+                group_counts[1],
+                group_counts[2],
+            )
+        };
 
         self
     }
@@ -3836,7 +3852,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_dispatch_indirect(indirect_buffer.as_bytes())?;
 
-        Ok(self.dispatch_indirect_unchecked(indirect_buffer))
+        Ok(unsafe { self.dispatch_indirect_unchecked(indirect_buffer) })
     }
 
     fn validate_dispatch_indirect(
@@ -3895,11 +3911,13 @@ impl RecordingCommandBuffer {
         indirect_buffer: &Subbuffer<[DispatchIndirectCommand]>,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_dispatch_indirect)(
-            self.handle(),
-            indirect_buffer.buffer().handle(),
-            indirect_buffer.offset(),
-        );
+        unsafe {
+            (fns.v1_0.cmd_dispatch_indirect)(
+                self.handle(),
+                indirect_buffer.buffer().handle(),
+                indirect_buffer.offset(),
+            )
+        };
 
         self
     }
@@ -3914,7 +3932,9 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_draw(vertex_count, instance_count, first_vertex, first_instance)?;
 
-        Ok(self.draw_unchecked(vertex_count, instance_count, first_vertex, first_instance))
+        Ok(unsafe {
+            self.draw_unchecked(vertex_count, instance_count, first_vertex, first_instance)
+        })
     }
 
     fn validate_draw(
@@ -3950,13 +3970,15 @@ impl RecordingCommandBuffer {
         first_instance: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_draw)(
-            self.handle(),
-            vertex_count,
-            instance_count,
-            first_vertex,
-            first_instance,
-        );
+        unsafe {
+            (fns.v1_0.cmd_draw)(
+                self.handle(),
+                vertex_count,
+                instance_count,
+                first_vertex,
+                first_instance,
+            )
+        };
 
         self
     }
@@ -3970,7 +3992,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_draw_indirect(indirect_buffer.as_bytes(), draw_count, stride)?;
 
-        Ok(self.draw_indirect_unchecked(indirect_buffer, draw_count, stride))
+        Ok(unsafe { self.draw_indirect_unchecked(indirect_buffer, draw_count, stride) })
     }
 
     fn validate_draw_indirect(
@@ -4085,13 +4107,15 @@ impl RecordingCommandBuffer {
         stride: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_draw_indirect)(
-            self.handle(),
-            indirect_buffer.buffer().handle(),
-            indirect_buffer.offset(),
-            draw_count,
-            stride,
-        );
+        unsafe {
+            (fns.v1_0.cmd_draw_indirect)(
+                self.handle(),
+                indirect_buffer.buffer().handle(),
+                indirect_buffer.offset(),
+                draw_count,
+                stride,
+            )
+        };
 
         self
     }
@@ -4111,12 +4135,14 @@ impl RecordingCommandBuffer {
             stride,
         )?;
 
-        Ok(self.draw_indirect_count_unchecked(
-            indirect_buffer,
-            count_buffer,
-            max_draw_count,
-            stride,
-        ))
+        Ok(unsafe {
+            self.draw_indirect_count_unchecked(
+                indirect_buffer,
+                count_buffer,
+                max_draw_count,
+                stride,
+            )
+        })
     }
 
     fn validate_draw_indirect_count(
@@ -4224,36 +4250,42 @@ impl RecordingCommandBuffer {
         let fns = device.fns();
 
         if device.api_version() >= Version::V1_2 {
-            (fns.v1_2.cmd_draw_indirect_count)(
-                self.handle(),
-                indirect_buffer.buffer().handle(),
-                indirect_buffer.offset(),
-                count_buffer.buffer().handle(),
-                count_buffer.offset(),
-                max_draw_count,
-                stride,
-            );
+            unsafe {
+                (fns.v1_2.cmd_draw_indirect_count)(
+                    self.handle(),
+                    indirect_buffer.buffer().handle(),
+                    indirect_buffer.offset(),
+                    count_buffer.buffer().handle(),
+                    count_buffer.offset(),
+                    max_draw_count,
+                    stride,
+                )
+            };
         } else if device.enabled_extensions().khr_draw_indirect_count {
-            (fns.khr_draw_indirect_count.cmd_draw_indirect_count_khr)(
-                self.handle(),
-                indirect_buffer.buffer().handle(),
-                indirect_buffer.offset(),
-                count_buffer.buffer().handle(),
-                count_buffer.offset(),
-                max_draw_count,
-                stride,
-            );
+            unsafe {
+                (fns.khr_draw_indirect_count.cmd_draw_indirect_count_khr)(
+                    self.handle(),
+                    indirect_buffer.buffer().handle(),
+                    indirect_buffer.offset(),
+                    count_buffer.buffer().handle(),
+                    count_buffer.offset(),
+                    max_draw_count,
+                    stride,
+                )
+            };
         } else {
             debug_assert!(device.enabled_extensions().amd_draw_indirect_count);
-            (fns.amd_draw_indirect_count.cmd_draw_indirect_count_amd)(
-                self.handle(),
-                indirect_buffer.buffer().handle(),
-                indirect_buffer.offset(),
-                count_buffer.buffer().handle(),
-                count_buffer.offset(),
-                max_draw_count,
-                stride,
-            );
+            unsafe {
+                (fns.amd_draw_indirect_count.cmd_draw_indirect_count_amd)(
+                    self.handle(),
+                    indirect_buffer.buffer().handle(),
+                    indirect_buffer.offset(),
+                    count_buffer.buffer().handle(),
+                    count_buffer.offset(),
+                    max_draw_count,
+                    stride,
+                )
+            };
         }
 
         self
@@ -4276,13 +4308,15 @@ impl RecordingCommandBuffer {
             first_instance,
         )?;
 
-        Ok(self.draw_indexed_unchecked(
-            index_count,
-            instance_count,
-            first_index,
-            vertex_offset,
-            first_instance,
-        ))
+        Ok(unsafe {
+            self.draw_indexed_unchecked(
+                index_count,
+                instance_count,
+                first_index,
+                vertex_offset,
+                first_instance,
+            )
+        })
     }
 
     fn validate_draw_indexed(
@@ -4320,14 +4354,16 @@ impl RecordingCommandBuffer {
         first_instance: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_draw_indexed)(
-            self.handle(),
-            index_count,
-            instance_count,
-            first_index,
-            vertex_offset,
-            first_instance,
-        );
+        unsafe {
+            (fns.v1_0.cmd_draw_indexed)(
+                self.handle(),
+                index_count,
+                instance_count,
+                first_index,
+                vertex_offset,
+                first_instance,
+            )
+        };
 
         self
     }
@@ -4341,7 +4377,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_draw_indexed_indirect(indirect_buffer.as_bytes(), draw_count, stride)?;
 
-        Ok(self.draw_indexed_indirect_unchecked(indirect_buffer, draw_count, stride))
+        Ok(unsafe { self.draw_indexed_indirect_unchecked(indirect_buffer, draw_count, stride) })
     }
 
     fn validate_draw_indexed_indirect(
@@ -4456,13 +4492,15 @@ impl RecordingCommandBuffer {
         stride: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.v1_0.cmd_draw_indexed_indirect)(
-            self.handle(),
-            indirect_buffer.buffer().handle(),
-            indirect_buffer.offset(),
-            draw_count,
-            stride,
-        );
+        unsafe {
+            (fns.v1_0.cmd_draw_indexed_indirect)(
+                self.handle(),
+                indirect_buffer.buffer().handle(),
+                indirect_buffer.offset(),
+                draw_count,
+                stride,
+            )
+        };
 
         self
     }
@@ -4482,12 +4520,14 @@ impl RecordingCommandBuffer {
             stride,
         )?;
 
-        Ok(self.draw_indexed_indirect_count_unchecked(
-            indirect_buffer,
-            count_buffer,
-            max_draw_count,
-            stride,
-        ))
+        Ok(unsafe {
+            self.draw_indexed_indirect_count_unchecked(
+                indirect_buffer,
+                count_buffer,
+                max_draw_count,
+                stride,
+            )
+        })
     }
 
     fn validate_draw_indexed_indirect_count(
@@ -4595,38 +4635,44 @@ impl RecordingCommandBuffer {
         let fns = device.fns();
 
         if device.api_version() >= Version::V1_2 {
-            (fns.v1_2.cmd_draw_indexed_indirect_count)(
-                self.handle(),
-                indirect_buffer.buffer().handle(),
-                indirect_buffer.offset(),
-                count_buffer.buffer().handle(),
-                count_buffer.offset(),
-                max_draw_count,
-                stride,
-            );
+            unsafe {
+                (fns.v1_2.cmd_draw_indexed_indirect_count)(
+                    self.handle(),
+                    indirect_buffer.buffer().handle(),
+                    indirect_buffer.offset(),
+                    count_buffer.buffer().handle(),
+                    count_buffer.offset(),
+                    max_draw_count,
+                    stride,
+                )
+            };
         } else if device.enabled_extensions().khr_draw_indirect_count {
-            (fns.khr_draw_indirect_count
-                .cmd_draw_indexed_indirect_count_khr)(
-                self.handle(),
-                indirect_buffer.buffer().handle(),
-                indirect_buffer.offset(),
-                count_buffer.buffer().handle(),
-                count_buffer.offset(),
-                max_draw_count,
-                stride,
-            );
+            unsafe {
+                (fns.khr_draw_indirect_count
+                    .cmd_draw_indexed_indirect_count_khr)(
+                    self.handle(),
+                    indirect_buffer.buffer().handle(),
+                    indirect_buffer.offset(),
+                    count_buffer.buffer().handle(),
+                    count_buffer.offset(),
+                    max_draw_count,
+                    stride,
+                )
+            };
         } else {
             debug_assert!(device.enabled_extensions().amd_draw_indirect_count);
-            (fns.amd_draw_indirect_count
-                .cmd_draw_indexed_indirect_count_amd)(
-                self.handle(),
-                indirect_buffer.buffer().handle(),
-                indirect_buffer.offset(),
-                count_buffer.buffer().handle(),
-                count_buffer.offset(),
-                max_draw_count,
-                stride,
-            );
+            unsafe {
+                (fns.amd_draw_indirect_count
+                    .cmd_draw_indexed_indirect_count_amd)(
+                    self.handle(),
+                    indirect_buffer.buffer().handle(),
+                    indirect_buffer.offset(),
+                    count_buffer.buffer().handle(),
+                    count_buffer.offset(),
+                    max_draw_count,
+                    stride,
+                )
+            };
         }
 
         self
@@ -4639,7 +4685,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_draw_mesh_tasks(group_counts)?;
 
-        Ok(self.draw_mesh_tasks_unchecked(group_counts))
+        Ok(unsafe { self.draw_mesh_tasks_unchecked(group_counts) })
     }
 
     fn validate_draw_mesh_tasks(
@@ -4675,12 +4721,14 @@ impl RecordingCommandBuffer {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn draw_mesh_tasks_unchecked(&mut self, group_counts: [u32; 3]) -> &mut Self {
         let fns = self.device().fns();
-        (fns.ext_mesh_shader.cmd_draw_mesh_tasks_ext)(
-            self.handle(),
-            group_counts[0],
-            group_counts[1],
-            group_counts[2],
-        );
+        unsafe {
+            (fns.ext_mesh_shader.cmd_draw_mesh_tasks_ext)(
+                self.handle(),
+                group_counts[0],
+                group_counts[1],
+                group_counts[2],
+            )
+        };
 
         self
     }
@@ -4694,7 +4742,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_draw_mesh_tasks_indirect(indirect_buffer.as_bytes(), draw_count, stride)?;
 
-        Ok(self.draw_mesh_tasks_indirect_unchecked(indirect_buffer, draw_count, stride))
+        Ok(unsafe { self.draw_mesh_tasks_indirect_unchecked(indirect_buffer, draw_count, stride) })
     }
 
     fn validate_draw_mesh_tasks_indirect(
@@ -4831,13 +4879,15 @@ impl RecordingCommandBuffer {
         stride: u32,
     ) -> &mut Self {
         let fns = self.device().fns();
-        (fns.ext_mesh_shader.cmd_draw_mesh_tasks_indirect_ext)(
-            self.handle(),
-            indirect_buffer.buffer().handle(),
-            indirect_buffer.offset(),
-            draw_count,
-            stride,
-        );
+        unsafe {
+            (fns.ext_mesh_shader.cmd_draw_mesh_tasks_indirect_ext)(
+                self.handle(),
+                indirect_buffer.buffer().handle(),
+                indirect_buffer.offset(),
+                draw_count,
+                stride,
+            )
+        };
 
         self
     }
@@ -4857,12 +4907,14 @@ impl RecordingCommandBuffer {
             stride,
         )?;
 
-        Ok(self.draw_mesh_tasks_indirect_count_unchecked(
-            indirect_buffer,
-            count_buffer,
-            max_draw_count,
-            stride,
-        ))
+        Ok(unsafe {
+            self.draw_mesh_tasks_indirect_count_unchecked(
+                indirect_buffer,
+                count_buffer,
+                max_draw_count,
+                stride,
+            )
+        })
     }
 
     fn validate_draw_mesh_tasks_indirect_count(
@@ -4977,15 +5029,17 @@ impl RecordingCommandBuffer {
     ) -> &mut Self {
         let fns = self.device().fns();
 
-        (fns.ext_mesh_shader.cmd_draw_mesh_tasks_indirect_count_ext)(
-            self.handle(),
-            indirect_buffer.buffer().handle(),
-            indirect_buffer.offset(),
-            count_buffer.buffer().handle(),
-            count_buffer.offset(),
-            max_draw_count,
-            stride,
-        );
+        unsafe {
+            (fns.ext_mesh_shader.cmd_draw_mesh_tasks_indirect_count_ext)(
+                self.handle(),
+                indirect_buffer.buffer().handle(),
+                indirect_buffer.offset(),
+                count_buffer.buffer().handle(),
+                count_buffer.offset(),
+                max_draw_count,
+                stride,
+            )
+        };
 
         self
     }
@@ -4997,7 +5051,7 @@ impl RecordingCommandBuffer {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_trace_rays(shader_binding_table_addresses, dimensions)?;
 
-        Ok(self.trace_rays_unchecked(shader_binding_table_addresses, dimensions))
+        Ok(unsafe { self.trace_rays_unchecked(shader_binding_table_addresses, dimensions) })
     }
 
     fn validate_trace_rays(
@@ -5103,16 +5157,19 @@ impl RecordingCommandBuffer {
         let callable = shader_binding_table_addresses.callable.to_vk();
 
         let fns = self.device().fns();
-        (fns.khr_ray_tracing_pipeline.cmd_trace_rays_khr)(
-            self.handle(),
-            &raygen,
-            &miss,
-            &hit,
-            &callable,
-            dimensions[0],
-            dimensions[1],
-            dimensions[2],
-        );
+
+        unsafe {
+            (fns.khr_ray_tracing_pipeline.cmd_trace_rays_khr)(
+                self.handle(),
+                &raygen,
+                &miss,
+                &hit,
+                &callable,
+                dimensions[0],
+                dimensions[1],
+                dimensions[2],
+            )
+        };
 
         self
     }

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -86,7 +86,7 @@ impl RecordingCommandBuffer {
             let begin_info_vk = begin_info.to_vk(&begin_info_fields1_vk);
 
             let fns = allocation.inner.device().fns();
-            (fns.v1_0.begin_command_buffer)(allocation.inner.handle(), &begin_info_vk)
+            unsafe { (fns.v1_0.begin_command_buffer)(allocation.inner.handle(), &begin_info_vk) }
                 .result()
                 .map_err(VulkanError::from)?;
         }
@@ -110,7 +110,7 @@ impl RecordingCommandBuffer {
     #[inline]
     pub unsafe fn end(self) -> Result<CommandBuffer, VulkanError> {
         let fns = self.device().fns();
-        (fns.v1_0.end_command_buffer)(self.handle())
+        unsafe { (fns.v1_0.end_command_buffer)(self.handle()) }
             .result()
             .map_err(VulkanError::from)?;
 

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -217,7 +217,7 @@ where
     }
 
     unsafe fn unlock(&self) {
-        (**self).unlock();
+        unsafe { (**self).unlock() };
     }
 
     fn resources_usage(&self) -> &SecondaryCommandBufferResourcesUsage {
@@ -250,7 +250,7 @@ where
     // Implementation of `build_submission`. Doesn't check whenever the future was already flushed.
     // You must make sure to not submit same command buffer multiple times.
     unsafe fn build_submission_impl(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
-        Ok(match self.previous.build_submission()? {
+        Ok(match unsafe { self.previous.build_submission() }? {
             SubmitAnyBuilder::Empty => SubmitAnyBuilder::CommandBuffer(
                 SubmitInfo {
                     command_buffers: vec![CommandBufferSubmitInfo::new(
@@ -312,7 +312,7 @@ where
             return Ok(SubmitAnyBuilder::Empty);
         }
 
-        self.build_submission_impl()
+        unsafe { self.build_submission_impl() }
     }
 
     fn flush(&self) -> Result<(), Validated<VulkanError>> {
@@ -344,9 +344,9 @@ where
 
                 for (range, range_usage) in usage.ranges.iter() {
                     if range_usage.mutable {
-                        state.gpu_write_unlock(range.clone());
+                        unsafe { state.gpu_write_unlock(range.clone()) };
                     } else {
-                        state.gpu_read_unlock(range.clone());
+                        unsafe { state.gpu_read_unlock(range.clone()) };
                     }
                 }
             }
@@ -356,17 +356,17 @@ where
 
                 for (range, range_usage) in usage.ranges.iter() {
                     if range_usage.mutable {
-                        state.gpu_write_unlock(range.clone());
+                        unsafe { state.gpu_write_unlock(range.clone()) };
                     } else {
-                        state.gpu_read_unlock(range.clone());
+                        unsafe { state.gpu_read_unlock(range.clone()) };
                     }
                 }
             }
 
-            self.command_buffer.state().set_submit_finished();
+            unsafe { self.command_buffer.state().set_submit_finished() };
         }
 
-        self.previous.signal_finished();
+        unsafe { self.previous.signal_finished() };
     }
 
     fn queue_change_allowed(&self) -> bool {

--- a/vulkano/src/deferred.rs
+++ b/vulkano/src/deferred.rs
@@ -55,16 +55,20 @@ impl DeferredOperation {
         let handle = {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
-            (fns.khr_deferred_host_operations
-                .create_deferred_operation_khr)(
-                device.handle(), ptr::null(), output.as_mut_ptr()
-            )
+            unsafe {
+                (fns.khr_deferred_host_operations
+                    .create_deferred_operation_khr)(
+                    device.handle(),
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle))
+        Ok(unsafe { Self::from_handle(device, handle) })
     }
 
     /// Creates a new `DeferredOperation` from a raw object handle.

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -307,7 +307,7 @@ unsafe impl<T: DescriptorSetAllocator> DescriptorSetAllocator for Arc<T> {
 
     #[inline]
     unsafe fn deallocate(&self, allocation: DescriptorSetAlloc) {
-        (**self).deallocate(allocation)
+        unsafe { (**self).deallocate(allocation) }
     }
 }
 

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -92,18 +92,20 @@ impl DescriptorSetLayout {
         let handle = {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
-            (fns.v1_0.create_descriptor_set_layout)(
-                device.handle(),
-                &create_info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.v1_0.create_descriptor_set_layout)(
+                    device.handle(),
+                    &create_info_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `DescriptorSetLayout` from a raw object handle.

--- a/vulkano/src/descriptor_set/mod.rs
+++ b/vulkano/src/descriptor_set/mod.rs
@@ -227,12 +227,14 @@ impl DescriptorSet {
             return;
         }
 
-        Self::update_inner(
-            &self.inner,
-            self.resources.get_mut(),
-            &descriptor_writes,
-            &descriptor_copies,
-        );
+        unsafe {
+            Self::update_inner(
+                &self.inner,
+                self.resources.get_mut(),
+                &descriptor_writes,
+                &descriptor_copies,
+            )
+        };
     }
 
     /// Updates the descriptor set with new values.
@@ -254,12 +256,14 @@ impl DescriptorSet {
         self.inner
             .validate_update(&descriptor_writes, &descriptor_copies)?;
 
-        Self::update_inner(
-            &self.inner,
-            &mut self.resources.write(),
-            &descriptor_writes,
-            &descriptor_copies,
-        );
+        unsafe {
+            Self::update_inner(
+                &self.inner,
+                &mut self.resources.write(),
+                &descriptor_writes,
+                &descriptor_copies,
+            )
+        };
 
         Ok(())
     }
@@ -276,12 +280,14 @@ impl DescriptorSet {
             return;
         }
 
-        Self::update_inner(
-            &self.inner,
-            &mut self.resources.write(),
-            &descriptor_writes,
-            &descriptor_copies,
-        );
+        unsafe {
+            Self::update_inner(
+                &self.inner,
+                &mut self.resources.write(),
+                &descriptor_writes,
+                &descriptor_copies,
+            )
+        };
     }
 
     unsafe fn update_inner(
@@ -290,7 +296,7 @@ impl DescriptorSet {
         descriptor_writes: &[WriteDescriptorSet],
         descriptor_copies: &[CopyDescriptorSet],
     ) {
-        inner.update_unchecked(descriptor_writes, descriptor_copies);
+        unsafe { inner.update_unchecked(descriptor_writes, descriptor_copies) };
 
         for write in descriptor_writes {
             resources.write(write, inner.layout());

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -89,7 +89,7 @@ impl RawDescriptorSet {
 
         self.validate_update(descriptor_writes, descriptor_copies)?;
 
-        self.update_unchecked(descriptor_writes, descriptor_copies);
+        unsafe { self.update_unchecked(descriptor_writes, descriptor_copies) };
         Ok(())
     }
 
@@ -157,13 +157,15 @@ impl RawDescriptorSet {
             .collect();
 
         let fns = self.device().fns();
-        (fns.v1_0.update_descriptor_sets)(
-            self.device().handle(),
-            writes_vk.len() as u32,
-            writes_vk.as_ptr(),
-            copies_vk.len() as u32,
-            copies_vk.as_ptr(),
-        );
+        unsafe {
+            (fns.v1_0.update_descriptor_sets)(
+                self.device().handle(),
+                writes_vk.len() as u32,
+                writes_vk.as_ptr(),
+                copies_vk.len() as u32,
+                copies_vk.as_ptr(),
+            )
+        };
     }
 }
 

--- a/vulkano/src/device/private_data.rs
+++ b/vulkano/src/device/private_data.rs
@@ -76,27 +76,31 @@ impl PrivateDataSlot {
             let mut output = MaybeUninit::uninit();
 
             if device.api_version() >= Version::V1_3 {
-                (fns.v1_3.create_private_data_slot)(
-                    device.handle(),
-                    &create_info_vk,
-                    ptr::null(),
-                    output.as_mut_ptr(),
-                )
+                unsafe {
+                    (fns.v1_3.create_private_data_slot)(
+                        device.handle(),
+                        &create_info_vk,
+                        ptr::null(),
+                        output.as_mut_ptr(),
+                    )
+                }
             } else {
-                (fns.ext_private_data.create_private_data_slot_ext)(
-                    device.handle(),
-                    &create_info_vk,
-                    ptr::null(),
-                    output.as_mut_ptr(),
-                )
+                unsafe {
+                    (fns.ext_private_data.create_private_data_slot_ext)(
+                        device.handle(),
+                        &create_info_vk,
+                        ptr::null(),
+                        output.as_mut_ptr(),
+                    )
+                }
             }
             .result()
             .map_err(VulkanError::from)?;
 
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `PrivateDataSlot` from a raw object handle.
@@ -149,21 +153,25 @@ impl PrivateDataSlot {
         let fns = self.device.fns();
 
         if self.device.api_version() >= Version::V1_3 {
-            (fns.v1_3.set_private_data)(
-                self.device.handle(),
-                T::Handle::TYPE,
-                object.handle().as_raw(),
-                self.handle,
-                data,
-            )
+            unsafe {
+                (fns.v1_3.set_private_data)(
+                    self.device.handle(),
+                    T::Handle::TYPE,
+                    object.handle().as_raw(),
+                    self.handle,
+                    data,
+                )
+            }
         } else {
-            (fns.ext_private_data.set_private_data_ext)(
-                self.device.handle(),
-                T::Handle::TYPE,
-                object.handle().as_raw(),
-                self.handle,
-                data,
-            )
+            unsafe {
+                (fns.ext_private_data.set_private_data_ext)(
+                    self.device.handle(),
+                    T::Handle::TYPE,
+                    object.handle().as_raw(),
+                    self.handle,
+                    data,
+                )
+            }
         }
         .result()
         .map_err(VulkanError::from)

--- a/vulkano/src/display.rs
+++ b/vulkano/src/display.rs
@@ -384,16 +384,18 @@ impl DisplayMode {
         let handle = {
             let fns = physical_device.instance().fns();
             let mut output = MaybeUninit::uninit();
-            (fns.khr_display.create_display_mode_khr)(
-                physical_device.handle(),
-                display.handle,
-                &create_info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.khr_display.create_display_mode_khr)(
+                    physical_device.handle(),
+                    display.handle,
+                    &create_info_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
         Ok(display.display_modes.get_or_insert(handle, |&handle| {

--- a/vulkano/src/image/sampler/mod.rs
+++ b/vulkano/src/image/sampler/mod.rs
@@ -154,7 +154,7 @@ impl Sampler {
             unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `Sampler` from a raw object handle.

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -201,7 +201,7 @@ impl SamplerYcbcrConversion {
             unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `SamplerYcbcrConversion` from a raw object handle.

--- a/vulkano/src/library.rs
+++ b/vulkano/src/library.rs
@@ -113,13 +113,16 @@ impl VulkanLibrary {
         // Vulkan 1.0 implementation. Otherwise, the application can call vkEnumerateInstanceVersion
         // to determine the version of Vulkan.
 
-        let name = CStr::from_bytes_with_nul_unchecked(b"vkEnumerateInstanceVersion\0");
-        let func = loader.get_instance_proc_addr(ash::vk::Instance::null(), name.as_ptr());
+        let name = unsafe { CStr::from_bytes_with_nul_unchecked(b"vkEnumerateInstanceVersion\0") };
+        let func =
+            unsafe { loader.get_instance_proc_addr(ash::vk::Instance::null(), name.as_ptr()) };
 
         let version = if let Some(func) = func {
-            let func: ash::vk::PFN_vkEnumerateInstanceVersion = transmute(func);
+            let func: ash::vk::PFN_vkEnumerateInstanceVersion = unsafe { transmute(func) };
             let mut api_version = 0;
-            func(&mut api_version).result().map_err(VulkanError::from)?;
+            unsafe { func(&mut api_version) }
+                .result()
+                .map_err(VulkanError::from)?;
             Version::from(api_version)
         } else {
             Version {
@@ -140,28 +143,32 @@ impl VulkanLibrary {
 
         loop {
             let mut count = 0;
-            (fns.v1_0.enumerate_instance_extension_properties)(
-                layer_vk
-                    .as_ref()
-                    .map_or(ptr::null(), |layer| layer.as_ptr()),
-                &mut count,
-                ptr::null_mut(),
-            )
+            unsafe {
+                (fns.v1_0.enumerate_instance_extension_properties)(
+                    layer_vk
+                        .as_ref()
+                        .map_or(ptr::null(), |layer| layer.as_ptr()),
+                    &mut count,
+                    ptr::null_mut(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
 
             let mut output = Vec::with_capacity(count as usize);
-            let result = (fns.v1_0.enumerate_instance_extension_properties)(
-                layer_vk
-                    .as_ref()
-                    .map_or(ptr::null(), |layer| layer.as_ptr()),
-                &mut count,
-                output.as_mut_ptr(),
-            );
+            let result = unsafe {
+                (fns.v1_0.enumerate_instance_extension_properties)(
+                    layer_vk
+                        .as_ref()
+                        .map_or(ptr::null(), |layer| layer.as_ptr()),
+                    &mut count,
+                    output.as_mut_ptr(),
+                )
+            };
 
             match result {
                 ash::vk::Result::SUCCESS => {
-                    output.set_len(count as usize);
+                    unsafe { output.set_len(count as usize) };
                     return Ok(output.into_iter().map(Into::into).collect());
                 }
                 ash::vk::Result::INCOMPLETE => (),
@@ -292,7 +299,7 @@ impl VulkanLibrary {
         instance: ash::vk::Instance,
         name: *const c_char,
     ) -> ash::vk::PFN_vkVoidFunction {
-        self.loader.get_instance_proc_addr(instance, name)
+        unsafe { self.loader.get_instance_proc_addr(instance, name) }
     }
 }
 
@@ -318,7 +325,7 @@ where
         instance: ash::vk::Instance,
         name: *const c_char,
     ) -> ash::vk::PFN_vkVoidFunction {
-        (**self).get_instance_proc_addr(instance, name)
+        unsafe { (**self).get_instance_proc_addr(instance, name) }
     }
 }
 
@@ -342,10 +349,10 @@ impl DynamicLibraryLoader {
     ///
     /// - The dynamic library must be a valid Vulkan implementation.
     pub unsafe fn new(path: impl AsRef<Path>) -> Result<DynamicLibraryLoader, LoadingError> {
-        let vk_lib = Library::new(path.as_ref()).map_err(LoadingError::LibraryLoadFailure)?;
+        let vk_lib =
+            unsafe { Library::new(path.as_ref()) }.map_err(LoadingError::LibraryLoadFailure)?;
 
-        let get_instance_proc_addr = *vk_lib
-            .get(b"vkGetInstanceProcAddr")
+        let get_instance_proc_addr = *unsafe { vk_lib.get(b"vkGetInstanceProcAddr") }
             .map_err(LoadingError::LibraryLoadFailure)?;
 
         Ok(DynamicLibraryLoader {
@@ -362,7 +369,7 @@ unsafe impl Loader for DynamicLibraryLoader {
         instance: ash::vk::Instance,
         name: *const c_char,
     ) -> ash::vk::PFN_vkVoidFunction {
-        (self.get_instance_proc_addr)(instance, name)
+        unsafe { (self.get_instance_proc_addr)(instance, name) }
     }
 }
 

--- a/vulkano/src/memory/allocator/layout.rs
+++ b/vulkano/src/memory/allocator/layout.rs
@@ -99,10 +99,9 @@ impl DeviceLayout {
         size: DeviceSize,
         alignment: DeviceSize,
     ) -> Self {
-        DeviceLayout::new_unchecked(
-            NonZeroDeviceSize::new_unchecked(size),
-            DeviceAlignment::new_unchecked(alignment),
-        )
+        let size = unsafe { NonZeroDeviceSize::new_unchecked(size) };
+        let alignment = unsafe { DeviceAlignment::new_unchecked(alignment) };
+        unsafe { DeviceLayout::new_unchecked(size, alignment) }
     }
 
     /// Creates a new `DeviceLayout` for a sized `T`.

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -1475,11 +1475,11 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
             // memory and because a block isn't dropped until the allocator itself is dropped, at
             // which point it would be impossible to call this method. We also know that it must be
             // valid to create a reference to the block, because we locked the pool it belongs to.
-            let block = &mut *block_ptr;
+            let block = unsafe { &mut *block_ptr };
 
             // SAFETY: The caller must guarantee that `allocation` refers to a currently allocated
             // allocation of `self`.
-            block.deallocate(suballocation);
+            unsafe { block.deallocate(suballocation) };
         }
     }
 }
@@ -1534,7 +1534,7 @@ unsafe impl<T: MemoryAllocator> MemoryAllocator for Arc<T> {
     }
 
     unsafe fn deallocate(&self, allocation: MemoryAlloc) {
-        (**self).deallocate(allocation)
+        unsafe { (**self).deallocate(allocation) }
     }
 }
 
@@ -1626,7 +1626,7 @@ impl<S: Suballocator> DeviceMemoryBlock<S> {
     }
 
     unsafe fn deallocate(&mut self, suballocation: Suballocation) {
-        self.suballocator.deallocate(suballocation);
+        unsafe { self.suballocator.deallocate(suballocation) };
 
         self.allocation_count -= 1;
 

--- a/vulkano/src/memory/allocator/suballocator/free_list.rs
+++ b/vulkano/src/memory/allocator/suballocator/free_list.rs
@@ -446,7 +446,7 @@ impl SuballocationList {
 
             if prev.allocation_type == SuballocationType::Free {
                 // SAFETY: We checked that the suballocation is free.
-                self.allocate(prev_ptr);
+                unsafe { self.allocate(prev_ptr) };
 
                 unsafe { (*node_ptr.as_ptr()).prev = prev.prev };
                 unsafe { (*node_ptr.as_ptr()).offset = prev.offset };
@@ -480,7 +480,7 @@ impl SuballocationList {
 
             if next.allocation_type == SuballocationType::Free {
                 // SAFETY: Same as above.
-                self.allocate(next_ptr);
+                unsafe { self.allocate(next_ptr) };
 
                 unsafe { (*node_ptr.as_ptr()).next = next.next };
                 // This is overflow-safe for the same reason as above.

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -351,8 +351,10 @@ impl ResourceMemory {
     ) -> Result<(), Validated<VulkanError>> {
         self.validate_memory_range(&memory_range)?;
 
-        self.device_memory()
-            .invalidate_range(self.create_memory_range(memory_range))
+        unsafe {
+            self.device_memory()
+                .invalidate_range(self.create_memory_range(memory_range))
+        }
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
@@ -361,8 +363,10 @@ impl ResourceMemory {
         &self,
         memory_range: MappedMemoryRange,
     ) -> Result<(), VulkanError> {
-        self.device_memory()
-            .invalidate_range_unchecked(self.create_memory_range(memory_range))
+        unsafe {
+            self.device_memory()
+                .invalidate_range_unchecked(self.create_memory_range(memory_range))
+        }
     }
 
     /// Flushes the host cache for a range of the `ResourceMemory`.
@@ -385,8 +389,10 @@ impl ResourceMemory {
     ) -> Result<(), Validated<VulkanError>> {
         self.validate_memory_range(&memory_range)?;
 
-        self.device_memory()
-            .flush_range(self.create_memory_range(memory_range))
+        unsafe {
+            self.device_memory()
+                .flush_range(self.create_memory_range(memory_range))
+        }
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
@@ -395,8 +401,10 @@ impl ResourceMemory {
         &self,
         memory_range: MappedMemoryRange,
     ) -> Result<(), VulkanError> {
-        self.device_memory()
-            .flush_range_unchecked(self.create_memory_range(memory_range))
+        unsafe {
+            self.device_memory()
+                .flush_range_unchecked(self.create_memory_range(memory_range))
+        }
     }
 
     fn validate_memory_range(

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -92,20 +92,22 @@ impl ComputePipeline {
         let handle = {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
-            (fns.v1_0.create_compute_pipelines)(
-                device.handle(),
-                cache.as_ref().map_or_else(Default::default, |c| c.handle()),
-                1,
-                &create_info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.v1_0.create_compute_pipelines)(
+                    device.handle(),
+                    cache.as_ref().map_or_else(Default::default, |c| c.handle()),
+                    1,
+                    &create_info_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `ComputePipeline` from a raw object handle.

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -219,18 +219,20 @@ impl GraphicsPipeline {
 
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
-            (fns.v1_0.create_graphics_pipelines)(
-                device.handle(),
-                cache_handle,
-                1,
-                &create_info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.v1_0.create_graphics_pipelines)(
+                    device.handle(),
+                    cache_handle,
+                    1,
+                    &create_info_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
 
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
         // Some drivers return `VK_SUCCESS` but provide a null handle if they
@@ -240,7 +242,7 @@ impl GraphicsPipeline {
             panic!("vkCreateGraphicsPipelines provided a NULL handle");
         }
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `GraphicsPipeline` from a raw object handle.

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -129,18 +129,20 @@ impl PipelineLayout {
         let handle = {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
-            (fns.v1_0.create_pipeline_layout)(
-                device.handle(),
-                &create_info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.v1_0.create_pipeline_layout)(
+                    device.handle(),
+                    &create_info_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `PipelineLayout` from a raw object handle.

--- a/vulkano/src/pipeline/ray_tracing.rs
+++ b/vulkano/src/pipeline/ray_tracing.rs
@@ -131,23 +131,25 @@ impl RayTracingPipeline {
             let fns = device.fns();
             let mut output = MaybeUninit::uninit();
 
-            (fns.khr_ray_tracing_pipeline
-                .create_ray_tracing_pipelines_khr)(
-                device.handle(),
-                ash::vk::DeferredOperationKHR::null(), // TODO: RayTracing: deferred_operation
-                cache.map_or(ash::vk::PipelineCache::null(), |c| c.handle()),
-                1,
-                &create_infos_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.khr_ray_tracing_pipeline
+                    .create_ray_tracing_pipelines_khr)(
+                    device.handle(),
+                    ash::vk::DeferredOperationKHR::null(), // TODO: RayTracing: deferred_operation
+                    cache.map_or(ash::vk::PipelineCache::null(), |c| c.handle()),
+                    1,
+                    &create_infos_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
 
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `RayTracingPipeline` from a raw object handle.

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -78,7 +78,7 @@ impl QueryPool {
             unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Creates a new `QueryPool` from a raw object handle.
@@ -351,20 +351,24 @@ impl QueryPool {
         let fns = self.device.fns();
 
         if self.device.api_version() >= Version::V1_2 {
-            (fns.v1_2.reset_query_pool)(
-                self.device.handle(),
-                self.handle(),
-                range.start,
-                range.len() as u32,
-            );
+            unsafe {
+                (fns.v1_2.reset_query_pool)(
+                    self.device.handle(),
+                    self.handle(),
+                    range.start,
+                    range.len() as u32,
+                )
+            };
         } else {
             debug_assert!(self.device.enabled_extensions().ext_host_query_reset);
-            (fns.ext_host_query_reset.reset_query_pool_ext)(
-                self.device.handle(),
-                self.handle(),
-                range.start,
-                range.len() as u32,
-            );
+            unsafe {
+                (fns.ext_host_query_reset.reset_query_pool_ext)(
+                    self.device.handle(),
+                    self.handle(),
+                    range.start,
+                    range.len() as u32,
+                )
+            };
         }
     }
 }

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -266,7 +266,7 @@ impl Framebuffer {
             unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(render_pass, handle, create_info))
+        Ok(unsafe { Self::from_handle(render_pass, handle, create_info) })
     }
 
     /// Creates a new `Framebuffer` from a raw object handle.

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -428,9 +428,9 @@ impl Swapchain {
         create_info: SwapchainCreateInfo,
     ) -> Result<(Arc<Swapchain>, Vec<Arc<Image>>), VulkanError> {
         let (handle, image_handles) =
-            Self::new_inner_unchecked(&device, &surface, &create_info, None)?;
+            unsafe { Self::new_inner_unchecked(&device, &surface, &create_info, None) }?;
 
-        Self::from_handle(device, handle, image_handles, surface, create_info)
+        unsafe { Self::from_handle(device, handle, image_handles, surface, create_info) }
     }
 
     /// Creates a new swapchain from this one.
@@ -492,13 +492,15 @@ impl Swapchain {
             Self::new_inner_unchecked(&self.device, &self.surface, &create_info, Some(self))
         }?;
 
-        let (swapchain, swapchain_images) = Self::from_handle(
-            self.device.clone(),
-            handle,
-            image_handles,
-            self.surface.clone(),
-            create_info,
-        )?;
+        let (swapchain, swapchain_images) = unsafe {
+            Self::from_handle(
+                self.device.clone(),
+                handle,
+                image_handles,
+                self.surface.clone(),
+                create_info,
+            )
+        }?;
 
         if self.full_screen_exclusive == FullScreenExclusive::ApplicationControlled {
             swapchain.full_screen_exclusive_held.store(
@@ -979,39 +981,45 @@ impl Swapchain {
 
         let handle = {
             let mut output = MaybeUninit::uninit();
-            (fns.khr_swapchain.create_swapchain_khr)(
-                device.handle(),
-                &create_info_vk,
-                ptr::null(),
-                output.as_mut_ptr(),
-            )
+            unsafe {
+                (fns.khr_swapchain.create_swapchain_khr)(
+                    device.handle(),
+                    &create_info_vk,
+                    ptr::null(),
+                    output.as_mut_ptr(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
-            output.assume_init()
+            unsafe { output.assume_init() }
         };
 
         let image_handles = loop {
             let mut count = 0;
-            (fns.khr_swapchain.get_swapchain_images_khr)(
-                device.handle(),
-                handle,
-                &mut count,
-                ptr::null_mut(),
-            )
+            unsafe {
+                (fns.khr_swapchain.get_swapchain_images_khr)(
+                    device.handle(),
+                    handle,
+                    &mut count,
+                    ptr::null_mut(),
+                )
+            }
             .result()
             .map_err(VulkanError::from)?;
 
             let mut images = Vec::with_capacity(count as usize);
-            let result = (fns.khr_swapchain.get_swapchain_images_khr)(
-                device.handle(),
-                handle,
-                &mut count,
-                images.as_mut_ptr(),
-            );
+            let result = unsafe {
+                (fns.khr_swapchain.get_swapchain_images_khr)(
+                    device.handle(),
+                    handle,
+                    &mut count,
+                    images.as_mut_ptr(),
+                )
+            };
 
             match result {
                 ash::vk::Result::SUCCESS => {
-                    images.set_len(count as usize);
+                    unsafe { images.set_len(count as usize) };
                     break images;
                 }
                 ash::vk::Result::INCOMPLETE => (),
@@ -1289,7 +1297,7 @@ impl Swapchain {
         let is_retired_lock = self.is_retired.lock();
         self.validate_acquire_next_image(acquire_info, *is_retired_lock)?;
 
-        Ok(self.acquire_next_image_unchecked(acquire_info)?)
+        Ok(unsafe { self.acquire_next_image_unchecked(acquire_info) }?)
     }
 
     fn validate_acquire_next_image(
@@ -1325,48 +1333,54 @@ impl Swapchain {
     ) -> Result<AcquiredImage, VulkanError> {
         let acquire_info_vk = acquire_info.to_vk(self.handle(), self.device.device_mask());
 
-        let fns = self.device.fns();
-        let mut output = MaybeUninit::uninit();
+        let (image_index, is_suboptimal) = {
+            let fns = self.device.fns();
+            let mut output = MaybeUninit::uninit();
 
-        let result = if self.device.api_version() >= Version::V1_1
-            || self.device.enabled_extensions().khr_device_group
-        {
-            (fns.khr_swapchain.acquire_next_image2_khr)(
-                self.device.handle(),
-                &acquire_info_vk,
-                output.as_mut_ptr(),
-            )
-        } else {
-            debug_assert!(acquire_info_vk.p_next.is_null());
-            (fns.khr_swapchain.acquire_next_image_khr)(
-                self.device.handle(),
-                acquire_info_vk.swapchain,
-                acquire_info_vk.timeout,
-                acquire_info_vk.semaphore,
-                acquire_info_vk.fence,
-                output.as_mut_ptr(),
-            )
-        };
-
-        let is_suboptimal = match result {
-            ash::vk::Result::SUCCESS => false,
-            ash::vk::Result::SUBOPTIMAL_KHR => true,
-            ash::vk::Result::NOT_READY => return Err(VulkanError::NotReady),
-            ash::vk::Result::TIMEOUT => return Err(VulkanError::Timeout),
-            err => {
-                let err = VulkanError::from(err);
-
-                if matches!(err, VulkanError::FullScreenExclusiveModeLost) {
-                    self.full_screen_exclusive_held
-                        .store(false, Ordering::SeqCst);
+            let result = if self.device.api_version() >= Version::V1_1
+                || self.device.enabled_extensions().khr_device_group
+            {
+                unsafe {
+                    (fns.khr_swapchain.acquire_next_image2_khr)(
+                        self.device.handle(),
+                        &acquire_info_vk,
+                        output.as_mut_ptr(),
+                    )
                 }
+            } else {
+                debug_assert!(acquire_info_vk.p_next.is_null());
+                unsafe {
+                    (fns.khr_swapchain.acquire_next_image_khr)(
+                        self.device.handle(),
+                        acquire_info_vk.swapchain,
+                        acquire_info_vk.timeout,
+                        acquire_info_vk.semaphore,
+                        acquire_info_vk.fence,
+                        output.as_mut_ptr(),
+                    )
+                }
+            };
 
-                return Err(err);
+            match result {
+                ash::vk::Result::SUCCESS => (unsafe { output.assume_init() }, false),
+                ash::vk::Result::SUBOPTIMAL_KHR => (unsafe { output.assume_init() }, true),
+                ash::vk::Result::NOT_READY => return Err(VulkanError::NotReady),
+                ash::vk::Result::TIMEOUT => return Err(VulkanError::Timeout),
+                err => {
+                    let err = VulkanError::from(err);
+
+                    if matches!(err, VulkanError::FullScreenExclusiveModeLost) {
+                        self.full_screen_exclusive_held
+                            .store(false, Ordering::SeqCst);
+                    }
+
+                    return Err(err);
+                }
             }
         };
 
         Ok(AcquiredImage {
-            image_index: output.assume_init(),
+            image_index,
             is_suboptimal,
         })
     }
@@ -1436,14 +1450,16 @@ impl Swapchain {
     ) -> Result<bool, VulkanError> {
         let result = {
             let fns = self.device.fns();
-            (fns.khr_present_wait.wait_for_present_khr)(
-                self.device.handle(),
-                self.handle,
-                present_id.get(),
-                timeout.map_or(u64::MAX, |duration| {
-                    u64::try_from(duration.as_nanos()).unwrap()
-                }),
-            )
+            unsafe {
+                (fns.khr_present_wait.wait_for_present_khr)(
+                    self.device.handle(),
+                    self.handle,
+                    present_id.get(),
+                    timeout.map_or(u64::MAX, |duration| {
+                        u64::try_from(duration.as_nanos()).unwrap()
+                    }),
+                )
+            }
         };
 
         match result {
@@ -1515,8 +1531,12 @@ impl Swapchain {
             .store(true, Ordering::Relaxed);
 
         let fns = self.device.fns();
-        (fns.ext_full_screen_exclusive
-            .acquire_full_screen_exclusive_mode_ext)(self.device.handle(), self.handle)
+        unsafe {
+            (fns.ext_full_screen_exclusive
+                .acquire_full_screen_exclusive_mode_ext)(
+                self.device.handle(), self.handle
+            )
+        }
         .result()
         .map_err(VulkanError::from)?;
 
@@ -1561,8 +1581,12 @@ impl Swapchain {
             .store(false, Ordering::Release);
 
         let fns = self.device.fns();
-        (fns.ext_full_screen_exclusive
-            .release_full_screen_exclusive_mode_ext)(self.device.handle(), self.handle)
+        unsafe {
+            (fns.ext_full_screen_exclusive
+                .release_full_screen_exclusive_mode_ext)(
+                self.device.handle(), self.handle
+            )
+        }
         .result()
         .map_err(VulkanError::from)?;
 

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -102,7 +102,7 @@ impl Event {
             unsafe { output.assume_init() }
         };
 
-        Ok(Self::from_handle(device, handle, create_info))
+        Ok(unsafe { Self::from_handle(device, handle, create_info) })
     }
 
     /// Takes an event from the vulkano-provided event pool.
@@ -232,7 +232,7 @@ impl Event {
     pub unsafe fn reset(&mut self) -> Result<(), Validated<VulkanError>> {
         self.validate_reset()?;
 
-        Ok(self.reset_unchecked()?)
+        Ok(unsafe { self.reset_unchecked() }?)
     }
 
     fn validate_reset(&mut self) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -436,7 +436,7 @@ where
         let state = self.state.lock();
         match *state {
             FenceSignalFutureState::Flushed(ref prev, _) => {
-                prev.signal_finished();
+                unsafe { prev.signal_finished() };
             }
             FenceSignalFutureState::Cleaned | FenceSignalFutureState::Poisoned => (),
             _ => unreachable!(),
@@ -564,7 +564,7 @@ where
     unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         // Note that this is sound because we always return `SubmitAnyBuilder::Empty`. See the
         // documentation of `build_submission`.
-        (**self).build_submission()
+        unsafe { (**self).build_submission() }
     }
 
     fn flush(&self) -> Result<(), Validated<VulkanError>> {
@@ -572,7 +572,7 @@ where
     }
 
     unsafe fn signal_finished(&self) {
-        (**self).signal_finished()
+        unsafe { (**self).signal_finished() }
     }
 
     fn queue_change_allowed(&self) -> bool {

--- a/vulkano/src/sync/future/join.rs
+++ b/vulkano/src/sync/future/join.rs
@@ -64,8 +64,8 @@ where
 
     unsafe fn build_submission(&self) -> Result<SubmitAnyBuilder, Validated<VulkanError>> {
         // TODO: review this function
-        let first = self.first.build_submission()?;
-        let second = self.second.build_submission()?;
+        let first = unsafe { self.first.build_submission()? };
+        let second = unsafe { self.second.build_submission()? };
 
         // In some cases below we have to submit previous command buffers already, this s done by
         // flushing previous. Since the implementation should remember being flushed it's
@@ -162,8 +162,8 @@ where
     }
 
     unsafe fn signal_finished(&self) {
-        self.first.signal_finished();
-        self.second.signal_finished();
+        unsafe { self.first.signal_finished() };
+        unsafe { self.second.signal_finished() };
     }
 
     fn queue_change_allowed(&self) -> bool {

--- a/vulkano/src/sync/future/semaphore_signal.rs
+++ b/vulkano/src/sync/future/semaphore_signal.rs
@@ -200,7 +200,7 @@ where
     unsafe fn signal_finished(&self) {
         debug_assert!(*self.wait_submitted.lock());
         self.finished.store(true, Ordering::SeqCst);
-        self.previous.signal_finished();
+        unsafe { self.previous.signal_finished() };
     }
 
     fn queue_change_allowed(&self) -> bool {


### PR DESCRIPTION
To prepare for migration to Rust 2024.