### PR TITLE
Remove outdated maintainer references in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,6 @@ The project was initially developed by Pierre Krieger(Tomaka), who established V
 design goals, and the code structure. In the meantime, development is driven by Vulkano
 community members.
 
-**New Pull Requests are usually scheduled for review by the end of each week.**
-The older PRs that are already in review have priority over the new ones. We are trying to push
-development forward as quick as possible, but the review process sometimes takes time,
-please be patient as the maintainers need time to check everything properly.
-
-If something needs to get promoted urgently, please ping current Vulkano
-maintainer([@Eliah-Lakhin](https://github.com/Eliah-Lakhin/)) in the PR's
-or Issue's comments.
-
 If your change adds, removes or modifies a trait or a function, please
 specify changelog entries **in the Pull Request description**(not in the changelog file directly).
 They will be transferred to the changelog right after the PR merge.


### PR DESCRIPTION
Eliah hasn't been an active maintainer for years, yet the readme still references him. We also don't need pings to be notified of PRs. I also removed the notion of when and in what order PRs are reviewed, as this has since never been accurate.