### PR TITLE
Replace `NonZeroT` with `NonZero<T>`

### DIFF
--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -90,19 +90,19 @@ use crate::{
     format::{Format, FormatFeatures},
     instance::InstanceOwnedDebugWrapper,
     macros::{impl_id_counter, vulkan_bitflags, vulkan_enum},
-    DeviceAddress, DeviceSize, NonNullDeviceAddress, Packed24_8, Requires, RequiresAllOf,
-    RequiresOneOf, Validated, ValidationError, VulkanError, VulkanObject,
+    DeviceAddress, DeviceSize, Packed24_8, Requires, RequiresAllOf, RequiresOneOf, Validated,
+    ValidationError, VulkanError, VulkanObject,
 };
 use ash::vk;
 use bytemuck::{Pod, Zeroable};
-use std::{fmt::Debug, hash::Hash, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{fmt::Debug, hash::Hash, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// An opaque data structure that is used to accelerate spatial queries on geometry data.
 #[derive(Debug)]
 pub struct AccelerationStructure {
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
     handle: vk::AccelerationStructureKHR,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     create_flags: AccelerationStructureCreateFlags,
     buffer: Subbuffer<[u8]>,
@@ -245,7 +245,7 @@ impl AccelerationStructure {
     ///
     /// The device address of the acceleration structure may be different from the device address
     /// of the underlying buffer.
-    pub fn device_address(&self) -> NonNullDeviceAddress {
+    pub fn device_address(&self) -> NonZero<DeviceAddress> {
         let info_vk = vk::AccelerationStructureDeviceAddressInfoKHR::default()
             .acceleration_structure(self.handle);
         let fns = self.device.fns();
@@ -256,7 +256,7 @@ impl AccelerationStructure {
             )
         };
 
-        NonNullDeviceAddress::new(ptr).unwrap()
+        NonZero::new(ptr).unwrap()
     }
 }
 

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::SmallVec;
-use std::{marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{marker::PhantomData, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// A raw buffer, with no memory backing it.
 ///
@@ -31,7 +31,7 @@ use std::{marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc
 pub struct RawBuffer {
     handle: vk::Buffer,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: BufferCreateFlags,
     size: DeviceSize,

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -47,7 +47,7 @@ use crate::{
     DeviceSize, Validated, ValidationError, Version, VulkanError, VulkanObject,
 };
 use ash::vk;
-use std::{mem::MaybeUninit, num::NonZeroU64, ops::Range, ptr, sync::Arc};
+use std::{mem::MaybeUninit, num::NonZero, ops::Range, ptr, sync::Arc};
 
 /// Represents a way for the GPU to interpret buffer data. See the documentation of the
 /// `view` module.
@@ -55,7 +55,7 @@ use std::{mem::MaybeUninit, num::NonZeroU64, ops::Range, ptr, sync::Arc};
 pub struct BufferView {
     handle: vk::BufferView,
     subbuffer: Subbuffer<[u8]>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     format: Format,
     format_features: FormatFeatures,

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::SmallVec;
-use std::{cell::Cell, marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{cell::Cell, marker::PhantomData, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// Represents a Vulkan command pool.
 ///
@@ -29,7 +29,7 @@ use std::{cell::Cell, marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, pt
 pub struct CommandPool {
     handle: vk::CommandPool,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: CommandPoolCreateFlags,
     queue_family_index: u32,
@@ -485,7 +485,7 @@ impl Default for CommandBufferAllocateInfo {
 pub struct CommandPoolAlloc {
     handle: vk::CommandBuffer,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
     level: CommandBufferLevel,
 }
 

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -26,7 +26,7 @@ use std::{
     cell::UnsafeCell,
     fmt::{Debug, Error as FmtError, Formatter},
     mem,
-    num::NonZeroU64,
+    num::NonZero,
     ptr,
     sync::Arc,
 };
@@ -175,7 +175,7 @@ impl AllocationHandle {
 #[derive(Debug)]
 pub struct StandardDescriptorSetAllocator {
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    pools: ThreadLocal<UnsafeCell<SortedMap<NonZeroU64, Entry>>>,
+    pools: ThreadLocal<UnsafeCell<SortedMap<NonZero<u64>, Entry>>>,
     create_info: StandardDescriptorSetAllocatorCreateInfo,
 }
 

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -14,14 +14,14 @@ use crate::{
 use ash::vk;
 use foldhash::HashMap;
 use smallvec::SmallVec;
-use std::{collections::BTreeMap, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{collections::BTreeMap, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// Describes to the Vulkan implementation the layout of all descriptors within a descriptor set.
 #[derive(Debug)]
 pub struct DescriptorSetLayout {
     handle: vk::DescriptorSetLayout,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: DescriptorSetLayoutCreateFlags,
     bindings: BTreeMap<u32, DescriptorSetLayoutBinding>,

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -12,7 +12,7 @@ use crate::{
 use ash::vk;
 use foldhash::HashMap;
 use smallvec::SmallVec;
-use std::{cell::Cell, marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{cell::Cell, marker::PhantomData, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// Pool that descriptors are allocated from.
 ///
@@ -22,7 +22,7 @@ use std::{cell::Cell, marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, pt
 pub struct DescriptorPool {
     handle: vk::DescriptorPool,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: DescriptorPoolCreateFlags,
     max_sets: u32,
@@ -697,7 +697,7 @@ impl DescriptorSetAllocateInfo {
 #[derive(Debug)]
 pub struct DescriptorPoolAlloc {
     handle: vk::DescriptorSet,
-    id: NonZeroU64,
+    id: NonZero<u64>,
     layout: DeviceOwnedDebugWrapper<Arc<DescriptorSetLayout>>,
     variable_descriptor_count: u32,
 }

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -126,7 +126,7 @@ use std::{
     fs::File,
     marker::PhantomData,
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     ops::Deref,
     ptr, slice,
     sync::{
@@ -149,7 +149,7 @@ pub struct Device {
     handle: vk::Device,
     // NOTE: `physical_devices` always contains this.
     physical_device: InstanceOwnedDebugWrapper<Arc<PhysicalDevice>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     enabled_extensions: DeviceExtensions,
     enabled_features: DeviceFeatures,

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -33,7 +33,7 @@ use std::{
     fmt::{Debug, Error as FmtError, Formatter},
     marker::PhantomData,
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     ptr,
     sync::Arc,
 };
@@ -62,7 +62,7 @@ use std::{
 pub struct PhysicalDevice {
     handle: vk::PhysicalDevice,
     instance: DebugWrapper<Arc<Instance>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     // Data queried at `PhysicalDevice` creation.
     api_version: Version,

--- a/vulkano/src/image/sampler/mod.rs
+++ b/vulkano/src/image/sampler/mod.rs
@@ -49,7 +49,7 @@ use crate::{
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, VulkanError, VulkanObject,
 };
 use ash::vk;
-use std::{mem::MaybeUninit, num::NonZeroU64, ops::RangeInclusive, ptr, sync::Arc};
+use std::{mem::MaybeUninit, num::NonZero, ops::RangeInclusive, ptr, sync::Arc};
 
 pub mod ycbcr;
 
@@ -92,7 +92,7 @@ pub mod ycbcr;
 pub struct Sampler {
     handle: vk::Sampler,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     address_mode: [SamplerAddressMode; 3],
     anisotropy: Option<f32>,

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -118,14 +118,14 @@ use crate::{
     VulkanObject,
 };
 use ash::vk;
-use std::{mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// Describes how sampled image data should converted from a YCbCr representation to an RGB one.
 #[derive(Debug)]
 pub struct SamplerYcbcrConversion {
     handle: vk::SamplerYcbcrConversion,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     format: Format,
     ycbcr_model: SamplerYcbcrModelConversion,

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::{smallvec, SmallVec};
-use std::{marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{marker::PhantomData, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// A raw image, with no memory backing it.
 ///
@@ -50,7 +50,7 @@ use std::{marker::PhantomData, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc
 pub struct RawImage {
     handle: vk::Image,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: ImageCreateFlags,
     image_type: ImageType,

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::{smallvec, SmallVec};
-use std::{fmt::Debug, hash::Hash, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{fmt::Debug, hash::Hash, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// A wrapper around an image that makes it available to shaders or framebuffers.
 ///
@@ -33,7 +33,7 @@ use std::{fmt::Debug, hash::Hash, mem::MaybeUninit, num::NonZeroU64, ptr, sync::
 pub struct ImageView {
     handle: vk::ImageView,
     image: DeviceOwnedDebugWrapper<Arc<Image>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     view_type: ImageViewType,
     format: Format,

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -95,7 +95,7 @@ use std::{
     ffi::{c_char, CString},
     fmt::{Debug, Error as FmtError, Formatter},
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     ops::Deref,
     panic::{RefUnwindSafe, UnwindSafe},
     ptr, slice,
@@ -259,7 +259,7 @@ include!(concat!(env!("OUT_DIR"), "/instance_extensions.rs"));
 pub struct Instance {
     handle: vk::Instance,
     fns: InstanceFunctions,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: InstanceCreateFlags,
     api_version: Version,

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -128,7 +128,6 @@ use std::{
     borrow::Cow,
     error::Error,
     fmt::{Debug, Display, Error as FmtError, Formatter},
-    num::NonZeroU64,
     ops::Deref,
     sync::Arc,
 };
@@ -166,18 +165,11 @@ pub mod shader;
 pub mod swapchain;
 pub mod sync;
 
+/// Represents an address (pointer) on a Vulkan device.
+pub use vk::DeviceAddress;
 /// Represents memory size and offset values on a Vulkan device.
 /// Analogous to the Rust `usize` type on the host.
 pub use vk::DeviceSize;
-
-/// A [`DeviceSize`] that is known not to equal zero.
-pub type NonZeroDeviceSize = NonZeroU64;
-
-/// Represents an address (pointer) on a Vulkan device.
-pub use vk::DeviceAddress;
-
-/// A [`DeviceAddress`] that is known not to equal zero.
-pub type NonNullDeviceAddress = NonZeroU64;
 
 /// Represents a region of device addresses with a stride.
 #[derive(Debug, Copy, Clone, Default)]

--- a/vulkano/src/macros.rs
+++ b/vulkano/src/macros.rs
@@ -951,22 +951,22 @@ macro_rules! impl_id_counter {
     };
     (@inner $type:ident $(< $($param:ident),+ >)?, $($bounds:tt)*) => {
         impl< $($bounds)* > $type $(< $($param),+ >)? {
-            fn next_id() -> std::num::NonZeroU64 {
+            fn next_id() -> std::num::NonZero<u64> {
                 use std::{
-                    num::NonZeroU64,
+                    num::NonZero,
                     sync::atomic::{AtomicU64, Ordering},
                 };
 
                 static COUNTER: AtomicU64 = AtomicU64::new(1);
 
-                NonZeroU64::new(COUNTER.fetch_add(1, Ordering::Relaxed)).unwrap_or_else(|| {
+                NonZero::<u64>::new(COUNTER.fetch_add(1, Ordering::Relaxed)).unwrap_or_else(|| {
                     eprintln!("an ID counter has overflown ...somehow");
                     std::process::abort();
                 })
             }
 
             #[allow(dead_code)]
-            pub(crate) fn id(&self) -> std::num::NonZeroU64 {
+            pub(crate) fn id(&self) -> std::num::NonZero<u64> {
                 self.id
             }
         }

--- a/vulkano/src/memory/alignment.rs
+++ b/vulkano/src/memory/alignment.rs
@@ -1,10 +1,11 @@
-use crate::{DeviceSize, NonZeroDeviceSize};
+use crate::DeviceSize;
 use std::{
     cmp::Ordering,
     error::Error,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
     mem,
+    num::NonZero,
 };
 
 /// Vulkan analog of std's [`Alignment`], stored as a [`DeviceSize`] that is guaranteed to be a
@@ -70,11 +71,11 @@ impl DeviceAlignment {
         self.0 as DeviceSize
     }
 
-    /// Returns the alignment as a [`NonZeroDeviceSize`].
+    /// Returns the alignment as a `NonZero<DeviceSize>`.
     #[inline]
-    pub const fn as_nonzero(self) -> NonZeroDeviceSize {
+    pub const fn as_nonzero(self) -> NonZero<DeviceSize> {
         // SAFETY: All the discriminants are non-zero.
-        unsafe { NonZeroDeviceSize::new_unchecked(self.as_devicesize()) }
+        unsafe { NonZero::new_unchecked(self.as_devicesize()) }
     }
 
     /// Returns the base-2 logarithm of the alignment.
@@ -107,11 +108,11 @@ impl Default for DeviceAlignment {
     }
 }
 
-impl TryFrom<NonZeroDeviceSize> for DeviceAlignment {
+impl TryFrom<NonZero<DeviceSize>> for DeviceAlignment {
     type Error = TryFromIntError;
 
     #[inline]
-    fn try_from(alignment: NonZeroDeviceSize) -> Result<Self, Self::Error> {
+    fn try_from(alignment: NonZero<DeviceSize>) -> Result<Self, Self::Error> {
         if alignment.is_power_of_two() {
             Ok(unsafe { DeviceAlignment::new_unchecked(alignment.get()) })
         } else {
@@ -129,7 +130,7 @@ impl TryFrom<DeviceSize> for DeviceAlignment {
     }
 }
 
-impl From<DeviceAlignment> for NonZeroDeviceSize {
+impl From<DeviceAlignment> for NonZero<DeviceSize> {
     #[inline]
     fn from(alignment: DeviceAlignment) -> Self {
         alignment.as_nonzero()

--- a/vulkano/src/memory/allocator/suballocator/buddy.rs
+++ b/vulkano/src/memory/allocator/suballocator/buddy.rs
@@ -6,9 +6,9 @@ use crate::{
         allocator::{align_up, array_vec::ArrayVec, AllocationHandle, DeviceLayout},
         is_aligned, DeviceAlignment,
     },
-    DeviceSize, NonZeroDeviceSize,
+    DeviceSize,
 };
-use std::cmp;
+use std::{cmp, num::NonZero};
 
 /// A [suballocator] whose structure forms a binary tree of power-of-two-sized suballocations.
 ///
@@ -123,7 +123,7 @@ unsafe impl Suballocator for BuddyAllocator {
         fn prev_power_of_two(val: DeviceSize) -> DeviceSize {
             const MAX_POWER_OF_TWO: DeviceSize = DeviceAlignment::MAX.as_devicesize();
 
-            if let Some(val) = NonZeroDeviceSize::new(val) {
+            if let Some(val) = NonZero::new(val) {
                 // This can't overflow because `val` is non-zero, which means it has fewer leading
                 // zeroes than the total number of bits.
                 MAX_POWER_OF_TWO >> val.leading_zeros()

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -14,7 +14,7 @@ use std::{
     ffi::c_void,
     fs::File,
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     ops::Range,
     ptr::{self, NonNull},
     slice,
@@ -48,7 +48,7 @@ use std::{
 pub struct DeviceMemory {
     handle: vk::DeviceMemory,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     allocation_size: DeviceSize,
     memory_type_index: u32,

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -105,7 +105,7 @@ use ash::vk;
 use std::{
     cmp,
     mem::ManuallyDrop,
-    num::NonZeroU64,
+    num::NonZero,
     ops::{Bound, Range, RangeBounds, RangeTo},
     ptr::NonNull,
     sync::Arc,
@@ -858,8 +858,8 @@ pub enum DedicatedAllocation<'a> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DedicatedTo {
-    Buffer(NonZeroU64),
-    Image(NonZeroU64),
+    Buffer(NonZero<u64>),
+    Image(NonZero<u64>),
 }
 
 impl From<DedicatedAllocation<'_>> for DedicatedTo {

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::SmallVec;
-use std::{mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// Opaque cache that contains pipeline objects.
 ///
@@ -30,7 +30,7 @@ use std::{mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
 pub struct PipelineCache {
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
     handle: vk::PipelineCache,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: PipelineCacheCreateFlags,
 }

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use ash::vk;
 use foldhash::HashMap;
-use std::{fmt::Debug, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{fmt::Debug, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// A pipeline object that describes to the Vulkan implementation how it should perform compute
 /// operations.
@@ -41,7 +41,7 @@ use std::{fmt::Debug, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
 pub struct ComputePipeline {
     handle: vk::Pipeline,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: PipelineCreateFlags,
     layout: DeviceOwnedDebugWrapper<Arc<PipelineLayout>>,

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -118,7 +118,7 @@ use foldhash::{HashMap, HashSet};
 use fragment_shading_rate::FragmentShadingRateState;
 use smallvec::SmallVec;
 use std::{
-    collections::hash_map::Entry, fmt::Debug, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc,
+    collections::hash_map::Entry, fmt::Debug, mem::MaybeUninit, num::NonZero, ptr, sync::Arc,
 };
 
 pub mod color_blend;
@@ -143,7 +143,7 @@ pub mod viewport;
 pub struct GraphicsPipeline {
     handle: vk::Pipeline,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: PipelineCreateFlags,
     shader_stages: ShaderStages,

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -77,7 +77,7 @@ use std::{
     error::Error,
     fmt::{Display, Formatter, Write},
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     ptr,
     sync::Arc,
 };
@@ -87,7 +87,7 @@ use std::{
 pub struct PipelineLayout {
     handle: vk::PipelineLayout,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: PipelineLayoutCreateFlags,
     set_layouts: Vec<DeviceOwnedDebugWrapper<Arc<DescriptorSetLayout>>>,

--- a/vulkano/src/pipeline/ray_tracing.rs
+++ b/vulkano/src/pipeline/ray_tracing.rs
@@ -66,7 +66,7 @@ use crate::{
 use ash::vk;
 use foldhash::{HashMap, HashSet};
 use smallvec::SmallVec;
-use std::{collections::hash_map::Entry, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{collections::hash_map::Entry, mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// Defines how the implementation should perform ray tracing operations.
 ///
@@ -75,7 +75,7 @@ use std::{collections::hash_map::Entry, mem::MaybeUninit, num::NonZeroU64, ptr, 
 pub struct RayTracingPipeline {
     handle: vk::Pipeline,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: PipelineCreateFlags,
     layout: DeviceOwnedDebugWrapper<Arc<PipelineLayout>>,

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -15,7 +15,7 @@ use crate::{
 use ash::vk;
 use std::{
     mem::{size_of_val, MaybeUninit},
-    num::NonZeroU64,
+    num::NonZero,
     ops::Range,
     ptr,
     sync::Arc,
@@ -26,7 +26,7 @@ use std::{
 pub struct QueryPool {
     handle: vk::QueryPool,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     query_type: QueryType,
     query_count: u32,

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::SmallVec;
-use std::{mem::MaybeUninit, num::NonZeroU64, ops::Range, ptr, sync::Arc};
+use std::{mem::MaybeUninit, num::NonZero, ops::Range, ptr, sync::Arc};
 
 /// The image views that are attached to a render pass during drawing.
 ///
@@ -40,7 +40,7 @@ use std::{mem::MaybeUninit, num::NonZeroU64, ops::Range, ptr, sync::Arc};
 pub struct Framebuffer {
     handle: vk::Framebuffer,
     render_pass: DeviceOwnedDebugWrapper<Arc<RenderPass>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: FramebufferCreateFlags,
     attachments: Vec<DeviceOwnedDebugWrapper<Arc<ImageView>>>,

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -34,7 +34,7 @@ use std::{
     cmp::max,
     collections::hash_map::Entry,
     mem::{replace, MaybeUninit},
-    num::NonZeroU64,
+    num::NonZero,
     ptr,
     sync::Arc,
 };
@@ -103,7 +103,7 @@ mod framebuffer;
 pub struct RenderPass {
     handle: vk::RenderPass,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: RenderPassCreateFlags,
     attachments: Vec<AttachmentDescription>,

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -436,7 +436,7 @@ use spirv::ExecutionModel;
 use std::{
     collections::hash_map::Entry,
     mem::{discriminant, MaybeUninit},
-    num::NonZeroU64,
+    num::NonZero,
     ptr,
     sync::Arc,
 };
@@ -452,7 +452,7 @@ include!(concat!(env!("OUT_DIR"), "/spirv_reqs.rs"));
 pub struct ShaderModule {
     handle: vk::ShaderModule,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     spirv: Spirv,
     specialization_constants: HashMap<u32, SpecializationConstant>,

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -16,7 +16,7 @@ use smallvec::{smallvec, SmallVec};
 use std::{
     fmt::Debug,
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     ops::Range,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -748,7 +748,7 @@ pub struct SwapchainPresentInfo {
     /// used for `swapchain`. If a swapchain is recreated, this resets.
     ///
     /// The default value is `None`.
-    pub present_id: Option<NonZeroU64>,
+    pub present_id: Option<NonZero<u64>>,
 
     /// The new present mode to use for presenting. This mode will be used for the current
     /// present, and any future presents where this value is `None`.

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -337,7 +337,7 @@ use smallvec::SmallVec;
 use std::{
     fmt::Debug,
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     ptr,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -355,7 +355,7 @@ pub struct Swapchain {
     handle: vk::SwapchainKHR,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
     surface: InstanceOwnedDebugWrapper<Arc<Surface>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: SwapchainCreateFlags,
     min_image_count: u32,
@@ -1397,7 +1397,7 @@ impl Swapchain {
     #[inline]
     pub fn wait_for_present(
         &self,
-        present_id: NonZeroU64,
+        present_id: NonZero<u64>,
         timeout: Option<Duration>,
     ) -> Result<bool, Validated<VulkanError>> {
         let is_retired_lock = self.is_retired.lock();
@@ -1408,7 +1408,7 @@ impl Swapchain {
 
     fn validate_wait_for_present(
         &self,
-        _present_id: NonZeroU64,
+        _present_id: NonZero<u64>,
         timeout: Option<Duration>,
         is_retired: bool,
     ) -> Result<(), Box<ValidationError>> {
@@ -1446,7 +1446,7 @@ impl Swapchain {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn wait_for_present_unchecked(
         &self,
-        present_id: NonZeroU64,
+        present_id: NonZero<u64>,
         timeout: Option<Duration>,
     ) -> Result<bool, VulkanError> {
         let result = {
@@ -1635,7 +1635,7 @@ impl Swapchain {
     }
 
     #[inline]
-    pub(crate) unsafe fn try_claim_present_id(&self, present_id: NonZeroU64) -> bool {
+    pub(crate) unsafe fn try_claim_present_id(&self, present_id: NonZero<u64>) -> bool {
         let present_id = u64::from(present_id);
         self.prev_present_id.fetch_max(present_id, Ordering::SeqCst) < present_id
     }

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -22,7 +22,7 @@ use std::{
     fmt::{Debug, Display, Error as FmtError, Formatter},
     marker::PhantomData,
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     ptr,
     sync::Arc,
 };
@@ -33,7 +33,7 @@ use std::{
 pub struct Surface {
     handle: vk::SurfaceKHR,
     instance: DebugWrapper<Arc<Instance>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
     api: SurfaceApi,
     object: Option<Arc<dyn Any + Send + Sync>>,
     // Data queried by the user at runtime, cached for faster lookups.

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -22,7 +22,7 @@ use crate::{
     Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, VulkanError, VulkanObject,
 };
 use ash::vk;
-use std::{mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
+use std::{mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// Used to block the GPU execution until an event on the CPU occurs.
 ///
@@ -34,7 +34,7 @@ use std::{mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc};
 pub struct Event {
     handle: vk::Event,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
     must_put_in_pool: bool,
 
     flags: EventCreateFlags,

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -38,7 +38,7 @@ use std::{
     fs::File,
     future::Future,
     mem::MaybeUninit,
-    num::NonZeroU64,
+    num::NonZero,
     pin::Pin,
     ptr,
     sync::Arc,
@@ -52,7 +52,7 @@ use std::{
 pub struct Fence {
     handle: vk::Fence,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     flags: FenceCreateFlags,
     export_handle_types: ExternalFenceHandleTypes,

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -74,7 +74,7 @@ use crate::{
 use ash::vk;
 use core::slice;
 use smallvec::SmallVec;
-use std::{fs::File, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc, time::Duration};
+use std::{fs::File, mem::MaybeUninit, num::NonZero, ptr, sync::Arc, time::Duration};
 
 /// Used to provide synchronization between command buffers during their execution.
 ///
@@ -84,7 +84,7 @@ use std::{fs::File, mem::MaybeUninit, num::NonZeroU64, ptr, sync::Arc, time::Dur
 pub struct Semaphore {
     handle: vk::Semaphore,
     device: InstanceOwnedDebugWrapper<Arc<Device>>,
-    id: NonZeroU64,
+    id: NonZero<u64>,
 
     semaphore_type: SemaphoreType,
     export_handle_types: ExternalSemaphoreHandleTypes,


### PR DESCRIPTION
### Breaking changes
Miscellaneous:
- All occurrences of `NonZeroT` have been replaced with the generic `NonZero<T>`. The Vulkano-specific type aliases `NonZeroDeviceSize` and `NonNullDeviceAddress` have been replaced with `NonZero<DeviceSize>` and `NonZero<DeviceAddress>`, respectively.
```
