### PR TITLE
Rename existing `Info` struct constructors to `new`

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -617,7 +617,7 @@ impl ApplicationHandler for App {
                 )),
                 dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                 subpass: Some(subpass.into()),
-                ..GraphicsPipelineCreateInfo::layout(layout)
+                ..GraphicsPipelineCreateInfo::new(layout)
             },
         )
         .unwrap();

--- a/examples/basic-compute-shader/main.rs
+++ b/examples/basic-compute-shader/main.rs
@@ -145,7 +145,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };

--- a/examples/bloom/bloom.rs
+++ b/examples/bloom/bloom.rs
@@ -39,7 +39,7 @@ impl BloomTask {
             ComputePipeline::new(
                 app.device.clone(),
                 None,
-                ComputePipelineCreateInfo::stage_layout(stage, pipeline_layout.clone()),
+                ComputePipelineCreateInfo::new(stage, pipeline_layout.clone()),
             )
             .unwrap()
         };
@@ -54,7 +54,7 @@ impl BloomTask {
             ComputePipeline::new(
                 app.device.clone(),
                 None,
-                ComputePipelineCreateInfo::stage_layout(stage, pipeline_layout.clone()),
+                ComputePipelineCreateInfo::new(stage, pipeline_layout.clone()),
             )
             .unwrap()
         };

--- a/examples/bloom/main.rs
+++ b/examples/bloom/main.rs
@@ -244,18 +244,14 @@ impl ApplicationHandler for App {
                                 0,
                                 DescriptorSetLayoutBinding {
                                     stages: ShaderStages::FRAGMENT | ShaderStages::COMPUTE,
-                                    ..DescriptorSetLayoutBinding::descriptor_type(
-                                        DescriptorType::Sampler,
-                                    )
+                                    ..DescriptorSetLayoutBinding::new(DescriptorType::Sampler)
                                 },
                             ),
                             (
                                 1,
                                 DescriptorSetLayoutBinding {
                                     stages: ShaderStages::FRAGMENT | ShaderStages::COMPUTE,
-                                    ..DescriptorSetLayoutBinding::descriptor_type(
-                                        DescriptorType::SampledImage,
-                                    )
+                                    ..DescriptorSetLayoutBinding::new(DescriptorType::SampledImage)
                                 },
                             ),
                             (
@@ -263,9 +259,7 @@ impl ApplicationHandler for App {
                                 DescriptorSetLayoutBinding {
                                     stages: ShaderStages::COMPUTE,
                                     descriptor_count: MAX_BLOOM_MIP_LEVELS,
-                                    ..DescriptorSetLayoutBinding::descriptor_type(
-                                        DescriptorType::StorageImage,
-                                    )
+                                    ..DescriptorSetLayoutBinding::new(DescriptorType::StorageImage)
                                 },
                             ),
                         ]

--- a/examples/bloom/scene.rs
+++ b/examples/bloom/scene.rs
@@ -116,7 +116,7 @@ impl SceneTask {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(pipeline_layout.clone())
+                    ..GraphicsPipelineCreateInfo::new(pipeline_layout.clone())
                 },
             )
             .unwrap()

--- a/examples/bloom/tonemap.rs
+++ b/examples/bloom/tonemap.rs
@@ -61,7 +61,7 @@ impl TonemapTask {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(pipeline_layout.clone())
+                    ..GraphicsPipelineCreateInfo::new(pipeline_layout.clone())
                 },
             )
             .unwrap()

--- a/examples/buffer-allocator/main.rs
+++ b/examples/buffer-allocator/main.rs
@@ -297,7 +297,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -459,10 +459,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/clear-attachments/main.rs
+++ b/examples/clear-attachments/main.rs
@@ -329,10 +329,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/debug/main.rs
+++ b/examples/debug/main.rs
@@ -76,7 +76,7 @@ fn main() {
                 message_type: DebugUtilsMessageType::GENERAL
                     | DebugUtilsMessageType::VALIDATION
                     | DebugUtilsMessageType::PERFORMANCE,
-                ..DebugUtilsMessengerCreateInfo::user_callback(DebugUtilsMessengerCallback::new(
+                ..DebugUtilsMessengerCreateInfo::new(DebugUtilsMessengerCallback::new(
                     |message_severity, message_type, callback_data| {
                         let severity = if message_severity
                             .intersects(DebugUtilsMessageSeverity::ERROR)

--- a/examples/deferred/frame/ambient_lighting_system.rs
+++ b/examples/deferred/frame/ambient_lighting_system.rs
@@ -125,7 +125,7 @@ impl AmbientLightingSystem {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.clone().into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()

--- a/examples/deferred/frame/directional_lighting_system.rs
+++ b/examples/deferred/frame/directional_lighting_system.rs
@@ -126,7 +126,7 @@ impl DirectionalLightingSystem {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.clone().into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()

--- a/examples/deferred/frame/point_lighting_system.rs
+++ b/examples/deferred/frame/point_lighting_system.rs
@@ -125,7 +125,7 @@ impl PointLightingSystem {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.clone().into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -327,7 +327,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
+                        SwapchainPresentInfo::new(
                             rcx.swapchain.clone(),
                             image_index,
                         ),

--- a/examples/deferred/triangle_draw_system.rs
+++ b/examples/deferred/triangle_draw_system.rs
@@ -109,7 +109,7 @@ impl TriangleDrawSystem {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.clone().into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()

--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -140,7 +140,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };

--- a/examples/dynamic-local-size/main.rs
+++ b/examples/dynamic-local-size/main.rs
@@ -196,7 +196,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };
@@ -271,7 +271,7 @@ fn main() {
     unsafe { builder.dispatch([1024 / local_size_x, 1024 / local_size_y, 1]) }.unwrap();
 
     builder
-        .copy_image_to_buffer(CopyImageToBufferInfo::image_buffer(image, buf.clone()))
+        .copy_image_to_buffer(CopyImageToBufferInfo::new(image, buf.clone()))
         .unwrap();
 
     let command_buffer = builder.build().unwrap();

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -567,7 +567,7 @@ mod linux {
                         )),
                         dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                         subpass: Some(subpass.into()),
-                        ..GraphicsPipelineCreateInfo::layout(layout)
+                        ..GraphicsPipelineCreateInfo::new(layout)
                     },
                 )
                 .unwrap()
@@ -740,10 +740,7 @@ mod linux {
                         .unwrap()
                         .then_swapchain_present(
                             self.queue.clone(),
-                            SwapchainPresentInfo::swapchain_image_index(
-                                rcx.swapchain.clone(),
-                                image_index,
-                            ),
+                            SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                         )
                         .then_signal_fence_and_flush();
 

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -236,7 +236,7 @@ impl App {
             // Here, we perform image copying and blitting on the same image.
             uploads
                 // Clear the image buffer.
-                .clear_color_image(ClearColorImageInfo::image(image.clone()))
+                .clear_color_image(ClearColorImageInfo::new(image.clone()))
                 .unwrap()
                 // Put our image in the top left corner.
                 .copy_buffer_to_image(CopyBufferToImageInfo {
@@ -246,7 +246,7 @@ impl App {
                         ..Default::default()
                     }]
                     .into(),
-                    ..CopyBufferToImageInfo::buffer_image(upload_buffer, image.clone())
+                    ..CopyBufferToImageInfo::new(upload_buffer, image.clone())
                 })
                 .unwrap()
                 // Copy from the top left corner to the bottom right corner.
@@ -264,7 +264,7 @@ impl App {
                         ..Default::default()
                     }]
                     .into(),
-                    ..CopyImageInfo::images(image.clone(), image.clone())
+                    ..CopyImageInfo::new(image.clone(), image.clone())
                 })
                 .unwrap()
                 // Blit from the bottom right corner to the top right corner (flipped).
@@ -288,7 +288,7 @@ impl App {
                     }]
                     .into(),
                     filter: Filter::Nearest,
-                    ..BlitImageInfo::images(image.clone(), image.clone())
+                    ..BlitImageInfo::new(image.clone(), image.clone())
                 })
                 .unwrap();
 
@@ -427,7 +427,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -568,10 +568,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -230,10 +230,7 @@ impl App {
             .unwrap();
 
             uploads
-                .copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
-                    upload_buffer,
-                    image.clone(),
-                ))
+                .copy_buffer_to_image(CopyBufferToImageInfo::new(upload_buffer, image.clone()))
                 .unwrap();
 
             ImageView::new_default(image).unwrap()
@@ -371,7 +368,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -512,10 +509,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -236,10 +236,7 @@ impl App {
             .unwrap();
 
             uploads
-                .copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
-                    upload_buffer,
-                    image.clone(),
-                ))
+                .copy_buffer_to_image(CopyBufferToImageInfo::new(upload_buffer, image.clone()))
                 .unwrap();
 
             ImageView::new_default(image).unwrap()
@@ -390,7 +387,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -531,10 +528,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -248,7 +248,7 @@ impl App {
             ComputePipeline::new(
                 device.clone(),
                 None,
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };
@@ -397,7 +397,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -578,7 +578,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
+                        SwapchainPresentInfo::new(
                             rcx.swapchain.clone(),
                             image_index,
                         ),

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -359,7 +359,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -492,10 +492,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/interactive-fractal/fractal_compute_pipeline.rs
+++ b/examples/interactive-fractal/fractal_compute_pipeline.rs
@@ -82,7 +82,7 @@ impl FractalComputePipeline {
             ComputePipeline::new(
                 device.clone(),
                 None,
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };

--- a/examples/interactive-fractal/pixels_draw_pipeline.rs
+++ b/examples/interactive-fractal/pixels_draw_pipeline.rs
@@ -83,7 +83,7 @@ impl PixelsDrawPipeline {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.clone().into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -351,7 +351,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -490,7 +490,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
+                        SwapchainPresentInfo::new(
                             rcx.swapchain.clone(),
                             image_index,
                         ),

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -347,7 +347,7 @@ fn main() {
                 )),
                 dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                 subpass: Some(subpass.into()),
-                ..GraphicsPipelineCreateInfo::layout(layout)
+                ..GraphicsPipelineCreateInfo::new(layout)
             },
         )
         .unwrap()
@@ -406,7 +406,7 @@ fn main() {
     builder
         .end_render_pass(Default::default())
         .unwrap()
-        .copy_image_to_buffer(CopyImageToBufferInfo::image_buffer(image, buf.clone()))
+        .copy_image_to_buffer(CopyImageToBufferInfo::new(image, buf.clone()))
         .unwrap();
 
     let command_buffer = builder.build().unwrap();

--- a/examples/multi-window-game-of-life/game_of_life.rs
+++ b/examples/multi-window-game-of-life/game_of_life.rs
@@ -78,7 +78,7 @@ impl GameOfLifeComputePipeline {
             ComputePipeline::new(
                 device.clone(),
                 None,
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };

--- a/examples/multi-window-game-of-life/pixels_draw.rs
+++ b/examples/multi-window-game-of-life/pixels_draw.rs
@@ -79,7 +79,7 @@ impl PixelsDrawPipeline {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.clone().into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()

--- a/examples/multi-window/main.rs
+++ b/examples/multi-window/main.rs
@@ -311,7 +311,7 @@ impl App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -464,7 +464,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
+                        SwapchainPresentInfo::new(
                             rcx.swapchain.clone(),
                             image_index,
                         ),

--- a/examples/multiview/main.rs
+++ b/examples/multiview/main.rs
@@ -297,7 +297,7 @@ fn main() {
                     ColorBlendAttachmentState::default(),
                 )),
                 subpass: Some(subpass.into()),
-                ..GraphicsPipelineCreateInfo::layout(layout)
+                ..GraphicsPipelineCreateInfo::new(layout)
             },
         )
         .unwrap()
@@ -368,7 +368,7 @@ fn main() {
                 ..Default::default()
             }]
             .into(),
-            ..CopyImageToBufferInfo::image_buffer(image.clone(), buffer1.clone())
+            ..CopyImageToBufferInfo::new(image.clone(), buffer1.clone())
         })
         .unwrap()
         .copy_image_to_buffer(CopyImageToBufferInfo {
@@ -381,7 +381,7 @@ fn main() {
                 ..Default::default()
             }]
             .into(),
-            ..CopyImageToBufferInfo::image_buffer(image.clone(), buffer2.clone())
+            ..CopyImageToBufferInfo::new(image.clone(), buffer2.clone())
         })
         .unwrap();
 

--- a/examples/occlusion-query/main.rs
+++ b/examples/occlusion-query/main.rs
@@ -215,7 +215,7 @@ impl App {
             device.clone(),
             QueryPoolCreateInfo {
                 query_count: 3,
-                ..QueryPoolCreateInfo::query_type(QueryType::Occlusion)
+                ..QueryPoolCreateInfo::new(QueryType::Occlusion)
             },
         )
         .unwrap();
@@ -391,7 +391,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -563,10 +563,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -247,7 +247,7 @@ fn main() {
                     ColorBlendAttachmentState::default(),
                 )),
                 subpass: Some(subpass.into()),
-                ..GraphicsPipelineCreateInfo::layout(layout)
+                ..GraphicsPipelineCreateInfo::new(layout)
             },
         )
         .unwrap()
@@ -306,7 +306,7 @@ fn main() {
     // the device. This step copies the output image into a host-readable linear output buffer
     // where consecutive pixels in the image are laid out consecutively in memory.
     builder
-        .copy_image_to_buffer(CopyImageToBufferInfo::image_buffer(
+        .copy_image_to_buffer(CopyImageToBufferInfo::new(
             render_output_image.clone(),
             render_output_buf.clone(),
         ))

--- a/examples/pipeline-caching/main.rs
+++ b/examples/pipeline-caching/main.rs
@@ -139,7 +139,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             Some(pipeline_cache.clone()),
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };

--- a/examples/push-constants/main.rs
+++ b/examples/push-constants/main.rs
@@ -127,7 +127,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -220,10 +220,7 @@ impl App {
             .unwrap();
 
             uploads
-                .copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
-                    upload_buffer,
-                    image.clone(),
-                ))
+                .copy_buffer_to_image(CopyBufferToImageInfo::new(upload_buffer, image.clone()))
                 .unwrap();
 
             ImageView::new_default(image).unwrap()
@@ -369,7 +366,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -504,10 +501,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/ray-tracing-auto/main.rs
+++ b/examples/ray-tracing-auto/main.rs
@@ -226,7 +226,7 @@ impl ApplicationHandler for App {
                                     0,
                                     DescriptorSetLayoutBinding {
                                         stages: ShaderStages::RAYGEN,
-                                        ..DescriptorSetLayoutBinding::descriptor_type(
+                                        ..DescriptorSetLayoutBinding::new(
                                             DescriptorType::AccelerationStructure,
                                         )
                                     },
@@ -235,7 +235,7 @@ impl ApplicationHandler for App {
                                     1,
                                     DescriptorSetLayoutBinding {
                                         stages: ShaderStages::RAYGEN,
-                                        ..DescriptorSetLayoutBinding::descriptor_type(
+                                        ..DescriptorSetLayoutBinding::new(
                                             DescriptorType::UniformBuffer,
                                         )
                                     },
@@ -254,9 +254,7 @@ impl ApplicationHandler for App {
                                 0,
                                 DescriptorSetLayoutBinding {
                                     stages: ShaderStages::RAYGEN,
-                                    ..DescriptorSetLayoutBinding::descriptor_type(
-                                        DescriptorType::StorageImage,
-                                    )
+                                    ..DescriptorSetLayoutBinding::new(DescriptorType::StorageImage)
                                 },
                             )]
                             .into_iter()
@@ -372,10 +370,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/ray-tracing-auto/scene.rs
+++ b/examples/ray-tracing-auto/scene.rs
@@ -94,7 +94,7 @@ impl Scene {
                     stages: stages.into_iter().collect(),
                     groups: groups.into_iter().collect(),
                     max_pipeline_ray_recursion_depth: 1,
-                    ..RayTracingPipelineCreateInfo::layout(pipeline_layout.clone())
+                    ..RayTracingPipelineCreateInfo::new(pipeline_layout.clone())
                 },
             )
             .unwrap()

--- a/examples/ray-tracing/main.rs
+++ b/examples/ray-tracing/main.rs
@@ -234,7 +234,7 @@ impl ApplicationHandler for App {
                                     0,
                                     DescriptorSetLayoutBinding {
                                         stages: ShaderStages::RAYGEN,
-                                        ..DescriptorSetLayoutBinding::descriptor_type(
+                                        ..DescriptorSetLayoutBinding::new(
                                             DescriptorType::AccelerationStructure,
                                         )
                                     },
@@ -243,7 +243,7 @@ impl ApplicationHandler for App {
                                     1,
                                     DescriptorSetLayoutBinding {
                                         stages: ShaderStages::RAYGEN,
-                                        ..DescriptorSetLayoutBinding::descriptor_type(
+                                        ..DescriptorSetLayoutBinding::new(
                                             DescriptorType::UniformBuffer,
                                         )
                                     },
@@ -262,9 +262,7 @@ impl ApplicationHandler for App {
                                 0,
                                 DescriptorSetLayoutBinding {
                                     stages: ShaderStages::RAYGEN,
-                                    ..DescriptorSetLayoutBinding::descriptor_type(
-                                        DescriptorType::StorageImage,
-                                    )
+                                    ..DescriptorSetLayoutBinding::new(DescriptorType::StorageImage)
                                 },
                             )]
                             .into_iter()

--- a/examples/ray-tracing/scene.rs
+++ b/examples/ray-tracing/scene.rs
@@ -99,7 +99,7 @@ impl SceneTask {
                     stages: stages.into_iter().collect(),
                     groups: groups.into_iter().collect(),
                     max_pipeline_ray_recursion_depth: 1,
-                    ..RayTracingPipelineCreateInfo::layout(pipeline_layout.clone())
+                    ..RayTracingPipelineCreateInfo::new(pipeline_layout.clone())
                 },
             )
             .unwrap()

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -289,10 +289,7 @@ impl App {
             .unwrap();
 
             uploads
-                .copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
-                    upload_buffer,
-                    image.clone(),
-                ))
+                .copy_buffer_to_image(CopyBufferToImageInfo::new(upload_buffer, image.clone()))
                 .unwrap();
 
             ImageView::new_default(image).unwrap()
@@ -338,10 +335,7 @@ impl App {
             .unwrap();
 
             uploads
-                .copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
-                    upload_buffer,
-                    image.clone(),
-                ))
+                .copy_buffer_to_image(CopyBufferToImageInfo::new(upload_buffer, image.clone()))
                 .unwrap();
 
             ImageView::new_default(image).unwrap()
@@ -490,7 +484,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -639,10 +633,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -307,7 +307,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -428,10 +428,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/self-copy-buffer/main.rs
+++ b/examples/self-copy-buffer/main.rs
@@ -119,7 +119,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };
@@ -180,7 +180,7 @@ fn main() {
                 ..Default::default()
             }]
             .into(),
-            ..CopyBufferInfoTyped::buffers(data_buffer.clone(), data_buffer.clone())
+            ..CopyBufferInfoTyped::new(data_buffer.clone(), data_buffer.clone())
         })
         .unwrap()
         .bind_pipeline_compute(pipeline.clone())

--- a/examples/shader-include/main.rs
+++ b/examples/shader-include/main.rs
@@ -127,7 +127,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };

--- a/examples/shader-types-sharing/main.rs
+++ b/examples/shader-types-sharing/main.rs
@@ -268,7 +268,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };
@@ -289,12 +289,7 @@ fn main() {
                 .unwrap(),
         )
         .unwrap();
-        ComputePipeline::new(
-            device,
-            None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
-        )
-        .unwrap()
+        ComputePipeline::new(device, None, ComputePipelineCreateInfo::new(stage, layout)).unwrap()
     };
 
     // Multiply each value by 2.

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -216,7 +216,7 @@ impl App {
                 CommandBufferUsage::OneTimeSubmit,
             )
             .unwrap();
-            cbb.copy_buffer(CopyBufferInfo::buffers(
+            cbb.copy_buffer(CopyBufferInfo::new(
                 temporary_accessible_buffer,
                 device_local_buffer.clone(),
             ))
@@ -252,7 +252,7 @@ impl App {
             ComputePipeline::new(
                 device.clone(),
                 None,
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };
@@ -464,7 +464,7 @@ impl ApplicationHandler for App {
                         ColorBlendAttachmentState::default(),
                     )),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -591,10 +591,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/specialization-constants/main.rs
+++ b/examples/specialization-constants/main.rs
@@ -130,7 +130,7 @@ fn main() {
         ComputePipeline::new(
             device.clone(),
             None,
-            ComputePipelineCreateInfo::stage_layout(stage, layout),
+            ComputePipelineCreateInfo::new(stage, layout),
         )
         .unwrap()
     };

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -496,10 +496,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 
@@ -619,7 +616,7 @@ fn window_size_dependent_setup(
                     ColorBlendAttachmentState::default(),
                 )),
                 subpass: Some(subpass.into()),
-                ..GraphicsPipelineCreateInfo::layout(layout)
+                ..GraphicsPipelineCreateInfo::new(layout)
             },
         )
         .unwrap()

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -334,7 +334,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -455,7 +455,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
+                        SwapchainPresentInfo::new(
                             rcx.swapchain.clone(),
                             image_index,
                         ),

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -251,10 +251,7 @@ impl App {
             .unwrap();
 
             uploads
-                .copy_buffer_to_image(CopyBufferToImageInfo::buffer_image(
-                    upload_buffer,
-                    image.clone(),
-                ))
+                .copy_buffer_to_image(CopyBufferToImageInfo::new(upload_buffer, image.clone()))
                 .unwrap();
 
             ImageView::new_default(image).unwrap()
@@ -384,7 +381,7 @@ impl ApplicationHandler for App {
                     )),
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -525,10 +522,7 @@ impl ApplicationHandler for App {
                     .unwrap()
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -309,7 +309,7 @@ impl ApplicationHandler for App {
                     // that the viewport should be dynamic.
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -509,7 +509,7 @@ impl ApplicationHandler for App {
                     // that the viewport should be dynamic.
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -671,7 +671,7 @@ impl ApplicationHandler for App {
                             // Only attachments that have `AttachmentLoadOp::Clear` are provided
                             // with clear values, any others should use `None` as the clear value.
                             clear_value: Some([0.0, 0.0, 1.0, 1.0].into()),
-                            ..RenderingAttachmentInfo::image_view(
+                            ..RenderingAttachmentInfo::new(
                                 // We specify image view corresponding to the currently acquired
                                 // swapchain image, to use for this attachment.
                                 rcx.attachment_image_views[image_index as usize].clone(),
@@ -718,10 +718,7 @@ impl ApplicationHandler for App {
                     // that draws the triangle.
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
-                            rcx.swapchain.clone(),
-                            image_index,
-                        ),
+                        SwapchainPresentInfo::new(rcx.swapchain.clone(), image_index),
                     )
                     .then_signal_fence_and_flush();
 

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -510,7 +510,7 @@ impl ApplicationHandler for App {
                     // that the viewport should be dynamic.
                     dynamic_state: [DynamicState::Viewport].into_iter().collect(),
                     subpass: Some(subpass.into()),
-                    ..GraphicsPipelineCreateInfo::layout(layout)
+                    ..GraphicsPipelineCreateInfo::new(layout)
                 },
             )
             .unwrap()
@@ -719,7 +719,7 @@ impl ApplicationHandler for App {
                     // that draws the triangle.
                     .then_swapchain_present(
                         self.queue.clone(),
-                        SwapchainPresentInfo::swapchain_image_index(
+                        SwapchainPresentInfo::new(
                             rcx.swapchain.clone(),
                             image_index,
                         ),

--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -307,10 +307,7 @@ impl VulkanoWindowRenderer {
         let future = after_future
             .then_swapchain_present(
                 self.graphics_queue.clone(),
-                SwapchainPresentInfo::swapchain_image_index(
-                    self.swapchain.clone(),
-                    self.image_index,
-                ),
+                SwapchainPresentInfo::new(self.swapchain.clone(), self.image_index),
             )
             .then_signal_fence_and_flush();
         match future.map_err(Validated::unwrap) {

--- a/vulkano/autogen/features.rs
+++ b/vulkano/autogen/features.rs
@@ -287,7 +287,7 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
                 Ok(())
             }
 
-            /// Returns a `DeviceFeatures` object with none of the members set.
+            /// Returns a `DeviceFeatures` with none of the members set.
             #[inline]
             pub const fn empty() -> Self {
                 Self {
@@ -296,7 +296,7 @@ fn features_output(members: &[FeaturesMember]) -> TokenStream {
                 }
             }
 
-            /// Returns a `DeviceFeatures` object with all of the members set.
+            /// Returns a `DeviceFeatures` with all of the members set.
             #[cfg(test)]
             pub(crate) const fn all() -> DeviceFeatures {
                 Self {

--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -340,7 +340,7 @@ pub struct AccelerationStructureCreateInfo {
 impl AccelerationStructureCreateInfo {
     /// Returns a default `AccelerationStructureCreateInfo` with the provided `buffer`.
     #[inline]
-    pub fn new(buffer: Subbuffer<[u8]>) -> Self {
+    pub const fn new(buffer: Subbuffer<[u8]>) -> Self {
         Self {
             create_flags: AccelerationStructureCreateFlags::empty(),
             buffer,
@@ -500,7 +500,7 @@ pub struct AccelerationStructureBuildGeometryInfo {
 impl AccelerationStructureBuildGeometryInfo {
     /// Returns a default `AccelerationStructureBuildGeometryInfo` with the provided `geometries`.
     #[inline]
-    pub fn new(geometries: AccelerationStructureGeometries) -> Self {
+    pub const fn new(geometries: AccelerationStructureGeometries) -> Self {
         Self {
             flags: BuildAccelerationStructureFlags::empty(),
             mode: BuildAccelerationStructureMode::Build,
@@ -894,7 +894,7 @@ impl AccelerationStructureGeometryTrianglesData {
     /// Returns a default `AccelerationStructureGeometryTrianglesData` with the provided
     /// `vertex_format`.
     #[inline]
-    pub fn new(vertex_format: Format) -> Self {
+    pub const fn new(vertex_format: Format) -> Self {
         Self {
             flags: GeometryFlags::empty(),
             vertex_format,
@@ -1154,7 +1154,7 @@ pub struct AccelerationStructureGeometryInstancesData {
 impl AccelerationStructureGeometryInstancesData {
     /// Returns a default `AccelerationStructureGeometryInstancesData` with the provided `data`.
     #[inline]
-    pub fn new(data: AccelerationStructureGeometryInstancesDataType) -> Self {
+    pub const fn new(data: AccelerationStructureGeometryInstancesDataType) -> Self {
         Self {
             flags: GeometryFlags::empty(),
             data,
@@ -1413,7 +1413,7 @@ pub struct CopyAccelerationStructureInfo {
 impl CopyAccelerationStructureInfo {
     /// Returns a default `CopyAccelerationStructureInfo` with the provided `src` and `dst`.
     #[inline]
-    pub fn new(src: Arc<AccelerationStructure>, dst: Arc<AccelerationStructure>) -> Self {
+    pub const fn new(src: Arc<AccelerationStructure>, dst: Arc<AccelerationStructure>) -> Self {
         Self {
             src,
             dst,
@@ -1510,7 +1510,7 @@ impl CopyAccelerationStructureToMemoryInfo {
     /// Returns a default `CopyAccelerationStructureToMemoryInfo` with the provided `src` and
     /// `dst`.
     #[inline]
-    pub fn new(src: Arc<AccelerationStructure>, dst: Subbuffer<[u8]>) -> Self {
+    pub const fn new(src: Arc<AccelerationStructure>, dst: Subbuffer<[u8]>) -> Self {
         Self {
             src,
             dst,
@@ -1593,7 +1593,7 @@ impl CopyMemoryToAccelerationStructureInfo {
     /// Returns a default `CopyMemoryToAccelerationStructureInfo` with the specified `src` and
     /// `dst`.
     #[inline]
-    pub fn new(src: Subbuffer<[u8]>, dst: Arc<AccelerationStructure>) -> Self {
+    pub const fn new(src: Subbuffer<[u8]>, dst: Arc<AccelerationStructure>) -> Self {
         Self {
             src,
             dst,

--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -338,7 +338,7 @@ pub struct AccelerationStructureCreateInfo {
 }
 
 impl AccelerationStructureCreateInfo {
-    /// Returns a `AccelerationStructureCreateInfo` with the specified `buffer`.
+    /// Returns a default `AccelerationStructureCreateInfo` with the provided `buffer`.
     #[inline]
     pub fn new(buffer: Subbuffer<[u8]>) -> Self {
         Self {
@@ -498,7 +498,7 @@ pub struct AccelerationStructureBuildGeometryInfo {
 }
 
 impl AccelerationStructureBuildGeometryInfo {
-    /// Returns a `AccelerationStructureBuildGeometryInfo` with the specified `geometries`.
+    /// Returns a default `AccelerationStructureBuildGeometryInfo` with the provided `geometries`.
     #[inline]
     pub fn new(geometries: AccelerationStructureGeometries) -> Self {
         Self {
@@ -891,7 +891,7 @@ pub struct AccelerationStructureGeometryTrianglesData {
 }
 
 impl AccelerationStructureGeometryTrianglesData {
-    /// Returns a `AccelerationStructureGeometryTrianglesData` with the specified
+    /// Returns a default `AccelerationStructureGeometryTrianglesData` with the provided
     /// `vertex_format`.
     #[inline]
     pub fn new(vertex_format: Format) -> Self {
@@ -1152,7 +1152,7 @@ pub struct AccelerationStructureGeometryInstancesData {
 }
 
 impl AccelerationStructureGeometryInstancesData {
-    /// Returns a `AccelerationStructureGeometryInstancesData` with the specified `data`.
+    /// Returns a default `AccelerationStructureGeometryInstancesData` with the provided `data`.
     #[inline]
     pub fn new(data: AccelerationStructureGeometryInstancesDataType) -> Self {
         Self {
@@ -1411,7 +1411,7 @@ pub struct CopyAccelerationStructureInfo {
 }
 
 impl CopyAccelerationStructureInfo {
-    /// Returns a `CopyAccelerationStructureInfo` with the specified `src` and `dst`.
+    /// Returns a default `CopyAccelerationStructureInfo` with the provided `src` and `dst`.
     #[inline]
     pub fn new(src: Arc<AccelerationStructure>, dst: Arc<AccelerationStructure>) -> Self {
         Self {
@@ -1507,7 +1507,8 @@ pub struct CopyAccelerationStructureToMemoryInfo {
 }
 
 impl CopyAccelerationStructureToMemoryInfo {
-    /// Returns a `CopyAccelerationStructureToMemoryInfo` with the specified `src` and `dst`.
+    /// Returns a default `CopyAccelerationStructureToMemoryInfo` with the provided `src` and
+    /// `dst`.
     #[inline]
     pub fn new(src: Arc<AccelerationStructure>, dst: Subbuffer<[u8]>) -> Self {
         Self {
@@ -1589,7 +1590,8 @@ pub struct CopyMemoryToAccelerationStructureInfo {
 }
 
 impl CopyMemoryToAccelerationStructureInfo {
-    /// Returns a `CopyMemoryToAccelerationStructureInfo` with the specified `src` and `dst`.
+    /// Returns a default `CopyMemoryToAccelerationStructureInfo` with the specified `src` and
+    /// `dst`.
     #[inline]
     pub fn new(src: Subbuffer<[u8]>, dst: Arc<AccelerationStructure>) -> Self {
         Self {

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -872,7 +872,7 @@ pub struct ExternalBufferInfo {
 impl ExternalBufferInfo {
     /// Returns a default `ExternalBufferInfo` with the provided `handle_type`.
     #[inline]
-    pub fn new(handle_type: ExternalMemoryHandleType) -> Self {
+    pub const fn new(handle_type: ExternalMemoryHandleType) -> Self {
         Self {
             flags: BufferCreateFlags::empty(),
             usage: BufferUsage::empty(),

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -870,15 +870,21 @@ pub struct ExternalBufferInfo {
 }
 
 impl ExternalBufferInfo {
-    /// Returns an `ExternalBufferInfo` with the specified `handle_type`.
+    /// Returns a default `ExternalBufferInfo` with the provided `handle_type`.
     #[inline]
-    pub fn handle_type(handle_type: ExternalMemoryHandleType) -> Self {
+    pub fn new(handle_type: ExternalMemoryHandleType) -> Self {
         Self {
             flags: BufferCreateFlags::empty(),
             usage: BufferUsage::empty(),
             handle_type,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn handle_type(handle_type: ExternalMemoryHandleType) -> Self {
+        Self::new(handle_type)
     }
 
     pub(crate) fn validate(

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -436,7 +436,7 @@ mod tests {
                 ..Default::default()
             }]
             .into(),
-            ..CopyBufferInfoTyped::buffers(source, destination.clone())
+            ..CopyBufferInfoTyped::new(source, destination.clone())
         })
         .unwrap();
 
@@ -560,7 +560,7 @@ mod tests {
                     ..Default::default()
                 }]
                 .into(),
-                ..CopyBufferInfoTyped::buffers(source.clone(), source.clone())
+                ..CopyBufferInfoTyped::new(source.clone(), source.clone())
             })
             .unwrap();
 
@@ -618,7 +618,7 @@ mod tests {
                     ..Default::default()
                 }]
                 .into(),
-                ..CopyBufferInfoTyped::buffers(source.clone(), source)
+                ..CopyBufferInfoTyped::new(source.clone(), source)
             })
             .is_err());
     }
@@ -787,7 +787,7 @@ mod tests {
                     0,
                     DescriptorSetLayoutBinding {
                         stages: ShaderStages::all_graphics(),
-                        ..DescriptorSetLayoutBinding::descriptor_type(DescriptorType::Sampler)
+                        ..DescriptorSetLayoutBinding::new(DescriptorType::Sampler)
                     },
                 )]
                 .into(),

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -653,9 +653,9 @@ pub struct ClearColorImageInfo {
 }
 
 impl ClearColorImageInfo {
-    /// Returns a `ClearColorImageInfo` with the specified `image`.
+    /// Returns a default `ClearColorImageInfo` with the provided `image`.
     #[inline]
-    pub fn image(image: Arc<Image>) -> Self {
+    pub fn new(image: Arc<Image>) -> Self {
         let range = image.subresource_range();
 
         Self {
@@ -665,6 +665,12 @@ impl ClearColorImageInfo {
             regions: smallvec![range],
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn image(image: Arc<Image>) -> Self {
+        Self::new(image)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -861,9 +867,9 @@ pub struct ClearDepthStencilImageInfo {
 }
 
 impl ClearDepthStencilImageInfo {
-    /// Returns a `ClearDepthStencilImageInfo` with the specified `image`.
+    /// Returns a default `ClearDepthStencilImageInfo` with the provided `image`.
     #[inline]
-    pub fn image(image: Arc<Image>) -> Self {
+    pub fn new(image: Arc<Image>) -> Self {
         let range = image.subresource_range();
 
         Self {
@@ -873,6 +879,12 @@ impl ClearDepthStencilImageInfo {
             regions: smallvec![range],
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn image(image: Arc<Image>) -> Self {
+        Self::new(image)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -654,6 +654,7 @@ pub struct ClearColorImageInfo {
 
 impl ClearColorImageInfo {
     /// Returns a default `ClearColorImageInfo` with the provided `image`.
+    // TODO: make const
     #[inline]
     pub fn new(image: Arc<Image>) -> Self {
         let range = image.subresource_range();
@@ -868,6 +869,7 @@ pub struct ClearDepthStencilImageInfo {
 
 impl ClearDepthStencilImageInfo {
     /// Returns a default `ClearDepthStencilImageInfo` with the provided `image`.
+    // TODO: make const
     #[inline]
     pub fn new(image: Arc<Image>) -> Self {
         let range = image.subresource_range();

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -1755,9 +1755,9 @@ pub struct CopyBufferInfo {
 }
 
 impl CopyBufferInfo {
-    /// Returns a `CopyBufferInfo` with the specified `src_buffer` and `dst_buffer`.
+    /// Returns a default `CopyBufferInfo` with the provided `src_buffer` and `dst_buffer`.
     #[inline]
-    pub fn buffers(src_buffer: Subbuffer<impl ?Sized>, dst_buffer: Subbuffer<impl ?Sized>) -> Self {
+    pub fn new(src_buffer: Subbuffer<impl ?Sized>, dst_buffer: Subbuffer<impl ?Sized>) -> Self {
         let region = BufferCopy {
             src_offset: 0,
             dst_offset: 0,
@@ -1771,6 +1771,12 @@ impl CopyBufferInfo {
             regions: smallvec![region],
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn buffers(src_buffer: Subbuffer<impl ?Sized>, dst_buffer: Subbuffer<impl ?Sized>) -> Self {
+        Self::new(src_buffer, dst_buffer)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -1996,8 +2002,9 @@ pub struct CopyBufferInfoTyped<T> {
 }
 
 impl<T> CopyBufferInfoTyped<T> {
-    /// Returns a `CopyBufferInfoTyped` with the specified `src_buffer` and `dst_buffer`.
-    pub fn buffers(src_buffer: Subbuffer<[T]>, dst_buffer: Subbuffer<[T]>) -> Self {
+    /// Returns a default `CopyBufferInfoTyped` with the provided `src_buffer` and `dst_buffer`.
+    #[inline]
+    pub fn new(src_buffer: Subbuffer<[T]>, dst_buffer: Subbuffer<[T]>) -> Self {
         let region = BufferCopy {
             size: min(src_buffer.len(), dst_buffer.len()),
             ..Default::default()
@@ -2009,6 +2016,12 @@ impl<T> CopyBufferInfoTyped<T> {
             regions: smallvec![region],
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn buffers(src_buffer: Subbuffer<[T]>, dst_buffer: Subbuffer<[T]>) -> Self {
+        Self::new(src_buffer, dst_buffer)
     }
 }
 
@@ -2164,9 +2177,9 @@ pub struct CopyImageInfo {
 }
 
 impl CopyImageInfo {
-    /// Returns a `CopyImageInfo` with the specified `src_image` and `dst_image`.
+    /// Returns a default `CopyImageInfo` with the provided `src_image` and `dst_image`.
     #[inline]
-    pub fn images(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
+    pub fn new(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());
         let region = ImageCopy {
             src_subresource: ImageSubresourceLayers {
@@ -2198,6 +2211,12 @@ impl CopyImageInfo {
             regions: smallvec![region],
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn images(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
+        Self::new(src_image, dst_image)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -3655,10 +3674,10 @@ pub struct CopyBufferToImageInfo {
 }
 
 impl CopyBufferToImageInfo {
-    /// Returns a `CopyBufferToImageInfo` with the specified `src_buffer` and
+    /// Returns a default `CopyBufferToImageInfo` with the provided `src_buffer` and
     /// `dst_image`.
     #[inline]
-    pub fn buffer_image(src_buffer: Subbuffer<impl ?Sized>, dst_image: Arc<Image>) -> Self {
+    pub fn new(src_buffer: Subbuffer<impl ?Sized>, dst_image: Arc<Image>) -> Self {
         let region = BufferImageCopy {
             image_subresource: dst_image.subresource_layers(),
             image_extent: dst_image.extent(),
@@ -3672,6 +3691,12 @@ impl CopyBufferToImageInfo {
             regions: smallvec![region],
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn buffer_image(src_buffer: Subbuffer<impl ?Sized>, dst_image: Arc<Image>) -> Self {
+        Self::new(src_buffer, dst_image)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -4339,10 +4364,10 @@ pub struct CopyImageToBufferInfo {
 }
 
 impl CopyImageToBufferInfo {
-    /// Returns a `CopyImageToBufferInfo` with the specified `src_image` and
+    /// Returns a default `CopyImageToBufferInfo` with the provided `src_image` and
     /// `dst_buffer`.
     #[inline]
-    pub fn image_buffer(src_image: Arc<Image>, dst_buffer: Subbuffer<impl ?Sized>) -> Self {
+    pub fn new(src_image: Arc<Image>, dst_buffer: Subbuffer<impl ?Sized>) -> Self {
         let region = BufferImageCopy {
             image_subresource: src_image.subresource_layers(),
             image_extent: src_image.extent(),
@@ -4356,6 +4381,12 @@ impl CopyImageToBufferInfo {
             regions: smallvec![region],
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn image_buffer(src_image: Arc<Image>, dst_buffer: Subbuffer<impl ?Sized>) -> Self {
+        Self::new(src_image, dst_buffer)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -5275,9 +5306,9 @@ pub struct BlitImageInfo {
 }
 
 impl BlitImageInfo {
-    /// Returns a `BlitImageInfo` with the specified `src_image` and `dst_image`.
+    /// Returns a default `BlitImageInfo` with the provided `src_image` and `dst_image`.
     #[inline]
-    pub fn images(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
+    pub fn new(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());
         let region = ImageBlit {
             src_subresource: ImageSubresourceLayers {
@@ -5302,6 +5333,12 @@ impl BlitImageInfo {
             filter: Filter::Nearest,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn images(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
+        Self::new(src_image, dst_image)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -6309,9 +6346,9 @@ pub struct ResolveImageInfo {
 }
 
 impl ResolveImageInfo {
-    /// Returns a `ResolveImageInfo` with the specified `src_image` and `dst_image`.
+    /// Returns a default `ResolveImageInfo` with the provided `src_image` and `dst_image`.
     #[inline]
-    pub fn images(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
+    pub fn new(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());
         let region = ImageResolve {
             src_subresource: ImageSubresourceLayers {
@@ -6343,6 +6380,12 @@ impl ResolveImageInfo {
             regions: smallvec![region],
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn images(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
+        Self::new(src_image, dst_image)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -1756,6 +1756,7 @@ pub struct CopyBufferInfo {
 
 impl CopyBufferInfo {
     /// Returns a default `CopyBufferInfo` with the provided `src_buffer` and `dst_buffer`.
+    // TODO: make const
     #[inline]
     pub fn new(src_buffer: Subbuffer<impl ?Sized>, dst_buffer: Subbuffer<impl ?Sized>) -> Self {
         let region = BufferCopy {
@@ -2003,6 +2004,7 @@ pub struct CopyBufferInfoTyped<T> {
 
 impl<T> CopyBufferInfoTyped<T> {
     /// Returns a default `CopyBufferInfoTyped` with the provided `src_buffer` and `dst_buffer`.
+    // TODO: make const
     #[inline]
     pub fn new(src_buffer: Subbuffer<[T]>, dst_buffer: Subbuffer<[T]>) -> Self {
         let region = BufferCopy {
@@ -2178,6 +2180,7 @@ pub struct CopyImageInfo {
 
 impl CopyImageInfo {
     /// Returns a default `CopyImageInfo` with the provided `src_image` and `dst_image`.
+    // TODO: make const
     #[inline]
     pub fn new(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());
@@ -3676,6 +3679,7 @@ pub struct CopyBufferToImageInfo {
 impl CopyBufferToImageInfo {
     /// Returns a default `CopyBufferToImageInfo` with the provided `src_buffer` and
     /// `dst_image`.
+    // TODO: make const
     #[inline]
     pub fn new(src_buffer: Subbuffer<impl ?Sized>, dst_image: Arc<Image>) -> Self {
         let region = BufferImageCopy {
@@ -4366,6 +4370,7 @@ pub struct CopyImageToBufferInfo {
 impl CopyImageToBufferInfo {
     /// Returns a default `CopyImageToBufferInfo` with the provided `src_image` and
     /// `dst_buffer`.
+    // TODO: make const
     #[inline]
     pub fn new(src_image: Arc<Image>, dst_buffer: Subbuffer<impl ?Sized>) -> Self {
         let region = BufferImageCopy {
@@ -5307,6 +5312,7 @@ pub struct BlitImageInfo {
 
 impl BlitImageInfo {
     /// Returns a default `BlitImageInfo` with the provided `src_image` and `dst_image`.
+    // TODO: make const
     #[inline]
     pub fn new(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());
@@ -6347,6 +6353,7 @@ pub struct ResolveImageInfo {
 
 impl ResolveImageInfo {
     /// Returns a default `ResolveImageInfo` with the provided `src_image` and `dst_image`.
+    // TODO: make const
     #[inline]
     pub fn new(src_image: Arc<Image>, dst_image: Arc<Image>) -> Self {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -2892,6 +2892,7 @@ pub struct RenderingAttachmentInfo {
 
 impl RenderingAttachmentInfo {
     /// Returns a default `RenderingAttachmentInfo` with the provided `image_view`.
+    // TODO: make const
     #[inline]
     pub fn new(image_view: Arc<ImageView>) -> Self {
         let aspects = image_view.format().aspects();
@@ -3090,6 +3091,7 @@ pub struct RenderingAttachmentResolveInfo {
 
 impl RenderingAttachmentResolveInfo {
     /// Returns a default `RenderingAttachmentResolveInfo` with the provided `image_view`.
+    // TODO: make const
     #[inline]
     pub fn new(image_view: Arc<ImageView>) -> Self {
         let aspects = image_view.format().aspects();

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -2891,9 +2891,9 @@ pub struct RenderingAttachmentInfo {
 }
 
 impl RenderingAttachmentInfo {
-    /// Returns a `RenderingAttachmentInfo` with the specified `image_view`.
+    /// Returns a default `RenderingAttachmentInfo` with the provided `image_view`.
     #[inline]
-    pub fn image_view(image_view: Arc<ImageView>) -> Self {
+    pub fn new(image_view: Arc<ImageView>) -> Self {
         let aspects = image_view.format().aspects();
         let image_layout = if aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
             ImageLayout::DepthStencilAttachmentOptimal
@@ -2910,6 +2910,12 @@ impl RenderingAttachmentInfo {
             clear_value: None,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn image_view(image_view: Arc<ImageView>) -> Self {
+        Self::new(image_view)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -3083,9 +3089,9 @@ pub struct RenderingAttachmentResolveInfo {
 }
 
 impl RenderingAttachmentResolveInfo {
-    /// Returns a `RenderingAttachmentResolveInfo` with the specified `image_view`.
+    /// Returns a default `RenderingAttachmentResolveInfo` with the provided `image_view`.
     #[inline]
-    pub fn image_view(image_view: Arc<ImageView>) -> Self {
+    pub fn new(image_view: Arc<ImageView>) -> Self {
         let aspects = image_view.format().aspects();
         let image_layout = if aspects.intersects(ImageAspects::DEPTH | ImageAspects::STENCIL) {
             ImageLayout::DepthStencilAttachmentOptimal
@@ -3098,6 +3104,12 @@ impl RenderingAttachmentResolveInfo {
             image_view,
             image_layout,
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn image_view(image_view: Arc<ImageView>) -> Self {
+        Self::new(image_view)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -548,13 +548,19 @@ pub struct CommandBufferInheritanceRenderPassInfo {
 }
 
 impl CommandBufferInheritanceRenderPassInfo {
-    /// Returns a `CommandBufferInheritanceRenderPassInfo` with the specified `subpass`.
+    /// Returns a default `CommandBufferInheritanceRenderPassInfo` with the provided `subpass`.
     #[inline]
-    pub fn subpass(subpass: Subpass) -> Self {
+    pub fn new(subpass: Subpass) -> Self {
         Self {
             subpass,
             framebuffer: None,
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn subpass(subpass: Subpass) -> Self {
+        Self::new(subpass)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -1195,7 +1201,7 @@ pub struct CommandBufferSubmitInfo {
 }
 
 impl CommandBufferSubmitInfo {
-    /// Returns a `CommandBufferSubmitInfo` with the specified `command_buffer`.
+    /// Returns a default `CommandBufferSubmitInfo` with the provided `command_buffer`.
     #[inline]
     pub fn new(command_buffer: Arc<dyn PrimaryCommandBufferAbstract>) -> Self {
         Self {
@@ -1277,7 +1283,7 @@ pub struct SemaphoreSubmitInfo {
 }
 
 impl SemaphoreSubmitInfo {
-    /// Returns a `SemaphoreSubmitInfo` with the specified `semaphore`.
+    /// Returns a default `SemaphoreSubmitInfo` with the provided `semaphore`.
     #[inline]
     pub fn new(semaphore: Arc<Semaphore>) -> Self {
         Self {

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -550,7 +550,7 @@ pub struct CommandBufferInheritanceRenderPassInfo {
 impl CommandBufferInheritanceRenderPassInfo {
     /// Returns a default `CommandBufferInheritanceRenderPassInfo` with the provided `subpass`.
     #[inline]
-    pub fn new(subpass: Subpass) -> Self {
+    pub const fn new(subpass: Subpass) -> Self {
         Self {
             subpass,
             framebuffer: None,
@@ -1203,7 +1203,7 @@ pub struct CommandBufferSubmitInfo {
 impl CommandBufferSubmitInfo {
     /// Returns a default `CommandBufferSubmitInfo` with the provided `command_buffer`.
     #[inline]
-    pub fn new(command_buffer: Arc<dyn PrimaryCommandBufferAbstract>) -> Self {
+    pub const fn new(command_buffer: Arc<dyn PrimaryCommandBufferAbstract>) -> Self {
         Self {
             command_buffer,
             _ne: crate::NonExhaustive(()),
@@ -1285,7 +1285,7 @@ pub struct SemaphoreSubmitInfo {
 impl SemaphoreSubmitInfo {
     /// Returns a default `SemaphoreSubmitInfo` with the provided `semaphore`.
     #[inline]
-    pub fn new(semaphore: Arc<Semaphore>) -> Self {
+    pub const fn new(semaphore: Arc<Semaphore>) -> Self {
         Self {
             semaphore,
             value: 0,

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -627,7 +627,7 @@ pub struct DescriptorSetLayoutBinding {
 impl DescriptorSetLayoutBinding {
     /// Returns a default `DescriptorSetLayoutBinding` with the provided `descriptor_type`.
     #[inline]
-    pub fn new(descriptor_type: DescriptorType) -> Self {
+    pub const fn new(descriptor_type: DescriptorType) -> Self {
         Self {
             binding_flags: DescriptorBindingFlags::empty(),
             descriptor_type,

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -625,9 +625,9 @@ pub struct DescriptorSetLayoutBinding {
 }
 
 impl DescriptorSetLayoutBinding {
-    /// Returns a `DescriptorSetLayoutBinding` with the given type.
+    /// Returns a default `DescriptorSetLayoutBinding` with the provided `descriptor_type`.
     #[inline]
-    pub fn descriptor_type(descriptor_type: DescriptorType) -> Self {
+    pub fn new(descriptor_type: DescriptorType) -> Self {
         Self {
             binding_flags: DescriptorBindingFlags::empty(),
             descriptor_type,
@@ -636,6 +636,12 @@ impl DescriptorSetLayoutBinding {
             immutable_samplers: Vec::new(),
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn descriptor_type(descriptor_type: DescriptorType) -> Self {
+        Self::new(descriptor_type)
     }
 
     /// Checks whether the descriptor of a pipeline layout `self` is compatible with the
@@ -1418,7 +1424,7 @@ mod tests {
                     0,
                     DescriptorSetLayoutBinding {
                         stages: ShaderStages::all_graphics(),
-                        ..DescriptorSetLayoutBinding::descriptor_type(DescriptorType::UniformBuffer)
+                        ..DescriptorSetLayoutBinding::new(DescriptorType::UniformBuffer)
                     },
                 )]
                 .into(),

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -647,7 +647,7 @@ pub struct DescriptorSetAllocateInfo {
 }
 
 impl DescriptorSetAllocateInfo {
-    /// Returns a `DescriptorSetAllocateInfo` with the specified `layout`.
+    /// Returns a default `DescriptorSetAllocateInfo` with the provided `layout`.
     #[inline]
     pub fn new(layout: Arc<DescriptorSetLayout>) -> Self {
         Self {
@@ -803,7 +803,7 @@ mod tests {
                     0,
                     DescriptorSetLayoutBinding {
                         stages: ShaderStages::all_graphics(),
-                        ..DescriptorSetLayoutBinding::descriptor_type(DescriptorType::UniformBuffer)
+                        ..DescriptorSetLayoutBinding::new(DescriptorType::UniformBuffer)
                     },
                 )]
                 .into(),
@@ -839,7 +839,7 @@ mod tests {
                     0,
                     DescriptorSetLayoutBinding {
                         stages: ShaderStages::all_graphics(),
-                        ..DescriptorSetLayoutBinding::descriptor_type(DescriptorType::UniformBuffer)
+                        ..DescriptorSetLayoutBinding::new(DescriptorType::UniformBuffer)
                     },
                 )]
                 .into(),

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -649,7 +649,7 @@ pub struct DescriptorSetAllocateInfo {
 impl DescriptorSetAllocateInfo {
     /// Returns a default `DescriptorSetAllocateInfo` with the provided `layout`.
     #[inline]
-    pub fn new(layout: Arc<DescriptorSetLayout>) -> Self {
+    pub const fn new(layout: Arc<DescriptorSetLayout>) -> Self {
         Self {
             layout,
             variable_descriptor_count: 0,

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -1629,7 +1629,7 @@ pub struct CopyDescriptorSet {
 }
 
 impl CopyDescriptorSet {
-    /// Returns a `CopyDescriptorSet` with the specified `src_set`.
+    /// Returns a default `CopyDescriptorSet` with the provided `src_set`.
     #[inline]
     pub fn new(src_set: Arc<DescriptorSet>) -> Self {
         Self {

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -1631,7 +1631,7 @@ pub struct CopyDescriptorSet {
 impl CopyDescriptorSet {
     /// Returns a default `CopyDescriptorSet` with the provided `src_set`.
     #[inline]
-    pub fn new(src_set: Arc<DescriptorSet>) -> Self {
+    pub const fn new(src_set: Arc<DescriptorSet>) -> Self {
         Self {
             src_set,
             src_binding: 0,

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -69,7 +69,7 @@
 //!             DescriptorSetLayoutBinding {
 //!                 stages: ShaderStage::Fragment.into(),
 //!                 immutable_samplers: vec![sampler],
-//!                 ..DescriptorSetLayoutBinding::descriptor_type(
+//!                 ..DescriptorSetLayoutBinding::new(
 //!                     DescriptorType::CombinedImageSampler
 //!                 )
 //!             },

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -179,6 +179,7 @@ pub struct DebugUtilsMessengerCreateInfo {
 
 impl DebugUtilsMessengerCreateInfo {
     /// Returns a default `DebugUtilsMessengerCreateInfo` with the provided `user_callback`.
+    // TODO: make const
     #[inline]
     pub fn new(user_callback: Arc<DebugUtilsMessengerCallback>) -> Self {
         Self {

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -178,15 +178,21 @@ pub struct DebugUtilsMessengerCreateInfo {
 }
 
 impl DebugUtilsMessengerCreateInfo {
-    /// Returns a `DebugUtilsMessengerCreateInfo` with the specified `user_callback`.
+    /// Returns a default `DebugUtilsMessengerCreateInfo` with the provided `user_callback`.
     #[inline]
-    pub fn user_callback(user_callback: Arc<DebugUtilsMessengerCallback>) -> Self {
+    pub fn new(user_callback: Arc<DebugUtilsMessengerCallback>) -> Self {
         Self {
             message_severity: DebugUtilsMessageSeverity::ERROR | DebugUtilsMessageSeverity::WARNING,
             message_type: DebugUtilsMessageType::GENERAL,
             user_callback,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn user_callback(user_callback: Arc<DebugUtilsMessengerCallback>) -> Self {
+        Self::new(user_callback)
     }
 
     #[inline]
@@ -682,7 +688,7 @@ mod tests {
                 message_type: DebugUtilsMessageType::GENERAL
                     | DebugUtilsMessageType::VALIDATION
                     | DebugUtilsMessageType::PERFORMANCE,
-                ..DebugUtilsMessengerCreateInfo::user_callback(unsafe {
+                ..DebugUtilsMessengerCreateInfo::new(unsafe {
                     DebugUtilsMessengerCallback::new(|_, _, _| {})
                 })
             },

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -855,9 +855,9 @@ impl Default for MemoryAllocateInfo<'static> {
 }
 
 impl<'d> MemoryAllocateInfo<'d> {
-    /// Returns a `MemoryAllocateInfo` with the specified `dedicated_allocation`.
+    /// Returns a default `MemoryAllocateInfo` with the provided `dedicated_allocation`.
     #[inline]
-    pub fn dedicated_allocation(dedicated_allocation: DedicatedAllocation<'d>) -> Self {
+    pub fn new(dedicated_allocation: DedicatedAllocation<'d>) -> Self {
         Self {
             allocation_size: 0,
             memory_type_index: u32::MAX,
@@ -866,6 +866,12 @@ impl<'d> MemoryAllocateInfo<'d> {
             flags: MemoryAllocateFlags::empty(),
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn dedicated_allocation(dedicated_allocation: DedicatedAllocation<'d>) -> Self {
+        Self::new(dedicated_allocation)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -857,7 +857,7 @@ impl Default for MemoryAllocateInfo<'static> {
 impl<'d> MemoryAllocateInfo<'d> {
     /// Returns a default `MemoryAllocateInfo` with the provided `dedicated_allocation`.
     #[inline]
-    pub fn new(dedicated_allocation: DedicatedAllocation<'d>) -> Self {
+    pub const fn new(dedicated_allocation: DedicatedAllocation<'d>) -> Self {
         Self {
             allocation_size: 0,
             memory_type_index: u32::MAX,

--- a/vulkano/src/memory/sparse.rs
+++ b/vulkano/src/memory/sparse.rs
@@ -251,7 +251,7 @@ pub struct SparseBufferMemoryBindInfo {
 impl SparseBufferMemoryBindInfo {
     /// Returns a default `SparseBufferMemoryBindInfo` with the provided `buffer`.
     #[inline]
-    pub fn new(buffer: Arc<Buffer>) -> Self {
+    pub const fn new(buffer: Arc<Buffer>) -> Self {
         Self {
             buffer,
             binds: Vec::new(),
@@ -585,7 +585,7 @@ pub struct SparseImageOpaqueMemoryBindInfo {
 impl SparseImageOpaqueMemoryBindInfo {
     /// Returns a default `SparseImageOpaqueMemoryBindInfo` with the provided `image`.
     #[inline]
-    pub fn new(image: Arc<Image>) -> Self {
+    pub const fn new(image: Arc<Image>) -> Self {
         Self {
             image,
             binds: Vec::new(),
@@ -1054,7 +1054,7 @@ pub struct SparseImageMemoryBindInfo {
 impl SparseImageMemoryBindInfo {
     /// Returns a default `SparseImageMemoryBindInfo` with the provided `image`.
     #[inline]
-    pub fn new(image: Arc<Image>) -> Self {
+    pub const fn new(image: Arc<Image>) -> Self {
         Self {
             image,
             binds: Vec::new(),

--- a/vulkano/src/memory/sparse.rs
+++ b/vulkano/src/memory/sparse.rs
@@ -249,7 +249,7 @@ pub struct SparseBufferMemoryBindInfo {
 }
 
 impl SparseBufferMemoryBindInfo {
-    /// Returns a `SparseBufferMemoryBindInfo` with the specified `buffer`.
+    /// Returns a default `SparseBufferMemoryBindInfo` with the provided `buffer`.
     #[inline]
     pub fn new(buffer: Arc<Buffer>) -> Self {
         Self {
@@ -583,7 +583,7 @@ pub struct SparseImageOpaqueMemoryBindInfo {
 }
 
 impl SparseImageOpaqueMemoryBindInfo {
-    /// Returns a `SparseImageOpaqueMemoryBindInfo` with the specified `image`.
+    /// Returns a default `SparseImageOpaqueMemoryBindInfo` with the provided `image`.
     #[inline]
     pub fn new(image: Arc<Image>) -> Self {
         Self {
@@ -1052,7 +1052,7 @@ pub struct SparseImageMemoryBindInfo {
 }
 
 impl SparseImageMemoryBindInfo {
-    /// Returns a `SparseImageMemoryBindInfo` with the specified `image`.
+    /// Returns a default `SparseImageMemoryBindInfo` with the provided `image`.
     #[inline]
     pub fn new(image: Arc<Image>) -> Self {
         Self {

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -443,7 +443,7 @@ mod tests {
             ComputePipeline::new(
                 device,
                 Some(cache.clone()),
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };
@@ -491,7 +491,7 @@ mod tests {
             ComputePipeline::new(
                 device.clone(),
                 Some(cache.clone()),
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };
@@ -535,7 +535,7 @@ mod tests {
             ComputePipeline::new(
                 device,
                 Some(cache.clone()),
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };
@@ -585,7 +585,7 @@ mod tests {
             ComputePipeline::new(
                 device.clone(),
                 Some(cache.clone()),
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };
@@ -604,7 +604,7 @@ mod tests {
             ComputePipeline::new(
                 device,
                 Some(cache.clone()),
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -254,7 +254,7 @@ pub struct ComputePipelineCreateInfo {
 impl ComputePipelineCreateInfo {
     /// Returns a default `ComputePipelineCreateInfo` with the provided `stage` and `layout`.
     #[inline]
-    pub fn new(stage: PipelineShaderStageCreateInfo, layout: Arc<PipelineLayout>) -> Self {
+    pub const fn new(stage: PipelineShaderStageCreateInfo, layout: Arc<PipelineLayout>) -> Self {
         Self {
             flags: PipelineCreateFlags::empty(),
             stage,

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -252,9 +252,9 @@ pub struct ComputePipelineCreateInfo {
 }
 
 impl ComputePipelineCreateInfo {
-    /// Returns a `ComputePipelineCreateInfo` with the specified `stage` and `layout`.
+    /// Returns a default `ComputePipelineCreateInfo` with the provided `stage` and `layout`.
     #[inline]
-    pub fn stage_layout(stage: PipelineShaderStageCreateInfo, layout: Arc<PipelineLayout>) -> Self {
+    pub fn new(stage: PipelineShaderStageCreateInfo, layout: Arc<PipelineLayout>) -> Self {
         Self {
             flags: PipelineCreateFlags::empty(),
             stage,
@@ -262,6 +262,12 @@ impl ComputePipelineCreateInfo {
             base_pipeline: None,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn stage_layout(stage: PipelineShaderStageCreateInfo, layout: Arc<PipelineLayout>) -> Self {
+        Self::new(stage, layout)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -509,7 +515,7 @@ mod tests {
             ComputePipeline::new(
                 device.clone(),
                 None,
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };
@@ -658,7 +664,7 @@ mod tests {
             ComputePipeline::new(
                 device.clone(),
                 None,
-                ComputePipelineCreateInfo::stage_layout(stage, layout),
+                ComputePipelineCreateInfo::new(stage, layout),
             )
             .unwrap()
         };

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -750,6 +750,7 @@ pub struct GraphicsPipelineCreateInfo {
 
 impl GraphicsPipelineCreateInfo {
     /// Returns a default `GraphicsPipelineCreateInfo` with the provided `layout`.
+    // TODO: make const
     #[inline]
     pub fn new(layout: Arc<PipelineLayout>) -> Self {
         Self {

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -749,9 +749,9 @@ pub struct GraphicsPipelineCreateInfo {
 }
 
 impl GraphicsPipelineCreateInfo {
-    /// Returns a `GraphicsPipelineCreateInfo` with the specified `layout`.
+    /// Returns a default `GraphicsPipelineCreateInfo` with the provided `layout`.
     #[inline]
-    pub fn layout(layout: Arc<PipelineLayout>) -> Self {
+    pub fn new(layout: Arc<PipelineLayout>) -> Self {
         Self {
             flags: PipelineCreateFlags::empty(),
             stages: SmallVec::new(),
@@ -775,6 +775,12 @@ impl GraphicsPipelineCreateInfo {
 
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn layout(layout: Arc<PipelineLayout>) -> Self {
+        Self::new(layout)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/pipeline/ray_tracing.rs
+++ b/vulkano/src/pipeline/ray_tracing.rs
@@ -415,6 +415,7 @@ pub struct RayTracingPipelineCreateInfo {
 
 impl RayTracingPipelineCreateInfo {
     /// Returns a default `RayTracingPipelineCreateInfo` with the provided `layout`.
+    // TODO: make const
     #[inline]
     pub fn new(layout: Arc<PipelineLayout>) -> Self {
         Self {

--- a/vulkano/src/pipeline/ray_tracing.rs
+++ b/vulkano/src/pipeline/ray_tracing.rs
@@ -414,9 +414,9 @@ pub struct RayTracingPipelineCreateInfo {
 }
 
 impl RayTracingPipelineCreateInfo {
-    /// Returns a `RayTracingPipelineCreateInfo` with the specified `layout`.
+    /// Returns a default `RayTracingPipelineCreateInfo` with the provided `layout`.
     #[inline]
-    pub fn layout(layout: Arc<PipelineLayout>) -> Self {
+    pub fn new(layout: Arc<PipelineLayout>) -> Self {
         Self {
             flags: PipelineCreateFlags::empty(),
             stages: SmallVec::new(),
@@ -427,6 +427,12 @@ impl RayTracingPipelineCreateInfo {
             base_pipeline: None,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn layout(layout: Arc<PipelineLayout>) -> Self {
+        Self::new(layout)
     }
 
     fn validate(&self, device: &Arc<Device>) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/pipeline/shader/mod.rs
+++ b/vulkano/src/pipeline/shader/mod.rs
@@ -45,7 +45,7 @@ pub struct PipelineShaderStageCreateInfo {
 }
 
 impl PipelineShaderStageCreateInfo {
-    /// Returns a `PipelineShaderStageCreateInfo` with the specified `entry_point`.
+    /// Returns a default `PipelineShaderStageCreateInfo` with the provided `entry_point`.
     #[inline]
     pub fn new(entry_point: EntryPoint) -> Self {
         Self {

--- a/vulkano/src/pipeline/shader/mod.rs
+++ b/vulkano/src/pipeline/shader/mod.rs
@@ -47,7 +47,7 @@ pub struct PipelineShaderStageCreateInfo {
 impl PipelineShaderStageCreateInfo {
     /// Returns a default `PipelineShaderStageCreateInfo` with the provided `entry_point`.
     #[inline]
-    pub fn new(entry_point: EntryPoint) -> Self {
+    pub const fn new(entry_point: EntryPoint) -> Self {
         Self {
             flags: PipelineShaderStageCreateFlags::empty(),
             entry_point,

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -424,15 +424,21 @@ pub struct QueryPoolCreateInfo {
 }
 
 impl QueryPoolCreateInfo {
-    /// Returns a `QueryPoolCreateInfo` with the specified `query_type`.
+    /// Returns a default `QueryPoolCreateInfo` with the provided `query_type`.
     #[inline]
-    pub fn query_type(query_type: QueryType) -> Self {
+    pub fn new(query_type: QueryType) -> Self {
         Self {
             query_type,
             query_count: 0,
             pipeline_statistics: QueryPipelineStatisticFlags::empty(),
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn query_type(query_type: QueryType) -> Self {
+        Self::new(query_type)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -788,7 +794,7 @@ mod tests {
                 device,
                 QueryPoolCreateInfo {
                     query_count: 256,
-                    ..QueryPoolCreateInfo::query_type(QueryType::PipelineStatistics)
+                    ..QueryPoolCreateInfo::new(QueryType::PipelineStatistics)
                 },
             ),
             Err(Validated::ValidationError(_)),

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -426,7 +426,7 @@ pub struct QueryPoolCreateInfo {
 impl QueryPoolCreateInfo {
     /// Returns a default `QueryPoolCreateInfo` with the provided `query_type`.
     #[inline]
-    pub fn new(query_type: QueryType) -> Self {
+    pub const fn new(query_type: QueryType) -> Self {
         Self {
             query_type,
             query_count: 0,

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -717,7 +717,7 @@ pub struct ShaderModuleCreateInfo<'a> {
 impl<'a> ShaderModuleCreateInfo<'a> {
     /// Returns a default `ShaderModuleCreateInfo` with the provided `code`.
     #[inline]
-    pub fn new(code: &'a [u32]) -> Self {
+    pub const fn new(code: &'a [u32]) -> Self {
         Self {
             code,
             _ne: crate::NonExhaustive(()),

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -715,7 +715,7 @@ pub struct ShaderModuleCreateInfo<'a> {
 }
 
 impl<'a> ShaderModuleCreateInfo<'a> {
-    /// Returns a `ShaderModuleCreateInfo` with the specified `code`.
+    /// Returns a default `ShaderModuleCreateInfo` with the provided `code`.
     #[inline]
     pub fn new(code: &'a [u32]) -> Self {
         Self {

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -781,9 +781,9 @@ pub struct SwapchainPresentInfo {
 }
 
 impl SwapchainPresentInfo {
-    /// Returns a `SwapchainPresentInfo` with the specified `swapchain` and `image_index`.
+    /// Returns a default `SwapchainPresentInfo` with the provided `swapchain` and `image_index`.
     #[inline]
-    pub fn swapchain_image_index(swapchain: Arc<Swapchain>, image_index: u32) -> Self {
+    pub fn new(swapchain: Arc<Swapchain>, image_index: u32) -> Self {
         Self {
             swapchain,
             image_index,
@@ -792,6 +792,12 @@ impl SwapchainPresentInfo {
             present_region: Vec::new(),
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn swapchain_image_index(swapchain: Arc<Swapchain>, image_index: u32) -> Self {
+        Self::new(swapchain, image_index)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -974,7 +980,7 @@ pub struct SemaphorePresentInfo {
 }
 
 impl SemaphorePresentInfo {
-    /// Returns a `SemaphorePresentInfo` with the specified `semaphore`.
+    /// Returns a default `SemaphorePresentInfo` with the provided `semaphore`.
     #[inline]
     pub fn new(semaphore: Arc<Semaphore>) -> Self {
         Self {

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -783,7 +783,7 @@ pub struct SwapchainPresentInfo {
 impl SwapchainPresentInfo {
     /// Returns a default `SwapchainPresentInfo` with the provided `swapchain` and `image_index`.
     #[inline]
-    pub fn new(swapchain: Arc<Swapchain>, image_index: u32) -> Self {
+    pub const fn new(swapchain: Arc<Swapchain>, image_index: u32) -> Self {
         Self {
             swapchain,
             image_index,
@@ -982,7 +982,7 @@ pub struct SemaphorePresentInfo {
 impl SemaphorePresentInfo {
     /// Returns a default `SemaphorePresentInfo` with the provided `semaphore`.
     #[inline]
-    pub fn new(semaphore: Arc<Semaphore>) -> Self {
+    pub const fn new(semaphore: Arc<Semaphore>) -> Self {
         Self {
             semaphore,
             _ne: crate::NonExhaustive(()),

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -248,7 +248,7 @@
 //!         .unwrap()
 //!         .then_swapchain_present(
 //!             queue.clone(),
-//!             SwapchainPresentInfo::swapchain_image_index(swapchain.clone(), image_index),
+//!             SwapchainPresentInfo::new(swapchain.clone(), image_index),
 //!         )
 //!         .then_signal_fence_and_flush()
 //!         .unwrap();
@@ -309,7 +309,7 @@
 //!         // .then_execute(...)
 //!         .then_swapchain_present(
 //!             queue.clone(),
-//!             SwapchainPresentInfo::swapchain_image_index(swapchain.clone(), image_index),
+//!             SwapchainPresentInfo::new(swapchain.clone(), image_index),
 //!         )
 //!         .then_signal_fence_and_flush()
 //!         .unwrap(); // TODO: PresentError?

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -819,9 +819,7 @@ impl FenceCreateInfo {
                 let external_fence_properties = unsafe {
                     device
                         .physical_device()
-                        .external_fence_properties_unchecked(ExternalFenceInfo::handle_type(
-                            handle_type,
-                        ))
+                        .external_fence_properties_unchecked(ExternalFenceInfo::new(handle_type))
                 };
 
                 if !external_fence_properties.exportable {
@@ -994,15 +992,21 @@ pub struct ImportFenceFdInfo {
 }
 
 impl ImportFenceFdInfo {
-    /// Returns an `ImportFenceFdInfo` with the specified `handle_type`.
+    /// Returns a default `ImportFenceFdInfo` with the provided `handle_type`.
     #[inline]
-    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+    pub fn new(handle_type: ExternalFenceHandleType) -> Self {
         Self {
             flags: FenceImportFlags::empty(),
             handle_type,
             file: None,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+        Self::new(handle_type)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -1104,15 +1108,21 @@ pub struct ImportFenceWin32HandleInfo {
 }
 
 impl ImportFenceWin32HandleInfo {
-    /// Returns an `ImportFenceWin32HandleInfo` with the specified `handle_type`.
+    /// Returns a default `ImportFenceWin32HandleInfo` with the provided `handle_type`.
     #[inline]
-    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+    pub fn new(handle_type: ExternalFenceHandleType) -> Self {
         Self {
             flags: FenceImportFlags::empty(),
             handle_type,
             handle: 0,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+        Self::new(handle_type)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -1191,13 +1201,19 @@ pub struct ExternalFenceInfo {
 }
 
 impl ExternalFenceInfo {
-    /// Returns an `ExternalFenceInfo` with the specified `handle_type`.
+    /// Returns a default `ExternalFenceInfo` with the provided `handle_type`.
     #[inline]
-    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+    pub fn new(handle_type: ExternalFenceHandleType) -> Self {
         Self {
             handle_type,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn handle_type(handle_type: ExternalFenceHandleType) -> Self {
+        Self::new(handle_type)
     }
 
     pub(crate) fn validate(

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -994,7 +994,7 @@ pub struct ImportFenceFdInfo {
 impl ImportFenceFdInfo {
     /// Returns a default `ImportFenceFdInfo` with the provided `handle_type`.
     #[inline]
-    pub fn new(handle_type: ExternalFenceHandleType) -> Self {
+    pub const fn new(handle_type: ExternalFenceHandleType) -> Self {
         Self {
             flags: FenceImportFlags::empty(),
             handle_type,
@@ -1110,7 +1110,7 @@ pub struct ImportFenceWin32HandleInfo {
 impl ImportFenceWin32HandleInfo {
     /// Returns a default `ImportFenceWin32HandleInfo` with the provided `handle_type`.
     #[inline]
-    pub fn new(handle_type: ExternalFenceHandleType) -> Self {
+    pub const fn new(handle_type: ExternalFenceHandleType) -> Self {
         Self {
             flags: FenceImportFlags::empty(),
             handle_type,
@@ -1203,7 +1203,7 @@ pub struct ExternalFenceInfo {
 impl ExternalFenceInfo {
     /// Returns a default `ExternalFenceInfo` with the provided `handle_type`.
     #[inline]
-    pub fn new(handle_type: ExternalFenceHandleType) -> Self {
+    pub const fn new(handle_type: ExternalFenceHandleType) -> Self {
         Self {
             handle_type,
             _ne: crate::NonExhaustive(()),

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -1576,7 +1576,7 @@ pub struct SemaphoreWaitValueInfo {
 impl SemaphoreWaitValueInfo {
     /// Returns a default `SemaphoreWaitValueInfo` with the provided `semaphore` and `value`.
     #[inline]
-    pub fn new(semaphore: Arc<Semaphore>, value: u64) -> Self {
+    pub const fn new(semaphore: Arc<Semaphore>, value: u64) -> Self {
         Self {
             semaphore,
             value,
@@ -1647,7 +1647,7 @@ pub struct ImportSemaphoreFdInfo {
 impl ImportSemaphoreFdInfo {
     /// Returns a default `ImportSemaphoreFdInfo` with the provided `handle_type`.
     #[inline]
-    pub fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
+    pub const fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
         Self {
             flags: SemaphoreImportFlags::empty(),
             handle_type,
@@ -1768,7 +1768,7 @@ pub struct ImportSemaphoreWin32HandleInfo {
 impl ImportSemaphoreWin32HandleInfo {
     /// Returns a default `ImportSemaphoreWin32HandleInfo` with the provided `handle_type`.
     #[inline]
-    pub fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
+    pub const fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
         Self {
             flags: SemaphoreImportFlags::empty(),
             handle_type,
@@ -1880,7 +1880,7 @@ pub struct ImportSemaphoreZirconHandleInfo {
 impl ImportSemaphoreZirconHandleInfo {
     /// Returns a default `ImportSemaphoreZirconHandleInfo` with the provided `handle_type`.
     #[inline]
-    pub fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
+    pub const fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
         Self {
             flags: SemaphoreImportFlags::empty(),
             handle_type,
@@ -1984,7 +1984,7 @@ pub struct ExternalSemaphoreInfo {
 impl ExternalSemaphoreInfo {
     /// Returns a default `ExternalSemaphoreInfo` with the provided `handle_type`.
     #[inline]
-    pub fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
+    pub const fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
         Self {
             handle_type,
             semaphore_type: SemaphoreType::Binary,

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -1165,7 +1165,7 @@ impl SemaphoreCreateInfo {
                         .external_semaphore_properties_unchecked(ExternalSemaphoreInfo {
                             semaphore_type,
                             initial_value,
-                            ..ExternalSemaphoreInfo::handle_type(handle_type)
+                            ..ExternalSemaphoreInfo::new(handle_type)
                         })
                 };
 
@@ -1574,7 +1574,7 @@ pub struct SemaphoreWaitValueInfo {
 }
 
 impl SemaphoreWaitValueInfo {
-    /// Returns a `SemaphoreWaitValueInfo` with the specified `semaphore` and `value`.
+    /// Returns a default `SemaphoreWaitValueInfo` with the provided `semaphore` and `value`.
     #[inline]
     pub fn new(semaphore: Arc<Semaphore>, value: u64) -> Self {
         Self {
@@ -1645,15 +1645,21 @@ pub struct ImportSemaphoreFdInfo {
 }
 
 impl ImportSemaphoreFdInfo {
-    /// Returns an `ImportSemaphoreFdInfo` with the specified `handle_type`.
+    /// Returns a default `ImportSemaphoreFdInfo` with the provided `handle_type`.
     #[inline]
-    pub fn handle_type(handle_type: ExternalSemaphoreHandleType) -> Self {
+    pub fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
         Self {
             flags: SemaphoreImportFlags::empty(),
             handle_type,
             file: None,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn handle_type(handle_type: ExternalSemaphoreHandleType) -> Self {
+        Self::new(handle_type)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -1760,15 +1766,21 @@ pub struct ImportSemaphoreWin32HandleInfo {
 }
 
 impl ImportSemaphoreWin32HandleInfo {
-    /// Returns an `ImportSemaphoreWin32HandleInfo` with the specified `handle_type`.
+    /// Returns a default `ImportSemaphoreWin32HandleInfo` with the provided `handle_type`.
     #[inline]
-    pub fn handle_type(handle_type: ExternalSemaphoreHandleType) -> Self {
+    pub fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
         Self {
             flags: SemaphoreImportFlags::empty(),
             handle_type,
             handle: 0,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn handle_type(handle_type: ExternalSemaphoreHandleType) -> Self {
+        Self::new(handle_type)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -1866,15 +1878,21 @@ pub struct ImportSemaphoreZirconHandleInfo {
 }
 
 impl ImportSemaphoreZirconHandleInfo {
-    /// Returns an `ImportSemaphoreZirconHandleInfo` with the specified `handle_type`.
+    /// Returns a default `ImportSemaphoreZirconHandleInfo` with the provided `handle_type`.
     #[inline]
-    pub fn handle_type(handle_type: ExternalSemaphoreHandleType) -> Self {
+    pub fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
         Self {
             flags: SemaphoreImportFlags::empty(),
             handle_type,
             zircon_handle: 0,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn handle_type(handle_type: ExternalSemaphoreHandleType) -> Self {
+        Self::new(handle_type)
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
@@ -1964,15 +1982,21 @@ pub struct ExternalSemaphoreInfo {
 }
 
 impl ExternalSemaphoreInfo {
-    /// Returns an `ExternalSemaphoreInfo` with the specified `handle_type`.
+    /// Returns a default `ExternalSemaphoreInfo` with the provided `handle_type`.
     #[inline]
-    pub fn handle_type(handle_type: ExternalSemaphoreHandleType) -> Self {
+    pub fn new(handle_type: ExternalSemaphoreHandleType) -> Self {
         Self {
             handle_type,
             semaphore_type: SemaphoreType::Binary,
             initial_value: 0,
             _ne: crate::NonExhaustive(()),
         }
+    }
+
+    #[deprecated(since = "0.36.0", note = "use `new` instead")]
+    #[inline]
+    pub fn handle_type(handle_type: ExternalSemaphoreHandleType) -> Self {
+        Self::new(handle_type)
     }
 
     pub(crate) fn validate(


### PR DESCRIPTION
The old functions are kept, but deprecated.