### PR TITLE
Add `new` constructors for `Info` structs that implement `Default`

### DIFF
--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -1061,6 +1061,14 @@ pub struct AccelerationStructureGeometryAabbsData {
 impl Default for AccelerationStructureGeometryAabbsData {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AccelerationStructureGeometryAabbsData {
+    /// Returns a default `AccelerationStructureGeometryAabbsData`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: GeometryFlags::empty(),
             data: None,
@@ -1068,9 +1076,7 @@ impl Default for AccelerationStructureGeometryAabbsData {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl AccelerationStructureGeometryAabbsData {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,
@@ -1286,6 +1292,15 @@ pub struct AccelerationStructureInstance {
 impl Default for AccelerationStructureInstance {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AccelerationStructureInstance {
+    /// Returns a default `AccelerationStructureInstance`.
+    // TODO: make const
+    #[inline]
+    pub fn new() -> Self {
         Self {
             transform: [
                 [1.0, 0.0, 0.0, 0.0],

--- a/vulkano/src/buffer/allocator.rs
+++ b/vulkano/src/buffer/allocator.rs
@@ -428,6 +428,14 @@ pub struct SubbufferAllocatorCreateInfo {
 impl Default for SubbufferAllocatorCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SubbufferAllocatorCreateInfo {
+    /// Returns a default `SubbufferAllocatorCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         SubbufferAllocatorCreateInfo {
             arena_size: 0,
             buffer_usage: BufferUsage::empty(),

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -666,6 +666,14 @@ pub struct BufferCreateInfo {
 impl Default for BufferCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BufferCreateInfo {
+    /// Returns a default `BufferCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: BufferCreateFlags::empty(),
             sharing: Sharing::Exclusive,
@@ -675,9 +683,7 @@ impl Default for BufferCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl BufferCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -409,14 +409,20 @@ pub struct BufferViewCreateInfo {
 impl Default for BufferViewCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BufferViewCreateInfo {
+    /// Returns a default `BufferViewCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             format: Format::UNDEFINED,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl BufferViewCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let Self { format, _ne: _ } = self;
 

--- a/vulkano/src/cache.rs
+++ b/vulkano/src/cache.rs
@@ -17,16 +17,17 @@ pub(crate) struct OnceCache<K, V> {
 
 impl<K, V> Default for OnceCache<K, V> {
     fn default() -> Self {
-        Self {
-            inner: RwLock::new(HashMap::default()),
-        }
+        Self::new()
     }
 }
 
 impl<K, V> OnceCache<K, V> {
     /// Creates a new `OnceCache`.
+    // TODO: make const
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            inner: RwLock::new(HashMap::default()),
+        }
     }
 }
 
@@ -98,16 +99,17 @@ pub(crate) struct WeakArcOnceCache<K, V> {
 
 impl<K, V> Default for WeakArcOnceCache<K, V> {
     fn default() -> Self {
-        Self {
-            inner: RwLock::new(HashMap::default()),
-        }
+        Self::new()
     }
 }
 
 impl<K, V> WeakArcOnceCache<K, V> {
     /// Creates a new `OnceCache`.
+    // TODO: make const
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            inner: RwLock::new(HashMap::default()),
+        }
     }
 }
 

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -552,6 +552,14 @@ pub struct StandardCommandBufferAllocatorCreateInfo {
 impl Default for StandardCommandBufferAllocatorCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StandardCommandBufferAllocatorCreateInfo {
+    /// Returns a default `StandardCommandBufferAllocatorCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         StandardCommandBufferAllocatorCreateInfo {
             primary_buffer_count: 32,
             secondary_buffer_count: 0,

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -2062,6 +2062,14 @@ pub struct BufferCopy {
 impl Default for BufferCopy {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BufferCopy {
+    /// Returns a default `BufferCopy`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             src_offset: 0,
             dst_offset: 0,
@@ -2069,9 +2077,7 @@ impl Default for BufferCopy {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl BufferCopy {
     pub(crate) fn validate(&self, _device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             src_offset: _,
@@ -3468,6 +3474,14 @@ pub struct ImageCopy {
 impl Default for ImageCopy {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageCopy {
+    /// Returns a default `ImageCopy`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
@@ -3485,9 +3499,7 @@ impl Default for ImageCopy {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl ImageCopy {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             ref src_subresource,
@@ -5031,6 +5043,14 @@ pub struct BufferImageCopy {
 impl Default for BufferImageCopy {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BufferImageCopy {
+    /// Returns a default `BufferImageCopy`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             buffer_offset: 0,
             buffer_row_length: 0,
@@ -5045,9 +5065,7 @@ impl Default for BufferImageCopy {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl BufferImageCopy {
     // Following
     // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap20.html#copies-buffers-images-addressing
     pub(crate) fn buffer_copy_size(&self, format: Format) -> DeviceSize {
@@ -6131,6 +6149,14 @@ pub struct ImageBlit {
 impl Default for ImageBlit {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageBlit {
+    /// Returns a default `ImageBlit`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
@@ -6147,9 +6173,7 @@ impl Default for ImageBlit {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl ImageBlit {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             ref src_subresource,
@@ -6943,6 +6967,14 @@ pub struct ImageResolve {
 impl Default for ImageResolve {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageResolve {
+    /// Returns a default `ImageResolve`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
@@ -6960,9 +6992,7 @@ impl Default for ImageResolve {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl ImageResolve {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             ref src_subresource,

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -1935,14 +1935,20 @@ pub struct SubpassBeginInfo {
 impl Default for SubpassBeginInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SubpassBeginInfo {
+    /// Returns a default `SubpassBeginInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             contents: SubpassContents::Inline,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SubpassBeginInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self { contents, _ne: _ } = self;
 
@@ -1970,13 +1976,19 @@ pub struct SubpassEndInfo {
 impl Default for SubpassEndInfo {
     #[inline]
     fn default() -> Self {
-        Self {
-            _ne: crate::NonExhaustive(()),
-        }
+        Self::new()
     }
 }
 
 impl SubpassEndInfo {
+    /// Returns a default `SubpassEndInfo`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
     pub(crate) fn validate(&self, _device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self { _ne: _ } = self;
 
@@ -2072,6 +2084,14 @@ pub struct RenderingInfo {
 impl Default for RenderingInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RenderingInfo {
+    /// Returns a default `RenderingInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             render_area_offset: [0, 0],
             render_area_extent: [0, 0],
@@ -2084,9 +2104,7 @@ impl Default for RenderingInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl RenderingInfo {
     pub(crate) fn set_auto_extent_layers(&mut self) {
         let &mut RenderingInfo {
             render_area_offset,

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -307,6 +307,14 @@ pub struct CommandBufferInheritanceInfo {
 impl Default for CommandBufferInheritanceInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandBufferInheritanceInfo {
+    /// Returns a default `CommandBufferInheritanceInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             render_pass: None,
             occlusion_query: None,
@@ -314,9 +322,7 @@ impl Default for CommandBufferInheritanceInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl CommandBufferInheritanceInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             ref render_pass,
@@ -643,6 +649,14 @@ pub struct CommandBufferInheritanceRenderingInfo {
 impl Default for CommandBufferInheritanceRenderingInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandBufferInheritanceRenderingInfo {
+    /// Returns a default `CommandBufferInheritanceRenderingInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             view_mask: 0,
             color_attachment_formats: Vec::new(),
@@ -651,9 +665,7 @@ impl Default for CommandBufferInheritanceRenderingInfo {
             rasterization_samples: SampleCount::Sample1,
         }
     }
-}
 
-impl CommandBufferInheritanceRenderingInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             view_mask,
@@ -941,6 +953,14 @@ pub struct SubmitInfo {
 impl Default for SubmitInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SubmitInfo {
+    /// Returns a default `SubmitInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             wait_semaphores: Vec::new(),
             command_buffers: Vec::new(),
@@ -948,9 +968,7 @@ impl Default for SubmitInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SubmitInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             ref wait_semaphores,

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -356,15 +356,21 @@ pub struct CommandPoolCreateInfo {
 impl Default for CommandPoolCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandPoolCreateInfo {
+    /// Returns a default `CommandPoolCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: CommandPoolCreateFlags::empty(),
             queue_family_index: u32::MAX,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl CommandPoolCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,
@@ -472,6 +478,14 @@ impl CommandBufferAllocateInfo {
 impl Default for CommandBufferAllocateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandBufferAllocateInfo {
+    /// Returns a default `CommandBufferAllocateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             level: CommandBufferLevel::Primary,
             command_buffer_count: 1,

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -202,15 +202,21 @@ pub struct CommandBufferBeginInfo {
 impl Default for CommandBufferBeginInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandBufferBeginInfo {
+    /// Returns a default `CommandBufferBeginInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             usage: CommandBufferUsage::MultipleSubmit,
             inheritance_info: None,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl CommandBufferBeginInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let Self {
             usage: _,

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -245,15 +245,21 @@ pub struct DescriptorSetLayoutCreateInfo {
 impl Default for DescriptorSetLayoutCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DescriptorSetLayoutCreateInfo {
+    /// Returns a default `DescriptorSetLayoutCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: DescriptorSetLayoutCreateFlags::empty(),
             bindings: BTreeMap::new(),
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl DescriptorSetLayoutCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -445,6 +445,15 @@ pub struct DescriptorPoolCreateInfo {
 impl Default for DescriptorPoolCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DescriptorPoolCreateInfo {
+    /// Returns a default `DescriptorPoolCreateInfo`.
+    // TODO: make const
+    #[inline]
+    pub fn new() -> Self {
         Self {
             flags: DescriptorPoolCreateFlags::empty(),
             max_sets: 0,
@@ -453,9 +462,7 @@ impl Default for DescriptorPoolCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl DescriptorPoolCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -1466,6 +1466,15 @@ pub struct DeviceCreateInfo {
 impl Default for DeviceCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeviceCreateInfo {
+    /// Returns a default `DeviceCreateInfo`.
+    // TODO: make const
+    #[inline]
+    pub fn new() -> Self {
         Self {
             queue_create_infos: Vec::new(),
             enabled_extensions: DeviceExtensions::empty(),
@@ -1475,9 +1484,7 @@ impl Default for DeviceCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl DeviceCreateInfo {
     pub(crate) fn validate(
         &self,
         physical_device: &PhysicalDevice,
@@ -1961,6 +1968,15 @@ pub struct QueueCreateInfo {
 impl Default for QueueCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QueueCreateInfo {
+    /// Returns a default `QueueCreateInfo`.
+    // TODO: make const
+    #[inline]
+    pub fn new() -> Self {
         Self {
             flags: QueueCreateFlags::empty(),
             queue_family_index: 0,
@@ -1968,9 +1984,7 @@ impl Default for QueueCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl QueueCreateInfo {
     pub(crate) fn validate(
         &self,
         physical_device: &PhysicalDevice,

--- a/vulkano/src/device/private_data.rs
+++ b/vulkano/src/device/private_data.rs
@@ -256,13 +256,19 @@ pub struct PrivateDataSlotCreateInfo {
 impl Default for PrivateDataSlotCreateInfo {
     #[inline]
     fn default() -> Self {
-        Self {
-            _ne: crate::NonExhaustive(()),
-        }
+        Self::new()
     }
 }
 
 impl PrivateDataSlotCreateInfo {
+    /// Returns a default `PrivateDataSlotCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
     pub(crate) fn validate(&self, _device: &Device) -> Result<(), Box<ValidationError>> {
         Ok(())
     }

--- a/vulkano/src/display.rs
+++ b/vulkano/src/display.rs
@@ -590,15 +590,21 @@ pub struct DisplayModeCreateInfo {
 impl Default for DisplayModeCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DisplayModeCreateInfo {
+    /// Returns a default `DisplayModeCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             visible_region: [0; 2],
             refresh_rate: 0,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl DisplayModeCreateInfo {
     pub(crate) fn validate(
         &self,
         _physical_device: &PhysicalDevice,

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -803,19 +803,6 @@ pub struct FormatProperties {
     pub _ne: crate::NonExhaustive,
 }
 
-impl Default for FormatProperties {
-    #[inline]
-    fn default() -> Self {
-        Self {
-            linear_tiling_features: Default::default(),
-            optimal_tiling_features: Default::default(),
-            buffer_features: Default::default(),
-            drm_format_modifier_properties: Default::default(),
-            _ne: crate::NonExhaustive(()),
-        }
-    }
-}
-
 impl FormatProperties {
     /// Returns the format features for the specified tiling.
     pub fn format_features(

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -1756,6 +1756,14 @@ pub struct ImageFormatInfo {
 impl Default for ImageFormatInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageFormatInfo {
+    /// Returns a default `ImageFormatInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: ImageCreateFlags::empty(),
             format: Format::UNDEFINED,
@@ -1770,9 +1778,7 @@ impl Default for ImageFormatInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl ImageFormatInfo {
     pub(crate) fn validate(
         &self,
         physical_device: &PhysicalDevice,
@@ -2160,15 +2166,21 @@ pub struct ImageDrmFormatModifierInfo {
 impl Default for ImageDrmFormatModifierInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageDrmFormatModifierInfo {
+    /// Returns a default `ImageDrmFormatModifierInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             drm_format_modifier: 0,
             sharing: Sharing::Exclusive,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl ImageDrmFormatModifierInfo {
     pub(crate) fn validate(
         &self,
         physical_device: &PhysicalDevice,
@@ -2425,6 +2437,14 @@ pub struct SparseImageFormatInfo {
 impl Default for SparseImageFormatInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparseImageFormatInfo {
+    /// Returns a default `SparseImageFormatInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             format: Format::UNDEFINED,
             image_type: ImageType::Dim2d,
@@ -2434,9 +2454,7 @@ impl Default for SparseImageFormatInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SparseImageFormatInfo {
     pub(crate) fn validate(
         &self,
         physical_device: &PhysicalDevice,

--- a/vulkano/src/image/sampler/mod.rs
+++ b/vulkano/src/image/sampler/mod.rs
@@ -680,6 +680,14 @@ pub struct SamplerCreateInfo {
 impl Default for SamplerCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SamplerCreateInfo {
+    /// Returns a default `SamplerCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             mag_filter: Filter::Nearest,
             min_filter: Filter::Nearest,
@@ -696,9 +704,7 @@ impl Default for SamplerCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SamplerCreateInfo {
     /// Shortcut for creating a sampler with linear sampling, linear mipmaps, and with the repeat
     /// mode for borders.
     #[inline]
@@ -1171,8 +1177,13 @@ pub struct ComponentMapping {
 impl ComponentMapping {
     /// Creates a `ComponentMapping` with all components identity swizzled.
     #[inline]
-    pub fn identity() -> Self {
-        Self::default()
+    pub const fn identity() -> Self {
+        Self {
+            r: ComponentSwizzle::Identity,
+            g: ComponentSwizzle::Identity,
+            b: ComponentSwizzle::Identity,
+            a: ComponentSwizzle::Identity,
+        }
     }
 
     /// Returns `true` if all components are identity swizzled,

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -421,6 +421,14 @@ pub struct SamplerYcbcrConversionCreateInfo {
 impl Default for SamplerYcbcrConversionCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SamplerYcbcrConversionCreateInfo {
+    /// Returns a default `SamplerYcbcrConversionCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             format: Format::UNDEFINED,
             ycbcr_model: SamplerYcbcrModelConversion::RgbIdentity,
@@ -432,9 +440,7 @@ impl Default for SamplerYcbcrConversionCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SamplerYcbcrConversionCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             format,

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -1651,6 +1651,14 @@ pub struct ImageCreateInfo {
 impl Default for ImageCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageCreateInfo {
+    /// Returns a default `ImageCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: ImageCreateFlags::empty(),
             image_type: ImageType::Dim2d,
@@ -1671,9 +1679,7 @@ impl Default for ImageCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl ImageCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -844,6 +844,14 @@ pub struct ImageViewCreateInfo {
 impl Default for ImageViewCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageViewCreateInfo {
+    /// Returns a default `ImageViewCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             view_type: ImageViewType::Dim2d,
             format: Format::UNDEFINED,
@@ -858,9 +866,7 @@ impl Default for ImageViewCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl ImageViewCreateInfo {
     /// Returns an `ImageViewCreateInfo` with the `view_type` determined from the image type and
     /// array layers, and `subresource_range` determined from the image format and covering the
     /// whole image.

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -545,6 +545,16 @@ impl Default for DebugUtilsLabel {
 }
 
 impl DebugUtilsLabel {
+    /// Returns a default `DebugUtilsLabel`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            label_name: String::new(),
+            color: [0.0; 4],
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
     pub(crate) fn to_vk<'a>(
         &self,
         fields1_vk: &'a DebugUtilsLabelFields1Vk,

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -865,6 +865,14 @@ pub struct InstanceCreateInfo {
 impl Default for InstanceCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InstanceCreateInfo {
+    /// Returns a default `InstanceCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: InstanceCreateFlags::empty(),
             application_name: None,
@@ -880,9 +888,7 @@ impl Default for InstanceCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl InstanceCreateInfo {
     /// Returns an `InstanceCreateInfo` with the `application_name` and `application_version` set
     /// from information in your crate's Cargo.toml file.
     ///

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -208,6 +208,7 @@ pub struct Packed24_8(u32);
 
 impl Packed24_8 {
     /// Returns a new `Packed24_8` value.
+    // TODO: make const
     #[inline]
     pub fn new(low_24: u32, high_8: u8) -> Self {
         Self((low_24 & 0x00ff_ffff) | (u32::from(high_8) << 24))

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -679,7 +679,15 @@ pub struct AllocationCreateInfo {
 impl Default for AllocationCreateInfo {
     #[inline]
     fn default() -> Self {
-        AllocationCreateInfo {
+        Self::new()
+    }
+}
+
+impl AllocationCreateInfo {
+    /// Returns a default `AllocationCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
             memory_type_filter: MemoryTypeFilter::PREFER_DEVICE,
             memory_type_bits: u32::MAX,
             allocate_preference: MemoryAllocatePreference::Unknown,
@@ -1865,7 +1873,15 @@ pub struct GenericMemoryAllocatorCreateInfo<'a> {
 impl Default for GenericMemoryAllocatorCreateInfo<'_> {
     #[inline]
     fn default() -> Self {
-        GenericMemoryAllocatorCreateInfo {
+        Self::new()
+    }
+}
+
+impl GenericMemoryAllocatorCreateInfo<'_> {
+    /// Returns a default `GenericMemoryAllocatorCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
             block_sizes: &[],
             memory_type_bits: u32::MAX,
             dedicated_allocation: true,

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -843,6 +843,14 @@ pub struct MemoryAllocateInfo<'d> {
 impl Default for MemoryAllocateInfo<'static> {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryAllocateInfo<'_> {
+    /// Returns a default `MemoryAllocateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             allocation_size: 0,
             memory_type_index: u32::MAX,
@@ -1488,16 +1496,22 @@ pub struct MemoryMapInfo {
 impl Default for MemoryMapInfo {
     #[inline]
     fn default() -> Self {
-        MemoryMapInfo {
+        Self::new()
+    }
+}
+
+impl MemoryMapInfo {
+    /// Returns a default `MemoryMapInfo`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
             flags: MemoryMapFlags::empty(),
             offset: 0,
             size: 0,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl MemoryMapInfo {
     pub(crate) fn validate(
         &self,
         memory: &DeviceMemory,
@@ -1751,13 +1765,19 @@ pub struct MemoryUnmapInfo {
 impl Default for MemoryUnmapInfo {
     #[inline]
     fn default() -> Self {
-        MemoryUnmapInfo {
-            _ne: crate::NonExhaustive(()),
-        }
+        Self::new()
     }
 }
 
 impl MemoryUnmapInfo {
+    /// Returns a default `MemoryUnmapInfo`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
     pub(crate) fn validate(&self, _memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
         let &Self { _ne: _ } = self;
 
@@ -1885,7 +1905,24 @@ pub struct MappedMemoryRange {
     pub _ne: crate::NonExhaustive,
 }
 
+impl Default for MappedMemoryRange {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MappedMemoryRange {
+    /// Returns a default `MappedMemoryRange`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            offset: 0,
+            size: 0,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
     pub(crate) fn validate(&self, memory: &DeviceMemory) -> Result<(), Box<ValidationError>> {
         let &Self {
             offset,
@@ -1944,17 +1981,6 @@ impl MappedMemoryRange {
             .memory(memory_vk)
             .offset(offset)
             .size(size)
-    }
-}
-
-impl Default for MappedMemoryRange {
-    #[inline]
-    fn default() -> Self {
-        MappedMemoryRange {
-            offset: 0,
-            size: 0,
-            _ne: crate::NonExhaustive(()),
-        }
     }
 }
 

--- a/vulkano/src/memory/sparse.rs
+++ b/vulkano/src/memory/sparse.rs
@@ -58,6 +58,14 @@ pub struct BindSparseInfo {
 impl Default for BindSparseInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BindSparseInfo {
+    /// Returns a default `BindSparseInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             wait_semaphores: Vec::new(),
             buffer_binds: Vec::new(),
@@ -67,9 +75,7 @@ impl Default for BindSparseInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl BindSparseInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             ref wait_semaphores,
@@ -473,6 +479,14 @@ pub struct SparseBufferMemoryBind {
 
 impl Default for SparseBufferMemoryBind {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparseBufferMemoryBind {
+    /// Returns a default `SparseBufferMemoryBind`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             offset: 0,
             size: 0,
@@ -480,9 +494,7 @@ impl Default for SparseBufferMemoryBind {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SparseBufferMemoryBind {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             offset: _,
@@ -934,6 +946,14 @@ pub struct SparseImageOpaqueMemoryBind {
 
 impl Default for SparseImageOpaqueMemoryBind {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparseImageOpaqueMemoryBind {
+    /// Returns a default `SparseImageOpaqueMemoryBind`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             offset: 0,
             size: 0,
@@ -942,9 +962,7 @@ impl Default for SparseImageOpaqueMemoryBind {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SparseImageOpaqueMemoryBind {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             offset: _,
@@ -1499,6 +1517,14 @@ pub struct SparseImageMemoryBind {
 
 impl Default for SparseImageMemoryBind {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparseImageMemoryBind {
+    /// Returns a default `SparseImageMemoryBind`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             aspects: ImageAspects::empty(),
             mip_level: 0,
@@ -1509,9 +1535,7 @@ impl Default for SparseImageMemoryBind {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SparseImageMemoryBind {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             aspects,

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -330,15 +330,21 @@ pub struct PipelineCacheCreateInfo {
 impl Default for PipelineCacheCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PipelineCacheCreateInfo {
+    /// Returns a default `PipelineCacheCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: PipelineCacheCreateFlags::empty(),
             initial_data: Vec::new(),
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl PipelineCacheCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,

--- a/vulkano/src/pipeline/graphics/color_blend.rs
+++ b/vulkano/src/pipeline/graphics/color_blend.rs
@@ -67,6 +67,14 @@ impl Default for ColorBlendState {
     /// Returns [`ColorBlendState::new(1)`].
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ColorBlendState {
+    /// Returns a default `ColorBlendState`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: ColorBlendStateFlags::empty(),
             logic_op: None,
@@ -75,9 +83,7 @@ impl Default for ColorBlendState {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl ColorBlendState {
     /// Returns a default `ColorBlendState` with `count` duplicates of `attachment_state`.
     #[inline]
     pub fn with_attachment_states(count: u32, attachment_state: ColorBlendAttachmentState) -> Self {
@@ -86,23 +92,6 @@ impl ColorBlendState {
                 .take(count as usize)
                 .collect(),
             ..Default::default()
-        }
-    }
-
-    /// Creates a `ColorBlendState` with logical operations disabled, blend constants set to zero,
-    /// and `num` attachment entries that have blending disabled, and color write and all color
-    /// components enabled.
-    #[inline]
-    #[deprecated(since = "0.34.0")]
-    pub fn new(num: u32) -> Self {
-        Self {
-            flags: ColorBlendStateFlags::empty(),
-            logic_op: None,
-            attachments: (0..num)
-                .map(|_| ColorBlendAttachmentState::default())
-                .collect(),
-            blend_constants: [0.0; 4],
-            _ne: crate::NonExhaustive(()),
         }
     }
 
@@ -662,15 +651,21 @@ pub struct ColorBlendAttachmentState {
 impl Default for ColorBlendAttachmentState {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ColorBlendAttachmentState {
+    /// Returns a default `ColorBlendAttachmentState`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             blend: None,
             color_write_mask: ColorComponents::all(),
             color_write_enable: true,
         }
     }
-}
 
-impl ColorBlendAttachmentState {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             ref blend,
@@ -754,6 +749,14 @@ pub struct AttachmentBlend {
 impl Default for AttachmentBlend {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AttachmentBlend {
+    /// Returns a default `AttachmentBlend`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             src_color_blend_factor: BlendFactor::SrcColor,
             dst_color_blend_factor: BlendFactor::Zero,
@@ -763,9 +766,7 @@ impl Default for AttachmentBlend {
             alpha_blend_op: BlendOp::Add,
         }
     }
-}
 
-impl AttachmentBlend {
     /// Builds an `AttachmentBlend` where the output of the fragment shader is ignored and the
     /// destination is untouched.
     #[inline]

--- a/vulkano/src/pipeline/graphics/depth_stencil.rs
+++ b/vulkano/src/pipeline/graphics/depth_stencil.rs
@@ -58,20 +58,26 @@ pub struct DepthStencilState {
 impl Default for DepthStencilState {
     #[inline]
     fn default() -> Self {
-        Self {
-            flags: DepthStencilStateFlags::empty(),
-            depth: Default::default(),
-            depth_bounds: Default::default(),
-            stencil: Default::default(),
-            _ne: crate::NonExhaustive(()),
-        }
+        Self::new()
     }
 }
 
 impl DepthStencilState {
+    /// Returns a default `DepthStencilState`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            flags: DepthStencilStateFlags::empty(),
+            depth: None,
+            depth_bounds: None,
+            stencil: None,
+            _ne: crate::NonExhaustive(()),
+        }
+    }
+
     /// Creates a `DepthStencilState` where all tests are disabled and have no effect.
     #[inline]
-    #[deprecated(since = "0.34.0", note = "use `DepthStencilState::default` instead")]
+    #[deprecated(since = "0.34.0", note = "use `DepthStencilState::new` instead")]
     pub fn disabled() -> Self {
         Self::default()
     }
@@ -251,14 +257,20 @@ pub struct DepthState {
 impl Default for DepthState {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DepthState {
+    /// Returns a default `DepthState`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             write_enable: false,
             compare_op: CompareOp::Always,
         }
     }
-}
 
-impl DepthState {
     /// Returns a `DepthState` with a `Less` depth test and depth writes enabled.
     #[inline]
     pub fn simple() -> Self {
@@ -310,14 +322,20 @@ pub struct StencilState {
 impl Default for StencilState {
     #[inline]
     fn default() -> Self {
-        Self {
-            front: Default::default(),
-            back: Default::default(),
-        }
+        Self::new()
     }
 }
 
 impl StencilState {
+    /// Returns a default `StencilState`.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            front: StencilOpState::new(),
+            back: StencilOpState::new(),
+        }
+    }
+
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &StencilState {
             ref front,
@@ -375,17 +393,23 @@ pub struct StencilOpState {
 
 impl Default for StencilOpState {
     #[inline]
-    fn default() -> StencilOpState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StencilOpState {
+    /// Returns a default `StencilOpState`.
+    #[inline]
+    pub const fn new() -> Self {
         StencilOpState {
-            ops: Default::default(),
+            ops: StencilOps::new(),
             compare_mask: u32::MAX,
             write_mask: u32::MAX,
             reference: u32::MAX,
         }
     }
-}
 
-impl StencilOpState {
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_vk(&self) -> vk::StencilOpState {
         let &Self {
@@ -434,6 +458,14 @@ pub struct StencilOps {
 impl Default for StencilOps {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StencilOps {
+    /// Returns a default `StencilOps`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             pass_op: StencilOp::Keep,
             fail_op: StencilOp::Keep,
@@ -441,9 +473,7 @@ impl Default for StencilOps {
             compare_op: CompareOp::Never,
         }
     }
-}
 
-impl StencilOps {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             fail_op,

--- a/vulkano/src/pipeline/graphics/discard_rectangle.rs
+++ b/vulkano/src/pipeline/graphics/discard_rectangle.rs
@@ -37,23 +37,19 @@ pub struct DiscardRectangleState {
 impl Default for DiscardRectangleState {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DiscardRectangleState {
+    /// Returns a default `DiscardRectangleState`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             mode: DiscardRectangleMode::Exclusive,
             rectangles: Vec::new(),
             _ne: crate::NonExhaustive(()),
         }
-    }
-}
-
-impl DiscardRectangleState {
-    /// Creates a `DiscardRectangleState` in exclusive mode with zero rectangles.
-    #[inline]
-    #[deprecated(
-        since = "0.34.0",
-        note = "use `DiscardRectangleState::default` instead"
-    )]
-    pub fn new() -> Self {
-        Self::default()
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/pipeline/graphics/fragment_shading_rate.rs
+++ b/vulkano/src/pipeline/graphics/fragment_shading_rate.rs
@@ -42,15 +42,21 @@ pub struct FragmentShadingRateState {
 impl Default for FragmentShadingRateState {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FragmentShadingRateState {
+    /// Returns a default `FragmentShadingRateState`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             fragment_size: [1, 1],
             combiner_ops: [FragmentShadingRateCombinerOp::Keep; 2],
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl FragmentShadingRateState {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             fragment_size,

--- a/vulkano/src/pipeline/graphics/input_assembly.rs
+++ b/vulkano/src/pipeline/graphics/input_assembly.rs
@@ -40,20 +40,14 @@ impl Default for InputAssemblyState {
     /// Returns [`InputAssemblyState::new()`].
     #[inline]
     fn default() -> Self {
-        Self {
-            topology: PrimitiveTopology::TriangleList,
-            primitive_restart_enable: false,
-            _ne: crate::NonExhaustive(()),
-        }
+        Self::new()
     }
 }
 
 impl InputAssemblyState {
-    /// Creates an `InputAssemblyState` with the `TriangleList` topology and primitive restart
-    /// disabled.
+    /// Returns a default `InputAssemblyState`.
     #[inline]
-    #[deprecated(since = "0.34.0", note = "use `InputAssemblyState::default` instead")]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             topology: PrimitiveTopology::TriangleList,
             primitive_restart_enable: false,

--- a/vulkano/src/pipeline/graphics/multisample.rs
+++ b/vulkano/src/pipeline/graphics/multisample.rs
@@ -63,6 +63,14 @@ pub struct MultisampleState {
 impl Default for MultisampleState {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MultisampleState {
+    /// Returns a default `MultisampleState`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             rasterization_samples: SampleCount::Sample1,
             sample_shading: None,
@@ -71,15 +79,6 @@ impl Default for MultisampleState {
             alpha_to_one_enable: false,
             _ne: crate::NonExhaustive(()),
         }
-    }
-}
-
-impl MultisampleState {
-    /// Creates a `MultisampleState` with multisampling disabled.
-    #[inline]
-    #[deprecated(since = "0.34.0", note = "use `MultisampleState::default` instead")]
-    pub fn new() -> MultisampleState {
-        Self::default()
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/pipeline/graphics/rasterization.rs
+++ b/vulkano/src/pipeline/graphics/rasterization.rs
@@ -96,30 +96,27 @@ pub struct RasterizationState {
 impl Default for RasterizationState {
     #[inline]
     fn default() -> Self {
-        Self {
-            depth_clamp_enable: false,
-            rasterizer_discard_enable: false,
-            polygon_mode: Default::default(),
-            cull_mode: Default::default(),
-            front_face: Default::default(),
-            depth_bias: None,
-            line_width: 1.0,
-            line_rasterization_mode: Default::default(),
-            line_stipple: None,
-            conservative: None,
-            _ne: crate::NonExhaustive(()),
-        }
+        Self::new()
     }
 }
 
 impl RasterizationState {
-    /// Creates a `RasterizationState` with depth clamping, discard, depth biasing and line
-    /// stippling disabled, filled polygons, no culling, counterclockwise front face, and the
-    /// default line width and line rasterization mode.
+    /// Returns a default `RasterizationState`.
     #[inline]
-    #[deprecated(since = "0.34.0", note = "use `RasterizationState::default` instead")]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            depth_clamp_enable: false,
+            rasterizer_discard_enable: false,
+            polygon_mode: PolygonMode::Fill,
+            cull_mode: CullMode::None,
+            front_face: FrontFace::CounterClockwise,
+            depth_bias: None,
+            line_width: 1.0,
+            line_rasterization_mode: LineRasterizationMode::Default,
+            line_stipple: None,
+            conservative: None,
+            _ne: crate::NonExhaustive(()),
+        }
     }
 
     /// Sets the polygon mode.
@@ -507,6 +504,14 @@ pub struct DepthBiasState {
 impl Default for DepthBiasState {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DepthBiasState {
+    /// Returns a default `DepthBiasState`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             constant_factor: 1.0,
             clamp: 0.0,
@@ -643,7 +648,6 @@ vulkan_enum! {
 }
 
 impl Default for LineRasterizationMode {
-    /// Returns `LineRasterizationMode::Default`.
     #[inline]
     fn default() -> Self {
         Self::Default
@@ -682,15 +686,21 @@ pub struct RasterizationConservativeState {
 impl Default for RasterizationConservativeState {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RasterizationConservativeState {
+    /// Returns a default `RasterizationConservativeState`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             mode: ConservativeRasterizationMode::Disabled,
             overestimation_size: 0.0,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl RasterizationConservativeState {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             mode,

--- a/vulkano/src/pipeline/graphics/subpass.rs
+++ b/vulkano/src/pipeline/graphics/subpass.rs
@@ -91,6 +91,14 @@ pub struct PipelineRenderingCreateInfo {
 impl Default for PipelineRenderingCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PipelineRenderingCreateInfo {
+    /// Returns a default `PipelineRenderingCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             view_mask: 0,
             color_attachment_formats: Vec::new(),
@@ -99,9 +107,7 @@ impl Default for PipelineRenderingCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl PipelineRenderingCreateInfo {
     pub(crate) fn from_subpass(subpass: &Subpass) -> Self {
         let subpass_desc = subpass.subpass_desc();
         let rp_attachments = subpass.render_pass().attachments();

--- a/vulkano/src/pipeline/graphics/tessellation.rs
+++ b/vulkano/src/pipeline/graphics/tessellation.rs
@@ -30,20 +30,19 @@ pub struct TessellationState {
 impl Default for TessellationState {
     #[inline]
     fn default() -> Self {
-        Self {
-            patch_control_points: 3,
-            domain_origin: TessellationDomainOrigin::default(),
-            _ne: crate::NonExhaustive(()),
-        }
+        Self::new()
     }
 }
 
 impl TessellationState {
-    /// Creates a new `TessellationState` with 3 patch control points.
+    /// Returns a default `TessellationState`.
     #[inline]
-    #[deprecated(since = "0.34.0", note = "use `TessellationState::default` instead")]
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            patch_control_points: 3,
+            domain_origin: TessellationDomainOrigin::UpperLeft,
+            _ne: crate::NonExhaustive(()),
+        }
     }
 
     /// Sets the number of patch control points.

--- a/vulkano/src/pipeline/graphics/vertex_input/mod.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/mod.rs
@@ -135,10 +135,11 @@ impl Default for VertexInputState {
 }
 
 impl VertexInputState {
-    /// Constructs a new `VertexInputState` with no bindings or attributes.
+    /// Returns a default `VertexInputState`.
+    // TODO: make const
     #[inline]
-    pub fn new() -> VertexInputState {
-        VertexInputState {
+    pub fn new() -> Self {
+        Self {
             bindings: Default::default(),
             attributes: Default::default(),
             _ne: crate::NonExhaustive(()),
@@ -558,15 +559,21 @@ pub struct VertexInputBindingDescription {
 impl Default for VertexInputBindingDescription {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VertexInputBindingDescription {
+    /// Returns a default `VertexInputBindingDescription`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             stride: 0,
             input_rate: VertexInputRate::Vertex,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl VertexInputBindingDescription {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             stride,
@@ -742,6 +749,14 @@ pub struct VertexInputAttributeDescription {
 impl Default for VertexInputAttributeDescription {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VertexInputAttributeDescription {
+    /// Returns a default `VertexInputAttributeDescription`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             binding: 0,
             format: Format::UNDEFINED,
@@ -749,9 +764,7 @@ impl Default for VertexInputAttributeDescription {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl VertexInputAttributeDescription {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             binding,

--- a/vulkano/src/pipeline/graphics/viewport.rs
+++ b/vulkano/src/pipeline/graphics/viewport.rs
@@ -88,22 +88,18 @@ pub struct ViewportState {
 impl Default for ViewportState {
     #[inline]
     fn default() -> Self {
-        Self {
-            viewports: smallvec![Viewport::default()],
-            scissors: smallvec![Scissor::default()],
-            _ne: crate::NonExhaustive(()),
-        }
+        Self::new()
     }
 }
 
 impl ViewportState {
-    /// Creates a `ViewportState` with fixed state and no viewports or scissors.
-    #[deprecated(since = "0.34.0")]
+    /// Returns a default `ViewportState`.
+    // TODO: make const
     #[inline]
     pub fn new() -> Self {
         Self {
-            viewports: SmallVec::new(),
-            scissors: SmallVec::new(),
+            viewports: smallvec![Viewport::default()],
+            scissors: smallvec![Scissor::default()],
             _ne: crate::NonExhaustive(()),
         }
     }
@@ -301,15 +297,21 @@ pub struct Viewport {
 impl Default for Viewport {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Viewport {
+    /// Returns a default `Viewport`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             offset: [0.0; 2],
             extent: [1.0; 2],
             depth_range: 0.0..=1.0,
         }
     }
-}
 
-impl Viewport {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             offset,
@@ -478,21 +480,27 @@ pub struct Scissor {
 
 impl Default for Scissor {
     #[inline]
-    fn default() -> Scissor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Scissor {
+    /// Returns a default `Scissor`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             offset: [0; 2],
             extent: [i32::MAX as u32; 2],
         }
     }
-}
 
-impl Scissor {
     /// Returns a scissor that, when used, will instruct the pipeline to draw to the entire
     /// framebuffer no matter its size.
-    #[deprecated(since = "0.34.0", note = "use `Scissor::default` instead")]
+    #[deprecated(since = "0.34.0", note = "use `Scissor::new` instead")]
     #[inline]
     pub fn irrelevant() -> Scissor {
-        Self::default()
+        Self::new()
     }
 
     #[allow(clippy::wrong_self_convention)]

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -410,6 +410,14 @@ pub struct PipelineLayoutCreateInfo {
 impl Default for PipelineLayoutCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PipelineLayoutCreateInfo {
+    /// Returns a default `PipelineLayoutCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: PipelineLayoutCreateFlags::empty(),
             set_layouts: Vec::new(),
@@ -417,9 +425,7 @@ impl Default for PipelineLayoutCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl PipelineLayoutCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let properties = device.physical_device().properties();
 
@@ -973,15 +979,21 @@ pub struct PushConstantRange {
 impl Default for PushConstantRange {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PushConstantRange {
+    /// Returns a default `PushConstantRange`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             stages: ShaderStages::empty(),
             offset: 0,
             size: 0,
         }
     }
-}
 
-impl PushConstantRange {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             stages,

--- a/vulkano/src/range_map.rs
+++ b/vulkano/src/range_map.rs
@@ -54,7 +54,7 @@ where
 {
     /// Makes a new empty `RangeMap`.
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         RangeMap {
             btm: BTreeMap::new(),
         }

--- a/vulkano/src/range_set.rs
+++ b/vulkano/src/range_set.rs
@@ -9,7 +9,7 @@ pub struct RangeSet<T>(Vec<Range<T>>);
 impl<T: Ord + Copy> RangeSet<T> {
     /// Returns a new empty `RangeSet`.
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         RangeSet(Vec::new())
     }
 

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -436,6 +436,14 @@ pub struct FramebufferCreateInfo {
 impl Default for FramebufferCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FramebufferCreateInfo {
+    /// Returns a default `FramebufferCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: FramebufferCreateFlags::empty(),
             attachments: Vec::new(),
@@ -444,9 +452,7 @@ impl Default for FramebufferCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl FramebufferCreateInfo {
     fn set_auto_extent_layers(&mut self, render_pass: &RenderPass) {
         let Self {
             flags: _,

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -822,6 +822,14 @@ pub struct RenderPassCreateInfo {
 impl Default for RenderPassCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RenderPassCreateInfo {
+    /// Returns a default `RenderPassCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: RenderPassCreateFlags::empty(),
             attachments: Vec::new(),
@@ -831,9 +839,7 @@ impl Default for RenderPassCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl RenderPassCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,
@@ -2095,6 +2101,14 @@ pub struct AttachmentDescription {
 impl Default for AttachmentDescription {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AttachmentDescription {
+    /// Returns a default `AttachmentDescription`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: AttachmentDescriptionFlags::empty(),
             format: Format::UNDEFINED,
@@ -2110,9 +2124,7 @@ impl Default for AttachmentDescription {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl AttachmentDescription {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,
@@ -2775,6 +2787,14 @@ pub struct SubpassDescription {
 impl Default for SubpassDescription {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SubpassDescription {
+    /// Returns a default `SubpassDescription`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: SubpassDescriptionFlags::empty(),
             view_mask: 0,
@@ -2789,9 +2809,7 @@ impl Default for SubpassDescription {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SubpassDescription {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let properties = device.physical_device().properties();
 
@@ -3937,6 +3955,14 @@ pub struct AttachmentReference {
 impl Default for AttachmentReference {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AttachmentReference {
+    /// Returns a default `AttachmentReference`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             attachment: 0,
             layout: ImageLayout::Undefined,
@@ -3945,9 +3971,7 @@ impl Default for AttachmentReference {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl AttachmentReference {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             attachment: _,
@@ -4210,6 +4234,14 @@ pub struct SubpassDependency {
 impl Default for SubpassDependency {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SubpassDependency {
+    /// Returns a default `SubpassDependency`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             src_subpass: None,
             dst_subpass: None,
@@ -4222,9 +4254,7 @@ impl Default for SubpassDependency {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SubpassDependency {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             src_subpass,

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -57,6 +57,14 @@ pub struct AcquireNextImageInfo {
 impl Default for AcquireNextImageInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AcquireNextImageInfo {
+    /// Returns a default `AcquireNextImageInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             timeout: None,
             semaphore: None,
@@ -64,9 +72,7 @@ impl Default for AcquireNextImageInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl AcquireNextImageInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             timeout,
@@ -457,15 +463,21 @@ pub struct PresentInfo {
 impl Default for PresentInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PresentInfo {
+    /// Returns a default `PresentInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             wait_semaphores: Vec::new(),
             swapchain_infos: Vec::new(),
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl PresentInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             ref wait_semaphores,

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -1828,6 +1828,15 @@ pub struct SwapchainCreateInfo {
 impl Default for SwapchainCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SwapchainCreateInfo {
+    /// Returns a default `SwapchainCreateInfo`.
+    // TODO: make const
+    #[inline]
+    pub fn new() -> Self {
         Self {
             flags: SwapchainCreateFlags::empty(),
             min_image_count: 2,
@@ -1850,9 +1859,7 @@ impl Default for SwapchainCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SwapchainCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -1452,6 +1452,14 @@ pub struct DisplaySurfaceCreateInfo {
 impl Default for DisplaySurfaceCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DisplaySurfaceCreateInfo {
+    /// Returns a default `DisplaySurfaceCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             plane_index: 0,
             plane_stack_index: 0,
@@ -1462,9 +1470,7 @@ impl Default for DisplaySurfaceCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl DisplaySurfaceCreateInfo {
     pub(crate) fn validate(
         &self,
         physical_device: &PhysicalDevice,
@@ -2040,6 +2046,14 @@ pub struct SurfaceInfo {
 impl Default for SurfaceInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SurfaceInfo {
+    /// Returns a default `SurfaceInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             present_mode: None,
             full_screen_exclusive: FullScreenExclusive::Default,
@@ -2047,9 +2061,7 @@ impl Default for SurfaceInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SurfaceInfo {
     pub(crate) fn validate(
         &self,
         physical_device: &PhysicalDevice,

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -300,14 +300,20 @@ pub struct EventCreateInfo {
 impl Default for EventCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventCreateInfo {
+    /// Returns a default `EventCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: EventCreateFlags::empty(),
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl EventCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self { flags, _ne: _ } = self;
 

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -774,15 +774,21 @@ pub struct FenceCreateInfo {
 impl Default for FenceCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FenceCreateInfo {
+    /// Returns a default `FenceCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: FenceCreateFlags::empty(),
             export_handle_types: ExternalFenceHandleTypes::empty(),
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl FenceCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -1748,6 +1748,15 @@ pub struct DependencyInfo {
 impl Default for DependencyInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DependencyInfo {
+    /// Returns a default `DependencyInfo`.
+    // TODO: make const
+    #[inline]
+    pub fn new() -> Self {
         Self {
             dependency_flags: DependencyFlags::empty(),
             memory_barriers: SmallVec::new(),
@@ -1756,9 +1765,7 @@ impl Default for DependencyInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl DependencyInfo {
     /// Returns whether `self` contains any barriers.
     #[inline]
     pub fn is_empty(&self) -> bool {
@@ -2032,6 +2039,14 @@ pub struct MemoryBarrier {
 impl Default for MemoryBarrier {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryBarrier {
+    /// Returns a default `MemoryBarrier`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             src_stages: PipelineStages::empty(),
             src_access: AccessFlags::empty(),
@@ -2040,9 +2055,7 @@ impl Default for MemoryBarrier {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl MemoryBarrier {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             src_stages,

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -1089,6 +1089,14 @@ pub struct SemaphoreCreateInfo {
 impl Default for SemaphoreCreateInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SemaphoreCreateInfo {
+    /// Returns a default `SemaphoreCreateInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             semaphore_type: SemaphoreType::Binary,
             initial_value: 0,
@@ -1096,9 +1104,7 @@ impl Default for SemaphoreCreateInfo {
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SemaphoreCreateInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             semaphore_type,
@@ -1356,14 +1362,20 @@ pub struct SemaphoreSignalInfo {
 impl Default for SemaphoreSignalInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SemaphoreSignalInfo {
+    /// Returns a default `SemaphoreSignalInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             value: 0,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SemaphoreSignalInfo {
     pub(crate) fn validate(&self, _device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self { value: _, _ne: _ } = self;
 
@@ -1403,15 +1415,21 @@ pub struct SemaphoreWaitInfo {
 impl Default for SemaphoreWaitInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SemaphoreWaitInfo {
+    /// Returns a default `SemaphoreWaitInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: SemaphoreWaitFlags::empty(),
             value: 0,
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SemaphoreWaitInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,
@@ -1463,15 +1481,21 @@ pub struct SemaphoreWaitMultipleInfo {
 impl Default for SemaphoreWaitMultipleInfo {
     #[inline]
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SemaphoreWaitMultipleInfo {
+    /// Returns a default `SemaphoreWaitMultipleInfo`.
+    #[inline]
+    pub const fn new() -> Self {
         Self {
             flags: SemaphoreWaitFlags::empty(),
             semaphores: Vec::new(),
             _ne: crate::NonExhaustive(()),
         }
     }
-}
 
-impl SemaphoreWaitMultipleInfo {
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
             flags,


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Changes to `GraphicsPipeline`:
- `ColorBlendState::new` and `ViewportState::new` (previously deprecated, now undeprecated) now return the same as `Default::default()`.

### Additions
- Added `new` constructors to all `*Info`-like structs.
```
