### PR TITLE
Fix `FreeListAllocator::reset` leaving the free-list empty

### DIFF
--- a/vulkano/src/memory/allocator/suballocator/free_list.rs
+++ b/vulkano/src/memory/allocator/suballocator/free_list.rs
@@ -268,6 +268,7 @@ unsafe impl Suballocator for FreeListAllocator {
         self.suballocations.head = root_ptr;
         self.suballocations.tail = root_ptr;
         self.suballocations.len = 1;
+        self.suballocations.free_list.push(root_ptr);
     }
 
     #[inline]


### PR DESCRIPTION
This fixes a regression introduced in #2585, where `FreeListAllocator::reset` would mistakenly leave the free-list empty, such that all subsequent allocations would fail. This method is used in the `StandardMemoryAllocator` if the allocation count of a `DeviceMemory` blocks hits 0, so it can lead to needless allocations of new `DeviceMemory` blocks if the user frequently deallocates all allocations within a block.

Changelog:
```md
### Bugs fixed
- Fixed a bug in `StandardMemoryAllocator` where if the suballocation count of a `DeviceMemory` block would drop to zero, no more suballocations could be made, leading to needless allocations of new `DeviceMemory` blocks.
```