### PR TITLE
Fix `FreeListAllocator::reset` leaving the free-list empty

### DIFF
--- a/vulkano/src/memory/allocator/suballocator/free_list.rs
+++ b/vulkano/src/memory/allocator/suballocator/free_list.rs
@@ -268,6 +268,7 @@ unsafe impl Suballocator for FreeListAllocator {
         self.suballocations.head = root_ptr;
         self.suballocations.tail = root_ptr;
         self.suballocations.len = 1;
+        self.suballocations.free_list.push(root_ptr);
     }
 
     #[inline]


### PR DESCRIPTION
Replicates #2645 on master.