### PR TITLE
`std::mem::{size_of[val],align_of[val]}` are in the prelude now; use 'em

### DIFF
--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -4,7 +4,7 @@
 // Each draw or dispatch call can specify an offset into the buffer to read object data from,
 // without having to rebind descriptor sets.
 
-use std::{iter::repeat, mem::size_of, sync::Arc};
+use std::{iter::repeat, sync::Arc};
 use vulkano::{
     buffer::{Buffer, BufferCreateInfo, BufferUsage},
     command_buffer::{

--- a/examples/ray-tracing-auto/scene.rs
+++ b/examples/ray-tracing-auto/scene.rs
@@ -1,6 +1,6 @@
 use crate::App;
 use glam::{Mat4, Vec3};
-use std::{iter, mem::size_of, sync::Arc};
+use std::{iter, sync::Arc};
 use vulkano::{
     acceleration_structure::{
         AccelerationStructure, AccelerationStructureBuildGeometryInfo,

--- a/examples/ray-tracing/scene.rs
+++ b/examples/ray-tracing/scene.rs
@@ -1,6 +1,6 @@
 use crate::{App, RenderContext};
 use glam::{Mat4, Vec3};
-use std::{iter, mem::size_of, sync::Arc};
+use std::{iter, sync::Arc};
 use vulkano::{
     acceleration_structure::{
         AccelerationStructure, AccelerationStructureBuildGeometryInfo,

--- a/vulkano-taskgraph/src/command_buffer/commands/bind_push.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/bind_push.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::SmallVec;
-use std::{ffi::c_void, mem, ptr, sync::Arc};
+use std::{ffi::c_void, ptr, sync::Arc};
 use vulkano::{
     self,
     buffer::{Buffer, BufferContents, IndexType},
@@ -244,7 +244,7 @@ impl RecordingCommandBuffer<'_> {
                 layout,
                 offset,
                 <*const _>::cast(values),
-                mem::size_of_val(values) as u32,
+                size_of_val(values) as u32,
             )
         }
     }

--- a/vulkano-taskgraph/src/command_buffer/commands/clear.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/clear.rs
@@ -4,7 +4,7 @@ use crate::{
     Id,
 };
 use smallvec::SmallVec;
-use std::{ffi::c_void, mem};
+use std::ffi::c_void;
 use vulkano::{
     buffer::{Buffer, BufferContents},
     device::DeviceOwned,
@@ -186,7 +186,7 @@ impl RecordingCommandBuffer<'_> {
                 dst_buffer,
                 dst_offset,
                 <*const _>::cast(data),
-                mem::size_of_val(data) as DeviceSize,
+                size_of_val(data) as DeviceSize,
             )
         }
     }

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -21,7 +21,7 @@ use crate::{
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
 use smallvec::SmallVec;
-use std::{mem::size_of, sync::Arc};
+use std::sync::Arc;
 
 /// # Commands to do operations on acceleration structures.
 impl<L> AutoCommandBufferBuilder<L> {

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::SmallVec;
-use std::{cmp::min, ffi::c_void, mem::size_of, ptr, sync::Arc};
+use std::{cmp::min, ffi::c_void, ptr, sync::Arc};
 
 /// # Commands to bind or push state for pipeline execution commands.
 ///

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use ash::vk;
 use smallvec::{smallvec, SmallVec};
-use std::{mem::size_of_val, sync::Arc};
+use std::sync::Arc;
 
 /// # Commands to fill resources with new data.
 impl<L> AutoCommandBufferBuilder<L> {

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -16,7 +16,6 @@ use ash::vk;
 use smallvec::{smallvec, SmallVec};
 use std::{
     cmp::{max, min},
-    mem::size_of,
     sync::Arc,
 };
 

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -30,7 +30,7 @@ use crate::{
     sync::{PipelineStageAccess, PipelineStageAccessFlags},
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanObject,
 };
-use std::{mem::size_of, sync::Arc};
+use std::sync::Arc;
 
 macro_rules! vuids {
     ($vuid_type:ident, $($id:literal),+ $(,)?) => {

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -957,7 +957,7 @@ impl RecordingCommandBuffer {
 
         // VUID-vkCmdCopyQueryPoolResults-flags-00822
         // VUID-vkCmdCopyQueryPoolResults-flags-00823
-        debug_assert!(destination.offset() % std::mem::size_of::<T>() as DeviceSize == 0);
+        debug_assert!(destination.offset() % size_of::<T>() as DeviceSize == 0);
 
         if queries.end < queries.start {
             return Err(Box::new(ValidationError {
@@ -1031,7 +1031,7 @@ impl RecordingCommandBuffer {
         T: QueryResultElement,
     {
         let per_query_len = query_pool.result_len(flags);
-        let stride = per_query_len * std::mem::size_of::<T>() as DeviceSize;
+        let stride = per_query_len * size_of::<T>() as DeviceSize;
 
         let fns = self.device().fns();
         unsafe {

--- a/vulkano/src/memory/alignment.rs
+++ b/vulkano/src/memory/alignment.rs
@@ -16,10 +16,10 @@ use std::{
 #[repr(transparent)]
 pub struct DeviceAlignment(AlignmentEnum);
 
-const _: () = assert!(mem::size_of::<DeviceAlignment>() == mem::size_of::<DeviceSize>());
-const _: () = assert!(mem::align_of::<DeviceAlignment>() == mem::align_of::<DeviceSize>());
+const _: () = assert!(size_of::<DeviceAlignment>() == size_of::<DeviceSize>());
+const _: () = assert!(align_of::<DeviceAlignment>() == align_of::<DeviceSize>());
 
-const _: () = assert!(mem::size_of::<DeviceSize>() >= mem::size_of::<usize>());
+const _: () = assert!(size_of::<DeviceSize>() >= size_of::<usize>());
 
 impl DeviceAlignment {
     /// The smallest possible alignment, 1.
@@ -32,14 +32,14 @@ impl DeviceAlignment {
     #[inline]
     pub const fn of<T>() -> Self {
         // SAFETY: rustc guarantees that the alignment of types is a power of two.
-        unsafe { DeviceAlignment::new_unchecked(mem::align_of::<T>() as DeviceSize) }
+        unsafe { DeviceAlignment::new_unchecked(align_of::<T>() as DeviceSize) }
     }
 
     /// Returns the alignment for a value.
     #[inline]
     pub fn of_val<T: ?Sized>(value: &T) -> Self {
         // SAFETY: rustc guarantees that the alignment of types is a power of two.
-        unsafe { DeviceAlignment::new_unchecked(mem::align_of_val(value) as DeviceSize) }
+        unsafe { DeviceAlignment::new_unchecked(align_of_val(value) as DeviceSize) }
     }
 
     /// Tries to create a `DeviceAlignment` from a [`DeviceSize`], returning [`None`] if it's not a

--- a/vulkano/src/memory/allocator/layout.rs
+++ b/vulkano/src/memory/allocator/layout.rs
@@ -5,7 +5,6 @@ use std::{
     error::Error,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     hash::Hash,
-    mem,
     num::NonZero,
 };
 
@@ -18,7 +17,7 @@ pub struct DeviceLayout {
     alignment: DeviceAlignment,
 }
 
-const _: () = assert!(mem::size_of::<DeviceSize>() >= mem::size_of::<usize>());
+const _: () = assert!(size_of::<DeviceSize>() >= size_of::<usize>());
 const _: () = assert!(DeviceLayout::MAX_SIZE >= isize::MAX as DeviceSize);
 
 impl DeviceLayout {

--- a/vulkano/src/pipeline/graphics/vertex_input/collection.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/collection.rs
@@ -1,5 +1,5 @@
 use crate::buffer::Subbuffer;
-use std::mem::{self, ManuallyDrop};
+use std::mem::ManuallyDrop;
 
 /// A collection of vertex buffers.
 pub trait VertexBuffersCollection {
@@ -23,14 +23,8 @@ impl<T: ?Sized> VertexBuffersCollection for Subbuffer<T> {
 
 impl<T: ?Sized> VertexBuffersCollection for Vec<Subbuffer<T>> {
     fn into_vec(self) -> Vec<Subbuffer<[u8]>> {
-        assert_eq!(
-            mem::size_of::<Subbuffer<T>>(),
-            mem::size_of::<Subbuffer<[u8]>>(),
-        );
-        assert_eq!(
-            mem::align_of::<Subbuffer<T>>(),
-            mem::align_of::<Subbuffer<[u8]>>(),
-        );
+        assert_eq!(size_of::<Subbuffer<T>>(), size_of::<Subbuffer<[u8]>>());
+        assert_eq!(align_of::<Subbuffer<T>>(), align_of::<Subbuffer<[u8]>>());
 
         let mut this = ManuallyDrop::new(self);
         let cap = this.capacity();

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -265,7 +265,7 @@ impl QueryPool {
         T: QueryResultElement,
     {
         let per_query_len = self.result_len(flags);
-        let stride = per_query_len * std::mem::size_of::<T>() as DeviceSize;
+        let stride = per_query_len * size_of::<T>() as DeviceSize;
 
         let fns = self.device.fns();
         let result = unsafe {


### PR DESCRIPTION
These are in the prelude since Rust 1.80.0.