### PR TITLE
Fix panic if previous barrier is looked up and it's an initial barrier

### DIFF
--- a/vulkano-taskgraph/src/resource.rs
+++ b/vulkano-taskgraph/src/resource.rs
@@ -1690,6 +1690,7 @@ impl AccessTypes {
             .union(AccessFlags::TRANSFER_WRITE)
             .union(AccessFlags::MEMORY_READ)
             .union(AccessFlags::MEMORY_WRITE)
+            .union(AccessFlags::SHADER_SAMPLED_READ)
             .union(AccessFlags::SHADER_STORAGE_READ)
             .union(AccessFlags::SHADER_STORAGE_WRITE)
             .union(AccessFlags::VIDEO_DECODE_READ)


### PR DESCRIPTION
Changelog (add to version 0.35.1):
```md
### Bugs fixed
- Vulkano-taskgraph: Fixed a panic that would happen when looking up the previous barrier and it's an initial barrier.
```