### PR TITLE
Fix panic for non-contiguous push constants ranges

### DIFF
--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -196,16 +196,19 @@ impl PipelineLayout {
                         stages |= range.stages;
                     }
                 }
-                // finished all stages
-                if stages.is_empty() {
+
+                if !stages.is_empty() {
+                    push_constant_ranges_disjoint.push(PushConstantRange {
+                        stages,
+                        offset: min_offset,
+                        size: max_offset - min_offset,
+                    });
+                }
+
+                if max_offset == u32::MAX {
                     break;
                 }
 
-                push_constant_ranges_disjoint.push(PushConstantRange {
-                    stages,
-                    offset: min_offset,
-                    size: max_offset - min_offset,
-                });
                 // prepare for next range
                 min_offset = max_offset;
             }

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -1403,6 +1403,39 @@ mod tests {
                     },
                 ][..],
             ),
+            // input:
+            // - `0..8`, stage=vertex
+            // - `16..32`, stage=fragment
+            //
+            // output:
+            // - `0..8`, stage=vertex
+            // - `16..32`, stage=fragment
+            (
+                &[
+                    PushConstantRange {
+                        stages: ShaderStages::VERTEX,
+                        offset: 0,
+                        size: 8,
+                    },
+                    PushConstantRange {
+                        stages: ShaderStages::FRAGMENT,
+                        offset: 16,
+                        size: 16,
+                    },
+                ][..],
+                &[
+                    PushConstantRange {
+                        stages: ShaderStages::VERTEX,
+                        offset: 0,
+                        size: 8,
+                    },
+                    PushConstantRange {
+                        stages: ShaderStages::FRAGMENT,
+                        offset: 16,
+                        size: 16,
+                    },
+                ][..],
+            ),
         ];
 
         let (device, _) = gfx_dev_and_queue!();


### PR DESCRIPTION
1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [x] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   GitHub Issues, and highlight important implementation aspects.

If a pipeline's push constants ranges are not contiguous starting from 0, the current code panics when the pipeline is used, with this error message:
```
one or more bytes of `push_constants` are not within any push constant range of `pipeline_layout`
```
This happens because the `push_constant_ranges_disjoint` vector of `PipelineLayout` will only be populated up to the first gap in contiguity. For example, if there are push constants in the range 0-8 and in the range 16-32, only the first of these will end up in `push_constant_ranges_disjoint`. When pushing the constants in range 16-32, the validation logic panics.

I encountered this because
- my vertex shader took a vec2 of floats as push constants
- my fragment shader took a vec4 of floats as push constants
- I aligned the vertex shader push constants at 0-8
- I aligned the fragment shader push constants at 16-32 because this has to be 16-byte-aligned

I've added this particular case to an existing test (and the case triggered the bug). In a second commit, I've fixed the bug. My own application crashed, and now doesn't.

Please double-check my work. I am entirely new to both Vulkan (does the spec allow non-contiguous ranges?) and Rust (does the code look idiomatic?).


Changelog:
```markdown
### Bugs fixed
- `AutoCommandBufferBuilder.push_constants()` panics if push constants ranges are not contiguous.
```
