### PR TITLE
Update concurrent-slotmap dependency and add a single-threaded slotmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,8 +297,8 @@ dependencies = [
 
 [[package]]
 name = "concurrent-slotmap"
-version = "0.1.0-alpha.1"
-source = "git+https://github.com/vulkano-rs/concurrent-slotmap?rev=db6810ab699b99fd79052252c057851fa80117cf#db6810ab699b99fd79052252c057851fa80117cf"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/vulkano-rs/concurrent-slotmap?rev=c10c56adeae11fcc9cd0a1d5c36d3cf258d9f505#c10c56adeae11fcc9cd0a1d5c36d3cf258d9f505"
 dependencies = [
  "virtual-buffer",
 ]
@@ -1806,9 +1806,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "virtual-buffer"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bbb9a832cd697a36c2abd5ef58c263b0bc33cdf280f704b895646ed3e9f595"
+checksum = "b434093a2de01d3b27e6246b0ececca4cc2a77f046bef06a9dc1216e3d892a91"
 dependencies = [
  "libc",
  "windows-targets 0.52.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ path = "vulkano-util"
 # https://github.com/KhronosGroup/Vulkan-Headers/commits/main/registry/vk.xml
 ash = "0.38.0"
 bytemuck = "1.9"
-concurrent-slotmap = { git = "https://github.com/vulkano-rs/concurrent-slotmap", rev = "db6810ab699b99fd79052252c057851fa80117cf" }
+concurrent-slotmap = { git = "https://github.com/vulkano-rs/concurrent-slotmap", rev = "c10c56adeae11fcc9cd0a1d5c36d3cf258d9f505" }
 crossbeam-queue = "0.3"
 foldhash = "0.1"
 half = "2.0"

--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -467,7 +467,7 @@ impl ApplicationHandler for App {
                 .unwrap()
         });
 
-        let mut task_graph = TaskGraph::new(&self.resources, 1, 3);
+        let mut task_graph = TaskGraph::new(&self.resources);
 
         let virtual_swapchain_id = task_graph.add_swapchain(&SwapchainCreateInfo {
             image_format: swapchain_format,
@@ -813,7 +813,7 @@ fn run_worker(
             .unwrap()
     });
 
-    let mut task_graph = TaskGraph::new(&resources, 1, 3);
+    let mut task_graph = TaskGraph::new(&resources);
 
     let virtual_front_staging_buffer_id = task_graph.add_buffer(&BufferCreateInfo::default());
     let virtual_back_staging_buffer_id = task_graph.add_buffer(&BufferCreateInfo::default());

--- a/examples/bloom/main.rs
+++ b/examples/bloom/main.rs
@@ -248,7 +248,7 @@ impl ApplicationHandler for App {
         let (bloom_image_id, bloom_sampled_image_id, bloom_storage_image_ids) =
             window_size_dependent_setup(&self.resources, swapchain_id);
 
-        let mut task_graph = TaskGraph::new(&self.resources, 3, 2);
+        let mut task_graph = TaskGraph::new(&self.resources);
 
         let virtual_swapchain_id = task_graph.add_swapchain(&SwapchainCreateInfo {
             image_format: swapchain_format,

--- a/examples/deferred/deferred.rs
+++ b/examples/deferred/deferred.rs
@@ -141,6 +141,13 @@ impl AmbientLightingPipeline {
             )
             .unwrap();
 
+        // FIXME(taskgraph): sane initialization
+        app.resources
+            .flight(app.flight_id)
+            .unwrap()
+            .wait(None)
+            .unwrap();
+
         unsafe {
             vulkano_taskgraph::execute(
                 &app.queue,
@@ -330,6 +337,13 @@ impl DirectionalLightingPipeline {
                 },
                 DeviceLayout::for_value(vertices.as_slice()).unwrap(),
             )
+            .unwrap();
+
+        // FIXME(taskgraph): sane initialization
+        app.resources
+            .flight(app.flight_id)
+            .unwrap()
+            .wait(None)
             .unwrap();
 
         unsafe {
@@ -538,6 +552,13 @@ impl PointLightingPipeline {
                 },
                 DeviceLayout::for_value(vertices.as_slice()).unwrap(),
             )
+            .unwrap();
+
+        // FIXME(taskgraph): sane initialization
+        app.resources
+            .flight(app.flight_id)
+            .unwrap()
+            .wait(None)
             .unwrap();
 
         unsafe {

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -228,7 +228,7 @@ impl ApplicationHandler for App {
         let (diffuse_image_id, normals_image_id, depth_image_id) =
             window_size_dependent_setup(&self.resources, swapchain_id);
 
-        let mut task_graph = TaskGraph::new(&self.resources, 2, 4);
+        let mut task_graph = TaskGraph::new(&self.resources);
 
         let virtual_swapchain_id = task_graph.add_swapchain(&SwapchainCreateInfo {
             image_format: swapchain_format,

--- a/examples/deferred/scene.rs
+++ b/examples/deferred/scene.rs
@@ -66,6 +66,13 @@ impl SceneTask {
             )
             .unwrap();
 
+        // FIXME(taskgraph): sane initialization
+        app.resources
+            .flight(app.flight_id)
+            .unwrap()
+            .wait(None)
+            .unwrap();
+
         unsafe {
             vulkano_taskgraph::execute(
                 &app.queue,

--- a/examples/ray-tracing/main.rs
+++ b/examples/ray-tracing/main.rs
@@ -231,7 +231,7 @@ impl ApplicationHandler for App {
             Default::default(),
         ));
 
-        let mut task_graph = TaskGraph::new(&self.resources, 3, 2);
+        let mut task_graph = TaskGraph::new(&self.resources);
 
         let virtual_swapchain_id = task_graph.add_swapchain(&SwapchainCreateInfo::default());
 

--- a/vulkano-taskgraph/src/descriptor_set.rs
+++ b/vulkano-taskgraph/src/descriptor_set.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use ash::vk;
 use bytemuck::{Pod, Zeroable};
-use concurrent_slotmap::{epoch, SlotId, SlotMap};
+use concurrent_slotmap::{epoch, Key, SlotId, SlotMap};
 use foldhash::HashMap;
 use std::{collections::BTreeMap, iter, sync::Arc};
 use vulkano::{
@@ -269,11 +269,11 @@ pub struct GlobalDescriptorSet {
     resources: Arc<ResourceStorage>,
     inner: RawDescriptorSet,
 
-    samplers: SlotMap<SamplerDescriptor>,
-    sampled_images: SlotMap<SampledImageDescriptor>,
-    storage_images: SlotMap<StorageImageDescriptor>,
-    storage_buffers: SlotMap<StorageBufferDescriptor>,
-    acceleration_structures: SlotMap<AccelerationStructureDescriptor>,
+    samplers: SlotMap<SamplerId, SamplerDescriptor>,
+    sampled_images: SlotMap<SampledImageId, SampledImageDescriptor>,
+    storage_images: SlotMap<StorageImageId, StorageImageDescriptor>,
+    storage_buffers: SlotMap<StorageBufferId, StorageBufferDescriptor>,
+    acceleration_structures: SlotMap<AccelerationStructureId, AccelerationStructureDescriptor>,
 }
 
 #[derive(Debug)]
@@ -327,11 +327,11 @@ impl GlobalDescriptorSet {
         Ok(GlobalDescriptorSet {
             resources: resources.clone(),
             inner,
-            samplers: SlotMap::with_global(max_samplers, global.clone()),
-            sampled_images: SlotMap::with_global(max_sampled_images, global.clone()),
-            storage_images: SlotMap::with_global(max_storage_images, global.clone()),
-            storage_buffers: SlotMap::with_global(max_storage_buffers, global.clone()),
-            acceleration_structures: SlotMap::with_global(
+            samplers: SlotMap::with_global_and_key(max_samplers, global.clone()),
+            sampled_images: SlotMap::with_global_and_key(max_sampled_images, global.clone()),
+            storage_images: SlotMap::with_global_and_key(max_storage_images, global.clone()),
+            storage_buffers: SlotMap::with_global_and_key(max_storage_buffers, global.clone()),
+            acceleration_structures: SlotMap::with_global_and_key(
                 max_acceleration_structures,
                 global.clone(),
             ),
@@ -468,14 +468,14 @@ impl GlobalDescriptorSet {
         let descriptor = SamplerDescriptor {
             sampler: sampler.clone(),
         };
-        let slot = self.samplers.insert(descriptor, self.resources.pin());
+        let id = self.samplers.insert(descriptor, &self.resources.pin());
 
         let write =
-            WriteDescriptorSet::sampler_array(SAMPLER_BINDING, slot.index(), iter::once(sampler));
+            WriteDescriptorSet::sampler_array(SAMPLER_BINDING, id.index, iter::once(sampler));
 
         unsafe { self.inner.update_unchecked(&[write], &[]) };
 
-        SamplerId::new(slot)
+        id
     }
 
     pub fn add_sampled_image(
@@ -496,11 +496,13 @@ impl GlobalDescriptorSet {
             image_view: image_view.clone(),
             image_layout,
         };
-        let slot = self.sampled_images.insert(descriptor, self.resources.pin());
+        let id = self
+            .sampled_images
+            .insert(descriptor, &self.resources.pin());
 
         let write = WriteDescriptorSet::image_view_with_layout_array(
             SAMPLED_IMAGE_BINDING,
-            slot.index(),
+            id.index,
             iter::once(DescriptorImageViewInfo {
                 image_view,
                 image_layout,
@@ -509,7 +511,7 @@ impl GlobalDescriptorSet {
 
         unsafe { self.inner.update_unchecked(&[write], &[]) };
 
-        SampledImageId::new(slot)
+        id
     }
 
     pub fn add_storage_image(
@@ -523,11 +525,13 @@ impl GlobalDescriptorSet {
             image_view: image_view.clone(),
             image_layout,
         };
-        let slot = self.storage_images.insert(descriptor, self.resources.pin());
+        let id = self
+            .storage_images
+            .insert(descriptor, &self.resources.pin());
 
         let write = WriteDescriptorSet::image_view_with_layout_array(
             STORAGE_IMAGE_BINDING,
-            slot.index(),
+            id.index,
             iter::once(DescriptorImageViewInfo {
                 image_view,
                 image_layout,
@@ -536,7 +540,7 @@ impl GlobalDescriptorSet {
 
         unsafe { self.inner.update_unchecked(&[write], &[]) };
 
-        StorageImageId::new(slot)
+        id
     }
 
     pub fn add_storage_buffer(
@@ -552,19 +556,19 @@ impl GlobalDescriptorSet {
             offset,
             size,
         };
-        let slot = self
+        let id = self
             .storage_buffers
-            .insert(descriptor, self.resources.pin());
+            .insert(descriptor, &self.resources.pin());
 
         let write = WriteDescriptorSet::buffer_array(
             STORAGE_BUFFER_BINDING,
-            slot.index(),
+            id.index,
             iter::once(subbuffer),
         );
 
         unsafe { self.inner.update_unchecked(&[write], &[]) };
 
-        StorageBufferId::new(slot)
+        id
     }
 
     pub fn add_acceleration_structure(
@@ -574,99 +578,130 @@ impl GlobalDescriptorSet {
         let descriptor = AccelerationStructureDescriptor {
             acceleration_structure: acceleration_structure.clone(),
         };
-        let slot = self
+        let id = self
             .acceleration_structures
-            .insert(descriptor, self.resources.pin());
+            .insert(descriptor, &self.resources.pin());
 
         let write = WriteDescriptorSet::acceleration_structure_array(
             ACCELERATION_STRUCTURE_BINDING,
-            slot.index(),
+            id.index,
             iter::once(acceleration_structure),
         );
 
         unsafe { self.inner.update_unchecked(&[write], &[]) };
 
-        AccelerationStructureId::new(slot)
+        id
     }
 
     pub unsafe fn remove_sampler(&self, id: SamplerId) -> Option<Ref<'_, SamplerDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.samplers.remove(slot, self.resources.pin()).map(Ref)
+        // SAFETY: We own an `epoch::Guard`.
+        let inner = self.samplers.remove(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     pub unsafe fn remove_sampled_image(
         &self,
         id: SampledImageId,
     ) -> Option<Ref<'_, SampledImageDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.sampled_images
-            .remove(slot, self.resources.pin())
-            .map(Ref)
+        let inner = self
+            .sampled_images
+            // SAFETY: We own an `epoch::Guard`.
+            .remove(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     pub unsafe fn remove_storage_image(
         &self,
         id: StorageImageId,
     ) -> Option<Ref<'_, StorageImageDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.storage_images
-            .remove(slot, self.resources.pin())
-            .map(Ref)
+        let inner = self
+            .storage_images
+            // SAFETY: We own an `epoch::Guard`.
+            .remove(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     pub unsafe fn remove_storage_buffer(
         &self,
         id: StorageBufferId,
     ) -> Option<Ref<'_, StorageBufferDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.storage_buffers
-            .remove(slot, self.resources.pin())
-            .map(Ref)
+        let inner = self
+            .storage_buffers
+            // SAFETY: We own an `epoch::Guard`.
+            .remove(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     pub unsafe fn remove_acceleration_structure(
         &self,
         id: AccelerationStructureId,
     ) -> Option<Ref<'_, AccelerationStructureDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.acceleration_structures
-            .remove(slot, self.resources.pin())
-            .map(Ref)
+        let inner = self
+            .acceleration_structures
+            // SAFETY: We own an `epoch::Guard`.
+            .remove(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     #[inline]
     pub fn sampler(&self, id: SamplerId) -> Option<Ref<'_, SamplerDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.samplers.get(slot, self.resources.pin()).map(Ref)
+        // SAFETY: We own an `epoch::Guard`.
+        let inner = self.samplers.get(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     #[inline]
     pub fn sampled_image(&self, id: SampledImageId) -> Option<Ref<'_, SampledImageDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.sampled_images.get(slot, self.resources.pin()).map(Ref)
+        let inner = self
+            .sampled_images
+            // SAFETY: We own an `epoch::Guard`.
+            .get(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     #[inline]
     pub fn storage_image(&self, id: StorageImageId) -> Option<Ref<'_, StorageImageDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.storage_images.get(slot, self.resources.pin()).map(Ref)
+        let inner = self
+            .storage_images
+            // SAFETY: We own an `epoch::Guard`.
+            .get(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     #[inline]
     pub fn storage_buffer(&self, id: StorageBufferId) -> Option<Ref<'_, StorageBufferDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.storage_buffers
-            .get(slot, self.resources.pin())
-            .map(Ref)
+        let inner = self
+            .storage_buffers
+            // SAFETY: We own an `epoch::Guard`.
+            .get(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     #[inline]
@@ -674,11 +709,14 @@ impl GlobalDescriptorSet {
         &self,
         id: AccelerationStructureId,
     ) -> Option<Ref<'_, AccelerationStructureDescriptor>> {
-        let slot = SlotId::new(id.index, id.generation);
+        let guard = self.resources.pin();
 
-        self.acceleration_structures
-            .get(slot, self.resources.pin())
-            .map(Ref)
+        let inner = self
+            .acceleration_structures
+            // SAFETY: We own an `epoch::Guard`.
+            .get(id, unsafe { epoch::unprotected() })?;
+
+        Some(Ref { inner, guard })
     }
 
     pub(crate) fn try_collect(&self, guard: &epoch::Guard<'_>) {
@@ -815,149 +853,74 @@ impl GlobalDescriptorSetCreateInfo<'_> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[repr(C)]
-pub struct SamplerId {
-    index: u32,
-    generation: u32,
-}
-
-unsafe impl Pod for SamplerId {}
-unsafe impl Zeroable for SamplerId {}
-
-impl SamplerId {
-    /// An ID that's guaranteed to be invalid.
-    pub const INVALID: Self = Self::new(SlotId::INVALID);
-
-    const fn new(slot: SlotId) -> Self {
-        Self {
-            index: slot.index(),
-            generation: slot.generation(),
+macro_rules! declare_key {
+    (
+        $(#[$meta:meta])*
+        pub struct $name:ident $(;)?
+    ) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        #[repr(C)]
+        pub struct $name {
+            index: u32,
+            generation: u32,
         }
-    }
-}
 
-impl Default for SamplerId {
-    #[inline]
-    fn default() -> Self {
-        Self::INVALID
-    }
-}
+        unsafe impl Pod for $name {}
+        unsafe impl Zeroable for $name {}
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[repr(C)]
-pub struct SampledImageId {
-    index: u32,
-    generation: u32,
-}
-
-unsafe impl Pod for SampledImageId {}
-unsafe impl Zeroable for SampledImageId {}
-
-impl SampledImageId {
-    /// An ID that's guaranteed to be invalid.
-    pub const INVALID: Self = Self::new(SlotId::INVALID);
-
-    const fn new(slot: SlotId) -> Self {
-        Self {
-            index: slot.index(),
-            generation: slot.generation(),
+        impl Default for $name {
+            #[inline]
+            fn default() -> Self {
+                Self::INVALID
+            }
         }
-    }
-}
 
-impl Default for SampledImageId {
-    #[inline]
-    fn default() -> Self {
-        Self::INVALID
-    }
-}
+        impl $name {
+            /// An ID that's guaranteed to be invalid.
+            pub const INVALID: Self = Self::new(SlotId::INVALID);
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[repr(C)]
-pub struct StorageImageId {
-    index: u32,
-    generation: u32,
-}
-
-unsafe impl Pod for StorageImageId {}
-unsafe impl Zeroable for StorageImageId {}
-
-impl StorageImageId {
-    /// An ID that's guaranteed to be invalid.
-    pub const INVALID: Self = Self::new(SlotId::INVALID);
-
-    const fn new(slot: SlotId) -> Self {
-        Self {
-            index: slot.index(),
-            generation: slot.generation(),
+            #[inline]
+            const fn new(slot: SlotId) -> Self {
+                Self {
+                    index: slot.index(),
+                    generation: slot.generation(),
+                }
+            }
         }
-    }
-}
 
-impl Default for StorageImageId {
-    #[inline]
-    fn default() -> Self {
-        Self::INVALID
-    }
-}
+        impl Key for $name {
+            #[inline]
+            fn from_id(id: SlotId) -> Self {
+                Self::new(id)
+            }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[repr(C)]
-pub struct StorageBufferId {
-    index: u32,
-    generation: u32,
-}
-
-unsafe impl Pod for StorageBufferId {}
-unsafe impl Zeroable for StorageBufferId {}
-
-impl StorageBufferId {
-    /// An ID that's guaranteed to be invalid.
-    pub const INVALID: Self = Self::new(SlotId::INVALID);
-
-    const fn new(slot: SlotId) -> Self {
-        Self {
-            index: slot.index(),
-            generation: slot.generation(),
+            #[inline]
+            fn as_id(self) -> SlotId {
+                SlotId::new(self.index, self.generation)
+            }
         }
-    }
+    };
 }
 
-impl Default for StorageBufferId {
-    #[inline]
-    fn default() -> Self {
-        Self::INVALID
-    }
+declare_key! {
+    pub struct SamplerId;
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[repr(C)]
-pub struct AccelerationStructureId {
-    index: u32,
-    generation: u32,
+declare_key! {
+    pub struct SampledImageId;
 }
 
-unsafe impl Pod for AccelerationStructureId {}
-unsafe impl Zeroable for AccelerationStructureId {}
-
-impl AccelerationStructureId {
-    /// An ID that's guaranteed to be invalid.
-    pub const INVALID: Self = Self::new(SlotId::INVALID);
-
-    const fn new(slot: SlotId) -> Self {
-        Self {
-            index: slot.index(),
-            generation: slot.generation(),
-        }
-    }
+declare_key! {
+    pub struct StorageImageId;
 }
 
-impl Default for AccelerationStructureId {
-    #[inline]
-    fn default() -> Self {
-        Self::INVALID
-    }
+declare_key! {
+    pub struct StorageBufferId;
+}
+
+declare_key! {
+    pub struct AccelerationStructureId;
 }
 
 struct GlobalDescriptorSetAllocator {

--- a/vulkano-taskgraph/src/descriptor_set.rs
+++ b/vulkano-taskgraph/src/descriptor_set.rs
@@ -859,7 +859,7 @@ macro_rules! declare_key {
         pub struct $name:ident $(;)?
     ) => {
         $(#[$meta])*
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
         #[repr(C)]
         pub struct $name {
             index: u32,
@@ -886,6 +886,12 @@ macro_rules! declare_key {
                     index: slot.index(),
                     generation: slot.generation(),
                 }
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Debug::fmt(&self.as_id(), f)
             }
         }
 

--- a/vulkano-taskgraph/src/graph/compile.rs
+++ b/vulkano-taskgraph/src/graph/compile.rs
@@ -315,7 +315,7 @@ impl<W: ?Sized> TaskGraph<W> {
             }
         }
 
-        let mut visited = vec![false; self.nodes.capacity() as usize];
+        let mut visited = vec![false; self.nodes.reserved_len() as usize];
         let mut visited_count = 0;
 
         if let Some((id, _)) = self.nodes.nodes().next() {
@@ -366,7 +366,7 @@ impl<W: ?Sized> TaskGraph<W> {
             Ok(output_index.wrapping_sub(1))
         }
 
-        let mut state = vec![0; self.nodes.capacity() as usize];
+        let mut state = vec![0; self.nodes.reserved_len() as usize];
         let mut output = vec![0; self.nodes.len() as usize];
         let mut output_index = self.nodes.len().wrapping_sub(1);
 
@@ -386,7 +386,7 @@ impl<W: ?Sized> TaskGraph<W> {
     ///
     /// [longest path search]: https://en.wikipedia.org/wiki/Longest_path_problem#Acyclic_graphs
     unsafe fn dependency_levels(&mut self, topological_order: &[NodeIndex]) -> Vec<Vec<NodeIndex>> {
-        let mut distances = vec![0; self.nodes.capacity() as usize];
+        let mut distances = vec![0; self.nodes.reserved_len() as usize];
         let mut max_level = 0;
 
         for &node_index in topological_order {
@@ -506,8 +506,8 @@ impl<W: ?Sized> TaskGraph<W> {
         CompileErrorKind,
     > {
         let mut builder = IntermediateRepresentationBuilder::new(
-            self.nodes.capacity(),
-            self.resources.capacity(),
+            self.nodes.reserved_len(),
+            self.resources.reserved_len(),
         );
         let mut prev_queue_family_index = vk::QUEUE_FAMILY_IGNORED;
         let mut last_swapchain_accesses = LinearMap::new();
@@ -1787,7 +1787,7 @@ mod tests {
         // ┌───┐
         // │ B │
         // └───┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
         graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -1823,7 +1823,7 @@ mod tests {
         //      │  ┌───┐
         //      └─►│ D │
         //         └───┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let a = graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -1863,7 +1863,7 @@ mod tests {
         // └───┘│ └───┘│ └───┘┌─►│ G │
         //      │      └──────┘┌►│   │
         //      └──────────────┘ └───┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let a = graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -1912,7 +1912,7 @@ mod tests {
         // ┌►│ A ├─►│ B ├─►│ C ├┐
         // │ └───┘  └───┘  └───┘│
         // └────────────────────┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let a = graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -1949,7 +1949,7 @@ mod tests {
         // │      └►│ D ├─►│ E ├┴►│ F ├┐
         // │        └───┘  └───┘  └───┘│
         // └───────────────────────────┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let a = graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -2001,7 +2001,7 @@ mod tests {
         // │     ┌►└───┘  └───┘  └───┘││
         // │     └────────────────────┘│
         // └───────────────────────────┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let a = graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -2044,7 +2044,7 @@ mod tests {
     fn initial_pipeline_barrier() {
         let (resources, queues) = test_queues!();
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let buffer = graph.add_buffer(&BufferCreateInfo::default());
         let image = graph.add_image(&ImageCreateInfo::default());
         let node1 = graph
@@ -2104,7 +2104,7 @@ mod tests {
     fn barrier1() {
         let (resources, queues) = test_queues!();
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let buffer = graph.add_buffer(&BufferCreateInfo::default());
         let image = graph.add_image(&ImageCreateInfo::default());
         let node1 = graph
@@ -2181,7 +2181,7 @@ mod tests {
     fn barrier2() {
         let (resources, queues) = test_queues!();
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let buffer = graph.add_buffer(&BufferCreateInfo::default());
         let image = graph.add_image(&ImageCreateInfo::default());
         let node1 = graph
@@ -2294,7 +2294,7 @@ mod tests {
         //      │└►┌───┐
         //      └─►│ C │
         //         └───┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let a = graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -2363,7 +2363,7 @@ mod tests {
         //      │ ┌───┐
         //      └►│ C │
         //        └───┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let a = graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -2432,7 +2432,7 @@ mod tests {
         //      │ ┌───┐└►┌───┐│
         //      └►│ C ├─►│ D ├┘
         //        └───┘  └───┘
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let a = graph
             .create_task_node("A", QueueFamilyType::Graphics, PhantomData)
             .build();
@@ -2511,7 +2511,7 @@ mod tests {
     fn render_pass1() {
         let (resources, queues) = test_queues!();
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let color_image = graph.add_image(&ImageCreateInfo {
             format: Format::R8G8B8A8_UNORM,
             ..Default::default()
@@ -2579,7 +2579,7 @@ mod tests {
     fn render_pass2() {
         let (resources, queues) = test_queues!();
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let color_image = graph.add_image(&ImageCreateInfo {
             format: Format::R8G8B8A8_UNORM,
             ..Default::default()
@@ -2673,7 +2673,7 @@ mod tests {
     fn render_pass3() {
         let (resources, queues) = test_queues!();
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let color_image = graph.add_image(&ImageCreateInfo {
             format: Format::R8G8B8A8_UNORM,
             ..Default::default()
@@ -2774,7 +2774,7 @@ mod tests {
             return;
         }
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let buffer1 = graph.add_buffer(&BufferCreateInfo::default());
         let buffer2 = graph.add_buffer(&BufferCreateInfo::default());
         let image1 = graph.add_image(&ImageCreateInfo::default());
@@ -2926,7 +2926,7 @@ mod tests {
             return;
         }
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let sharing = Sharing::Concurrent(queues.iter().map(|q| q.queue_family_index()).collect());
         let buffer1 = graph.add_buffer(&BufferCreateInfo {
             sharing: sharing.clone(),
@@ -3024,7 +3024,7 @@ mod tests {
             return;
         }
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let buffer1 = graph.add_buffer(&BufferCreateInfo::default());
         let buffer2 = graph.add_buffer(&BufferCreateInfo::default());
         let image1 = graph.add_image(&ImageCreateInfo::default());
@@ -3219,7 +3219,7 @@ mod tests {
             return;
         }
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let sharing = Sharing::Concurrent(queues.iter().map(|q| q.queue_family_index()).collect());
         let buffer1 = graph.add_buffer(&BufferCreateInfo {
             sharing: sharing.clone(),
@@ -3369,7 +3369,7 @@ mod tests {
             queue_flags.contains(QueueFlags::GRAPHICS)
         });
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo::default());
         let swapchain2 = graph.add_swapchain(&SwapchainCreateInfo::default());
         let node = graph
@@ -3482,7 +3482,7 @@ mod tests {
             return;
         }
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let concurrent_sharing =
             Sharing::Concurrent(queues.iter().map(|q| q.queue_family_index()).collect());
         let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo::default());
@@ -3703,7 +3703,7 @@ mod tests {
             queue_flags.contains(QueueFlags::GRAPHICS)
         });
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let swapchain = graph.add_swapchain(&SwapchainCreateInfo {
             image_format: Format::R8G8B8A8_UNORM,
             ..Default::default()
@@ -3828,7 +3828,7 @@ mod tests {
             return;
         }
 
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 10);
+        let mut graph = TaskGraph::<()>::new(&resources);
         let concurrent_sharing =
             Sharing::Concurrent(queues.iter().map(|q| q.queue_family_index()).collect());
         let swapchain1 = graph.add_swapchain(&SwapchainCreateInfo {

--- a/vulkano-taskgraph/src/graph/execute.rs
+++ b/vulkano-taskgraph/src/graph/execute.rs
@@ -2260,8 +2260,10 @@ impl<W: ?Sized + 'static> Drop for StateGuard<'_, W> {
             }
         }
 
-        let mut last_accesses =
-            vec![ResourceAccess::default(); self.executable.graph.resources.capacity() as usize];
+        let mut last_accesses = vec![
+            ResourceAccess::default();
+            self.executable.graph.resources.reserved_len() as usize
+        ];
         let instruction_range = 0..submissions[self.submission_count - 1].instruction_range.end;
 
         // Determine the last accesses of resources up until before the failed submission.
@@ -2313,7 +2315,7 @@ impl<'a> ResourceMap<'a> {
     pub fn new(executable: &'a ExecutableTaskGraph<impl ?Sized>) -> Result<Self, InvalidSlotError> {
         let virtual_resources = &executable.graph.resources;
         let physical_resources = virtual_resources.physical_resources.clone();
-        let mut map = vec![ptr::null(); virtual_resources.capacity() as usize];
+        let mut map = vec![ptr::null(); virtual_resources.reserved_len() as usize];
         let guard = virtual_resources.physical_resources.pin();
 
         for (&physical_id, &virtual_id) in &virtual_resources.physical_map {

--- a/vulkano-taskgraph/src/graph/mod.rs
+++ b/vulkano-taskgraph/src/graph/mod.rs
@@ -551,7 +551,7 @@ unsafe impl<W: ?Sized> DeviceOwned for TaskGraph<W> {
 
 declare_key! {
     /// The ID type used to refer to a node within a [`TaskGraph`].
-    #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub struct NodeId;
 }
 

--- a/vulkano-taskgraph/src/graph/mod.rs
+++ b/vulkano-taskgraph/src/graph/mod.rs
@@ -7,11 +7,11 @@ pub use self::{
 use crate::{
     linear_map::LinearMap,
     resource::{self, AccessTypes, Flight, HostAccessType, ImageLayoutType},
-    slotmap::{self, Iter, IterMut, SlotMap},
+    slotmap::{self, declare_key, Iter, IterMut, SlotMap},
     Id, InvalidSlotError, Object, ObjectType, QueueFamilyType, Task,
 };
 use ash::vk;
-use concurrent_slotmap::{declare_key, SlotId};
+use concurrent_slotmap::SlotId;
 use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::{
@@ -551,19 +551,12 @@ unsafe impl<W: ?Sized> DeviceOwned for TaskGraph<W> {
 
 declare_key! {
     /// The ID type used to refer to a node within a [`TaskGraph`].
-    #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub struct NodeId;
 }
 
 impl NodeId {
     fn index(self) -> NodeIndex {
         self.0.index()
-    }
-}
-
-impl fmt::Debug for NodeId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.0, f)
     }
 }
 

--- a/vulkano-taskgraph/src/graph/mod.rs
+++ b/vulkano-taskgraph/src/graph/mod.rs
@@ -7,10 +7,11 @@ pub use self::{
 use crate::{
     linear_map::LinearMap,
     resource::{self, AccessTypes, Flight, HostAccessType, ImageLayoutType},
+    slotmap::{self, Iter, IterMut, SlotMap},
     Id, InvalidSlotError, Object, ObjectType, QueueFamilyType, Task,
 };
 use ash::vk;
-use concurrent_slotmap::{IterMut, IterUnprotected, SlotId, SlotMap};
+use concurrent_slotmap::{declare_key, SlotId};
 use foldhash::HashMap;
 use smallvec::SmallVec;
 use std::{
@@ -42,7 +43,7 @@ pub struct TaskGraph<W: ?Sized> {
 }
 
 struct Nodes<W: ?Sized> {
-    inner: SlotMap<Node<W>>,
+    inner: SlotMap<NodeId, Node<W>>,
 }
 
 struct Node<W: ?Sized> {
@@ -64,12 +65,12 @@ enum NodeInner<W: ?Sized> {
 type NodeIndex = u32;
 
 pub(crate) struct Resources {
-    inner: SlotMap<ResourceInfo>,
+    inner: SlotMap<Id, ResourceInfo>,
     physical_resources: Arc<resource::Resources>,
     physical_map: HashMap<Id, Id>,
     host_reads: Vec<Id<Buffer>>,
     host_writes: Vec<Id<Buffer>>,
-    framebuffers: SlotMap<()>,
+    framebuffers: SlotMap<Id<Framebuffer>, ()>,
 }
 
 struct ResourceInfo {
@@ -80,27 +81,19 @@ struct ResourceInfo {
 
 impl<W: ?Sized> TaskGraph<W> {
     /// Creates a new `TaskGraph`.
-    ///
-    /// `max_nodes` is the maximum number of nodes the graph can ever have. `max_resources` is the
-    /// maximum number of virtual resources the graph can ever have.
     #[must_use]
-    pub fn new(
-        physical_resources: &Arc<resource::Resources>,
-        max_nodes: u32,
-        max_resources: u32,
-    ) -> Self {
+    pub fn new(physical_resources: &Arc<resource::Resources>) -> Self {
         TaskGraph {
             nodes: Nodes {
-                inner: SlotMap::new(max_nodes),
+                inner: SlotMap::with_key(),
             },
             resources: Resources {
-                inner: SlotMap::new(max_resources),
+                inner: SlotMap::with_key(),
                 physical_resources: physical_resources.clone(),
                 physical_map: HashMap::default(),
                 host_reads: Vec::new(),
                 host_writes: Vec::new(),
-                // FIXME:
-                framebuffers: SlotMap::new(256),
+                framebuffers: SlotMap::with_key(),
             },
         }
     }
@@ -244,18 +237,16 @@ impl<W: ?Sized> TaskGraph<W> {
 
 impl<W: ?Sized> Nodes<W> {
     fn add_node(&mut self, name: Cow<'static, str>, inner: NodeInner<W>) -> NodeId {
-        let slot = self.inner.insert_mut(Node {
+        self.inner.insert(Node {
             name,
             inner,
             in_edges: Vec::new(),
             out_edges: Vec::new(),
-        });
-
-        NodeId { slot }
+        })
     }
 
     fn remove_node(&mut self, id: NodeId) -> Node<W> {
-        let node = self.inner.remove_mut(id.slot).unwrap();
+        let node = self.inner.remove(id).unwrap();
 
         // NOTE(Marc): We must not leave any broken edges because the rest of the code relies on
         // this being impossible.
@@ -277,8 +268,8 @@ impl<W: ?Sized> Nodes<W> {
         node
     }
 
-    fn capacity(&self) -> u32 {
-        self.inner.capacity()
+    fn reserved_len(&self) -> u32 {
+        self.inner.reserved_len()
     }
 
     fn len(&self) -> u32 {
@@ -330,52 +321,40 @@ impl<W: ?Sized> Nodes<W> {
     }
 
     fn node(&self, id: NodeId) -> Result<&Node<W>> {
-        // SAFETY: We never modify the map concurrently.
-        unsafe { self.inner.get_unprotected(id.slot) }.ok_or(TaskGraphError::InvalidNode)
+        self.inner.get(id).ok_or(TaskGraphError::InvalidNode)
     }
 
     unsafe fn node_unchecked(&self, index: NodeIndex) -> &Node<W> {
-        // SAFETY:
-        // * The caller must ensure that the `index` is valid.
-        // * We never modify the map concurrently.
-        unsafe { self.inner.index_unchecked_unprotected(index) }
+        // SAFETY: The `OCCUPIED_BIT` is set.
+        let id = NodeId(unsafe { SlotId::new_unchecked(index, SlotId::OCCUPIED_BIT) });
+
+        // SAFETY: The caller must ensure that the `index` is valid.
+        unsafe { self.inner.get_unchecked(id) }
     }
 
     fn node_mut(&mut self, id: NodeId) -> Result<&mut Node<W>> {
-        self.inner
-            .get_mut(id.slot)
-            .ok_or(TaskGraphError::InvalidNode)
+        self.inner.get_mut(id).ok_or(TaskGraphError::InvalidNode)
     }
 
     unsafe fn node_unchecked_mut(&mut self, index: NodeIndex) -> &mut Node<W> {
+        // SAFETY: The `OCCUPIED_BIT` is set.
+        let id = NodeId(unsafe { SlotId::new_unchecked(index, SlotId::OCCUPIED_BIT) });
+
         // SAFETY: The caller must ensure that the `index` is valid.
-        unsafe { self.inner.index_unchecked_mut(index) }
+        unsafe { self.inner.get_unchecked_mut(id) }
     }
 
     fn node_many_mut<const N: usize>(&mut self, ids: [NodeId; N]) -> Result<[&mut Node<W>; N]> {
-        union Transmute<const N: usize> {
-            src: [NodeId; N],
-            dst: [SlotId; N],
-        }
-
-        // HACK: `transmute_unchecked` is not exposed even unstably at the moment, and the compiler
-        // isn't currently smart enough to figure this out using `transmute`.
-        //
-        // SAFETY: `NodeId` is `#[repr(transparent)]` over `SlotId` and both arrays have the same
-        // length.
-        let ids = unsafe { Transmute { src: ids }.dst };
-
         self.inner
             .get_many_mut(ids)
             .ok_or(TaskGraphError::InvalidNode)
     }
 
-    fn nodes(&self) -> IterUnprotected<'_, Node<W>> {
-        // SAFETY: We never modify the map concurrently.
-        unsafe { self.inner.iter_unprotected() }
+    fn nodes(&self) -> Iter<'_, NodeId, Node<W>> {
+        self.inner.iter()
     }
 
-    fn nodes_mut(&mut self) -> IterMut<'_, Node<W>> {
+    fn nodes_mut(&mut self) -> IterMut<'_, NodeId, Node<W>> {
         self.inner.iter_mut()
     }
 }
@@ -394,9 +373,9 @@ impl Resources {
             usage: ImageUsage::empty(),
         };
 
-        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
+        let id = self.inner.insert_with_tag(resource_info, tag);
 
-        unsafe { Id::new(slot) }
+        unsafe { id.parametrize() }
     }
 
     fn add_image(&mut self, create_info: &ImageCreateInfo) -> Id<Image> {
@@ -412,9 +391,9 @@ impl Resources {
             usage: create_info.usage,
         };
 
-        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
+        let id = self.inner.insert_with_tag(resource_info, tag);
 
-        unsafe { Id::new(slot) }
+        unsafe { id.parametrize() }
     }
 
     fn add_swapchain(&mut self, create_info: &SwapchainCreateInfo) -> Id<Swapchain> {
@@ -430,9 +409,9 @@ impl Resources {
             usage: create_info.image_usage,
         };
 
-        let slot = self.inner.insert_with_tag_mut(resource_info, tag);
+        let id = self.inner.insert_with_tag(resource_info, tag);
 
-        unsafe { Id::new(slot) }
+        unsafe { id.parametrize() }
     }
 
     fn add_physical_buffer(
@@ -506,13 +485,12 @@ impl Resources {
 
     fn add_framebuffer(&mut self) -> Id<Framebuffer> {
         let tag = Framebuffer::TAG | Id::VIRTUAL_BIT;
-        let slot = self.framebuffers.insert_with_tag_mut((), tag);
 
-        unsafe { Id::new(slot) }
+        self.framebuffers.insert_with_tag((), tag)
     }
 
-    fn capacity(&self) -> u32 {
-        self.inner.capacity()
+    fn reserved_len(&self) -> u32 {
+        self.inner.reserved_len()
     }
 
     fn len(&self) -> u32 {
@@ -524,13 +502,11 @@ impl Resources {
     }
 
     fn get(&self, id: Id) -> Result<&ResourceInfo, InvalidSlotError> {
-        // SAFETY: We never modify the map concurrently.
-        unsafe { self.inner.get_unprotected(id.slot) }.ok_or(InvalidSlotError::new(id))
+        self.inner.get(id).ok_or(InvalidSlotError::new(id))
     }
 
-    fn iter(&self) -> impl Iterator<Item = (Id, &ResourceInfo)> {
-        // SAFETY: We never modify the map concurrently.
-        unsafe { self.inner.iter_unprotected() }.map(|(slot, v)| (unsafe { Id::new(slot) }, v))
+    fn iter(&self) -> Iter<'_, Id, ResourceInfo> {
+        self.inner.iter()
     }
 
     pub(crate) fn contains_host_buffer_access(
@@ -555,7 +531,7 @@ impl Resources {
     }
 
     fn framebuffer_mut(&mut self, id: Id<Framebuffer>) -> Option<&mut ()> {
-        self.framebuffers.get_mut(id.slot)
+        self.framebuffers.get_mut(id)
     }
 }
 
@@ -573,25 +549,21 @@ unsafe impl<W: ?Sized> DeviceOwned for TaskGraph<W> {
     }
 }
 
-/// The ID type used to refer to a node within a [`TaskGraph`].
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(transparent)]
-pub struct NodeId {
-    slot: SlotId,
+declare_key! {
+    /// The ID type used to refer to a node within a [`TaskGraph`].
+    #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct NodeId;
 }
 
 impl NodeId {
     fn index(self) -> NodeIndex {
-        self.slot.index()
+        self.0.index()
     }
 }
 
 impl fmt::Debug for NodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NodeId")
-            .field("index", &self.slot.index())
-            .field("generation", &self.slot.generation())
-            .finish()
+        fmt::Debug::fmt(&self.0, f)
     }
 }
 
@@ -1417,7 +1389,7 @@ unsafe impl<W: ?Sized> DeviceOwned for ExecutableTaskGraph<W> {
 ///
 /// [`task_nodes`]: TaskGraph::task_nodes
 pub struct TaskNodes<'a, W: ?Sized> {
-    inner: concurrent_slotmap::IterUnprotected<'a, Node<W>>,
+    inner: slotmap::Iter<'a, NodeId, Node<W>>,
 }
 
 impl<W: ?Sized> fmt::Debug for TaskNodes<'_, W> {
@@ -1467,7 +1439,7 @@ impl<W: ?Sized> FusedIterator for TaskNodes<'_, W> {}
 ///
 /// [`task_nodes_mut`]: TaskGraph::task_nodes_mut
 pub struct TaskNodesMut<'a, W: ?Sized> {
-    inner: concurrent_slotmap::IterMut<'a, Node<W>>,
+    inner: slotmap::IterMut<'a, NodeId, Node<W>>,
 }
 
 impl<W: ?Sized> fmt::Debug for TaskNodesMut<'_, W> {
@@ -1548,7 +1520,7 @@ mod tests {
     #[test]
     fn basic_usage1() {
         let (resources, _) = test_queues!();
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
 
         let x = graph
             .create_task_node("X", QueueFamilyType::Graphics, PhantomData)
@@ -1583,7 +1555,7 @@ mod tests {
     #[test]
     fn basic_usage2() {
         let (resources, _) = test_queues!();
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
 
         let x = graph
             .create_task_node("X", QueueFamilyType::Graphics, PhantomData)
@@ -1620,7 +1592,7 @@ mod tests {
     #[test]
     fn self_referential_node() {
         let (resources, _) = test_queues!();
-        let mut graph = TaskGraph::<()>::new(&resources, 10, 0);
+        let mut graph = TaskGraph::<()>::new(&resources);
 
         let x = graph
             .create_task_node("X", QueueFamilyType::Graphics, PhantomData)

--- a/vulkano-taskgraph/src/lib.rs
+++ b/vulkano-taskgraph/src/lib.rs
@@ -830,6 +830,7 @@ impl<T> Hash for Id<T> {
     }
 }
 
+#[doc(hidden)]
 impl Key for Id {
     #[inline]
     fn from_id(id: SlotId) -> Self {
@@ -842,6 +843,7 @@ impl Key for Id {
     }
 }
 
+#[doc(hidden)]
 impl Key for Id<Framebuffer> {
     #[inline]
     fn from_id(id: SlotId) -> Self {

--- a/vulkano-taskgraph/src/slotmap.rs
+++ b/vulkano-taskgraph/src/slotmap.rs
@@ -1,0 +1,1008 @@
+use concurrent_slotmap::{Key, SlotId};
+use core::slice;
+use std::{
+    iter::{self, FusedIterator},
+    marker::PhantomData,
+    mem::{ManuallyDrop, MaybeUninit},
+};
+
+const NIL: u32 = u32::MAX;
+
+const TAG_MASK: u32 = SlotId::TAG_MASK;
+
+const OCCUPIED_BIT: u32 = SlotId::OCCUPIED_BIT;
+
+pub struct SlotMap<K, V> {
+    inner: SlotMapInner<V>,
+    marker: PhantomData<fn(K) -> K>,
+}
+
+struct SlotMapInner<V> {
+    slots: Vec<Slot<V>>,
+    len: u32,
+    free_list_head: u32,
+}
+
+impl<K, V> Default for SlotMap<K, V> {
+    #[inline]
+    fn default() -> Self {
+        Self::with_key()
+    }
+}
+
+impl<V> SlotMap<SlotId, V> {
+    #[cfg(test)]
+    #[inline]
+    pub fn new() -> Self {
+        Self::with_key()
+    }
+}
+
+impl<K, V> SlotMap<K, V> {
+    #[inline]
+    pub fn with_key() -> Self {
+        SlotMap {
+            inner: SlotMapInner {
+                slots: Vec::new(),
+                len: 0,
+                free_list_head: NIL,
+            },
+            marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn reserved_len(&self) -> u32 {
+        self.inner.slots.len() as u32
+    }
+
+    #[inline]
+    pub fn len(&self) -> u32 {
+        self.inner.len
+    }
+}
+
+impl<K: Key, V> SlotMap<K, V> {
+    #[inline]
+    pub fn insert(&mut self, value: V) -> K {
+        K::from_id(self.inner.insert_with_tag(value, 0))
+    }
+
+    #[inline]
+    pub fn insert_with_tag(&mut self, value: V, tag: u32) -> K {
+        K::from_id(self.inner.insert_with_tag(value, tag))
+    }
+
+    #[inline]
+    pub fn remove(&mut self, key: K) -> Option<V> {
+        self.inner.remove(key.as_id())
+    }
+
+    #[inline(always)]
+    pub fn get(&self, key: K) -> Option<&V> {
+        self.inner.get(key.as_id())
+    }
+
+    #[inline(always)]
+    pub unsafe fn get_unchecked(&self, key: K) -> &V {
+        // SAFETY: Enforced by the caller.
+        unsafe { self.inner.get_unchecked(key.as_id()) }
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self, key: K) -> Option<&mut V> {
+        self.inner.get_mut(key.as_id())
+    }
+
+    #[inline(always)]
+    pub unsafe fn get_unchecked_mut(&mut self, key: K) -> &mut V {
+        // SAFETY: Enforced by the caller.
+        unsafe { self.inner.get_unchecked_mut(key.as_id()) }
+    }
+
+    #[inline]
+    pub fn get_many_mut<const N: usize>(&mut self, keys: [K; N]) -> Option<[&mut V; N]> {
+        self.inner.get_many_mut(keys.map(K::as_id))
+    }
+
+    #[inline]
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        Iter {
+            inner: self.inner.slots.iter().enumerate(),
+            marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
+        IterMut {
+            inner: self.inner.slots.iter_mut().enumerate(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<V> SlotMapInner<V> {
+    fn insert_with_tag(&mut self, value: V, tag: u32) -> SlotId {
+        assert_eq!(tag & !TAG_MASK, 0);
+
+        if self.free_list_head != NIL {
+            // SAFETY: We always push indices of existing slots into the free-list and the slots
+            // vector never shrinks, therefore the index must have staid in bounds.
+            let slot = unsafe { self.slots.get_unchecked_mut(self.free_list_head as usize) };
+
+            let index = self.free_list_head;
+            let generation = slot.generation.wrapping_add(OCCUPIED_BIT | tag);
+
+            // SAFETY: We always link free slots into the free-list by setting the `next_free`
+            // union field.
+            self.free_list_head = unsafe { slot.inner.next_free };
+
+            slot.generation = generation;
+            slot.inner.value = ManuallyDrop::new(value);
+
+            self.len += 1;
+
+            // SAFETY: The `OCCUPIED_BIT` is set.
+            unsafe { SlotId::new_unchecked(index, generation) }
+        } else {
+            if self.slots.len() == (NIL - 1) as usize {
+                capacity_overflow();
+            }
+
+            let index = self.slots.len() as u32;
+            let generation = OCCUPIED_BIT | tag;
+
+            self.slots.push(Slot {
+                generation,
+                inner: SlotInner {
+                    value: ManuallyDrop::new(value),
+                },
+            });
+
+            self.len += 1;
+
+            // SAFETY: The `OCCUPIED_BIT` is set.
+            unsafe { SlotId::new_unchecked(index, generation) }
+        }
+    }
+
+    fn remove(&mut self, id: SlotId) -> Option<V> {
+        let slot = self.slots.get_mut(id.index() as usize)?;
+
+        if slot.generation == id.generation() {
+            slot.generation = (id.generation() & !TAG_MASK).wrapping_add(OCCUPIED_BIT);
+
+            // SAFETY: We checked that the slot's generation matches `id.generation`. By `SlotId`'s
+            // invariant, its generation's `OCCUPIED_BIT` bit must be set. Therefore, reading the
+            // slot is safe, as the only way the slot's occupied bit can be set is when inserting
+            // after initialization of the slot.
+            let value = unsafe { &mut slot.inner.value };
+
+            // SAFETY: We unset the slot's `OCCUPIED_BIT` such that it can't be accessed again.
+            let value = unsafe { ManuallyDrop::take(value) };
+
+            slot.inner.next_free = self.free_list_head;
+            self.free_list_head = id.index();
+
+            self.len -= 1;
+
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn get(&self, id: SlotId) -> Option<&V> {
+        let slot = self.slots.get(id.index() as usize)?;
+
+        if slot.generation == id.generation() {
+            // SAFETY: We checked that the slot's generation matches `id.generation`. By `SlotId`'s
+            // invariant, its generation's `OCCUPIED_BIT` bit must be set. Therefore, reading the
+            // value is safe, as the only way the slot's occupied bit can be set is when inserting
+            // after initialization of the slot.
+            Some(unsafe { slot.value_unchecked() })
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn get_unchecked(&self, id: SlotId) -> &V {
+        // SAFETY: The caller must ensure that the index is in bounds.
+        let slot = unsafe { self.slots.get_unchecked(id.index() as usize) };
+
+        // SAFETY: The caller must ensure that the slot is occupied.
+        unsafe { slot.value_unchecked() }
+    }
+
+    #[inline(always)]
+    fn get_mut(&mut self, id: SlotId) -> Option<&mut V> {
+        let slot = self.slots.get_mut(id.index() as usize)?;
+
+        if slot.generation == id.generation() {
+            // SAFETY: We checked that the slot's generation matches `id.generation`. By `SlotId`'s
+            // invariant, its generation's `OCCUPIED_BIT` bit must be set. Therefore, reading the
+            // value is safe, as the only way the slot's occupied bit can be set is when inserting
+            // after initialization of the slot.
+            Some(unsafe { slot.value_unchecked_mut() })
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn get_unchecked_mut(&mut self, id: SlotId) -> &mut V {
+        // SAFETY: The caller must ensure that the index is in bounds.
+        let slot = unsafe { self.slots.get_unchecked_mut(id.index() as usize) };
+
+        // SAFETY: The caller must ensure that the slot is occupied.
+        unsafe { slot.value_unchecked_mut() }
+    }
+
+    #[inline]
+    fn get_many_mut<const N: usize>(&mut self, ids: [SlotId; N]) -> Option<[&mut V; N]> {
+        #[inline]
+        fn get_many_check_valid<const N: usize>(ids: &[SlotId; N], len: u32) -> bool {
+            let mut valid = true;
+
+            for (i, id) in ids.iter().enumerate() {
+                valid &= id.index() < len;
+
+                for id2 in &ids[..i] {
+                    valid &= id.index() != id2.index();
+                }
+            }
+
+            valid
+        }
+
+        if get_many_check_valid(&ids, self.slots.len() as u32) {
+            // SAFETY: We checked that all indices are disjunct and in bounds of the slots vector.
+            unsafe { self.get_many_unchecked_mut(ids) }
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    unsafe fn get_many_unchecked_mut<const N: usize>(
+        &mut self,
+        ids: [SlotId; N],
+    ) -> Option<[&mut V; N]> {
+        let slots = self.slots.as_mut_ptr();
+        let mut refs = MaybeUninit::<[&mut V; N]>::uninit();
+        let refs_ptr = refs.as_mut_ptr().cast::<&mut V>();
+
+        for i in 0..N {
+            // SAFETY: `i` is in bounds of the array.
+            let id = unsafe { ids.get_unchecked(i) };
+
+            // SAFETY: The caller must ensure that `ids` contains only IDs whose indices are in
+            // bounds of the slots vector.
+            let slot = unsafe { slots.add(id.index() as usize) };
+
+            // SAFETY: The caller must ensure that `ids` contains only IDs with disjunct indices.
+            let slot = unsafe { &mut *slot };
+
+            if slot.generation != id.generation() {
+                return None;
+            }
+
+            // SAFETY: We checked that the slot's generation matches `id.generation`. By `SlotId`'s
+            // invariant, its generation's `OCCUPIED_BIT` bit must be set. Therefore, reading the
+            // value is safe, as the only way the slot's occupied bit can be set is when inserting
+            // after initialization of the slot.
+            let value = unsafe { slot.value_unchecked_mut() };
+
+            // SAFETY: `i` is in bounds of the array.
+            let ptr = unsafe { refs_ptr.add(i) };
+
+            // SAFETY: The pointer is valid.
+            unsafe { *ptr = value };
+        }
+
+        // SAFETY: We initialized all the elements.
+        Some(unsafe { refs.assume_init() })
+    }
+}
+
+#[inline(never)]
+fn capacity_overflow() -> ! {
+    panic!("capacity overflow");
+}
+
+struct Slot<V> {
+    generation: u32,
+    inner: SlotInner<V>,
+}
+
+union SlotInner<V> {
+    next_free: u32,
+    value: ManuallyDrop<V>,
+}
+
+impl<V> Slot<V> {
+    #[inline(always)]
+    unsafe fn value_unchecked(&self) -> &V {
+        unsafe { &self.inner.value }
+    }
+
+    #[inline(always)]
+    unsafe fn value_unchecked_mut(&mut self) -> &mut V {
+        unsafe { &mut self.inner.value }
+    }
+}
+
+impl<V> Drop for Slot<V> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.generation & OCCUPIED_BIT != 0 {
+            // SAFETY: We checked that the slot is occupied.
+            let value = unsafe { &mut self.inner.value };
+
+            // SAFETY: The fact that the slot is being dropped is proof that the value cannot be
+            // accessed again.
+            unsafe { ManuallyDrop::drop(value) };
+        }
+    }
+}
+
+pub struct Iter<'a, K, V> {
+    inner: iter::Enumerate<slice::Iter<'a, Slot<V>>>,
+    marker: PhantomData<fn(K) -> K>,
+}
+
+impl<'a, K: Key, V> Iterator for Iter<'a, K, V> {
+    type Item = (K, &'a V);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (index, slot) = self.inner.next()?;
+
+            if slot.generation & OCCUPIED_BIT != 0 {
+                // SAFETY: We checked that the occupied bit is set.
+                let id = unsafe { SlotId::new_unchecked(index as u32, slot.generation) };
+
+                // SAFETY: We checked that the slot is occupied, which means that it must have been
+                // initialized in `SlotMap::insert`.
+                let value = unsafe { slot.value_unchecked() };
+
+                break Some((K::from_id(id), value));
+            }
+        }
+    }
+}
+
+impl<K: Key, V> DoubleEndedIterator for Iter<'_, K, V> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            let (index, slot) = self.inner.next_back()?;
+
+            if slot.generation & OCCUPIED_BIT != 0 {
+                // SAFETY: We checked that the occupied bit is set.
+                let id = unsafe { SlotId::new_unchecked(index as u32, slot.generation) };
+
+                // SAFETY: We checked that the slot is occupied, which means that it must have been
+                // initialized in `SlotMap::insert`.
+                let value = unsafe { slot.value_unchecked() };
+
+                break Some((K::from_id(id), value));
+            }
+        }
+    }
+}
+
+impl<K: Key, V> FusedIterator for Iter<'_, K, V> {}
+
+pub struct IterMut<'a, K, V> {
+    inner: iter::Enumerate<slice::IterMut<'a, Slot<V>>>,
+    marker: PhantomData<fn(K) -> K>,
+}
+
+impl<'a, K: Key, V> Iterator for IterMut<'a, K, V> {
+    type Item = (K, &'a mut V);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (index, slot) = self.inner.next()?;
+
+            if slot.generation & OCCUPIED_BIT != 0 {
+                // SAFETY: We checked that the occupied bit is set.
+                let id = unsafe { SlotId::new_unchecked(index as u32, slot.generation) };
+
+                // SAFETY: We checked that the slot is occupied, which means that it must have been
+                // initialized in `SlotMap::insert`.
+                let value = unsafe { slot.value_unchecked_mut() };
+
+                break Some((K::from_id(id), value));
+            }
+        }
+    }
+}
+
+impl<K: Key, V> DoubleEndedIterator for IterMut<'_, K, V> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            let (index, slot) = self.inner.next_back()?;
+
+            if slot.generation & OCCUPIED_BIT != 0 {
+                // SAFETY: We checked that the occupied bit is set.
+                let id = unsafe { SlotId::new_unchecked(index as u32, slot.generation) };
+
+                // SAFETY: We checked that the slot is occupied, which means that it must have been
+                // initialized in `SlotMap::insert`.
+                let value = unsafe { slot.value_unchecked_mut() };
+
+                break Some((K::from_id(id), value));
+            }
+        }
+    }
+}
+
+impl<K: Key, V> FusedIterator for IterMut<'_, K, V> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_usage1() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(69);
+        let y = map.insert(42);
+
+        assert_eq!(map.get(x), Some(&69));
+        assert_eq!(map.get(y), Some(&42));
+
+        map.remove(x);
+
+        let x2 = map.insert(12);
+
+        assert_eq!(map.get(x2), Some(&12));
+        assert_eq!(map.get(x), None);
+
+        map.remove(y);
+        map.remove(x2);
+
+        assert_eq!(map.get(y), None);
+        assert_eq!(map.get(x2), None);
+    }
+
+    #[test]
+    fn basic_usage2() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let y = map.insert(2);
+        let z = map.insert(3);
+
+        assert_eq!(map.get(x), Some(&1));
+        assert_eq!(map.get(y), Some(&2));
+        assert_eq!(map.get(z), Some(&3));
+
+        map.remove(y);
+
+        let y2 = map.insert(20);
+
+        assert_eq!(map.get(y2), Some(&20));
+        assert_eq!(map.get(y), None);
+
+        map.remove(x);
+        map.remove(z);
+
+        let x2 = map.insert(10);
+
+        assert_eq!(map.get(x2), Some(&10));
+        assert_eq!(map.get(x), None);
+
+        let z2 = map.insert(30);
+
+        assert_eq!(map.get(z2), Some(&30));
+        assert_eq!(map.get(x), None);
+
+        map.remove(x2);
+
+        assert_eq!(map.get(x2), None);
+
+        map.remove(y2);
+        map.remove(z2);
+
+        assert_eq!(map.get(y2), None);
+        assert_eq!(map.get(z2), None);
+    }
+
+    #[test]
+    fn basic_usage3() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let y = map.insert(2);
+
+        assert_eq!(map.get(x), Some(&1));
+        assert_eq!(map.get(y), Some(&2));
+
+        let z = map.insert(3);
+
+        assert_eq!(map.get(z), Some(&3));
+
+        map.remove(x);
+        map.remove(z);
+
+        let z2 = map.insert(30);
+        let x2 = map.insert(10);
+
+        assert_eq!(map.get(x2), Some(&10));
+        assert_eq!(map.get(z2), Some(&30));
+        assert_eq!(map.get(x), None);
+        assert_eq!(map.get(z), None);
+
+        map.remove(x2);
+        map.remove(y);
+        map.remove(z2);
+
+        assert_eq!(map.get(x2), None);
+        assert_eq!(map.get(y), None);
+        assert_eq!(map.get(z2), None);
+    }
+
+    #[test]
+    fn basic_usage_mut1() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(69);
+        let y = map.insert(42);
+
+        assert_eq!(map.get_mut(x), Some(&mut 69));
+        assert_eq!(map.get_mut(y), Some(&mut 42));
+
+        map.remove(x);
+
+        let x2 = map.insert(12);
+
+        assert_eq!(map.get_mut(x2), Some(&mut 12));
+        assert_eq!(map.get_mut(x), None);
+
+        map.remove(y);
+        map.remove(x2);
+
+        assert_eq!(map.get_mut(y), None);
+        assert_eq!(map.get_mut(x2), None);
+    }
+
+    #[test]
+    fn basic_usage_mut2() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let y = map.insert(2);
+        let z = map.insert(3);
+
+        assert_eq!(map.get_mut(x), Some(&mut 1));
+        assert_eq!(map.get_mut(y), Some(&mut 2));
+        assert_eq!(map.get_mut(z), Some(&mut 3));
+
+        map.remove(y);
+
+        let y2 = map.insert(20);
+
+        assert_eq!(map.get_mut(y2), Some(&mut 20));
+        assert_eq!(map.get_mut(y), None);
+
+        map.remove(x);
+        map.remove(z);
+
+        let x2 = map.insert(10);
+
+        assert_eq!(map.get_mut(x2), Some(&mut 10));
+        assert_eq!(map.get_mut(x), None);
+
+        let z2 = map.insert(30);
+
+        assert_eq!(map.get_mut(z2), Some(&mut 30));
+        assert_eq!(map.get_mut(x), None);
+
+        map.remove(x2);
+
+        assert_eq!(map.get_mut(x2), None);
+
+        map.remove(y2);
+        map.remove(z2);
+
+        assert_eq!(map.get_mut(y2), None);
+        assert_eq!(map.get_mut(z2), None);
+    }
+
+    #[test]
+    fn basic_usage_mut3() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let y = map.insert(2);
+
+        assert_eq!(map.get_mut(x), Some(&mut 1));
+        assert_eq!(map.get_mut(y), Some(&mut 2));
+
+        let z = map.insert(3);
+
+        assert_eq!(map.get_mut(z), Some(&mut 3));
+
+        map.remove(x);
+        map.remove(z);
+
+        let z2 = map.insert(30);
+        let x2 = map.insert(10);
+
+        assert_eq!(map.get_mut(x2), Some(&mut 10));
+        assert_eq!(map.get_mut(z2), Some(&mut 30));
+        assert_eq!(map.get_mut(x), None);
+        assert_eq!(map.get_mut(z), None);
+
+        map.remove(x2);
+        map.remove(y);
+        map.remove(z2);
+
+        assert_eq!(map.get_mut(x2), None);
+        assert_eq!(map.get_mut(y), None);
+        assert_eq!(map.get_mut(z2), None);
+    }
+
+    #[test]
+    fn iter1() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let _ = map.insert(2);
+        let y = map.insert(3);
+
+        let mut iter = map.iter();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+
+        map.remove(x);
+        map.remove(y);
+
+        let mut iter = map.iter();
+
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert!(iter.next().is_none());
+
+        map.insert(3);
+        map.insert(1);
+
+        let mut iter = map.iter();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn iter2() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let y = map.insert(2);
+        let z = map.insert(3);
+
+        map.remove(x);
+
+        let mut iter = map.iter();
+
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+
+        map.remove(y);
+
+        let mut iter = map.iter();
+
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+
+        map.remove(z);
+
+        let mut iter = map.iter();
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn iter3() {
+        let mut map = SlotMap::new();
+
+        let _ = map.insert(1);
+        let x = map.insert(2);
+
+        let mut iter = map.iter();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert!(iter.next().is_none());
+
+        map.remove(x);
+
+        let x = map.insert(2);
+        let _ = map.insert(3);
+        let y = map.insert(4);
+
+        map.remove(y);
+
+        let mut iter = map.iter();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+
+        map.remove(x);
+
+        let mut iter = map.iter();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn iter_mut1() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let _ = map.insert(2);
+        let y = map.insert(3);
+
+        let mut iter = map.iter_mut();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+
+        map.remove(x);
+        map.remove(y);
+
+        let mut iter = map.iter_mut();
+
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert!(iter.next().is_none());
+
+        map.insert(3);
+        map.insert(1);
+
+        let mut iter = map.iter_mut();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn iter_mut2() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let y = map.insert(2);
+        let z = map.insert(3);
+
+        map.remove(x);
+
+        let mut iter = map.iter_mut();
+
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+
+        map.remove(y);
+
+        let mut iter = map.iter_mut();
+
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+
+        map.remove(z);
+
+        let mut iter = map.iter_mut();
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn iter_mut3() {
+        let mut map = SlotMap::new();
+
+        let _ = map.insert(1);
+        let x = map.insert(2);
+
+        let mut iter = map.iter_mut();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert!(iter.next().is_none());
+
+        map.remove(x);
+
+        let x = map.insert(2);
+        let _ = map.insert(3);
+        let y = map.insert(4);
+
+        map.remove(y);
+
+        let mut iter = map.iter_mut();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 2);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+
+        map.remove(x);
+
+        let mut iter = map.iter_mut();
+
+        assert_eq!(*iter.next().unwrap().1, 1);
+        assert_eq!(*iter.next().unwrap().1, 3);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn reusing_slots1() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(0);
+        let y = map.insert(0);
+
+        map.remove(y);
+
+        let y2 = map.insert(0);
+        assert_eq!(y2.index(), y.index());
+        assert_ne!(y2.generation(), y.generation());
+
+        map.remove(x);
+
+        let x2 = map.insert(0);
+        assert_eq!(x2.index(), x.index());
+        assert_ne!(x2.generation(), x.generation());
+
+        map.remove(y2);
+        map.remove(x2);
+    }
+
+    #[test]
+    fn reusing_slots2() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(0);
+
+        map.remove(x);
+
+        let x2 = map.insert(0);
+        assert_eq!(x.index(), x2.index());
+        assert_ne!(x.generation(), x2.generation());
+
+        let y = map.insert(0);
+        let z = map.insert(0);
+
+        map.remove(y);
+        map.remove(x2);
+
+        let x3 = map.insert(0);
+        let y2 = map.insert(0);
+        assert_eq!(x3.index(), x2.index());
+        assert_ne!(x3.generation(), x2.generation());
+        assert_eq!(y2.index(), y.index());
+        assert_ne!(y2.generation(), y.generation());
+
+        map.remove(x3);
+        map.remove(y2);
+        map.remove(z);
+    }
+
+    #[test]
+    fn reusing_slots3() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(0);
+        let y = map.insert(0);
+
+        map.remove(x);
+        map.remove(y);
+
+        let y2 = map.insert(0);
+        let x2 = map.insert(0);
+        let z = map.insert(0);
+        assert_eq!(x2.index(), x.index());
+        assert_ne!(x2.generation(), x.generation());
+        assert_eq!(y2.index(), y.index());
+        assert_ne!(y2.generation(), y.generation());
+
+        map.remove(x2);
+        map.remove(z);
+        map.remove(y2);
+
+        let y3 = map.insert(0);
+        let z2 = map.insert(0);
+        let x3 = map.insert(0);
+        assert_eq!(y3.index(), y2.index());
+        assert_ne!(y3.generation(), y2.generation());
+        assert_eq!(z2.index(), z.index());
+        assert_ne!(z2.generation(), z.generation());
+        assert_eq!(x3.index(), x2.index());
+        assert_ne!(x3.generation(), x2.generation());
+
+        map.remove(x3);
+        map.remove(y3);
+        map.remove(z2);
+    }
+
+    #[test]
+    fn get_many_mut() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert(1);
+        let y = map.insert(2);
+        let z = map.insert(3);
+
+        assert_eq!(map.get_many_mut([x, y]), Some([&mut 1, &mut 2]));
+        assert_eq!(map.get_many_mut([y, z]), Some([&mut 2, &mut 3]));
+        assert_eq!(map.get_many_mut([z, x]), Some([&mut 3, &mut 1]));
+
+        assert_eq!(map.get_many_mut([x, y, z]), Some([&mut 1, &mut 2, &mut 3]));
+        assert_eq!(map.get_many_mut([z, y, x]), Some([&mut 3, &mut 2, &mut 1]));
+
+        assert_eq!(map.get_many_mut([x, x]), None);
+        assert_eq!(map.get_many_mut([x, SlotId::new(3, OCCUPIED_BIT)]), None);
+
+        map.remove(y);
+
+        assert_eq!(map.get_many_mut([x, z]), Some([&mut 1, &mut 3]));
+
+        assert_eq!(map.get_many_mut([y]), None);
+        assert_eq!(map.get_many_mut([x, y]), None);
+        assert_eq!(map.get_many_mut([y, z]), None);
+
+        let y = map.insert(2);
+
+        assert_eq!(map.get_many_mut([x, y, z]), Some([&mut 1, &mut 2, &mut 3]));
+
+        map.remove(x);
+        map.remove(z);
+
+        assert_eq!(map.get_many_mut([y]), Some([&mut 2]));
+
+        assert_eq!(map.get_many_mut([x]), None);
+        assert_eq!(map.get_many_mut([z]), None);
+
+        map.remove(y);
+
+        assert_eq!(map.get_many_mut([]), Some([]));
+    }
+
+    #[test]
+    fn tagged() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert_with_tag(42, 1);
+        assert_eq!(x.generation() & TAG_MASK, 1);
+        assert_eq!(map.get(x), Some(&42));
+    }
+
+    #[test]
+    fn tagged_mut() {
+        let mut map = SlotMap::new();
+
+        let x = map.insert_with_tag(42, 1);
+        assert_eq!(x.generation() & TAG_MASK, 1);
+        assert_eq!(map.get_mut(x), Some(&mut 42));
+    }
+}


### PR DESCRIPTION
This updates our concurrent-slotmap dependency which has had many breaking changes. With the new version, we can finally fix resource destroying and make it safe next.

I also implemented a new single-threaded slotmap because the concurrent slotmap that was being used in places was always just a stand-in and there are many reasons not to use it in these places:
- Allocating pages can be expensive and so is not suited for something that might be transient in the game loop.
- It's not as efficient due to atomic operations in the immutable case.
- It's not as efficient memory-wise.
- Unneccessary unsafe code for things such as immutable getting and immutable iteration.
- Having to specify a max capacity is an unnecessary hassle.