### PR TITLE
Fix min swapchain image amount to allow variable MAX_FRAMES_IN_FLIGHT in examples

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -414,7 +414,9 @@ impl ApplicationHandler for App {
                     self.graphics_flight_id,
                     surface,
                     SwapchainCreateInfo {
-                        min_image_count: surface_capabilities.min_image_count.max(3),
+                        min_image_count: surface_capabilities
+                            .min_image_count
+                            .max(MAX_FRAMES_IN_FLIGHT + 1),
                         image_format: swapchain_format,
                         image_extent: window_size.into(),
                         image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/bloom/main.rs
+++ b/examples/bloom/main.rs
@@ -213,7 +213,9 @@ impl ApplicationHandler for App {
                     self.flight_id,
                     surface,
                     SwapchainCreateInfo {
-                        min_image_count: surface_capabilities.min_image_count.max(3),
+                        min_image_count: surface_capabilities
+                            .min_image_count
+                            .max(MAX_FRAMES_IN_FLIGHT + 1),
                         image_format: swapchain_format,
                         image_extent: window.inner_size().into(),
                         image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -204,7 +204,9 @@ impl ApplicationHandler for App {
                     self.flight_id,
                     surface,
                     SwapchainCreateInfo {
-                        min_image_count: surface_capabilities.min_image_count.max(2),
+                        min_image_count: surface_capabilities
+                            .min_image_count
+                            .max(MAX_FRAMES_IN_FLIGHT + 1),
                         image_format: swapchain_format,
                         image_extent: window_size.into(),
                         image_usage: ImageUsage::COLOR_ATTACHMENT,

--- a/examples/ray-tracing/main.rs
+++ b/examples/ray-tracing/main.rs
@@ -203,7 +203,9 @@ impl ApplicationHandler for App {
                     self.flight_id,
                     surface,
                     SwapchainCreateInfo {
-                        min_image_count: surface_capabilities.min_image_count.max(3),
+                        min_image_count: surface_capabilities
+                            .min_image_count
+                            .max(MAX_FRAMES_IN_FLIGHT + 1),
                         image_format,
                         image_extent: window_size.into(),
                         // To simplify the example, we will directly write to the swapchain images


### PR DESCRIPTION
This change allows the user to play with the example code and modify `MAX_FRAMES_IN_FLIGHT` in taskgraph examples without having to experience errors.

There is 1 extra frame breathing room in the swapchain as seen by the `+ 1`.

This one is merely an example update and has no changelog worthy changes.
