### PR TITLE
Refactor properties autogen

### DIFF
--- a/vulkano/autogen/properties.rs
+++ b/vulkano/autogen/properties.rs
@@ -1,5 +1,5 @@
 use super::{write_file, IndexMap, VkRegistryData};
-use foldhash::{HashMap, HashSet};
+use foldhash::HashMap;
 use heck::ToSnakeCase;
 use nom::{
     bytes::complete::{tag, take_until, take_while1},
@@ -8,382 +8,424 @@ use nom::{
     sequence::{delimited, tuple},
     IResult,
 };
-use proc_macro2::{Ident, Span, TokenStream};
-use quote::{format_ident, quote};
-use std::{collections::hash_map::Entry, fmt::Write as _};
-use vk_parse::{Extension, Type, TypeMember, TypeMemberDefinition, TypeMemberMarkup, TypeSpec};
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote, ToTokens};
+use vk_parse::{Extension, Type, TypeMember, TypeMemberMarkup, TypeSpec};
 
 pub fn write(vk_data: &VkRegistryData<'_>) {
-    let properties_output = properties_output(&properties_members(&vk_data.types));
-    let properties_ffi_output =
-        properties_ffi_output(&properties_ffi_members(&vk_data.types, &vk_data.extensions));
+    let device_properties = DeviceProperties::new(&vk_data.types, &vk_data.extensions);
+    let device_properties_output = device_properties.to_definitions();
+
     write_file(
         "properties.rs",
         format!(
             "vk.xml header version {}.{}.{}",
             vk_data.header_version.0, vk_data.header_version.1, vk_data.header_version.2
         ),
-        quote! {
-            #properties_output
-            #properties_ffi_output
-        },
+        device_properties_output,
     );
 }
 
-#[derive(Clone, Debug)]
-struct PropertiesMember {
-    name: Ident,
-    ty: TokenStream,
-    doc: String,
-    raw: String,
-    ffi_name: Ident,
-    ffi_members: Vec<FFIMember>,
-    optional: bool,
+struct DeviceProperties {
+    properties: Vec<Property>,
+    structs: Vec<PropertiesStruct>,
+    extension_structs: Vec<PropertiesStruct>,
 }
 
-#[derive(Debug, Clone)]
-struct FFIMember {
-    ident: Ident,
-    tokens: TokenStream,
-    len_field_name: Option<String>,
-}
+impl DeviceProperties {
+    fn new(
+        types: &HashMap<&str, (&Type, Vec<&str>)>,
+        extensions: &IndexMap<&str, &Extension>,
+    ) -> Self {
+        let mut structs: Vec<_> = [
+            "VkPhysicalDeviceProperties",
+            "VkPhysicalDeviceLimits",
+            "VkPhysicalDeviceSparseProperties",
+        ]
+        .into_iter()
+        .filter_map(|struct_name_c| {
+            let (struct_type_info, provided_by) = &types[struct_name_c];
+            PropertiesStruct::new(struct_type_info, provided_by, extensions)
+        })
+        .collect();
 
-fn properties_output(members: &[PropertiesMember]) -> TokenStream {
-    let struct_items = members.iter().map(
-        |PropertiesMember {
-             name,
-             ty,
-             doc,
-             optional,
-             ..
-         }| {
-            if *optional {
-                quote! {
-                    #[doc = #doc]
-                    pub #name: Option<#ty>,
-                }
-            } else {
-                quote! {
-                    #[doc = #doc]
-                    pub #name: #ty,
-                }
-            }
-        },
-    );
+        let mut extension_structs: Vec<_> = extension_structs_sorted(types)
+            .into_iter()
+            .filter_map(|(struct_type_info, provided_by)| {
+                PropertiesStruct::new(struct_type_info, provided_by, extensions)
+            })
+            .collect();
 
-    let default_items = members.iter().map(|PropertiesMember { name, .. }| {
-        quote! {
-            #name: Default::default(),
-        }
-    });
+        // Sort properties
+        let mut properties = HashMap::default();
+        let mut property_names = Vec::new();
 
-    let from_items = members.iter().map(
-        |PropertiesMember {
-             name,
-             ty,
-             ffi_name,
-             ffi_members,
-             optional,
-             ..
-         }| {
-            if *optional {
-                let ffi_members = ffi_members.iter().map(|FFIMember { ident: ffi_member, tokens: ffi_member_field, len_field_name }| {
-                    if let Some(len_field_name) = len_field_name {
-                        let len_field_name = Ident::new(len_field_name.as_str(), Span::call_site());
-
-                        quote! {
-                            properties_ffi.#ffi_member.and_then(|s| {
-                                let ptr = s #ffi_member_field .#ffi_name .cast_const();
-                                if ptr.is_null() {
-                                    return None;
-                                };
-
-                                Some(unsafe {
-                                    std::slice::from_raw_parts(
-                                        ptr,
-                                        s #ffi_member_field .#len_field_name as _,
-                                    )
-                                })
-                            })
-                        }
-                    } else {
-                        quote! { properties_ffi.#ffi_member.map(|s| s #ffi_member_field .#ffi_name) }
-                    }
-                });
-
-                quote! {
-                    #name: [
-                        #(#ffi_members),*
-                    ].into_iter().flatten().next().and_then(<#ty>::from_vulkan),
-                }
-            } else {
-                let ffi_members = ffi_members.iter().map(|FFIMember { ident: ffi_member, tokens: ffi_member_field, len_field_name }| {
-                    assert_eq!(*len_field_name, None);
-                    quote! { properties_ffi.#ffi_member #ffi_member_field .#ffi_name }
-                });
-
-                quote! {
-                    #name: [
-                        #(#ffi_members),*
-                    ].into_iter().next().and_then(<#ty>::from_vulkan).unwrap(),
-                }
-            }
-        },
-    );
-
-    quote! {
-        /// Represents all the properties of a physical device.
-        ///
-        /// Depending on the highest version of Vulkan supported by the physical device, and the
-        /// available extensions, not every property may be available. For that reason, some
-        /// properties are wrapped in an `Option`.
-        #[derive(Clone, Debug)]
-        pub struct DeviceProperties {
-            #(#struct_items)*
-            pub _ne: crate::NonExhaustive,
-        }
-
-        impl Default for DeviceProperties {
-            fn default() -> Self {
-                DeviceProperties {
-                    #(#default_items)*
-                    _ne: crate::NonExhaustive(()),
-                }
+        for properties_struct in structs.iter_mut().chain(extension_structs.iter_mut()) {
+            for property in &properties_struct.members {
+                properties
+                    .entry(property.property_name.to_string())
+                    .or_insert_with_key(|key| {
+                        property_names.push(key.clone());
+                        property
+                    });
             }
         }
 
-        impl From<&DevicePropertiesFfi> for DeviceProperties {
-            fn from(properties_ffi: &DevicePropertiesFfi) -> Self {
-                DeviceProperties {
-                    #(#from_items)*
-                    _ne: crate::NonExhaustive(()),
-                }
-            }
+        property_names.sort_unstable();
+
+        Self {
+            properties: property_names
+                .into_iter()
+                .map(|name| properties.remove(&name).unwrap().clone())
+                .collect(),
+            structs,
+            extension_structs,
         }
     }
-}
 
-fn properties_members(types: &HashMap<&str, (&Type, Vec<&str>)>) -> Vec<PropertiesMember> {
-    let mut properties = HashMap::default();
+    fn to_definitions(&self) -> TokenStream {
+        let Self {
+            properties,
+            structs,
+            extension_structs,
+        } = self;
 
-    [
-        &types["VkPhysicalDeviceProperties"],
-        &types["VkPhysicalDeviceLimits"],
-        &types["VkPhysicalDeviceSparseProperties"],
-    ]
-    .into_iter()
-    .chain(sorted_structs(types))
-    .filter(|(ty, _)| {
-        let name = ty.name.as_deref();
-        name == Some("VkPhysicalDeviceProperties")
-            || name == Some("VkPhysicalDeviceLimits")
-            || name == Some("VkPhysicalDeviceSparseProperties")
-            || ty.structextends.as_deref() == Some("VkPhysicalDeviceProperties2")
-    })
-    .for_each(|(ty, _)| {
-        let vulkan_ty_name = ty.name.as_ref().unwrap();
+        let struct_definition = {
+            let iter = properties.iter().map(Property::to_properties_struct_member);
 
-        let (ty_name, optional) = if vulkan_ty_name == "VkPhysicalDeviceProperties" {
-            (
-                (format_ident!("properties_vulkan10"), quote! { .properties }),
-                false,
-            )
-        } else if vulkan_ty_name == "VkPhysicalDeviceLimits" {
-            (
-                (
-                    format_ident!("properties_vulkan10"),
-                    quote! { .properties.limits },
-                ),
-                false,
-            )
-        } else if vulkan_ty_name == "VkPhysicalDeviceSparseProperties" {
-            (
-                (
-                    format_ident!("properties_vulkan10"),
-                    quote! { .properties.sparse_properties },
-                ),
-                false,
-            )
-        } else {
-            (
-                (format_ident!("{}", ffi_member(vulkan_ty_name)), quote! {}),
-                true,
-            )
+            quote! {
+                /// Represents all the properties of a physical device.
+                ///
+                /// Depending on the highest version of Vulkan supported by the physical device, and
+                /// the available extensions, not every property may be available. For that reason,
+                /// some properties are wrapped in an `Option`.
+                #[derive(Clone, Debug)]
+                pub struct DeviceProperties {
+                    #(#iter)*
+                    pub _ne: crate::NonExhaustive,
+                }
+            }
         };
 
-        members(ty)
-            .into_iter()
-            .for_each(|Member { name, ty, len }| {
-                if ty == "VkPhysicalDeviceLimits" || ty == "VkPhysicalDeviceSparseProperties" {
-                    return;
-                }
-
-                let ffi_name = name.to_snake_case();
-                let vulkano_ty = match name {
-                    "apiVersion" => quote! { Version },
-                    "bufferImageGranularity"
-                    | "minStorageBufferOffsetAlignment"
-                    | "minTexelBufferOffsetAlignment"
-                    | "minUniformBufferOffsetAlignment"
-                    | "nonCoherentAtomSize"
-                    | "optimalBufferCopyOffsetAlignment"
-                    | "optimalBufferCopyRowPitchAlignment"
-                    | "robustStorageBufferAccessSizeAlignment"
-                    | "robustUniformBufferAccessSizeAlignment"
-                    | "storageTexelBufferOffsetAlignmentBytes"
-                    | "uniformTexelBufferOffsetAlignmentBytes"
-                    | "minPlacedMemoryMapAlignment" => {
-                        quote! { DeviceAlignment }
-                    }
-                    _ => vulkano_type(ty, len),
-                };
-
-                let len_field_name = len.and_then(|it| match it {
-                    LenKind::Field(it) => Some(it.to_snake_case()),
-                    _ => None,
-                });
-
-                let vulkano_member = if len_field_name.is_some() {
-                    ffi_name
-                        .strip_prefix("p_")
-                        .map(|it| it.to_string())
-                        .unwrap()
-                } else {
-                    ffi_name.clone()
-                };
-
-                let ffi_member = FFIMember {
-                    ident: ty_name.0.clone(),
-                    tokens: ty_name.1.clone(),
-                    len_field_name,
-                };
-
-                match properties.entry(ffi_name.clone()) {
-                    Entry::Vacant(entry) => {
-                        let mut member = PropertiesMember {
-                            name: format_ident!("{}", vulkano_member),
-                            ty: vulkano_ty,
-                            doc: String::new(),
-                            raw: name.to_owned(),
-                            ffi_name: format_ident!("{}", ffi_name),
-                            ffi_members: vec![ffi_member],
-                            optional,
-                        };
-                        make_doc(&mut member, vulkan_ty_name);
-                        entry.insert(member);
-                    }
-                    Entry::Occupied(entry) => {
-                        entry.into_mut().ffi_members.push(ffi_member);
-                    }
-                };
-            });
-    });
-
-    let mut ffi_names: Vec<_> = properties
-        .values()
-        .map(|prop| prop.ffi_name.to_string())
-        .collect();
-    ffi_names.sort_unstable();
-
-    let to_remove = properties
-        .values()
-        .flat_map(|value| {
-            value
-                .ffi_members
-                .iter()
-                .flat_map(|ffi_member| ffi_member.len_field_name.clone())
-        })
-        .collect::<HashSet<String>>();
-
-    let ffi_names = ffi_names
-        .iter()
-        .filter(|it| !to_remove.contains(it.as_str()));
-
-    ffi_names
-        .into_iter()
-        .map(|name| properties.remove(name).unwrap())
-        .collect()
-}
-
-fn make_doc(prop: &mut PropertiesMember, vulkan_ty_name: &str) {
-    let writer = &mut prop.doc;
-    write!(
-        writer,
-        "- [Vulkan documentation](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/{}.html#limits-{})",
-        vulkan_ty_name,
-        prop.raw
-    )
-        .unwrap();
-}
-
-#[derive(Clone, Debug)]
-struct PropertiesFfiMember {
-    name: Ident,
-    ty: Ident,
-    provided_by: Vec<TokenStream>,
-    conflicts: Vec<Ident>,
-}
-
-fn properties_ffi_output(members: &[PropertiesFfiMember]) -> TokenStream {
-    let struct_items = members.iter().map(|PropertiesFfiMember { name, ty, .. }| {
-        quote! { #name: Option<ash::vk::#ty<'static>>, }
-    });
-
-    let make_chain_items = members.iter().map(
-        |PropertiesFfiMember {
-             name,
-             provided_by,
-             conflicts,
-             ..
-         }| {
+        let to_mut_vk = {
             quote! {
-                if [#(#provided_by),*].into_iter().any(|x| x) &&
-                    [#(self.#conflicts.is_none()),*].into_iter().all(|x| x) {
-                    self.#name = Some(Default::default());
-                    let member = self.#name.as_mut().unwrap();
-                    member.p_next = head.p_next;
-                    head.p_next = <*mut _>::cast(member);
+                pub(crate) fn to_mut_vk(
+                ) -> ash::vk::PhysicalDeviceProperties {
+                    ash::vk::PhysicalDeviceProperties::default()
                 }
             }
-        },
-    );
+        };
 
-    quote! {
-        #[derive(Default)]
-        pub(crate) struct DevicePropertiesFfi {
-            properties_vulkan10: ash::vk::PhysicalDeviceProperties2KHR<'static>,
-            #(#struct_items)*
-        }
+        let to_mut_vk2 = {
+            let extensions_vk_push_next_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_extensions_vk_push_next);
 
-        impl DevicePropertiesFfi {
-            pub(crate) fn make_chain(
-                &mut self,
-                api_version: Version,
-                device_extensions: &DeviceExtensions,
-                instance_extensions: &InstanceExtensions,
-            ) {
-                self.properties_vulkan10 = Default::default();
-                let head = &mut self.properties_vulkan10;
-                #(#make_chain_items)*
+            quote! {
+                pub(crate) fn to_mut_vk2<'a>(
+                    extensions_vk: &'a mut PhysicalDeviceProperties2ExtensionsVk<'_>,
+                ) -> ash::vk::PhysicalDeviceProperties2<'a> {
+                    let mut val_vk = ash::vk::PhysicalDeviceProperties2::default();
+
+                    #(#extensions_vk_push_next_iter)*
+
+                    val_vk
+                }
+            }
+        };
+
+        let to_mut_vk2_extensions = {
+            let fields1_vk_destructure_iter = extension_structs
+                .iter()
+                .filter_map(PropertiesStruct::to_fields1_vk_destructure);
+            let extensions_vk_constructor_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_extensions_vk_constructor);
+
+            quote! {
+                pub(crate) fn to_mut_vk2_extensions<'a>(
+                    fields1_vk: &'a mut PhysicalDeviceProperties2Fields1Vk,
+                    api_version: Version,
+                    device_extensions: &DeviceExtensions,
+                    instance_extensions: &InstanceExtensions,
+                ) -> PhysicalDeviceProperties2ExtensionsVk<'a> {
+                    let PhysicalDeviceProperties2Fields1Vk {
+                        #(#fields1_vk_destructure_iter)*
+                    } = fields1_vk;
+
+                    PhysicalDeviceProperties2ExtensionsVk {
+                        #(#extensions_vk_constructor_iter)*
+                    }
+                }
+            }
+        };
+
+        let to_mut_vk2_extensions_query_count = {
+            let extensions_vk_constructor_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_extensions_vk_constructor_query_count);
+
+            quote! {
+                pub(crate) fn to_mut_vk2_extensions_query_count(
+                    #[allow(unused)]
+                    api_version: Version,
+                    device_extensions: &DeviceExtensions,
+                    #[allow(unused)]
+                    instance_extensions: &InstanceExtensions,
+                ) -> PhysicalDeviceProperties2ExtensionsVk<'static> {
+                    PhysicalDeviceProperties2ExtensionsVk {
+                        #(#extensions_vk_constructor_iter)*
+                    }
+                }
+            }
+        };
+
+        let to_mut_vk2_fields1 = {
+            let extensions_vk_destructure_iter = extension_structs
+                .iter()
+                .filter(PropertiesStruct::has_fields_struct)
+                .map(PropertiesStruct::to_extensions_vk_destructure);
+            let fields1_vk_constructor_iter = extension_structs
+                .iter()
+                .filter_map(PropertiesStruct::to_fields1_vk_constructor);
+
+            quote! {
+                pub(crate) fn to_mut_vk2_fields1(
+                    extensions_vk: PhysicalDeviceProperties2ExtensionsVk<'_>,
+                ) -> PhysicalDeviceProperties2Fields1Vk {
+                    let PhysicalDeviceProperties2ExtensionsVk {
+                        #(#extensions_vk_destructure_iter)*
+                        ..
+                    } = extensions_vk;
+
+                    PhysicalDeviceProperties2Fields1Vk {
+                        #(#fields1_vk_constructor_iter)*
+                    }
+                }
+            }
+        };
+
+        let from_vk = {
+            let device_properties_members_iter =
+                properties.iter().map(Property::to_properties_constructor);
+            let structs_iter = structs.iter().map(PropertiesStruct::to_destructure);
+
+            quote! {
+                pub(crate) fn from_vk(
+                    val_vk: &ash::vk::PhysicalDeviceProperties,
+                ) -> Self {
+                    let ash::vk::PhysicalDeviceProperties {
+                        limits,
+                        sparse_properties,
+                        ..
+                    } = val_vk;
+
+                    #(#structs_iter)*
+
+                    Self {
+                        #(#device_properties_members_iter)*
+                        _ne: crate::NonExhaustive(()),
+                    }
+                }
+            }
+        };
+
+        let from_vk2 = {
+            let device_properties_members_iter =
+                properties.iter().map(Property::to_properties_constructor);
+            let destructure_extensions_vk_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_extensions_vk_destructure);
+            let destructure_fields1_vk_iter = extension_structs
+                .iter()
+                .filter_map(PropertiesStruct::to_fields1_vk_destructure);
+            let structs_iter = structs.iter().map(PropertiesStruct::to_destructure);
+            let extension_structs_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_from_vk2_extension);
+
+            quote! {
+                pub(crate) fn from_vk2(
+                    val_vk: &ash::vk::PhysicalDeviceProperties2<'_>,
+                    extensions_vk: &PhysicalDeviceProperties2ExtensionsVk<'_>,
+                    fields1_vk: &PhysicalDeviceProperties2Fields1Vk,
+                ) -> Self {
+                    let ash::vk::PhysicalDeviceProperties2 {
+                        properties: val_vk @ ash::vk::PhysicalDeviceProperties {
+                            limits,
+                            sparse_properties,
+                            ..
+                        },
+                        ..
+                    } = val_vk;
+                    let PhysicalDeviceProperties2ExtensionsVk {
+                        #(#destructure_extensions_vk_iter)*
+                    } = extensions_vk;
+                    let PhysicalDeviceProperties2Fields1Vk {
+                        #(#destructure_fields1_vk_iter)*
+                    } = fields1_vk;
+
+                    #(#structs_iter)*
+
+                    let mut val = Self {
+                        #(#device_properties_members_iter)*
+                        _ne: crate::NonExhaustive(()),
+                    };
+
+                    #(#extension_structs_iter)*
+
+                    val
+                }
+            }
+        };
+
+        let default = {
+            let iter = properties.iter().map(Property::to_default_constructor);
+
+            quote! {
+                impl Default for DeviceProperties {
+                    fn default() -> Self {
+                        DeviceProperties {
+                            #(#iter)*
+                            _ne: crate::NonExhaustive(()),
+                        }
+                    }
+                }
+            }
+        };
+
+        let structs_vk = {
+            let extensions_vk_members_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_extensions_vk_struct_member);
+            let extensions_vk_destructure_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_extensions_vk_destructure);
+            let extensions_vk_unborrow_fields1_iter = extension_structs
+                .iter()
+                .filter(PropertiesStruct::has_fields_struct)
+                .map(PropertiesStruct::to_extension_vk_unborrow);
+            let extensions_vk_constructor_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_extensions_vk_destructure);
+
+            let fields1_vk_members_iter = extension_structs
+                .iter()
+                .filter_map(PropertiesStruct::to_fields1_vk_struct_member);
+            let fields_structs_iter = extension_structs
+                .iter()
+                .map(PropertiesStruct::to_fields_struct);
+
+            quote! {
+                pub(crate) struct PhysicalDeviceProperties2ExtensionsVk<'a> {
+                    #(#extensions_vk_members_iter)*
+                }
+
+                impl PhysicalDeviceProperties2ExtensionsVk<'_> {
+                    pub(crate) fn unborrow(self) -> PhysicalDeviceProperties2ExtensionsVk<'static> {
+                        let Self {
+                            #(#extensions_vk_destructure_iter)*
+                        } = self;
+
+                        #(#extensions_vk_unborrow_fields1_iter)*
+
+                        PhysicalDeviceProperties2ExtensionsVk {
+                            #(#extensions_vk_constructor_iter)*
+                        }
+                    }
+                }
+
+                pub(crate) struct PhysicalDeviceProperties2Fields1Vk {
+                    #(#fields1_vk_members_iter)*
+                }
+
+                #(#fields_structs_iter)*
+            }
+        };
+
+        quote! {
+            #struct_definition
+
+            impl DeviceProperties {
+                #to_mut_vk
+                #to_mut_vk2
+                #to_mut_vk2_extensions
+                #to_mut_vk2_extensions_query_count
+                #to_mut_vk2_fields1
+
+                #from_vk
+                #from_vk2
             }
 
-            pub(crate) fn head_as_mut(&mut self) -> &mut ash::vk::PhysicalDeviceProperties2KHR<'static> {
-                &mut self.properties_vulkan10
-            }
+            #default
+            #structs_vk
         }
     }
 }
 
-fn properties_ffi_members<'a>(
-    types: &'a HashMap<&str, (&Type, Vec<&str>)>,
-    extensions: &IndexMap<&'a str, &Extension>,
-) -> Vec<PropertiesFfiMember> {
-    let mut property_included_in: HashMap<&str, Vec<&str>> = HashMap::default();
-    sorted_structs(types)
-        .into_iter()
-        .map(|(ty, provided_by)| {
-            let ty_name = ty.name.as_ref().unwrap();
-            let provided_by = provided_by
+#[derive(Debug)]
+struct PropertiesStruct {
+    struct_name: Ident,
+    var_name: Ident,
+    var_ty: TokenStream,
+    is_extension: bool,
+    provided_by: Vec<TokenStream>,
+    members: Vec<Property>,
+    fields_struct: Option<FieldsStruct>,
+}
+
+#[derive(Debug)]
+struct FieldsStruct {
+    fields_struct_name: Ident,
+    fields1_vk_member: Ident,
+}
+
+impl PropertiesStruct {
+    fn new(
+        struct_type_info: &Type,
+        provided_by: &[&str],
+        extensions: &IndexMap<&str, &Extension>,
+    ) -> Option<Self> {
+        let TypeSpec::Members(members) = &struct_type_info.spec else {
+            return None;
+        };
+
+        let is_extension = is_extension_struct(struct_type_info);
+
+        let struct_name_c = struct_type_info.name.as_ref().unwrap();
+        let struct_name = struct_name_c.strip_prefix("Vk").unwrap();
+        let mut has_pointer_property = false;
+
+        let members = members
+            .iter()
+            .filter_map(|member| {
+                let property = Property::new(member, members, struct_name_c, is_extension)?;
+
+                if property.pointer.is_some() {
+                    has_pointer_property = true;
+                }
+
+                Some(property)
+            })
+            .collect();
+
+        Some(PropertiesStruct {
+            struct_name: format_ident!("{}", struct_name),
+            var_name: match struct_name {
+                "PhysicalDeviceProperties" => format_ident!("val_vk"),
+                "PhysicalDeviceLimits" => format_ident!("limits"),
+                "PhysicalDeviceSparseProperties" => format_ident!("sparse_properties"),
+                _ => format_ident!(
+                    "{}_vk",
+                    struct_name
+                        .strip_prefix("PhysicalDevice")
+                        .unwrap()
+                        .to_snake_case()
+                ),
+            },
+            var_ty: format_ident!("{}", struct_name).to_token_stream(),
+            is_extension,
+            provided_by: provided_by
                 .iter()
                 .map(|provided_by| {
                     if let Some(version) = provided_by.strip_prefix("VK_VERSION_") {
@@ -405,48 +447,615 @@ fn properties_ffi_members<'a>(
                         quote! { #member.#name }
                     }
                 })
-                .collect();
-            let mut conflicts = vec![];
-            members(ty).into_iter().for_each(|Member { name, .. }| {
-                match property_included_in.entry(name) {
-                    Entry::Vacant(entry) => {
-                        entry.insert(vec![ty_name]);
-                    }
-                    Entry::Occupied(entry) => {
-                        let conflicters = entry.into_mut();
-                        conflicters.iter().for_each(|conflicter| {
-                            let conflicter = ffi_member(conflicter);
-                            if !conflicts.contains(&conflicter) {
-                                conflicts.push(conflicter);
-                            }
-                        });
-                        conflicters.push(ty_name);
-                    }
-                }
-            });
+                .collect(),
+            members,
+            fields_struct: has_pointer_property.then(|| FieldsStruct {
+                fields_struct_name: format_ident!("{}Fields1Vk", struct_name),
+                fields1_vk_member: format_ident!("{}_fields1_vk", struct_name.to_snake_case()),
+            }),
+        })
+    }
 
-            PropertiesFfiMember {
-                name: format_ident!("{}", ffi_member(ty_name)),
-                ty: format_ident!("{}", ty_name.strip_prefix("Vk").unwrap()),
-                provided_by,
-                conflicts: conflicts
-                    .into_iter()
-                    .map(|s| format_ident!("{}", s))
-                    .collect(),
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn has_fields_struct(self: &&Self) -> bool {
+        self.fields_struct.is_some()
+    }
+
+    fn to_fields_struct(&self) -> Option<TokenStream> {
+        let Self {
+            members,
+            fields_struct,
+            ..
+        } = self;
+
+        fields_struct.as_ref().map(|fields_struct| {
+            let FieldsStruct {
+                fields_struct_name, ..
+            } = fields_struct;
+            let members_iter = members.iter().map(Property::to_fields_struct_member);
+
+            quote! {
+                pub(crate) struct #fields_struct_name {
+                    #(#members_iter)*
+                }
             }
         })
-        .collect()
+    }
+
+    fn to_extensions_vk_struct_member(&self) -> TokenStream {
+        let Self {
+            var_name,
+            var_ty,
+            fields_struct,
+            ..
+        } = self;
+
+        let lifetime = if fields_struct.is_some() {
+            quote! { 'a }
+        } else {
+            quote! { 'static }
+        };
+
+        quote! {
+            pub(crate) #var_name: Option<ash::vk::#var_ty<#lifetime>>,
+        }
+    }
+
+    fn to_extensions_vk_constructor(&self) -> TokenStream {
+        let Self {
+            var_name,
+            var_ty,
+            provided_by,
+            fields_struct,
+            members,
+            ..
+        } = self;
+
+        if let Some(fields_struct) = fields_struct {
+            let FieldsStruct {
+                fields_struct_name,
+                fields1_vk_member,
+                ..
+            } = fields_struct;
+
+            let destructure_iter = members
+                .iter()
+                .filter(Property::is_pointer)
+                .map(Property::to_destructure);
+            let builder_iter = members
+                .iter()
+                .filter(Property::is_pointer)
+                .map(Property::to_builder);
+
+            quote! {
+                #var_name: #fields1_vk_member
+                    .as_mut()
+                    .filter(|_| #(#provided_by)||*)
+                    .map(|fields_struct| {
+                        let #fields_struct_name {
+                            #(#destructure_iter)*
+                        } = fields_struct;
+
+                        <ash::vk::#var_ty<'_>>::default()
+                            #(#builder_iter)*
+                    }),
+            }
+        } else {
+            quote! {
+                #var_name: (#(#provided_by)||*)
+                    .then(<ash::vk::#var_ty<'_>>::default),
+            }
+        }
+    }
+
+    fn to_extensions_vk_constructor_query_count(&self) -> TokenStream {
+        let Self {
+            var_name,
+            var_ty,
+            provided_by,
+            fields_struct,
+            ..
+        } = self;
+
+        let value = if fields_struct.is_some() {
+            quote! {
+                (#(#provided_by)||*).then(<ash::vk::#var_ty<'_>>::default)
+            }
+        } else {
+            quote! {
+                None
+            }
+        };
+
+        quote! {
+            #var_name: #value,
+        }
+    }
+
+    fn to_extensions_vk_destructure(&self) -> TokenStream {
+        let Self { var_name, .. } = self;
+
+        quote! { #var_name, }
+    }
+
+    fn to_extensions_vk_push_next(&self) -> TokenStream {
+        let Self { var_name, .. } = self;
+
+        quote! {
+            if let Some(next) = &mut extensions_vk.#var_name {
+                val_vk = val_vk.push_next(next);
+            }
+        }
+    }
+
+    fn to_extension_vk_unborrow(&self) -> TokenStream {
+        let Self {
+            var_name, var_ty, ..
+        } = self;
+
+        quote! {
+            let #var_name = #var_name.map(|val_vk| {
+                ash::vk::#var_ty {
+                    _marker: std::marker::PhantomData,
+                    ..val_vk
+                }
+            });
+        }
+    }
+
+    fn to_destructure(&self) -> TokenStream {
+        let &Self {
+            ref struct_name,
+            ref var_name,
+            is_extension,
+            ref members,
+            ..
+        } = self;
+
+        let destructure_iter = members.iter().map(Property::to_destructure_len_or_name);
+
+        if is_extension {
+            quote! {
+                let &ash::vk::#struct_name {
+                    #(#destructure_iter)*
+                    ..
+                } = val_vk;
+            }
+        } else {
+            quote! {
+                let &ash::vk::#struct_name {
+                    #(#destructure_iter)*
+                    ..
+                } = #var_name;
+            }
+        }
+    }
+
+    fn to_from_vk2_extension(&self) -> TokenStream {
+        let &Self {
+            ref var_name,
+            ref fields_struct,
+            ref members,
+            ..
+        } = self;
+
+        let destructure = self.to_destructure();
+        let constructor_iter = members
+            .iter()
+            .map(Property::to_extension_properties_constructor);
+
+        if let Some(fields_struct) = fields_struct {
+            let FieldsStruct {
+                fields_struct_name,
+                fields1_vk_member,
+                ..
+            } = fields_struct;
+
+            let destructure_fields_iter = members
+                .iter()
+                .filter(Property::is_pointer)
+                .map(Property::to_destructure);
+
+            quote! {
+                if let Some((val_vk, fields_vk)) = #var_name.as_ref().zip(#fields1_vk_member.as_ref()) {
+                    #destructure
+                    let #fields_struct_name {
+                        #(#destructure_fields_iter)*
+                    } = fields_vk;
+
+                    #(#constructor_iter)*
+                }
+            }
+        } else {
+            quote! {
+                if let Some(val_vk) = #var_name {
+                    #destructure
+
+                    #(#constructor_iter)*
+                }
+            }
+        }
+    }
+
+    fn to_fields1_vk_struct_member(&self) -> Option<TokenStream> {
+        let Self { fields_struct, .. } = self;
+
+        fields_struct.as_ref().map(|fields_struct| {
+            let FieldsStruct {
+                fields_struct_name,
+                fields1_vk_member,
+                ..
+            } = fields_struct;
+
+            quote! {
+                pub(crate) #fields1_vk_member: Option<#fields_struct_name>,
+            }
+        })
+    }
+
+    fn to_fields1_vk_constructor(&self) -> Option<TokenStream> {
+        let Self {
+            struct_name,
+            var_name,
+            fields_struct,
+            members,
+            ..
+        } = self;
+
+        fields_struct.as_ref().map(|fields_struct| {
+            let FieldsStruct {
+                fields_struct_name,
+                fields1_vk_member,
+            } = fields_struct;
+
+            let fields_struct_constructor_iter = members
+                .iter()
+                .filter_map(Property::to_fields1_vk_constructor);
+            let len_field_destructure_iter =
+                members.iter().filter_map(Property::to_destructure_len);
+
+            quote! {
+                #fields1_vk_member: #var_name.map(|val_vk| {
+                    let ash::vk::#struct_name {
+                        #(#len_field_destructure_iter)*
+                        ..
+                    } = val_vk;
+
+                    #fields_struct_name {
+                        #(#fields_struct_constructor_iter)*
+                    }
+                }),
+            }
+        })
+    }
+
+    fn to_fields1_vk_destructure(&self) -> Option<TokenStream> {
+        let Self { fields_struct, .. } = self;
+
+        fields_struct.as_ref().map(|fields_struct| {
+            let FieldsStruct {
+                fields1_vk_member, ..
+            } = fields_struct;
+
+            quote! {
+                #fields1_vk_member,
+            }
+        })
+    }
 }
 
-fn sorted_structs<'a>(
+#[derive(Clone, Debug)]
+struct Property {
+    property_name: Ident,
+    property_name_c: String,
+    property_ty: TokenStream,
+    pointer: Option<PointerProperty>,
+    struct_name_c: String,
+    is_extension: bool,
+}
+
+#[derive(Clone, Debug)]
+struct PointerProperty {
+    len_name: Ident,
+    pointed_ty_vk: TokenStream,
+}
+
+impl Property {
+    fn new(
+        member: &TypeMember,
+        members: &[TypeMember],
+        struct_name_c: &str,
+        is_extension: bool,
+    ) -> Option<Self> {
+        let TypeMember::Definition(definition) = member else {
+            return None;
+        };
+
+        let property_name_c = definition.markup.iter().find_map(|markup| match markup {
+            TypeMemberMarkup::Name(name) => Some(name.as_str()),
+            _ => None,
+        })?;
+
+        if matches!(property_name_c, "sType" | "pNext") {
+            return None;
+        }
+
+        let ty_c = definition.markup.iter().find_map(|markup| match markup {
+            TypeMemberMarkup::Type(ty) => Some(ty.as_str()),
+            _ => None,
+        })?;
+
+        if matches!(
+            ty_c,
+            "VkPhysicalDeviceLimits" | "VkPhysicalDeviceSparseProperties"
+        ) {
+            return None;
+        }
+
+        let len_name = definition
+            .len
+            .as_deref()
+            .filter(|&len_member| {
+                // Only use the len= field if it refers to another member of this
+                // struct, since the len= value can also be
+                // other special values such as
+                // "null-terminated".
+                members.iter().any(|member| match member {
+                    TypeMember::Definition(definition) => definition
+                        .markup
+                        .iter()
+                        .find_map(|markup| match markup {
+                            TypeMemberMarkup::Name(name) => Some(name.as_str()),
+                            _ => None,
+                        })
+                        .is_some_and(|member_name| member_name == len_member),
+                    _ => false,
+                })
+            })
+            .map(|len_member| format_ident!("{}", len_member.to_snake_case()));
+
+        if len_name.is_none() {
+            // If this member is the len= field of another member, skip it.
+            let is_len = members.iter().any(|member2| match member2 {
+                TypeMember::Definition(definition2) => {
+                    definition2.len.as_deref() == Some(property_name_c)
+                }
+                _ => false,
+            });
+
+            if is_len {
+                return None;
+            }
+        }
+
+        let array_len = {
+            fn array_len(input: &str) -> IResult<&str, &str> {
+                let (input, _) = take_until("[")(input)?;
+                all_consuming(delimited(
+                    complete::char('['),
+                    take_while1(|c: char| c.is_ascii_alphanumeric() || c == '_'),
+                    complete::char(']'),
+                ))(input)
+            }
+
+            definition
+                .markup
+                .iter()
+                .find_map(|markup| match markup {
+                    TypeMemberMarkup::Enum(len) => Some(len.as_str()),
+                    _ => None,
+                })
+                .or_else(|| array_len(&definition.code).map(|(_, len)| len).ok())
+        };
+        let property_ty =
+            c_type_to_vulkano_type(property_name_c, ty_c, array_len, len_name.is_some());
+
+        let property_name = if len_name.is_some() {
+            property_name_c.strip_prefix("p").unwrap()
+        } else {
+            property_name_c
+        }
+        .to_snake_case();
+        let property_name_ident = format_ident!("{}", property_name);
+
+        let pointer = len_name.map(|len_name| {
+            let pointed_ty_vk = c_type_to_vk_type(ty_c);
+
+            PointerProperty {
+                len_name,
+                pointed_ty_vk,
+            }
+        });
+
+        Some(Property {
+            property_name: property_name_ident.clone(),
+            property_name_c: property_name_c.to_owned(),
+            property_ty: property_ty.clone(),
+            pointer,
+            struct_name_c: struct_name_c.to_owned(),
+            is_extension,
+        })
+    }
+
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn is_pointer(self: &&Self) -> bool {
+        self.pointer.is_some()
+    }
+
+    fn to_properties_struct_member(&self) -> TokenStream {
+        let &Self {
+            ref property_name,
+            ref property_name_c,
+            ref property_ty,
+            ref struct_name_c,
+            is_extension,
+            ..
+        } = self;
+
+        let doc = format!(
+            "- [Vulkan documentation](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/{}.html#limits-{})",
+            struct_name_c,
+            property_name_c,
+        );
+
+        if is_extension {
+            quote! {
+                #[doc = #doc]
+                pub #property_name: Option<#property_ty>,
+            }
+        } else {
+            quote! {
+                #[doc = #doc]
+                pub #property_name: #property_ty,
+            }
+        }
+    }
+
+    fn to_fields_struct_member(&self) -> Option<TokenStream> {
+        let Self {
+            property_name,
+            pointer,
+            ..
+        } = self;
+
+        pointer.as_ref().map(|pointer| {
+            let pointed_ty_vk = &pointer.pointed_ty_vk;
+
+            quote! {
+                pub(crate) #property_name: Vec<#pointed_ty_vk>,
+            }
+        })
+    }
+
+    fn to_default_constructor(&self) -> TokenStream {
+        let Self { property_name, .. } = self;
+
+        quote! {
+            #property_name: Default::default(),
+        }
+    }
+
+    fn to_properties_constructor(&self) -> TokenStream {
+        let &Self {
+            ref property_name,
+            ref property_ty,
+            is_extension,
+            ..
+        } = self;
+
+        if is_extension {
+            quote! {
+                #property_name: None,
+            }
+        } else {
+            quote! {
+                #property_name: <#property_ty>::from_vulkan(#property_name).unwrap(),
+            }
+        }
+    }
+
+    fn to_extension_properties_constructor(&self) -> TokenStream {
+        let Self {
+            property_name,
+            property_ty,
+            pointer,
+            ..
+        } = self;
+
+        let expr = if let Some(pointer) = pointer {
+            let PointerProperty { len_name, .. } = pointer;
+
+            quote! {
+                &#property_name[..#len_name as usize]
+            }
+        } else {
+            property_name.to_token_stream()
+        };
+
+        quote! {
+            if val.#property_name.is_none() {
+                val.#property_name = <#property_ty>::from_vulkan(#expr);
+            }
+        }
+    }
+
+    fn to_fields1_vk_constructor(&self) -> Option<TokenStream> {
+        let Self {
+            property_name,
+            pointer,
+            ..
+        } = self;
+
+        pointer.as_ref().map(|pointer| {
+            let len_name = &pointer.len_name;
+
+            quote! {
+                #property_name: vec![
+                    Default::default();
+                    #len_name as usize
+                ],
+            }
+        })
+    }
+
+    fn to_destructure(&self) -> TokenStream {
+        let Self { property_name, .. } = self;
+
+        quote! {
+            #property_name,
+        }
+    }
+
+    fn to_destructure_len(&self) -> Option<TokenStream> {
+        let Self { pointer, .. } = self;
+
+        pointer.as_ref().map(|pointer| {
+            let len_name = &pointer.len_name;
+
+            quote! {
+                #len_name,
+            }
+        })
+    }
+
+    fn to_destructure_len_or_name(&self) -> TokenStream {
+        let Self {
+            property_name,
+            pointer,
+            ..
+        } = self;
+
+        let member = pointer
+            .as_ref()
+            .map_or(property_name, |pointer| &pointer.len_name);
+
+        quote! {
+            #member,
+        }
+    }
+
+    fn to_builder(&self) -> TokenStream {
+        let Self { property_name, .. } = self;
+
+        quote! {
+            .#property_name(#property_name)
+        }
+    }
+}
+
+fn is_extension_struct(ty: &Type) -> bool {
+    ty.structextends.as_deref() == Some("VkPhysicalDeviceProperties2")
+}
+
+fn extension_structs_sorted<'a>(
     types: &'a HashMap<&str, (&'a Type, Vec<&'a str>)>,
 ) -> Vec<&'a (&'a Type, Vec<&'a str>)> {
-    let mut structs: Vec<_> = types
+    let mut extension_structs: Vec<_> = types
         .values()
-        .filter(|(ty, _)| ty.structextends.as_deref() == Some("VkPhysicalDeviceProperties2"))
+        .filter(|(ty, _)| is_extension_struct(ty))
         .collect();
 
-    fn is_physical_device_properties(name: &str) -> bool {
+    fn is_vulkan_n_struct(name: &str) -> bool {
         tuple((
             tag::<_, &str, ()>("VkPhysicalDeviceVulkan"),
             digit1,
@@ -456,151 +1065,66 @@ fn sorted_structs<'a>(
         .is_ok()
     }
 
-    structs.sort_unstable_by_key(|&(ty, provided_by)| {
+    extension_structs.sort_unstable_by_key(|&(ty, provided_by)| {
         let name = ty.name.as_ref().unwrap();
-        (
-            !is_physical_device_properties(name),
-            if let Some(version) = provided_by
-                .iter()
-                .find_map(|s| s.strip_prefix("VK_VERSION_"))
-            {
-                let (major, minor) = version.split_once('_').unwrap();
-                (major.parse::<i32>().unwrap() << 22) | (minor.parse::<i32>().unwrap() << 12)
-            } else if provided_by.iter().any(|s| s.starts_with("VK_KHR_")) {
-                i32::MAX - 2
-            } else if provided_by.iter().any(|s| s.starts_with("VK_EXT_")) {
-                i32::MAX - 1
-            } else {
-                i32::MAX
-            },
-            name,
-        )
+
+        // Sort by groups:
+        // - PhysicalDeviceVulkanNProperties, sorted ascending by Vulkan version
+        // - Other core Vulkan properties structs, sorted ascending by Vulkan version
+        // - _KHR extension structs
+        // - _EXT extension structs
+        // - Other extension structs
+        let group_key = if is_vulkan_n_struct(name) {
+            0
+        } else if let Some(version) = provided_by
+            .iter()
+            .find_map(|s| s.strip_prefix("VK_VERSION_"))
+        {
+            let (major, minor) = version.split_once('_').unwrap();
+            (major.parse::<i32>().unwrap() << 22) | (minor.parse::<i32>().unwrap() << 12)
+        } else if provided_by.iter().any(|s| s.starts_with("VK_KHR_")) {
+            i32::MAX - 2
+        } else if provided_by.iter().any(|s| s.starts_with("VK_EXT_")) {
+            i32::MAX - 1
+        } else {
+            i32::MAX
+        };
+
+        (group_key, name)
     });
 
-    structs
+    extension_structs
 }
 
-fn ffi_member(ty_name: &str) -> String {
-    let ty_name = ty_name
-        .strip_prefix("VkPhysicalDevice")
-        .unwrap()
-        .to_snake_case();
-    let (base, suffix) = ty_name.rsplit_once("_properties").unwrap();
-    format!("properties_{}{}", base, suffix)
-}
-
-struct Member<'a> {
-    name: &'a str,
-    ty: &'a str,
-    len: Option<LenKind<'a>>,
-}
-
-#[derive(Copy, Clone)]
-enum LenKind<'a> {
-    /// Length information in a member with this name
-    Field(&'a str),
-    Raw(&'a str),
-}
-
-fn members(ty: &Type) -> Vec<Member<'_>> {
-    fn array_len(input: &str) -> IResult<&str, &str> {
-        let (input, _) = take_until("[")(input)?;
-        all_consuming(delimited(
-            complete::char('['),
-            take_while1(|c: char| c.is_ascii_alphanumeric() || c == '_'),
-            complete::char(']'),
-        ))(input)
-    }
-
-    fn type_member_name(def: &TypeMemberDefinition) -> Option<&str> {
-        def.markup.iter().find_map(|markup| match markup {
-            TypeMemberMarkup::Name(name) => Some(name.as_str()),
-            _ => None,
-        })
-    }
-
-    fn member_by_name<'a>(
-        members: &'a [TypeMember],
-        name: &str,
-    ) -> Option<&'a TypeMemberDefinition> {
-        members.iter().find_map(|it| {
-            let TypeMember::Definition(defs) = it else {
-                return None;
-            };
-
-            let member_name = type_member_name(defs)?;
-
-            if member_name != name {
-                return None;
-            };
-
-            Some(defs)
-        })
-    }
-
-    let TypeSpec::Members(members) = &ty.spec else {
-        return vec![];
-    };
-
-    members
-        .iter()
-        .filter_map(|member| {
-            let TypeMember::Definition(def) = member else {
-                return None;
-            };
-
-            let name = type_member_name(def);
-            let ty = def.markup.iter().find_map(|markup| match markup {
-                TypeMemberMarkup::Type(ty) => Some(ty.as_str()),
-                _ => None,
-            });
-
-            let len = def
-                .markup
-                .iter()
-                .find_map(|markup| match markup {
-                    TypeMemberMarkup::Enum(len) => Some(len.as_str()),
-                    _ => None,
-                })
-                .or_else(|| array_len(&def.code).map(|(_, len)| len).ok())
-                .map(LenKind::Raw)
-                .or_else(|| {
-                    let len = def.len.as_ref()?;
-                    let _member = member_by_name(members.as_slice(), len)?;
-
-                    Some(LenKind::Field(len.as_str()))
-                });
-
-            if name == Some("sType") || name == Some("pNext") {
-                return None;
-            }
-
-            name.map(|name| Member {
-                name,
-                ty: ty.unwrap(),
-                len,
-            })
-        })
-        .collect()
-}
-
-fn vulkano_type(ty: &str, len: Option<LenKind<'_>>) -> TokenStream {
-    match len {
-        Some(LenKind::Raw(len)) => match ty {
-            "char" => quote! { String },
-            "uint8_t" if len == "VK_LUID_SIZE" => quote! { [u8; 8] },
-            "uint8_t" if len == "VK_UUID_SIZE" => quote! { [u8; 16] },
-            "uint32_t" if len == "2" => quote! { [u32; 2] },
-            "uint32_t" if len == "3" => quote! { [u32; 3] },
-            "float" if len == "2" => quote! { [f32; 2] },
-            _ => unimplemented!("{}[{}]", ty, len),
-        },
-        Some(LenKind::Field(_)) => {
-            let inner = vulkano_type(ty, None);
-
-            quote! { Vec<#inner> }
+fn c_type_to_vk_type(ty: &str) -> TokenStream {
+    match ty {
+        "float" => quote! { f32 },
+        "int32_t" => quote! { i32 },
+        "int64_t" => quote! { i64 },
+        "size_t" => quote! { usize },
+        "uint8_t" => quote! { u8 },
+        "uint32_t" => quote! { u32 },
+        "uint64_t" => quote! { u64 },
+        _ => {
+            let ident = format_ident!(
+                "{}",
+                ty.strip_prefix("Vk")
+                    .unwrap_or_else(|| unimplemented!("{}", ty))
+            );
+            quote! { ash::vk::#ident }
         }
-        None => match ty {
+    }
+}
+
+fn c_type_to_vulkano_type(
+    name_c: &str,
+    ty_c: &str,
+    array_len: Option<&str>,
+    has_len_field: bool,
+) -> TokenStream {
+    fn vulkano_type_basic(ty: &str) -> TokenStream {
+        // TODO: make this more automatic?
+        match ty {
             "float" => quote! { f32 },
             "int32_t" => quote! { i32 },
             "int64_t" => quote! { i64 },
@@ -637,6 +1161,52 @@ fn vulkano_type(ty: &str, len: Option<LenKind<'_>>) -> TokenStream {
                 quote! { PhysicalDeviceSchedulingControlsFlags }
             }
             _ => unimplemented!("{}", ty),
-        },
+        }
+    }
+
+    // Override the type for these specific properties.
+    match name_c {
+        "apiVersion" => quote! { Version },
+        "bufferImageGranularity"
+        | "minStorageBufferOffsetAlignment"
+        | "minTexelBufferOffsetAlignment"
+        | "minUniformBufferOffsetAlignment"
+        | "nonCoherentAtomSize"
+        | "optimalBufferCopyOffsetAlignment"
+        | "optimalBufferCopyRowPitchAlignment"
+        | "robustStorageBufferAccessSizeAlignment"
+        | "robustUniformBufferAccessSizeAlignment"
+        | "storageTexelBufferOffsetAlignmentBytes"
+        | "uniformTexelBufferOffsetAlignmentBytes"
+        | "minPlacedMemoryMapAlignment" => {
+            quote! { DeviceAlignment }
+        }
+        _ => {
+            let inner = if ty_c == "char" && array_len.is_some() {
+                quote! { String }
+            } else {
+                let element_ty = vulkano_type_basic(ty_c);
+
+                if let Some(array_len) = array_len {
+                    let array_len: usize = match array_len {
+                        "VK_LUID_SIZE" => 8,
+                        "VK_UUID_SIZE" => 16,
+                        _ => array_len
+                            .parse()
+                            .unwrap_or_else(|_| unimplemented!("{}[{}]", ty_c, array_len)),
+                    };
+
+                    quote! { [#element_ty; #array_len] }
+                } else {
+                    element_ty
+                }
+            };
+
+            if has_len_field {
+                quote! { Vec<#inner> }
+            } else {
+                inner
+            }
+        }
     }
 }

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -96,7 +96,6 @@
 //!
 //! TODO: write
 
-pub(crate) use self::properties::DevicePropertiesFfi;
 use self::{physical::PhysicalDevice, queue::DeviceQueueInfo};
 pub use self::{
     properties::DeviceProperties,


### PR DESCRIPTION
Changelog:
```markdown
### Bugs fixed
- The `copy_src_layouts` and `copy_dst_layouts` device properties are now correctly retrieved.
```

This completely rewrites the device properties generation in autogen. The code is restructured to be based around types and various methods to generate specific output token streams. Hopefully it makes the code easier to read and maintain by sectioning off subtasks into sensible locations. Additionally, the generated properties code now follows the same Vulkan struct naming/creation/borrowing scheme that all other parts of Vulkano already use.