### PR TITLE
Reexport `ash`

### DIFF
--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -428,13 +428,11 @@ impl<'a> Iterator for DebugUtilsMessengerCallbackLabelIter<'a> {
     }
 }
 
-pub type ObjectType = vk::ObjectType;
-
 /// An object that triggered a callback.
 #[non_exhaustive]
 pub struct DebugUtilsMessengerCallbackObjectNameInfo<'a> {
     /// The type of object.
-    pub object_type: ObjectType,
+    pub object_type: vk::ObjectType,
 
     /// The handle of the object.
     pub object_handle: u64,

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -119,6 +119,7 @@
 //! [`vulkano-macros`]: vulkano_macros
 //! [`serde`]: https://crates.io/crates/serde
 
+pub use ash;
 use ash::vk;
 use bytemuck::{Pod, Zeroable};
 pub use extensions::ExtensionProperties;


### PR DESCRIPTION
I did not see this type being exposed despite it being used inside of a public field. So I assume that was by mistake.

1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [x] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

Changelog:
```markdown
### Additions
- Exposing the `ObjectType` from ash inside of `instance/debug.rs`.
```
