### PR TITLE
Remove ranges from public APIs

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -443,7 +443,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let sampler_id = bcx
@@ -965,7 +966,8 @@ impl Task for UploadTask {
                 image_subresource: ImageSubresourceLayers {
                     aspects: ImageAspects::COLOR,
                     mip_level: 0,
-                    array_layers: 0..1,
+                    base_array_layer: 0,
+                    layer_count: 1,
                 },
                 image_offset: CORNER_OFFSETS[current_corner % 4],
                 image_extent: [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 1],
@@ -982,7 +984,8 @@ impl Task for UploadTask {
                     image_subresource: ImageSubresourceLayers {
                         aspects: ImageAspects::COLOR,
                         mip_level: 0,
-                        array_layers: 0..1,
+                        base_array_layer: 0,
+                        layer_count: 1,
                     },
                     image_offset: CORNER_OFFSETS[(current_corner - 1) % 4],
                     image_extent: [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 1],

--- a/examples/bloom/main.rs
+++ b/examples/bloom/main.rs
@@ -234,7 +234,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let bloom_sampler_id = bcx
@@ -243,7 +244,7 @@ impl ApplicationHandler for App {
                 mag_filter: Filter::Linear,
                 min_filter: Filter::Linear,
                 mipmap_mode: SamplerMipmapMode::Nearest,
-                lod: 0.0..=LOD_CLAMP_NONE,
+                max_lod: LOD_CLAMP_NONE,
                 ..Default::default()
             })
             .unwrap();
@@ -515,8 +516,10 @@ fn window_size_dependent_setup(
                     format: Format::R32_UINT,
                     subresource_range: ImageSubresourceRange {
                         aspects: ImageAspects::COLOR,
-                        mip_levels: mip_level..mip_level + 1,
-                        array_layers: 0..1,
+                        base_mip_level: mip_level,
+                        level_count: 1,
+                        base_array_layer: 0,
+                        layer_count: 1,
                     },
                     usage: ImageUsage::STORAGE,
                     ..Default::default()

--- a/examples/buffer-allocator/main.rs
+++ b/examples/buffer-allocator/main.rs
@@ -293,7 +293,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());

--- a/examples/clear-attachments/main.rs
+++ b/examples/clear-attachments/main.rs
@@ -297,19 +297,22 @@ impl ApplicationHandler for App {
                             ClearRect {
                                 offset: [0, 0],
                                 extent: [100, 100],
-                                array_layers: 0..1,
+                                base_array_layer: 0,
+                                layer_count: 1,
                             },
                             // Fixed offset, relative extent.
                             ClearRect {
                                 offset: [100, 150],
                                 extent: [rcx.width / 4, rcx.height / 4],
-                                array_layers: 0..1,
+                                base_array_layer: 0,
+                                layer_count: 1,
                             },
                             // Relative offset and extent.
                             ClearRect {
                                 offset: [rcx.width / 2, rcx.height / 2],
                                 extent: [rcx.width / 3, rcx.height / 5],
-                                array_layers: 0..1,
+                                base_array_layer: 0,
+                                layer_count: 1,
                             },
                         ]
                         .into_iter()

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -225,7 +225,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let (diffuse_image_id, normals_image_id, depth_image_id) =

--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -245,7 +245,8 @@ fn main() {
                 0,
                 DescriptorBufferInfo {
                     buffer: input_buffer,
-                    range: 0..size_of::<cs::InData>() as DeviceSize,
+                    offset: 0,
+                    range: size_of::<cs::InData>() as DeviceSize,
                 },
             ),
             WriteDescriptorSet::buffer(1, output_buffer.clone()),

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -423,7 +423,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let layout = &pipeline.layout().set_layouts()[0];

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -364,7 +364,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let layout = &pipeline.layout().set_layouts()[0];

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -418,7 +418,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -385,7 +385,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -355,7 +355,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());

--- a/examples/interactive-fractal/pixels_draw_pipeline.rs
+++ b/examples/interactive-fractal/pixels_draw_pipeline.rs
@@ -140,7 +140,8 @@ impl PixelsDrawPipeline {
                 [Viewport {
                     offset: [0.0, 0.0],
                     extent: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
-                    depth_range: 0.0..=1.0,
+                    min_depth: 0.0,
+                    max_depth: 1.0,
                 }]
                 .into_iter()
                 .collect(),

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -350,7 +350,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let descriptor_set = DescriptorSet::new(

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -343,7 +343,8 @@ fn main() {
     let viewport = Viewport {
         offset: [0.0, 0.0],
         extent: [1024.0, 1024.0],
-        depth_range: 0.0..=1.0,
+        min_depth: 0.0,
+        max_depth: 1.0,
     };
 
     let command_buffer_allocator = Arc::new(StandardCommandBufferAllocator::new(

--- a/examples/multi-window-game-of-life/pixels_draw.rs
+++ b/examples/multi-window-game-of-life/pixels_draw.rs
@@ -136,7 +136,8 @@ impl PixelsDrawPipeline {
                 [Viewport {
                     offset: [0.0, 0.0],
                     extent: [viewport_dimensions[0] as f32, viewport_dimensions[1] as f32],
-                    depth_range: 0.0..=1.0,
+                    min_depth: 0.0,
+                    max_depth: 1.0,
                 }]
                 .into_iter()
                 .collect(),

--- a/examples/multi-window/main.rs
+++ b/examples/multi-window/main.rs
@@ -307,7 +307,8 @@ impl App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());

--- a/examples/multiview/main.rs
+++ b/examples/multiview/main.rs
@@ -275,7 +275,8 @@ fn main() {
                     viewports: &[Viewport {
                         offset: [0.0, 0.0],
                         extent: [image.extent()[0] as f32, image.extent()[1] as f32],
-                        depth_range: 0.0..=1.0,
+                        min_depth: 0.0,
+                        max_depth: 1.0,
                     }],
                     ..Default::default()
                 }),
@@ -350,7 +351,8 @@ fn main() {
         .copy_image_to_buffer(CopyImageToBufferInfo {
             regions: [BufferImageCopy {
                 image_subresource: ImageSubresourceLayers {
-                    array_layers: 0..1,
+                    base_array_layer: 0,
+                    layer_count: 1,
                     ..image.subresource_layers()
                 },
                 image_extent: image.extent(),
@@ -363,7 +365,8 @@ fn main() {
         .copy_image_to_buffer(CopyImageToBufferInfo {
             regions: [BufferImageCopy {
                 image_subresource: ImageSubresourceLayers {
-                    array_layers: 1..2,
+                    base_array_layer: 1,
+                    layer_count: 1,
                     ..image.subresource_layers()
                 },
                 image_extent: image.extent(),

--- a/examples/occlusion-query/main.rs
+++ b/examples/occlusion-query/main.rs
@@ -387,7 +387,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());
@@ -574,7 +575,8 @@ impl ApplicationHandler for App {
                 // operations further down the line, either in the same frame or a future frame.
                 #[rustfmt::skip]
                 self.query_pool.get_results(
-                    0..3,
+                    0,
+                    3,
                     &mut self.query_results,
                     // Block the function call until the results are available.
                     // NOTE: If not all the queries have actually been executed, then this will

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -221,7 +221,8 @@ fn main() {
                     viewports: &[Viewport {
                         offset: [0.0, 0.0],
                         extent: [1920.0, 1080.0],
-                        depth_range: 0.0..=1.0,
+                        min_depth: 0.0,
+                        max_depth: 1.0,
                     }],
                     ..Default::default()
                 }),

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -391,7 +391,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -509,7 +509,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let layout = &pipeline.layout().set_layouts()[0];

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -307,7 +307,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -430,7 +430,8 @@ impl ApplicationHandler for App {
                         viewports: &[Viewport {
                             offset: [0.0, 0.0],
                             extent: [WINDOW_WIDTH as f32, WINDOW_HEIGHT as f32],
-                            depth_range: 0.0..=1.0,
+                            min_depth: 0.0,
+                            max_depth: 1.0,
                         }],
                         ..Default::default()
                     }),

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -586,7 +586,8 @@ fn window_size_dependent_setup(
                     viewports: &[Viewport {
                         offset: [0.0, 0.0],
                         extent: window_size.into(),
-                        depth_range: 0.0..=1.0,
+                        min_depth: 0.0,
+                        max_depth: 1.0,
                     }],
                     ..Default::default()
                 }),

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -330,7 +330,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let previous_frame_end = Some(sync::now(self.device.clone()).boxed());

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -376,7 +376,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         let layout = &pipeline.layout().set_layouts()[0];

--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -314,7 +314,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         // In the `window_event` handler below we are going to submit commands to the GPU.

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -508,7 +508,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         // In some situations, the swapchain will become invalid by itself. This includes for

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -509,7 +509,8 @@ impl ApplicationHandler for App {
         let viewport = Viewport {
             offset: [0.0, 0.0],
             extent: window_size.into(),
-            depth_range: 0.0..=1.0,
+            min_depth: 0.0,
+            max_depth: 1.0,
         };
 
         // In some situations, the swapchain will become invalid by itself. This includes for

--- a/vulkano-taskgraph/src/command_buffer/commands/copy.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/copy.rs
@@ -193,7 +193,7 @@ impl RecordingCommandBuffer<'_> {
                 let regions_vk = [vk::ImageCopy2::default()
                     .src_subresource(
                         ImageSubresourceLayers {
-                            array_layers: 0..min_array_layers,
+                            layer_count: min_array_layers,
                             ..src_image.subresource_layers()
                         }
                         .to_vk(),
@@ -201,7 +201,7 @@ impl RecordingCommandBuffer<'_> {
                     .src_offset(convert_offset([0; 3]))
                     .dst_subresource(
                         ImageSubresourceLayers {
-                            array_layers: 0..min_array_layers,
+                            layer_count: min_array_layers,
                             ..dst_image.subresource_layers()
                         }
                         .to_vk(),
@@ -226,9 +226,9 @@ impl RecordingCommandBuffer<'_> {
                     .iter()
                     .map(|region| {
                         let &ImageCopy {
-                            ref src_subresource,
+                            src_subresource,
                             src_offset,
-                            ref dst_subresource,
+                            dst_subresource,
                             dst_offset,
                             extent,
                             _ne: _,
@@ -261,13 +261,13 @@ impl RecordingCommandBuffer<'_> {
                 let dst_extent = dst_image.extent();
                 let region_vk = vk::ImageCopy {
                     src_subresource: ImageSubresourceLayers {
-                        array_layers: 0..min_array_layers,
+                        layer_count: min_array_layers,
                         ..src_image.subresource_layers()
                     }
                     .to_vk(),
                     src_offset: convert_offset([0; 3]),
                     dst_subresource: ImageSubresourceLayers {
-                        array_layers: 0..min_array_layers,
+                        layer_count: min_array_layers,
                         ..dst_image.subresource_layers()
                     }
                     .to_vk(),
@@ -295,9 +295,9 @@ impl RecordingCommandBuffer<'_> {
                     .iter()
                     .map(|region| {
                         let &ImageCopy {
-                            ref src_subresource,
+                            src_subresource,
                             src_offset,
-                            ref dst_subresource,
+                            dst_subresource,
                             dst_offset,
                             extent,
                             _ne: _,
@@ -389,7 +389,7 @@ impl RecordingCommandBuffer<'_> {
                             buffer_offset,
                             buffer_row_length,
                             buffer_image_height,
-                            ref image_subresource,
+                            image_subresource,
                             image_offset,
                             image_extent,
                             _ne: _,
@@ -444,7 +444,7 @@ impl RecordingCommandBuffer<'_> {
                             buffer_offset,
                             buffer_row_length,
                             buffer_image_height,
-                            ref image_subresource,
+                            image_subresource,
                             image_offset,
                             image_extent,
                             _ne: _,
@@ -536,7 +536,7 @@ impl RecordingCommandBuffer<'_> {
                             buffer_offset,
                             buffer_row_length,
                             buffer_image_height,
-                            ref image_subresource,
+                            image_subresource,
                             image_offset,
                             image_extent,
                             _ne: _,
@@ -591,7 +591,7 @@ impl RecordingCommandBuffer<'_> {
                             buffer_offset,
                             buffer_row_length,
                             buffer_image_height,
-                            ref image_subresource,
+                            image_subresource,
                             image_offset,
                             image_extent,
                             _ne: _,
@@ -689,7 +689,7 @@ impl RecordingCommandBuffer<'_> {
                 let regions_vk = [vk::ImageBlit2::default()
                     .src_subresource(
                         ImageSubresourceLayers {
-                            array_layers: 0..min_array_layers,
+                            layer_count: min_array_layers,
                             ..src_image.subresource_layers()
                         }
                         .to_vk(),
@@ -697,7 +697,7 @@ impl RecordingCommandBuffer<'_> {
                     .src_offsets([[0; 3], src_image.extent()].map(convert_offset))
                     .dst_subresource(
                         ImageSubresourceLayers {
-                            array_layers: 0..min_array_layers,
+                            layer_count: min_array_layers,
                             ..src_image.subresource_layers()
                         }
                         .to_vk(),
@@ -718,9 +718,9 @@ impl RecordingCommandBuffer<'_> {
                     .iter()
                     .map(|region| {
                         let &ImageBlit {
-                            ref src_subresource,
+                            src_subresource,
                             src_offsets,
-                            ref dst_subresource,
+                            dst_subresource,
                             dst_offsets,
                             _ne: _,
                         } = region;
@@ -750,13 +750,13 @@ impl RecordingCommandBuffer<'_> {
                 let min_array_layers = cmp::min(src_image.array_layers(), dst_image.array_layers());
                 let region_vk = vk::ImageBlit {
                     src_subresource: ImageSubresourceLayers {
-                        array_layers: 0..min_array_layers,
+                        layer_count: min_array_layers,
                         ..src_image.subresource_layers()
                     }
                     .to_vk(),
                     src_offsets: [[0; 3], src_image.extent()].map(convert_offset),
                     dst_subresource: ImageSubresourceLayers {
-                        array_layers: 0..min_array_layers,
+                        layer_count: min_array_layers,
                         ..dst_image.subresource_layers()
                     }
                     .to_vk(),
@@ -780,9 +780,9 @@ impl RecordingCommandBuffer<'_> {
                     .iter()
                     .map(|region| {
                         let &ImageBlit {
-                            ref src_subresource,
+                            src_subresource,
                             src_offsets,
-                            ref dst_subresource,
+                            dst_subresource,
                             dst_offsets,
                             _ne: _,
                         } = region;
@@ -858,7 +858,7 @@ impl RecordingCommandBuffer<'_> {
                 let regions_vk = [vk::ImageResolve2::default()
                     .src_subresource(
                         ImageSubresourceLayers {
-                            array_layers: 0..min_array_layers,
+                            layer_count: min_array_layers,
                             ..src_image.subresource_layers()
                         }
                         .to_vk(),
@@ -866,7 +866,7 @@ impl RecordingCommandBuffer<'_> {
                     .src_offset(convert_offset([0; 3]))
                     .dst_subresource(
                         ImageSubresourceLayers {
-                            array_layers: 0..min_array_layers,
+                            layer_count: min_array_layers,
                             ..src_image.subresource_layers()
                         }
                         .to_vk(),
@@ -891,9 +891,9 @@ impl RecordingCommandBuffer<'_> {
                     .iter()
                     .map(|region| {
                         let &ImageResolve {
-                            ref src_subresource,
+                            src_subresource,
                             src_offset,
-                            ref dst_subresource,
+                            dst_subresource,
                             dst_offset,
                             extent,
                             _ne: _,
@@ -926,13 +926,13 @@ impl RecordingCommandBuffer<'_> {
                 let dst_extent = dst_image.extent();
                 let regions_vk = [vk::ImageResolve {
                     src_subresource: ImageSubresourceLayers {
-                        array_layers: 0..min_array_layers,
+                        layer_count: min_array_layers,
                         ..src_image.subresource_layers()
                     }
                     .to_vk(),
                     src_offset: convert_offset([0; 3]),
                     dst_subresource: ImageSubresourceLayers {
-                        array_layers: 0..min_array_layers,
+                        layer_count: min_array_layers,
                         ..dst_image.subresource_layers()
                     }
                     .to_vk(),
@@ -960,9 +960,9 @@ impl RecordingCommandBuffer<'_> {
                     .iter()
                     .map(|region| {
                         let &ImageResolve {
-                            ref src_subresource,
+                            src_subresource,
                             src_offset,
-                            ref dst_subresource,
+                            dst_subresource,
                             dst_offset,
                             extent,
                             _ne: _,
@@ -1184,13 +1184,15 @@ impl ImageCopy<'_> {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             src_offset: [0; 3],
             dst_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             dst_offset: [0; 3],
             extent: [0; 3],
@@ -1353,7 +1355,8 @@ impl BufferImageCopy<'_> {
             image_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             image_offset: [0; 3],
             image_extent: [0; 3],
@@ -1472,13 +1475,15 @@ impl ImageBlit<'_> {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             src_offsets: [[0; 3]; 2],
             dst_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             dst_offsets: [[0; 3]; 2],
             _ne: crate::NE,
@@ -1587,13 +1592,15 @@ impl ImageResolve<'_> {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             src_offset: [0; 3],
             dst_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             dst_offset: [0; 3],
             extent: [0; 3],

--- a/vulkano-taskgraph/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/dynamic_state.rs
@@ -1,7 +1,6 @@
 use crate::command_buffer::{RecordingCommandBuffer, Result};
 use ash::vk;
 use smallvec::SmallVec;
-use std::ops::RangeInclusive;
 use vulkano::{
     device::DeviceOwned,
     pipeline::graphics::{
@@ -124,13 +123,23 @@ impl RecordingCommandBuffer<'_> {
     }
 
     /// Sets the dynamic depth bounds for future draw calls.
-    pub unsafe fn set_depth_bounds(&mut self, bounds: RangeInclusive<f32>) -> Result<&mut Self> {
-        Ok(unsafe { self.set_depth_bounds_unchecked(bounds.clone()) })
+    pub unsafe fn set_depth_bounds(
+        &mut self,
+        min_depth_bounds: f32,
+        max_depth_bounds: f32,
+    ) -> Result<&mut Self> {
+        Ok(unsafe { self.set_depth_bounds_unchecked(min_depth_bounds, max_depth_bounds) })
     }
 
-    pub unsafe fn set_depth_bounds_unchecked(&mut self, bounds: RangeInclusive<f32>) -> &mut Self {
+    pub unsafe fn set_depth_bounds_unchecked(
+        &mut self,
+        min_depth_bounds: f32,
+        max_depth_bounds: f32,
+    ) -> &mut Self {
         let fns = self.device().fns();
-        unsafe { (fns.v1_0.cmd_set_depth_bounds)(self.handle(), *bounds.start(), *bounds.end()) };
+        unsafe {
+            (fns.v1_0.cmd_set_depth_bounds)(self.handle(), min_depth_bounds, max_depth_bounds)
+        };
 
         self
     }

--- a/vulkano-taskgraph/src/command_buffer/commands/sync.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/sync.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use ash::vk;
 use smallvec::SmallVec;
-use std::ops::Range;
 use vulkano::{
     buffer::Buffer,
     device::DeviceOwned,
@@ -67,7 +66,8 @@ impl RecordingCommandBuffer<'_> {
                         dst_stages,
                         dst_access,
                         buffer,
-                        ref range,
+                        offset,
+                        size,
                         _ne: _,
                     } = barrier;
 
@@ -81,8 +81,8 @@ impl RecordingCommandBuffer<'_> {
                         .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
                         .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
                         .buffer(buffer.handle())
-                        .offset(range.start)
-                        .size(range.end - range.start)
+                        .offset(offset)
+                        .size(size)
                 })
                 .collect();
 
@@ -97,7 +97,7 @@ impl RecordingCommandBuffer<'_> {
                         old_layout,
                         new_layout,
                         image,
-                        ref subresource_range,
+                        subresource_range,
                         _ne: _,
                     } = barrier;
 
@@ -164,7 +164,8 @@ impl RecordingCommandBuffer<'_> {
                         dst_stages,
                         dst_access,
                         buffer,
-                        ref range,
+                        offset,
+                        size,
                         _ne: _,
                     } = barrier;
 
@@ -179,8 +180,8 @@ impl RecordingCommandBuffer<'_> {
                         .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
                         .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
                         .buffer(buffer.handle())
-                        .offset(range.start)
-                        .size(range.end - range.start)
+                        .offset(offset)
+                        .size(size)
                 })
                 .collect();
 
@@ -195,7 +196,7 @@ impl RecordingCommandBuffer<'_> {
                         old_layout,
                         new_layout,
                         image,
-                        ref subresource_range,
+                        subresource_range,
                         _ne: _,
                     } = barrier;
 
@@ -394,10 +395,15 @@ pub struct BufferMemoryBarrier<'a> {
     /// The default value is [`Id::INVALID`], which must be overridden.
     pub buffer: Id<Buffer>,
 
-    /// The byte range of `buffer` to apply the barrier to.
+    /// The byte offset from `buffer` to apply the barrier to.
     ///
-    /// The default value is empty, which must be overridden.
-    pub range: Range<DeviceSize>,
+    /// The default value is `0`.
+    pub offset: DeviceSize,
+
+    /// The byte size to apply the barrier to.
+    ///
+    /// The default value is `0`, which must be overridden.
+    pub size: DeviceSize,
 
     pub _ne: crate::NonExhaustive<'a>,
 }
@@ -419,7 +425,8 @@ impl BufferMemoryBarrier<'_> {
             dst_stages: PipelineStages::empty(),
             dst_access: AccessFlags::empty(),
             buffer: Id::INVALID,
-            range: 0..0,
+            offset: 0,
+            size: 0,
             _ne: crate::NE,
         }
     }
@@ -495,8 +502,10 @@ impl ImageMemoryBarrier<'_> {
             image: Id::INVALID,
             subresource_range: ImageSubresourceRange {
                 aspects: ImageAspects::empty(),
-                mip_levels: 0..0,
-                array_layers: 0..0,
+                base_mip_level: 0,
+                level_count: 0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             _ne: crate::NE,
         }

--- a/vulkano-taskgraph/src/graph/execute.rs
+++ b/vulkano-taskgraph/src/graph/execute.rs
@@ -773,10 +773,11 @@ unsafe fn create_framebuffers(
                         component_mapping: attachment.component_mapping,
                         subresource_range: ImageSubresourceRange {
                             aspects: attachment.format.aspects(),
-                            mip_levels: attachment.mip_level..attachment.mip_level + 1,
+                            base_mip_level: attachment.mip_level,
+                            level_count: 1,
+                            base_array_layer: attachment.base_array_layer,
                             // FIXME:
-                            array_layers: attachment.base_array_layer
-                                ..attachment.base_array_layer + 1,
+                            layer_count: 1,
                         },
                         ..Default::default()
                     },

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -773,11 +773,16 @@ impl ClearColorImageInfo {
                 }));
             }
 
-            if subresource_range.mip_levels.end > image.mip_levels() {
+            if !subresource_range
+                .base_mip_level
+                .checked_add(subresource_range.level_count)
+                .is_some_and(|end| end <= image.mip_levels())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].mip_levels.end` is greater than `image.mip_levels()`",
-                        region_index
+                        "`regions[{0}].base_mip_level + regions[{0}].level_count` is greater than \
+                        `image.mip_levels()`",
+                        region_index,
                     )
                     .into(),
                     vuids: &[
@@ -788,11 +793,16 @@ impl ClearColorImageInfo {
                 }));
             }
 
-            if subresource_range.array_layers.end > image.array_layers() {
+            if !subresource_range
+                .base_array_layer
+                .checked_add(subresource_range.layer_count)
+                .is_some_and(|end| end <= image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].array_layers.end` is greater than `image.array_layers()`",
-                        region_index
+                        "`regions[{0}].base_array_level + regions[{0}].layer_count` is greater \
+                        than `image.array_layers()`",
+                        region_index,
                     )
                     .into(),
                     vuids: &[
@@ -1015,11 +1025,16 @@ impl ClearDepthStencilImageInfo {
                 }));
             }
 
-            if subresource_range.mip_levels.end > image.mip_levels() {
+            if !subresource_range
+                .base_mip_level
+                .checked_add(subresource_range.level_count)
+                .is_some_and(|end| end <= image.mip_levels())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].mip_levels.end` is greater than `image.mip_levels()`",
-                        region_index
+                        "`regions[{0}].base_mip_level + regions[{0}].level_count` is greater than \
+                        `image.mip_levels()`",
+                        region_index,
                     )
                     .into(),
                     vuids: &[
@@ -1030,11 +1045,16 @@ impl ClearDepthStencilImageInfo {
                 }));
             }
 
-            if subresource_range.array_layers.end > image.array_layers() {
+            if !subresource_range
+                .base_array_layer
+                .checked_add(subresource_range.layer_count)
+                .is_some_and(|end| end <= image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].array_layers.end` is greater than `image.array_layers()`",
-                        region_index
+                        "`regions[{0}].base_array_layer + regions[{0}].layer_count` is greater \
+                        than `image.array_layers()`",
+                        region_index,
                     )
                     .into(),
                     vuids: &[

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -168,9 +168,9 @@ impl<L> AutoCommandBufferBuilder<L> {
                 .iter()
                 .flat_map(|region| {
                     let &ImageCopy {
-                        ref src_subresource,
+                        src_subresource,
                         src_offset: _,
-                        ref dst_subresource,
+                        dst_subresource,
                         dst_offset: _,
                         extent: _,
                         _ne: _,
@@ -181,7 +181,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             ResourceInCommand::Source.into(),
                             Resource::Image {
                                 image: src_image.clone(),
-                                subresource_range: src_subresource.clone().into(),
+                                subresource_range: src_subresource.into(),
                                 memory_access: PipelineStageAccessFlags::Copy_TransferRead,
                                 start_layout: src_image_layout,
                                 end_layout: src_image_layout,
@@ -191,7 +191,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             ResourceInCommand::Destination.into(),
                             Resource::Image {
                                 image: dst_image.clone(),
-                                subresource_range: dst_subresource.clone().into(),
+                                subresource_range: dst_subresource.into(),
                                 memory_access: PipelineStageAccessFlags::Copy_TransferWrite,
                                 start_layout: dst_image_layout,
                                 end_layout: dst_image_layout,
@@ -258,7 +258,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                         buffer_offset,
                         buffer_row_length: _,
                         buffer_image_height: _,
-                        ref image_subresource,
+                        image_subresource,
                         image_offset: _,
                         image_extent: _,
                         _ne: _,
@@ -278,7 +278,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             ResourceInCommand::Destination.into(),
                             Resource::Image {
                                 image: dst_image.clone(),
-                                subresource_range: image_subresource.clone().into(),
+                                subresource_range: image_subresource.into(),
                                 memory_access: PipelineStageAccessFlags::Copy_TransferWrite,
                                 start_layout: dst_image_layout,
                                 end_layout: dst_image_layout,
@@ -345,7 +345,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                         buffer_offset,
                         buffer_row_length: _,
                         buffer_image_height: _,
-                        ref image_subresource,
+                        image_subresource,
                         image_offset: _,
                         image_extent: _,
                         _ne: _,
@@ -356,7 +356,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             ResourceInCommand::Source.into(),
                             Resource::Image {
                                 image: src_image.clone(),
-                                subresource_range: image_subresource.clone().into(),
+                                subresource_range: image_subresource.into(),
                                 memory_access: PipelineStageAccessFlags::Copy_TransferRead,
                                 start_layout: src_image_layout,
                                 end_layout: src_image_layout,
@@ -456,9 +456,9 @@ impl<L> AutoCommandBufferBuilder<L> {
                 .iter()
                 .flat_map(|region| {
                     let &ImageBlit {
-                        ref src_subresource,
+                        src_subresource,
                         src_offsets: _,
-                        ref dst_subresource,
+                        dst_subresource,
                         dst_offsets: _,
                         _ne: _,
                     } = region;
@@ -468,7 +468,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             ResourceInCommand::Source.into(),
                             Resource::Image {
                                 image: src_image.clone(),
-                                subresource_range: src_subresource.clone().into(),
+                                subresource_range: src_subresource.into(),
                                 memory_access: PipelineStageAccessFlags::Blit_TransferRead,
                                 start_layout: src_image_layout,
                                 end_layout: src_image_layout,
@@ -478,7 +478,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             ResourceInCommand::Destination.into(),
                             Resource::Image {
                                 image: dst_image.clone(),
-                                subresource_range: dst_subresource.clone().into(),
+                                subresource_range: dst_subresource.into(),
                                 memory_access: PipelineStageAccessFlags::Blit_TransferWrite,
                                 start_layout: dst_image_layout,
                                 end_layout: dst_image_layout,
@@ -546,9 +546,9 @@ impl<L> AutoCommandBufferBuilder<L> {
                 .iter()
                 .flat_map(|region| {
                     let &ImageResolve {
-                        ref src_subresource,
+                        src_subresource,
                         src_offset: _,
-                        ref dst_subresource,
+                        dst_subresource,
                         dst_offset: _,
                         extent: _,
                         _ne: _,
@@ -559,7 +559,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             ResourceInCommand::Source.into(),
                             Resource::Image {
                                 image: src_image.clone(),
-                                subresource_range: src_subresource.clone().into(),
+                                subresource_range: src_subresource.into(),
                                 memory_access: PipelineStageAccessFlags::Resolve_TransferRead,
                                 start_layout: src_image_layout,
                                 end_layout: src_image_layout,
@@ -569,7 +569,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             ResourceInCommand::Destination.into(),
                             Resource::Image {
                                 image: dst_image.clone(),
-                                subresource_range: dst_subresource.clone().into(),
+                                subresource_range: dst_subresource.into(),
                                 memory_access: PipelineStageAccessFlags::Resolve_TransferWrite,
                                 start_layout: dst_image_layout,
                                 end_layout: dst_image_layout,
@@ -768,9 +768,9 @@ impl RecordingCommandBuffer {
         if min_image_transfer_granularity.is_some() {
             for (region_index, region) in regions.iter().enumerate() {
                 let &ImageCopy {
-                    ref src_subresource,
+                    src_subresource,
                     src_offset,
-                    ref dst_subresource,
+                    dst_subresource,
                     dst_offset,
                     extent,
                     _ne: _,
@@ -1106,7 +1106,7 @@ impl RecordingCommandBuffer {
                     buffer_offset,
                     buffer_row_length: _,
                     buffer_image_height: _,
-                    ref image_subresource,
+                    image_subresource,
                     image_offset,
                     image_extent,
                     _ne,
@@ -1386,7 +1386,7 @@ impl RecordingCommandBuffer {
                     buffer_offset,
                     buffer_row_length: _,
                     buffer_image_height: _,
-                    ref image_subresource,
+                    image_subresource,
                     image_offset,
                     image_extent,
                     _ne,
@@ -2191,11 +2191,11 @@ impl CopyImageInfo {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());
         let region = ImageCopy {
             src_subresource: ImageSubresourceLayers {
-                array_layers: 0..min_array_layers,
+                layer_count: min_array_layers,
                 ..src_image.subresource_layers()
             },
             dst_subresource: ImageSubresourceLayers {
-                array_layers: 0..min_array_layers,
+                layer_count: min_array_layers,
                 ..dst_image.subresource_layers()
             },
             extent: {
@@ -2369,9 +2369,9 @@ impl CopyImageInfo {
                 .map_err(|err| err.add_context(format!("regions[{}]", region_index)))?;
 
             let &ImageCopy {
-                ref src_subresource,
+                src_subresource,
                 src_offset,
-                ref dst_subresource,
+                dst_subresource,
                 dst_offset,
                 extent,
                 _ne,
@@ -2539,11 +2539,13 @@ impl CopyImageInfo {
                     }
                 }
                 ImageType::Dim3d => {
-                    if src_subresource.array_layers != (0..1) {
+                    if !(src_subresource.base_array_layer == 0 && src_subresource.layer_count == 1)
+                    {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`src_image.image_type()` is `ImageType::Dim3d`, but \
-                                `regions[{}].src_subresource.array_layers` is not `0..1`",
+                                `(regions[{0}].src_subresource.base_array_layer, \
+                                regions[{0}].src_subresource.layer_count)` is not `(0, 1)`",
                                 region_index,
                             )
                             .into(),
@@ -2557,12 +2559,17 @@ impl CopyImageInfo {
                 }
             }
 
-            if src_subresource.array_layers.end > src_image.array_layers() {
+            if !src_subresource
+                .base_array_layer
+                .checked_add(src_subresource.layer_count)
+                .is_some_and(|end| end <= src_image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].src_subresource.array_layers.end` is not less than \
+                        "`regions[{0}].src_subresource.base_array_layer + \
+                        regions[{0}].src_subresource.layer_count` is greater than \
                         `src_image.array_layers()`",
-                        region_index
+                        region_index,
                     )
                     .into(),
                     vuids: &["VUID-VkCopyImageInfo2-srcSubresource-07968"],
@@ -2907,11 +2914,13 @@ impl CopyImageInfo {
                     }
                 }
                 ImageType::Dim3d => {
-                    if dst_subresource.array_layers != (0..1) {
+                    if !(dst_subresource.base_array_layer == 0 && dst_subresource.layer_count == 1)
+                    {
                         return Err(Box::new(ValidationError {
                             problem: format!(
-                                "`dst_image.image_type()` is  `ImageType::Dim3d`, but \
-                                `regions[{}].dst_subresource.array_layers` is not `0..1`",
+                                "`dst_image.image_type()` is `ImageType::Dim3d`, but \
+                                `(regions[{0}].dst_subresource.base_array_layer, \
+                                regions[{0}].dst_subresource.layer_count)` is not `(0, 1)`",
                                 region_index,
                             )
                             .into(),
@@ -2925,12 +2934,17 @@ impl CopyImageInfo {
                 }
             }
 
-            if dst_subresource.array_layers.end > dst_image.array_layers() {
+            if !dst_subresource
+                .base_array_layer
+                .checked_add(dst_subresource.layer_count)
+                .is_some_and(|end| end <= dst_image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].dst_subresource.array_layers.end` is not less than \
+                        "`regions[{0}].dst_subresource.base_array_layer + \
+                        regions[{0}].dst_subresource.layer_count` is greater than \
                         `dst_image.array_layers()`",
-                        region_index
+                        region_index,
                     )
                     .into(),
                     vuids: &["VUID-VkCopyImageInfo2-dstSubresource-07968"],
@@ -3234,13 +3248,12 @@ impl CopyImageInfo {
             }
 
             if src_image.image_type() == dst_image.image_type() {
-                if src_subresource.array_layers.len() != dst_subresource.array_layers.len() {
+                if src_subresource.layer_count != dst_subresource.layer_count {
                     return Err(Box::new(ValidationError {
                         problem: format!(
                             "`src_image.image_type()` equals `dst_image.image_type()`, but \
-                            the length of `regions[{0}].src_subresource.array_layers` \
-                            does not equal \
-                            the length of `regions[{0}].dst_subresource.array_layers`",
+                            `regions[{0}].src_subresource.layer_count` does not equal \
+                            `regions[{0}].dst_subresource.layer_count`",
                             region_index,
                         )
                         .into(),
@@ -3269,13 +3282,13 @@ impl CopyImageInfo {
                     }
                 }
                 (ImageType::Dim2d, ImageType::Dim3d) => {
-                    if extent[2] as usize != src_subresource.array_layers.len() {
+                    if extent[2] != src_subresource.layer_count {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`src_image.image_type()` is `ImageType::Dim2d` and \
                                 `dst_image.image_type()` is `ImageType::Dim3d`, but \
-                                `regions[{0}].extent[2]` does not equal the length of \
-                                `regions[{0}].src_subresource.array_layers`",
+                                `regions[{0}].extent[2]` does not equal \
+                                `regions[{0}].src_subresource.layer_count`",
                                 region_index,
                             )
                             .into(),
@@ -3285,13 +3298,13 @@ impl CopyImageInfo {
                     }
                 }
                 (ImageType::Dim3d, ImageType::Dim2d) => {
-                    if extent[2] as usize != dst_subresource.array_layers.len() {
+                    if extent[2] != dst_subresource.layer_count {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`src_image.image_type()` is `ImageType::Dim3d` and \
                                 `dst_image.image_type()` is `ImageType::Dim2d`, but \
-                                `regions[{0}].extent[2]` does not equal the length of \
-                                `regions[{0}].dst_subresource.array_layers`",
+                                `regions[{0}].extent[2]` does not equal \
+                                `regions[{0}].dst_subresource.layer_count`",
                                 region_index,
                             )
                             .into(),
@@ -3308,7 +3321,8 @@ impl CopyImageInfo {
                 let src_region_index = region_index;
                 let src_subresource_axes = [
                     src_subresource.mip_level..src_subresource.mip_level + 1,
-                    src_subresource.array_layers.start..src_subresource.array_layers.end,
+                    src_subresource.base_array_layer
+                        ..src_subresource.base_array_layer + src_subresource.layer_count,
                 ];
                 let src_extent_axes = [
                     src_offset[0]..src_offset[0] + extent[0],
@@ -3318,7 +3332,7 @@ impl CopyImageInfo {
 
                 for (dst_region_index, dst_region) in regions.iter().enumerate() {
                     let &ImageCopy {
-                        ref dst_subresource,
+                        dst_subresource,
                         dst_offset,
                         ..
                     } = dst_region;
@@ -3332,7 +3346,8 @@ impl CopyImageInfo {
 
                     let dst_subresource_axes = [
                         dst_subresource.mip_level..dst_subresource.mip_level + 1,
-                        src_subresource.array_layers.start..src_subresource.array_layers.end,
+                        src_subresource.base_array_layer
+                            ..src_subresource.base_array_layer + src_subresource.layer_count,
                     ];
 
                     if src_subresource_axes.iter().zip(dst_subresource_axes).any(
@@ -3507,13 +3522,15 @@ impl ImageCopy {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             src_offset: [0; 3],
             dst_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             dst_offset: [0; 3],
             extent: [0; 3],
@@ -3523,9 +3540,9 @@ impl ImageCopy {
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offset: _,
-            ref dst_subresource,
+            dst_subresource,
             dst_offset: _,
             extent,
             _ne,
@@ -3551,12 +3568,12 @@ impl ImageCopy {
                 }));
             }
 
-            if src_subresource.array_layers.len() != dst_subresource.array_layers.len()
+            if src_subresource.layer_count != dst_subresource.layer_count
                 && !device.enabled_extensions().khr_maintenance1
             {
                 return Err(Box::new(ValidationError {
-                    problem: "the length of `src_subresource.array_layers` does not equal \
-                        the length of `dst_subresource.array_layers`"
+                    problem: "`src_subresource.layer_count` does not equal \
+                        `dst_subresource.layer_count`"
                         .into(),
                     vuids: &["VUID-VkImageCopy2-extent-00140"],
                     ..Default::default()
@@ -3596,9 +3613,9 @@ impl ImageCopy {
 
     pub(crate) fn to_vk2(&self) -> vk::ImageCopy2<'static> {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offset,
-            ref dst_subresource,
+            dst_subresource,
             dst_offset,
             extent,
             _ne: _,
@@ -3626,9 +3643,9 @@ impl ImageCopy {
 
     pub(crate) fn to_vk(&self) -> vk::ImageCopy {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offset,
-            ref dst_subresource,
+            dst_subresource,
             dst_offset,
             extent,
             _ne: _,
@@ -3808,7 +3825,7 @@ impl CopyBufferToImageInfo {
                 buffer_offset,
                 buffer_row_length,
                 buffer_image_height,
-                ref image_subresource,
+                image_subresource,
                 image_offset,
                 image_extent,
                 _ne: _,
@@ -3989,11 +4006,14 @@ impl CopyBufferToImageInfo {
                     }
                 }
                 ImageType::Dim3d => {
-                    if image_subresource.array_layers != (0..1) {
+                    if !(image_subresource.base_array_layer == 0
+                        && image_subresource.layer_count == 1)
+                    {
                         return Err(Box::new(ValidationError {
                             problem: format!(
-                                "`dst_image.image_type()` is  `ImageType::Dim3d`, but \
-                                `regions[{}].image_subresource.array_layers` is not `0..1`",
+                                "`dst_image.image_type()` is `ImageType::Dim3d`, but \
+                                `(regions[{0}].image_subresource.base_array_layer, \
+                                regions[{0}].image_subresource.layer_count)` is not `(0, 1)`",
                                 region_index,
                             )
                             .into(),
@@ -4004,12 +4024,17 @@ impl CopyBufferToImageInfo {
                 }
             }
 
-            if image_subresource.array_layers.end > dst_image.array_layers() {
+            if !image_subresource
+                .base_array_layer
+                .checked_add(image_subresource.layer_count)
+                .is_some_and(|end| end <= dst_image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].dst_subresource.array_layers.end` is not less than \
+                        "`regions[{0}].dst_subresource.base_array_layer + \
+                        regions[{0}].dst_subresource.layer_count` is greater than \
                         `dst_image.array_layers()`",
-                        region_index
+                        region_index,
                     )
                     .into(),
                     vuids: &["VUID-VkCopyBufferToImageInfo2-imageSubresource-07968"],
@@ -4499,7 +4524,7 @@ impl CopyImageToBufferInfo {
                 buffer_offset,
                 buffer_row_length,
                 buffer_image_height,
-                ref image_subresource,
+                image_subresource,
                 image_offset,
                 image_extent,
                 _ne: _,
@@ -4680,11 +4705,14 @@ impl CopyImageToBufferInfo {
                     }
                 }
                 ImageType::Dim3d => {
-                    if image_subresource.array_layers != (0..1) {
+                    if !(image_subresource.base_array_layer == 0
+                        && image_subresource.layer_count == 1)
+                    {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`src_image.image_type()` is  `ImageType::Dim3d`, but \
-                                `regions[{}].image_subresource.array_layers` is not `0..1`",
+                                `(regions[{0}].image_subresource.base_array_layer, \
+                                regions[{0}].image_subresource.layer_count)` is not `(0, 1)`",
                                 region_index,
                             )
                             .into(),
@@ -4695,12 +4723,17 @@ impl CopyImageToBufferInfo {
                 }
             }
 
-            if image_subresource.array_layers.end > src_image.array_layers() {
+            if !image_subresource
+                .base_array_layer
+                .checked_add(image_subresource.layer_count)
+                .is_some_and(|end| end <= src_image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].dst_subresource.array_layers.end` is not less than \
+                        "`regions[{0}].image_subresource.base_array_layer + \
+                        regions[{0}].image_subresource.layer_count` is greater than \
                         `src_image.array_layers()`",
-                        region_index
+                        region_index,
                     )
                     .into(),
                     vuids: &["VUID-VkCopyImageToBufferInfo2-imageSubresource-07968"],
@@ -5093,7 +5126,8 @@ impl BufferImageCopy {
             image_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             image_offset: [0; 3],
             image_extent: [0; 3],
@@ -5108,7 +5142,7 @@ impl BufferImageCopy {
             buffer_offset: _,
             mut buffer_row_length,
             mut buffer_image_height,
-            ref image_subresource,
+            image_subresource,
             image_offset: _,
             mut image_extent,
             _ne: _,
@@ -5132,10 +5166,7 @@ impl BufferImageCopy {
         }
 
         // Only one of these is greater than 1, take the greater number.
-        image_extent[2] = max(
-            image_extent[2],
-            image_subresource.array_layers.end - image_subresource.array_layers.start,
-        );
+        image_extent[2] = max(image_extent[2], image_subresource.layer_count);
 
         let blocks_to_last_slice = (image_extent[2] as DeviceSize - 1)
             * buffer_image_height as DeviceSize
@@ -5152,7 +5183,7 @@ impl BufferImageCopy {
             buffer_offset: _,
             buffer_row_length,
             buffer_image_height,
-            ref image_subresource,
+            image_subresource,
             image_offset: _,
             image_extent,
             _ne: _,
@@ -5226,7 +5257,7 @@ impl BufferImageCopy {
             buffer_offset,
             buffer_row_length,
             buffer_image_height,
-            ref image_subresource,
+            image_subresource,
             image_offset,
             image_extent,
             _ne: _,
@@ -5254,7 +5285,7 @@ impl BufferImageCopy {
             buffer_offset,
             buffer_row_length,
             buffer_image_height,
-            ref image_subresource,
+            image_subresource,
             image_offset,
             image_extent,
             _ne: _,
@@ -5335,12 +5366,12 @@ impl BlitImageInfo {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());
         let region = ImageBlit {
             src_subresource: ImageSubresourceLayers {
-                array_layers: 0..min_array_layers,
+                layer_count: min_array_layers,
                 ..src_image.subresource_layers()
             },
             src_offsets: [[0; 3], src_image.extent()],
             dst_subresource: ImageSubresourceLayers {
-                array_layers: 0..min_array_layers,
+                layer_count: min_array_layers,
                 ..dst_image.subresource_layers()
             },
             dst_offsets: [[0; 3], dst_image.extent()],
@@ -5605,9 +5636,9 @@ impl BlitImageInfo {
                 .map_err(|err| err.add_context(format!("regions[{}]", region_index)))?;
 
             let &ImageBlit {
-                ref src_subresource,
+                src_subresource,
                 src_offsets,
-                ref dst_subresource,
+                dst_subresource,
                 dst_offsets,
                 _ne: _,
             } = region;
@@ -5727,11 +5758,13 @@ impl BlitImageInfo {
                     }
                 }
                 ImageType::Dim3d => {
-                    if src_subresource.array_layers != (0..1) {
+                    if !(src_subresource.base_array_layer == 0 && src_subresource.layer_count == 1)
+                    {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`src_image.image_type()` is `ImageType::Dim3d`, but \
-                                `regions[{}].src_subresource.array_layers` is not `0..1`",
+                                `(regions[{0}].src_subresource.base_array_layer, \
+                                regions[{0}].src_subresource.layer_count)` is not `(0, 1)`",
                                 region_index,
                             )
                             .into(),
@@ -5742,12 +5775,17 @@ impl BlitImageInfo {
                 }
             }
 
-            if src_subresource.array_layers.end > src_image.array_layers() {
+            if !src_subresource
+                .base_array_layer
+                .checked_add(src_subresource.layer_count)
+                .is_some_and(|end| end <= src_image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].src_subresource.array_layers.end` is not less than \
+                        "`regions[{0}].src_subresource.base_array_layer + \
+                        regions[{0}].src_subresource.layer_count` is greater than \
                         `src_image.array_layers()`",
-                        region_index
+                        region_index,
                     )
                     .into(),
                     vuids: &["VUID-VkBlitImageInfo2-srcSubresource-01707"],
@@ -5918,11 +5956,13 @@ impl BlitImageInfo {
                     }
                 }
                 ImageType::Dim3d => {
-                    if dst_subresource.array_layers != (0..1) {
+                    if !(dst_subresource.base_array_layer == 0 && dst_subresource.layer_count == 1)
+                    {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`dst_image.image_type()` is `ImageType::Dim3d`, but \
-                                `regions[{}].dst_subresource.array_layers` is not `0..1`",
+                                `(regions[{0}].dst_subresource.base_array_layer, \
+                                regions[{0}].dst_subresource.layer_count)` is not `(0, 1)`",
                                 region_index,
                             )
                             .into(),
@@ -5933,12 +5973,17 @@ impl BlitImageInfo {
                 }
             }
 
-            if dst_subresource.array_layers.end > dst_image.array_layers() {
+            if !dst_subresource
+                .base_array_layer
+                .checked_add(dst_subresource.layer_count)
+                .is_some_and(|end| end <= dst_image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].dst_subresource.array_layers.end` is not less than \
+                        "`(regions[{0}].dst_subresource.base_array_layer, \
+                        regions[{0}].dst_subresource.layer_count)` is greater than \
                         `dst_image.array_layers()`",
-                        region_index
+                        region_index,
                     )
                     .into(),
                     vuids: &["VUID-VkBlitImageInfo2-srcSubresource-01707"],
@@ -5999,7 +6044,8 @@ impl BlitImageInfo {
                 let src_region_index = region_index;
                 let src_subresource_axes = [
                     src_subresource.mip_level..src_subresource.mip_level + 1,
-                    src_subresource.array_layers.start..src_subresource.array_layers.end,
+                    src_subresource.base_array_layer
+                        ..src_subresource.base_array_layer + src_subresource.layer_count,
                 ];
                 let src_extent_axes = [
                     min(src_offsets[0][0], src_offsets[1][0])
@@ -6012,14 +6058,15 @@ impl BlitImageInfo {
 
                 for (dst_region_index, dst_region) in regions.iter().enumerate() {
                     let &ImageBlit {
-                        ref dst_subresource,
+                        dst_subresource,
                         dst_offsets,
                         ..
                     } = dst_region;
 
                     let dst_subresource_axes = [
                         dst_subresource.mip_level..dst_subresource.mip_level + 1,
-                        src_subresource.array_layers.start..src_subresource.array_layers.end,
+                        src_subresource.base_array_layer
+                            ..src_subresource.base_array_layer + src_subresource.layer_count,
                     ];
 
                     if src_subresource_axes.iter().zip(dst_subresource_axes).any(
@@ -6203,13 +6250,15 @@ impl ImageBlit {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             src_offsets: [[0; 3]; 2],
             dst_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             dst_offsets: [[0; 3]; 2],
             _ne: crate::NE,
@@ -6218,9 +6267,9 @@ impl ImageBlit {
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offsets: _,
-            ref dst_subresource,
+            dst_subresource,
             dst_offsets: _,
             _ne: _,
         } = self;
@@ -6242,10 +6291,10 @@ impl ImageBlit {
             }));
         }
 
-        if src_subresource.array_layers.len() != dst_subresource.array_layers.len() {
+        if src_subresource.layer_count != dst_subresource.layer_count {
             return Err(Box::new(ValidationError {
-                problem: "the length of `src_subresource.array_layers` does not equal \
-                    the length of `dst_subresource.array_layers`"
+                problem: "`src_subresource.layer_count` does not equal \
+                    `dst_subresource.layer_count`"
                     .into(),
                 vuids: &["VUID-VkImageBlit2-layerCount-00239"],
                 ..Default::default()
@@ -6257,9 +6306,9 @@ impl ImageBlit {
 
     pub(crate) fn to_vk2(&self) -> vk::ImageBlit2<'static> {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offsets,
-            ref dst_subresource,
+            dst_subresource,
             dst_offsets,
             _ne: _,
         } = self;
@@ -6295,9 +6344,9 @@ impl ImageBlit {
 
     pub(crate) fn to_vk(&self) -> vk::ImageBlit {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offsets,
-            ref dst_subresource,
+            dst_subresource,
             dst_offsets,
             _ne: _,
         } = self;
@@ -6382,11 +6431,11 @@ impl ResolveImageInfo {
         let min_array_layers = src_image.array_layers().min(dst_image.array_layers());
         let region = ImageResolve {
             src_subresource: ImageSubresourceLayers {
-                array_layers: 0..min_array_layers,
+                layer_count: min_array_layers,
                 ..src_image.subresource_layers()
             },
             dst_subresource: ImageSubresourceLayers {
-                array_layers: 0..min_array_layers,
+                layer_count: min_array_layers,
                 ..dst_image.subresource_layers()
             },
             extent: {
@@ -6567,9 +6616,9 @@ impl ResolveImageInfo {
                 .map_err(|err| err.add_context(format!("regions[{}]", region_index)))?;
 
             let &ImageResolve {
-                ref src_subresource,
+                src_subresource,
                 src_offset,
-                ref dst_subresource,
+                dst_subresource,
                 dst_offset,
                 extent,
                 _ne: _,
@@ -6677,11 +6726,13 @@ impl ResolveImageInfo {
                     }
                 }
                 ImageType::Dim3d => {
-                    if src_subresource.array_layers != (0..1) {
+                    if !(src_subresource.base_array_layer == 0 && src_subresource.layer_count == 1)
+                    {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`src_image.image_type()` is `ImageType::Dim3d`, but \
-                                `regions[{}].src_subresource.array_layers` is not `0..1`",
+                                `(regions[{0}].src_subresource.base_array_layer, \
+                                regions[{0}].src_subresource.layer_count)` is not `(0, 1)`",
                                 region_index,
                             )
                             .into(),
@@ -6692,12 +6743,17 @@ impl ResolveImageInfo {
                 }
             }
 
-            if src_subresource.array_layers.end > src_image.array_layers() {
+            if !src_subresource
+                .base_array_layer
+                .checked_add(src_subresource.layer_count)
+                .is_some_and(|end| end <= src_image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].src_subresource.array_layers.end` is not less than \
+                        "`regions[{0}].src_subresource.base_array_layer + \
+                        regions[{0}].src_subresource.layer_count` is greater than \
                         `src_image.array_layers()`",
-                        region_index
+                        region_index,
                     )
                     .into(),
                     vuids: &["VUID-VkResolveImageInfo2-srcSubresource-01711"],
@@ -6849,11 +6905,13 @@ impl ResolveImageInfo {
                     }
                 }
                 ImageType::Dim3d => {
-                    if dst_subresource.array_layers != (0..1) {
+                    if !(dst_subresource.base_array_layer == 0 && dst_subresource.layer_count == 1)
+                    {
                         return Err(Box::new(ValidationError {
                             problem: format!(
                                 "`dst_image.image_type()` is `ImageType::Dim3d`, but \
-                                `regions[{}].dst_subresource.array_layers` is not `0..1`",
+                                `(regions[{0}].dst_subresource.base_array_layer, \
+                                regions[{0}].dst_subresource.layer_count)` is not `(0, 1)`",
                                 region_index,
                             )
                             .into(),
@@ -6864,12 +6922,17 @@ impl ResolveImageInfo {
                 }
             }
 
-            if dst_subresource.array_layers.end > dst_image.array_layers() {
+            if !dst_subresource
+                .base_array_layer
+                .checked_add(dst_subresource.layer_count)
+                .is_some_and(|end| end <= dst_image.array_layers())
+            {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{}].dst_subresource.array_layers.end` is not less than \
+                        "`regions[{0}].dst_subresource.base_array_layer + \
+                        regions[{0}].dst_subresource.layer_count` is greater than \
                         `dst_image.array_layers()`",
-                        region_index
+                        region_index,
                     )
                     .into(),
                     vuids: &["VUID-VkResolveImageInfo2-dstSubresource-01712"],
@@ -7028,13 +7091,15 @@ impl ImageResolve {
             src_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             src_offset: [0; 3],
             dst_subresource: ImageSubresourceLayers {
                 aspects: ImageAspects::empty(),
                 mip_level: 0,
-                array_layers: 0..0,
+                base_array_layer: 0,
+                layer_count: 0,
             },
             dst_offset: [0; 3],
             extent: [0; 3],
@@ -7044,9 +7109,9 @@ impl ImageResolve {
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offset: _,
-            ref dst_subresource,
+            dst_subresource,
             dst_offset: _,
             extent: _,
             _ne: _,
@@ -7076,10 +7141,10 @@ impl ImageResolve {
             }));
         }
 
-        if src_subresource.array_layers.len() != dst_subresource.array_layers.len() {
+        if src_subresource.layer_count != dst_subresource.layer_count {
             return Err(Box::new(ValidationError {
-                problem: "the length of `src_subresource.array_layers` does not equal \
-                    the length of `dst_subresource.array_layers`"
+                problem: "`src_subresource.layer_count` does not equal \
+                    `dst_subresource.layer_count`"
                     .into(),
                 vuids: &["VUID-VkImageResolve2-layerCount-00267"],
                 ..Default::default()
@@ -7091,9 +7156,9 @@ impl ImageResolve {
 
     pub(crate) fn to_vk2(&self) -> vk::ImageResolve2<'static> {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offset,
-            ref dst_subresource,
+            dst_subresource,
             dst_offset,
             extent,
             _ne: _,
@@ -7121,9 +7186,9 @@ impl ImageResolve {
 
     pub(crate) fn to_vk(&self) -> vk::ImageResolve {
         let &Self {
-            ref src_subresource,
+            src_subresource,
             src_offset,
-            ref dst_subresource,
+            dst_subresource,
             dst_offset,
             extent,
             _ne: _,

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -4031,8 +4031,8 @@ impl CopyBufferToImageInfo {
             {
                 return Err(Box::new(ValidationError {
                     problem: format!(
-                        "`regions[{0}].dst_subresource.base_array_layer + \
-                        regions[{0}].dst_subresource.layer_count` is greater than \
+                        "`regions[{0}].image_subresource.base_array_layer + \
+                        regions[{0}].image_subresource.layer_count` is greater than \
                         `dst_image.array_layers()`",
                         region_index,
                     )

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -3604,14 +3604,17 @@ impl<L> AutoCommandBufferBuilder<L> {
 
                         for (index, element) in elements.iter().enumerate() {
                             if let Some(buffer_info) = element {
-                                let DescriptorBufferInfo { buffer, range } = buffer_info;
+                                let &DescriptorBufferInfo {
+                                    ref buffer,
+                                    offset,
+                                    range,
+                                } = buffer_info;
 
                                 let dynamic_offset = dynamic_offsets[index] as DeviceSize;
                                 let (use_ref, memory_access) = use_iter(index as u32);
 
-                                let mut range = range.clone();
-                                range.start += dynamic_offset;
-                                range.end += dynamic_offset;
+                                let range =
+                                    dynamic_offset + offset..dynamic_offset + offset + range;
 
                                 used_resources.push((
                                     use_ref,
@@ -3626,7 +3629,11 @@ impl<L> AutoCommandBufferBuilder<L> {
                     } else {
                         for (index, element) in elements.iter().enumerate() {
                             if let Some(buffer_info) = element {
-                                let DescriptorBufferInfo { buffer, range } = buffer_info;
+                                let &DescriptorBufferInfo {
+                                    ref buffer,
+                                    offset,
+                                    range,
+                                } = buffer_info;
 
                                 let (use_ref, memory_access) = use_iter(index as u32);
 
@@ -3634,7 +3641,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                                     use_ref,
                                     Resource::Buffer {
                                         buffer: buffer.clone(),
-                                        range: range.clone(),
+                                        range: offset..offset + range,
                                         memory_access,
                                     },
                                 ));
@@ -3677,7 +3684,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                                 use_ref,
                                 Resource::Image {
                                     image: image_view.image().clone(),
-                                    subresource_range: image_view.subresource_range().clone(),
+                                    subresource_range: *image_view.subresource_range(),
                                     memory_access,
                                     start_layout: image_layout,
                                     end_layout: image_layout,
@@ -3704,7 +3711,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                                 use_ref,
                                 Resource::Image {
                                     image: image_view.image().clone(),
-                                    subresource_range: image_view.subresource_range().clone(),
+                                    subresource_range: *image_view.subresource_range(),
                                     memory_access,
                                     start_layout: image_layout,
                                     end_layout: image_layout,

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -516,7 +516,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                         let &SecondaryCommandBufferImageUsage {
                             use_ref,
                             ref image,
-                            ref subresource_range,
+                            subresource_range,
                             memory_access,
                             start_layout,
                             end_layout,
@@ -531,7 +531,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             },
                             Resource::Image {
                                 image: image.clone(),
-                                subresource_range: subresource_range.clone(),
+                                subresource_range,
                                 memory_access,
                                 start_layout,
                                 end_layout,

--- a/vulkano/src/command_buffer/commands/sync.rs
+++ b/vulkano/src/command_buffer/commands/sync.rs
@@ -105,7 +105,8 @@ impl RecordingCommandBuffer {
                 dst_access: _,
                 queue_family_ownership_transfer: _,
                 buffer: _,
-                range: _,
+                offset: _,
+                size: _,
                 _ne: _,
             } = buffer_memory_barrier;
 
@@ -358,7 +359,8 @@ impl RecordingCommandBuffer {
                 dst_access: _,
                 queue_family_ownership_transfer: _,
                 buffer: _,
-                range: _,
+                offset: _,
+                size: _,
                 _ne: _,
             } = buffer_memory_barrier;
 
@@ -585,7 +587,8 @@ impl RecordingCommandBuffer {
                     dst_access: _,
                     queue_family_ownership_transfer: _,
                     buffer: _,
-                    range: _,
+                    offset: _,
+                    size: _,
                     _ne: _,
                 } = buffer_memory_barrier;
 

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -906,13 +906,13 @@ impl SubresourceRangeIterator {
         image_mip_level_size: DeviceSize,
         image_array_layers: u32,
     ) -> Self {
+        assert_ne!(subresource_range.level_count, 0);
+        assert_ne!(subresource_range.layer_count, 0);
+
         let mip_levels = subresource_range.base_mip_level
             ..subresource_range.base_mip_level + subresource_range.level_count;
         let array_layers = subresource_range.base_array_layer
             ..subresource_range.base_array_layer + subresource_range.layer_count;
-
-        assert!(!mip_levels.is_empty());
-        assert!(!array_layers.is_empty());
 
         let next_fn = if array_layers.start != 0 || array_layers.end != image_array_layers {
             Self::next_some_layers

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -1176,7 +1176,8 @@ impl RawImage {
                 }
             },
             mip_level: 0,
-            array_layers: 0..self.array_layers,
+            base_array_layer: 0,
+            layer_count: self.array_layers,
         }
     }
 
@@ -1187,8 +1188,10 @@ impl RawImage {
         ImageSubresourceRange {
             aspects: self.format.aspects()
                 - (ImageAspects::PLANE_0 | ImageAspects::PLANE_1 | ImageAspects::PLANE_2),
-            mip_levels: 0..self.mip_levels,
-            array_layers: 0..self.array_layers,
+            base_mip_level: 0,
+            level_count: self.mip_levels,
+            base_array_layer: 0,
+            layer_count: self.array_layers,
         }
     }
 
@@ -3328,8 +3331,10 @@ mod tests {
                     | ImageAspects::DEPTH
                     | ImageAspects::STENCIL
                     | ImageAspects::PLANE_0,
-                mip_levels: 0..6,
-                array_layers: 0..8,
+                base_mip_level: 0,
+                level_count: 6,
+                base_array_layer: 0,
+                layer_count: 8,
             },
             &image_aspect_list,
             asp,
@@ -3345,8 +3350,10 @@ mod tests {
         let mut iter = SubresourceRangeIterator::new(
             ImageSubresourceRange {
                 aspects: ImageAspects::COLOR | ImageAspects::DEPTH | ImageAspects::PLANE_0,
-                mip_levels: 0..6,
-                array_layers: 0..8,
+                base_mip_level: 0,
+                level_count: 6,
+                base_array_layer: 0,
+                layer_count: 8,
             },
             &image_aspect_list,
             asp,
@@ -3363,8 +3370,10 @@ mod tests {
         let mut iter = SubresourceRangeIterator::new(
             ImageSubresourceRange {
                 aspects: ImageAspects::DEPTH | ImageAspects::STENCIL,
-                mip_levels: 2..4,
-                array_layers: 0..8,
+                base_mip_level: 2,
+                level_count: 2,
+                base_array_layer: 0,
+                layer_count: 8,
             },
             &image_aspect_list,
             asp,
@@ -3380,9 +3389,10 @@ mod tests {
         let mut iter = SubresourceRangeIterator::new(
             ImageSubresourceRange {
                 aspects: ImageAspects::COLOR,
-
-                mip_levels: 0..1,
-                array_layers: 2..4,
+                base_mip_level: 0,
+                level_count: 1,
+                base_array_layer: 2,
+                layer_count: 2,
             },
             &image_aspect_list,
             asp,
@@ -3401,8 +3411,10 @@ mod tests {
         let mut iter = SubresourceRangeIterator::new(
             ImageSubresourceRange {
                 aspects: ImageAspects::DEPTH | ImageAspects::STENCIL,
-                mip_levels: 2..4,
-                array_layers: 6..8,
+                base_mip_level: 2,
+                level_count: 2,
+                base_array_layer: 6,
+                layer_count: 2,
             },
             &image_aspect_list,
             asp,

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -174,8 +174,7 @@ impl Framebuffer {
             }
 
             let image_view_extent = image_view.image().extent();
-            let image_view_array_layers = image_view.subresource_range().array_layers.end
-                - image_view.subresource_range().array_layers.start;
+            let image_view_array_layers = image_view.subresource_range().layer_count;
 
             if attachment_use.input_attachment
                 || attachment_use.color_attachment
@@ -347,7 +346,10 @@ impl Framebuffer {
     pub fn attached_layers_ranges(&self) -> SmallVec<[Range<u32>; 4]> {
         self.attachments
             .iter()
-            .map(|img| img.subresource_range().array_layers.clone())
+            .map(|img| {
+                img.subresource_range().base_array_layer
+                    ..img.subresource_range().base_array_layer + img.subresource_range().layer_count
+            })
             .collect()
     }
 }
@@ -481,8 +483,7 @@ impl<'a> FramebufferCreateInfo<'a> {
 
             for image_view in attachments.iter() {
                 let image_view_extent = image_view.image().extent();
-                let image_view_array_layers =
-                    image_view.subresource_range().array_layers.len() as u32;
+                let image_view_array_layers = image_view.subresource_range().layer_count;
 
                 auto_extent[0] = auto_extent[0].min(image_view_extent[0]);
                 auto_extent[1] = auto_extent[1].min(image_view_extent[1]);
@@ -516,8 +517,7 @@ impl<'a> FramebufferCreateInfo<'a> {
         for (index, image_view) in attachments.iter().enumerate() {
             assert_eq!(device, image_view.device().as_ref());
 
-            let image_view_mip_levels = image_view.subresource_range().mip_levels.end
-                - image_view.subresource_range().mip_levels.start;
+            let image_view_mip_levels = image_view.subresource_range().level_count;
 
             if image_view_mip_levels != 1 {
                 return Err(Box::new(ValidationError {


### PR DESCRIPTION
Besides this being more consistent with the original API and other parts of our own code base, ranges are also still unergonomic because they are unfortunately still not fixed in edition 2024 in the sense that they don't implement `Copy`. Now `ImageSubresourceRange` and the like finally implement `Copy`. I believe having a size/count like in the original API is also more ergonomic because that's what you have most of the time, resulting in a whole lot of `offset..offset + size` ugliness. It's also not uncommon to want to leave the offset/base at 0, which you can now leave the default for. Separate fields also provide us with the future possibility of making the size/count an `Option` for `None` to mean that it's unbounded.

I haven't *completely* removed ranges from public APIs because the APIs that do slicing don't have a Vulkan counterpart and ranges are well established for this purpose in Rust.

Changelog:
```markdown
### Breaking changes
Global changes:
- Where `Range` and `RangeInclusive` were previously used in parameters, two separate parameters for the offset/base and size/count are now used instead to match Vulkan.
```
