### PR TITLE
Pass `World` to the task node's clear color implementation

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -717,7 +717,7 @@ struct RenderTask {
 impl Task for RenderTask {
     type World = RenderContext;
 
-    fn clear_values(&self, clear_values: &mut ClearValues<'_>) {
+    fn clear_values(&self, clear_values: &mut ClearValues<'_>, _world: &Self::World) {
         clear_values.set(self.swapchain_id.current_image_id(), [0.0; 4]);
     }
 

--- a/examples/bloom/scene.rs
+++ b/examples/bloom/scene.rs
@@ -125,7 +125,7 @@ impl SceneTask {
 impl Task for SceneTask {
     type World = RenderContext;
 
-    fn clear_values(&self, clear_values: &mut ClearValues<'_>) {
+    fn clear_values(&self, clear_values: &mut ClearValues<'_>, _world: &Self::World) {
         clear_values.set(self.bloom_image_id, [0.0; 4]);
     }
 

--- a/examples/deferred/deferred.rs
+++ b/examples/deferred/deferred.rs
@@ -54,7 +54,7 @@ impl DeferredTask {
 impl Task for DeferredTask {
     type World = RenderContext;
 
-    fn clear_values(&self, clear_values: &mut ClearValues<'_>) {
+    fn clear_values(&self, clear_values: &mut ClearValues<'_>, _world: &Self::World) {
         clear_values.set(self.swapchain_id.current_image_id(), [0.0; 4]);
     }
 

--- a/examples/deferred/scene.rs
+++ b/examples/deferred/scene.rs
@@ -149,7 +149,7 @@ impl SceneTask {
 impl Task for SceneTask {
     type World = RenderContext;
 
-    fn clear_values(&self, clear_values: &mut ClearValues<'_>) {
+    fn clear_values(&self, clear_values: &mut ClearValues<'_>, _world: &Self::World) {
         clear_values.set(self.diffuse_image_id, [0.0; 4]);
         clear_values.set(self.normals_image_id, [0.0; 4]);
         clear_values.set(self.depth_image_id, 1.0);

--- a/vulkano-taskgraph/src/lib.rs
+++ b/vulkano-taskgraph/src/lib.rs
@@ -147,7 +147,7 @@ pub trait Task: Any + Send + Sync {
     /// [set to be cleared]: graph::AttachmentInfo::clear
     /// [`execute`]: Self::execute
     #[allow(unused)]
-    fn clear_values(&self, clear_values: &mut ClearValues<'_>) {}
+    fn clear_values(&self, clear_values: &mut ClearValues<'_>, world: &Self::World) {}
 
     /// Executes the task, which should record its commands using the provided command buffer and
     /// context.


### PR DESCRIPTION
Provides access to a task node's `World` in the `clear_color()` implementation. I ran into this when trying to dynamically change the clear color of an image at runtime.

Changelog:
```markdown
### Breaking changes
Changes to `Task` trait:
- Added a `&Self::World` parameter to `clear_values()`.
```