### PR TITLE
Implement `Default` for `ImageSubresource*`, deprecations and maintenance

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -965,9 +965,7 @@ impl Task for UploadTask {
             regions: &[BufferImageCopy {
                 image_subresource: ImageSubresourceLayers {
                     aspects: ImageAspects::COLOR,
-                    mip_level: 0,
-                    base_array_layer: 0,
-                    layer_count: 1,
+                    ..Default::default()
                 },
                 image_offset: CORNER_OFFSETS[current_corner % 4],
                 image_extent: [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 1],
@@ -983,9 +981,7 @@ impl Task for UploadTask {
                 regions: &[BufferImageCopy {
                     image_subresource: ImageSubresourceLayers {
                         aspects: ImageAspects::COLOR,
-                        mip_level: 0,
-                        base_array_layer: 0,
-                        layer_count: 1,
+                        ..Default::default()
                     },
                     image_offset: CORNER_OFFSETS[(current_corner - 1) % 4],
                     image_extent: [TRANSFER_GRANULARITY, TRANSFER_GRANULARITY, 1],

--- a/examples/bloom/main.rs
+++ b/examples/bloom/main.rs
@@ -507,8 +507,6 @@ fn window_size_dependent_setup(
         .unwrap();
 
     let bloom_storage_image_ids = array::from_fn(|mip_level| {
-        let mip_level = cmp::min(mip_level as u32, max_mip_levels(extent) - 1);
-
         bcx.global_set()
             .create_storage_image(
                 bloom_image_id,
@@ -516,10 +514,8 @@ fn window_size_dependent_setup(
                     format: Format::R32_UINT,
                     subresource_range: ImageSubresourceRange {
                         aspects: ImageAspects::COLOR,
-                        base_mip_level: mip_level,
-                        level_count: 1,
-                        base_array_layer: 0,
-                        layer_count: 1,
+                        base_mip_level: cmp::min(mip_level as u32, max_mip_levels(extent) - 1),
+                        ..Default::default()
                     },
                     usage: ImageUsage::STORAGE,
                     ..Default::default()

--- a/vulkano-taskgraph/src/command_buffer/commands/copy.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/copy.rs
@@ -9,7 +9,7 @@ use std::cmp;
 use vulkano::{
     buffer::Buffer,
     device::DeviceOwned,
-    image::{sampler::Filter, Image, ImageAspects, ImageSubresourceLayers},
+    image::{sampler::Filter, Image, ImageSubresourceLayers},
     DeviceSize, Version, VulkanObject,
 };
 
@@ -1143,7 +1143,7 @@ impl CopyImageInfo<'_> {
 pub struct ImageCopy<'a> {
     /// The subresource of `src_image` to copy from.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub src_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `src_image` that copying will start from.
@@ -1153,7 +1153,7 @@ pub struct ImageCopy<'a> {
 
     /// The subresource of `dst_image` to copy to.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub dst_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `dst_image` that copying will start from.
@@ -1178,22 +1178,13 @@ impl Default for ImageCopy<'_> {
 
 impl ImageCopy<'_> {
     /// Returns a default `ImageCopy`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            src_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            src_subresource: ImageSubresourceLayers::default(),
             src_offset: [0; 3],
-            dst_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            dst_subresource: ImageSubresourceLayers::default(),
             dst_offset: [0; 3],
             extent: [0; 3],
             _ne: crate::NE,
@@ -1321,7 +1312,7 @@ pub struct BufferImageCopy<'a> {
 
     /// The subresource of the image to copy from/to.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub image_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of the image that copying will start from.
@@ -1346,18 +1337,14 @@ impl Default for BufferImageCopy<'_> {
 
 impl BufferImageCopy<'_> {
     /// Returns a default `BufferImageCopy`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             buffer_offset: 0,
             buffer_row_length: 0,
             buffer_image_height: 0,
-            image_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            image_subresource: ImageSubresourceLayers::default(),
             image_offset: [0; 3],
             image_extent: [0; 3],
             _ne: crate::NE,
@@ -1433,7 +1420,7 @@ impl BlitImageInfo<'_> {
 pub struct ImageBlit<'a> {
     /// The subresource of `src_image` to blit from.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub src_subresource: ImageSubresourceLayers,
 
     /// The offsets from the zero coordinate of `src_image`, defining two corners of the region
@@ -1446,7 +1433,7 @@ pub struct ImageBlit<'a> {
 
     /// The subresource of `dst_image` to blit to.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub dst_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `dst_image` defining two corners of the
@@ -1469,22 +1456,13 @@ impl Default for ImageBlit<'_> {
 
 impl ImageBlit<'_> {
     /// Returns a default `ImageBlit`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            src_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            src_subresource: ImageSubresourceLayers::default(),
             src_offsets: [[0; 3]; 2],
-            dst_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            dst_subresource: ImageSubresourceLayers::default(),
             dst_offsets: [[0; 3]; 2],
             _ne: crate::NE,
         }
@@ -1551,7 +1529,7 @@ impl ResolveImageInfo<'_> {
 pub struct ImageResolve<'a> {
     /// The subresource of `src_image` to resolve from.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub src_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `src_image` that resolving will start from.
@@ -1561,7 +1539,7 @@ pub struct ImageResolve<'a> {
 
     /// The subresource of `dst_image` to resolve into.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub dst_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `dst_image` that resolving will start from.
@@ -1586,22 +1564,13 @@ impl Default for ImageResolve<'_> {
 
 impl ImageResolve<'_> {
     /// Returns a default `ImageResolve`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            src_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            src_subresource: ImageSubresourceLayers::default(),
             src_offset: [0; 3],
-            dst_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            dst_subresource: ImageSubresourceLayers::default(),
             dst_offset: [0; 3],
             extent: [0; 3],
             _ne: crate::NE,

--- a/vulkano-taskgraph/src/command_buffer/commands/sync.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/sync.rs
@@ -7,7 +7,7 @@ use smallvec::SmallVec;
 use vulkano::{
     buffer::Buffer,
     device::DeviceOwned,
-    image::{Image, ImageAspects, ImageLayout, ImageSubresourceRange},
+    image::{Image, ImageLayout, ImageSubresourceRange},
     sync::{AccessFlags, DependencyFlags, PipelineStages},
     DeviceSize, Version, VulkanObject,
 };
@@ -465,7 +465,7 @@ pub struct ImageMemoryBarrier<'a> {
     /// The layout that the specified `subresource_range` of `image` will be transitioned to before
     /// the destination scope begins.
     ///
-    /// The default value is [`ImageLayout::Undefined`].
+    /// The default value is [`ImageLayout::Undefined`], which must be overridden.
     pub new_layout: ImageLayout,
 
     /// The image to apply the barrier to.
@@ -475,7 +475,7 @@ pub struct ImageMemoryBarrier<'a> {
 
     /// The subresource range of `image` to apply the barrier to.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceRange::default()`].
     pub subresource_range: ImageSubresourceRange,
 
     pub _ne: crate::NonExhaustive<'a>,
@@ -490,8 +490,9 @@ impl Default for ImageMemoryBarrier<'_> {
 
 impl ImageMemoryBarrier<'_> {
     /// Returns a default `ImageMemoryBarrier`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             src_stages: PipelineStages::empty(),
             src_access: AccessFlags::empty(),
@@ -500,13 +501,7 @@ impl ImageMemoryBarrier<'_> {
             old_layout: ImageLayout::Undefined,
             new_layout: ImageLayout::Undefined,
             image: Id::INVALID,
-            subresource_range: ImageSubresourceRange {
-                aspects: ImageAspects::empty(),
-                base_mip_level: 0,
-                level_count: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            subresource_range: ImageSubresourceRange::default(),
             _ne: crate::NE,
         }
     }

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -3481,7 +3481,7 @@ pub(crate) struct CopyImageInfoVk {
 pub struct ImageCopy {
     /// The subresource of `src_image` to copy from.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub src_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `src_image` that copying will start from.
@@ -3491,7 +3491,7 @@ pub struct ImageCopy {
 
     /// The subresource of `dst_image` to copy to.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub dst_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `dst_image` that copying will start from.
@@ -3516,22 +3516,13 @@ impl Default for ImageCopy {
 
 impl ImageCopy {
     /// Returns a default `ImageCopy`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            src_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            src_subresource: ImageSubresourceLayers::default(),
             src_offset: [0; 3],
-            dst_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            dst_subresource: ImageSubresourceLayers::default(),
             dst_offset: [0; 3],
             extent: [0; 3],
             _ne: crate::NE,
@@ -5092,7 +5083,7 @@ pub struct BufferImageCopy {
 
     /// The subresource of the image to copy from/to.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub image_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of the image that copying will start from.
@@ -5117,18 +5108,14 @@ impl Default for BufferImageCopy {
 
 impl BufferImageCopy {
     /// Returns a default `BufferImageCopy`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             buffer_offset: 0,
             buffer_row_length: 0,
             buffer_image_height: 0,
-            image_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            image_subresource: ImageSubresourceLayers::default(),
             image_offset: [0; 3],
             image_extent: [0; 3],
             _ne: crate::NE,
@@ -6208,7 +6195,7 @@ pub(crate) struct BlitImageInfoVk {
 pub struct ImageBlit {
     /// The subresource of `src_image` to blit from.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub src_subresource: ImageSubresourceLayers,
 
     /// The offsets from the zero coordinate of `src_image`, defining two corners of the region
@@ -6221,7 +6208,7 @@ pub struct ImageBlit {
 
     /// The subresource of `dst_image` to blit to.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub dst_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `dst_image` defining two corners of the
@@ -6244,22 +6231,13 @@ impl Default for ImageBlit {
 
 impl ImageBlit {
     /// Returns a default `ImageBlit`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            src_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            src_subresource: ImageSubresourceLayers::default(),
             src_offsets: [[0; 3]; 2],
-            dst_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            dst_subresource: ImageSubresourceLayers::default(),
             dst_offsets: [[0; 3]; 2],
             _ne: crate::NE,
         }
@@ -7050,7 +7028,7 @@ pub(crate) struct ResolveImageInfoVk {
 pub struct ImageResolve {
     /// The subresource of `src_image` to resolve from.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub src_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `src_image` that resolving will start from.
@@ -7060,7 +7038,7 @@ pub struct ImageResolve {
 
     /// The subresource of `dst_image` to resolve into.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceLayers::default()`].
     pub dst_subresource: ImageSubresourceLayers,
 
     /// The offset from the zero coordinate of `dst_image` that resolving will start from.
@@ -7085,22 +7063,13 @@ impl Default for ImageResolve {
 
 impl ImageResolve {
     /// Returns a default `ImageResolve`.
+    // TODO: make const
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
-            src_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            src_subresource: ImageSubresourceLayers::default(),
             src_offset: [0; 3],
-            dst_subresource: ImageSubresourceLayers {
-                aspects: ImageAspects::empty(),
-                mip_level: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            dst_subresource: ImageSubresourceLayers::default(),
             dst_offset: [0; 3],
             extent: [0; 3],
             _ne: crate::NE,

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -1175,23 +1175,21 @@ impl RawImage {
                     aspects
                 }
             },
-            mip_level: 0,
-            base_array_layer: 0,
             layer_count: self.array_layers,
+            ..Default::default()
         }
     }
 
     /// Returns an `ImageSubresourceRange` covering the whole image. If the image is multi-planar,
-    /// only the `color` aspect is selected.
+    /// only the `COLOR` aspect is selected.
     #[inline]
     pub fn subresource_range(&self) -> ImageSubresourceRange {
         ImageSubresourceRange {
             aspects: self.format.aspects()
                 - (ImageAspects::PLANE_0 | ImageAspects::PLANE_1 | ImageAspects::PLANE_2),
-            base_mip_level: 0,
             level_count: self.mip_levels,
-            base_array_layer: 0,
             layer_count: self.array_layers,
+            ..Default::default()
         }
     }
 
@@ -1201,7 +1199,7 @@ impl RawImage {
     /// depth and a stencil format. Images with optimal tiling have an opaque image layout that is
     /// not suitable for direct memory accesses, and likewise for combined depth/stencil formats.
     /// Multi-planar formats are supported, but you must specify one of the planes as the `aspect`,
-    /// not [`ImageAspect::Color`].
+    /// not [`ImageAspect::COLOR`].
     ///
     /// The results of this function are cached, so that future calls with the same arguments
     /// do not need to make a call to the Vulkan API again.
@@ -3331,10 +3329,9 @@ mod tests {
                     | ImageAspects::DEPTH
                     | ImageAspects::STENCIL
                     | ImageAspects::PLANE_0,
-                base_mip_level: 0,
                 level_count: 6,
-                base_array_layer: 0,
                 layer_count: 8,
+                ..Default::default()
             },
             &image_aspect_list,
             asp,
@@ -3350,10 +3347,9 @@ mod tests {
         let mut iter = SubresourceRangeIterator::new(
             ImageSubresourceRange {
                 aspects: ImageAspects::COLOR | ImageAspects::DEPTH | ImageAspects::PLANE_0,
-                base_mip_level: 0,
                 level_count: 6,
-                base_array_layer: 0,
                 layer_count: 8,
+                ..Default::default()
             },
             &image_aspect_list,
             asp,
@@ -3372,8 +3368,8 @@ mod tests {
                 aspects: ImageAspects::DEPTH | ImageAspects::STENCIL,
                 base_mip_level: 2,
                 level_count: 2,
-                base_array_layer: 0,
                 layer_count: 8,
+                ..Default::default()
             },
             &image_aspect_list,
             asp,
@@ -3389,10 +3385,10 @@ mod tests {
         let mut iter = SubresourceRangeIterator::new(
             ImageSubresourceRange {
                 aspects: ImageAspects::COLOR,
-                base_mip_level: 0,
                 level_count: 1,
                 base_array_layer: 2,
                 layer_count: 2,
+                ..Default::default()
             },
             &image_aspect_list,
             asp,

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -818,7 +818,7 @@ pub struct ImageViewCreateInfo<'a> {
 
     /// The subresource range of the image that the view should cover.
     ///
-    /// The default value is empty, which must be overridden.
+    /// The default value is [`ImageSubresourceRange::default()`].
     pub subresource_range: ImageSubresourceRange,
 
     /// How the image view is going to be used.
@@ -862,18 +862,12 @@ impl Default for ImageViewCreateInfo<'_> {
 impl<'a> ImageViewCreateInfo<'a> {
     /// Returns a default `ImageViewCreateInfo`.
     #[inline]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             view_type: ImageViewType::Dim2d,
             format: Format::UNDEFINED,
             component_mapping: ComponentMapping::identity(),
-            subresource_range: ImageSubresourceRange {
-                aspects: ImageAspects::empty(),
-                base_mip_level: 0,
-                level_count: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            subresource_range: ImageSubresourceRange::default(),
             usage: ImageUsage::empty(),
             sampler_ycbcr_conversion: None,
             _ne: crate::NE,

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -343,6 +343,7 @@ impl Framebuffer {
 
     /// Returns the layer ranges for all attachments.
     #[inline]
+    #[deprecated(since = "0.36.0")]
     pub fn attached_layers_ranges(&self) -> SmallVec<[Range<u32>; 4]> {
         self.attachments
             .iter()

--- a/vulkano/src/sync/pipeline.rs
+++ b/vulkano/src/sync/pipeline.rs
@@ -3299,30 +3299,43 @@ pub struct ImageMemoryBarrier {
 
     /// The memory accesses in the destination scope that must wait for `src_access` to be made
     /// available and visible.
+    ///
+    /// The default value is [`AccessFlags::empty()`].
     pub dst_access: AccessFlags,
 
     /// The layout that the specified `subresource_range` of `image` is expected to be in when the
     /// source scope completes.
+    ///
+    /// The default value is [`ImageLayout::Undefined`].
     pub old_layout: ImageLayout,
 
     /// The layout that the specified `subresource_range` of `image` will be transitioned to before
     /// the destination scope begins.
+    ///
+    /// The default value is [`ImageLayout::Undefined`], which must be overridden.
     pub new_layout: ImageLayout,
 
     /// For resources created with [`Sharing::Exclusive`](crate::sync::Sharing), transfers
     /// ownership of a resource from one queue family to another.
+    ///
+    /// The default value is `None`.
     pub queue_family_ownership_transfer: Option<QueueFamilyOwnershipTransfer>,
 
     /// The image to apply the barrier to.
+    ///
+    /// There is no default value.
     pub image: Arc<Image>,
 
     /// The subresource range of `image` to apply the barrier to.
+    ///
+    /// The default value is [`ImageSubresourceRange::default()`].
     pub subresource_range: ImageSubresourceRange,
 
     pub _ne: crate::NonExhaustive<'static>,
 }
 
 impl ImageMemoryBarrier {
+    // TODO: make const
     #[inline]
     pub fn image(image: Arc<Image>) -> Self {
         Self {
@@ -3334,14 +3347,7 @@ impl ImageMemoryBarrier {
             new_layout: ImageLayout::Undefined,
             queue_family_ownership_transfer: None,
             image,
-            subresource_range: ImageSubresourceRange {
-                // Can't use image format aspects because `color` can't be specified with `planeN`.
-                aspects: ImageAspects::empty(),
-                base_mip_level: 0,
-                level_count: 0,
-                base_array_layer: 0,
-                layer_count: 0,
-            },
+            subresource_range: ImageSubresourceRange::default(),
             _ne: crate::NE,
         }
     }


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
Global changes:
- All structs containing `ImageSubresourceLayers` and `ImageSubresourceRange` use have `Default::default()` as the default value for that field, instead of an empty value (all zeroes).

### Additions
- `ImageSubresourceLayers` and `ImageSubresourceRange` now implement `Default`.
```
