### PR TITLE
Switch to new CI and use Nix in workflows

### DIFF
--- a/.ci/set-executable.sh
+++ b/.ci/set-executable.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s globstar nullglob
+
+# This script searches the `~/.cargo/target` folder for any `exe` files and sets their executable
+# bit. This is a hacky workaround for the fact that rustc's MSVC target doesn't set the bit when
+# cross-compiling from within WSL even though the files are stored on the Linux filesystem and can't
+# be executed from within WSL otherwise.
+
+for exe in ~/.cargo/target/**/*.exe; do
+  chmod +x "$exe"
+done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,72 +8,61 @@ on:
     paths-ignore:
       - '**.md'
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
   build:
     strategy:
       matrix:
         include:
         - name: windows-latest
-          runs-on: [self-hosted, Windows]
+          runs-on: [self-hosted, Windows, 25.05]
           self-hosted: true
+          shell: wsl -e wsl-bash {0}
+          target: x86_64-pc-windows-msvc
         - name: ubuntu-latest
           runs-on: ubuntu-latest
           self-hosted: false
+          shell: bash
+          target: x86_64-unknown-linux-gnu
         - name: macos-latest
           runs-on: macos-latest
           self-hosted: false
+          shell: bash
+          target: aarch64-apple-darwin
       fail-fast: false
     name: build / ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    env:
+      common_args: --target ${{ matrix.target }} --profile CI --color always --verbose
     steps:
     - uses: actions/checkout@v4
-    - run: rustup toolchain install stable
+    - uses: cachix/install-nix-action@v31
+      if: ${{ ! matrix.self-hosted }}
     - uses: Swatinem/rust-cache@v2
       if: ${{ ! matrix.self-hosted }}
       with:
         shared-key: ${{ matrix.name }}
+    - name: Run clippy
+      run: nix develop .#CI -c cargo clippy ${{ env.common_args }} -- -Dwarnings
     - name: Build tests
-      run: cargo build --profile=CI --verbose --tests
-    - name: Run tests
-      run: cargo test --profile=CI --verbose
+      run: nix develop .#CI -c cargo build ${{ env.common_args }} --tests
     - name: Build examples
-      run: cargo build --profile=CI --verbose --bins
-  clippy:
-    strategy:
-      matrix:
-        include:
-        - name: windows-latest
-          runs-on: [self-hosted, Windows]
-          self-hosted: true
-        - name: ubuntu-latest
-          runs-on: ubuntu-latest
-          self-hosted: false
-        - name: macos-latest
-          runs-on: macos-latest
-          self-hosted: false
-      fail-fast: false
-    name: clippy / ${{ matrix.name }}
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-    - uses: actions/checkout@v4
-    - run: rustup toolchain install stable --component clippy
-    - uses: Swatinem/rust-cache@v2
-      if: ${{ ! matrix.self-hosted }}
-      with:
-        shared-key: ${{ matrix.name }}
-        save-if: false
-    - name: Run clippy check
-      run: cargo clippy --profile=CI -- -Dwarnings
+      run: nix develop .#CI -c cargo build ${{ env.common_args }} --bins
+    # HACK: rustc's MSVC target doesn't set the generated `exe`s' executable bit even though the
+    # Windows runner is cross-compiling from within WSL and can't run the `exe`s otherwise.
+    - run: .ci/set-executable.sh
+      if: ${{ matrix.self-hosted }}
+    - name: Run tests
+      run: nix develop .#CI -c cargo test ${{ env.common_args }}
   fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - run: rustup toolchain install nightly --component rustfmt
+    - uses: cachix/install-nix-action@v31
     - name: Run fmt check
-      run: cargo +nightly fmt --check
+      run: nix develop .#CI -c cargo fmt --check
   typos:
     runs-on: ubuntu-latest
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,32 @@
           SHADERC_LIB_DIR = lib.makeLibraryPath [ shaderc ];
           VK_LAYER_PATH = "${vulkan-validation-layers}/share/vulkan/explicit_layer.d";
         };
+        devShells.CI = with pkgs; mkShell rec {
+          buildInputs = [
+            (rust-bin.stable.latest.minimal.override {
+              extensions = [ "clippy" ];
+              # Windows CI unfortunately needs to cross-compile from within WSL because Nix doesn't
+              # work on Windows.
+              targets = [ "x86_64-pc-windows-msvc" ];
+            })
+            # We use nightly rustfmt features.
+            (rust-bin.selectLatestNightlyWith (toolchain: toolchain.rustfmt))
+
+            # Vulkan dependencies
+            shaderc
+
+            # winit dependencies
+            libxkbcommon
+            wayland
+            xorg.libX11
+            xorg.libXcursor
+            xorg.libXi
+            xorg.libXrandr
+          ];
+
+          LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+          SHADERC_LIB_DIR = lib.makeLibraryPath [ shaderc ];
+        };
       }
     );
 }


### PR DESCRIPTION
This moves us to the new and shiny CI we've been setting up. The main benefit is reliability due to the amazing new hardware. We also set up Nix for reproducibility: no more Clippy errors in CI that don't happen locally because CI has updated Rust. That means that I also removed the separate Clippy jobs because the only reason I made them separate was so that we can ignore them precisely because of the aforementioned issue.