### PR TITLE
Use not mutable reference for get_additional_image_view

### DIFF
--- a/vulkano-util/src/renderer.rs
+++ b/vulkano-util/src/renderer.rs
@@ -241,7 +241,7 @@ impl VulkanoWindowRenderer {
 
     /// Get additional image view by key.
     #[inline]
-    pub fn get_additional_image_view(&mut self, key: usize) -> Arc<ImageView> {
+    pub fn get_additional_image_view(&self, key: usize) -> Arc<ImageView> {
         self.additional_image_views.get(&key).unwrap().clone()
     }
 


### PR DESCRIPTION
Mutable reference is useless to just get the additional image view and add rust complexity, I think it's just a mistake