### PR TITLE
Remove vulkano build-dependencies

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -36,17 +36,6 @@ raw-window-metal = { workspace = true }
 x11-dl = { workspace = true, optional = true }
 x11rb = { workspace = true, features = ["allow-unsafe-code"], optional = true }
 
-[build-dependencies]
-foldhash = { workspace = true }
-heck = { workspace = true }
-indexmap = { workspace = true }
-nom = { workspace = true }
-proc-macro2 = { workspace = true }
-quote = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-vk-parse = { workspace = true }
-
 [dev-dependencies]
 libc = "0.2.153"
 


### PR DESCRIPTION
These are not used anymore following #2679 .

Fixes #2712 .