### PR TITLE
Update build dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750994206,
-        "narHash": "sha256-3u6rEbIX9CN/5A5/mc3u0wIO1geZ0EhjvPBXmRDHqWM=",
+        "lastModified": 1755175540,
+        "narHash": "sha256-V0j2S1r25QnbqBLzN2Rg/dKKil789bI3P3id7bDPVc4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "80d50fc87924c2a0d346372d242c27973cf8cdbf",
+        "rev": "a595dde4d0d31606e19dcec73db02279db59d201",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751165203,
-        "narHash": "sha256-3QhlpAk2yn+ExwvRLtaixWsVW1q3OX3KXXe0l8VMLl4=",
+        "lastModified": 1755225702,
+        "narHash": "sha256-i7Rgs943NqX0RgQW0/l1coi8eWBj3XhxVggMpjjzTsk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "90f547b90e73d3c6025e66c5b742d6db51c418c3",
+        "rev": "4abaeba6b176979be0da0195b9e4ce86bc501ae4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -59,17 +59,6 @@
 
             # Vulkan dependencies
             shaderc
-
-            # OpenGL dependencies (needed for the gl-interop example)
-            libGL
-
-            # winit dependencies
-            libxkbcommon
-            wayland
-            xorg.libX11
-            xorg.libXcursor
-            xorg.libXi
-            xorg.libXrandr
           ];
 
           LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;

--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -1127,7 +1127,7 @@ impl AccelerationStructureGeometryAabbsData {
 /// Specifies two opposing corners of an axis-aligned bounding box.
 ///
 /// Each value in `min` must be less than or equal to the corresponding value in `max`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Zeroable, Pod)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[repr(C)]
 pub struct AabbPositions {
     /// The minimum of the corner coordinates of the bounding box.
@@ -1140,6 +1140,9 @@ pub struct AabbPositions {
     /// The default value is `[0.0; 3]`.
     pub max: [f32; 3],
 }
+
+unsafe impl Pod for AabbPositions {}
+unsafe impl Zeroable for AabbPositions {}
 
 /// A top-level geometry consisting of instances of bottom-level acceleration structures.
 #[derive(Clone, Debug)]
@@ -1259,7 +1262,7 @@ impl From<Subbuffer<[DeviceSize]>> for AccelerationStructureGeometryInstancesDat
 
 /// Specifies a bottom-level acceleration structure instance when
 /// building a top-level structure.
-#[derive(Clone, Copy, Debug, PartialEq, Zeroable, Pod)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C)]
 pub struct AccelerationStructureInstance {
     /// A 3x4 transformation matrix to be applied to the bottom-level acceleration structure.
@@ -1288,6 +1291,9 @@ pub struct AccelerationStructureInstance {
     /// The default value is 0 (null).
     pub acceleration_structure_reference: DeviceAddress,
 }
+
+unsafe impl Pod for AccelerationStructureInstance {}
+unsafe impl Zeroable for AccelerationStructureInstance {}
 
 impl Default for AccelerationStructureInstance {
     #[inline]
@@ -1355,7 +1361,7 @@ impl From<GeometryInstanceFlags> for u8 {
 }
 
 /// Counts and offsets for an acceleration structure build operation.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Zeroable, Pod)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct AccelerationStructureBuildRangeInfo {
     /// The number of primitives.
@@ -1384,6 +1390,9 @@ pub struct AccelerationStructureBuildRangeInfo {
     /// The default value is 0.
     pub transform_offset: u32,
 }
+
+unsafe impl Pod for AccelerationStructureBuildRangeInfo {}
+unsafe impl Zeroable for AccelerationStructureBuildRangeInfo {}
 
 impl AccelerationStructureBuildRangeInfo {
     #[allow(clippy::wrong_self_convention)]

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -1308,9 +1308,12 @@ mod tests {
         assert!(buffer.memory_offset() >= 17);
 
         {
-            #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+            #[derive(Clone, Copy)]
             #[repr(C, align(16))]
             struct Test([u8; 16]);
+
+            unsafe impl bytemuck::Pod for Test {}
+            unsafe impl bytemuck::Zeroable for Test {}
 
             let aligned = buffer.clone().cast_aligned::<Test>();
             assert_eq!(aligned.memory_offset() % 16, 0);

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -147,12 +147,15 @@ mod traits;
 ///   [`max_compute_work_group_count`](DeviceProperties::max_compute_work_group_count) device
 ///   limit.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DispatchIndirectCommand {
     pub x: u32,
     pub y: u32,
     pub z: u32,
 }
+
+unsafe impl Pod for DispatchIndirectCommand {}
+unsafe impl Zeroable for DispatchIndirectCommand {}
 
 /// Used as buffer contents to provide input for the
 /// [`AutoCommandBufferBuilder::draw_indirect`] command.
@@ -169,13 +172,16 @@ pub struct DispatchIndirectCommand {
 ///   [`supports_non_zero_first_instance`](DeviceProperties::supports_non_zero_first_instance)
 ///   device property is `false`, then `first_instance` must be `0`.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DrawIndirectCommand {
     pub vertex_count: u32,
     pub instance_count: u32,
     pub first_vertex: u32,
     pub first_instance: u32,
 }
+
+unsafe impl Pod for DrawIndirectCommand {}
+unsafe impl Zeroable for DrawIndirectCommand {}
 
 /// Used as buffer contents to provide input for the
 /// [`AutoCommandBufferBuilder::draw_mesh_tasks_indirect`] command.
@@ -195,12 +201,15 @@ pub struct DrawIndirectCommand {
 ///   [`max_task_work_group_total_count`](DeviceProperties::max_task_work_group_total_count) device
 ///   limit.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DrawMeshTasksIndirectCommand {
     pub group_count_x: u32,
     pub group_count_y: u32,
     pub group_count_z: u32,
 }
+
+unsafe impl Pod for DrawMeshTasksIndirectCommand {}
+unsafe impl Zeroable for DrawMeshTasksIndirectCommand {}
 
 /// Used as buffer contents to provide input for the
 /// [`AutoCommandBufferBuilder::draw_indexed_indirect`] command.
@@ -222,7 +231,7 @@ pub struct DrawMeshTasksIndirectCommand {
 ///   [`supports_non_zero_first_instance`](DeviceProperties::supports_non_zero_first_instance)
 ///   device property is `false`, then `first_instance` must be `0`.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, Zeroable, Pod, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DrawIndexedIndirectCommand {
     pub index_count: u32,
     pub instance_count: u32,
@@ -230,6 +239,9 @@ pub struct DrawIndexedIndirectCommand {
     pub vertex_offset: u32,
     pub first_instance: u32,
 }
+
+unsafe impl Pod for DrawIndexedIndirectCommand {}
+unsafe impl Zeroable for DrawIndexedIndirectCommand {}
 
 vulkan_enum! {
     #[non_exhaustive]

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -210,9 +210,12 @@ impl StridedDeviceAddressRegion {
 /// and 8 bytes in the most significant bits of that memory,
 /// occupying a single [`u32`] in total.
 // NOTE: This is copied from Ash, but duplicated here so that we can implement traits on it.
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug, Zeroable, Pod)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug)]
 #[repr(transparent)]
 pub struct Packed24_8(u32);
+
+unsafe impl Pod for Packed24_8 {}
+unsafe impl Zeroable for Packed24_8 {}
 
 impl Packed24_8 {
     /// Returns a new `Packed24_8` value.

--- a/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/impl_vertex.rs
@@ -166,13 +166,17 @@ mod tests {
     #[allow(deprecated)]
     fn impl_vertex() {
         #[repr(C)]
-        #[derive(Clone, Copy, Debug, Default, Zeroable, Pod)]
+        #[derive(Clone, Copy, Debug, Default)]
         struct TestVertex {
             matrix: [f32; 16],
             vector: [f32; 4],
             scalar: u16,
             _padding: u16,
         }
+
+        unsafe impl Pod for TestVertex {}
+        unsafe impl Zeroable for TestVertex {}
+
         impl_vertex!(TestVertex, scalar, vector, matrix);
 
         let info = TestVertex::per_vertex();

--- a/vulkano/src/pipeline/graphics/vertex_input/vertex.rs
+++ b/vulkano/src/pipeline/graphics/vertex_input/vertex.rs
@@ -117,12 +117,15 @@ mod tests {
     #[test]
     fn derive_vertex_multiple_names() {
         #[repr(C)]
-        #[derive(Clone, Copy, Debug, Default, Zeroable, Pod, Vertex)]
+        #[derive(Clone, Copy, Debug, Default, Vertex)]
         struct TestVertex {
             #[name("b", "c")]
             #[format(R32G32B32A32_SFLOAT)]
             a: [f32; 16],
         }
+
+        unsafe impl Pod for TestVertex {}
+        unsafe impl Zeroable for TestVertex {}
 
         let info = TestVertex::per_vertex();
         let b = info.members.get("b").unwrap();
@@ -136,11 +139,14 @@ mod tests {
     #[test]
     fn derive_vertex_format() {
         #[repr(C)]
-        #[derive(Clone, Copy, Debug, Default, Zeroable, Pod, Vertex)]
+        #[derive(Clone, Copy, Debug, Default, Vertex)]
         struct TestVertex {
             #[format(R8_UNORM)]
             unorm: u8,
         }
+
+        unsafe impl Pod for TestVertex {}
+        unsafe impl Zeroable for TestVertex {}
 
         let info = TestVertex::per_instance();
         let unorm = info.members.get("unorm").unwrap();

--- a/vulkano/src/pipeline/shader/mod.rs
+++ b/vulkano/src/pipeline/shader/mod.rs
@@ -471,13 +471,11 @@ impl<'a> PipelineShaderStageCreateInfo<'a> {
                 stage_enum,
                 ShaderStage::Compute | ShaderStage::Mesh | ShaderStage::Task
             ) && workgroup_size
-                > required_subgroup_size
-                    .checked_mul(
-                        properties
-                            .max_compute_workgroup_subgroups
-                            .unwrap_or_default(),
-                    )
-                    .unwrap_or(u32::MAX)
+                > required_subgroup_size.saturating_mul(
+                    properties
+                        .max_compute_workgroup_subgroups
+                        .unwrap_or_default(),
+                )
             {
                 return Err(Box::new(ValidationError {
                     problem: "the product of the `local_size_x`, `local_size_y` and \


### PR DESCRIPTION
I removed the bytemuck derives because they were causing warnings with the new toolchain and I wanted to remove them anyway because we have no business pulling in derive macro crate just for that.