### PR TITLE
Remove useless `DescriptorPoolCreateInfo::pool_sizes` validation

### DIFF
--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -785,20 +785,6 @@ mod tests {
     }
 
     #[test]
-    fn zero_descriptors() {
-        let (device, _) = gfx_dev_and_queue!();
-
-        DescriptorPool::new(
-            &device,
-            &DescriptorPoolCreateInfo {
-                max_sets: 10,
-                ..Default::default()
-            },
-        )
-        .unwrap_err();
-    }
-
-    #[test]
     fn basic_alloc() {
         let (device, _) = gfx_dev_and_queue!();
 

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -494,15 +494,6 @@ impl<'a> DescriptorPoolCreateInfo<'a> {
             }));
         }
 
-        if pool_sizes.is_empty() {
-            return Err(Box::new(ValidationError {
-                context: "pool_sizes".into(),
-                problem: "is empty".into(),
-                // vuids?
-                ..Default::default()
-            }));
-        }
-
         // VUID-VkDescriptorPoolCreateInfo-pPoolSizes-parameter
         for &(descriptor_type, pool_size) in pool_sizes {
             flags.validate_device(device).map_err(|err| {


### PR DESCRIPTION
This has caused unspeakable grief over the years. If only I had realized that the validation was useless sooner...

Fixes #1632

Changelog:
```markdown
### Bugs fixed
- Removed the validation of `DescriptorPoolCreateInfo::pool_sizes` being non-empty. This would manifest itself as a panic when attempting to allocate a descriptor set with no descriptors.
```
