### PR TITLE
Use references as params in `Queue::submit` and `Queue::bind_sparse`

### DIFF
--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -947,48 +947,48 @@ impl From<CommandBufferUsage> for vk::CommandBufferUsageFlags {
 
 /// Parameters to submit command buffers to a queue.
 #[derive(Clone, Debug)]
-pub struct SubmitInfo {
+pub struct SubmitInfo<'a> {
     /// The semaphores to wait for before beginning the execution of this batch of
     /// command buffer operations.
     ///
     /// The default value is empty.
-    pub wait_semaphores: Vec<SemaphoreSubmitInfo>,
+    pub wait_semaphores: &'a [SemaphoreSubmitInfo<'a>],
 
     /// The command buffers to execute.
     ///
     /// The default value is empty.
-    pub command_buffers: Vec<CommandBufferSubmitInfo>,
+    pub command_buffers: &'a [CommandBufferSubmitInfo<'a>],
 
     /// The semaphores to signal after the execution of this batch of command buffer operations
     /// has completed.
     ///
     /// The default value is empty.
-    pub signal_semaphores: Vec<SemaphoreSubmitInfo>,
+    pub signal_semaphores: &'a [SemaphoreSubmitInfo<'a>],
 
-    pub _ne: crate::NonExhaustive<'static>,
+    pub _ne: crate::NonExhaustive<'a>,
 }
 
-impl Default for SubmitInfo {
+impl Default for SubmitInfo<'_> {
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl SubmitInfo {
+impl SubmitInfo<'_> {
     /// Returns a default `SubmitInfo`.
     #[inline]
     pub const fn new() -> Self {
         Self {
-            wait_semaphores: Vec::new(),
-            command_buffers: Vec::new(),
-            signal_semaphores: Vec::new(),
+            wait_semaphores: &[],
+            command_buffers: &[],
+            signal_semaphores: &[],
             _ne: crate::NE,
         }
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
-        let Self {
+        let &Self {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
@@ -1055,7 +1055,7 @@ impl SubmitInfo {
     }
 
     pub(crate) fn to_vk2_fields1(&self) -> SubmitInfo2Fields1Vk {
-        let Self {
+        let &Self {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
@@ -1113,7 +1113,7 @@ impl SubmitInfo {
         &self,
         fields1_vk: &'a SubmitInfoFields1Vk,
     ) -> SubmitInfoExtensionsVk<'a> {
-        let Self {
+        let &Self {
             wait_semaphores,
             command_buffers: _,
             signal_semaphores,
@@ -1145,7 +1145,7 @@ impl SubmitInfo {
     }
 
     pub(crate) fn to_vk_fields1(&self) -> SubmitInfoFields1Vk {
-        let Self {
+        let &Self {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
@@ -1158,7 +1158,7 @@ impl SubmitInfo {
 
         for semaphore_submit_info in wait_semaphores {
             let &SemaphoreSubmitInfo {
-                ref semaphore,
+                semaphore,
                 value,
                 stages,
                 _ne: _,
@@ -1179,7 +1179,7 @@ impl SubmitInfo {
 
         for semaphore_submit_info in signal_semaphores {
             let &SemaphoreSubmitInfo {
-                ref semaphore,
+                semaphore,
                 value,
                 stages: _,
                 _ne: _,
@@ -1221,19 +1221,19 @@ pub(crate) struct SubmitInfoFields1Vk {
 
 /// Parameters for a command buffer in a queue submit operation.
 #[derive(Clone, Debug)]
-pub struct CommandBufferSubmitInfo {
+pub struct CommandBufferSubmitInfo<'a> {
     /// The command buffer to execute.
     ///
     /// There is no default value.
-    pub command_buffer: Arc<dyn PrimaryCommandBufferAbstract>,
+    pub command_buffer: &'a CommandBuffer,
 
-    pub _ne: crate::NonExhaustive<'static>,
+    pub _ne: crate::NonExhaustive<'a>,
 }
 
-impl CommandBufferSubmitInfo {
+impl<'a> CommandBufferSubmitInfo<'a> {
     /// Returns a default `CommandBufferSubmitInfo` with the provided `command_buffer`.
     #[inline]
-    pub const fn new(command_buffer: Arc<dyn PrimaryCommandBufferAbstract>) -> Self {
+    pub const fn new(command_buffer: &'a CommandBuffer) -> Self {
         Self {
             command_buffer,
             _ne: crate::NE,
@@ -1241,7 +1241,7 @@ impl CommandBufferSubmitInfo {
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
-        let Self {
+        let &Self {
             command_buffer,
             _ne: _,
         } = self;
@@ -1253,7 +1253,7 @@ impl CommandBufferSubmitInfo {
     }
 
     pub(crate) fn to_vk2(&self) -> vk::CommandBufferSubmitInfo<'static> {
-        let Self {
+        let &Self {
             command_buffer,
             _ne: _,
         } = self;
@@ -1264,7 +1264,7 @@ impl CommandBufferSubmitInfo {
     }
 
     pub(crate) fn to_vk(&self) -> vk::CommandBuffer {
-        let Self {
+        let &Self {
             command_buffer,
             _ne: _,
         } = self;
@@ -1275,11 +1275,11 @@ impl CommandBufferSubmitInfo {
 
 /// Parameters for a semaphore signal or wait operation in a queue submit operation.
 #[derive(Clone, Debug)]
-pub struct SemaphoreSubmitInfo {
+pub struct SemaphoreSubmitInfo<'a> {
     /// The semaphore to signal or wait for.
     ///
     /// There is no default value.
-    pub semaphore: Arc<Semaphore>,
+    pub semaphore: &'a Semaphore,
 
     /// If `semaphore.semaphore_type()` is [`SemaphoreType::Timeline`], specifies the value that
     /// will be used for the semaphore operation:
@@ -1309,13 +1309,13 @@ pub struct SemaphoreSubmitInfo {
     /// [`synchronization2`]: crate::device::DeviceFeatures::synchronization2
     pub stages: PipelineStages,
 
-    pub _ne: crate::NonExhaustive<'static>,
+    pub _ne: crate::NonExhaustive<'a>,
 }
 
-impl SemaphoreSubmitInfo {
+impl<'a> SemaphoreSubmitInfo<'a> {
     /// Returns a default `SemaphoreSubmitInfo` with the provided `semaphore`.
     #[inline]
-    pub const fn new(semaphore: Arc<Semaphore>) -> Self {
+    pub const fn new(semaphore: &'a Semaphore) -> Self {
         Self {
             semaphore,
             value: 0,
@@ -1326,7 +1326,7 @@ impl SemaphoreSubmitInfo {
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
         let &Self {
-            ref semaphore,
+            semaphore,
             value,
             stages,
             _ne: _,
@@ -1519,7 +1519,7 @@ impl SemaphoreSubmitInfo {
 
     pub(crate) fn to_vk2(&self) -> vk::SemaphoreSubmitInfo<'static> {
         let &Self {
-            ref semaphore,
+            semaphore,
             value,
             stages,
             _ne: _,
@@ -1531,6 +1531,14 @@ impl SemaphoreSubmitInfo {
             .stage_mask(stages.into())
             .device_index(0) // TODO:
     }
+}
+
+#[derive(Clone, Debug, Default)]
+#[doc(hidden)]
+pub struct OldSubmitInfo {
+    pub(crate) wait_semaphores: Vec<Arc<Semaphore>>,
+    pub(crate) command_buffers: Vec<Arc<dyn PrimaryCommandBufferAbstract>>,
+    pub(crate) signal_semaphores: Vec<Arc<Semaphore>>,
 }
 
 #[derive(Debug, Default)]

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -260,7 +260,7 @@ impl QueueGuard<'_> {
     #[inline]
     pub unsafe fn bind_sparse(
         &mut self,
-        bind_infos: &[BindSparseInfo],
+        bind_infos: &[BindSparseInfo<'_>],
         fence: Option<&Arc<Fence>>,
     ) -> Result<(), Validated<VulkanError>> {
         self.validate_bind_sparse(bind_infos, fence)?;
@@ -270,7 +270,7 @@ impl QueueGuard<'_> {
 
     fn validate_bind_sparse(
         &self,
-        bind_infos: &[BindSparseInfo],
+        bind_infos: &[BindSparseInfo<'_>],
         fence: Option<&Arc<Fence>>,
     ) -> Result<(), Box<ValidationError>> {
         if !self
@@ -314,7 +314,7 @@ impl QueueGuard<'_> {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn bind_sparse_unchecked(
         &mut self,
-        bind_infos: &[BindSparseInfo],
+        bind_infos: &[BindSparseInfo<'_>],
         fence: Option<&Arc<Fence>>,
     ) -> Result<(), VulkanError> {
         let bind_infos_fields2_vk: SmallVec<[_; 4]> = bind_infos
@@ -529,7 +529,7 @@ impl QueueGuard<'_> {
     #[inline]
     pub unsafe fn submit(
         &mut self,
-        submit_infos: &[SubmitInfo],
+        submit_infos: &[SubmitInfo<'_>],
         fence: Option<&Arc<Fence>>,
     ) -> Result<(), Validated<VulkanError>> {
         self.validate_submit(submit_infos, fence)?;
@@ -539,7 +539,7 @@ impl QueueGuard<'_> {
 
     fn validate_submit(
         &self,
-        submit_infos: &[SubmitInfo],
+        submit_infos: &[SubmitInfo<'_>],
         fence: Option<&Arc<Fence>>,
     ) -> Result<(), Box<ValidationError>> {
         let device = self.queue.device();
@@ -558,7 +558,7 @@ impl QueueGuard<'_> {
                 .validate(device)
                 .map_err(|err| err.add_context(format!("submit_infos[{}]", index)))?;
 
-            let SubmitInfo {
+            let &SubmitInfo {
                 wait_semaphores,
                 command_buffers,
                 signal_semaphores,
@@ -659,7 +659,7 @@ impl QueueGuard<'_> {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn submit_unchecked(
         &mut self,
-        submit_infos: &[SubmitInfo],
+        submit_infos: &[SubmitInfo<'_>],
         fence: Option<&Arc<Fence>>,
     ) -> Result<(), VulkanError> {
         if self.queue.device.enabled_features().synchronization2 {

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -1115,14 +1115,6 @@ where
                     ..Default::default()
                 })
             }
-            SubmitAnyBuilder::BindSparse(_, _) => {
-                self.previous.flush()?;
-
-                SubmitAnyBuilder::QueuePresent(PresentInfo {
-                    swapchain_infos: vec![self.swapchain_info.clone()],
-                    ..Default::default()
-                })
-            }
             SubmitAnyBuilder::QueuePresent(mut present_info) => {
                 if present_info.swapchain_infos.first().is_some_and(|prev| {
                     prev.present_mode.is_some() != self.swapchain_info.present_mode.is_some()

--- a/vulkano/src/sync/future/join.rs
+++ b/vulkano/src/sync/future/join.rs
@@ -93,14 +93,6 @@ where
                 self.first.flush()?;
                 SubmitAnyBuilder::SemaphoresWait(b)
             }
-            (SubmitAnyBuilder::SemaphoresWait(a), SubmitAnyBuilder::BindSparse(_, _)) => {
-                self.second.flush()?;
-                SubmitAnyBuilder::SemaphoresWait(a)
-            }
-            (SubmitAnyBuilder::BindSparse(_, _), SubmitAnyBuilder::SemaphoresWait(b)) => {
-                self.first.flush()?;
-                SubmitAnyBuilder::SemaphoresWait(b)
-            }
             (
                 SubmitAnyBuilder::CommandBuffer(mut submit_info_a, fence_a),
                 SubmitAnyBuilder::CommandBuffer(submit_info_b, fence_b),
@@ -132,31 +124,6 @@ where
             }
             (SubmitAnyBuilder::QueuePresent(_), SubmitAnyBuilder::CommandBuffer(_, _)) => {
                 unimplemented!()
-            }
-            (SubmitAnyBuilder::BindSparse(_, _), SubmitAnyBuilder::QueuePresent(_)) => {
-                unimplemented!()
-            }
-            (SubmitAnyBuilder::QueuePresent(_), SubmitAnyBuilder::BindSparse(_, _)) => {
-                unimplemented!()
-            }
-            (SubmitAnyBuilder::BindSparse(_, _), SubmitAnyBuilder::CommandBuffer(_, _)) => {
-                unimplemented!()
-            }
-            (SubmitAnyBuilder::CommandBuffer(_, _), SubmitAnyBuilder::BindSparse(_, _)) => {
-                unimplemented!()
-            }
-            (
-                SubmitAnyBuilder::BindSparse(mut bind_infos_a, fence_a),
-                SubmitAnyBuilder::BindSparse(bind_infos_b, fence_b),
-            ) => {
-                if fence_a.is_some() && fence_b.is_some() {
-                    // TODO: this happens if both bind sparse have been given a fence already
-                    //       annoying, but not impossible, to handle
-                    unimplemented!()
-                }
-
-                bind_infos_a.extend(bind_infos_b);
-                SubmitAnyBuilder::BindSparse(bind_infos_a, fence_a)
             }
         })
     }


### PR DESCRIPTION
See #2682 for rationale. I originally didn't update the queue functions because it would break `SubmitAnyBulider`, which is old sync; we want to deprecate old sync. But breaking it doesn't seem so bad because it only breaks manual `GpuFuture` implementations and those have been broken for years. Alas, `Queue::present` persists as it is because `GpuFuture::then_swapchain_present` uses `SwapchainPresentInfo`.

Closes #2681