### PR TITLE
Fix `DriverId::VeriSiliconProprietary` spelling

### DIFF
--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -3106,7 +3106,7 @@ vulkan_enum! {
     JuiceProprietary = JUICE_PROPRIETARY,
 
     // TODO: document
-    VeriSiliconPropertary = VERISILICON_PROPRIETARY,
+    VeriSiliconProprietary = VERISILICON_PROPRIETARY,
 
     // TODO: document
     MesaTurnip = MESA_TURNIP,


### PR DESCRIPTION
Changelog:
```markdown
### Breaking changes
- `DriverId::VeriSiliconPropertary` is now correctly spelled `DriverId::VeriSiliconProprietary`.
```
