### PR TITLE
Fix documentation links within suballocators

### DIFF
--- a/vulkano/src/memory/allocator/suballocator/buddy.rs
+++ b/vulkano/src/memory/allocator/suballocator/buddy.rs
@@ -53,8 +53,8 @@ use std::{cmp, num::NonZero};
 /// the highest order, which equates to *O*(log (*n*)) where *n* is the size of the region.
 ///
 /// [suballocator]: Suballocator
-/// [internal fragmentation]: super#internal-fragmentation
-/// [external fragmentation]: super#external-fragmentation
+/// [internal fragmentation]: super::super#internal-fragmentation
+/// [external fragmentation]: super::super#external-fragmentation
 /// [`FreeListAllocator`]: super::FreeListAllocator
 /// [the `Suballocator` implementation]: Suballocator#impl-Suballocator-for-Arc<BuddyAllocator>
 /// [region]: Suballocator#regions
@@ -263,7 +263,7 @@ unsafe impl Suballocator for BuddyAllocator {
     /// allocator, which means that [internal fragmentation] is excluded.
     ///
     /// [region]: Suballocator#regions
-    /// [internal fragmentation]: super#internal-fragmentation
+    /// [internal fragmentation]: super::super#internal-fragmentation
     #[inline]
     fn free_size(&self) -> DeviceSize {
         self.free_size

--- a/vulkano/src/memory/allocator/suballocator/bump.rs
+++ b/vulkano/src/memory/allocator/suballocator/bump.rs
@@ -49,7 +49,7 @@ use std::iter::FusedIterator;
 /// [the `Suballocator` implementation]: Suballocator#impl-Suballocator-for-Arc<BumpAllocator>
 /// [region]: Suballocator#regions
 /// [free-list]: Suballocator#free-lists
-/// [memory leaks]: super#leakage
+/// [memory leaks]: super::super#leakage
 /// [`reset`]: Self::reset
 /// [hierarchy]: Suballocator#memory-hierarchies
 #[derive(Debug)]

--- a/vulkano/src/memory/allocator/suballocator/free_list.rs
+++ b/vulkano/src/memory/allocator/suballocator/free_list.rs
@@ -54,12 +54,12 @@ use std::{cmp, iter::FusedIterator, marker::PhantomData, ptr::NonNull};
 ///
 /// [suballocator]: Suballocator
 /// [free-list]: Suballocator#free-lists
-/// [external fragmentation]: super#external-fragmentation
+/// [external fragmentation]: super::super#external-fragmentation
 /// [`BuddyAllocator`]: super::BuddyAllocator
 /// [`BumpAllocator`]: super::BumpAllocator
 /// [the `Suballocator` implementation]: Suballocator#impl-Suballocator-for-Arc<FreeListAllocator>
-/// [internal fragmentation]: super#internal-fragmentation
-/// [alignment requirements]: super#alignment
+/// [internal fragmentation]: super::super#internal-fragmentation
+/// [alignment requirements]: super::super#alignment
 #[derive(Debug)]
 pub struct FreeListAllocator {
     region: Region,


### PR DESCRIPTION
This PR addresses a minor link issue in suballocator documentation. Section links point to the `suballocator` module, which does not have these sections in its documentation. They exist in the `allocator` module, which makes me believe this is mistake. This PR makes these links point one level up, which fixes them.

There are no functionality changes.