### PR TITLE
Make the typos CI job reproducible

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,5 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v31
     - name: Run typos
-      uses: crate-ci/typos@master
+      run: nix develop .#CI -c typos

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,9 @@
 
             # Vulkan dependencies
             shaderc
+
+            # Workflow dependencies
+            typos
           ];
 
           LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;


### PR DESCRIPTION
We have reproducible CI jobs these days but for the typos job. This too can result in a PR not building by no fault of the author, or worse, a PR passing CI and not passing CI when merged into master, as has happened recently (compare #2720 vs d460e284f3d78233346d559b905105ddb0667969).