### PR TITLE
Remove the `paths-ignore` filter from the `merge_group` CI trigger

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,6 @@ on:
     paths-ignore:
     - '**.md'
   merge_group:
-    paths-ignore:
-    - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
The `merge_group` CI trigger doesn't seem to support `paths-ignore`, and it wouldn't make sense to have this filter anyway. Hopefully this will fix the merge queue.