### PR TITLE
Increase MSRV to 1.84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.84.0"
 license = "MIT OR Apache-2.0"
 homepage = "https://vulkano.rs"
 keywords = ["vulkan", "bindings", "graphics", "gpu", "rendering"]

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -22,7 +22,7 @@ use std::{
     cell::UnsafeCell,
     error::Error,
     fmt::{Debug, Display, Error as FmtError, Formatter},
-    mem, ptr,
+    ptr,
     sync::{Arc, Weak},
 };
 use thread_local::ThreadLocal;
@@ -127,11 +127,9 @@ impl AllocationHandle {
     /// Stores an index inside an `AllocationHandle`.
     ///
     /// Use this if you want to associate an allocation with some index.
-    #[allow(clippy::useless_transmute)]
     #[inline]
     pub const fn from_index(index: usize) -> Self {
-        // SAFETY: `usize` and `*mut ()` have the same layout.
-        AllocationHandle(unsafe { mem::transmute::<usize, *mut ()>(index) })
+        AllocationHandle(ptr::without_provenance_mut(index))
     }
 
     /// Retrieves a previously-stored pointer from the `AllocationHandle`.
@@ -151,11 +149,9 @@ impl AllocationHandle {
     /// result.
     ///
     /// [`from_index`]: Self::from_index
-    #[allow(clippy::transmutes_expressible_as_ptr_casts)]
     #[inline]
     pub fn as_index(self) -> usize {
-        // SAFETY: `usize` and `*mut ()` have the same layout.
-        unsafe { mem::transmute::<*mut (), usize>(self.0) }
+        self.0.addr()
     }
 }
 

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -25,7 +25,6 @@ use crossbeam_queue::ArrayQueue;
 use std::{
     cell::UnsafeCell,
     fmt::{Debug, Error as FmtError, Formatter},
-    mem,
     num::NonZero,
     ptr, slice,
     sync::Arc,
@@ -126,11 +125,9 @@ impl AllocationHandle {
     /// Stores an index inside an `AllocationHandle`.
     ///
     /// Use this if you want to associate an allocation with some index.
-    #[allow(clippy::useless_transmute)]
     #[inline]
     pub const fn from_index(index: usize) -> Self {
-        // SAFETY: `usize` and `*mut ()` have the same layout.
-        AllocationHandle(unsafe { mem::transmute::<usize, *mut ()>(index) })
+        AllocationHandle(ptr::without_provenance_mut(index))
     }
 
     /// Retrieves a previously-stored pointer from the `AllocationHandle`.
@@ -150,11 +147,9 @@ impl AllocationHandle {
     /// result.
     ///
     /// [`from_index`]: Self::from_index
-    #[allow(clippy::transmutes_expressible_as_ptr_casts)]
     #[inline]
     pub fn as_index(self) -> usize {
-        // SAFETY: `usize` and `*mut ()` have the same layout.
-        unsafe { mem::transmute::<*mut (), usize>(self.0) }
+        self.0.addr()
     }
 }
 

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -231,7 +231,6 @@ use std::{
     error::Error,
     fmt::{Debug, Display, Error as FmtError, Formatter},
     iter::FusedIterator,
-    mem,
     ops::BitOr,
     ptr, slice,
     sync::Arc,
@@ -762,11 +761,9 @@ impl AllocationHandle {
     /// Stores an index inside an `AllocationHandle`.
     ///
     /// Use this if you want to associate an allocation with some index.
-    #[allow(clippy::useless_transmute)]
     #[inline]
     pub const fn from_index(index: usize) -> Self {
-        // SAFETY: `usize` and `*mut ()` have the same layout.
-        AllocationHandle(unsafe { mem::transmute::<usize, *mut ()>(index) })
+        AllocationHandle(ptr::without_provenance_mut(index))
     }
 
     /// Retrieves a previously-stored pointer from the `AllocationHandle`.
@@ -786,11 +783,9 @@ impl AllocationHandle {
     /// result.
     ///
     /// [`from_index`]: Self::from_index
-    #[allow(clippy::transmutes_expressible_as_ptr_casts)]
     #[inline]
     pub fn as_index(self) -> usize {
-        // SAFETY: `usize` and `*mut ()` have the same layout.
-        unsafe { mem::transmute::<*mut (), usize>(self.0) }
+        self.0.addr()
     }
 }
 


### PR DESCRIPTION
This finally allows us to use the strict provenance API.

Changelog:
```md
### Public dependency updates
- Rust version: 1.84
```