### PR TITLE
Restrict the push trigger type to non-master non-merge-queue branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,9 @@ name: Rust
 
 on:
   push:
+    branches-ignore:
+      - master
+      - 'gh-readonly-queue/**'
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
The `merge_group` trigger type should be enough for master, given that its checks are displayed on the final commit after being merged into master. The `push` trigger type seems superfluous then (especially since our entire CI is reproducible). The `push` trigger type is also superfluous for the merge queue branches (why does it apply in the first place? WHY??).