### PR TITLE
Remove `Loader`

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -114,7 +114,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/basic-compute-shader/main.rs
+++ b/examples/basic-compute-shader/main.rs
@@ -29,7 +29,7 @@ use vulkano::{
 
 fn main() {
     // As with other examples, the first step is to create an instance.
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/bloom/main.rs
+++ b/examples/bloom/main.rs
@@ -76,7 +76,7 @@ pub struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/clear-attachments/main.rs
+++ b/examples/clear-attachments/main.rs
@@ -55,7 +55,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/debug/main.rs
+++ b/examples/debug/main.rs
@@ -27,7 +27,7 @@ fn main() {
         ..InstanceExtensions::empty()
     };
 
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
 
     // You also need to specify (unless you've used the methods linked above) which debugging
     // layers your code should use. Each layer is a bunch of checks or messages that provide

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -86,7 +86,7 @@ pub struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -36,7 +36,7 @@ use vulkano::{
 };
 
 fn main() {
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/dynamic-local-size/main.rs
+++ b/examples/dynamic-local-size/main.rs
@@ -31,7 +31,7 @@ use vulkano::{
 };
 
 fn main() {
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -150,7 +150,7 @@ mod linux {
                 )
             };
 
-            let library = VulkanLibrary::new().unwrap();
+            let library = unsafe { VulkanLibrary::new() }.unwrap();
             let required_extensions = Surface::required_extensions(event_loop).unwrap();
             let instance = Instance::new(
                 &library,

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -84,7 +84,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -83,7 +83,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -96,7 +96,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -95,7 +95,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -74,7 +74,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -91,7 +91,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -87,7 +87,7 @@ use vulkano::{
 
 fn main() {
     // The usual Vulkan initialization.
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/multi-window/main.rs
+++ b/examples/multi-window/main.rs
@@ -70,7 +70,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/multiview/main.rs
+++ b/examples/multiview/main.rs
@@ -43,7 +43,7 @@ use vulkano::{
 };
 
 fn main() {
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/occlusion-query/main.rs
+++ b/examples/occlusion-query/main.rs
@@ -79,7 +79,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -35,7 +35,7 @@ fn main() {
     // The start of this example is exactly the same as `triangle`. You should read the `triangle`
     // example if you haven't done so yet.
 
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
 
     let instance = Instance::new(
         &library,

--- a/examples/pipeline-caching/main.rs
+++ b/examples/pipeline-caching/main.rs
@@ -37,7 +37,7 @@ use vulkano::{
 
 fn main() {
     // As with other examples, the first step is to create an instance.
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/push-constants/main.rs
+++ b/examples/push-constants/main.rs
@@ -27,7 +27,7 @@ use vulkano::{
 };
 
 fn main() {
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -84,7 +84,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/ray-tracing-auto/main.rs
+++ b/examples/ray-tracing-auto/main.rs
@@ -60,7 +60,7 @@ pub struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/ray-tracing/main.rs
+++ b/examples/ray-tracing/main.rs
@@ -59,7 +59,7 @@ pub struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -91,7 +91,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -82,7 +82,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/self-copy-buffer/main.rs
+++ b/examples/self-copy-buffer/main.rs
@@ -27,7 +27,7 @@ use vulkano::{
 };
 
 fn main() {
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/shader-include/main.rs
+++ b/examples/shader-include/main.rs
@@ -26,7 +26,7 @@ use vulkano::{
 };
 
 fn main() {
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/shader-types-sharing/main.rs
+++ b/examples/shader-types-sharing/main.rs
@@ -40,7 +40,7 @@ use vulkano::{
 };
 
 fn main() {
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -88,7 +88,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/specialization-constants/main.rs
+++ b/examples/specialization-constants/main.rs
@@ -24,7 +24,7 @@ use vulkano::{
 };
 
 fn main() {
-    let library = VulkanLibrary::new().unwrap();
+    let library = unsafe { VulkanLibrary::new() }.unwrap();
     let instance = Instance::new(
         &library,
         &InstanceCreateInfo {

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -92,7 +92,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -82,7 +82,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -85,7 +85,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
         let required_extensions = Surface::required_extensions(event_loop).unwrap();
         let instance = Instance::new(
             &library,

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -81,7 +81,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
 
         // The first step of any Vulkan program is to create an instance.
         //

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -76,7 +76,7 @@ struct RenderContext {
 
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
-        let library = VulkanLibrary::new().unwrap();
+        let library = unsafe { VulkanLibrary::new() }.unwrap();
 
         // The first step of any Vulkan program is to create an instance.
         //

--- a/vulkano-taskgraph/src/lib.rs
+++ b/vulkano-taskgraph/src/lib.rs
@@ -997,7 +997,7 @@ fn panic_nounwind(message: &'static str) -> ! {
 mod tests {
     macro_rules! test_queues {
         () => {{
-            let Ok(library) = vulkano::VulkanLibrary::new() else {
+            let Ok(library) = (unsafe { vulkano::VulkanLibrary::new() }) else {
                 return;
             };
             let Ok(instance) = vulkano::instance::Instance::new(&library, &Default::default())

--- a/vulkano-util/src/context.rs
+++ b/vulkano-util/src/context.rs
@@ -111,7 +111,7 @@ impl VulkanoContext {
     ///
     /// - Panics where the underlying Vulkano struct creations fail
     pub fn new(config: VulkanoConfig<'_>) -> Self {
-        let library = match VulkanLibrary::new() {
+        let library = match unsafe { VulkanLibrary::new() } {
             Ok(x) => x,
             #[cfg(target_vendor = "apple")]
             Err(vulkano::library::LoadingError::LibraryLoadFailure(err)) => panic!(

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -16,7 +16,7 @@
 //! };
 //!
 //! // Creating the instance. See the documentation of the `instance` module.
-//! let library = VulkanLibrary::new()
+//! let library = unsafe { VulkanLibrary::new() }
 //!     .unwrap_or_else(|err| panic!("couldn't load Vulkan library: {:?}", err));
 //! let instance = Instance::new(&library, &Default::default())
 //!     .unwrap_or_else(|err| panic!("couldn't create instance: {:?}", err));

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -47,7 +47,7 @@ use std::{
 /// # };
 /// use vulkano::device::physical::PhysicalDevice;
 ///
-/// # let library = VulkanLibrary::new().unwrap();
+/// # let library = unsafe { VulkanLibrary::new() }.unwrap();
 /// # let instance = Instance::new(&library, &Default::default()).unwrap();
 /// #
 /// for physical_device in instance.enumerate_physical_devices().unwrap() {

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -654,7 +654,7 @@ mod tests {
         // It's useful to be able to initialize a DebugUtilsMessenger on one thread
         // and keep it alive on another thread.
         let instance = {
-            let library = match VulkanLibrary::new() {
+            let library = match unsafe { VulkanLibrary::new() } {
                 Ok(x) => x,
                 Err(_) => return,
             };

--- a/vulkano/src/instance/layers.rs
+++ b/vulkano/src/instance/layers.rs
@@ -18,7 +18,7 @@ impl LayerProperties {
     /// ```no_run
     /// use vulkano::VulkanLibrary;
     ///
-    /// let library = VulkanLibrary::new().unwrap();
+    /// let library = unsafe { VulkanLibrary::new() }.unwrap();
     ///
     /// for layer in library.layer_properties().unwrap() {
     ///     println!("Layer name: {}", layer.name());
@@ -38,7 +38,7 @@ impl LayerProperties {
     /// ```no_run
     /// use vulkano::VulkanLibrary;
     ///
-    /// let library = VulkanLibrary::new().unwrap();
+    /// let library = unsafe { VulkanLibrary::new() }.unwrap();
     ///
     /// for layer in library.layer_properties().unwrap() {
     ///     println!("Layer description: {}", layer.description());
@@ -56,7 +56,7 @@ impl LayerProperties {
     /// ```no_run
     /// use vulkano::{Version, VulkanLibrary};
     ///
-    /// let library = VulkanLibrary::new().unwrap();
+    /// let library = unsafe { VulkanLibrary::new() }.unwrap();
     ///
     /// for layer in library.layer_properties().unwrap() {
     ///     if layer.vulkan_version() >= Version::major_minor(2, 0) {
@@ -78,7 +78,7 @@ impl LayerProperties {
     /// ```no_run
     /// use vulkano::VulkanLibrary;
     ///
-    /// let library = VulkanLibrary::new().unwrap();
+    /// let library = unsafe { VulkanLibrary::new() }.unwrap();
     ///
     /// for layer in library.layer_properties().unwrap() {
     ///     println!(
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn layers_list() {
-        let library = match VulkanLibrary::new() {
+        let library = match unsafe { VulkanLibrary::new() } {
             Ok(x) => x,
             Err(_) => return,
         };

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -10,7 +10,7 @@
 //!     Version, VulkanLibrary,
 //! };
 //!
-//! let library = VulkanLibrary::new()
+//! let library = unsafe { VulkanLibrary::new() }
 //!     .unwrap_or_else(|err| panic!("couldn't load Vulkan library: {:?}", err));
 //! let instance = Instance::new(&library, &Default::default())
 //!     .unwrap_or_else(|err| panic!("couldn't create instance: {:?}", err));
@@ -26,7 +26,7 @@
 //! # };
 //! use vulkano::device::physical::PhysicalDevice;
 //!
-//! # let library = VulkanLibrary::new().unwrap();
+//! # let library = unsafe { VulkanLibrary::new() }.unwrap();
 //! # let instance = Instance::new(&library, &Default::default()).unwrap();
 //! #
 //! for physical_device in instance.enumerate_physical_devices().unwrap() {
@@ -130,7 +130,7 @@ include!(crate::autogen_output!("instance_extensions.rs"));
 ///     Version, VulkanLibrary,
 /// };
 ///
-/// let library = VulkanLibrary::new().unwrap();
+/// let library = unsafe { VulkanLibrary::new() }.unwrap();
 /// let _instance =
 ///     Instance::new(&library, &InstanceCreateInfo::application_from_cargo_toml()).unwrap();
 /// # }
@@ -188,7 +188,7 @@ include!(crate::autogen_output!("instance_extensions.rs"));
 ///     Version, VulkanLibrary,
 /// };
 ///
-/// let library = VulkanLibrary::new()
+/// let library = unsafe { VulkanLibrary::new() }
 ///     .unwrap_or_else(|err| panic!("couldn't load Vulkan library: {:?}", err));
 ///
 /// let extensions = InstanceExtensions {
@@ -240,7 +240,7 @@ include!(crate::autogen_output!("instance_extensions.rs"));
 /// # };
 /// #
 /// # fn test() -> Result<Arc<Instance>, Box<dyn Error>> {
-/// let library = VulkanLibrary::new()?;
+/// let library = unsafe { VulkanLibrary::new() }?;
 ///
 /// // For the sake of the example, we activate all the layers that
 /// // contain the word "foo" in their description.
@@ -515,7 +515,7 @@ impl Instance {
     /// #     Version, VulkanLibrary,
     /// # };
     /// #
-    /// # let library = VulkanLibrary::new().unwrap();
+    /// # let library = unsafe { VulkanLibrary::new() }.unwrap();
     /// # let instance = Instance::new(&library, &Default::default()).unwrap();
     /// #
     /// for physical_device in instance.enumerate_physical_devices().unwrap() {

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -53,7 +53,7 @@
 //! };
 //!
 //! let instance = {
-//!     let library = VulkanLibrary::new()
+//!     let library = unsafe { VulkanLibrary::new() }
 //!         .unwrap_or_else(|err| panic!("couldn't load Vulkan library: {:?}", err));
 //!
 //!     let extensions = InstanceExtensions {

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -2194,7 +2194,7 @@ mod tests {
 
     #[test]
     fn semaphore_export_fd() {
-        let library = match VulkanLibrary::new() {
+        let library = match unsafe { VulkanLibrary::new() } {
             Ok(x) => x,
             Err(_) => return,
         };

--- a/vulkano/src/tests.rs
+++ b/vulkano/src/tests.rs
@@ -5,7 +5,7 @@ macro_rules! instance {
     () => {{
         use crate::{instance::Instance, VulkanLibrary};
 
-        let library = match VulkanLibrary::new() {
+        let library = match unsafe { VulkanLibrary::new() } {
             Ok(x) => x,
             Err(_) => return,
         };


### PR DESCRIPTION
This removes the `Loader` trait and simultaneously improves `VulkanLibrary`'s usability.

The trait is tech debt from back when everything was a trait, and its existence is the reason why we couldn't have a way to retrieve the `get_instance_proc_addr` function pointer from the `VulkanLibrary` (at least, not without hacks that rely on Vulkan 1.2). This is a pretty big usability issue when trying to interoperate with external libraries that came up many times. And there is just no need to have this layer of indirection when calling `get_instance_proc_addr` (not because of performance, but because it's just unnecessary).

Changelog:
```markdown
### Breaking changes
Changes to Vulkan initialization:
- `VulkanLibrary::new` is now marked unsafe. It has always been unsafe, but marked incorrectly.
- `Loader` was removed. The `get_instance_proc_addr` function pointer is now used directly instead.
- `VulkanLibrary::with_loader` was renamed to `VulkanLibrary::from_loader`.
- `statically_linked_vulkan_loader` was replaced with `statically_linked_vulkan_library`.

### Additions
- Added `VulkanLibrary::loader`, which allows you to get the `get_instance_proc_addr` function pointer and give it to an external library.
- Added `VulkanLibrary::from_path`, which allows you to load a Vulkan library from a specific path.
```
