### PR TITLE
Add MSRV checks to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,16 +22,19 @@ jobs:
             self-hosted: true
             shell: wsl -e wsl-bash {0}
             target: x86_64-pc-windows-msvc
+            target-dir: ~/.cargo/target
           - name: ubuntu-latest
             runs-on: ubuntu-latest
             self-hosted: false
             shell: bash
             target: x86_64-unknown-linux-gnu
+            target-dir: target
           - name: macos-latest
             runs-on: macos-latest
             self-hosted: false
             shell: bash
             target: aarch64-apple-darwin
+            target-dir: target
       fail-fast: false
     name: build / ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
@@ -39,7 +42,12 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
     env:
-      common_args: --target ${{ matrix.target }} --profile CI --color always --verbose
+      common_args: >-
+        --target ${{ matrix.target }}
+        --target-dir ${{ matrix.target-dir }}
+        --profile CI
+        --color always
+        --verbose
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -57,6 +65,52 @@ jobs:
         run: nix develop .#CI -c cargo test ${{ env.common_args }}
       - name: Build examples
         run: nix develop .#CI -c cargo build ${{ env.common_args }} --bins
+  msrv:
+    strategy:
+      matrix:
+        include:
+          - name: windows-latest
+            runs-on: [self-hosted, Windows, 25.05]
+            self-hosted: true
+            shell: wsl -e wsl-bash {0}
+            target: x86_64-pc-windows-msvc
+            target-dir: ~/.cargo/target-msrv
+          - name: ubuntu-latest
+            runs-on: ubuntu-latest
+            self-hosted: false
+            shell: bash
+            target: x86_64-unknown-linux-gnu
+            target-dir: target
+          - name: macos-latest
+            runs-on: macos-latest
+            self-hosted: false
+            shell: bash
+            target: aarch64-apple-darwin
+            target-dir: target
+      fail-fast: false
+    name: msrv / ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    env:
+      common_args: >-
+        --target ${{ matrix.target }}
+        --target-dir ${{ matrix.target-dir }}
+        --profile CI
+        --color always
+        --verbose
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        if: ${{ ! matrix.self-hosted }}
+      - uses: Swatinem/rust-cache@151eeee51b94b648db7d5aa68ce6a3cad1ddea4e
+        if: ${{ ! matrix.self-hosted }}
+        with:
+          cache-bin: false
+          cmd-format: nix develop .#CI-MSRV -c {0}
+      - name: Build libraries
+        run: nix develop .#CI-MSRV -c cargo build ${{ env.common_args }} --lib
   fmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I had a bit of an existential crisis when I wrote something along the lines of:
```rs
let foo = Foo {
    bar: Some(&bar()),
};
```
Forgetting that this only works as of Rust 1.89.0. And of course, since this is a language feature, that one Clippy lint for library features doesn't warn against it. It seems very easy to accidentally introduce something that's not compliant with our MSRV, and this protects against that.