### PR TITLE
Update comment in the immutable-sampler example

### DIFF
--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -405,7 +405,7 @@ impl ApplicationHandler for App {
 
         let layout = &pipeline.layout().set_layouts()[0];
 
-        // Use `image_view` instead of `image_view_sampler`, since the sampler is already in the
+        // Use `image_view` instead of `image`, since the sampler is already in the
         // layout.
         let descriptor_set = DescriptorSet::new(
             self.descriptor_set_allocator.clone(),


### PR DESCRIPTION
This is just a simple comment fix relating to #2705, which changed `image_view_sampler` to `image`. To avoid potential confusion, I think it's best to update this comment to match.

1. [X] Update documentation to reflect any user-facing changes - in this repository.
2. [X] Make sure that the changes are covered by unit-tests.
3. [X] Run `cargo clippy` on the changes.
4. [X] Run `cargo +nightly fmt` on the changes.
5. [X] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [X] Describe in common words what is the purpose of this change, related
   GitHub Issues, and highlight important implementation aspects.
   
Changelog:
N/A
