### PR TITLE
Use references as params in `DescriptorSet`

### DIFF
--- a/examples/basic-compute-shader/main.rs
+++ b/examples/basic-compute-shader/main.rs
@@ -11,7 +11,8 @@ use vulkano::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
@@ -179,10 +180,16 @@ fn main() {
     // descriptor sets that each contain the buffer you want to run the shader on.
     let layout = &pipeline.layout().set_layouts()[0];
     let set = DescriptorSet::new(
-        descriptor_set_allocator,
-        layout.clone(),
-        [WriteDescriptorSet::buffer(0, data_buffer.clone())],
-        [],
+        &descriptor_set_allocator,
+        layout,
+        &[WriteDescriptorSet::buffer(
+            0,
+            &DescriptorBufferInfo {
+                buffer: Some(data_buffer.buffer()),
+                ..Default::default()
+            },
+        )],
+        &[],
     )
     .unwrap();
 

--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -234,24 +234,30 @@ fn main() {
 
     let layout = &pipeline.layout().set_layouts()[0];
     let set = DescriptorSet::new(
-        descriptor_set_allocator,
-        layout.clone(),
-        [
+        &descriptor_set_allocator,
+        layout,
+        &[
             // When writing to the dynamic buffer binding, the range of the buffer that the shader
             // will access must also be provided. We specify the size of the `InData` struct here.
-            // When dynamic offsets are provided later, they get added to the start and end of
-            // this range.
-            WriteDescriptorSet::buffer_with_range(
+            // When dynamic offsets are provided later, they get added to the start and end of this
+            // range.
+            WriteDescriptorSet::buffer(
                 0,
-                DescriptorBufferInfo {
-                    buffer: input_buffer,
-                    offset: 0,
+                &DescriptorBufferInfo {
+                    buffer: Some(input_buffer.buffer()),
                     range: Some(size_of::<cs::InData>() as DeviceSize),
+                    ..Default::default()
                 },
             ),
-            WriteDescriptorSet::buffer(1, output_buffer.clone()),
+            WriteDescriptorSet::buffer(
+                1,
+                &DescriptorBufferInfo {
+                    buffer: Some(output_buffer.buffer()),
+                    ..Default::default()
+                },
+            ),
         ],
-        [],
+        &[],
     )
     .unwrap();
 

--- a/examples/dynamic-local-size/main.rs
+++ b/examples/dynamic-local-size/main.rs
@@ -12,7 +12,8 @@ use vulkano::{
         CopyImageToBufferInfo,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorImageInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
@@ -217,10 +218,16 @@ fn main() {
 
     let layout = &pipeline.layout().set_layouts()[0];
     let set = DescriptorSet::new(
-        descriptor_set_allocator,
-        layout.clone(),
-        [WriteDescriptorSet::image_view(0, view)],
-        [],
+        &descriptor_set_allocator,
+        layout,
+        &[WriteDescriptorSet::image(
+            0,
+            &DescriptorImageInfo {
+                image_view: Some(&view),
+                ..Default::default()
+            },
+        )],
+        &[],
     )
     .unwrap();
 

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -38,7 +38,8 @@ mod linux {
             CommandBufferUsage, RenderPassBeginInfo, SemaphoreSubmitInfo, SubmitInfo,
         },
         descriptor_set::{
-            allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+            allocator::StandardDescriptorSetAllocator, DescriptorImageInfo, DescriptorSet,
+            WriteDescriptorSet,
         },
         device::{
             physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -559,13 +560,25 @@ mod linux {
             let layout = &pipeline.layout().set_layouts()[0];
 
             let descriptor_set = DescriptorSet::new(
-                self.descriptor_set_allocator.clone(),
-                layout.clone(),
-                [
-                    WriteDescriptorSet::sampler(0, self.sampler.clone()),
-                    WriteDescriptorSet::image_view(1, self.image_view.clone()),
+                &self.descriptor_set_allocator,
+                layout,
+                &[
+                    WriteDescriptorSet::image(
+                        0,
+                        &DescriptorImageInfo {
+                            sampler: Some(&self.sampler),
+                            ..Default::default()
+                        },
+                    ),
+                    WriteDescriptorSet::image(
+                        1,
+                        &DescriptorImageInfo {
+                            image_view: Some(&self.image_view),
+                            ..Default::default()
+                        },
+                    ),
                 ],
-                [],
+                &[],
             )
             .unwrap();
 

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -7,7 +7,8 @@ use vulkano::{
         CopyImageInfo, ImageBlit, ImageCopy, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorImageInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -429,13 +430,25 @@ impl ApplicationHandler for App {
 
         let layout = &pipeline.layout().set_layouts()[0];
         let descriptor_set = DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
-            [
-                WriteDescriptorSet::sampler(0, self.sampler.clone()),
-                WriteDescriptorSet::image_view(1, self.texture.clone()),
+            &self.descriptor_set_allocator,
+            layout,
+            &[
+                WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        sampler: Some(&self.sampler),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::image(
+                    1,
+                    &DescriptorImageInfo {
+                        image_view: Some(&self.texture),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap();
 

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -6,7 +6,8 @@ use vulkano::{
         CopyBufferToImageInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorImageInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -370,13 +371,25 @@ impl ApplicationHandler for App {
 
         let layout = &pipeline.layout().set_layouts()[0];
         let descriptor_set = DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
-            [
-                WriteDescriptorSet::sampler(0, self.sampler.clone()),
-                WriteDescriptorSet::image_view(1, self.texture.clone()),
+            &self.descriptor_set_allocator,
+            layout,
+            &[
+                WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        sampler: Some(&self.sampler),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::image(
+                    1,
+                    &DescriptorImageInfo {
+                        image_view: Some(&self.texture),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap();
 

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -20,7 +20,7 @@ use vulkano::{
             DescriptorSetLayout, DescriptorSetLayoutBinding, DescriptorSetLayoutCreateInfo,
             DescriptorType,
         },
-        DescriptorSet, WriteDescriptorSet,
+        DescriptorImageInfo, DescriptorSet, WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -408,10 +408,16 @@ impl ApplicationHandler for App {
         // Use `image_view` instead of `image`, since the sampler is already in the
         // layout.
         let descriptor_set = DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
-            [WriteDescriptorSet::image_view(1, self.texture.clone())],
-            [],
+            &self.descriptor_set_allocator,
+            layout,
+            &[WriteDescriptorSet::image(
+                1,
+                &DescriptorImageInfo {
+                    image_view: Some(&self.texture),
+                    ..Default::default()
+                },
+            )],
+            &[],
         )
         .unwrap();
 

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -25,7 +25,8 @@ use vulkano::{
         DrawIndirectCommand, RenderPassBeginInfo,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -509,13 +510,25 @@ impl ApplicationHandler for App {
                 // Pass the two buffers to the compute shader.
                 let layout = &self.compute_pipeline.layout().set_layouts()[0];
                 let cs_descriptor_set = DescriptorSet::new(
-                    self.descriptor_set_allocator.clone(),
-                    layout.clone(),
-                    [
-                        WriteDescriptorSet::buffer(0, vertex_buffer.clone()),
-                        WriteDescriptorSet::buffer(1, indirect_buffer.clone()),
+                    &self.descriptor_set_allocator,
+                    layout,
+                    &[
+                        WriteDescriptorSet::buffer(
+                            0,
+                            &DescriptorBufferInfo {
+                                buffer: Some(vertex_buffer.buffer()),
+                                ..Default::default()
+                            },
+                        ),
+                        WriteDescriptorSet::buffer(
+                            1,
+                            &DescriptorBufferInfo {
+                                buffer: Some(indirect_buffer.buffer()),
+                                ..Default::default()
+                            },
+                        ),
                     ],
-                    [],
+                    &[],
                 )
                 .unwrap();
 

--- a/examples/interactive-fractal/fractal_compute_pipeline.rs
+++ b/examples/interactive-fractal/fractal_compute_pipeline.rs
@@ -8,7 +8,8 @@ use vulkano::{
         PrimaryCommandBufferAbstract,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorImageInfo,
+        DescriptorSet, WriteDescriptorSet,
     },
     device::Queue,
     image::view::ImageView,
@@ -129,13 +130,25 @@ impl FractalComputePipeline {
         let image_extent = image_view.image().extent();
         let layout = &self.pipeline.layout().set_layouts()[0];
         let descriptor_set = DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
-            [
-                WriteDescriptorSet::image_view(0, image_view),
-                WriteDescriptorSet::buffer(1, self.palette.clone()),
+            &self.descriptor_set_allocator,
+            layout,
+            &[
+                WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        image_view: Some(&image_view),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::buffer(
+                    1,
+                    &DescriptorBufferInfo {
+                        buffer: Some(self.palette.buffer()),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap();
         let mut builder = AutoCommandBufferBuilder::primary(

--- a/examples/interactive-fractal/pixels_draw_pipeline.rs
+++ b/examples/interactive-fractal/pixels_draw_pipeline.rs
@@ -5,7 +5,8 @@ use vulkano::{
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorImageInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::Queue,
     image::{
@@ -106,13 +107,25 @@ impl PixelsDrawPipeline {
         .unwrap();
 
         DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
-            [
-                WriteDescriptorSet::sampler(0, sampler),
-                WriteDescriptorSet::image_view(1, image),
+            &self.descriptor_set_allocator,
+            layout,
+            &[
+                WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        sampler: Some(&sampler),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::image(
+                    1,
+                    &DescriptorImageInfo {
+                        image_view: Some(&image),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap()
     }

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -21,7 +21,8 @@ use vulkano::{
         RenderPassBeginInfo,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceFeatures,
@@ -355,13 +356,25 @@ impl ApplicationHandler for App {
         };
 
         let descriptor_set = DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            pipeline.layout().set_layouts()[0].clone(),
-            [
-                WriteDescriptorSet::buffer(0, self.vertex_buffer.clone()),
-                WriteDescriptorSet::buffer(1, self.instance_buffer.clone()),
+            &self.descriptor_set_allocator,
+            &pipeline.layout().set_layouts()[0],
+            &[
+                WriteDescriptorSet::buffer(
+                    0,
+                    &DescriptorBufferInfo {
+                        buffer: Some(self.vertex_buffer.buffer()),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::buffer(
+                    1,
+                    &DescriptorBufferInfo {
+                        buffer: Some(self.instance_buffer.buffer()),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap();
 

--- a/examples/multi-window-game-of-life/game_of_life.rs
+++ b/examples/multi-window-game-of-life/game_of_life.rs
@@ -9,7 +9,8 @@ use vulkano::{
         PrimaryAutoCommandBuffer,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorImageInfo,
+        DescriptorSet, WriteDescriptorSet,
     },
     device::Queue,
     format::Format,
@@ -166,14 +167,32 @@ impl GameOfLifeComputePipeline {
         let image_extent = self.image.image().extent();
         let layout = &self.compute_life_pipeline.layout().set_layouts()[0];
         let descriptor_set = DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
-            [
-                WriteDescriptorSet::image_view(0, self.image.clone()),
-                WriteDescriptorSet::buffer(1, self.life_in.clone()),
-                WriteDescriptorSet::buffer(2, self.life_out.clone()),
+            &self.descriptor_set_allocator,
+            layout,
+            &[
+                WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        image_view: Some(&self.image),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::buffer(
+                    1,
+                    &DescriptorBufferInfo {
+                        buffer: Some(self.life_in.buffer()),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::buffer(
+                    2,
+                    &DescriptorBufferInfo {
+                        buffer: Some(self.life_out.buffer()),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap();
 

--- a/examples/multi-window-game-of-life/pixels_draw.rs
+++ b/examples/multi-window-game-of-life/pixels_draw.rs
@@ -6,7 +6,8 @@ use vulkano::{
         CommandBufferInheritanceInfo, CommandBufferUsage, SecondaryAutoCommandBuffer,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorImageInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::Queue,
     image::{
@@ -102,13 +103,25 @@ impl PixelsDrawPipeline {
         .unwrap();
 
         DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
-            [
-                WriteDescriptorSet::sampler(0, sampler),
-                WriteDescriptorSet::image_view(1, image),
+            &self.descriptor_set_allocator,
+            layout,
+            &[
+                WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        sampler: Some(&sampler),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::image(
+                    1,
+                    &DescriptorImageInfo {
+                        image_view: Some(&image),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap()
     }

--- a/examples/push-constants/main.rs
+++ b/examples/push-constants/main.rs
@@ -10,7 +10,8 @@ use vulkano::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
@@ -150,10 +151,16 @@ fn main() {
 
     let layout = &pipeline.layout().set_layouts()[0];
     let set = DescriptorSet::new(
-        descriptor_set_allocator,
-        layout.clone(),
-        [WriteDescriptorSet::buffer(0, data_buffer.clone())],
-        [],
+        &descriptor_set_allocator,
+        layout,
+        &[WriteDescriptorSet::buffer(
+            0,
+            &DescriptorBufferInfo {
+                buffer: Some(data_buffer.buffer()),
+                ..Default::default()
+            },
+        )],
+        &[],
     )
     .unwrap();
 

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -10,7 +10,7 @@ use vulkano::{
             DescriptorSetLayout, DescriptorSetLayoutBinding, DescriptorSetLayoutCreateFlags,
             DescriptorSetLayoutCreateInfo, DescriptorType,
         },
-        WriteDescriptorSet,
+        DescriptorImageInfo, WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -492,14 +492,18 @@ impl ApplicationHandler for App {
                         PipelineBindPoint::Graphics,
                         rcx.pipeline.layout().clone(),
                         0,
-                        [
+                        &[
                             // If the binding is an immutable sampler, using push descriptors
                             // you must write a dummy value to the binding.
-                            WriteDescriptorSet::sampler(0, None),
-                            WriteDescriptorSet::image_view(1, self.texture.clone()),
-                        ]
-                        .into_iter()
-                        .collect(),
+                            WriteDescriptorSet::image(0, &DescriptorImageInfo::default()),
+                            WriteDescriptorSet::image(
+                                1,
+                                &DescriptorImageInfo {
+                                    image_view: Some(&self.texture),
+                                    ..Default::default()
+                                },
+                            ),
+                        ],
                     )
                     .unwrap()
                     .bind_vertex_buffers(0, self.vertex_buffer.clone())

--- a/examples/ray-tracing-auto/scene.rs
+++ b/examples/ray-tracing-auto/scene.rs
@@ -16,7 +16,8 @@ use vulkano::{
         PrimaryAutoCommandBuffer, PrimaryCommandBufferAbstract,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorImageInfo,
+        DescriptorSet, WriteDescriptorSet,
     },
     device::{Device, Queue},
     format::Format,
@@ -182,13 +183,19 @@ impl Scene {
         .unwrap();
 
         let descriptor_set = DescriptorSet::new(
-            descriptor_set_allocator.clone(),
-            pipeline_layout.set_layouts()[0].clone(),
-            [
-                WriteDescriptorSet::acceleration_structure(0, tlas.clone()),
-                WriteDescriptorSet::buffer(1, uniform_buffer.clone()),
+            descriptor_set_allocator,
+            &pipeline_layout.set_layouts()[0],
+            &[
+                WriteDescriptorSet::acceleration_structure(0, &Some(&tlas)),
+                WriteDescriptorSet::buffer(
+                    1,
+                    &DescriptorBufferInfo {
+                        buffer: Some(uniform_buffer.buffer()),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap();
 
@@ -285,10 +292,16 @@ fn window_size_dependent_setup(
         .map(|image| {
             let image_view = ImageView::new_default(image).unwrap();
             let descriptor_set = DescriptorSet::new(
-                descriptor_set_allocator.clone(),
-                pipeline_layout.set_layouts()[1].clone(),
-                [WriteDescriptorSet::image_view(0, image_view.clone())],
-                [],
+                descriptor_set_allocator,
+                &pipeline_layout.set_layouts()[1],
+                &[WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        image_view: Some(&image_view),
+                        ..Default::default()
+                    },
+                )],
+                &[],
             )
             .unwrap();
 

--- a/examples/ray-tracing/scene.rs
+++ b/examples/ray-tracing/scene.rs
@@ -30,7 +30,6 @@ use vulkano::{
     },
     swapchain::Swapchain,
     sync::GpuFuture,
-    DeviceSize,
 };
 use vulkano_taskgraph::{
     command_buffer::RecordingCommandBuffer,
@@ -209,11 +208,7 @@ impl SceneTask {
 
         let camera_storage_buffer_id = bcx
             .global_set()
-            .create_storage_buffer(
-                camera_buffer_id,
-                0,
-                size_of::<raygen::Camera>() as DeviceSize,
-            )
+            .create_storage_buffer(camera_buffer_id, 0, None)
             .unwrap();
 
         let shader_binding_table = ShaderBindingTable::new(memory_allocator, &pipeline).unwrap();

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -11,7 +11,7 @@ use vulkano::{
             DescriptorBindingFlags, DescriptorSetLayout, DescriptorSetLayoutBinding,
             DescriptorSetLayoutCreateInfo, DescriptorType,
         },
-        DescriptorSet, WriteDescriptorSet,
+        DescriptorImageInfo, DescriptorSet, WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceFeatures,
@@ -515,21 +515,33 @@ impl ApplicationHandler for App {
 
         let layout = &pipeline.layout().set_layouts()[0];
         let descriptor_set = DescriptorSet::new_variable(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
+            &self.descriptor_set_allocator,
+            layout,
             2,
-            [
-                WriteDescriptorSet::sampler(0, self.sampler.clone()),
-                WriteDescriptorSet::image_view_array(
+            &[
+                WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        sampler: Some(&self.sampler),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::image_array(
                     1,
                     0,
-                    [
-                        Some(self.mascot_texture.clone()),
-                        Some(self.vulkano_texture.clone()),
+                    &[
+                        DescriptorImageInfo {
+                            image_view: Some(&self.mascot_texture),
+                            ..Default::default()
+                        },
+                        DescriptorImageInfo {
+                            image_view: Some(&self.vulkano_texture),
+                            ..Default::default()
+                        },
                     ],
                 ),
             ],
-            [],
+            &[],
         )
         .unwrap();
 

--- a/examples/self-copy-buffer/main.rs
+++ b/examples/self-copy-buffer/main.rs
@@ -10,7 +10,8 @@ use vulkano::{
         CommandBufferUsage, CopyBufferInfoTyped,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
@@ -146,10 +147,16 @@ fn main() {
 
     let layout = &pipeline.layout().set_layouts()[0];
     let set = DescriptorSet::new(
-        descriptor_set_allocator,
-        layout.clone(),
-        [WriteDescriptorSet::buffer(0, data_buffer.clone())],
-        [],
+        &descriptor_set_allocator,
+        layout,
+        &[WriteDescriptorSet::buffer(
+            0,
+            &DescriptorBufferInfo {
+                buffer: Some(data_buffer.buffer()),
+                ..Default::default()
+            },
+        )],
+        &[],
     )
     .unwrap();
 

--- a/examples/shader-include/main.rs
+++ b/examples/shader-include/main.rs
@@ -9,7 +9,8 @@ use vulkano::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
@@ -150,10 +151,16 @@ fn main() {
 
     let layout = &pipeline.layout().set_layouts()[0];
     let set = DescriptorSet::new(
-        descriptor_set_allocator,
-        layout.clone(),
-        [WriteDescriptorSet::buffer(0, data_buffer.clone())],
-        [],
+        &descriptor_set_allocator,
+        layout,
+        &[WriteDescriptorSet::buffer(
+            0,
+            &DescriptorBufferInfo {
+                buffer: Some(data_buffer.buffer()),
+                ..Default::default()
+            },
+        )],
+        &[],
     )
     .unwrap();
 

--- a/examples/shader-types-sharing/main.rs
+++ b/examples/shader-types-sharing/main.rs
@@ -23,7 +23,8 @@ use vulkano::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -184,10 +185,16 @@ fn main() {
     ) {
         let layout = &pipeline.layout().set_layouts()[0];
         let set = DescriptorSet::new(
-            descriptor_set_allocator.clone(),
-            layout.clone(),
-            [WriteDescriptorSet::buffer(0, data_buffer.clone())],
-            [],
+            descriptor_set_allocator,
+            layout,
+            &[WriteDescriptorSet::buffer(
+                0,
+                &DescriptorBufferInfo {
+                    buffer: Some(data_buffer.buffer()),
+                    ..Default::default()
+                },
+            )],
+            &[],
         )
         .unwrap();
 

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -11,7 +11,8 @@ use vulkano::{
         CopyBufferInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -249,14 +250,20 @@ impl App {
 
         // Create a new descriptor set for binding vertices as a storage buffer.
         let descriptor_set = DescriptorSet::new(
-            descriptor_set_allocator.clone(),
+            &descriptor_set_allocator,
             // 0 is the index of the descriptor set.
-            compute_pipeline.layout().set_layouts()[0].clone(),
-            [
+            &compute_pipeline.layout().set_layouts()[0],
+            &[
                 // 0 is the binding of the data in this set. We bind the `Buffer` of vertices here.
-                WriteDescriptorSet::buffer(0, vertex_buffer.clone()),
+                WriteDescriptorSet::buffer(
+                    0,
+                    &DescriptorBufferInfo {
+                        buffer: Some(vertex_buffer.buffer()),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap();
 

--- a/examples/specialization-constants/main.rs
+++ b/examples/specialization-constants/main.rs
@@ -7,7 +7,8 @@ use vulkano::{
         allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, QueueCreateInfo,
@@ -151,10 +152,16 @@ fn main() {
 
     let layout = &pipeline.layout().set_layouts()[0];
     let descriptor_set = DescriptorSet::new(
-        descriptor_set_allocator,
-        layout.clone(),
-        [WriteDescriptorSet::buffer(0, data_buffer.clone())],
-        [],
+        &descriptor_set_allocator,
+        layout,
+        &[WriteDescriptorSet::buffer(
+            0,
+            &DescriptorBufferInfo {
+                buffer: Some(data_buffer.buffer()),
+                ..Default::default()
+            },
+        )],
+        &[],
     )
     .unwrap();
 

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -11,7 +11,8 @@ use vulkano::{
         RenderPassBeginInfo,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, DeviceOwned,
@@ -431,10 +432,16 @@ impl ApplicationHandler for App {
 
                 let layout = &rcx.pipeline.layout().set_layouts()[0];
                 let descriptor_set = DescriptorSet::new(
-                    self.descriptor_set_allocator.clone(),
-                    layout.clone(),
-                    [WriteDescriptorSet::buffer(0, uniform_buffer)],
-                    [],
+                    &self.descriptor_set_allocator,
+                    layout,
+                    &[WriteDescriptorSet::buffer(
+                        0,
+                        &DescriptorBufferInfo {
+                            buffer: Some(uniform_buffer.buffer()),
+                            ..Default::default()
+                        },
+                    )],
+                    &[],
                 )
                 .unwrap();
 

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -6,7 +6,8 @@ use vulkano::{
         CopyBufferToImageInfo, PrimaryCommandBufferAbstract, RenderPassBeginInfo,
     },
     descriptor_set::{
-        allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+        allocator::StandardDescriptorSetAllocator, DescriptorImageInfo, DescriptorSet,
+        WriteDescriptorSet,
     },
     device::{
         physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceExtensions, Queue,
@@ -382,13 +383,25 @@ impl ApplicationHandler for App {
 
         let layout = &pipeline.layout().set_layouts()[0];
         let descriptor_set = DescriptorSet::new(
-            self.descriptor_set_allocator.clone(),
-            layout.clone(),
-            [
-                WriteDescriptorSet::sampler(0, self.sampler.clone()),
-                WriteDescriptorSet::image_view(1, self.texture.clone()),
+            &self.descriptor_set_allocator,
+            layout,
+            &[
+                WriteDescriptorSet::image(
+                    0,
+                    &DescriptorImageInfo {
+                        sampler: Some(&self.sampler),
+                        ..Default::default()
+                    },
+                ),
+                WriteDescriptorSet::image(
+                    1,
+                    &DescriptorImageInfo {
+                        image_view: Some(&self.texture),
+                        ..Default::default()
+                    },
+                ),
             ],
-            [],
+            &[],
         )
         .unwrap();
 

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -336,7 +336,7 @@ mod tests {
                 DescriptorSetLayout, DescriptorSetLayoutBinding, DescriptorSetLayoutCreateInfo,
                 DescriptorType,
             },
-            DescriptorSet, WriteDescriptorSet,
+            DescriptorImageInfo, DescriptorSet, WriteDescriptorSet,
         },
         device::{Device, DeviceCreateInfo, QueueCreateInfo},
         image::sampler::{Sampler, SamplerCreateInfo},
@@ -807,13 +807,18 @@ mod tests {
         ));
 
         let set = DescriptorSet::new(
-            ds_allocator.clone(),
-            set_layout.clone(),
-            [WriteDescriptorSet::sampler(
+            &ds_allocator,
+            &set_layout,
+            &[WriteDescriptorSet::image(
                 0,
-                Sampler::new(&device, &SamplerCreateInfo::simple_repeat_linear()).unwrap(),
+                &DescriptorImageInfo {
+                    sampler: Some(
+                        &Sampler::new(&device, &SamplerCreateInfo::simple_repeat_linear()).unwrap(),
+                    ),
+                    ..Default::default()
+                },
             )],
-            [],
+            &[],
         )
         .unwrap();
 
@@ -880,13 +885,18 @@ mod tests {
         .unwrap();
 
         let set = DescriptorSet::new(
-            ds_allocator,
-            set_layout,
-            [WriteDescriptorSet::sampler(
+            &ds_allocator,
+            &set_layout,
+            &[WriteDescriptorSet::image(
                 0,
-                Sampler::new(&device, &SamplerCreateInfo::simple_repeat_linear()).unwrap(),
+                &DescriptorImageInfo {
+                    sampler: Some(
+                        &Sampler::new(&device, &SamplerCreateInfo::simple_repeat_linear()).unwrap(),
+                    ),
+                    ..Default::default()
+                },
             )],
-            [],
+            &[],
         )
         .unwrap();
 

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -960,7 +960,7 @@ impl RecordingCommandBuffer {
         pipeline_bind_point: PipelineBindPoint,
         pipeline: &PipelineLayout,
         set: u32,
-        descriptor_writes: &[WriteDescriptorSet],
+        descriptor_writes: &[WriteDescriptorSet<'_>],
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_push_descriptor_set(pipeline_bind_point, pipeline, set, descriptor_writes)?;
 
@@ -979,7 +979,7 @@ impl RecordingCommandBuffer {
         pipeline_bind_point: PipelineBindPoint,
         layout: &PipelineLayout,
         set: u32,
-        descriptor_writes: &[WriteDescriptorSet],
+        descriptor_writes: &[WriteDescriptorSet<'_>],
     ) -> Result<(), Box<ValidationError>> {
         if !self.device().enabled_extensions().khr_push_descriptor {
             return Err(Box::new(ValidationError {
@@ -1101,7 +1101,7 @@ impl RecordingCommandBuffer {
         pipeline_bind_point: PipelineBindPoint,
         layout: &PipelineLayout,
         set: u32,
-        descriptor_writes: &[WriteDescriptorSet],
+        descriptor_writes: &[WriteDescriptorSet<'_>],
     ) -> &mut Self {
         if descriptor_writes.is_empty() {
             return self;
@@ -1112,7 +1112,7 @@ impl RecordingCommandBuffer {
             .iter()
             .map(|write| {
                 let default_image_layout = set_layout
-                    .binding(write.binding())
+                    .binding(write.dst_binding())
                     .unwrap()
                     .descriptor_type
                     .default_image_layout();
@@ -1131,7 +1131,10 @@ impl RecordingCommandBuffer {
             .map(|((write, write_info_vk), write_extension_vk)| {
                 write.to_vk(
                     vk::DescriptorSet::null(),
-                    set_layout.binding(write.binding()).unwrap().descriptor_type,
+                    set_layout
+                        .binding(write.dst_binding())
+                        .unwrap()
+                        .descriptor_type,
                     write_info_vk,
                     write_extension_vk,
                 )

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -93,8 +93,8 @@ impl RawDescriptorSet {
     #[inline]
     pub unsafe fn update(
         &self,
-        descriptor_writes: &[WriteDescriptorSet],
-        descriptor_copies: &[CopyDescriptorSet],
+        descriptor_writes: &[WriteDescriptorSet<'_>],
+        descriptor_copies: &[CopyDescriptorSet<'_>],
     ) -> Result<(), Box<ValidationError>> {
         if descriptor_writes.is_empty() && descriptor_copies.is_empty() {
             return Ok(());
@@ -108,8 +108,8 @@ impl RawDescriptorSet {
 
     pub(super) fn validate_update(
         &self,
-        descriptor_writes: &[WriteDescriptorSet],
-        descriptor_copies: &[CopyDescriptorSet],
+        descriptor_writes: &[WriteDescriptorSet<'_>],
+        descriptor_copies: &[CopyDescriptorSet<'_>],
     ) -> Result<(), Box<ValidationError>> {
         for (index, write) in descriptor_writes.iter().enumerate() {
             write
@@ -128,8 +128,8 @@ impl RawDescriptorSet {
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn update_unchecked(
         &self,
-        descriptor_writes: &[WriteDescriptorSet],
-        descriptor_copies: &[CopyDescriptorSet],
+        descriptor_writes: &[WriteDescriptorSet<'_>],
+        descriptor_copies: &[CopyDescriptorSet<'_>],
     ) {
         if descriptor_writes.is_empty() && descriptor_copies.is_empty() {
             return;
@@ -140,7 +140,7 @@ impl RawDescriptorSet {
             .iter()
             .map(|write| {
                 let default_image_layout = set_layout
-                    .binding(write.binding())
+                    .binding(write.dst_binding())
                     .unwrap()
                     .descriptor_type
                     .default_image_layout();
@@ -159,7 +159,10 @@ impl RawDescriptorSet {
             .map(|((write, write_info_vk), write_extension_vk)| {
                 write.to_vk(
                     self.handle(),
-                    set_layout.binding(write.binding()).unwrap().descriptor_type,
+                    set_layout
+                        .binding(write.dst_binding())
+                        .unwrap()
+                        .descriptor_type,
                     write_info_vk,
                     write_extension_vk,
                 )

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -20,7 +20,7 @@
 //!             DescriptorSetLayout, DescriptorSetLayoutBinding, DescriptorSetLayoutCreateInfo,
 //!             DescriptorType,
 //!         },
-//!         DescriptorSet, WriteDescriptorSet,
+//!         DescriptorImageInfo, DescriptorSet, WriteDescriptorSet,
 //!     },
 //!     format::Format,
 //!     image::{
@@ -98,10 +98,16 @@
 //! .unwrap();
 //!
 //! let descriptor_set = DescriptorSet::new(
-//!     descriptor_set_allocator.clone(),
-//!     descriptor_set_layout.clone(),
-//!     [WriteDescriptorSet::image_view(0, image_view)],
-//!     [],
+//!     &descriptor_set_allocator,
+//!     &descriptor_set_layout,
+//!     &[WriteDescriptorSet::image(
+//!         0,
+//!         &DescriptorImageInfo {
+//!             image_view: Some(&image_view),
+//!             ..Default::default()
+//!         },
+//!     )],
+//!     &[],
 //! )
 //! .unwrap();
 //! ```

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -440,7 +440,8 @@ mod tests {
             allocator::StandardCommandBufferAllocator, AutoCommandBufferBuilder, CommandBufferUsage,
         },
         descriptor_set::{
-            allocator::StandardDescriptorSetAllocator, DescriptorSet, WriteDescriptorSet,
+            allocator::StandardDescriptorSetAllocator, DescriptorBufferInfo, DescriptorSet,
+            WriteDescriptorSet,
         },
         memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
         pipeline::{
@@ -532,10 +533,16 @@ mod tests {
             &Default::default(),
         ));
         let set = DescriptorSet::new(
-            ds_allocator,
-            pipeline.layout().set_layouts()[0].clone(),
-            [WriteDescriptorSet::buffer(0, data_buffer.clone())],
-            [],
+            &ds_allocator,
+            &pipeline.layout().set_layouts()[0],
+            &[WriteDescriptorSet::buffer(
+                0,
+                &DescriptorBufferInfo {
+                    buffer: Some(data_buffer.buffer()),
+                    ..Default::default()
+                },
+            )],
+            &[],
         )
         .unwrap();
 
@@ -676,10 +683,16 @@ mod tests {
             &Default::default(),
         ));
         let set = DescriptorSet::new(
-            ds_allocator,
-            pipeline.layout().set_layouts()[0].clone(),
-            [WriteDescriptorSet::buffer(0, data_buffer.clone())],
-            [],
+            &ds_allocator,
+            &pipeline.layout().set_layouts()[0],
+            &[WriteDescriptorSet::buffer(
+                0,
+                &DescriptorBufferInfo {
+                    buffer: Some(data_buffer.buffer()),
+                    ..Default::default()
+                },
+            )],
+            &[],
         )
         .unwrap();
 


### PR DESCRIPTION
See #2682 for rationale. Thanks to #2752, we can now make `DescriptorBufferInfo::buffer` an option, which resolves the remaining concern from #2705. Additionally, I was really not a fan of how inconsistent the `WriteDescriptorSet` constructors were even within vulkano itself, but also with raw Vulkan, which made it really confusing. This also removes `Subbuffer`s from `DescriptorSet` APIs for the same reasons as #2746.

Changelog:
```markdown
### Breaking changes
Changes to descriptor sets:
- `WriteDescriptorSet` constructors that previously took buffers, image views and samplers were replaced with constructors that take `DescriptorBufferInfo` and `DescriptorImageInfo`:
  - `WriteDescriptorSet::{none,image_view,image_view_with_layout,image_view_sampler,image_view_with_layout_sampler,sampler}` were replaced with `WriteDescriptorSet::image`.
  - `WriteDescriptorSet::{none_array,image_view_array,image_view_with_layout_array,image_view_sampler_array,image_view_with_layout_sampler_array,sampler_array}` were replaced with `WriteDescriptorSet::image_array`.
  - `WriteDescriptorSet::{buffer,buffer_with_range}` were replaced with `WriteDescriptorSet::buffer`.
  - `WriteDescriptorSet::{buffer_array,buffer_with_range_array}` were replaced with `WriteDescriptorSet::buffer_array`.
  - `DescriptorImageViewInfo` was replaced with `DescriptorImageInfo`.
- `WriteDescriptorSetElements` is now marked `#[non_exhaustive]`.
- `DescriptorSetResources` and `DescriptorBindingResources` were removed.
```