### PR TITLE
image creation with drm modifier but no planes VUID 02261

### DIFF
--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -3060,8 +3060,8 @@ impl<'a> ImageCreateInfo<'a> {
                 .plane_layouts(plane_layouts_vk)
         });
 
-        let drm_format_modifier_list_vk = (!self.drm_format_modifier_plane_layouts.is_empty())
-            .then(|| {
+        let drm_format_modifier_list_vk =
+            (plane_layouts_vk.is_empty() && !self.drm_format_modifiers.is_empty()).then(|| {
                 vk::ImageDrmFormatModifierListCreateInfoEXT::default()
                     .drm_format_modifiers(self.drm_format_modifiers)
             });


### PR DESCRIPTION
1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [x] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   GitHub Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Bugs fixed
- Image creation when `drm_format_modifiers` is provided, but `drm_format_modifier_plane_layouts` isn't.
```

When creating a vkImage for DMA-buf export, it's usually created with `drm_format_modifiers` but without `drm_format_modifier_plane_layouts`. In this case, Vulkano's behavior is inconsistent. 

When not including `drm_format_modifier_plane_layouts`, no `ImageDrmFormatModifierListCreateInfoEXT` is sent and thus the image ends up with an inconsistent modifier that may not be supported by the recipient of the DMA-buf.

When including `drm_format_modifier_plane_layouts`, Vulkano does not log errors, but Vulkan validation layers will complain:
```
Validation Error: [ VUID-VkImageCreateInfo-tiling-02261 ] | MessageID = 0xdefb5562
vkCreateImage(): pCreateInfo->tiling is VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT but pNext has both VkImageDrmFormatModifierListCreateInfoEXT and VkImageDrmFormatModifierExplicitCreateInfoEXT.
The Vulkan spec states: If tiling is VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT, then the pNext chain must include exactly one of VkImageDrmFormatModifierListCreateInfoEXT or VkImageDrmFormatModifierExplicitCreateInfoEXT structures (https://docs.vulkan.org/spec/latest/chapters/resources.html#VUID-VkImageCreateInfo-tiling-02261)
```

This change fixes the behavior so that:
- `drm_format_modifier_plane_layouts` present → `ImageDrmFormatModifierExplicitCreateInfoEXT`
- `drm_format_modifiers` present but not `drm_format_modifier_plane_layouts` → `ImageDrmFormatModifierListCreateInfoEXT`
