### PR TITLE
Allow task graph execution without swapchains

### DIFF
--- a/vulkano-taskgraph/src/graph/execute.rs
+++ b/vulkano-taskgraph/src/graph/execute.rs
@@ -604,6 +604,10 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
             return Ok(());
         };
 
+        if self.swapchains.is_empty() {
+            return Ok(());
+        }
+
         let swapchain_count = self.swapchains.len();
         let mut semaphores = SmallVec::<[_; 1]>::with_capacity(swapchain_count);
         let mut swapchains = SmallVec::<[_; 1]>::with_capacity(swapchain_count);


### PR DESCRIPTION
This change allows using the taskgraph without the extension `VK_KHR_swapchain`, which would panic with `Unable to load queue_present_khr` otherwise.

It also fixes a validation error for `vkQueuePresentKHR` which states that `swapchainCount` must be greater than 0.