### PR TITLE
Fix format aspects validation for DRM format modifier images

### DIFF
--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -1409,7 +1409,8 @@ impl RawImage {
         // VUID-vkGetImageSubresourceLayout-format-04464
         // VUID-vkGetImageSubresourceLayout-format-01581
         // VUID-vkGetImageSubresourceLayout-format-01582
-        if !format_aspects.contains(aspect.into()) {
+        if self.tiling != ImageTiling::DrmFormatModifier && !format_aspects.contains(aspect.into())
+        {
             return Err(Box::new(ValidationError {
                 context: "array_layer".into(),
                 problem: "is greater than the number of array layers in the image".into(),


### PR DESCRIPTION
1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [x] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   GitHub Issues, and highlight important implementation aspects.

   When calling `subresource_layout()` on a `RawImage` that uses DRM format modifiers (`ImageTiling::DrmFormatModifier`), the validation would fall through into the format-aspects checks after correctly validating the `MemoryPlane` aspect. This caused spurious validation errors because DRM format modifier images use `MemoryPlane` aspects, not the usual format aspects (`Color`, `Depth`, `Stencil`, `Plane0`, etc.).

   The fix adds an extra `self.tiling != ImageTiling::DrmFormatModifier` around the validation which was previously failing.

Changelog:
```markdown
### Bugs fixed
- `RawImage::subresource_layout` validation incorrectly rejected valid `MemoryPlane` aspects for DRM format modifier images.
```
