### PR TITLE
Fix invalid virtual ID check

### DIFF
--- a/vulkano-taskgraph/src/graph/execute.rs
+++ b/vulkano-taskgraph/src/graph/execute.rs
@@ -2492,6 +2492,10 @@ impl<'a> ResourceMap<'a> {
     ///
     /// - Panics if the physical resource doesn't match the virtual resource.
     /// - Panics if the physical resource already has a mapping from another virtual resource.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either `virtual_id` or `physical_id` is invalid.
     #[inline]
     pub fn insert_buffer(
         &mut self,
@@ -2571,15 +2575,19 @@ impl<'a> ResourceMap<'a> {
     /// - Panics if the physical resource doesn't match the virtual resource.
     /// - Panics if the physical resource already has a mapping from another virtual resource.
     /// - Panics if `virtual_id` refers to a swapchain image.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either `virtual_id` or `physical_id` is invalid.
     #[inline]
     pub fn insert_image(
         &mut self,
         virtual_id: Id<Image>,
         physical_id: Id<Image>,
     ) -> Result<(), InvalidSlotError> {
-        assert_ne!(virtual_id.object_type(), ObjectType::Swapchain);
-
         self.virtual_resources.get(virtual_id.erase())?;
+
+        assert_ne!(virtual_id.object_type(), ObjectType::Swapchain);
 
         let state = self
             .physical_resources
@@ -2647,6 +2655,10 @@ impl<'a> ResourceMap<'a> {
     ///
     /// - Panics if the physical resource doesn't match the virtual resource.
     /// - Panics if the physical resource already has a mapping from another virtual resource.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either `virtual_id` or `physical_id` is invalid.
     #[inline]
     pub fn insert_swapchain(
         &mut self,

--- a/vulkano-taskgraph/src/lib.rs
+++ b/vulkano-taskgraph/src/lib.rs
@@ -777,6 +777,8 @@ impl<T> Id<T> {
     }
 
     fn object_type(self) -> ObjectType {
+        assert_ne!(self, Self::INVALID, "cannot determine type for invalid ID");
+
         match self.slot.tag() & Id::OBJECT_TYPE_MASK {
             Buffer::TAG => ObjectType::Buffer,
             Image::TAG => ObjectType::Image,


### PR DESCRIPTION
1. [X] Update documentation to reflect any user-facing changes - in this repository.

2. [X] Make sure that the changes are covered by unit-tests.

3. [X] Run `cargo clippy` on the changes.

4. [X] Run `cargo +nightly fmt` on the changes.

5. [X] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [X] Describe in common words what is the purpose of this change, related
   GitHub Issues, and highlight important implementation aspects.

This PR addresses a minor bug/confusion point which can arise when invalid virtual image ID is inserted into the resource map. As `insert_image()` asserts the object type before `virtual_resources.get()`, if the virtual ID happens to be invalid, then it will trigger the `unreachable!()` condition in the match statement in `object_type()`. This is a bit confusing. I fixed this by moving the assertion after `virtual_resources.get()`. In addition I added error documentation and an additional assert in `object_type()` to hopefully clear this up in the future. Let me know if this is right.

Changelog:
```markdown
### Bugs fixed
- ResourceMap::insert_image() now correctly returns an error with invalid virtual_id instead of panicking
```
