### PR TITLE
Emit type alias for runtime array element types in generated shader structs

### DIFF
--- a/vulkano-shaders/src/structs.rs
+++ b/vulkano-shaders/src/structs.rs
@@ -132,7 +132,21 @@ pub(super) fn write_structs(
             #[derive(::vulkano::buffer::BufferContents #(, #custom_derives )* )]
             #[repr(C)]
             #struct_ser
-        })
+        });
+
+        // Emit type aliases for runtime array element types
+        for member in &struct_ty.members {
+            if let Type::Array(ty) = &member.ty {
+                let alias_ident = format_ident!("{}Element", struct_ty.ident);
+                let element_type = array_element_type(&ty, input);
+
+                if let None = ty.length.map(NonZeroUsize::get) {
+                    structs.extend(quote! {
+                        pub type #alias_ident = #element_type;
+                    });
+                }
+            }
+        }
     }
 
     Ok(structs)
@@ -995,13 +1009,7 @@ impl ToTokens for Serializer<'_, TypeMatrix> {
 
 impl ToTokens for Serializer<'_, TypeArray> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let element_type = &*self.0.element_type;
-        // This can't panic because array elements must be sized.
-        let element_size = element_type.size().unwrap();
-        // This can't overflow because the stride must be at least the element size.
-        let padding = self.0.stride - element_size;
-
-        let element_type = Padded(Serializer(element_type, self.1), padding);
+        let element_type = array_element_type(&self.0, self.1);
 
         if let Some(length) = self.0.length.map(NonZero::get) {
             tokens.extend(quote! { [#element_type; #length] });
@@ -1009,6 +1017,15 @@ impl ToTokens for Serializer<'_, TypeArray> {
             tokens.extend(quote! { [#element_type] });
         }
     }
+}
+fn array_element_type<'a>(ty: &'a TypeArray, macro_input: &'a MacroInput) -> Padded<Serializer<'a, Type>> {
+    let element_type = &*ty.element_type;
+    // This can't panic because array elements must be sized.
+    let element_size = element_type.size().unwrap();
+    // This can't overflow because the stride must be at least the element size.
+    let padding = ty.stride - element_size;
+
+    Padded(Serializer(element_type, macro_input), padding)
 }
 
 impl ToTokens for Serializer<'_, TypeStruct> {


### PR DESCRIPTION
This PR acts as a proposal for a maintainability issue when working with vulkano-generated shader structs containing runtime arrays.
##
Issue:

When creating GPU buffers for shader structs, the padding information differs between singular types and array elements due to std430 layout rules.
For example, given this GLSL:
```
struct SurfaceProperty {
      <fields>...
};

layout(set = 0, std430, binding = 0) buffer SurfaceProperties {
      SurfaceProperty surface_properties[];
};
```
Vulkano generates:
```
pub struct SurfaceProperty {
      <fields>...
}

pub struct SurfaceProperties {
      pub surface_properties: [Padded<SurfaceProperty, 12>],
}
```
When allocating a buffer with `vulkano::buffer::Buffer::new_slice`, using an array of `SurfaceProperty` directly produces incorrect std430 stride, while the array wrapper type has the correct stride. However, the correctly-padded element type `Padded<SurfaceProperty, 12>` is anonymous — to use it, I must inspect the generated code with `cargo expand` and recreate the padding myself in my Rust code.
##
Proposal:

Emit a type alias for the padded element type alongside each struct containing a runtime array:
```
pub type SurfacePropertiesElement = Padded<SurfaceProperty, 12>;
```
This allows users to write `Buffer<[SurfacePropertiesElement]>` with correct std430 layout without hardcoding padding or inspecting generated code. 