### PR TITLE
Make raw-window-handle an optional dependency

### DIFF
--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -22,7 +22,7 @@ foldhash = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 libloading = { workspace = true }
 parking_lot = { workspace = true, features = ["send_guard"] }
-raw-window-handle = { workspace = true, features = ["std"] }
+raw-window-handle = { workspace = true, optional = true, features = ["std"] }
 serde = { workspace = true, optional = true }
 slabbin = { workspace = true }
 smallvec = { workspace = true }
@@ -40,10 +40,11 @@ x11rb = { workspace = true, features = ["allow-unsafe-code"], optional = true }
 libc = "0.2.153"
 
 [features]
-default = ["macros", "x11"]
+default = ["macros", "x11", "raw_window_handle"]
 document_unchecked = []
 macros = ["dep:vulkano-macros"]
 x11 = ["dep:x11-dl", "dep:x11rb"]
+raw_window_handle = ["dep:raw-window-handle"]
 
 [lints]
 workspace = true

--- a/vulkano/Cargo.toml
+++ b/vulkano/Cargo.toml
@@ -34,17 +34,17 @@ raw-window-metal = { workspace = true }
 
 [target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "hurd", target_os = "illumos", target_os = "linux", target_os = "netbsd", target_os = "openbsd", target_os = "solaris"))'.dependencies]
 x11-dl = { workspace = true, optional = true }
-x11rb = { workspace = true, features = ["allow-unsafe-code"], optional = true }
+x11rb = { workspace = true, optional = true, features = ["allow-unsafe-code"] }
 
 [dev-dependencies]
 libc = "0.2.153"
 
 [features]
-default = ["macros", "x11", "raw_window_handle"]
+default = ["macros", "raw_window_handle", "x11"]
 document_unchecked = []
 macros = ["dep:vulkano-macros"]
-x11 = ["dep:x11-dl", "dep:x11rb"]
 raw_window_handle = ["dep:raw-window-handle"]
+x11 = ["dep:x11-dl", "dep:x11rb"]
 
 [lints]
 workspace = true

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -26,6 +26,7 @@ use crate::{
 use ash::vk;
 use bytemuck::cast_slice;
 use parking_lot::RwLock;
+#[cfg(feature = "raw_window_handle")]
 use raw_window_handle::{HandleError, HasDisplayHandle, RawDisplayHandle};
 use std::{
     fmt::{Debug, Error as FmtError, Formatter},
@@ -2361,6 +2362,7 @@ impl PhysicalDevice {
     /// [`xcb_presentation_support`]: Self::xcb_presentation_support
     /// [`xlib_presentation_support`]: Self::xlib_presentation_support
     /// [`surface_support`]: Self::surface_support
+    #[cfg(feature = "raw_window_handle")]
     pub fn presentation_support(
         &self,
         queue_family_index: u32,

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -21,7 +21,7 @@
 //!    example, if you use a `winit` version that uses a different version from the one vulkano
 //!    uses, you can add one of the [features](https://docs.rs/crate/winit/latest/features) that
 //!    starts with `rwh` to `winit`. Currently, vulkano is compatible with `rwh_06`.
-//!    
+//!
 //! 4. [Enumerate the physical devices] that are available on the `Instance`, and choose one that
 //!    is suitable for your program. A [`PhysicalDevice`] represents a Vulkan-capable device that
 //!    is available on the system, such as a graphics card, a software implementation, etc.
@@ -96,6 +96,7 @@
 //! | `x11`                | Support for X11 platforms. Enabled by default.                 |
 //! | `document_unchecked` | Include `_unchecked` functions in the generated documentation. |
 //! | `serde`              | Enables (de)serialization of certain types using [`serde`].    |
+//! | `raw_window_handle`  | Include the raw-window-handle dependency and its dependents.   |
 //!
 //! [`Instance`]: instance::Instance
 //! [`Surface`]: swapchain::Surface

--- a/vulkano/src/lib.rs
+++ b/vulkano/src/lib.rs
@@ -90,13 +90,13 @@
 //!
 //! # Cargo features
 //!
-//! | Feature              | Description                                                    |
-//! |----------------------|----------------------------------------------------------------|
-//! | `macros`             | Include reexports from [`vulkano-macros`]. Enabled by default. |
-//! | `x11`                | Support for X11 platforms. Enabled by default.                 |
-//! | `document_unchecked` | Include `_unchecked` functions in the generated documentation. |
-//! | `serde`              | Enables (de)serialization of certain types using [`serde`].    |
-//! | `raw_window_handle`  | Include the raw-window-handle dependency and its dependents.   |
+//! | Feature              | Description                                                                               |
+//! |----------------------|-------------------------------------------------------------------------------------------|
+//! | `macros`             | Include reexports from [`vulkano-macros`]. Enabled by default.                            |
+//! | `raw_window_handle`  | Enables interop with windowing libraries using [`raw-window-handle`]. Enabled by default. |
+//! | `x11`                | When `raw_window_handle` is enabled, support for X11 platforms. Enabled by default.       |
+//! | `document_unchecked` | Include `_unchecked` functions in the generated documentation.                            |
+//! | `serde`              | Enables (de)serialization of certain types using [`serde`].                               |
 //!
 //! [`Instance`]: instance::Instance
 //! [`Surface`]: swapchain::Surface
@@ -118,6 +118,7 @@
 //! [`RenderPass`]: render_pass::RenderPass
 //! [`Framebuffer`]: render_pass::Framebuffer
 //! [`vulkano-macros`]: vulkano_macros
+//! [`raw-window-handle`]: raw_window_handle
 //! [`serde`]: https://crates.io/crates/serde
 
 pub use ash;

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -5,26 +5,30 @@ use crate::{
     display::{DisplayMode, DisplayPlaneAlpha},
     format::Format,
     image::ImageUsage,
-    instance::{Instance, InstanceExtensions, InstanceOwned},
+    instance::{Instance, InstanceOwned},
     macros::{impl_id_counter, vulkan_bitflags_enum, vulkan_enum},
     DebugWrapper, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, VulkanError,
     VulkanObject,
 };
 use ash::vk;
-use raw_window_handle::{
-    HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,
-};
 use smallvec::SmallVec;
 use std::{
     any::Any,
-    error::Error,
     ffi::c_void,
-    fmt::{Debug, Display, Error as FmtError, Formatter},
+    fmt::{Debug, Error as FmtError, Formatter},
     marker::PhantomData,
     mem::MaybeUninit,
     num::NonZero,
     ptr,
     sync::Arc,
+};
+#[cfg(feature = "raw_window_handle")]
+use {
+    crate::instance::InstanceExtensions,
+    raw_window_handle::{
+        HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,
+    },
+    std::{error::Error, fmt::Display},
 };
 
 /// Represents a surface on the screen.
@@ -49,6 +53,7 @@ pub struct Surface {
 impl Surface {
     /// Returns the instance extensions required to create a surface from a window of the given
     /// event loop.
+    #[cfg(feature = "raw_window_handle")]
     pub fn required_extensions(
         event_loop: &impl HasDisplayHandle,
     ) -> Result<InstanceExtensions, HandleError> {
@@ -71,6 +76,7 @@ impl Surface {
     }
 
     /// Creates a new `Surface` from the given `window`.
+    #[cfg(feature = "raw_window_handle")]
     pub fn from_window(
         instance: &Arc<Instance>,
         window: &Arc<impl HasWindowHandle + HasDisplayHandle + Any + Send + Sync>,
@@ -87,6 +93,7 @@ impl Surface {
     /// # Safety
     ///
     /// - The given `window` must outlive the created surface.
+    #[cfg(feature = "raw_window_handle")]
     pub unsafe fn from_window_ref(
         instance: &Arc<Instance>,
         window: &(impl HasWindowHandle + HasDisplayHandle),
@@ -1649,6 +1656,7 @@ pub enum SurfaceApi {
     Xlib,
 }
 
+#[cfg(feature = "raw_window_handle")]
 impl TryFrom<RawWindowHandle> for SurfaceApi {
     type Error = ();
 
@@ -2530,6 +2538,7 @@ fn filter_max(extent: vk::Extent2D) -> Option<[u32; 2]> {
 }
 
 /// Error that can happen when creating a [`Surface`] from a window.
+#[cfg(feature = "raw_window_handle")]
 #[derive(Clone, Debug)]
 pub enum FromWindowError {
     /// Retrieving the window or display handle failed.
@@ -2538,6 +2547,7 @@ pub enum FromWindowError {
     CreateSurface(Validated<VulkanError>),
 }
 
+#[cfg(feature = "raw_window_handle")]
 impl Error for FromWindowError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -2547,6 +2557,7 @@ impl Error for FromWindowError {
     }
 }
 
+#[cfg(feature = "raw_window_handle")]
 impl Display for FromWindowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         match self {

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -1,4 +1,6 @@
 use super::{FullScreenExclusive, PresentGravityFlags, PresentScalingFlags, Win32Monitor};
+#[cfg(feature = "raw_window_handle")]
+use crate::instance::InstanceExtensions;
 use crate::{
     cache::OnceCache,
     device::physical::PhysicalDevice,
@@ -11,6 +13,10 @@ use crate::{
     VulkanObject,
 };
 use ash::vk;
+#[cfg(feature = "raw_window_handle")]
+use raw_window_handle::{
+    HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,
+};
 use smallvec::SmallVec;
 use std::{
     any::Any,
@@ -23,13 +29,7 @@ use std::{
     sync::Arc,
 };
 #[cfg(feature = "raw_window_handle")]
-use {
-    crate::instance::InstanceExtensions,
-    raw_window_handle::{
-        HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,
-    },
-    std::{error::Error, fmt::Display},
-};
+use std::{error::Error, fmt::Display};
 
 /// Represents a surface on the screen.
 ///


### PR DESCRIPTION
1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [x] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   * Make `raw-window-handle` an optional dependency

6. [x] Describe in common words what is the purpose of this change, related
   GitHub Issues, and highlight important implementation aspects.

This PR makes the `raw-window-handle` dependency optional. This is useful because there are a few use cases where this dependency is simply not needed:
* Compute shaders
* Off-screen rendering
* Device info querying

The dependency is now hidden begind a corresponding feature called "raw_window_handle". This feature is enabled by deafult, so it shouldn't break anything.
Without this feature, and the following functions are not included:
* `PhysicalDevice::presentation_support()`,
* `Surface::required_extensions()`,
* `Surface::from_window()`,
* `Surface::from_window_ref()`,
* `SurfaceApi::try_from()`;
and the whole `FromWindowError` enum.

Changelog:
```markdown

### Feature list updates:
- A new feature is introduced: `raw_window_handle`.
```
