### PR TITLE
Add protected support to AutoCommandBufferBuilder

### DIFF
--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -851,7 +851,6 @@ vulkan_bitflags! {
     /// [`sparse_residency_aliased`]: crate::device::DeviceFeatures::sparse_residency_aliased
     SPARSE_ALIASED = SPARSE_ALIASED,*/
 
-    /* TODO: enable
     /// The buffer is protected, and can only be used in combination with protected memory and other
     /// protected objects.
     ///
@@ -859,7 +858,7 @@ vulkan_bitflags! {
     PROTECTED = PROTECTED
     RequiresOneOf([
         RequiresAllOf([APIVersion(V1_1)]),
-    ]),*/
+    ]),
 
     /* TODO: enable
     /// The buffer's device address can be saved and reused on a subsequent run.

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -977,7 +977,6 @@ vulkan_bitflags! {
     /// [`sparse_residency_aliased`]: crate::device::DeviceFeatures::sparse_residency_aliased
     SPARSE_ALIASED = SPARSE_ALIASED,*/
 
-    /* TODO: enable
     /// The buffer is protected, and can only be used in combination with protected memory and other
     /// protected objects.
     ///
@@ -985,7 +984,7 @@ vulkan_bitflags! {
     PROTECTED = PROTECTED
     RequiresOneOf([
         RequiresAllOf([APIVersion(V1_1)]),
-    ]),*/
+    ]),
 
     /* TODO: enable
     /// The buffer's device address can be saved and reused on a subsequent run.

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -363,13 +363,11 @@ impl RawBuffer {
                         the `property_flags` of the memory type of `allocation.device_memory()` \
                         does not contain `MemoryPropertyFlags::PROTECTED`"
                         .into(),
-                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01899"],
+                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01898"],
                     ..Default::default()
                 }));
             }
-        }
-
-        if !self.flags.intersects(BufferCreateFlags::PROTECTED) {
+        } else {
             if memory_type
                 .property_flags
                 .intersects(MemoryPropertyFlags::PROTECTED)
@@ -379,7 +377,7 @@ impl RawBuffer {
                         the `property_flags` of the memory type of `allocation.device_memory()` \
                         contains `MemoryPropertyFlags::PROTECTED`"
                         .into(),
-                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01900"],
+                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01899"],
                     ..Default::default()
                 }));
             }

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -353,17 +353,36 @@ impl RawBuffer {
             }
         }
 
-        if memory_type
-            .property_flags
-            .intersects(MemoryPropertyFlags::PROTECTED)
-        {
-            return Err(Box::new(ValidationError {
-                problem: "the `property_flags` of the memory type of \
-                    `allocation.device_memory()` contains `MemoryPropertyFlags::PROTECTED`"
-                    .into(),
-                vuids: &["VUID-VkBindBufferMemoryInfo-None-01899"],
-                ..Default::default()
-            }));
+        if self.flags.intersects(BufferCreateFlags::PROTECTED) {
+            if !memory_type
+                .property_flags
+                .intersects(MemoryPropertyFlags::PROTECTED)
+            {
+                return Err(Box::new(ValidationError {
+                    problem: "the buffer was created with `BufferCreateFlags::PROTECTED`, but \
+                        the `property_flags` of the memory type of `allocation.device_memory()` \
+                        does not contain `MemoryPropertyFlags::PROTECTED`"
+                        .into(),
+                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01899"],
+                    ..Default::default()
+                }));
+            }
+        }
+
+        if !self.flags.intersects(BufferCreateFlags::PROTECTED) {
+            if memory_type
+                .property_flags
+                .intersects(MemoryPropertyFlags::PROTECTED)
+            {
+                return Err(Box::new(ValidationError {
+                    problem: "the buffer was not created with `BufferCreateFlags::PROTECTED`, but \
+                        the `property_flags` of the memory type of `allocation.device_memory()` \
+                        contains `MemoryPropertyFlags::PROTECTED`"
+                        .into(),
+                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01900"],
+                    ..Default::default()
+                }));
+            }
         }
 
         if !memory.export_handle_types().is_empty() {

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -829,6 +829,57 @@ impl<'a> BufferCreateInfo<'a> {
             }
         }
 
+        if flags.intersects(BufferCreateFlags::PROTECTED) {
+            if !device.enabled_features().protected_memory {
+                return Err(Box::new(ValidationError {
+                    context: "flags".into(),
+                    problem: "contains `BufferCreateFlags::PROTECTED`".into(),
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
+                        "protected_memory",
+                    )])]),
+                    vuids: &["VUID-VkBufferCreateInfo-flags-01887"],
+                }));
+            }
+
+            // If VK_BUFFER_CREATE_SPARSE_ALIASED_BIT support is added, then it should be added to
+            // this validation.
+            if flags
+                .intersects(BufferCreateFlags::SPARSE_BINDING | BufferCreateFlags::SPARSE_RESIDENCY)
+            {
+                return Err(Box::new(ValidationError {
+                    context: "flags".into(),
+                    problem: "contains `BufferCreateFlags::PROTECTED`, but also \
+                        contains one of the sparse memory flags"
+                        .into(),
+                    vuids: &["VUID-VkBufferCreateInfo-None-01888"],
+                    ..Default::default()
+                }));
+            }
+
+            // If VK_BUFFER_USAGE_2_VIDEO_DECODE_SRC_BIT_KHR,
+            // VK_BUFFER_USAGE_2_VIDEO_ENCODE_DST_BIT_KHR,
+            // or VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT get added, then they should be added to
+            // the allowed list.
+            if !(usage
+                - (BufferUsage::TRANSFER_SRC
+                    | BufferUsage::TRANSFER_DST
+                    | BufferUsage::UNIFORM_TEXEL_BUFFER
+                    | BufferUsage::STORAGE_TEXEL_BUFFER
+                    | BufferUsage::UNIFORM_BUFFER
+                    | BufferUsage::STORAGE_BUFFER
+                    | BufferUsage::SHADER_DEVICE_ADDRESS))
+                .is_empty()
+            {
+                return Err(Box::new(ValidationError {
+                    problem: "contains `BufferCreateFlags::PROTECTED`, but also contains \
+                        usages other than [allowed list]"
+                        .into(),
+                    vuids: &["VUID-VkBufferCreateInfo-flags-09641"],
+                    ..Default::default()
+                }));
+            }
+        }
+
         if flags.intersects(BufferCreateFlags::SPARSE_BINDING) {
             if !device.enabled_features().sparse_binding {
                 return Err(Box::new(ValidationError {
@@ -958,8 +1009,8 @@ pub(crate) struct BufferCreateInfoExtensionsVk {
 
 #[cfg(test)]
 mod tests {
-    use super::{BufferCreateInfo, BufferUsage, RawBuffer};
-    use crate::device::DeviceOwned;
+    use super::{BufferCreateFlags, BufferCreateInfo, BufferUsage, RawBuffer};
+    use crate::{device::DeviceOwned, Validated};
 
     #[test]
     fn create() {
@@ -978,6 +1029,56 @@ mod tests {
         assert!(reqs.layout.size() >= 128);
         assert_eq!(buf.size(), 128);
         assert_eq!(buf.device(), &device);
+    }
+
+    #[test]
+    fn validate_no_protected_sparse() {
+        let (device, _) = gfx_dev_and_queue!(protected_memory, sparse_binding);
+        match RawBuffer::new(
+            &device,
+            &BufferCreateInfo {
+                size: 128,
+                flags: (BufferCreateFlags::PROTECTED | BufferCreateFlags::SPARSE_BINDING),
+                usage: BufferUsage::TRANSFER_DST,
+                ..Default::default()
+            },
+        ) {
+            Err(Validated::ValidationError(_)) => {}
+            Err(Validated::Error(err)) => {
+                panic!(
+                    "Expected a ValidationError, but got a runtime error: {:?}",
+                    err
+                );
+            }
+            Ok(_) => {
+                panic!("RawBuffer::new succeeded when it should have failed!");
+            }
+        };
+    }
+
+    #[test]
+    fn validate_invalid_protected_usage() {
+        let (device, _) = gfx_dev_and_queue!(protected_memory);
+        match RawBuffer::new(
+            &device,
+            &BufferCreateInfo {
+                size: 128,
+                flags: BufferCreateFlags::PROTECTED,
+                usage: BufferUsage::INDEX_BUFFER,
+                ..Default::default()
+            },
+        ) {
+            Err(Validated::ValidationError(err)) => {}
+            Err(Validated::Error(err)) => {
+                panic!(
+                    "Expected a ValidationError, but got a runtime error: {:?}",
+                    err
+                );
+            }
+            Ok(_) => {
+                panic!("bind_memory succeeded when it should have failed!");
+            }
+        };
     }
 
     /* Re-enable when sparse binding is properly implemented

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -1034,7 +1034,7 @@ mod tests {
     #[test]
     fn validate_no_protected_sparse() {
         let (device, _) = gfx_dev_and_queue!(protected_memory, sparse_binding);
-        match RawBuffer::new(
+        match RawBuffer::try_new(
             &device,
             &BufferCreateInfo {
                 size: 128,
@@ -1051,7 +1051,7 @@ mod tests {
                 );
             }
             Ok(_) => {
-                panic!("RawBuffer::new succeeded when it should have failed!");
+                panic!("RawBuffer::try_new succeeded when it should have failed!");
             }
         };
     }
@@ -1059,7 +1059,7 @@ mod tests {
     #[test]
     fn validate_invalid_protected_usage() {
         let (device, _) = gfx_dev_and_queue!(protected_memory);
-        match RawBuffer::new(
+        match RawBuffer::try_new(
             &device,
             &BufferCreateInfo {
                 size: 128,
@@ -1068,7 +1068,7 @@ mod tests {
                 ..Default::default()
             },
         ) {
-            Err(Validated::ValidationError(err)) => {}
+            Err(Validated::ValidationError(_)) => {}
             Err(Validated::Error(err)) => {
                 panic!(
                     "Expected a ValidationError, but got a runtime error: {:?}",
@@ -1076,7 +1076,7 @@ mod tests {
                 );
             }
             Ok(_) => {
-                panic!("bind_memory succeeded when it should have failed!");
+                panic!("RawBuffer::try_new succeeded when it should have failed!");
             }
         };
     }

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -410,13 +410,11 @@ impl RawBuffer {
                         the `property_flags` of the memory type of `allocation.device_memory()` \
                         does not contain `MemoryPropertyFlags::PROTECTED`"
                         .into(),
-                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01899"],
+                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01898"],
                     ..Default::default()
                 }));
             }
-        }
-
-        if !self.flags.intersects(BufferCreateFlags::PROTECTED) {
+        } else {
             if memory_type
                 .property_flags
                 .intersects(MemoryPropertyFlags::PROTECTED)
@@ -426,7 +424,7 @@ impl RawBuffer {
                         the `property_flags` of the memory type of `allocation.device_memory()` \
                         contains `MemoryPropertyFlags::PROTECTED`"
                         .into(),
-                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01900"],
+                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01899"],
                     ..Default::default()
                 }));
             }

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -400,17 +400,36 @@ impl RawBuffer {
             }
         }
 
-        if memory_type
-            .property_flags
-            .intersects(MemoryPropertyFlags::PROTECTED)
-        {
-            return Err(Box::new(ValidationError {
-                problem: "the `property_flags` of the memory type of \
-                    `allocation.device_memory()` contains `MemoryPropertyFlags::PROTECTED`"
-                    .into(),
-                vuids: &["VUID-VkBindBufferMemoryInfo-None-01899"],
-                ..Default::default()
-            }));
+        if self.flags.intersects(BufferCreateFlags::PROTECTED) {
+            if !memory_type
+                .property_flags
+                .intersects(MemoryPropertyFlags::PROTECTED)
+            {
+                return Err(Box::new(ValidationError {
+                    problem: "the buffer was created with `BufferCreateFlags::PROTECTED`, but \
+                        the `property_flags` of the memory type of `allocation.device_memory()` \
+                        does not contain `MemoryPropertyFlags::PROTECTED`"
+                        .into(),
+                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01899"],
+                    ..Default::default()
+                }));
+            }
+        }
+
+        if !self.flags.intersects(BufferCreateFlags::PROTECTED) {
+            if memory_type
+                .property_flags
+                .intersects(MemoryPropertyFlags::PROTECTED)
+            {
+                return Err(Box::new(ValidationError {
+                    problem: "the buffer was not created with `BufferCreateFlags::PROTECTED`, but \
+                        the `property_flags` of the memory type of `allocation.device_memory()` \
+                        contains `MemoryPropertyFlags::PROTECTED`"
+                        .into(),
+                    vuids: &["VUID-VkBindBufferMemoryInfo-None-01900"],
+                    ..Default::default()
+                }));
+            }
         }
 
         if !memory.export_handle_types().is_empty() {

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -178,7 +178,7 @@ pub struct StandardCommandBufferAllocator {
     // Each queue family index points directly to its entry.
     pools: ThreadLocal<SmallVec<[UnsafeCell<Option<Entry>>; 8]>>,
     buffer_count: [usize; 2],
-    _command_pool_create_flags: CommandPoolCreateFlags,
+    command_pool_create_flags: CommandPoolCreateFlags,
 }
 
 impl StandardCommandBufferAllocator {
@@ -196,7 +196,7 @@ impl StandardCommandBufferAllocator {
             device: InstanceOwnedDebugWrapper(device.clone()),
             pools: ThreadLocal::new(),
             buffer_count,
-            _command_pool_create_flags: create_info.command_pool_create_flags,
+            command_pool_create_flags: create_info.command_pool_create_flags,
         }
     }
 
@@ -281,7 +281,7 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
         let entry_ptr = self.entry(queue_family_index);
         let entry = unsafe { &mut *entry_ptr };
         let command_pool_create_info = CommandPoolCreateInfo {
-            flags: self._command_pool_create_flags,
+            flags: self.command_pool_create_flags,
             queue_family_index,
             ..Default::default()
         };

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -6,8 +6,8 @@
 
 use super::{
     pool::{
-        CommandBufferAllocateInfo, CommandPool, CommandPoolAlloc, CommandPoolCreateInfo,
-        CommandPoolResetFlags,
+        CommandBufferAllocateInfo, CommandPool, CommandPoolAlloc, CommandPoolCreateFlags,
+        CommandPoolCreateInfo, CommandPoolResetFlags,
     },
     CommandBufferLevel,
 };
@@ -178,6 +178,7 @@ pub struct StandardCommandBufferAllocator {
     // Each queue family index points directly to its entry.
     pools: ThreadLocal<SmallVec<[UnsafeCell<Option<Entry>>; 8]>>,
     buffer_count: [usize; 2],
+    _command_pool_create_flags: CommandPoolCreateFlags,
 }
 
 impl StandardCommandBufferAllocator {
@@ -195,6 +196,7 @@ impl StandardCommandBufferAllocator {
             device: InstanceOwnedDebugWrapper(device.clone()),
             pools: ThreadLocal::new(),
             buffer_count,
+            _command_pool_create_flags: create_info.command_pool_create_flags,
         }
     }
 
@@ -278,11 +280,16 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
 
         let entry_ptr = self.entry(queue_family_index);
         let entry = unsafe { &mut *entry_ptr };
+        let command_pool_create_info = CommandPoolCreateInfo {
+            flags: self._command_pool_create_flags,
+            queue_family_index,
+            ..Default::default()
+        };
 
         if entry.is_none() {
             *entry = Some(Entry::new(
                 &self.device,
-                queue_family_index,
+                &command_pool_create_info,
                 &self.buffer_count,
                 Arc::new(ArrayQueue::new(MAX_POOLS)),
             )?);
@@ -290,7 +297,7 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
 
         let entry = entry.as_mut().unwrap();
 
-        Ok(entry.allocate(queue_family_index, level, &self.buffer_count)?)
+        Ok(entry.allocate(&command_pool_create_info, level, &self.buffer_count)?)
     }
 
     #[inline]
@@ -384,12 +391,17 @@ unsafe impl Send for Entry {}
 impl Entry {
     fn new(
         device: &Arc<Device>,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         buffer_count: &[usize; 2],
         pool_reserve: Arc<ArrayQueue<Arc<Pool>>>,
     ) -> Result<Self, VulkanError> {
         Ok(Entry {
-            pool: Pool::new(device, queue_family_index, buffer_count, &pool_reserve)?,
+            pool: Pool::new(
+                device,
+                command_pool_create_info,
+                buffer_count,
+                &pool_reserve,
+            )?,
             allocations: [0; 2],
             pool_reserve,
         })
@@ -397,7 +409,7 @@ impl Entry {
 
     fn allocate(
         &mut self,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         level: CommandBufferLevel,
         buffer_count: &[usize; 2],
     ) -> Result<CommandBufferAlloc, VulkanError> {
@@ -435,7 +447,7 @@ impl Entry {
                 } else {
                     *self = Entry::new(
                         self.pool.inner.device(),
-                        queue_family_index,
+                        command_pool_create_info,
                         buffer_count,
                         self.pool_reserve.clone(),
                     )?;
@@ -493,18 +505,12 @@ struct Pool {
 impl Pool {
     fn new(
         device: &Arc<Device>,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         buffer_counts: &[usize; 2],
         pool_reserve: &Arc<ArrayQueue<Arc<Self>>>,
     ) -> Result<Arc<Self>, VulkanError> {
-        let inner = CommandPool::new(
-            device,
-            &CommandPoolCreateInfo {
-                queue_family_index,
-                ..Default::default()
-            },
-        )
-        .map_err(Validated::unwrap)?;
+        let inner =
+            CommandPool::new(device, command_pool_create_info).map_err(Validated::unwrap)?;
 
         let levels = [CommandBufferLevel::Primary, CommandBufferLevel::Secondary];
         let mut buffer_reserve = [None, None];
@@ -558,6 +564,11 @@ pub struct StandardCommandBufferAllocatorCreateInfo<'a> {
     /// The default value is `0`.
     pub secondary_buffer_count: usize,
 
+    /// Used to set the flags for pools that the allocator creates.
+    ///
+    /// The default value is empty.
+    pub command_pool_create_flags: CommandPoolCreateFlags,
+
     pub _ne: crate::NonExhaustive<'a>,
 }
 
@@ -575,6 +586,7 @@ impl StandardCommandBufferAllocatorCreateInfo<'_> {
         StandardCommandBufferAllocatorCreateInfo {
             primary_buffer_count: 32,
             secondary_buffer_count: 0,
+            command_pool_create_flags: CommandPoolCreateFlags::empty(),
             _ne: crate::NE,
         }
     }
@@ -610,5 +622,67 @@ impl From<VulkanError> for ResetCommandPoolError {
 impl From<ResetCommandPoolError> for Validated<ResetCommandPoolError> {
     fn from(err: ResetCommandPoolError) -> Self {
         Self::Error(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CommandBufferAllocator, StandardCommandBufferAllocator,
+        StandardCommandBufferAllocatorCreateInfo,
+    };
+    use crate::{
+        command_buffer::{pool::CommandPoolCreateFlags, CommandBufferLevel},
+        Version,
+    };
+
+    #[test]
+    fn basic_create() {
+        let (device, _) = gfx_dev_and_queue!();
+        let _ = StandardCommandBufferAllocator::new(
+            &device,
+            &StandardCommandBufferAllocatorCreateInfo {
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
+    fn basic_alloc() {
+        let (device, queue) = gfx_dev_and_queue!();
+        let allocator = StandardCommandBufferAllocator::new(
+            &device,
+            &StandardCommandBufferAllocatorCreateInfo {
+                ..Default::default()
+            },
+        );
+        let buffer = allocator
+            .allocate(queue.queue_family_index(), CommandBufferLevel::Primary)
+            .unwrap();
+        assert_eq!(buffer.pool.flags(), CommandPoolCreateFlags::empty());
+    }
+
+    #[test]
+    fn alloc_with_command_pool_create_flags() {
+        let (device, queue) = gfx_dev_and_queue!();
+        let desired_flags = {
+            let mut flags = CommandPoolCreateFlags::TRANSIENT;
+
+            if device.api_version() >= Version::V1_1 {
+                flags |= CommandPoolCreateFlags::PROTECTED;
+            }
+            flags
+        };
+        let allocator = StandardCommandBufferAllocator::new(
+            &device,
+            &StandardCommandBufferAllocatorCreateInfo {
+                command_pool_create_flags: desired_flags,
+                ..Default::default()
+            },
+        );
+        let buffer = allocator
+            .allocate(queue.queue_family_index(), CommandBufferLevel::Primary)
+            .unwrap();
+        assert_eq!(buffer.pool.flags(), desired_flags);
     }
 }

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -322,7 +322,7 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
         let entry_ptr = self.entry(queue_family_index);
         let entry = unsafe { &mut *entry_ptr };
         let command_pool_create_info = CommandPoolCreateInfo {
-            flags: self._command_pool_create_flags,
+            flags: self.command_pool_create_flags,
             queue_family_index,
             ..Default::default()
         };

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -450,7 +450,12 @@ impl Entry {
         pool_reserve: Arc<ArrayQueue<Arc<Pool>>>,
     ) -> Result<Self, Validated<VulkanError>> {
         Ok(Entry {
-            pool: Pool::try_new(device, command_pool_create_info, buffer_count, &pool_reserve)?,
+            pool: Pool::try_new(
+                device,
+                command_pool_create_info,
+                buffer_count,
+                &pool_reserve,
+            )?,
             allocations: [0; 2],
             pool_reserve,
         })
@@ -466,10 +471,11 @@ impl Entry {
             // SAFETY: Enforced by the caller.
             pool: unsafe {
                 Pool::new_unchecked(
-                device,
-                command_pool_create_info,
-                buffer_count,
-                &pool_reserve)
+                    device,
+                    command_pool_create_info,
+                    buffer_count,
+                    &pool_reserve,
+                )
             }?,
             allocations: [0; 2],
             pool_reserve,
@@ -639,10 +645,7 @@ impl Pool {
         buffer_counts: &[usize; 2],
         pool_reserve: &Arc<ArrayQueue<Arc<Self>>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
-        let inner = CommandPool::try_new(
-            device,
-            command_pool_create_info,
-        )?;
+        let inner = CommandPool::try_new(device, command_pool_create_info)?;
 
         let levels = [CommandBufferLevel::Primary, CommandBufferLevel::Secondary];
         let mut buffer_reserve = [None, None];
@@ -681,12 +684,7 @@ impl Pool {
         pool_reserve: &Arc<ArrayQueue<Arc<Self>>>,
     ) -> Result<Arc<Self>, VulkanError> {
         // SAFETY: Enforced by the caller.
-        let inner = unsafe {
-            CommandPool::new_unchecked(
-                device,
-                command_pool_create_info,
-            )
-        }?;
+        let inner = unsafe { CommandPool::new_unchecked(device, command_pool_create_info) }?;
 
         let levels = [CommandBufferLevel::Primary, CommandBufferLevel::Secondary];
         let mut buffer_reserve = [None, None];

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -6,8 +6,8 @@
 
 use super::{
     pool::{
-        CommandBufferAllocateInfo, CommandPool, CommandPoolAlloc, CommandPoolCreateInfo,
-        CommandPoolResetFlags,
+        CommandBufferAllocateInfo, CommandPool, CommandPoolAlloc, CommandPoolCreateFlags,
+        CommandPoolCreateInfo, CommandPoolResetFlags,
     },
     CommandBufferLevel,
 };
@@ -204,6 +204,7 @@ pub struct StandardCommandBufferAllocator {
     // Each queue family index points directly to its entry.
     pools: ThreadLocal<SmallVec<[UnsafeCell<Option<Entry>>; 8]>>,
     buffer_count: [usize; 2],
+    _command_pool_create_flags: CommandPoolCreateFlags,
 }
 
 impl StandardCommandBufferAllocator {
@@ -221,6 +222,7 @@ impl StandardCommandBufferAllocator {
             device: InstanceOwnedDebugWrapper(device.clone()),
             pools: ThreadLocal::new(),
             buffer_count,
+            _command_pool_create_flags: create_info.command_pool_create_flags,
         }
     }
 
@@ -291,11 +293,16 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
     ) -> Result<CommandBufferAlloc, Validated<VulkanError>> {
         let entry_ptr = self.entry(queue_family_index);
         let entry = unsafe { &mut *entry_ptr };
+        let command_pool_create_info = CommandPoolCreateInfo {
+            flags: self._command_pool_create_flags,
+            queue_family_index,
+            ..Default::default()
+        };
 
         if entry.is_none() {
             *entry = Some(Entry::try_new(
                 &self.device,
-                queue_family_index,
+                &command_pool_create_info,
                 &self.buffer_count,
                 Arc::new(ArrayQueue::new(MAX_POOLS)),
             )?);
@@ -303,7 +310,7 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
 
         let entry = entry.as_mut().unwrap();
 
-        entry.try_allocate(queue_family_index, level, &self.buffer_count)
+        entry.try_allocate(&command_pool_create_info, level, &self.buffer_count)
     }
 
     #[inline]
@@ -314,13 +321,18 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
     ) -> Result<CommandBufferAlloc, VulkanError> {
         let entry_ptr = self.entry(queue_family_index);
         let entry = unsafe { &mut *entry_ptr };
+        let command_pool_create_info = CommandPoolCreateInfo {
+            flags: self._command_pool_create_flags,
+            queue_family_index,
+            ..Default::default()
+        };
 
         if entry.is_none() {
             // SAFETY: Enforced by the caller.
             *entry = Some(unsafe {
                 Entry::new_unchecked(
                     &self.device,
-                    queue_family_index,
+                    &command_pool_create_info,
                     &self.buffer_count,
                     Arc::new(ArrayQueue::new(MAX_POOLS)),
                 )
@@ -330,7 +342,7 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
         let entry = entry.as_mut().unwrap();
 
         // SAFETY: Enforced by the caller.
-        unsafe { entry.allocate_unchecked(queue_family_index, level, &self.buffer_count) }
+        unsafe { entry.allocate_unchecked(&command_pool_create_info, level, &self.buffer_count) }
     }
 
     #[inline]
@@ -433,12 +445,12 @@ unsafe impl Send for Entry {}
 impl Entry {
     fn try_new(
         device: &Arc<Device>,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         buffer_count: &[usize; 2],
         pool_reserve: Arc<ArrayQueue<Arc<Pool>>>,
     ) -> Result<Self, Validated<VulkanError>> {
         Ok(Entry {
-            pool: Pool::try_new(device, queue_family_index, buffer_count, &pool_reserve)?,
+            pool: Pool::try_new(device, command_pool_create_info, buffer_count, &pool_reserve)?,
             allocations: [0; 2],
             pool_reserve,
         })
@@ -446,14 +458,18 @@ impl Entry {
 
     unsafe fn new_unchecked(
         device: &Arc<Device>,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         buffer_count: &[usize; 2],
         pool_reserve: Arc<ArrayQueue<Arc<Pool>>>,
     ) -> Result<Self, VulkanError> {
         Ok(Entry {
             // SAFETY: Enforced by the caller.
             pool: unsafe {
-                Pool::new_unchecked(device, queue_family_index, buffer_count, &pool_reserve)
+                Pool::new_unchecked(
+                device,
+                command_pool_create_info,
+                buffer_count,
+                &pool_reserve)
             }?,
             allocations: [0; 2],
             pool_reserve,
@@ -462,7 +478,7 @@ impl Entry {
 
     fn try_allocate(
         &mut self,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         level: CommandBufferLevel,
         buffer_count: &[usize; 2],
     ) -> Result<CommandBufferAlloc, Validated<VulkanError>> {
@@ -496,7 +512,7 @@ impl Entry {
                 } else {
                     *self = Entry::try_new(
                         self.pool.inner.device(),
-                        queue_family_index,
+                        command_pool_create_info,
                         buffer_count,
                         self.pool_reserve.clone(),
                     )?;
@@ -526,7 +542,7 @@ impl Entry {
 
     unsafe fn allocate_unchecked(
         &mut self,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         level: CommandBufferLevel,
         buffer_count: &[usize; 2],
     ) -> Result<CommandBufferAlloc, VulkanError> {
@@ -566,7 +582,7 @@ impl Entry {
                     *self = unsafe {
                         Entry::new_unchecked(
                             self.pool.inner.device(),
-                            queue_family_index,
+                            command_pool_create_info,
                             buffer_count,
                             self.pool_reserve.clone(),
                         )
@@ -619,16 +635,13 @@ struct Pool {
 impl Pool {
     fn try_new(
         device: &Arc<Device>,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         buffer_counts: &[usize; 2],
         pool_reserve: &Arc<ArrayQueue<Arc<Self>>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
         let inner = CommandPool::try_new(
             device,
-            &CommandPoolCreateInfo {
-                queue_family_index,
-                ..Default::default()
-            },
+            command_pool_create_info,
         )?;
 
         let levels = [CommandBufferLevel::Primary, CommandBufferLevel::Secondary];
@@ -663,7 +676,7 @@ impl Pool {
 
     unsafe fn new_unchecked(
         device: &Arc<Device>,
-        queue_family_index: u32,
+        command_pool_create_info: &CommandPoolCreateInfo<'_>,
         buffer_counts: &[usize; 2],
         pool_reserve: &Arc<ArrayQueue<Arc<Self>>>,
     ) -> Result<Arc<Self>, VulkanError> {
@@ -671,10 +684,7 @@ impl Pool {
         let inner = unsafe {
             CommandPool::new_unchecked(
                 device,
-                &CommandPoolCreateInfo {
-                    queue_family_index,
-                    ..Default::default()
-                },
+                command_pool_create_info,
             )
         }?;
 
@@ -732,6 +742,11 @@ pub struct StandardCommandBufferAllocatorCreateInfo<'a> {
     /// The default value is `0`.
     pub secondary_buffer_count: usize,
 
+    /// Used to set the flags for pools that the allocator creates.
+    ///
+    /// The default value is empty.
+    pub command_pool_create_flags: CommandPoolCreateFlags,
+
     pub _ne: crate::NonExhaustive<'a>,
 }
 
@@ -749,6 +764,7 @@ impl StandardCommandBufferAllocatorCreateInfo<'_> {
         StandardCommandBufferAllocatorCreateInfo {
             primary_buffer_count: 32,
             secondary_buffer_count: 0,
+            command_pool_create_flags: CommandPoolCreateFlags::empty(),
             _ne: crate::NE,
         }
     }
@@ -784,5 +800,67 @@ impl From<VulkanError> for ResetCommandPoolError {
 impl From<ResetCommandPoolError> for Validated<ResetCommandPoolError> {
     fn from(err: ResetCommandPoolError) -> Self {
         Self::Error(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CommandBufferAllocator, StandardCommandBufferAllocator,
+        StandardCommandBufferAllocatorCreateInfo,
+    };
+    use crate::{
+        command_buffer::{pool::CommandPoolCreateFlags, CommandBufferLevel},
+        Version,
+    };
+
+    #[test]
+    fn basic_create() {
+        let (device, _) = gfx_dev_and_queue!();
+        let _ = StandardCommandBufferAllocator::new(
+            &device,
+            &StandardCommandBufferAllocatorCreateInfo {
+                ..Default::default()
+            },
+        );
+    }
+
+    #[test]
+    fn basic_alloc() {
+        let (device, queue) = gfx_dev_and_queue!();
+        let allocator = StandardCommandBufferAllocator::new(
+            &device,
+            &StandardCommandBufferAllocatorCreateInfo {
+                ..Default::default()
+            },
+        );
+        let buffer = allocator
+            .try_allocate(queue.queue_family_index(), CommandBufferLevel::Primary)
+            .unwrap();
+        assert_eq!(buffer.pool.flags(), CommandPoolCreateFlags::empty());
+    }
+
+    #[test]
+    fn alloc_with_command_pool_create_flags() {
+        let (device, queue) = gfx_dev_and_queue!();
+        let desired_flags = {
+            let mut flags = CommandPoolCreateFlags::TRANSIENT;
+
+            if device.api_version() >= Version::V1_1 {
+                flags |= CommandPoolCreateFlags::PROTECTED;
+            }
+            flags
+        };
+        let allocator = StandardCommandBufferAllocator::new(
+            &device,
+            &StandardCommandBufferAllocatorCreateInfo {
+                command_pool_create_flags: desired_flags,
+                ..Default::default()
+            },
+        );
+        let buffer = allocator
+            .try_allocate(queue.queue_family_index(), CommandBufferLevel::Primary)
+            .unwrap();
+        assert_eq!(buffer.pool.flags(), desired_flags);
     }
 }

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -204,7 +204,7 @@ pub struct StandardCommandBufferAllocator {
     // Each queue family index points directly to its entry.
     pools: ThreadLocal<SmallVec<[UnsafeCell<Option<Entry>>; 8]>>,
     buffer_count: [usize; 2],
-    _command_pool_create_flags: CommandPoolCreateFlags,
+    command_pool_create_flags: CommandPoolCreateFlags,
 }
 
 impl StandardCommandBufferAllocator {
@@ -222,7 +222,7 @@ impl StandardCommandBufferAllocator {
             device: InstanceOwnedDebugWrapper(device.clone()),
             pools: ThreadLocal::new(),
             buffer_count,
-            _command_pool_create_flags: create_info.command_pool_create_flags,
+            command_pool_create_flags: create_info.command_pool_create_flags,
         }
     }
 
@@ -294,7 +294,7 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
         let entry_ptr = self.entry(queue_family_index);
         let entry = unsafe { &mut *entry_ptr };
         let command_pool_create_info = CommandPoolCreateInfo {
-            flags: self._command_pool_create_flags,
+            flags: self.command_pool_create_flags,
             queue_family_index,
             ..Default::default()
         };

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -136,11 +136,6 @@ unsafe impl PrimaryCommandBufferAbstract for PrimaryAutoCommandBuffer {
         self.inner.usage()
     }
 
-    #[inline]
-    fn is_protected(&self) -> bool {
-        self.inner.is_protected()
-    }
-
     fn state(&self) -> MutexGuard<'_, CommandBufferState> {
         self.state.lock()
     }
@@ -682,7 +677,7 @@ mod tests {
         builder.fill_buffer(my_buffer.clone(), 0u32).unwrap();
 
         let cb = builder.build().unwrap();
-        assert!(cb.is_protected());
+        assert!(cb.inner.is_protected());
 
         let future = cb
             .execute(queue)

--- a/vulkano/src/command_buffer/auto/mod.rs
+++ b/vulkano/src/command_buffer/auto/mod.rs
@@ -136,6 +136,11 @@ unsafe impl PrimaryCommandBufferAbstract for PrimaryAutoCommandBuffer {
         self.inner.usage()
     }
 
+    #[inline]
+    fn is_protected(&self) -> bool {
+        self.inner.is_protected()
+    }
+
     fn state(&self) -> MutexGuard<'_, CommandBufferState> {
         self.state.lock()
     }
@@ -324,9 +329,10 @@ impl Debug for CommandInfo {
 #[cfg(test)]
 mod tests {
     use crate::{
-        buffer::{Buffer, BufferCreateInfo, BufferUsage},
+        buffer::{Buffer, BufferCreateFlags, BufferCreateInfo, BufferUsage},
         command_buffer::{
             allocator::{StandardCommandBufferAllocator, StandardCommandBufferAllocatorCreateInfo},
+            pool::CommandPoolCreateFlags,
             AutoCommandBufferBuilder, BufferCopy, CommandBufferUsage, CopyBufferInfoTyped,
             PrimaryCommandBufferAbstract,
         },
@@ -338,9 +344,15 @@ mod tests {
             },
             DescriptorImageInfo, DescriptorSet, WriteDescriptorSet,
         },
-        device::{Device, DeviceCreateInfo, QueueCreateInfo},
+        device::{
+            physical::PhysicalDeviceType, Device, DeviceCreateInfo, DeviceFeatures,
+            QueueCreateFlags, QueueCreateInfo,
+        },
         image::sampler::{Sampler, SamplerCreateInfo},
-        memory::allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
+        memory::{
+            allocator::{AllocationCreateInfo, MemoryTypeFilter, StandardMemoryAllocator},
+            MemoryPropertyFlags,
+        },
         pipeline::{layout::PipelineLayoutCreateInfo, PipelineBindPoint, PipelineLayout},
         shader::ShaderStages,
         sync::GpuFuture,
@@ -577,6 +589,107 @@ mod tests {
         let result = source.read().unwrap();
 
         assert_eq!(*result, [0_u32, 1, 0, 1]);
+    }
+
+    #[test]
+    fn build_protected() {
+        let instance = instance!();
+
+        let protected_memory_feature = DeviceFeatures {
+            protected_memory: true,
+            ..DeviceFeatures::empty()
+        };
+        let select = match instance.enumerate_physical_devices() {
+            Ok(x) => x,
+            Err(_) => return,
+        }
+        .filter(|p| p.supported_features().contains(&protected_memory_feature))
+        .filter_map(|p| {
+            p.queue_family_properties()
+                .iter()
+                .position(|q| {
+                    q.queue_flags
+                        .intersects(crate::device::QueueFlags::GRAPHICS)
+                })
+                .map(|i| (p, i as u32))
+        })
+        .min_by_key(|(p, _)| match p.properties().device_type {
+            PhysicalDeviceType::DiscreteGpu => 0,
+            PhysicalDeviceType::IntegratedGpu => 1,
+            PhysicalDeviceType::VirtualGpu => 2,
+            PhysicalDeviceType::Cpu => 3,
+            PhysicalDeviceType::Other => 4,
+        });
+
+        let (physical_device, queue_family_index) = match select {
+            Some(x) => x,
+            None => return, // skips the test if no device supported protected_memory
+        };
+
+        let (device, mut queues) = Device::new(
+            &physical_device,
+            &DeviceCreateInfo {
+                enabled_features: &DeviceFeatures {
+                    protected_memory: true,
+                    ..DeviceFeatures::empty()
+                },
+                queue_create_infos: &[QueueCreateInfo {
+                    flags: QueueCreateFlags::PROTECTED,
+                    queue_family_index,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let queue = queues.next().unwrap();
+
+        let memory_allocator = Arc::new(StandardMemoryAllocator::new(&device, &Default::default()));
+        let my_buffer = Buffer::new_slice::<u32>(
+            &memory_allocator,
+            &BufferCreateInfo {
+                flags: BufferCreateFlags::PROTECTED,
+                usage: BufferUsage::TRANSFER_DST | BufferUsage::TRANSFER_SRC,
+                ..Default::default()
+            },
+            &AllocationCreateInfo {
+                memory_type_filter: MemoryTypeFilter {
+                    required_flags: MemoryPropertyFlags::PROTECTED,
+                    preferred_flags: MemoryPropertyFlags::empty(),
+                    not_preferred_flags: MemoryPropertyFlags::empty(),
+                },
+                ..Default::default()
+            },
+            1024,
+        )
+        .expect("Failed to create protected buffer");
+
+        let cb_allocator = Arc::new(StandardCommandBufferAllocator::new(
+            &device,
+            &StandardCommandBufferAllocatorCreateInfo {
+                command_pool_create_flags: CommandPoolCreateFlags::PROTECTED,
+                ..Default::default()
+            },
+        ));
+        let mut builder = AutoCommandBufferBuilder::primary(
+            cb_allocator,
+            queue.queue_family_index(),
+            CommandBufferUsage::OneTimeSubmit,
+        )
+        .unwrap();
+
+        builder.fill_buffer(my_buffer.clone(), 0u32).unwrap();
+
+        let cb = builder.build().unwrap();
+        assert!(cb.is_protected());
+
+        let future = cb
+            .execute(queue)
+            .unwrap()
+            .then_signal_fence_and_flush()
+            .unwrap();
+        future.wait(None).unwrap();
     }
 
     #[test]

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -973,6 +973,11 @@ pub struct SubmitInfo<'a> {
     /// The default value is empty.
     pub signal_semaphores: &'a [SemaphoreSubmitInfo<'a>],
 
+    /// Indicates whether the submission is protected.
+    ///
+    /// The default value indicates unprotected submit.
+    pub protected: ProtectedSubmitInfo,
+
     pub _ne: crate::NonExhaustive<'a>,
 }
 
@@ -991,6 +996,7 @@ impl SubmitInfo<'_> {
             wait_semaphores: &[],
             command_buffers: &[],
             signal_semaphores: &[],
+            protected: ProtectedSubmitInfo::new(),
             _ne: crate::NE,
         }
     }
@@ -1000,6 +1006,7 @@ impl SubmitInfo<'_> {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
+            protected,
             _ne: _,
         } = self;
 
@@ -1013,6 +1020,30 @@ impl SubmitInfo<'_> {
             command_buffer_submit_info
                 .validate(device)
                 .map_err(|err| err.add_context(format!("command_buffers[{}]", index)))?;
+
+            if !protected.protected_submit
+                && command_buffer_submit_info.command_buffer.is_protected()
+            {
+                return Err(Box::new(ValidationError {
+                    context: format!("command_buffer[{}]", index).into(),
+                    problem: "is a protected command_buffer, but the protected structure has protected_submit set to false.".into(),
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
+                    "protected_memory",
+                )])]),
+                    vuids: &["VUID-VkSubmitInfo-pNext-04120"],
+                }));
+            } else if protected.protected_submit
+                && !command_buffer_submit_info.command_buffer.is_protected()
+            {
+                return Err(Box::new(ValidationError {
+                    context: format!("command_buffer[{}]", index).into(),
+                    problem: "is an unprotected command_buffer, but the protected structure has protected_submit set to true.".into(),
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
+                    "protected_memory",
+                )])]),
+                    vuids: &["VUID-VkSubmitInfo-pNext-04148"],
+                }));
+            }
         }
 
         for (index, semaphore_submit_info) in signal_semaphores.iter().enumerate() {
@@ -1067,6 +1098,7 @@ impl SubmitInfo<'_> {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
+            protected: _,
             _ne: _,
         } = self;
 
@@ -1128,8 +1160,9 @@ impl SubmitInfo<'_> {
     ) -> SubmitInfoExtensionsVk<'a> {
         let &Self {
             wait_semaphores,
-            command_buffers,
+            command_buffers: _,
             signal_semaphores,
+            protected,
             _ne: _,
         } = self;
         let SubmitInfoFields1Vk {
@@ -1152,10 +1185,8 @@ impl SubmitInfo<'_> {
                     .signal_semaphore_values(signal_semaphore_values_vk)
             });
 
-        let protected_vk = (command_buffers.iter())
-            .any(|command_buffer_submit_info| {
-                command_buffer_submit_info.command_buffer.is_protected()
-            })
+        let protected_vk = protected
+            .protected_submit
             .then(|| vk::ProtectedSubmitInfo::default().protected_submit(true));
 
         SubmitInfoExtensionsVk {
@@ -1169,6 +1200,7 @@ impl SubmitInfo<'_> {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
+            protected: _,
             _ne: _,
         } = self;
 
@@ -1554,12 +1586,44 @@ impl<'a> SemaphoreSubmitInfo<'a> {
     }
 }
 
+/// Structure indicating whether the submission is protected.
+#[derive(Copy, Clone, Debug)]
+pub struct ProtectedSubmitInfo {
+    pub protected_submit: bool,
+    pub _ne: crate::NonExhaustive<'static>,
+}
+
+impl ProtectedSubmitInfo {
+    /// An unprotected ProtectedSubmitInfo.
+    pub const UNPROTECTED: Self = Self {
+        protected_submit: false,
+        _ne: crate::NE,
+    };
+
+    /// A protected ProtectedSubmitInfo.
+    pub const PROTECTED: Self = Self {
+        protected_submit: true,
+        _ne: crate::NE,
+    };
+
+    pub const fn new() -> Self {
+        Self::UNPROTECTED
+    }
+}
+
+impl Default for ProtectedSubmitInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 #[doc(hidden)]
 pub struct OldSubmitInfo {
     pub(crate) wait_semaphores: Vec<Arc<Semaphore>>,
     pub(crate) command_buffers: Vec<Arc<dyn PrimaryCommandBufferAbstract>>,
     pub(crate) signal_semaphores: Vec<Arc<Semaphore>>,
+    pub(crate) protected: ProtectedSubmitInfo,
 }
 
 #[derive(Debug, Default)]

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -1108,9 +1108,14 @@ impl SubmitInfo<'_> {
 
         let SubmitInfoExtensionsVk {
             timeline_semaphore_vk,
+            protected_vk,
         } = extensions_vk;
 
         if let Some(next) = timeline_semaphore_vk {
+            val_vk = val_vk.push_next(next);
+        }
+
+        if let Some(next) = protected_vk {
             val_vk = val_vk.push_next(next);
         }
 
@@ -1123,7 +1128,7 @@ impl SubmitInfo<'_> {
     ) -> SubmitInfoExtensionsVk<'a> {
         let &Self {
             wait_semaphores,
-            command_buffers: _,
+            command_buffers,
             signal_semaphores,
             _ne: _,
         } = self;
@@ -1147,8 +1152,15 @@ impl SubmitInfo<'_> {
                     .signal_semaphore_values(signal_semaphore_values_vk)
             });
 
+        let protected_vk = (command_buffers.iter())
+            .any(|command_buffer_submit_info| {
+                command_buffer_submit_info.command_buffer.is_protected()
+            })
+            .then(|| vk::ProtectedSubmitInfo::default().protected_submit(true));
+
         SubmitInfoExtensionsVk {
             timeline_semaphore_vk,
+            protected_vk,
         }
     }
 
@@ -1216,6 +1228,7 @@ pub(crate) struct SubmitInfo2Fields1Vk {
 
 pub(crate) struct SubmitInfoExtensionsVk<'a> {
     pub(crate) timeline_semaphore_vk: Option<vk::TimelineSemaphoreSubmitInfo<'a>>,
+    pub(crate) protected_vk: Option<vk::ProtectedSubmitInfo<'a>>,
 }
 
 pub(crate) struct SubmitInfoFields1Vk {

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -975,8 +975,8 @@ pub struct SubmitInfo<'a> {
 
     /// Indicates whether the submission is protected.
     ///
-    /// The default value indicates unprotected submit.
-    pub protected: ProtectedSubmitInfo,
+    /// The default value is false, indicating an unprotected submit.
+    pub protected_submit: bool,
 
     pub _ne: crate::NonExhaustive<'a>,
 }
@@ -996,7 +996,7 @@ impl SubmitInfo<'_> {
             wait_semaphores: &[],
             command_buffers: &[],
             signal_semaphores: &[],
-            protected: ProtectedSubmitInfo::new(),
+            protected_submit: false,
             _ne: crate::NE,
         }
     }
@@ -1006,7 +1006,7 @@ impl SubmitInfo<'_> {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
-            protected,
+            protected_submit,
             _ne: _,
         } = self;
 
@@ -1021,7 +1021,7 @@ impl SubmitInfo<'_> {
                 .validate(device)
                 .map_err(|err| err.add_context(format!("command_buffers[{}]", index)))?;
 
-            if !protected.protected_submit
+            if !protected_submit
                 && command_buffer_submit_info.command_buffer.is_protected()
             {
                 return Err(Box::new(ValidationError {
@@ -1032,7 +1032,7 @@ impl SubmitInfo<'_> {
                 )])]),
                     vuids: &["VUID-VkSubmitInfo-pNext-04120"],
                 }));
-            } else if protected.protected_submit
+            } else if protected_submit
                 && !command_buffer_submit_info.command_buffer.is_protected()
             {
                 return Err(Box::new(ValidationError {
@@ -1098,7 +1098,7 @@ impl SubmitInfo<'_> {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
-            protected: _,
+            protected_submit: _,
             _ne: _,
         } = self;
 
@@ -1162,7 +1162,7 @@ impl SubmitInfo<'_> {
             wait_semaphores,
             command_buffers: _,
             signal_semaphores,
-            protected,
+            protected_submit,
             _ne: _,
         } = self;
         let SubmitInfoFields1Vk {
@@ -1185,8 +1185,7 @@ impl SubmitInfo<'_> {
                     .signal_semaphore_values(signal_semaphore_values_vk)
             });
 
-        let protected_vk = protected
-            .protected_submit
+        let protected_vk = protected_submit
             .then(|| vk::ProtectedSubmitInfo::default().protected_submit(true));
 
         SubmitInfoExtensionsVk {
@@ -1200,7 +1199,7 @@ impl SubmitInfo<'_> {
             wait_semaphores,
             command_buffers,
             signal_semaphores,
-            protected: _,
+            protected_submit: _,
             _ne: _,
         } = self;
 
@@ -1586,44 +1585,13 @@ impl<'a> SemaphoreSubmitInfo<'a> {
     }
 }
 
-/// Structure indicating whether the submission is protected.
-#[derive(Copy, Clone, Debug)]
-pub struct ProtectedSubmitInfo {
-    pub protected_submit: bool,
-    pub _ne: crate::NonExhaustive<'static>,
-}
-
-impl ProtectedSubmitInfo {
-    /// An unprotected ProtectedSubmitInfo.
-    pub const UNPROTECTED: Self = Self {
-        protected_submit: false,
-        _ne: crate::NE,
-    };
-
-    /// A protected ProtectedSubmitInfo.
-    pub const PROTECTED: Self = Self {
-        protected_submit: true,
-        _ne: crate::NE,
-    };
-
-    pub const fn new() -> Self {
-        Self::UNPROTECTED
-    }
-}
-
-impl Default for ProtectedSubmitInfo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[derive(Clone, Debug, Default)]
 #[doc(hidden)]
 pub struct OldSubmitInfo {
     pub(crate) wait_semaphores: Vec<Arc<Semaphore>>,
     pub(crate) command_buffers: Vec<Arc<dyn PrimaryCommandBufferAbstract>>,
     pub(crate) signal_semaphores: Vec<Arc<Semaphore>>,
-    pub(crate) protected: ProtectedSubmitInfo,
+    pub(crate) protected_submit: bool,
 }
 
 #[derive(Debug, Default)]

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -1024,10 +1024,11 @@ impl SubmitInfo<'_> {
             if !protected_submit && command_buffer_submit_info.command_buffer.is_protected() {
                 return Err(Box::new(ValidationError {
                     context: format!("command_buffer[{}]", index).into(),
-                    problem: "is a protected command_buffer, but the protected structure has protected_submit set to false.".into(),
-                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
-                    "protected_memory",
-                )])]),
+                    problem: "is a protected command buffer, but `protected_submit` is `false`"
+                        .into(),
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
+                        "protected_memory",
+                    )])]),
                     vuids: &["VUID-VkSubmitInfo-pNext-04120"],
                 }));
             } else if protected_submit && !command_buffer_submit_info.command_buffer.is_protected()

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -1035,10 +1035,11 @@ impl SubmitInfo<'_> {
             {
                 return Err(Box::new(ValidationError {
                     context: format!("command_buffer[{}]", index).into(),
-                    problem: "is an unprotected command_buffer, but the protected structure has protected_submit set to true.".into(),
-                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
-                    "protected_memory",
-                )])]),
+                    problem: "is an unprotected command buffer, but `protected_submit` is `true`"
+                        .into(),
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
+                        "protected_memory",
+                    )])]),
                     vuids: &["VUID-VkSubmitInfo-pNext-04148"],
                 }));
             }

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -1021,9 +1021,7 @@ impl SubmitInfo<'_> {
                 .validate(device)
                 .map_err(|err| err.add_context(format!("command_buffers[{}]", index)))?;
 
-            if !protected_submit
-                && command_buffer_submit_info.command_buffer.is_protected()
-            {
+            if !protected_submit && command_buffer_submit_info.command_buffer.is_protected() {
                 return Err(Box::new(ValidationError {
                     context: format!("command_buffer[{}]", index).into(),
                     problem: "is a protected command_buffer, but the protected structure has protected_submit set to false.".into(),
@@ -1032,8 +1030,7 @@ impl SubmitInfo<'_> {
                 )])]),
                     vuids: &["VUID-VkSubmitInfo-pNext-04120"],
                 }));
-            } else if protected_submit
-                && !command_buffer_submit_info.command_buffer.is_protected()
+            } else if protected_submit && !command_buffer_submit_info.command_buffer.is_protected()
             {
                 return Err(Box::new(ValidationError {
                     context: format!("command_buffer[{}]", index).into(),
@@ -1185,8 +1182,8 @@ impl SubmitInfo<'_> {
                     .signal_semaphore_values(signal_semaphore_values_vk)
             });
 
-        let protected_vk = protected_submit
-            .then(|| vk::ProtectedSubmitInfo::default().protected_submit(true));
+        let protected_vk =
+            protected_submit.then(|| vk::ProtectedSubmitInfo::default().protected_submit(true));
 
         SubmitInfoExtensionsVk {
             timeline_semaphore_vk,

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -422,12 +422,11 @@ vulkan_bitflags! {
     /// Command buffers allocated from this pool can be reset individually.
     RESET_COMMAND_BUFFER = RESET_COMMAND_BUFFER,
 
-    /* TODO: enable
-    // TODO: document
+    /// Specifies that command buffers allocated from the pool are protected command buffers.
     PROTECTED = PROTECTED
     RequiresOneOf([
         RequiresAllOf([APIVersion(V1_1)])
-    ]), */
+    ]),
 }
 
 vulkan_bitflags! {
@@ -529,10 +528,10 @@ impl_id_counter!(CommandPoolAlloc);
 
 #[cfg(test)]
 mod tests {
-    use super::{CommandPool, CommandPoolCreateInfo};
+    use super::{CommandPool, CommandPoolCreateFlags, CommandPoolCreateInfo};
     use crate::{
         command_buffer::{pool::CommandBufferAllocateInfo, CommandBufferLevel},
-        Validated,
+        Validated, Version,
     };
 
     #[test]
@@ -546,6 +545,29 @@ mod tests {
             },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn create_with_flags() {
+        let (device, queue) = gfx_dev_and_queue!();
+        let desired_flags = {
+            let mut flags = CommandPoolCreateFlags::TRANSIENT;
+
+            if device.api_version() >= Version::V1_1 {
+                flags |= CommandPoolCreateFlags::PROTECTED;
+            }
+            flags
+        };
+        let pool = CommandPool::new(
+            &device,
+            &CommandPoolCreateInfo {
+                flags: desired_flags,
+                queue_family_index: queue.queue_family_index(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(desired_flags, pool.flags());
     }
 
     #[test]

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -556,12 +556,11 @@ vulkan_bitflags! {
     /// Command buffers allocated from this pool can be reset individually.
     RESET_COMMAND_BUFFER = RESET_COMMAND_BUFFER,
 
-    /* TODO: enable
-    // TODO: document
+    /// Specifies that command buffers allocated from the pool are protected command buffers.
     PROTECTED = PROTECTED
     RequiresOneOf([
         RequiresAllOf([APIVersion(V1_1)])
-    ]), */
+    ]),
 }
 
 vulkan_bitflags! {
@@ -663,10 +662,10 @@ impl_id_counter!(CommandPoolAlloc);
 
 #[cfg(test)]
 mod tests {
-    use super::{CommandPool, CommandPoolCreateInfo};
+    use super::{CommandPool, CommandPoolCreateFlags, CommandPoolCreateInfo};
     use crate::{
         command_buffer::{pool::CommandBufferAllocateInfo, CommandBufferLevel},
-        Validated,
+        Validated, Version,
     };
 
     #[test]
@@ -680,6 +679,29 @@ mod tests {
             },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn create_with_flags() {
+        let (device, queue) = gfx_dev_and_queue!();
+        let desired_flags = {
+            let mut flags = CommandPoolCreateFlags::TRANSIENT;
+
+            if device.api_version() >= Version::V1_1 {
+                flags |= CommandPoolCreateFlags::PROTECTED;
+            }
+            flags
+        };
+        let pool = CommandPool::new(
+            &device,
+            &CommandPoolCreateInfo {
+                flags: desired_flags,
+                queue_family_index: queue.queue_family_index(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(desired_flags, pool.flags());
     }
 
     #[test]

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1,5 +1,6 @@
 use super::{
     allocator::{CommandBufferAlloc, CommandBufferAllocator},
+    pool::CommandPoolCreateFlags,
     CommandBufferInheritanceInfo, CommandBufferInheritanceInfoExtensionsVk,
     CommandBufferInheritanceInfoFields1Vk, CommandBufferLevel, CommandBufferUsage,
 };
@@ -382,6 +383,16 @@ impl CommandBuffer {
     #[inline]
     pub fn usage(&self) -> CommandBufferUsage {
         self.inner.usage
+    }
+
+    /// Returns true if the command buffer was created from a protected pool.
+    #[inline]
+    pub(crate) fn is_protected(&self) -> bool {
+        self.inner
+            .allocation
+            .pool
+            .flags()
+            .contains(CommandPoolCreateFlags::PROTECTED)
     }
 
     /// Returns the inheritance info of the command buffer, if it is a secondary command buffer.

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -1,5 +1,6 @@
 use super::{
     allocator::{CommandBufferAlloc, CommandBufferAllocator},
+    pool::CommandPoolCreateFlags,
     CommandBufferInheritanceInfo, CommandBufferInheritanceInfoExtensionsVk,
     CommandBufferInheritanceInfoFields1Vk, CommandBufferLevel, CommandBufferUsage,
 };
@@ -451,6 +452,16 @@ impl CommandBuffer {
     #[inline]
     pub fn usage(&self) -> CommandBufferUsage {
         self.inner.usage
+    }
+
+    /// Returns true if the command buffer was created from a protected pool.
+    #[inline]
+    pub(crate) fn is_protected(&self) -> bool {
+        self.inner
+            .allocation
+            .pool
+            .flags()
+            .contains(CommandPoolCreateFlags::PROTECTED)
     }
 
     /// Returns the inheritance info of the command buffer, if it is a secondary command buffer.

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -38,6 +38,9 @@ pub unsafe trait PrimaryCommandBufferAbstract:
     /// Returns the usage of this command buffer.
     fn usage(&self) -> CommandBufferUsage;
 
+    /// Returns true if this command buffer was created in a protected pool.
+    fn is_protected(&self) -> bool;
+
     /// Executes this command buffer on a queue.
     ///
     /// This function returns an object that implements the [`GpuFuture`] trait. See the
@@ -150,6 +153,10 @@ where
 
     fn usage(&self) -> CommandBufferUsage {
         (**self).usage()
+    }
+
+    fn is_protected(&self) -> bool {
+        (**self).is_protected()
     }
 
     fn state(&self) -> MutexGuard<'_, CommandBufferState> {

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -1,6 +1,6 @@
 use super::{
     CommandBuffer, CommandBufferInheritanceInfo, CommandBufferResourcesUsage, CommandBufferState,
-    CommandBufferUsage, OldSubmitInfo, SecondaryCommandBufferResourcesUsage,
+    CommandBufferUsage, OldSubmitInfo, ProtectedSubmitInfo, SecondaryCommandBufferResourcesUsage,
 };
 use crate::{
     buffer::Buffer,
@@ -250,6 +250,10 @@ where
             SubmitAnyBuilder::Empty => SubmitAnyBuilder::CommandBuffer(
                 OldSubmitInfo {
                     command_buffers: vec![self.command_buffer.clone()],
+                    protected: ProtectedSubmitInfo {
+                        protected_submit: self.command_buffer.as_raw().is_protected(),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 None,
@@ -258,6 +262,10 @@ where
                 OldSubmitInfo {
                     wait_semaphores: semaphores.into_iter().collect(),
                     command_buffers: vec![self.command_buffer.clone()],
+                    protected: ProtectedSubmitInfo {
+                        protected_submit: self.command_buffer.as_raw().is_protected(),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 None,

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -38,9 +38,6 @@ pub unsafe trait PrimaryCommandBufferAbstract:
     /// Returns the usage of this command buffer.
     fn usage(&self) -> CommandBufferUsage;
 
-    /// Returns true if this command buffer was created in a protected pool.
-    fn is_protected(&self) -> bool;
-
     /// Executes this command buffer on a queue.
     ///
     /// This function returns an object that implements the [`GpuFuture`] trait. See the
@@ -153,10 +150,6 @@ where
 
     fn usage(&self) -> CommandBufferUsage {
         (**self).usage()
-    }
-
-    fn is_protected(&self) -> bool {
-        (**self).is_protected()
     }
 
     fn state(&self) -> MutexGuard<'_, CommandBufferState> {

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -38,6 +38,9 @@ pub unsafe trait PrimaryCommandBufferAbstract:
     /// Returns the usage of this command buffer.
     fn usage(&self) -> CommandBufferUsage;
 
+    /// Returns true if this command buffer was created in a protected pool.
+    fn is_protected(&self) -> bool;
+
     /// Executes this command buffer on a queue.
     ///
     /// This function returns an object that implements the [`GpuFuture`] trait. See the
@@ -166,6 +169,10 @@ where
 
     fn usage(&self) -> CommandBufferUsage {
         (**self).usage()
+    }
+
+    fn is_protected(&self) -> bool {
+        (**self).is_protected()
     }
 
     fn state(&self) -> MutexGuard<'_, CommandBufferState> {

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -38,9 +38,6 @@ pub unsafe trait PrimaryCommandBufferAbstract:
     /// Returns the usage of this command buffer.
     fn usage(&self) -> CommandBufferUsage;
 
-    /// Returns true if this command buffer was created in a protected pool.
-    fn is_protected(&self) -> bool;
-
     /// Executes this command buffer on a queue.
     ///
     /// This function returns an object that implements the [`GpuFuture`] trait. See the
@@ -169,10 +166,6 @@ where
 
     fn usage(&self) -> CommandBufferUsage {
         (**self).usage()
-    }
-
-    fn is_protected(&self) -> bool {
-        (**self).is_protected()
     }
 
     fn state(&self) -> MutexGuard<'_, CommandBufferState> {

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -1,6 +1,6 @@
 use super::{
     CommandBuffer, CommandBufferInheritanceInfo, CommandBufferResourcesUsage, CommandBufferState,
-    CommandBufferUsage, OldSubmitInfo, ProtectedSubmitInfo, SecondaryCommandBufferResourcesUsage,
+    CommandBufferUsage, OldSubmitInfo, SecondaryCommandBufferResourcesUsage,
 };
 use crate::{
     buffer::Buffer,
@@ -266,10 +266,7 @@ where
             SubmitAnyBuilder::Empty => SubmitAnyBuilder::CommandBuffer(
                 OldSubmitInfo {
                     command_buffers: vec![self.command_buffer.clone()],
-                    protected: ProtectedSubmitInfo {
-                        protected_submit: self.command_buffer.as_raw().is_protected(),
-                        ..Default::default()
-                    },
+                    protected_submit: self.command_buffer.as_raw().is_protected(),
                     ..Default::default()
                 },
                 None,
@@ -278,10 +275,7 @@ where
                 OldSubmitInfo {
                     wait_semaphores: semaphores.into_iter().collect(),
                     command_buffers: vec![self.command_buffer.clone()],
-                    protected: ProtectedSubmitInfo {
-                        protected_submit: self.command_buffer.as_raw().is_protected(),
-                        ..Default::default()
-                    },
+                    protected_submit: self.command_buffer.as_raw().is_protected(),
                     ..Default::default()
                 },
                 None,

--- a/vulkano/src/command_buffer/traits.rs
+++ b/vulkano/src/command_buffer/traits.rs
@@ -1,6 +1,6 @@
 use super::{
     CommandBuffer, CommandBufferInheritanceInfo, CommandBufferResourcesUsage, CommandBufferState,
-    CommandBufferUsage, OldSubmitInfo, SecondaryCommandBufferResourcesUsage,
+    CommandBufferUsage, OldSubmitInfo, ProtectedSubmitInfo, SecondaryCommandBufferResourcesUsage,
 };
 use crate::{
     buffer::Buffer,
@@ -266,6 +266,10 @@ where
             SubmitAnyBuilder::Empty => SubmitAnyBuilder::CommandBuffer(
                 OldSubmitInfo {
                     command_buffers: vec![self.command_buffer.clone()],
+                    protected: ProtectedSubmitInfo {
+                        protected_submit: self.command_buffer.as_raw().is_protected(),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 None,
@@ -274,6 +278,10 @@ where
                 OldSubmitInfo {
                     wait_semaphores: semaphores.into_iter().collect(),
                     command_buffers: vec![self.command_buffer.clone()],
+                    protected: ProtectedSubmitInfo {
+                        protected_submit: self.command_buffer.as_raw().is_protected(),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
                 None,

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -660,6 +660,7 @@ impl<'a> QueueGuard<'a> {
                 wait_semaphores,
                 command_buffers,
                 signal_semaphores,
+                protected: _,
                 _ne: _,
             } = submit_info;
 

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -807,6 +807,7 @@ impl<'a> QueueGuard<'a> {
                 wait_semaphores,
                 command_buffers,
                 signal_semaphores,
+                protected: _,
                 _ne: _,
             } = submit_info;
 

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -807,7 +807,7 @@ impl<'a> QueueGuard<'a> {
                 wait_semaphores,
                 command_buffers,
                 signal_semaphores,
-                protected: _,
+                protected_submit: _,
                 _ne: _,
             } = submit_info;
 

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -1140,12 +1140,11 @@ vulkan_bitflags! {
         RequiresAllOf([DeviceExtension(khr_maintenance2)]),
     ]),
 
-    /* TODO: enable
-    // TODO: document
+    /// Specifies that the image is a protected image.
     PROTECTED = PROTECTED
     RequiresOneOf([
         RequiresAllOf([APIVersion(V1_1)]),
-    ]),*/
+    ]),
 
     /// For images with a multi-planar format, whether each plane will have its memory bound
     /// separately, rather than having a single memory binding for the whole image.

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -1245,12 +1245,11 @@ vulkan_bitflags! {
         RequiresAllOf([DeviceExtension(khr_maintenance2)]),
     ]),
 
-    /* TODO: enable
-    // TODO: document
+    /// Specifies that the image is a protected image.
     PROTECTED = PROTECTED
     RequiresOneOf([
         RequiresAllOf([APIVersion(V1_1)]),
-    ]),*/
+    ]),
 
     /// For images with a multi-planar format, whether each plane will have its memory bound
     /// separately, rather than having a single memory binding for the whole image.

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -3132,7 +3132,7 @@ mod tests {
             ImageAspect, ImageAspects, ImageCreateFlags, ImageSubresourceRange, ImageType,
             SampleCount, SubresourceRangeIterator,
         },
-        DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError,
+        DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version,
     };
     use smallvec::SmallVec;
 
@@ -3168,6 +3168,27 @@ mod tests {
             },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn create_protected() {
+        let (device, _) = gfx_dev_and_queue!();
+
+        if device.api_version() >= Version::V1_1 {
+            let image = RawImage::new(
+                &device,
+                &ImageCreateInfo {
+                    flags: ImageCreateFlags::PROTECTED,
+                    image_type: ImageType::Dim2d,
+                    format: Format::R8G8B8A8_UNORM,
+                    extent: [32, 32, 1],
+                    usage: ImageUsage::SAMPLED,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            assert_eq!(image.flags(), ImageCreateFlags::PROTECTED);
+        }
     }
 
     #[test]

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -3220,7 +3220,7 @@ mod tests {
             ImageAspect, ImageAspects, ImageCreateFlags, ImageSubresourceRange, ImageType,
             SampleCount, SubresourceRangeIterator,
         },
-        DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError,
+        DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version,
     };
     use smallvec::SmallVec;
 
@@ -3256,6 +3256,27 @@ mod tests {
             },
         )
         .unwrap();
+    }
+
+    #[test]
+    fn create_protected() {
+        let (device, _) = gfx_dev_and_queue!();
+
+        if device.api_version() >= Version::V1_1 {
+            let image = RawImage::new(
+                &device,
+                &ImageCreateInfo {
+                    flags: ImageCreateFlags::PROTECTED,
+                    image_type: ImageType::Dim2d,
+                    format: Format::R8G8B8A8_UNORM,
+                    extent: [32, 32, 1],
+                    usage: ImageUsage::SAMPLED,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            assert_eq!(image.flags(), ImageCreateFlags::PROTECTED);
+        }
     }
 
     #[test]

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -773,21 +773,42 @@ impl RawImage {
                 }
             }
 
-            if memory_type
-                .property_flags
-                .intersects(MemoryPropertyFlags::PROTECTED)
-            {
-                return Err(Box::new(ValidationError {
-                    problem: format!(
-                        "the `property_flags` of the memory type of \
-                        `allocations[{}].device_memory()` contains \
-                        `MemoryPropertyFlags::PROTECTED`",
-                        index
-                    )
-                    .into(),
-                    vuids: &["VUID-VkBindImageMemoryInfo-None-01901"],
-                    ..Default::default()
-                }));
+            if self.flags.intersects(ImageCreateFlags::PROTECTED) {
+                if !memory_type
+                    .property_flags
+                    .intersects(MemoryPropertyFlags::PROTECTED)
+                {
+                    return Err(Box::new(ValidationError {
+                        problem: format!(
+                            "the image was created with `ImageCreateFlags::PROTECTED`, \
+                            but the `property_flags` of the memory type of \
+                            `allocations[{}].device_memory()` does not contain \
+                            `MemoryPropertyFlags::PROTECTED`",
+                            index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkBindImageMemoryInfo-None-01901"],
+                        ..Default::default()
+                    }));
+                }
+            } else {
+                if memory_type
+                    .property_flags
+                    .intersects(MemoryPropertyFlags::PROTECTED)
+                {
+                    return Err(Box::new(ValidationError {
+                        problem: format!(
+                            "the image was not created with `ImageCreateFlags::PROTECTED`, \
+                            but the `property_flags` of the memory type of \
+                            `allocations[{}].device_memory()` contains \
+                            `MemoryPropertyFlags::PROTECTED`",
+                            index
+                        )
+                        .into(),
+                        vuids: &["VUID-VkBindImageMemoryInfo-None-01902"],
+                        ..Default::default()
+                    }));
+                }
             }
 
             if !memory.export_handle_types().is_empty() {
@@ -3220,9 +3241,11 @@ mod tests {
             ImageAspect, ImageAspects, ImageCreateFlags, ImageSubresourceRange, ImageType,
             SampleCount, SubresourceRangeIterator,
         },
-        DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError, Version,
+        memory::{DeviceMemory, MemoryAllocateInfo, MemoryPropertyFlags, ResourceMemory},
+        DeviceSize, Requires, RequiresAllOf, RequiresOneOf, Validated, ValidationError,
     };
     use smallvec::SmallVec;
+    use std::iter;
 
     #[test]
     fn create_sampled() {
@@ -3260,22 +3283,165 @@ mod tests {
 
     #[test]
     fn create_protected() {
-        let (device, _) = gfx_dev_and_queue!();
+        let (device, _) = gfx_dev_and_queue!(protected_memory);
 
-        if device.api_version() >= Version::V1_1 {
-            let image = RawImage::new(
-                &device,
-                &ImageCreateInfo {
-                    flags: ImageCreateFlags::PROTECTED,
-                    image_type: ImageType::Dim2d,
-                    format: Format::R8G8B8A8_UNORM,
-                    extent: [32, 32, 1],
-                    usage: ImageUsage::SAMPLED,
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-            assert_eq!(image.flags(), ImageCreateFlags::PROTECTED);
+        let image = RawImage::new(
+            &device,
+            &ImageCreateInfo {
+                flags: ImageCreateFlags::PROTECTED,
+                image_type: ImageType::Dim2d,
+                format: Format::R8G8B8A8_UNORM,
+                extent: [32, 32, 1],
+                usage: ImageUsage::SAMPLED,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(image.flags(), ImageCreateFlags::PROTECTED);
+
+        let requirements = image.memory_requirements()[0];
+
+        let memory_type_index = device
+            .physical_device()
+            .memory_properties()
+            .memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, ty)| {
+                (requirements.memory_type_bits & (1 << id)) != 0
+                    && ty.property_flags.contains(MemoryPropertyFlags::PROTECTED)
+            })
+            .expect("Failed to find suitable memory type") as u32;
+
+        let memory = DeviceMemory::allocate(
+            &device,
+            &MemoryAllocateInfo {
+                allocation_size: requirements.layout.size(),
+                memory_type_index,
+                ..Default::default()
+            },
+        )
+        .expect("Failed to allocate memory");
+
+        let resource_memory = ResourceMemory::new_dedicated(memory);
+
+        let result = image.bind_memory(iter::once(resource_memory));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn create_unprotected_image_bind_protected_memory() {
+        let (device, _) = gfx_dev_and_queue!(protected_memory);
+
+        let image = RawImage::new(
+            &device,
+            &ImageCreateInfo {
+                image_type: ImageType::Dim2d,
+                format: Format::R8G8B8A8_UNORM,
+                extent: [32, 32, 1],
+                usage: ImageUsage::SAMPLED,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let requirements = image.memory_requirements()[0];
+
+        let memory_type_index = device
+            .physical_device()
+            .memory_properties()
+            .memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, ty)| {
+                (requirements.memory_type_bits & (1 << id)) == 0
+                    && ty.property_flags.contains(MemoryPropertyFlags::PROTECTED)
+            })
+            .expect("Failed to find suitable memory type") as u32;
+
+        let memory = DeviceMemory::allocate(
+            &device,
+            &MemoryAllocateInfo {
+                allocation_size: requirements.layout.size(),
+                memory_type_index,
+                ..Default::default()
+            },
+        )
+        .expect("Failed to allocate memory");
+
+        let resource_memory = ResourceMemory::new_dedicated(memory);
+
+        let res = image.bind_memory(iter::once(resource_memory));
+        match res {
+            Err((Validated::ValidationError(_), _, _)) => {}
+            Ok(_) => {
+                panic!("bind_memory succeeded when it should have failed!");
+            }
+            Err((Validated::Error(err), _, _)) => {
+                panic!(
+                    "Expected a ValidationError, but got a runtime error: {:?}",
+                    err
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn create_protected_image_bind_unprotected_memory() {
+        let (device, _) = gfx_dev_and_queue!(protected_memory);
+
+        let image = RawImage::new(
+            &device,
+            &ImageCreateInfo {
+                flags: ImageCreateFlags::PROTECTED,
+                image_type: ImageType::Dim2d,
+                format: Format::R8G8B8A8_UNORM,
+                extent: [32, 32, 1],
+                usage: ImageUsage::SAMPLED,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(image.flags(), ImageCreateFlags::PROTECTED);
+
+        let requirements = image.memory_requirements()[0];
+
+        let memory_type_index = device
+            .physical_device()
+            .memory_properties()
+            .memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, ty)| {
+                (requirements.memory_type_bits & (1 << id)) == 0
+                    && !ty.property_flags.contains(MemoryPropertyFlags::PROTECTED)
+            })
+            .expect("Failed to find suitable memory type") as u32;
+
+        let memory = DeviceMemory::allocate(
+            &device,
+            &MemoryAllocateInfo {
+                allocation_size: requirements.layout.size(),
+                memory_type_index,
+                ..Default::default()
+            },
+        )
+        .expect("Failed to allocate memory");
+
+        let resource_memory = ResourceMemory::new_dedicated(memory);
+
+        let res = image.bind_memory(iter::once(resource_memory));
+        match res {
+            Err((Validated::ValidationError(_), _, _)) => {}
+            Ok(_) => {
+                panic!("bind_memory succeeded when it should have failed!");
+            }
+            Err((Validated::Error(err), _, _)) => {
+                panic!(
+                    "Expected a ValidationError, but got a runtime error: {:?}",
+                    err
+                );
+            }
         }
     }
 

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -3361,7 +3361,7 @@ mod tests {
     fn create_protected_and_sparse_is_disallowed() {
         let (device, _) = gfx_dev_and_queue!(protected_memory, sparse_binding);
 
-        match RawImage::new(
+        match RawImage::try_new(
             &device,
             &ImageCreateInfo {
                 flags: (ImageCreateFlags::PROTECTED | ImageCreateFlags::SPARSE_BINDING),
@@ -3372,7 +3372,7 @@ mod tests {
                 ..Default::default()
             },
         ) {
-            Err(Validated::ValidationError(err)) => {}
+            Err(Validated::ValidationError(_)) => {}
             Err(Validated::Error(err)) => {
                 panic!(
                     "Expected a ValidationError, but got a runtime error: {:?}",
@@ -3380,7 +3380,7 @@ mod tests {
                 );
             }
             Ok(_) => {
-                panic!("RawImage::new succeeded when it should have failed!");
+                panic!("RawImage::try_new succeeded when it should have failed!");
             }
         }
     }
@@ -3389,7 +3389,7 @@ mod tests {
     fn create_unprotected_image_bind_protected_memory() {
         let (device, _) = gfx_dev_and_queue!(protected_memory);
 
-        let image = RawImage::new(
+        let image = RawImage::try_new(
             &device,
             &ImageCreateInfo {
                 image_type: ImageType::Dim2d,
@@ -3427,7 +3427,7 @@ mod tests {
 
         let resource_memory = ResourceMemory::new_dedicated(memory);
 
-        let res = image.bind_memory(iter::once(resource_memory));
+        let res = image.try_bind_memory(iter::once(resource_memory));
         match res {
             Err((Validated::ValidationError(_), _, _)) => {}
             Ok(_) => {
@@ -3446,7 +3446,7 @@ mod tests {
     fn create_protected_image_bind_unprotected_memory() {
         let (device, _) = gfx_dev_and_queue!(protected_memory);
 
-        let image = RawImage::new(
+        let image = RawImage::try_new(
             &device,
             &ImageCreateInfo {
                 flags: ImageCreateFlags::PROTECTED,
@@ -3486,11 +3486,11 @@ mod tests {
 
         let resource_memory = ResourceMemory::new_dedicated(memory);
 
-        let res = image.bind_memory(iter::once(resource_memory));
+        let res = image.try_bind_memory(iter::once(resource_memory));
         match res {
             Err((Validated::ValidationError(_), _, _)) => {}
             Ok(_) => {
-                panic!("bind_memory succeeded when it should have failed!");
+                panic!("try_bind_memory succeeded when it should have failed!");
             }
             Err((Validated::Error(err), _, _)) => {
                 panic!(

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -1903,6 +1903,34 @@ impl<'a> ImageCreateInfo<'a> {
             }));
         }
 
+        if flags.intersects(ImageCreateFlags::PROTECTED) {
+            if !device.enabled_features().protected_memory {
+                return Err(Box::new(ValidationError {
+                    context: "flags".into(),
+                    problem: "contains `ImageCreateFlags::PROTECTED`".into(),
+                    requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
+                        "protected_memory",
+                    )])]),
+                    vuids: &["VUID-VkImageCreateInfo-flags-01890"],
+                }));
+            }
+
+            // If VK_IMAGE_CREATE_SPARSE_ALIASED_BIT support is added, then it should be added to
+            // this validation.
+            if flags
+                .intersects(ImageCreateFlags::SPARSE_BINDING | ImageCreateFlags::SPARSE_RESIDENCY)
+            {
+                return Err(Box::new(ValidationError {
+                    context: "flags".into(),
+                    problem: "contains `BufferCreateFlags::PROTECTED`, but also \
+                        contains one of the sparse memory flags"
+                        .into(),
+                    vuids: &["VUID-VkImageCreateInfo-None-01891"],
+                    ..Default::default()
+                }));
+            }
+        }
+
         if !view_formats.is_empty() {
             if !(device.api_version() >= Version::V1_2
                 || device.enabled_extensions().khr_image_format_list)
@@ -3327,6 +3355,34 @@ mod tests {
 
         let result = image.bind_memory(iter::once(resource_memory));
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn create_protected_and_sparse_is_disallowed() {
+        let (device, _) = gfx_dev_and_queue!(protected_memory, sparse_binding);
+
+        match RawImage::new(
+            &device,
+            &ImageCreateInfo {
+                flags: (ImageCreateFlags::PROTECTED | ImageCreateFlags::SPARSE_BINDING),
+                image_type: ImageType::Dim2d,
+                format: Format::R8G8B8A8_UNORM,
+                extent: [32, 32, 1],
+                usage: ImageUsage::SAMPLED,
+                ..Default::default()
+            },
+        ) {
+            Err(Validated::ValidationError(err)) => {}
+            Err(Validated::Error(err)) => {
+                panic!(
+                    "Expected a ValidationError, but got a runtime error: {:?}",
+                    err
+                );
+            }
+            Ok(_) => {
+                panic!("RawImage::new succeeded when it should have failed!");
+            }
+        }
     }
 
     #[test]

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -749,16 +749,18 @@ pub(crate) unsafe fn queue_submit(
                     .iter()
                     .map(|semaphore| SemaphoreSubmitInfo::new(semaphore))
                     .collect::<Vec<_>>(),
+                submit_info.protected,
             )
         })
         .collect::<Vec<_>>();
     let new_submit_infos = new_submit_infos
         .iter()
         .map(
-            |(wait_semaphores, command_buffers, signal_semaphores)| SubmitInfo {
+            |(wait_semaphores, command_buffers, signal_semaphores, protected)| SubmitInfo {
                 wait_semaphores,
                 command_buffers,
                 signal_semaphores,
+                protected: *protected,
                 ..Default::default()
             },
         )
@@ -772,6 +774,7 @@ pub(crate) unsafe fn queue_submit(
             wait_semaphores: _,
             command_buffers,
             signal_semaphores: _,
+            protected: _,
         } = submit_info;
 
         for command_buffer in command_buffers {
@@ -837,6 +840,7 @@ impl<'a> States<'a> {
                 wait_semaphores: _,
                 command_buffers: info_command_buffers,
                 signal_semaphores: _,
+                protected: _,
             } = submit_info;
 
             for command_buffer in info_command_buffers {

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -801,16 +801,18 @@ pub(crate) unsafe fn queue_submit(
                     .iter()
                     .map(|semaphore| SemaphoreSubmitInfo::new(semaphore))
                     .collect::<Vec<_>>(),
+                submit_info.protected,
             )
         })
         .collect::<Vec<_>>();
     let new_submit_infos = new_submit_infos
         .iter()
         .map(
-            |(wait_semaphores, command_buffers, signal_semaphores)| SubmitInfo {
+            |(wait_semaphores, command_buffers, signal_semaphores, protected)| SubmitInfo {
                 wait_semaphores,
                 command_buffers,
                 signal_semaphores,
+                protected: *protected,
                 ..Default::default()
             },
         )
@@ -824,6 +826,7 @@ pub(crate) unsafe fn queue_submit(
             wait_semaphores: _,
             command_buffers,
             signal_semaphores: _,
+            protected: _,
         } = submit_info;
 
         for command_buffer in command_buffers {
@@ -889,6 +892,7 @@ impl<'a> States<'a> {
                 wait_semaphores: _,
                 command_buffers: info_command_buffers,
                 signal_semaphores: _,
+                protected: _,
             } = submit_info;
 
             for command_buffer in info_command_buffers {

--- a/vulkano/src/sync/future/mod.rs
+++ b/vulkano/src/sync/future/mod.rs
@@ -801,18 +801,18 @@ pub(crate) unsafe fn queue_submit(
                     .iter()
                     .map(|semaphore| SemaphoreSubmitInfo::new(semaphore))
                     .collect::<Vec<_>>(),
-                submit_info.protected,
+                submit_info.protected_submit,
             )
         })
         .collect::<Vec<_>>();
     let new_submit_infos = new_submit_infos
         .iter()
         .map(
-            |(wait_semaphores, command_buffers, signal_semaphores, protected)| SubmitInfo {
+            |(wait_semaphores, command_buffers, signal_semaphores, protected_submit)| SubmitInfo {
                 wait_semaphores,
                 command_buffers,
                 signal_semaphores,
-                protected: *protected,
+                protected_submit: *protected_submit,
                 ..Default::default()
             },
         )
@@ -826,7 +826,7 @@ pub(crate) unsafe fn queue_submit(
             wait_semaphores: _,
             command_buffers,
             signal_semaphores: _,
-            protected: _,
+            protected_submit: _,
         } = submit_info;
 
         for command_buffer in command_buffers {
@@ -892,7 +892,7 @@ impl<'a> States<'a> {
                 wait_semaphores: _,
                 command_buffers: info_command_buffers,
                 signal_semaphores: _,
-                protected: _,
+                protected_submit: _,
             } = submit_info;
 
             for command_buffer in info_command_buffers {


### PR DESCRIPTION
1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [x] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.

5. [x] Please put changelog entries **in the description of this Pull Request**
   if knowledge of this change could be valuable to users. No need to put the
   entries to the changelog directly, they will be transferred to the changelog
   file by maintainers right after the Pull Request merge.

   Please remove any items from the template below that are not applicable.

6. [x] Describe in common words what is the purpose of this change, related
   GitHub Issues, and highlight important implementation aspects.

Changelog:
```markdown
### Additions
- Support for AutoCommandBuffer protected Vulkan workflows.
```

Hi reviewers. I have been using Vulkano for an Android protected Vulkan pipeline workflow. The following commits unblock use of protected Vulkan and add unit tests including an end-to-end test which passes on a dev-mode Lenovo Chromebook Plus 14". All unit tests also pass on a device with no `protected_memory` vulkan support.

There are some design decisions that I made that are worth pointing out.

1. Modifying StandardCommandBufferAllocator is not strictly necessary, but to avoid changing it, users need to re-implement a lot of code. The second commit lets the user specify the pool flags when using the StandardCommandBufferAllocator wtihout many changes.

2. In the third commit, I am adding a way to, at SubmitInfo time determine if any CommandBuffers were protected. Another approach would be to add a "use protected" metadata in the SubmitInfo structs. The user would have to do additional tracking to handle that. The most visible side effect of the is the addition of an `is_protected()` function to the `PrimaryCommandBufferAbstract`. Maybe there is a better way to handle getting the protected status at submission time.

3. I split up the changes into 3 commits for ease of review, but I am happy to let them squash. :)

Thanks for taking a look!