### PR TITLE
Avoid allocation in InstructionReader::next_word

### DIFF
--- a/vulkano/src/shader/spirv/mod.rs
+++ b/vulkano/src/shader/spirv/mod.rs
@@ -763,7 +763,7 @@ impl<'a> InstructionReader<'a> {
 
     /// Returns the next word in the sequence.
     fn next_word(&mut self) -> Result<u32, ParseError> {
-        let word = *self.words.get(self.next_word).ok_or(ParseError {
+        let word = *self.words.get(self.next_word).ok_or_else(|| ParseError {
             instruction: self.instruction,
             word: self.next_word, // No -1 because we didn't advance yet
             error: ParseErrors::MissingOperands,


### PR DESCRIPTION
When parsing SPIRV `next_word` always allocated a `Vec<>` for the parse error, even if successful.