### PR TITLE
Make the `push` trigger type ignore dependabot branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - master
       - 'gh-readonly-queue/**'
+      - 'dependabot/**'
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
Dependabot creates branches in our repo of its own accord :neutral_face: It then pushes to this branch, triggering a CI run, but then also opens a PR against master, triggering another CI run. This makes it only trigger on `pull_request` like normal pull requests.