### PR TITLE
Add `--locked` argument to CI Cargo invocations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,7 @@ jobs:
         shell: ${{ matrix.shell }}
     env:
       common_args: >-
+        --locked
         --target ${{ matrix.target }}
         --target-dir ${{ matrix.target-dir }}
         --profile CI
@@ -95,6 +96,7 @@ jobs:
         shell: ${{ matrix.shell }}
     env:
       common_args: >-
+        --locked
         --target ${{ matrix.target }}
         --target-dir ${{ matrix.target-dir }}
         --profile CI


### PR DESCRIPTION
The `--locked` argument ensures that CI will not locally overwrite the `Cargo.lock` file, which can otherwise silently ignore an invalid lockfile.