### PR TITLE
Use cargo-hack in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,8 @@ jobs:
           cmd-format: nix develop .#CI -c {0}
       - name: Run clippy
         run: nix develop .#CI -c cargo clippy ${{ env.common_args }} -- -Dwarnings
+      - name: Build with each feature
+        run: nix develop .#CI -s RUSTFLAGS '-Dwarnings' -c cargo hack build ${{ env.common_args }} --ignore-private --each-feature --optional-deps --exclude-features shaderc-build-from-source
       - name: Build tests
         run: nix develop .#CI -c cargo build ${{ env.common_args }} --tests
       - name: Run tests

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
             shaderc
 
             # Workflow dependencies
+            cargo-hack
             typos
           ];
 

--- a/vulkano-util/Cargo.toml
+++ b/vulkano-util/Cargo.toml
@@ -15,7 +15,7 @@ categories = { workspace = true }
 
 [dependencies]
 foldhash = { workspace = true }
-vulkano = { workspace = true }
+vulkano = { workspace = true, features = ["raw_window_handle"] }
 winit = { workspace = true }
 
 [lints]

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -2917,6 +2917,8 @@ unsafe impl InstanceOwned for PhysicalDevice {
 impl_id_counter!(PhysicalDevice);
 
 #[cfg(all(
+    feature = "raw_window_handle",
+    feature = "x11",
     any(
         target_os = "dragonfly",
         target_os = "freebsd",
@@ -2926,8 +2928,7 @@ impl_id_counter!(PhysicalDevice);
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "solaris"
-    ),
-    feature = "x11"
+    )
 ))]
 unsafe fn get_xcb_root_visual_id(
     connection: *mut std::ffi::c_void,
@@ -2944,6 +2945,8 @@ unsafe fn get_xcb_root_visual_id(
 }
 
 #[cfg(all(
+    feature = "raw_window_handle",
+    feature = "x11",
     any(
         target_os = "dragonfly",
         target_os = "freebsd",
@@ -2953,8 +2956,7 @@ unsafe fn get_xcb_root_visual_id(
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "solaris"
-    ),
-    feature = "x11"
+    )
 ))]
 unsafe fn get_xlib_root_visual_id(
     display: *mut std::ffi::c_void,


### PR DESCRIPTION
Since we recently added a feature and will most likely be adding more soon (see #2775), now would be the time to set up cargo-hack jobs so that we are checking that each feature works correctly by itself. Case in point, #2775 introduced some issues: one is just "unused function" warnings when the `x11` feature is enabled without the `raw_window_handle` feature, and one is a compilation failure of vulkano-util because it uses `Surface::from_window` but doesn't have the `raw_window_handle` feature enabled.