### PR TITLE
Add lang option to vulkano_shaders::shader! macro for source language selection

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -1,7 +1,4 @@
-use crate::{
-    structs::{self, TypeRegistry},
-    MacroInput,
-};
+use crate::{structs::{self, TypeRegistry}, MacroInput, SourceLanguage};
 use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -153,9 +150,12 @@ pub(super) fn compile(
     macro_defines: &[(String, String)],
 ) -> Result<(CompilationArtifact, Vec<String>), String> {
     let includes = RefCell::new(Vec::new());
-    let compiler = Compiler::new().or(Err("failed to create GLSL compiler"))?;
+    let compiler = Compiler::new().or(Err("failed to create shader compiler"))?;
     let mut compile_options =
         CompileOptions::new().or(Err("failed to initialize compile options"))?;
+
+    let source_language = input.source_language.unwrap_or(SourceLanguage::GLSL);
+    compile_options.set_source_language(source_language);
 
     compile_options.set_target_env(
         TargetEnv::Vulkan,
@@ -168,7 +168,10 @@ pub(super) fn compile(
 
     let root_source_path = path.as_deref().unwrap_or(
         // An arbitrary placeholder file name for embedded shaders.
-        "shader.glsl",
+        match source_language {
+            SourceLanguage::GLSL => "shader.glsl",
+            SourceLanguage::HLSL => "shader.hlsl",
+        },
     );
 
     // Specify the file resolution callback for the `#include` directive.

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -1,4 +1,7 @@
-use crate::{structs::{self, TypeRegistry}, MacroInput, SourceLanguage};
+use crate::{
+    structs::{self, TypeRegistry},
+    MacroInput, SourceLanguage,
+};
 use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -1,5 +1,5 @@
 //! The procedural macro for vulkano's shader system.
-//! Manages the compile-time compilation of GLSL into SPIR-V and generation of associated Rust
+//! Manages the compile-time compilation of shader code into SPIR-V and generation of associated Rust
 //! code.
 //!
 //! # Basic usage
@@ -92,7 +92,7 @@
 //!
 //! ## `ty: "..."`
 //!
-//! This defines what shader type the given GLSL source will be compiled into. The type can be any
+//! This defines what shader type the given shader source will be compiled into. The type can be any
 //! of the following:
 //!
 //! - `vertex`
@@ -114,12 +114,12 @@
 //!
 //! ## `src: "..."`
 //!
-//! Provides the raw GLSL source to be compiled in the form of a string. Cannot be used in
+//! Provides the raw shader source to be compiled in the form of a string. Cannot be used in
 //! conjunction with the `path` or `bytes` field.
 //!
 //! ## `path: "..."`
 //!
-//! Provides the path to the GLSL source to be compiled, relative to your `Cargo.toml`. Cannot be
+//! Provides the path to the shader source to be compiled, relative to your `Cargo.toml`. Cannot be
 //! used in conjunction with the `src` or `bytes` field.
 //!
 //! ## `bytes: "..."`
@@ -167,6 +167,11 @@
 //!
 //! Adds the given macro definitions to the pre-processor. This is equivalent to passing the
 //! `-DNAME=VALUE` argument on the command line.
+//!
+//! ## `lang: "..."`
+//!
+//! Provides the language of the shader source. Must be either `glsl` or `hlsl` (defaults to
+//! `glsl`).
 //!
 //! ## `vulkan_version: "major.minor"` and `spirv_version: "major.minor"`
 //!
@@ -235,7 +240,7 @@ use crate::codegen::ShaderKind;
 use foldhash::HashMap;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use shaderc::{EnvVersion, SpirvVersion};
+use shaderc::{EnvVersion, SourceLanguage, SpirvVersion};
 use std::{
     env, fs, mem,
     path::{Path, PathBuf},
@@ -405,6 +410,7 @@ struct MacroInput {
     include_directories: Vec<PathBuf>,
     global_macro_defines: Vec<(String, String)>,
     shaders: HashMap<String, ShaderFields>,
+    source_language: Option<SourceLanguage>,
     spirv_version: Option<SpirvVersion>,
     vulkan_version: Option<EnvVersion>,
     generate_structs: bool,
@@ -433,6 +439,7 @@ impl MacroInput {
             custom_derives: Vec::new(),
             linalg_type: LinAlgType::default(),
             dump: LitBool::new(false, Span::call_site()),
+            source_language: None,
         }
     }
 }
@@ -458,6 +465,7 @@ impl Parse for MacroInput {
         let mut custom_derives = None;
         let mut linalg_type = None;
         let mut dump = None;
+        let mut source_language = None;
 
         fn parse_shader_fields(
             output: &mut MaybeShaderFields,
@@ -679,6 +687,18 @@ impl Parse for MacroInput {
                         }
                     }
                 }
+                "lang" => {
+                    let lit = input.parse::<LitStr>()?;
+                    if source_language.is_some() {
+                        bail!(lit, "field `lang` is already defined");
+                    }
+
+                    source_language = Some(match lit.value().as_str() {
+                        "glsl" => SourceLanguage::GLSL,
+                        "hlsl" => SourceLanguage::HLSL,
+                        lang => bail!(lit, "expected `glsl` or `hlsl`, found `{lang}`"),
+                    })
+                }
                 "vulkan_version" => {
                     let lit = input.parse::<LitStr>()?;
                     if vulkan_version.is_some() {
@@ -846,6 +866,7 @@ impl Parse for MacroInput {
             }),
             linalg_type: linalg_type.unwrap_or_default(),
             dump: dump.unwrap_or_else(|| LitBool::new(false, Span::call_site())),
+            source_language,
         })
     }
 }

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -1,6 +1,6 @@
 //! The procedural macro for vulkano's shader system.
-//! Manages the compile-time compilation of shader code into SPIR-V and generation of associated Rust
-//! code.
+//! Manages the compile-time compilation of shader code into SPIR-V and generation of associated
+//! Rust code.
 //!
 //! # Basic usage
 //!
@@ -92,8 +92,8 @@
 //!
 //! ## `ty: "..."`
 //!
-//! This defines what shader type the given shader source will be compiled into. The type can be any
-//! of the following:
+//! This defines what shader type the given shader source will be compiled into. The type can be
+//! any of the following:
 //!
 //! - `vertex`
 //! - `tess_ctrl`


### PR DESCRIPTION
Adds `source_language` field to `MacroInput` to support compiling shaders in multiple languages (e.g. HLSL, Slang), motivated by https://github.com/vulkano-rs/vulkano/issues/2622. Changes adapted from https://github.com/vulkano-rs/vulkano/pull/2568 as suggested by @marc0246.

Currently adds HLSL as the first supported language variant, which is passed to `shaderc` during shader compilation.

Closes #2568