### PR TITLE
Remove `Subbuffer` from `BufferView`

### DIFF
--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -123,7 +123,8 @@ impl BufferView {
 
         if offset >= buffer.size() {
             return Err(Box::new(ValidationError {
-                problem: "`create_info.offset` must be less than `buffer.size()`".into(),
+                context: "offset".into(),
+                problem: "must be less than `buffer.size()`".into(),
                 vuids: &["VUID-VkBufferViewCreateInfo-offset-00925"],
                 ..Default::default()
             }));
@@ -175,7 +176,8 @@ impl BufferView {
         if let Some(range) = range {
             if range == 0 {
                 return Err(Box::new(ValidationError {
-                    problem: "`create_info.range` was specified but must be greater than 0".into(),
+                    context: "range".into(),
+                    problem: "is zero".into(),
                     vuids: &["VUID-VkBufferViewCreateInfo-range-00928"],
                     ..Default::default()
                 }));
@@ -183,9 +185,8 @@ impl BufferView {
 
             if !range.is_multiple_of(block_size) {
                 return Err(Box::new(ValidationError {
-                    problem: "`create_info.range` was specified but is not a multiple of \
-                        `create_info.format.block_size()`"
-                        .into(),
+                    context: "range".into(),
+                    problem: "is not a multiple of `create_info.format.block_size()`".into(),
                     vuids: &["VUID-VkBufferViewCreateInfo-range-00929"],
                     ..Default::default()
                 }));
@@ -195,7 +196,7 @@ impl BufferView {
                 > properties.max_texel_buffer_elements
             {
                 return Err(Box::new(ValidationError {
-                    problem: "`buffer.size / create_info.format.block_size() * \
+                    problem: "`buffer.size() / create_info.format.block_size() * \
                         create_info.format.texels_per_block()` is greater than the \
                         `max_texel_buffer_elements` limit"
                         .into(),
@@ -204,7 +205,7 @@ impl BufferView {
                 }));
             }
 
-            if range.saturating_add(offset) > buffer.size() {
+            if range > buffer.size() - offset {
                 return Err(Box::new(ValidationError {
                     problem: "`create_info.offset + create_info.range` must be less than or \
                         equal to `buffer.size()`"
@@ -457,11 +458,15 @@ pub struct BufferViewCreateInfo<'a> {
     pub format: Format,
 
     /// The offset in bytes.
+    ///
+    /// The default value is `0`.
     pub offset: DeviceSize,
 
     /// The size in bytes.
     ///
-    /// The default value `None` refers to the remaining length of the buffer.
+    /// If set to `None`, the size until the end of the buffer will be used.
+    ///
+    /// The default value is `None`.
     pub range: Option<DeviceSize>,
 
     pub _ne: crate::NonExhaustive<'a>,

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -11,9 +11,9 @@
 //! ```
 //! # use std::sync::Arc;
 //! use vulkano::{
-//!     buffer::{view::{BufferView, BufferViewCreateInfo}, Buffer, BufferContents, BufferCreateInfo, BufferUsage},
+//!     buffer::{view::{BufferView, BufferViewCreateInfo}, Buffer, BufferCreateInfo, BufferUsage},
 //!     format::Format,
-//!     memory::allocator::AllocationCreateInfo,
+//!     memory::allocator::{AllocationCreateInfo, DeviceLayout},
 //! };
 //!
 //! # let queue: Arc<vulkano::device::Queue> = return;
@@ -26,7 +26,7 @@
 //!         ..Default::default()
 //!     },
 //!     &AllocationCreateInfo::default(),
-//!     u32::LAYOUT.layout_for_len(128).unwrap(),
+//!     DeviceLayout::new_unsized::<[u32]>(128).unwrap(),
 //! )
 //! .unwrap();
 //!
@@ -528,9 +528,9 @@ impl BufferViewCreateInfo<'_> {
 mod tests {
     use super::{BufferView, BufferViewCreateInfo};
     use crate::{
-        buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
+        buffer::{Buffer, BufferCreateInfo, BufferUsage},
         format::Format,
-        memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator},
+        memory::allocator::{AllocationCreateInfo, DeviceLayout, StandardMemoryAllocator},
     };
     use std::sync::Arc;
 
@@ -547,7 +547,7 @@ mod tests {
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            <[u8; 4]>::LAYOUT.layout_for_len(128).unwrap(),
+            DeviceLayout::new_unsized::<[[u8; 4]]>(128).unwrap(),
         )
         .unwrap();
 
@@ -574,7 +574,7 @@ mod tests {
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            <[u8; 4]>::LAYOUT.layout_for_len(128).unwrap(),
+            DeviceLayout::new_unsized::<[[u8; 4]]>(128).unwrap(),
         )
         .unwrap();
         BufferView::new(
@@ -600,7 +600,7 @@ mod tests {
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            u32::LAYOUT.layout_for_len(128).unwrap(),
+            DeviceLayout::new_unsized::<[u32]>(128).unwrap(),
         )
         .unwrap();
         BufferView::new(
@@ -626,7 +626,7 @@ mod tests {
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            <[u8; 4]>::LAYOUT.layout_for_len(128).unwrap(),
+            DeviceLayout::new_unsized::<[[u8; 4]]>(128).unwrap(),
         )
         .unwrap();
 
@@ -654,7 +654,7 @@ mod tests {
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            <[f64; 4]>::LAYOUT.layout_for_len(128).unwrap(),
+            DeviceLayout::new_unsized::<[[f64; 4]]>(128).unwrap(),
         )
         .unwrap();
 

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -31,7 +31,7 @@
 //! .unwrap();
 //!
 //! let view = BufferView::new(
-//!     &buffer,
+//!     &buffer.buffer(),
 //!     &BufferViewCreateInfo {
 //!         format: Format::R32_UINT,
 //!         ..Default::default()
@@ -40,8 +40,9 @@
 //! .unwrap();
 //! ```
 
-use super::{BufferUsage, Subbuffer};
+use super::BufferUsage;
 use crate::{
+    buffer::Buffer,
     device::{Device, DeviceOwned},
     format::{Format, FormatFeatures},
     macros::impl_id_counter,
@@ -56,7 +57,7 @@ use std::{mem::MaybeUninit, num::NonZero, ops::Range, ptr, sync::Arc};
 #[derive(Debug)]
 pub struct BufferView {
     handle: vk::BufferView,
-    subbuffer: Subbuffer<[u8]>,
+    buffer: Arc<Buffer>,
     id: NonZero<u64>,
 
     format: Format,
@@ -77,7 +78,7 @@ impl BufferView {
     #[inline]
     #[track_caller]
     pub fn new(
-        subbuffer: &Subbuffer<impl ?Sized>,
+        buffer: &Arc<Buffer>,
         create_info: &BufferViewCreateInfo<'_>,
     ) -> Result<Arc<BufferView>, VulkanError> {
         match Self::try_new(subbuffer, create_info) {
@@ -92,37 +93,48 @@ impl BufferView {
         subbuffer: &Subbuffer<impl ?Sized>,
         create_info: &BufferViewCreateInfo<'_>,
     ) -> Result<Arc<BufferView>, Validated<VulkanError>> {
-        let subbuffer = subbuffer.as_bytes();
-        Self::validate_new(subbuffer, create_info)?;
+        Self::validate_new(buffer, create_info)?;
 
-        Ok(unsafe { Self::new_unchecked(subbuffer, create_info) }?)
+        Ok(unsafe { Self::new_unchecked(buffer, create_info) }?)
     }
 
     fn validate_new(
-        subbuffer: &Subbuffer<[u8]>,
+        buffer: &Arc<Buffer>,
         create_info: &BufferViewCreateInfo<'_>,
     ) -> Result<(), Box<ValidationError>> {
-        let device = subbuffer.device();
+        let device = buffer.device();
 
         create_info
             .validate(device)
             .map_err(|err| err.add_context("create_info"))?;
 
-        let &BufferViewCreateInfo { format, _ne: _ } = create_info;
+        let &BufferViewCreateInfo {
+            format,
+            offset,
+            range,
+            _ne: _,
+        } = create_info;
 
-        let buffer = subbuffer.buffer();
         let properties = device.physical_device().properties();
 
         let format_properties =
             unsafe { device.physical_device().format_properties_unchecked(format) };
         let format_features = format_properties.buffer_features;
 
+        if offset >= buffer.size() {
+            return Err(Box::new(ValidationError {
+                problem: "`create_info.offset` must be less than `buffer.size()`".into(),
+                vuids: &["VUID-VkBufferViewCreateInfo-offset-00925"],
+                ..Default::default()
+            }));
+        }
+
         if !buffer
             .usage()
             .intersects(BufferUsage::UNIFORM_TEXEL_BUFFER | BufferUsage::STORAGE_TEXEL_BUFFER)
         {
             return Err(Box::new(ValidationError {
-                context: "subbuffer".into(),
+                context: "buffer".into(),
                 problem: "was not created with the `BufferUsage::UNIFORM_TEXEL_BUFFER` \
                     or `BufferUsage::STORAGE_TEXEL_BUFFER` usage"
                     .into(),
@@ -135,7 +147,7 @@ impl BufferView {
             && !format_features.intersects(FormatFeatures::UNIFORM_TEXEL_BUFFER)
         {
             return Err(Box::new(ValidationError {
-                problem: "`subbuffer` was created with the `BufferUsage::UNIFORM_TEXEL_BUFFER` \
+                problem: "`buffer` was created with the `BufferUsage::UNIFORM_TEXEL_BUFFER` \
                     usage, but the format features of `create_info.format` do not include \
                     `FormatFeatures::UNIFORM_TEXEL_BUFFER`"
                     .into(),
@@ -148,7 +160,7 @@ impl BufferView {
             && !format_features.intersects(FormatFeatures::STORAGE_TEXEL_BUFFER)
         {
             return Err(Box::new(ValidationError {
-                problem: "`subbuffer` was created with the `BufferUsage::STORAGE_TEXEL_BUFFER` \
+                problem: "`buffer` was created with the `BufferUsage::STORAGE_TEXEL_BUFFER` \
                     usage, but the format features of `create_info.format` do not include \
                     `FormatFeatures::STORAGE_TEXEL_BUFFER`"
                     .into(),
@@ -160,27 +172,47 @@ impl BufferView {
         let block_size = format.block_size();
         let texels_per_block = format.texels_per_block();
 
-        if !subbuffer.size().is_multiple_of(block_size) {
-            return Err(Box::new(ValidationError {
-                problem: "`subbuffer.size()` is not a multiple of \
-                    `create_info.format.block_size()`"
-                    .into(),
-                vuids: &["VUID-VkBufferViewCreateInfo-range-00929"],
-                ..Default::default()
-            }));
-        }
+        if let Some(range) = range {
+            if range == 0 {
+                return Err(Box::new(ValidationError {
+                    problem: "`create_info.range` was specified but must be greater than 0".into(),
+                    vuids: &["VUID-VkBufferViewCreateInfo-range-00928"],
+                    ..Default::default()
+                }));
+            }
 
-        if ((subbuffer.size() / block_size) * texels_per_block as DeviceSize) as u32
-            > properties.max_texel_buffer_elements
-        {
-            return Err(Box::new(ValidationError {
-                problem: "`subbuffer.size() / create_info.format.block_size() * \
-                    create_info.format.texels_per_block()` is greater than the \
-                    `max_texel_buffer_elements` limit"
-                    .into(),
-                vuids: &["VUID-VkBufferViewCreateInfo-range-00930"],
-                ..Default::default()
-            }));
+            if !range.is_multiple_of(block_size) {
+                return Err(Box::new(ValidationError {
+                    problem: "`create_info.range` was specified but is not a multiple of \
+                        `create_info.format.block_size()`"
+                        .into(),
+                    vuids: &["VUID-VkBufferViewCreateInfo-range-00929"],
+                    ..Default::default()
+                }));
+            }
+
+            if ((range / block_size) * texels_per_block as DeviceSize) as u32
+                > properties.max_texel_buffer_elements
+            {
+                return Err(Box::new(ValidationError {
+                    problem: "`buffer.size / create_info.format.block_size() * \
+                        create_info.format.texels_per_block()` is greater than the \
+                        `max_texel_buffer_elements` limit"
+                        .into(),
+                    vuids: &["VUID-VkBufferViewCreateInfo-range-00930"],
+                    ..Default::default()
+                }));
+            }
+
+            if range.saturating_add(offset) >= buffer.size() {
+                return Err(Box::new(ValidationError {
+                    problem: "`create_info.offset + create_info.range` must be less than or \
+                        equal to `buffer.size()`"
+                        .into(),
+                    vuids: &["VUID-VkBufferViewCreateInfo-offset-00931"],
+                    ..Default::default()
+                }));
+            }
         }
 
         if device.api_version() >= Version::V1_3 || device.enabled_features().texel_buffer_alignment
@@ -198,18 +230,18 @@ impl BufferView {
                     .unwrap()
                 {
                     if !is_aligned(
-                        subbuffer.offset(),
+                        offset,
                         properties
                             .storage_texel_buffer_offset_alignment_bytes
                             .unwrap()
                             .min(element_size),
                     ) {
                         return Err(Box::new(ValidationError {
-                            problem: "`subbuffer` was created with the \
+                            problem: "`buffer` was created with the \
                                 `BufferUsage::STORAGE_TEXEL_BUFFER` usage, and the \
                                 `storage_texel_buffer_offset_single_texel_alignment` \
                                 property is `true`, but \
-                                `subbuffer.offset()` is not a multiple of the \
+                                `create_info.offset` is not a multiple of the \
                                 minimum of `create_info.format.block_size()` and the \
                                 `storage_texel_buffer_offset_alignment_bytes` limit"
                                 .into(),
@@ -219,17 +251,17 @@ impl BufferView {
                     }
                 } else {
                     if !is_aligned(
-                        subbuffer.offset(),
+                        offset,
                         properties
                             .storage_texel_buffer_offset_alignment_bytes
                             .unwrap(),
                     ) {
                         return Err(Box::new(ValidationError {
-                            problem: "`subbuffer` was created with the \
+                            problem: "`buffer` was created with the \
                                 `BufferUsage::STORAGE_TEXEL_BUFFER` usage, and the \
                                 `storage_texel_buffer_offset_single_texel_alignment` \
                                 property is `false`, but \
-                                `subbuffer.offset()` is not a multiple of the \
+                                `create_info.offset` is not a multiple of the \
                                 `storage_texel_buffer_offset_alignment_bytes` limit"
                                 .into(),
                             vuids: &["VUID-VkBufferViewCreateInfo-buffer-02750"],
@@ -245,18 +277,18 @@ impl BufferView {
                     .unwrap()
                 {
                     if !is_aligned(
-                        subbuffer.offset(),
+                        offset,
                         properties
                             .uniform_texel_buffer_offset_alignment_bytes
                             .unwrap()
                             .min(element_size),
                     ) {
                         return Err(Box::new(ValidationError {
-                            problem: "`subbuffer` was created with the \
+                            problem: "`buffer` was created with the \
                                 `BufferUsage::UNIFORM_TEXEL_BUFFER` usage, and the \
                                 `uniform_texel_buffer_offset_single_texel_alignment` \
                                 property is `false`, but \
-                                `subbuffer.offset()` is not a multiple of the \
+                                `create_info.offset` is not a multiple of the \
                                 minimum of `create_info.format.block_size()` and the \
                                 `uniform_texel_buffer_offset_alignment_bytes` limit"
                                 .into(),
@@ -266,17 +298,17 @@ impl BufferView {
                     }
                 } else {
                     if !is_aligned(
-                        subbuffer.offset(),
+                        offset,
                         properties
                             .uniform_texel_buffer_offset_alignment_bytes
                             .unwrap(),
                     ) {
                         return Err(Box::new(ValidationError {
-                            problem: "`subbuffer` was created with the \
+                            problem: "`buffer` was created with the \
                                 `BufferUsage::UNIFORM_TEXEL_BUFFER` usage, and the \
                                 `uniform_texel_buffer_offset_single_texel_alignment` \
                                 property is `false`, but \
-                                `subbuffer.offset()` is not a multiple of the \
+                                `create_info.offset` is not a multiple of the \
                                 `uniform_texel_buffer_offset_alignment_bytes` limit"
                                 .into(),
                             vuids: &["VUID-VkBufferViewCreateInfo-buffer-02751"],
@@ -286,12 +318,9 @@ impl BufferView {
                 }
             }
         } else {
-            if !is_aligned(
-                subbuffer.offset(),
-                properties.min_texel_buffer_offset_alignment,
-            ) {
+            if !is_aligned(offset, properties.min_texel_buffer_offset_alignment) {
                 return Err(Box::new(ValidationError {
-                    problem: "`subbuffer.offset()` is not a multiple of the \
+                    problem: "`create_info.offset` is not a multiple of the \
                         `min_texel_buffer_offset_alignment` limit"
                         .into(),
                     vuids: &["VUID-VkBufferViewCreateInfo-offset-02749"],
@@ -305,11 +334,11 @@ impl BufferView {
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
     pub unsafe fn new_unchecked(
-        subbuffer: &Subbuffer<impl ?Sized>,
+        buffer: &Arc<Buffer>,
         create_info: &BufferViewCreateInfo<'_>,
     ) -> Result<Arc<BufferView>, VulkanError> {
-        let device = subbuffer.device();
-        let create_info_vk = create_info.to_vk(subbuffer.as_bytes());
+        let device = buffer.device();
+        let create_info_vk = create_info.to_vk(buffer);
 
         let fns = device.fns();
         let handle = {
@@ -327,7 +356,7 @@ impl BufferView {
             unsafe { output.assume_init() }
         };
 
-        Ok(unsafe { Self::from_handle(subbuffer, handle, create_info) })
+        Ok(unsafe { Self::from_handle(buffer, handle, create_info) })
     }
 
     /// Creates a new `BufferView` from a raw object handle.
@@ -335,36 +364,41 @@ impl BufferView {
     /// # Safety
     ///
     /// - `handle` must be a valid Vulkan object handle created from `device`.
-    /// - `subbuffer` and `create_info` must match the info used to create the object.
+    /// - `buffer` and `create_info` must match the info used to create the object.
     pub unsafe fn from_handle(
-        subbuffer: &Subbuffer<impl ?Sized>,
+        buffer: &Arc<Buffer>,
         handle: vk::BufferView,
         create_info: &BufferViewCreateInfo<'_>,
     ) -> Arc<BufferView> {
-        let &BufferViewCreateInfo { format, _ne: _ } = create_info;
-        let size = subbuffer.size();
+        let &BufferViewCreateInfo {
+            format,
+            offset,
+            range,
+            _ne: _,
+        } = create_info;
         let format_properties = unsafe {
-            subbuffer
+            buffer
                 .device()
                 .physical_device()
                 .format_properties_unchecked(format)
         };
         let format_features = format_properties.buffer_features;
+        let size = range.unwrap_or(buffer.size());
 
         Arc::new(BufferView {
             handle,
-            subbuffer: subbuffer.clone().into_bytes(),
+            buffer: buffer.clone(),
             id: Self::next_id(),
             format,
             format_features,
-            range: 0..size,
+            range: offset..(offset + size),
         })
     }
 
     /// Returns the buffer associated to this view.
     #[inline]
-    pub fn buffer(&self) -> &Subbuffer<[u8]> {
-        &self.subbuffer
+    pub fn buffer(&self) -> &Arc<Buffer> {
+        &self.buffer
     }
 
     /// Returns the format of this view.
@@ -389,13 +423,9 @@ impl BufferView {
 impl Drop for BufferView {
     #[inline]
     fn drop(&mut self) {
-        let fns = self.subbuffer.device().fns();
+        let fns = self.buffer.device().fns();
         unsafe {
-            (fns.v1_0.destroy_buffer_view)(
-                self.subbuffer.device().handle(),
-                self.handle,
-                ptr::null(),
-            )
+            (fns.v1_0.destroy_buffer_view)(self.buffer.device().handle(), self.handle, ptr::null())
         };
     }
 }
@@ -412,7 +442,7 @@ unsafe impl VulkanObject for BufferView {
 unsafe impl DeviceOwned for BufferView {
     #[inline]
     fn device(&self) -> &Arc<Device> {
-        self.subbuffer.device()
+        self.buffer.device()
     }
 }
 
@@ -425,6 +455,14 @@ pub struct BufferViewCreateInfo<'a> {
     ///
     /// The default value is `Format::UNDEFINED`.
     pub format: Format,
+
+    /// The offset in bytes.
+    pub offset: DeviceSize,
+
+    /// The size in bytes.
+    ///
+    /// The default value `None` refers to the remaining length of the buffer.
+    pub range: Option<DeviceSize>,
 
     pub _ne: crate::NonExhaustive<'a>,
 }
@@ -442,12 +480,19 @@ impl BufferViewCreateInfo<'_> {
     pub const fn new() -> Self {
         Self {
             format: Format::UNDEFINED,
+            offset: 0,
+            range: None,
             _ne: crate::NE,
         }
     }
 
     pub(crate) fn validate(&self, device: &Device) -> Result<(), Box<ValidationError>> {
-        let Self { format, _ne: _ } = self;
+        let Self {
+            format,
+            offset: _,
+            range: _,
+            _ne: _,
+        } = self;
 
         format.validate_device(device).map_err(|err| {
             err.add_context("format")
@@ -457,15 +502,20 @@ impl BufferViewCreateInfo<'_> {
         Ok(())
     }
 
-    pub(crate) fn to_vk(&self, subbuffer: &Subbuffer<[u8]>) -> vk::BufferViewCreateInfo<'static> {
-        let &Self { format, _ne: _ } = self;
+    pub(crate) fn to_vk(&self, buffer: &Arc<Buffer>) -> vk::BufferViewCreateInfo<'static> {
+        let &Self {
+            format,
+            offset,
+            range,
+            _ne: _,
+        } = self;
 
         vk::BufferViewCreateInfo::default()
             .flags(vk::BufferViewCreateFlags::empty())
-            .buffer(subbuffer.buffer().handle())
+            .buffer(buffer.handle())
             .format(format.into())
-            .offset(subbuffer.offset())
-            .range(subbuffer.size())
+            .offset(offset)
+            .range(range.unwrap_or(vk::WHOLE_SIZE))
     }
 }
 
@@ -497,7 +547,7 @@ mod tests {
         .unwrap();
 
         BufferView::new(
-            &buffer,
+            &buffer.buffer(),
             &BufferViewCreateInfo {
                 format: Format::R8G8B8A8_UNORM,
                 ..Default::default()
@@ -523,7 +573,7 @@ mod tests {
         )
         .unwrap();
         BufferView::new(
-            &buffer,
+            &buffer.buffer(),
             &BufferViewCreateInfo {
                 format: Format::R8G8B8A8_UNORM,
                 ..Default::default()
@@ -549,7 +599,7 @@ mod tests {
         )
         .unwrap();
         BufferView::new(
-            &buffer,
+            &buffer.buffer(),
             &BufferViewCreateInfo {
                 format: Format::R32_UINT,
                 ..Default::default()

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -204,7 +204,7 @@ impl BufferView {
                 }));
             }
 
-            if range.saturating_add(offset) >= buffer.size() {
+            if range.saturating_add(offset) > buffer.size() {
                 return Err(Box::new(ValidationError {
                     problem: "`create_info.offset + create_info.range` must be less than or \
                         equal to `buffer.size()`"

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -50,7 +50,7 @@ use crate::{
     DeviceSize, Validated, ValidationError, Version, VulkanError, VulkanObject,
 };
 use ash::vk;
-use std::{mem::MaybeUninit, num::NonZero, ops::Range, ptr, sync::Arc};
+use std::{mem::MaybeUninit, num::NonZero, ptr, sync::Arc};
 
 /// Represents a way for the GPU to interpret buffer data. See the documentation of the
 /// `view` module.
@@ -62,7 +62,8 @@ pub struct BufferView {
 
     format: Format,
     format_features: FormatFeatures,
-    range: Range<DeviceSize>,
+    offset: DeviceSize,
+    range: Option<DeviceSize>,
 }
 
 impl BufferView {
@@ -384,7 +385,6 @@ impl BufferView {
                 .format_properties_unchecked(format)
         };
         let format_features = format_properties.buffer_features;
-        let size = range.unwrap_or(buffer.size());
 
         Arc::new(BufferView {
             handle,
@@ -392,7 +392,8 @@ impl BufferView {
             id: Self::next_id(),
             format,
             format_features,
-            range: offset..(offset + size),
+            offset,
+            range,
         })
     }
 
@@ -414,10 +415,16 @@ impl BufferView {
         self.format_features
     }
 
-    /// Returns the byte range of the wrapped buffer that this view exposes.
+    /// Returns the offset of the view in bytes.
     #[inline]
-    pub fn range(&self) -> Range<DeviceSize> {
-        self.range.clone()
+    pub fn offset(&self) -> DeviceSize {
+        self.offset
+    }
+
+    /// Returns the range of the view in bytes.
+    #[inline]
+    pub fn range(&self) -> Option<DeviceSize> {
+        self.range
     }
 }
 

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -11,7 +11,7 @@
 //! ```
 //! # use std::sync::Arc;
 //! use vulkano::{
-//!     buffer::{view::{BufferView, BufferViewCreateInfo}, Buffer, BufferCreateInfo, BufferUsage},
+//!     buffer::{view::{BufferView, BufferViewCreateInfo}, Buffer, BufferContents, BufferCreateInfo, BufferUsage},
 //!     format::Format,
 //!     memory::allocator::AllocationCreateInfo,
 //! };
@@ -19,19 +19,19 @@
 //! # let queue: Arc<vulkano::device::Queue> = return;
 //! # let memory_allocator: Arc<vulkano::memory::allocator::StandardMemoryAllocator> = return;
 //! #
-//! let buffer = Buffer::new_slice::<u32>(
+//! let buffer = Buffer::new(
 //!     &memory_allocator,
 //!     &BufferCreateInfo {
 //!         usage: BufferUsage::STORAGE_TEXEL_BUFFER,
 //!         ..Default::default()
 //!     },
 //!     &AllocationCreateInfo::default(),
-//!     128,
+//!     u32::LAYOUT.layout_for_len(128).unwrap(),
 //! )
 //! .unwrap();
 //!
 //! let view = BufferView::new(
-//!     &buffer.buffer(),
+//!     &buffer,
 //!     &BufferViewCreateInfo {
 //!         format: Format::R32_UINT,
 //!         ..Default::default()
@@ -81,7 +81,7 @@ impl BufferView {
         buffer: &Arc<Buffer>,
         create_info: &BufferViewCreateInfo<'_>,
     ) -> Result<Arc<BufferView>, VulkanError> {
-        match Self::try_new(subbuffer, create_info) {
+        match Self::try_new(buffer, create_info) {
             Ok(res) => Ok(res),
             Err(err) => Err(err.unwrap()),
         }
@@ -90,7 +90,7 @@ impl BufferView {
     /// Creates a new `BufferView`, returning an error on failure.
     #[inline]
     pub fn try_new(
-        subbuffer: &Subbuffer<impl ?Sized>,
+        buffer: &Arc<Buffer>,
         create_info: &BufferViewCreateInfo<'_>,
     ) -> Result<Arc<BufferView>, Validated<VulkanError>> {
         Self::validate_new(buffer, create_info)?;
@@ -523,7 +523,7 @@ impl BufferViewCreateInfo<'_> {
 mod tests {
     use super::{BufferView, BufferViewCreateInfo};
     use crate::{
-        buffer::{Buffer, BufferCreateInfo, BufferUsage},
+        buffer::{Buffer, BufferContents, BufferCreateInfo, BufferUsage},
         format::Format,
         memory::allocator::{AllocationCreateInfo, StandardMemoryAllocator},
     };
@@ -535,19 +535,19 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let memory_allocator = Arc::new(StandardMemoryAllocator::new(&device, &Default::default()));
 
-        let buffer = Buffer::new_slice::<[u8; 4]>(
+        let buffer = Buffer::new(
             &memory_allocator,
             &BufferCreateInfo {
                 usage: BufferUsage::UNIFORM_TEXEL_BUFFER,
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            128,
+            <[u8; 4]>::LAYOUT.layout_for_len(128).unwrap(),
         )
         .unwrap();
 
         BufferView::new(
-            &buffer.buffer(),
+            &buffer,
             &BufferViewCreateInfo {
                 format: Format::R8G8B8A8_UNORM,
                 ..Default::default()
@@ -562,18 +562,18 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let memory_allocator = Arc::new(StandardMemoryAllocator::new(&device, &Default::default()));
 
-        let buffer = Buffer::new_slice::<[u8; 4]>(
+        let buffer = Buffer::new(
             &memory_allocator,
             &BufferCreateInfo {
                 usage: BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            128,
+            <[u8; 4]>::LAYOUT.layout_for_len(128).unwrap(),
         )
         .unwrap();
         BufferView::new(
-            &buffer.buffer(),
+            &buffer,
             &BufferViewCreateInfo {
                 format: Format::R8G8B8A8_UNORM,
                 ..Default::default()
@@ -588,18 +588,18 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let memory_allocator = Arc::new(StandardMemoryAllocator::new(&device, &Default::default()));
 
-        let buffer = Buffer::new_slice::<u32>(
+        let buffer = Buffer::new(
             &memory_allocator,
             &BufferCreateInfo {
                 usage: BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            128,
+            u32::LAYOUT.layout_for_len(128).unwrap(),
         )
         .unwrap();
         BufferView::new(
-            &buffer.buffer(),
+            &buffer,
             &BufferViewCreateInfo {
                 format: Format::R32_UINT,
                 ..Default::default()
@@ -614,14 +614,14 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let memory_allocator = Arc::new(StandardMemoryAllocator::new(&device, &Default::default()));
 
-        let buffer = Buffer::new_slice::<[u8; 4]>(
+        let buffer = Buffer::new(
             &memory_allocator,
             &BufferCreateInfo {
                 usage: BufferUsage::TRANSFER_DST, // Dummy value
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            128,
+            <[u8; 4]>::LAYOUT.layout_for_len(128).unwrap(),
         )
         .unwrap();
 
@@ -642,14 +642,14 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
         let memory_allocator = Arc::new(StandardMemoryAllocator::new(&device, &Default::default()));
 
-        let buffer = Buffer::new_slice::<[f64; 4]>(
+        let buffer = Buffer::new(
             &memory_allocator,
             &BufferCreateInfo {
                 usage: BufferUsage::UNIFORM_TEXEL_BUFFER | BufferUsage::STORAGE_TEXEL_BUFFER,
                 ..Default::default()
             },
             &AllocationCreateInfo::default(),
-            128,
+            <[f64; 4]>::LAYOUT.layout_for_len(128).unwrap(),
         )
         .unwrap();
 

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -3683,7 +3683,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             let buffer = Subbuffer::new(buffer_view.buffer().clone());
                             let (use_ref, memory_access) = use_iter(index as u32);
                             let offset = buffer_view.offset();
-                            let size = buffer_view.range().unwrap_or(buffer.size());
+                            let size = buffer_view.range().unwrap_or(buffer.size() - offset);
 
                             used_resources.push((
                                 use_ref,

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -3682,12 +3682,14 @@ impl<L> AutoCommandBufferBuilder<L> {
                         if let Some(Some(buffer_view)) = element {
                             let buffer = Subbuffer::new(buffer_view.buffer().clone());
                             let (use_ref, memory_access) = use_iter(index as u32);
+                            let offset = buffer_view.offset();
+                            let size = buffer_view.range().unwrap_or(buffer.size());
 
                             used_resources.push((
                                 use_ref,
                                 Resource::Buffer {
                                     buffer,
-                                    range: buffer_view.range().clone(),
+                                    range: offset..(offset + size),
                                     memory_access,
                                 },
                             ));

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -3680,7 +3680,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 DescriptorBindingResources::BufferView(elements) => {
                     for (index, element) in elements.iter().enumerate() {
                         if let Some(Some(buffer_view)) = element {
-                            let buffer = buffer_view.buffer();
+                            let buffer = Subbuffer::new(buffer_view.buffer().clone());
                             let (use_ref, memory_access) = use_iter(index as u32);
 
                             used_resources.push((

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -3686,7 +3686,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                             used_resources.push((
                                 use_ref,
                                 Resource::Buffer {
-                                    buffer: buffer.clone(),
+                                    buffer,
                                     range: buffer_view.range().clone(),
                                     memory_access,
                                 },

--- a/vulkano/src/descriptor_set/update.rs
+++ b/vulkano/src/descriptor_set/update.rs
@@ -943,7 +943,6 @@ impl<'a> WriteDescriptorSet<'a> {
 
                     if !buffer_view
                         .buffer()
-                        .buffer()
                         .usage()
                         .intersects(BufferUsage::UNIFORM_TEXEL_BUFFER)
                     {
@@ -997,7 +996,6 @@ impl<'a> WriteDescriptorSet<'a> {
 
                     // TODO: storage_texel_buffer_atomic
                     if !buffer_view
-                        .buffer()
                         .buffer()
                         .usage()
                         .intersects(BufferUsage::STORAGE_TEXEL_BUFFER)


### PR DESCRIPTION
This removes `Subbuffer` from `BufferView` for the same reason as #2746 and instead specifies the range of the buffer in `BufferViewCreateInfo`.

Changelog:
```markdown
### Breaking changes
Changes to `BufferView` and `BufferViewCreateInfo`:
- `BufferView` is now created from a `Buffer` instead of a `Subbuffer`. Use `offset` and `range` of `BufferViewCreateInfo` to specify a sub range within the buffer.
- `BufferView::buffer()` now returns the underlying `Buffer`.
```
