### PR TITLE
Add a panicking variant of every function

### DIFF
--- a/examples/async-update/main.rs
+++ b/examples/async-update/main.rs
@@ -115,7 +115,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -144,7 +144,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -323,14 +323,14 @@ impl App {
                 &resources,
                 graphics_flight_id,
                 |cbf, tcx| {
-                    tcx.write_buffer::<[MyVertex]>(vertex_buffer_id, ..)?
+                    tcx.write_buffer::<[MyVertex]>(vertex_buffer_id, ..)
                         .copy_from_slice(&vertices);
 
                     for &texture_id in &texture_ids {
                         cbf.clear_color_image(&ClearColorImageInfo {
                             image: texture_id,
                             ..Default::default()
-                        })?;
+                        });
                     }
 
                     Ok(())
@@ -430,8 +430,14 @@ impl ApplicationHandler for App {
                 .unwrap()
         };
 
-        let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-        let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+        let vs = unsafe { vs::load(&self.device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
+        let fs = unsafe { fs::load(&self.device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
         let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(&vs),
@@ -451,7 +457,7 @@ impl ApplicationHandler for App {
             .create_sampler(&SamplerCreateInfo::simple_repeat_linear())
             .unwrap();
         let sampled_image_ids = self.texture_ids.map(|texture_id| {
-            let texture_state = self.resources.image(texture_id).unwrap();
+            let texture_state = self.resources.image(texture_id);
             let texture = texture_state.image();
 
             bcx.global_set()
@@ -600,7 +606,7 @@ impl ApplicationHandler for App {
                     return;
                 }
 
-                let flight = self.resources.flight(self.graphics_flight_id).unwrap();
+                let flight = self.resources.flight(self.graphics_flight_id);
 
                 if rcx.recreate_swapchain {
                     rcx.swapchain_id = self
@@ -743,8 +749,8 @@ impl Task for RenderTask {
 
         let pipeline = self.pipeline.as_ref().unwrap();
 
-        cbf.set_viewport(0, slice::from_ref(&rcx.viewport))?;
-        cbf.bind_pipeline_graphics(pipeline)?;
+        cbf.set_viewport(0, slice::from_ref(&rcx.viewport));
+        cbf.bind_pipeline_graphics(pipeline);
         cbf.push_constants(
             pipeline.layout(),
             0,
@@ -755,10 +761,10 @@ impl Task for RenderTask {
                 texture_id: self.sampled_image_ids
                     [self.current_texture_index.load(Ordering::Relaxed) as usize],
             },
-        )?;
-        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
+        );
+        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[]);
 
-        unsafe { cbf.draw(4, 1, 0, 0) }?;
+        unsafe { cbf.draw(4, 1, 0, 0) };
 
         Ok(())
     }
@@ -863,7 +869,7 @@ fn run_worker(
         // you would likely send some actual data over the channel, instructing the worker what to
         // do, but our work is hard-coded.
         while let Ok(()) = channel.recv() {
-            let graphics_flight = resources.flight(graphics_flight_id).unwrap();
+            let graphics_flight = resources.flight(graphics_flight_id);
 
             // We can't wait for a frame that hasn't been executed yet.
             while last_frame == graphics_flight.current_frame() {
@@ -904,11 +910,7 @@ fn run_worker(
             unsafe { task_graph.execute(resource_map, &current_corner, || {}) }.unwrap();
 
             // Block the thread until the transfer finishes.
-            resources
-                .flight(transfer_flight_id)
-                .unwrap()
-                .wait_idle()
-                .unwrap();
+            resources.flight(transfer_flight_id).wait_idle().unwrap();
 
             last_frame = graphics_flight.current_frame();
 
@@ -955,7 +957,7 @@ impl Task for UploadTask {
         // that the update is in fact asynchronous due to the latency of the updates while the
         // rendering continues without any.
         let color = [rng.gen(), rng.gen(), rng.gen(), u8::MAX];
-        tcx.write_buffer::<[_]>(self.front_staging_buffer_id, ..)?
+        tcx.write_buffer::<[_]>(self.front_staging_buffer_id, ..)
             .fill(color);
 
         cbf.copy_buffer_to_image(&CopyBufferToImageInfo {
@@ -971,7 +973,7 @@ impl Task for UploadTask {
                 ..Default::default()
             }],
             ..Default::default()
-        })?;
+        });
 
         if current_corner > 0 {
             cbf.copy_buffer_to_image(&CopyBufferToImageInfo {
@@ -987,7 +989,7 @@ impl Task for UploadTask {
                     ..Default::default()
                 }],
                 ..Default::default()
-            })?;
+            });
         }
 
         Ok(())

--- a/examples/basic-compute-shader/main.rs
+++ b/examples/basic-compute-shader/main.rs
@@ -165,7 +165,7 @@ fn main() {
     // If you are familiar with graphics pipeline, the principle is the same except that compute
     // pipelines are much simpler to create.
     let pipeline = {
-        let module = compute_shader::load(&device)
+        let module = unsafe { compute_shader::load(&device) }
             .unwrap()
             .entry_point("main")
             .unwrap();
@@ -225,11 +225,11 @@ fn main() {
             flight_id,
             |cbf, tcx| {
                 // Initialize the buffer with our data.
-                for (i, value) in (0..).zip(tcx.write_buffer::<[u32]>(buffer_id, ..)?) {
+                for (i, value) in (0..).zip(tcx.write_buffer::<[u32]>(buffer_id, ..)) {
                     *value = i;
                 }
 
-                cbf.bind_pipeline_compute(&pipeline)?;
+                cbf.bind_pipeline_compute(&pipeline);
                 cbf.push_constants(
                     pipeline.layout(),
                     0,
@@ -237,12 +237,12 @@ fn main() {
                         buffer_id: buffer_bindless_id,
                         buffer_len: BUFFER_LEN,
                     },
-                )?;
+                );
 
                 // We have set the local size of the shader to (64, 1, 1). Each thread processes
                 // one item in the buffer, so ceil(n / 64) groups are required.
                 let groups_x = BUFFER_LEN.div_ceil(64);
-                cbf.dispatch([groups_x, 1, 1])?;
+                cbf.dispatch([groups_x, 1, 1]);
 
                 Ok(())
             },
@@ -258,7 +258,7 @@ fn main() {
     .unwrap();
 
     // Wait for the compute work to finish on the GPU before proceeding.
-    resources.flight(flight_id).unwrap().wait_idle().unwrap();
+    resources.flight(flight_id).wait_idle().unwrap();
 
     // Read our data back from the GPU and verify the result.
     let mut data_buffer_content: Vec<u32> = Vec::new();
@@ -268,7 +268,8 @@ fn main() {
             &resources,
             flight_id,
             |_cbf, tcx| {
-                data_buffer_content = tcx.read_buffer::<[u32]>(buffer_id, ..)?.to_vec();
+                data_buffer_content = tcx.read_buffer::<[u32]>(buffer_id, ..).to_vec();
+
                 Ok(())
             },
             [(buffer_id, HostAccessType::Read)],

--- a/examples/bloom/bloom.rs
+++ b/examples/bloom/bloom.rs
@@ -29,7 +29,7 @@ impl BloomTask {
         let bcx = app.resources.bindless_context().unwrap();
 
         let downsample_pipeline = {
-            let cs = downsample::load(&app.device)
+            let cs = unsafe { downsample::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
@@ -47,7 +47,7 @@ impl BloomTask {
         };
 
         let upsample_pipeline = {
-            let cs = upsample::load(&app.device)
+            let cs = unsafe { upsample::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
@@ -81,7 +81,7 @@ impl Task for BloomTask {
         tcx: &mut TaskContext<'_>,
         rcx: &Self::World,
     ) -> TaskResult {
-        let bloom_image = tcx.image(self.bloom_image_id)?.image();
+        let bloom_image = tcx.image(self.bloom_image_id).image();
 
         let dependency_info = DependencyInfo {
             memory_barriers: &[MemoryBarrier {
@@ -94,7 +94,7 @@ impl Task for BloomTask {
             ..Default::default()
         };
 
-        cbf.bind_pipeline_compute(&self.downsample_pipeline)?;
+        cbf.bind_pipeline_compute(&self.downsample_pipeline);
 
         for src_mip_level in 0..bloom_image.mip_levels() - 1 {
             let dst_mip_level = src_mip_level + 1;
@@ -112,14 +112,14 @@ impl Task for BloomTask {
                     threshold: THRESHOLD,
                     knee: KNEE,
                 },
-            )?;
+            );
 
-            unsafe { cbf.dispatch(group_counts) }?;
+            unsafe { cbf.dispatch(group_counts) };
 
-            cbf.pipeline_barrier(&dependency_info)?;
+            cbf.pipeline_barrier(&dependency_info);
         }
 
-        cbf.bind_pipeline_compute(&self.upsample_pipeline)?;
+        cbf.bind_pipeline_compute(&self.upsample_pipeline);
 
         for dst_mip_level in (0..bloom_image.mip_levels() - 1).rev() {
             let dst_extent = mip_level_extent(bloom_image.extent(), dst_mip_level).unwrap();
@@ -135,12 +135,12 @@ impl Task for BloomTask {
                     dst_mip_level,
                     intensity: INTENSITY,
                 },
-            )?;
+            );
 
-            unsafe { cbf.dispatch(group_counts) }?;
+            unsafe { cbf.dispatch(group_counts) };
 
             if dst_mip_level != 0 {
-                cbf.pipeline_barrier(&dependency_info)?;
+                cbf.pipeline_barrier(&dependency_info);
             }
         }
 

--- a/examples/bloom/main.rs
+++ b/examples/bloom/main.rs
@@ -77,7 +77,7 @@ pub struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -110,7 +110,7 @@ impl App {
                     .position(|(i, q)| {
                         q.queue_flags
                             .contains(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -374,7 +374,7 @@ impl ApplicationHandler for App {
                     return;
                 }
 
-                let flight = self.resources.flight(self.flight_id).unwrap();
+                let flight = self.resources.flight(self.flight_id);
 
                 if rcx.recreate_swapchain {
                     rcx.swapchain_id = self
@@ -452,7 +452,7 @@ fn window_size_dependent_setup(
 ) {
     let device = resources.device();
     let bcx = resources.bindless_context().unwrap();
-    let swapchain_state = resources.swapchain(swapchain_id).unwrap();
+    let swapchain_state = resources.swapchain(swapchain_id);
     let images = swapchain_state.images();
     let extent = images[0].extent();
 
@@ -487,7 +487,7 @@ fn window_size_dependent_setup(
             .unwrap()
     };
 
-    let bloom_image_state = resources.image(bloom_image_id).unwrap();
+    let bloom_image_state = resources.image(bloom_image_id);
     let bloom_image = bloom_image_state.image();
 
     let bloom_sampled_image_id = bcx

--- a/examples/bloom/scene.rs
+++ b/examples/bloom/scene.rs
@@ -64,7 +64,7 @@ impl SceneTask {
                 &app.resources,
                 app.flight_id,
                 |_cbf, tcx| {
-                    tcx.write_buffer::<[MyVertex]>(vertex_buffer_id, ..)?
+                    tcx.write_buffer::<[MyVertex]>(vertex_buffer_id, ..)
                         .copy_from_slice(&vertices);
 
                     Ok(())
@@ -87,8 +87,14 @@ impl SceneTask {
         let bcx = app.resources.bindless_context().unwrap();
 
         let pipeline = {
-            let vs = vs::load(&app.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&app.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&app.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&app.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),
@@ -135,11 +141,11 @@ impl Task for SceneTask {
         _tcx: &mut TaskContext<'_>,
         rcx: &Self::World,
     ) -> TaskResult {
-        cbf.set_viewport(0, slice::from_ref(&rcx.viewport))?;
-        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap())?;
-        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
+        cbf.set_viewport(0, slice::from_ref(&rcx.viewport));
+        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap());
+        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[]);
 
-        unsafe { cbf.draw(3, 1, 0, 0) }?;
+        unsafe { cbf.draw(3, 1, 0, 0) };
 
         Ok(())
     }

--- a/examples/bloom/tonemap.rs
+++ b/examples/bloom/tonemap.rs
@@ -32,8 +32,14 @@ impl TonemapTask {
         let bcx = app.resources.bindless_context().unwrap();
 
         let pipeline = {
-            let vs = vs::load(&app.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&app.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&app.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&app.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),
                 PipelineShaderStageCreateInfo::new(&fs),
@@ -75,8 +81,8 @@ impl Task for TonemapTask {
         _tcx: &mut TaskContext<'_>,
         rcx: &Self::World,
     ) -> TaskResult {
-        cbf.set_viewport(0, slice::from_ref(&rcx.viewport))?;
-        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap())?;
+        cbf.set_viewport(0, slice::from_ref(&rcx.viewport));
+        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap());
         cbf.push_constants(
             self.pipeline.as_ref().unwrap().layout(),
             0,
@@ -85,9 +91,9 @@ impl Task for TonemapTask {
                 texture_id: rcx.bloom_sampled_image_id,
                 exposure: EXPOSURE,
             },
-        )?;
+        );
 
-        unsafe { cbf.draw(3, 1, 0, 0) }?;
+        unsafe { cbf.draw(3, 1, 0, 0) };
 
         Ok(())
     }

--- a/examples/clear-attachments/main.rs
+++ b/examples/clear-attachments/main.rs
@@ -56,7 +56,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -81,7 +81,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })

--- a/examples/deferred/deferred.rs
+++ b/examples/deferred/deferred.rs
@@ -64,7 +64,7 @@ impl Task for DeferredTask {
         _tcx: &mut TaskContext<'_>,
         rcx: &Self::World,
     ) -> TaskResult {
-        cbf.set_viewport(0, slice::from_ref(&rcx.viewport))?;
+        cbf.set_viewport(0, slice::from_ref(&rcx.viewport));
 
         let world_to_screen = Mat4::IDENTITY;
         let screen_to_world = world_to_screen.inverse();
@@ -141,11 +141,7 @@ impl AmbientLightingPipeline {
             .unwrap();
 
         // FIXME(taskgraph): sane initialization
-        app.resources
-            .flight(app.flight_id)
-            .unwrap()
-            .wait(None)
-            .unwrap();
+        app.resources.flight(app.flight_id).wait(None).unwrap();
 
         unsafe {
             vulkano_taskgraph::execute(
@@ -153,7 +149,7 @@ impl AmbientLightingPipeline {
                 &app.resources,
                 app.flight_id,
                 |_cbf, tcx| {
-                    tcx.write_buffer::<[LightingVertex]>(vertex_buffer_id, ..)?
+                    tcx.write_buffer::<[LightingVertex]>(vertex_buffer_id, ..)
                         .copy_from_slice(&vertices);
 
                     Ok(())
@@ -175,11 +171,11 @@ impl AmbientLightingPipeline {
         let bcx = app.resources.bindless_context().unwrap();
 
         let pipeline = {
-            let vs = ambient_lighting_vs::load(&app.device)
+            let vs = unsafe { ambient_lighting_vs::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let fs = ambient_lighting_fs::load(&app.device)
+            let fs = unsafe { ambient_lighting_fs::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
@@ -245,17 +241,17 @@ impl AmbientLightingPipeline {
         cbf: &mut RecordingCommandBuffer<'_>,
         ambient_color: [f32; 3],
     ) -> TaskResult {
-        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap())?;
+        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap());
         cbf.push_constants(
             self.pipeline.as_ref().unwrap().layout(),
             0,
             &ambient_lighting_fs::PushConstants {
                 color: [ambient_color[0], ambient_color[1], ambient_color[2], 1.0],
             },
-        )?;
-        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
+        );
+        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[]);
 
-        unsafe { cbf.draw(3, 1, 0, 0) }?;
+        unsafe { cbf.draw(3, 1, 0, 0) };
 
         Ok(())
     }
@@ -339,11 +335,7 @@ impl DirectionalLightingPipeline {
             .unwrap();
 
         // FIXME(taskgraph): sane initialization
-        app.resources
-            .flight(app.flight_id)
-            .unwrap()
-            .wait(None)
-            .unwrap();
+        app.resources.flight(app.flight_id).wait(None).unwrap();
 
         unsafe {
             vulkano_taskgraph::execute(
@@ -351,7 +343,7 @@ impl DirectionalLightingPipeline {
                 &app.resources,
                 app.flight_id,
                 |_cbf, tcx| {
-                    tcx.write_buffer::<[LightingVertex]>(vertex_buffer_id, ..)?
+                    tcx.write_buffer::<[LightingVertex]>(vertex_buffer_id, ..)
                         .copy_from_slice(&vertices);
 
                     Ok(())
@@ -373,11 +365,11 @@ impl DirectionalLightingPipeline {
         let bcx = app.resources.bindless_context().unwrap();
 
         let pipeline = {
-            let vs = directional_lighting_vs::load(&app.device)
+            let vs = unsafe { directional_lighting_vs::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let fs = directional_lighting_fs::load(&app.device)
+            let fs = unsafe { directional_lighting_fs::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
@@ -446,7 +438,7 @@ impl DirectionalLightingPipeline {
         direction: Vec3,
         color: [f32; 3],
     ) -> TaskResult {
-        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap())?;
+        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap());
         cbf.push_constants(
             self.pipeline.as_ref().unwrap().layout(),
             0,
@@ -454,10 +446,10 @@ impl DirectionalLightingPipeline {
                 color: [color[0], color[1], color[2], 1.0],
                 direction: direction.extend(0.0).into(),
             },
-        )?;
-        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
+        );
+        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[]);
 
-        unsafe { cbf.draw(3, 1, 0, 0) }?;
+        unsafe { cbf.draw(3, 1, 0, 0) };
 
         Ok(())
     }
@@ -554,11 +546,7 @@ impl PointLightingPipeline {
             .unwrap();
 
         // FIXME(taskgraph): sane initialization
-        app.resources
-            .flight(app.flight_id)
-            .unwrap()
-            .wait(None)
-            .unwrap();
+        app.resources.flight(app.flight_id).wait(None).unwrap();
 
         unsafe {
             vulkano_taskgraph::execute(
@@ -566,7 +554,7 @@ impl PointLightingPipeline {
                 &app.resources,
                 app.flight_id,
                 |_cbf, tcx| {
-                    tcx.write_buffer::<[LightingVertex]>(vertex_buffer_id, ..)?
+                    tcx.write_buffer::<[LightingVertex]>(vertex_buffer_id, ..)
                         .copy_from_slice(&vertices);
 
                     Ok(())
@@ -588,11 +576,11 @@ impl PointLightingPipeline {
         let bcx = app.resources.bindless_context().unwrap();
 
         let pipeline = {
-            let vs = point_lighting_vs::load(&app.device)
+            let vs = unsafe { point_lighting_vs::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let fs = point_lighting_fs::load(&app.device)
+            let fs = unsafe { point_lighting_fs::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
@@ -670,7 +658,7 @@ impl PointLightingPipeline {
         position: Vec3,
         color: [f32; 3],
     ) -> TaskResult {
-        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap())?;
+        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap());
         cbf.push_constants(
             self.pipeline.as_ref().unwrap().layout(),
             0,
@@ -679,10 +667,10 @@ impl PointLightingPipeline {
                 color: [color[0], color[1], color[2], 1.0],
                 position: position.extend(0.0).into(),
             },
-        )?;
-        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
+        );
+        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[]);
 
-        unsafe { cbf.draw(3, 1, 0, 0) }?;
+        unsafe { cbf.draw(3, 1, 0, 0) };
 
         Ok(())
     }

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -87,7 +87,7 @@ pub struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -116,7 +116,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -419,7 +419,7 @@ impl ApplicationHandler for App {
                     return;
                 }
 
-                let flight = self.resources.flight(self.flight_id).unwrap();
+                let flight = self.resources.flight(self.flight_id);
 
                 if rcx.recreate_swapchain {
                     rcx.swapchain_id = self
@@ -489,7 +489,7 @@ fn window_size_dependent_setup(
     resources: &Resources,
     swapchain_id: Id<Swapchain>,
 ) -> (Id<Image>, Id<Image>, Id<Image>) {
-    let swapchain_state = resources.swapchain(swapchain_id).unwrap();
+    let swapchain_state = resources.swapchain(swapchain_id);
     let images = swapchain_state.images();
     let extent = images[0].extent();
 

--- a/examples/deferred/scene.rs
+++ b/examples/deferred/scene.rs
@@ -67,11 +67,7 @@ impl SceneTask {
             .unwrap();
 
         // FIXME(taskgraph): sane initialization
-        app.resources
-            .flight(app.flight_id)
-            .unwrap()
-            .wait(None)
-            .unwrap();
+        app.resources.flight(app.flight_id).wait(None).unwrap();
 
         unsafe {
             vulkano_taskgraph::execute(
@@ -79,7 +75,7 @@ impl SceneTask {
                 &app.resources,
                 app.flight_id,
                 |_cbf, tcx| {
-                    tcx.write_buffer::<[TriangleVertex]>(vertex_buffer_id, ..)?
+                    tcx.write_buffer::<[TriangleVertex]>(vertex_buffer_id, ..)
                         .copy_from_slice(&vertices);
 
                     Ok(())
@@ -104,8 +100,14 @@ impl SceneTask {
         let bcx = app.resources.bindless_context().unwrap();
 
         let pipeline = {
-            let vs = vs::load(&app.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&app.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&app.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&app.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = TriangleVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),
@@ -161,11 +163,11 @@ impl Task for SceneTask {
         _tcx: &mut TaskContext<'_>,
         rcx: &Self::World,
     ) -> TaskResult {
-        cbf.set_viewport(0, slice::from_ref(&rcx.viewport))?;
-        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap())?;
-        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
+        cbf.set_viewport(0, slice::from_ref(&rcx.viewport));
+        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap());
+        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[]);
 
-        unsafe { cbf.draw(3, 1, 0, 0) }?;
+        unsafe { cbf.draw(3, 1, 0, 0) };
 
         Ok(())
     }

--- a/examples/dynamic-buffers/main.rs
+++ b/examples/dynamic-buffers/main.rs
@@ -121,7 +121,10 @@ fn main() {
     }
 
     let pipeline = {
-        let cs = cs::load(&device).unwrap().entry_point("main").unwrap();
+        let cs = unsafe { cs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);
         let layout = PipelineLayout::new(
             &device,

--- a/examples/dynamic-local-size/main.rs
+++ b/examples/dynamic-local-size/main.rs
@@ -169,7 +169,7 @@ fn main() {
     println!("Local size will be set to: ({local_size_x}, {local_size_y}, 1)");
 
     let pipeline = {
-        let cs = cs::load(&device)
+        let cs = unsafe { cs::load(&device) }
             .unwrap()
             .specialize(&[
                 (0, 0.2f32.into()),
@@ -178,7 +178,6 @@ fn main() {
                 (3, 0.5f32.into()),
                 (4, 1.0f32.into()),
             ])
-            .unwrap()
             .entry_point("main")
             .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);

--- a/examples/gl-interop/main.rs
+++ b/examples/gl-interop/main.rs
@@ -152,7 +152,7 @@ mod linux {
             };
 
             let library = unsafe { VulkanLibrary::new() }.unwrap();
-            let required_extensions = Surface::required_extensions(event_loop).unwrap();
+            let required_extensions = Surface::required_extensions(event_loop);
             let instance = Instance::new(
                 &library,
                 &InstanceCreateInfo {
@@ -190,7 +190,7 @@ mod linux {
                         .enumerate()
                         .position(|(i, q)| {
                             q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                                && p.presentation_support(i as u32, event_loop).unwrap()
+                                && p.presentation_support(i as u32, event_loop)
                         })
                         .map(|i| (p, i as u32))
                 })
@@ -512,8 +512,14 @@ mod linux {
             let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
             let pipeline = {
-                let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-                let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+                let vs = unsafe { vs::load(&self.device) }
+                    .unwrap()
+                    .entry_point("main")
+                    .unwrap();
+                let fs = unsafe { fs::load(&self.device) }
+                    .unwrap()
+                    .entry_point("main")
+                    .unwrap();
                 let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
                 let stages = [
                     PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/image-self-copy-blit/main.rs
+++ b/examples/image-self-copy-blit/main.rs
@@ -86,7 +86,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -111,7 +111,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -383,8 +383,14 @@ impl ApplicationHandler for App {
         let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/image/main.rs
+++ b/examples/image/main.rs
@@ -85,7 +85,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -110,7 +110,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -324,8 +324,14 @@ impl ApplicationHandler for App {
         let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/immutable-sampler/main.rs
+++ b/examples/immutable-sampler/main.rs
@@ -97,7 +97,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -122,7 +122,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -336,8 +336,14 @@ impl ApplicationHandler for App {
         let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/indirect/main.rs
+++ b/examples/indirect/main.rs
@@ -97,7 +97,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -123,7 +123,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -212,7 +212,10 @@ impl App {
         }
 
         let compute_pipeline = {
-            let cs = cs::load(&device).unwrap().entry_point("main").unwrap();
+            let cs = unsafe { cs::load(&device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let stage = PipelineShaderStageCreateInfo::new(&cs);
             let layout = PipelineLayout::from_stages(&device, slice::from_ref(&stage)).unwrap();
 
@@ -329,8 +332,14 @@ impl ApplicationHandler for App {
         }
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -75,7 +75,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -100,7 +100,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -316,8 +316,14 @@ impl ApplicationHandler for App {
         }
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = [TriangleVertex::per_vertex(), InstanceData::per_instance()]
                 .definition(&vs)
                 .unwrap();

--- a/examples/interactive-fractal/fractal_compute_pipeline.rs
+++ b/examples/interactive-fractal/fractal_compute_pipeline.rs
@@ -67,7 +67,10 @@ impl FractalComputePipeline {
 
         let pipeline = {
             let device = queue.device();
-            let cs = cs::load(device).unwrap().entry_point("main").unwrap();
+            let cs = unsafe { cs::load(device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let stage = PipelineShaderStageCreateInfo::new(&cs);
             let layout = PipelineLayout::from_stages(device, slice::from_ref(&stage)).unwrap();
 

--- a/examples/interactive-fractal/pixels_draw_pipeline.rs
+++ b/examples/interactive-fractal/pixels_draw_pipeline.rs
@@ -47,11 +47,11 @@ impl PixelsDrawPipeline {
     ) -> PixelsDrawPipeline {
         let pipeline = {
             let device = gfx_queue.device();
-            let vs = vs::load(device)
+            let vs = unsafe { vs::load(device) }
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
-            let fs = fs::load(device)
+            let fs = unsafe { fs::load(device) }
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");

--- a/examples/mesh-shader/main.rs
+++ b/examples/mesh-shader/main.rs
@@ -93,7 +93,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -119,7 +119,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -316,11 +316,14 @@ impl ApplicationHandler for App {
         let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
         let pipeline = {
-            let mesh = mesh::load(&self.device)
+            let mesh = unsafe { mesh::load(&self.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&mesh),
                 PipelineShaderStageCreateInfo::new(&fs),

--- a/examples/msaa-renderpass/main.rs
+++ b/examples/msaa-renderpass/main.rs
@@ -305,8 +305,14 @@ fn main() {
     .unwrap();
 
     let pipeline = {
-        let vs = vs::load(&device).unwrap().entry_point("main").unwrap();
-        let fs = fs::load(&device).unwrap().entry_point("main").unwrap();
+        let vs = unsafe { vs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
+        let fs = unsafe { fs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
         let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/multi-window-game-of-life/game_of_life.rs
+++ b/examples/multi-window-game-of-life/game_of_life.rs
@@ -62,7 +62,7 @@ impl GameOfLifeComputePipeline {
 
         let compute_life_pipeline = {
             let device = compute_queue.device();
-            let cs = compute_life_cs::load(device)
+            let cs = unsafe { compute_life_cs::load(device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();

--- a/examples/multi-window-game-of-life/pixels_draw.rs
+++ b/examples/multi-window-game-of-life/pixels_draw.rs
@@ -43,11 +43,11 @@ impl PixelsDrawPipeline {
     pub fn new(app: &App, gfx_queue: &Arc<Queue>, subpass: &Subpass) -> PixelsDrawPipeline {
         let pipeline = {
             let device = gfx_queue.device();
-            let vs = vs::load(device)
+            let vs = unsafe { vs::load(device) }
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");
-            let fs = fs::load(device)
+            let fs = unsafe { fs::load(device) }
                 .expect("failed to create shader module")
                 .entry_point("main")
                 .expect("shader entry point not found");

--- a/examples/multi-window/main.rs
+++ b/examples/multi-window/main.rs
@@ -71,7 +71,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -96,7 +96,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -167,7 +167,7 @@ impl App {
                 &resources,
                 flight_id,
                 |_cbf, tcx| {
-                    tcx.write_buffer::<[MyVertex]>(vertex_buffer_id, ..)?
+                    tcx.write_buffer::<[MyVertex]>(vertex_buffer_id, ..)
                         .copy_from_slice(&vertices);
 
                     Ok(())
@@ -313,8 +313,14 @@ impl App {
         let scene_node = task_graph.task_node_mut(scene_node_id).unwrap();
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),
@@ -386,7 +392,7 @@ impl ApplicationHandler for App {
             WindowEvent::CloseRequested => {
                 let rcx = self.rcxs.remove(&window_id).unwrap();
 
-                self.resources.remove_swapchain(rcx.swapchain_id).unwrap();
+                self.resources.remove_swapchain(rcx.swapchain_id);
 
                 // Unfortunately, the only way to guarantee that a swapchain is no longer being used
                 // by the presentation engine is to do a device-wide wait for idle. Without this,
@@ -426,7 +432,7 @@ impl ApplicationHandler for App {
                     return;
                 }
 
-                let flight = self.resources.flight(self.flight_id).unwrap();
+                let flight = self.resources.flight(self.flight_id);
 
                 if rcx.recreate_swapchain {
                     rcx.swapchain_id = self
@@ -494,11 +500,11 @@ impl Task for SceneTask {
         _tcx: &mut TaskContext<'_>,
         rcx: &Self::World,
     ) -> TaskResult {
-        cbf.set_viewport(0, slice::from_ref(&rcx.viewport))?;
-        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap())?;
-        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[])?;
+        cbf.set_viewport(0, slice::from_ref(&rcx.viewport));
+        cbf.bind_pipeline_graphics(self.pipeline.as_ref().unwrap());
+        cbf.bind_vertex_buffers(0, &[self.vertex_buffer_id], &[0], &[], &[]);
 
-        unsafe { cbf.draw(3, 1, 0, 0) }?;
+        unsafe { cbf.draw(3, 1, 0, 0) };
 
         Ok(())
     }

--- a/examples/multiview/main.rs
+++ b/examples/multiview/main.rs
@@ -254,8 +254,14 @@ fn main() {
     .unwrap();
 
     let pipeline = {
-        let vs = vs::load(&device).unwrap().entry_point("main").unwrap();
-        let fs = fs::load(&device).unwrap().entry_point("main").unwrap();
+        let vs = unsafe { vs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
+        let fs = unsafe { fs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
         let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
         let stages = [
             PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/occlusion-query/main.rs
+++ b/examples/occlusion-query/main.rs
@@ -80,7 +80,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -105,7 +105,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -345,8 +345,14 @@ impl ApplicationHandler for App {
         }
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/offscreen/main.rs
+++ b/examples/offscreen/main.rs
@@ -196,8 +196,14 @@ fn main() {
     .unwrap();
 
     let pipeline = {
-        let vs = vs::load(&device).unwrap().entry_point("main").unwrap();
-        let fs = fs::load(&device).unwrap().entry_point("main").unwrap();
+        let vs = unsafe { vs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
+        let fs = unsafe { fs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
 
         let vertex_input_state = Vertex::per_vertex().definition(&vs).unwrap();
 

--- a/examples/pipeline-caching/main.rs
+++ b/examples/pipeline-caching/main.rs
@@ -124,7 +124,10 @@ fn main() {
                 ",
             }
         }
-        let cs = cs::load(&device).unwrap().entry_point("main").unwrap();
+        let cs = unsafe { cs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);
         let layout = PipelineLayout::from_stages(&device, slice::from_ref(&stage)).unwrap();
 

--- a/examples/push-constants/main.rs
+++ b/examples/push-constants/main.rs
@@ -112,7 +112,10 @@ fn main() {
     }
 
     let pipeline = {
-        let cs = cs::load(&device).unwrap().entry_point("main").unwrap();
+        let cs = unsafe { cs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);
         let layout = PipelineLayout::from_stages(&device, slice::from_ref(&stage)).unwrap();
 

--- a/examples/push-descriptors/main.rs
+++ b/examples/push-descriptors/main.rs
@@ -85,7 +85,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -111,7 +111,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -320,8 +320,14 @@ impl ApplicationHandler for App {
         let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/ray-tracing-auto/main.rs
+++ b/examples/ray-tracing-auto/main.rs
@@ -61,7 +61,7 @@ pub struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -106,7 +106,7 @@ impl App {
                     .position(|(i, q)| {
                         q.queue_flags
                             .contains(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })

--- a/examples/ray-tracing-auto/scene.rs
+++ b/examples/ray-tracing-auto/scene.rs
@@ -57,15 +57,15 @@ impl Scene {
         command_buffer_allocator: &Arc<StandardCommandBufferAllocator>,
     ) -> Self {
         let pipeline = {
-            let raygen = raygen::load(&app.device)
+            let raygen = unsafe { raygen::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let closest_hit = closest_hit::load(&app.device)
+            let closest_hit = unsafe { closest_hit::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let miss = miss::load(&app.device)
+            let miss = unsafe { miss::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
@@ -333,13 +333,11 @@ unsafe fn build_acceleration_structure_common(
         ..AccelerationStructureBuildGeometryInfo::new(geometries)
     };
 
-    let as_build_sizes_info = device
-        .acceleration_structure_build_sizes(
-            AccelerationStructureBuildType::Device,
-            &as_build_geometry_info,
-            &[primitive_count],
-        )
-        .unwrap();
+    let as_build_sizes_info = device.acceleration_structure_build_sizes(
+        AccelerationStructureBuildType::Device,
+        &as_build_geometry_info,
+        &[primitive_count],
+    );
 
     // We create a new scratch buffer for each acceleration structure for simplicity. You may want
     // to reuse scratch buffers if you need to build many acceleration structures.

--- a/examples/ray-tracing/main.rs
+++ b/examples/ray-tracing/main.rs
@@ -60,7 +60,7 @@ pub struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -106,7 +106,7 @@ impl App {
                     .position(|(i, q)| {
                         q.queue_flags
                             .contains(QueueFlags::GRAPHICS | QueueFlags::COMPUTE)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -299,7 +299,7 @@ impl ApplicationHandler for App {
                     return;
                 }
 
-                let flight = self.resources.flight(self.flight_id).unwrap();
+                let flight = self.resources.flight(self.flight_id);
 
                 if rcx.recreate_swapchain {
                     rcx.swapchain_id = self
@@ -364,7 +364,7 @@ fn window_size_dependent_setup(
     swapchain_id: Id<Swapchain>,
 ) -> Vec<StorageImageId> {
     let bcx = resources.bindless_context().unwrap();
-    let swapchain_state = resources.swapchain(swapchain_id).unwrap();
+    let swapchain_state = resources.swapchain(swapchain_id);
     let images = swapchain_state.images();
 
     let swapchain_storage_image_ids = images

--- a/examples/ray-tracing/scene.rs
+++ b/examples/ray-tracing/scene.rs
@@ -59,15 +59,15 @@ impl SceneTask {
         let bcx = app.resources.bindless_context().unwrap();
 
         let pipeline = {
-            let raygen = raygen::load(&app.device)
+            let raygen = unsafe { raygen::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let closest_hit = closest_hit::load(&app.device)
+            let closest_hit = unsafe { closest_hit::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let miss = miss::load(&app.device)
+            let miss = unsafe { miss::load(&app.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
@@ -189,7 +189,7 @@ impl SceneTask {
                 &app.resources,
                 app.flight_id,
                 |_cbf, tcx| {
-                    *tcx.write_buffer(camera_buffer_id, ..)? = raygen::Camera {
+                    *tcx.write_buffer(camera_buffer_id, ..) = raygen::Camera {
                         view_proj: (proj * view).to_cols_array_2d(),
                         view_inverse: view.inverse().to_cols_array_2d(),
                         proj_inverse: proj.inverse().to_cols_array_2d(),
@@ -233,7 +233,7 @@ impl Task for SceneTask {
         tcx: &mut TaskContext<'_>,
         rcx: &Self::World,
     ) -> TaskResult {
-        let swapchain_state = tcx.swapchain(self.swapchain_id)?;
+        let swapchain_state = tcx.swapchain(self.swapchain_id);
         let image_index = swapchain_state.current_image_index().unwrap();
         let extent = swapchain_state.images()[0].extent();
 
@@ -245,10 +245,10 @@ impl Task for SceneTask {
                 acceleration_structure_id: self.acceleration_structure_id,
                 camera_buffer_id: self.camera_storage_buffer_id,
             },
-        )?;
-        cbf.bind_pipeline_ray_tracing(&self.pipeline)?;
+        );
+        cbf.bind_pipeline_ray_tracing(&self.pipeline);
 
-        unsafe { cbf.trace_rays(self.shader_binding_table.addresses(), extent) }?;
+        unsafe { cbf.trace_rays(self.shader_binding_table.addresses(), extent) };
 
         Ok(())
     }
@@ -306,13 +306,11 @@ unsafe fn build_acceleration_structure_common(
         ..AccelerationStructureBuildGeometryInfo::new(geometries)
     };
 
-    let as_build_sizes_info = device
-        .acceleration_structure_build_sizes(
-            AccelerationStructureBuildType::Device,
-            &as_build_geometry_info,
-            &[primitive_count],
-        )
-        .unwrap();
+    let as_build_sizes_info = device.acceleration_structure_build_sizes(
+        AccelerationStructureBuildType::Device,
+        &as_build_geometry_info,
+        &[primitive_count],
+    );
 
     // We create a new scratch buffer for each acceleration structure for simplicity. You may want
     // to reuse scratch buffers if you need to build many acceleration structures.

--- a/examples/runtime-array/main.rs
+++ b/examples/runtime-array/main.rs
@@ -92,7 +92,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -117,7 +117,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -435,8 +435,14 @@ impl ApplicationHandler for App {
         let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/runtime-shader/main.rs
+++ b/examples/runtime-shader/main.rs
@@ -83,7 +83,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -108,7 +108,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })

--- a/examples/self-copy-buffer/main.rs
+++ b/examples/self-copy-buffer/main.rs
@@ -104,7 +104,10 @@ fn main() {
             }
         }
 
-        let cs = cs::load(&device).unwrap().entry_point("main").unwrap();
+        let cs = unsafe { cs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);
         let layout = PipelineLayout::from_stages(&device, slice::from_ref(&stage)).unwrap();
 

--- a/examples/shader-include/main.rs
+++ b/examples/shader-include/main.rs
@@ -112,7 +112,10 @@ fn main() {
             }
         }
 
-        let cs = cs::load(&device).unwrap().entry_point("main").unwrap();
+        let cs = unsafe { cs::load(&device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);
         let layout = PipelineLayout::from_stages(&device, slice::from_ref(&stage)).unwrap();
 

--- a/examples/shader-types-sharing/main.rs
+++ b/examples/shader-types-sharing/main.rs
@@ -257,10 +257,9 @@ fn main() {
 
     // Load the first shader, and create a pipeline for the shader.
     let mult_pipeline = {
-        let cs = shaders::load_mult(&device)
+        let cs = unsafe { shaders::load_mult(&device) }
             .unwrap()
             .specialize(&[(0, true.into())])
-            .unwrap()
             .entry_point("main")
             .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);
@@ -276,10 +275,9 @@ fn main() {
 
     // Load the second shader, and create a pipeline for the shader.
     let add_pipeline = {
-        let cs = shaders::load_add(&device)
+        let cs = unsafe { shaders::load_add(&device) }
             .unwrap()
             .specialize(&[(0, true.into())])
-            .unwrap()
             .entry_point("main")
             .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);

--- a/examples/simple-particles/main.rs
+++ b/examples/simple-particles/main.rs
@@ -90,7 +90,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -115,7 +115,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -236,7 +236,10 @@ impl App {
 
         // Create a compute-pipeline for applying the compute shader to vertices.
         let compute_pipeline = {
-            let cs = cs::load(&device).unwrap().entry_point("main").unwrap();
+            let cs = unsafe { cs::load(&device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let stage = PipelineShaderStageCreateInfo::new(&cs);
             let layout = PipelineLayout::from_stages(&device, slice::from_ref(&stage)).unwrap();
 
@@ -412,8 +415,14 @@ impl ApplicationHandler for App {
 
         // Create a basic graphics pipeline for rendering particles.
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/specialization-constants/main.rs
+++ b/examples/specialization-constants/main.rs
@@ -108,10 +108,9 @@ fn main() {
     }
 
     let pipeline = {
-        let cs = cs::load(&device)
+        let cs = unsafe { cs::load(&device) }
             .unwrap()
             .specialize(&[(0, 1i32.into()), (1, 1.0f32.into()), (2, true.into())])
-            .unwrap()
             .entry_point("main")
             .unwrap();
         let stage = PipelineShaderStageCreateInfo::new(&cs);

--- a/examples/teapot/main.rs
+++ b/examples/teapot/main.rs
@@ -94,7 +94,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -119,7 +119,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -286,8 +286,14 @@ impl ApplicationHandler for App {
         )
         .unwrap();
 
-        let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-        let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+        let vs = unsafe { vs::load(&self.device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
+        let fs = unsafe { fs::load(&self.device) }
+            .unwrap()
+            .entry_point("main")
+            .unwrap();
 
         let (framebuffers, pipeline) = window_size_dependent_setup(
             window_size,

--- a/examples/tessellation/main.rs
+++ b/examples/tessellation/main.rs
@@ -83,7 +83,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -114,7 +114,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -272,16 +272,22 @@ impl ApplicationHandler for App {
         let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let tcs = tcs::load(&self.device)
+            let vs = unsafe { vs::load(&self.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let tes = tes::load(&self.device)
+            let tcs = unsafe { tcs::load(&self.device) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let tes = unsafe { tes::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/texture-array/main.rs
+++ b/examples/texture-array/main.rs
@@ -87,7 +87,7 @@ struct RenderContext {
 impl App {
     fn new(event_loop: &EventLoop<()>) -> Self {
         let library = unsafe { VulkanLibrary::new() }.unwrap();
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
         let instance = Instance::new(
             &library,
             &InstanceCreateInfo {
@@ -112,7 +112,7 @@ impl App {
                     .enumerate()
                     .position(|(i, q)| {
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     .map(|i| (p, i as u32))
             })
@@ -336,8 +336,14 @@ impl ApplicationHandler for App {
         let framebuffers = window_size_dependent_setup(&images, &render_pass);
 
         let pipeline = {
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
             let vertex_input_state = MyVertex::per_vertex().definition(&vs).unwrap();
             let stages = [
                 PipelineShaderStageCreateInfo::new(&vs),

--- a/examples/triangle-util/main.rs
+++ b/examples/triangle-util/main.rs
@@ -232,11 +232,11 @@ impl ApplicationHandler for App {
             //
             // A Vulkan shader can in theory contain multiple entry points, so we have to specify
             // which one.
-            let vs = vs::load(self.context.device())
+            let vs = unsafe { vs::load(self.context.device()) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();
-            let fs = fs::load(self.context.device())
+            let fs = unsafe { fs::load(self.context.device()) }
                 .unwrap()
                 .entry_point("main")
                 .unwrap();

--- a/examples/triangle-v1_3/main.rs
+++ b/examples/triangle-v1_3/main.rs
@@ -90,7 +90,7 @@ impl App {
         // All the window-drawing functionalities are part of non-core extensions that we need to
         // enable manually. To do so, we ask `Surface` for the list of extensions required to draw
         // to a window.
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
 
         // Now creating the instance.
         let instance = Instance::new(
@@ -151,7 +151,7 @@ impl App {
                         // that queues in this queue family are capable of presenting images to the
                         // surface.
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     // The code here searches for the first queue family that is suitable. If none
                     // is found, `None` is returned to `filter_map`, which disqualifies this
@@ -425,8 +425,14 @@ impl ApplicationHandler for App {
             //
             // A Vulkan shader can in theory contain multiple entry points, so we have to specify
             // which one.
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
 
             // Automatically generate a vertex input state from the vertex shader's input
             // interface, that takes a single vertex buffer containing `Vertex` structs.

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -85,7 +85,7 @@ impl App {
         // All the window-drawing functionalities are part of non-core extensions that we need to
         // enable manually. To do so, we ask `Surface` for the list of extensions required to draw
         // to a window.
-        let required_extensions = Surface::required_extensions(event_loop).unwrap();
+        let required_extensions = Surface::required_extensions(event_loop);
 
         // Now creating the instance.
         let instance = Instance::new(
@@ -142,7 +142,7 @@ impl App {
                         // that queues in this queue family are capable of presenting images to the
                         // surface.
                         q.queue_flags.intersects(QueueFlags::GRAPHICS)
-                            && p.presentation_support(i as u32, event_loop).unwrap()
+                            && p.presentation_support(i as u32, event_loop)
                     })
                     // The code here searches for the first queue family that is suitable. If none
                     // is found, `None` is returned to `filter_map`, which
@@ -433,8 +433,14 @@ impl ApplicationHandler for App {
             //
             // A Vulkan shader can in theory contain multiple entry points, so we have to specify
             // which one.
-            let vs = vs::load(&self.device).unwrap().entry_point("main").unwrap();
-            let fs = fs::load(&self.device).unwrap().entry_point("main").unwrap();
+            let vs = unsafe { vs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
+            let fs = unsafe { fs::load(&self.device) }
+                .unwrap()
+                .entry_point("main")
+                .unwrap();
 
             // Automatically generate a vertex input state from the vertex shader's input
             // interface, that takes a single vertex buffer containing `Vertex` structs.

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -245,12 +245,33 @@ pub(super) fn reflect(
     } else {
         format_ident!("load_{}", shader.name.to_snake_case())
     };
+    let try_load_name = format_ident!("try_{load_name}");
 
     let shader_code = quote! {
+        /// Loads the shader as a `ShaderModule`, panicking on a validation error.
+        #[allow(unsafe_code)]
+        #[inline]
+        #[track_caller]
+        pub unsafe fn #load_name(
+            device: &::std::sync::Arc<::vulkano::device::Device>,
+        ) -> ::std::result::Result<
+            ::std::sync::Arc<::vulkano::shader::ShaderModule>,
+            ::vulkano::VulkanError,
+        > {
+            match unsafe { #try_load_name(device) } {
+                ::std::result::Result::Ok(shader_module) => {
+                    ::std::result::Result::Ok(shader_module)
+                }
+                ::std::result::Result::Err(err) => {
+                    ::std::result::Result::Err(::vulkano::Validated::unwrap(err))
+                }
+            }
+        }
+
         /// Loads the shader as a `ShaderModule`.
         #[allow(unsafe_code)]
         #[inline]
-        pub fn #load_name(
+        pub unsafe fn #try_load_name(
             device: &::std::sync::Arc<::vulkano::device::Device>,
         ) -> ::std::result::Result<
             ::std::sync::Arc<::vulkano::shader::ShaderModule>,
@@ -261,7 +282,7 @@ pub(super) fn reflect(
             static WORDS: &[u32] = &[ #( #words ),* ];
 
             unsafe {
-                ::vulkano::shader::ShaderModule::new(
+                ::vulkano::shader::ShaderModule::try_new(
                     device,
                     &::vulkano::shader::ShaderModuleCreateInfo::new(WORDS),
                 )

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -33,11 +33,11 @@
 //!
 //! The macro generates the following items of interest:
 //!
-//! - The `load` constructor. This function takes an `Arc<Device>`, constructs a [`ShaderModule`]
+//! - The `load` function. This function takes an `&Arc<Device>`, constructs a [`ShaderModule`]
 //!   with the passed-in device and the shader data provided via the macro, and returns
-//!   `Result<Arc<ShaderModule>, Validated<VulkanError>>`. Before doing so, it checks every
-//!   capability instruction in the shader data, verifying that the passed-in `Device` has the
-//!   appropriate features enabled.
+//!   `Result<Arc<ShaderModule>, VulkanError>`. It also generates the `try_load` function, which
+//!   works the same, but returns a `Result<Arc<ShaderModule>, Validated<VulkanError>>`. These
+//!   functions are both unsafe because they delegate to the unsafe [`ShaderModule::try_new`].
 //! - If the `shaders` option is used, then instead of one `load` constructor, there is one for
 //!   each shader. They are named based on the provided names, `load_first`, `load_second` etc.
 //! - A Rust struct translated from each struct contained in the shader data. By default, each
@@ -78,9 +78,9 @@
 //! }
 //!
 //! impl Shaders {
-//!     pub fn load(device: &Arc<Device>) -> Result<Self, Validated<VulkanError>> {
+//!     pub unsafe fn load(device: &Arc<Device>) -> Result<Self, VulkanError> {
 //!         Ok(Self {
-//!             vs: vs::load(device)?,
+//!             vs: unsafe { vs::load(device) }?,
 //!         })
 //!     }
 //! }
@@ -228,6 +228,7 @@
 //! [`cargo-env-vars`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html
 //! [cargo-expand]: https://github.com/dtolnay/cargo-expand
 //! [`ShaderModule`]: vulkano::shader::ShaderModule
+//! [`ShaderModule::try_new`]: vulkano::shader::ShaderModule::try_new
 //! [pipeline]: vulkano::pipeline
 //! [`set_target_env`]: shaderc::CompileOptions::set_target_env
 //! [`set_target_spirv`]: shaderc::CompileOptions::set_target_spirv

--- a/vulkano-taskgraph/src/collector.rs
+++ b/vulkano-taskgraph/src/collector.rs
@@ -68,7 +68,7 @@ impl<'a> DeferredBatch<'a> {
     #[track_caller]
     pub fn destroy_buffer(&mut self, id: Id<Buffer>) -> &mut Self {
         self.resources
-            .invalidate_buffer(id, &self.guard)
+            .try_invalidate_buffer(id, &self.guard)
             .expect("invalid buffer ID");
 
         self.defer(move |resources| {
@@ -88,7 +88,7 @@ impl<'a> DeferredBatch<'a> {
     #[track_caller]
     pub fn destroy_image(&mut self, id: Id<Image>) -> &mut Self {
         self.resources
-            .invalidate_image(id, &self.guard)
+            .try_invalidate_image(id, &self.guard)
             .expect("invalid image ID");
 
         self.defer(move |resources| {
@@ -305,7 +305,7 @@ impl<'a> DeferredBatch<'a> {
         let biased_frames = flight_ids.into_iter().flat_map(|flight_id| {
             let flight = self
                 .resources
-                .flight_protected(flight_id, &guard)
+                .try_flight_protected(flight_id, &guard)
                 .expect("invalid flight ID");
             let biased_frame = flight.biased_started_frame();
 
@@ -355,7 +355,7 @@ impl<'a> DeferredBatch<'a> {
         let biased_frames = frames.into_iter().flat_map(|(flight_id, frame)| {
             let flight = self
                 .resources
-                .flight_protected(flight_id, &guard)
+                .try_flight_protected(flight_id, &guard)
                 .expect("invalid flight ID");
             let biased_frame = frame + u64::from(flight.frame_count()) + 1;
 
@@ -609,7 +609,7 @@ impl GlobalQueue {
     pub(crate) unsafe fn collect(&self, resources: &Resources, guard: &hyaline::Guard<'_>) {
         let predicate = |biased_frames: &[(Id<Flight>, u64)]| {
             for &(flight_id, biased_frame) in biased_frames {
-                let Ok(flight) = resources.flight_protected(flight_id, guard) else {
+                let Ok(flight) = resources.try_flight_protected(flight_id, guard) else {
                     continue;
                 };
 

--- a/vulkano-taskgraph/src/command_buffer/commands/bind_push.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/bind_push.rs
@@ -22,8 +22,28 @@ use vulkano::{
 ///
 /// These commands require a queue with a pipeline type that uses the given state.
 impl RecordingCommandBuffer<'_> {
-    /// Binds an index buffer for future indexed draw calls.
+    /// Binds an index buffer for future indexed draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_bind_index_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_bind_index_buffer`] returns a [`ValidationError`].
+    ///
+    /// [`try_bind_index_buffer`]: Self::try_bind_index_buffer
+    #[track_caller]
     pub unsafe fn bind_index_buffer(
+        &mut self,
+        buffer: Id<Buffer>,
+        offset: DeviceSize,
+        size: Option<DeviceSize>,
+        index_type: IndexType,
+    ) -> &mut Self {
+        unsafe { self.try_bind_index_buffer(buffer, offset, size, index_type) }.unwrap()
+    }
+
+    /// Binds an index buffer for future indexed draw calls.
+    pub unsafe fn try_bind_index_buffer(
         &mut self,
         buffer: Id<Buffer>,
         offset: DeviceSize,
@@ -68,8 +88,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Binds a compute pipeline for future dispatch calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_bind_pipeline_compute().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_bind_pipeline_compute`] returns a [`ValidationError`].
+    ///
+    /// [`try_bind_pipeline_compute`]: Self::try_bind_pipeline_compute
+    #[track_caller]
+    pub unsafe fn bind_pipeline_compute(&mut self, pipeline: &Arc<ComputePipeline>) -> &mut Self {
+        unsafe { self.try_bind_pipeline_compute(pipeline) }.unwrap()
+    }
+
     /// Binds a compute pipeline for future dispatch calls.
-    pub unsafe fn bind_pipeline_compute(
+    pub unsafe fn try_bind_pipeline_compute(
         &mut self,
         pipeline: &Arc<ComputePipeline>,
     ) -> Result<&mut Self> {
@@ -104,8 +138,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Binds a graphics pipeline for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_bind_pipeline_graphics().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_bind_pipeline_graphics`] returns a [`ValidationError`].
+    ///
+    /// [`try_bind_pipeline_graphics`]: Self::try_bind_pipeline_graphics
+    #[track_caller]
+    pub unsafe fn bind_pipeline_graphics(&mut self, pipeline: &Arc<GraphicsPipeline>) -> &mut Self {
+        unsafe { self.try_bind_pipeline_graphics(pipeline) }.unwrap()
+    }
+
     /// Binds a graphics pipeline for future draw calls.
-    pub unsafe fn bind_pipeline_graphics(
+    pub unsafe fn try_bind_pipeline_graphics(
         &mut self,
         pipeline: &Arc<GraphicsPipeline>,
     ) -> Result<&mut Self> {
@@ -140,8 +188,25 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Binds a ray tracing pipeline for future ray tracing calls.
+    /// Binds a ray tracing pipeline for future ray tracing calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_bind_pipeline_ray_tracing().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_bind_pipeline_ray_tracing`] returns a [`ValidationError`].
+    ///
+    /// [`try_bind_pipeline_ray_tracing`]: Self::try_bind_pipeline_ray_tracing
+    #[track_caller]
     pub unsafe fn bind_pipeline_ray_tracing(
+        &mut self,
+        pipeline: &Arc<RayTracingPipeline>,
+    ) -> &mut Self {
+        unsafe { self.try_bind_pipeline_ray_tracing(pipeline) }.unwrap()
+    }
+
+    /// Binds a ray tracing pipeline for future ray tracing calls.
+    pub unsafe fn try_bind_pipeline_ray_tracing(
         &mut self,
         pipeline: &Arc<RayTracingPipeline>,
     ) -> Result<&mut Self> {
@@ -180,8 +245,30 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Binds vertex buffers for future draw calls.
+    /// Binds vertex buffers for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_bind_vertex_buffers().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_bind_vertex_buffers`] returns a [`ValidationError`].
+    ///
+    /// [`try_bind_vertex_buffers`]: Self::try_bind_vertex_buffers
+    #[track_caller]
     pub unsafe fn bind_vertex_buffers(
+        &mut self,
+        first_binding: u32,
+        buffers: &[Id<Buffer>],
+        offsets: &[DeviceSize],
+        sizes: &[DeviceSize],
+        strides: &[DeviceSize],
+    ) -> &mut Self {
+        unsafe { self.try_bind_vertex_buffers(first_binding, buffers, offsets, sizes, strides) }
+            .unwrap()
+    }
+
+    /// Binds vertex buffers for future draw calls.
+    pub unsafe fn try_bind_vertex_buffers(
         &mut self,
         first_binding: u32,
         buffers: &[Id<Buffer>],
@@ -260,8 +347,27 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets push constants for future dispatch or draw calls.
+    /// Sets push constants for future dispatch or draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_push_constants().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_push_constants`] returns a [`ValidationError`].
+    ///
+    /// [`try_push_constants`]: Self::try_push_constants
+    #[track_caller]
     pub unsafe fn push_constants(
+        &mut self,
+        layout: &Arc<PipelineLayout>,
+        offset: u32,
+        values: &(impl BufferContents + ?Sized),
+    ) -> &mut Self {
+        unsafe { self.try_push_constants(layout, offset, values) }.unwrap()
+    }
+
+    /// Sets push constants for future dispatch or draw calls.
+    pub unsafe fn try_push_constants(
         &mut self,
         layout: &Arc<PipelineLayout>,
         offset: u32,

--- a/vulkano-taskgraph/src/command_buffer/commands/clear.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/clear.rs
@@ -16,8 +16,22 @@ use vulkano::{
 
 /// # Commands to fill resources with new data
 impl RecordingCommandBuffer<'_> {
+    /// Clears a color image with a specific value, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_clear_color_image().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_clear_color_image`] returns a [`ValidationError`].
+    ///
+    /// [`try_clear_color_image`]: Self::try_clear_color_image
+    #[track_caller]
+    pub unsafe fn clear_color_image(&mut self, clear_info: &ClearColorImageInfo<'_>) -> &mut Self {
+        unsafe { self.try_clear_color_image(clear_info) }.unwrap()
+    }
+
     /// Clears a color image with a specific value.
-    pub unsafe fn clear_color_image(
+    pub unsafe fn try_clear_color_image(
         &mut self,
         clear_info: &ClearColorImageInfo<'_>,
     ) -> Result<&mut Self> {
@@ -76,8 +90,25 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Clears a depth/stencil image with a specific value.
+    /// Clears a depth/stencil image with a specific value, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_clear_depth_stencil_image().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_clear_depth_stencil_image`] returns a [`ValidationError`].
+    ///
+    /// [`try_clear_depth_stencil_image`]: Self::try_clear_depth_stencil_image
+    #[track_caller]
     pub unsafe fn clear_depth_stencil_image(
+        &mut self,
+        clear_info: &ClearDepthStencilImageInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_clear_depth_stencil_image(clear_info) }.unwrap()
+    }
+
+    /// Clears a depth/stencil image with a specific value.
+    pub unsafe fn try_clear_depth_stencil_image(
         &mut self,
         clear_info: &ClearDepthStencilImageInfo<'_>,
     ) -> Result<&mut Self> {
@@ -136,11 +167,29 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Fills a region of a buffer with repeated copies of a value, panicking on a validation
+    /// error.
+    ///
+    /// This function is similar to the `memset` function in C. The `data` parameter is a number
+    /// that will be repeatedly written through the entire buffer.
+    ///
+    /// This is a shortcut for `try_fill_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_fill_buffer`] returns a [`ValidationError`].
+    ///
+    /// [`try_fill_buffer`]: Self::try_fill_buffer
+    #[track_caller]
+    pub unsafe fn fill_buffer(&mut self, fill_info: &FillBufferInfo<'_>) -> &mut Self {
+        unsafe { self.try_fill_buffer(fill_info) }.unwrap()
+    }
+
     /// Fills a region of a buffer with repeated copies of a value.
     ///
     /// This function is similar to the `memset` function in C. The `data` parameter is a number
     /// that will be repeatedly written through the entire buffer.
-    pub unsafe fn fill_buffer(&mut self, fill_info: &FillBufferInfo<'_>) -> Result<&mut Self> {
+    pub unsafe fn try_fill_buffer(&mut self, fill_info: &FillBufferInfo<'_>) -> Result<&mut Self> {
         Ok(unsafe { self.fill_buffer_unchecked(fill_info) })
     }
 
@@ -170,8 +219,27 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Writes data to a region of a buffer.
+    /// Writes data to a region of a buffer, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_update_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_update_buffer`] returns a [`ValidationError`].
+    ///
+    /// [`try_update_buffer`]: Self::try_update_buffer
+    #[track_caller]
     pub unsafe fn update_buffer(
+        &mut self,
+        dst_buffer: Id<Buffer>,
+        dst_offset: DeviceSize,
+        data: &(impl BufferContents + ?Sized),
+    ) -> &mut Self {
+        unsafe { self.try_update_buffer(dst_buffer, dst_offset, data) }.unwrap()
+    }
+
+    /// Writes data to a region of a buffer.
+    pub unsafe fn try_update_buffer(
         &mut self,
         dst_buffer: Id<Buffer>,
         dst_offset: DeviceSize,

--- a/vulkano-taskgraph/src/command_buffer/commands/copy.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/copy.rs
@@ -15,8 +15,22 @@ use vulkano::{
 
 /// # Commands to transfer data between resources
 impl RecordingCommandBuffer<'_> {
+    /// Copies data from a buffer to another buffer, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_copy_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_copy_buffer`] returns a [`ValidationError`].
+    ///
+    /// [`try_copy_buffer`]: Self::try_copy_buffer
+    #[track_caller]
+    pub unsafe fn copy_buffer(&mut self, copy_buffer_info: &CopyBufferInfo<'_>) -> &mut Self {
+        unsafe { self.try_copy_buffer(copy_buffer_info) }.unwrap()
+    }
+
     /// Copies data from a buffer to another buffer.
-    pub unsafe fn copy_buffer(
+    pub unsafe fn try_copy_buffer(
         &mut self,
         copy_buffer_info: &CopyBufferInfo<'_>,
     ) -> Result<&mut Self> {
@@ -138,6 +152,34 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Copies data from an image to another image, panicking on a validation error.
+    ///
+    /// There are several restrictions:
+    ///
+    /// - The number of samples in the source and destination images must be equal.
+    /// - The size of the uncompressed element format of the source image must be equal to the
+    ///   compressed element format of the destination.
+    /// - If you copy between depth, stencil or depth-stencil images, the format of both images
+    ///   must match exactly.
+    /// - For two-dimensional images, the Z coordinate must be 0 for the image offsets and 1 for
+    ///   the extent. Same for the Y coordinate for one-dimensional images.
+    /// - For non-array images, the base array layer must be 0 and the number of layers must be 1.
+    ///
+    /// If `layer_count` is greater than 1, the copy will happen between each individual layer as
+    /// if they were separate images.
+    ///
+    /// This is a shortcut for `try_copy_image().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_copy_image`] returns a [`ValidationError`].
+    ///
+    /// [`try_copy_image`]: Self::try_copy_image
+    #[track_caller]
+    pub unsafe fn copy_image(&mut self, copy_image_info: &CopyImageInfo<'_>) -> &mut Self {
+        unsafe { self.try_copy_image(copy_image_info) }.unwrap()
+    }
+
     /// Copies data from an image to another image.
     ///
     /// There are several restrictions:
@@ -153,7 +195,10 @@ impl RecordingCommandBuffer<'_> {
     ///
     /// If `layer_count` is greater than 1, the copy will happen between each individual layer as
     /// if they were separate images.
-    pub unsafe fn copy_image(&mut self, copy_image_info: &CopyImageInfo<'_>) -> Result<&mut Self> {
+    pub unsafe fn try_copy_image(
+        &mut self,
+        copy_image_info: &CopyImageInfo<'_>,
+    ) -> Result<&mut Self> {
         Ok(unsafe { self.copy_image_unchecked(copy_image_info) })
     }
 
@@ -330,8 +375,25 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Copies from a buffer to an image.
+    /// Copies from a buffer to an image, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_copy_buffer_to_image().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_copy_buffer_to_image`] returns a [`ValidationError`].
+    ///
+    /// [`try_copy_buffer_to_image`]: Self::try_copy_buffer_to_image
+    #[track_caller]
     pub unsafe fn copy_buffer_to_image(
+        &mut self,
+        copy_buffer_to_image_info: &CopyBufferToImageInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_copy_buffer_to_image(copy_buffer_to_image_info) }.unwrap()
+    }
+
+    /// Copies from a buffer to an image.
+    pub unsafe fn try_copy_buffer_to_image(
         &mut self,
         copy_buffer_to_image_info: &CopyBufferToImageInfo<'_>,
     ) -> Result<&mut Self> {
@@ -485,8 +547,25 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Copies from an image to a buffer.
+    /// Copies from an image to a buffer, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_copy_image_to_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_copy_image_to_buffer`] returns a [`ValidationError`].
+    ///
+    /// [`try_copy_image_to_buffer`]: Self::try_copy_image_to_buffer
+    #[track_caller]
     pub unsafe fn copy_image_to_buffer(
+        &mut self,
+        copy_image_to_buffer_info: &CopyImageToBufferInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_copy_image_to_buffer(copy_image_to_buffer_info) }.unwrap()
+    }
+
+    /// Copies from an image to a buffer.
+    pub unsafe fn try_copy_image_to_buffer(
         &mut self,
         copy_image_to_buffer_info: &CopyImageToBufferInfo<'_>,
     ) -> Result<&mut Self> {
@@ -640,6 +719,45 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Blits an image to another, panicking on a validation error.
+    ///
+    /// A *blit* is similar to an image copy operation, except that the portion of the image that
+    /// is transferred can be resized. You choose an area of the source and an area of the
+    /// destination, and the implementation will resize the area of the source so that it matches
+    /// the size of the area of the destination before writing it.
+    ///
+    /// Blit operations have several restrictions:
+    ///
+    /// - Blit operations are only allowed on queue families that support graphics operations.
+    /// - The format of the source and destination images must support blit operations, which
+    ///   depends on the Vulkan implementation. Vulkan guarantees that some specific formats must
+    ///   always be supported. See tables 52 to 61 of the specifications.
+    /// - Only single-sampled images are allowed.
+    /// - You can only blit between two images whose formats belong to the same type. The types
+    ///   are: floating-point, signed integers, unsigned integers, depth-stencil.
+    /// - If you blit between depth, stencil or depth-stencil images, the format of both images
+    ///   must match exactly.
+    /// - If you blit between depth, stencil or depth-stencil images, only the `Nearest` filter is
+    ///   allowed.
+    /// - For two-dimensional images, the Z coordinate must be 0 for the top-left offset and 1 for
+    ///   the bottom-right offset. Same for the Y coordinate for one-dimensional images.
+    /// - For non-array images, the base array layer must be 0 and the number of layers must be 1.
+    ///
+    /// If `layer_count` is greater than 1, the blit will happen between each individual layer as
+    /// if they were separate images.
+    ///
+    /// This is a shortcut for `try_blit_image().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_blit_image`] returns a [`ValidationError`].
+    ///
+    /// [`try_blit_image`]: Self::try_blit_image
+    #[track_caller]
+    pub unsafe fn blit_image(&mut self, blit_image_info: &BlitImageInfo<'_>) -> &mut Self {
+        unsafe { self.try_blit_image(blit_image_info) }.unwrap()
+    }
+
     /// Blits an image to another.
     ///
     /// A *blit* is similar to an image copy operation, except that the portion of the image that
@@ -666,7 +784,10 @@ impl RecordingCommandBuffer<'_> {
     ///
     /// If `layer_count` is greater than 1, the blit will happen between each individual layer as
     /// if they were separate images.
-    pub unsafe fn blit_image(&mut self, blit_image_info: &BlitImageInfo<'_>) -> Result<&mut Self> {
+    pub unsafe fn try_blit_image(
+        &mut self,
+        blit_image_info: &BlitImageInfo<'_>,
+    ) -> Result<&mut Self> {
         Ok(unsafe { self.blit_image_unchecked(blit_image_info) })
     }
 
@@ -830,8 +951,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Resolves a multisampled image into a single-sampled image, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_resolve_image().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_resolve_image`] returns a [`ValidationError`].
+    ///
+    /// [`try_resolve_image`]: Self::try_resolve_image
+    #[track_caller]
+    pub unsafe fn resolve_image(&mut self, resolve_image_info: &ResolveImageInfo<'_>) -> &mut Self {
+        unsafe { self.try_resolve_image(resolve_image_info) }.unwrap()
+    }
+
     /// Resolves a multisampled image into a single-sampled image.
-    pub unsafe fn resolve_image(
+    pub unsafe fn try_resolve_image(
         &mut self,
         resolve_image_info: &ResolveImageInfo<'_>,
     ) -> Result<&mut Self> {

--- a/vulkano-taskgraph/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/dynamic_state.rs
@@ -21,8 +21,22 @@ use vulkano::{
 ///
 /// These commands require a queue with a pipeline type that uses the given state.
 impl RecordingCommandBuffer<'_> {
+    /// Sets the dynamic blend constants for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_blend_constants().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_blend_constants`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_blend_constants`]: Self::try_set_blend_constants
+    #[track_caller]
+    pub unsafe fn set_blend_constants(&mut self, constants: &[f32; 4]) -> &mut Self {
+        unsafe { self.try_set_blend_constants(constants) }.unwrap()
+    }
+
     /// Sets the dynamic blend constants for future draw calls.
-    pub unsafe fn set_blend_constants(&mut self, constants: &[f32; 4]) -> Result<&mut Self> {
+    pub unsafe fn try_set_blend_constants(&mut self, constants: &[f32; 4]) -> Result<&mut Self> {
         Ok(unsafe { self.set_blend_constants_unchecked(constants) })
     }
 
@@ -33,8 +47,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets whether dynamic color writes should be enabled for each attachment in the framebuffer,
+    /// panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_color_write_enable().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_color_write_enable`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_color_write_enable`]: Self::try_set_color_write_enable
+    #[track_caller]
+    pub unsafe fn set_color_write_enable(&mut self, enables: &[bool]) -> &mut Self {
+        unsafe { self.try_set_color_write_enable(enables) }.unwrap()
+    }
+
     /// Sets whether dynamic color writes should be enabled for each attachment in the framebuffer.
-    pub unsafe fn set_color_write_enable(&mut self, enables: &[bool]) -> Result<&mut Self> {
+    pub unsafe fn try_set_color_write_enable(&mut self, enables: &[bool]) -> Result<&mut Self> {
         Ok(unsafe { self.set_color_write_enable_unchecked(enables) })
     }
 
@@ -61,8 +90,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic cull mode for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_cull_mode().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_cull_mode`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_cull_mode`]: Self::try_set_cull_mode
+    #[track_caller]
+    pub unsafe fn set_cull_mode(&mut self, cull_mode: CullMode) -> &mut Self {
+        unsafe { self.try_set_cull_mode(cull_mode) }.unwrap()
+    }
+
     /// Sets the dynamic cull mode for future draw calls.
-    pub unsafe fn set_cull_mode(&mut self, cull_mode: CullMode) -> Result<&mut Self> {
+    pub unsafe fn try_set_cull_mode(&mut self, cull_mode: CullMode) -> Result<&mut Self> {
         Ok(unsafe { self.set_cull_mode_unchecked(cull_mode) })
     }
 
@@ -79,8 +122,27 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic depth bias values for future draw calls.
+    /// Sets the dynamic depth bias values for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_depth_bias().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_depth_bias`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_depth_bias`]: Self::try_set_depth_bias
+    #[track_caller]
     pub unsafe fn set_depth_bias(
+        &mut self,
+        constant_factor: f32,
+        clamp: f32,
+        slope_factor: f32,
+    ) -> &mut Self {
+        unsafe { self.try_set_depth_bias(constant_factor, clamp, slope_factor) }.unwrap()
+    }
+
+    /// Sets the dynamic depth bias values for future draw calls.
+    pub unsafe fn try_set_depth_bias(
         &mut self,
         constant_factor: f32,
         clamp: f32,
@@ -103,8 +165,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets whether dynamic depth bias is enabled for future draw calls, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_set_depth_bias_enable().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_depth_bias_enable`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_depth_bias_enable`]: Self::try_set_depth_bias_enable
+    #[track_caller]
+    pub unsafe fn set_depth_bias_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_depth_bias_enable(enable) }.unwrap()
+    }
+
     /// Sets whether dynamic depth bias is enabled for future draw calls.
-    pub unsafe fn set_depth_bias_enable(&mut self, enable: bool) -> Result<&mut Self> {
+    pub unsafe fn try_set_depth_bias_enable(&mut self, enable: bool) -> Result<&mut Self> {
         Ok(unsafe { self.set_depth_bias_enable_unchecked(enable) })
     }
 
@@ -122,8 +199,26 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic depth bounds for future draw calls.
+    /// Sets the dynamic depth bounds for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_depth_bounds().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_depth_bounds`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_depth_bounds`]: Self::try_set_depth_bounds
+    #[track_caller]
     pub unsafe fn set_depth_bounds(
+        &mut self,
+        min_depth_bounds: f32,
+        max_depth_bounds: f32,
+    ) -> &mut Self {
+        unsafe { self.try_set_depth_bounds(min_depth_bounds, max_depth_bounds) }.unwrap()
+    }
+
+    /// Sets the dynamic depth bounds for future draw calls.
+    pub unsafe fn try_set_depth_bounds(
         &mut self,
         min_depth_bounds: f32,
         max_depth_bounds: f32,
@@ -144,8 +239,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets whether dynamic depth bounds testing is enabled for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_set_depth_bounds_test_enable().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_depth_bounds_test_enable`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_depth_bounds_test_enable`]: Self::try_set_depth_bounds_test_enable
+    #[track_caller]
+    pub unsafe fn set_depth_bounds_test_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_depth_bounds_test_enable(enable) }.unwrap()
+    }
+
     /// Sets whether dynamic depth bounds testing is enabled for future draw calls.
-    pub unsafe fn set_depth_bounds_test_enable(&mut self, enable: bool) -> Result<&mut Self> {
+    pub unsafe fn try_set_depth_bounds_test_enable(&mut self, enable: bool) -> Result<&mut Self> {
         Ok(unsafe { self.set_depth_bounds_test_enable_unchecked(enable) })
     }
 
@@ -163,8 +273,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic depth compare op for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_depth_compare_op().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_depth_compare_op`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_depth_compare_op`]: Self::try_set_depth_compare_op
+    #[track_caller]
+    pub unsafe fn set_depth_compare_op(&mut self, compare_op: CompareOp) -> &mut Self {
+        unsafe { self.try_set_depth_compare_op(compare_op) }.unwrap()
+    }
+
     /// Sets the dynamic depth compare op for future draw calls.
-    pub unsafe fn set_depth_compare_op(&mut self, compare_op: CompareOp) -> Result<&mut Self> {
+    pub unsafe fn try_set_depth_compare_op(&mut self, compare_op: CompareOp) -> Result<&mut Self> {
         Ok(unsafe { self.set_depth_compare_op_unchecked(compare_op) })
     }
 
@@ -181,8 +305,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets whether dynamic depth testing is enabled for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_set_depth_test_enable().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_depth_test_enable`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_depth_test_enable`]: Self::try_set_depth_test_enable
+    #[track_caller]
+    pub unsafe fn set_depth_test_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_depth_test_enable(enable) }.unwrap()
+    }
+
     /// Sets whether dynamic depth testing is enabled for future draw calls.
-    pub unsafe fn set_depth_test_enable(&mut self, enable: bool) -> Result<&mut Self> {
+    pub unsafe fn try_set_depth_test_enable(&mut self, enable: bool) -> Result<&mut Self> {
         Ok(unsafe { self.set_depth_test_enable_unchecked(enable) })
     }
 
@@ -199,8 +338,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets whether dynamic depth write is enabled for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_set_depth_write_enable().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_depth_write_enable`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_depth_write_enable`]: Self::try_set_depth_write_enable
+    #[track_caller]
+    pub unsafe fn set_depth_write_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_depth_write_enable(enable) }.unwrap()
+    }
+
     /// Sets whether dynamic depth write is enabled for future draw calls.
-    pub unsafe fn set_depth_write_enable(&mut self, enable: bool) -> Result<&mut Self> {
+    pub unsafe fn try_set_depth_write_enable(&mut self, enable: bool) -> Result<&mut Self> {
         Ok(unsafe { self.set_depth_write_enable_unchecked(enable) })
     }
 
@@ -218,8 +372,26 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic discard rectangles for future draw calls.
+    /// Sets the dynamic discard rectangles for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_discard_rectangle().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_discard_rectangle`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_discard_rectangle`]: Self::try_set_discard_rectangle
+    #[track_caller]
     pub unsafe fn set_discard_rectangle(
+        &mut self,
+        first_rectangle: u32,
+        rectangles: &[Scissor],
+    ) -> &mut Self {
+        unsafe { self.try_set_discard_rectangle(first_rectangle, rectangles) }.unwrap()
+    }
+
+    /// Sets the dynamic discard rectangles for future draw calls.
+    pub unsafe fn try_set_discard_rectangle(
         &mut self,
         first_rectangle: u32,
         rectangles: &[Scissor],
@@ -254,8 +426,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic front face for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_front_face().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_front_face`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_front_face`]: Self::try_set_front_face
+    #[track_caller]
+    pub unsafe fn set_front_face(&mut self, face: FrontFace) -> &mut Self {
+        unsafe { self.try_set_front_face(face) }.unwrap()
+    }
+
     /// Sets the dynamic front face for future draw calls.
-    pub unsafe fn set_front_face(&mut self, face: FrontFace) -> Result<&mut Self> {
+    pub unsafe fn try_set_front_face(&mut self, face: FrontFace) -> Result<&mut Self> {
         Ok(unsafe { self.set_front_face_unchecked(face) })
     }
 
@@ -272,8 +458,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic line stipple values for future draw calls, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_set_line_stipple().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_line_stipple`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_line_stipple`]: Self::try_set_line_stipple
+    #[track_caller]
+    pub unsafe fn set_line_stipple(&mut self, factor: u32, pattern: u16) -> &mut Self {
+        unsafe { self.try_set_line_stipple(factor, pattern) }.unwrap()
+    }
+
     /// Sets the dynamic line stipple values for future draw calls.
-    pub unsafe fn set_line_stipple(&mut self, factor: u32, pattern: u16) -> Result<&mut Self> {
+    pub unsafe fn try_set_line_stipple(&mut self, factor: u32, pattern: u16) -> Result<&mut Self> {
         Ok(unsafe { self.set_line_stipple_unchecked(factor, pattern) })
     }
 
@@ -286,8 +487,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic line width for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_line_width().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_line_width`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_line_width`]: Self::try_set_line_width
+    #[track_caller]
+    pub unsafe fn set_line_width(&mut self, line_width: f32) -> &mut Self {
+        unsafe { self.try_set_line_width(line_width) }.unwrap()
+    }
+
     /// Sets the dynamic line width for future draw calls.
-    pub unsafe fn set_line_width(&mut self, line_width: f32) -> Result<&mut Self> {
+    pub unsafe fn try_set_line_width(&mut self, line_width: f32) -> Result<&mut Self> {
         Ok(unsafe { self.set_line_width_unchecked(line_width) })
     }
 
@@ -298,8 +513,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic logic op for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_logic_op().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_logic_op`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_logic_op`]: Self::try_set_logic_op
+    #[track_caller]
+    pub unsafe fn set_logic_op(&mut self, logic_op: LogicOp) -> &mut Self {
+        unsafe { self.try_set_logic_op(logic_op) }.unwrap()
+    }
+
     /// Sets the dynamic logic op for future draw calls.
-    pub unsafe fn set_logic_op(&mut self, logic_op: LogicOp) -> Result<&mut Self> {
+    pub unsafe fn try_set_logic_op(&mut self, logic_op: LogicOp) -> Result<&mut Self> {
         Ok(unsafe { self.set_logic_op_unchecked(logic_op) })
     }
 
@@ -312,8 +541,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic number of patch control points for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_set_patch_control_points().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_patch_control_points`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_patch_control_points`]: Self::try_set_patch_control_points
+    #[track_caller]
+    pub unsafe fn set_patch_control_points(&mut self, num: u32) -> &mut Self {
+        unsafe { self.try_set_patch_control_points(num) }.unwrap()
+    }
+
     /// Sets the dynamic number of patch control points for future draw calls.
-    pub unsafe fn set_patch_control_points(&mut self, num: u32) -> Result<&mut Self> {
+    pub unsafe fn try_set_patch_control_points(&mut self, num: u32) -> Result<&mut Self> {
         Ok(unsafe { self.set_patch_control_points_unchecked(num) })
     }
 
@@ -327,8 +571,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets whether dynamic primitive restart is enabled for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_set_primitive_restart_enable().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_primitive_restart_enable`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_primitive_restart_enable`]: Self::try_set_primitive_restart_enable
+    #[track_caller]
+    pub unsafe fn set_primitive_restart_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_primitive_restart_enable(enable) }.unwrap()
+    }
+
     /// Sets whether dynamic primitive restart is enabled for future draw calls.
-    pub unsafe fn set_primitive_restart_enable(&mut self, enable: bool) -> Result<&mut Self> {
+    pub unsafe fn try_set_primitive_restart_enable(&mut self, enable: bool) -> Result<&mut Self> {
         Ok(unsafe { self.set_primitive_restart_enable_unchecked(enable) })
     }
 
@@ -346,8 +605,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic primitive topology for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_primitive_topology().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_primitive_topology`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_primitive_topology`]: Self::try_set_primitive_topology
+    #[track_caller]
+    pub unsafe fn set_primitive_topology(&mut self, topology: PrimitiveTopology) -> &mut Self {
+        unsafe { self.try_set_primitive_topology(topology) }.unwrap()
+    }
+
     /// Sets the dynamic primitive topology for future draw calls.
-    pub unsafe fn set_primitive_topology(
+    pub unsafe fn try_set_primitive_topology(
         &mut self,
         topology: PrimitiveTopology,
     ) -> Result<&mut Self> {
@@ -371,8 +644,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets whether dynamic rasterizer discard is enabled for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_set_rasterizer_discard_enable().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_rasterizer_discard_enable`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_rasterizer_discard_enable`]: Self::try_set_rasterizer_discard_enable
+    #[track_caller]
+    pub unsafe fn set_rasterizer_discard_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_rasterizer_discard_enable(enable) }.unwrap()
+    }
+
     /// Sets whether dynamic rasterizer discard is enabled for future draw calls.
-    pub unsafe fn set_rasterizer_discard_enable(&mut self, enable: bool) -> Result<&mut Self> {
+    pub unsafe fn try_set_rasterizer_discard_enable(&mut self, enable: bool) -> Result<&mut Self> {
         Ok(unsafe { self.set_rasterizer_discard_enable_unchecked(enable) })
     }
 
@@ -390,8 +678,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic scissors for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_scissor().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_scissor`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_scissor`]: Self::try_set_scissor
+    #[track_caller]
+    pub unsafe fn set_scissor(&mut self, first_scissor: u32, scissors: &[Scissor]) -> &mut Self {
+        unsafe { self.try_set_scissor(first_scissor, scissors) }.unwrap()
+    }
+
     /// Sets the dynamic scissors for future draw calls.
-    pub unsafe fn set_scissor(
+    pub unsafe fn try_set_scissor(
         &mut self,
         first_scissor: u32,
         scissors: &[Scissor],
@@ -426,8 +728,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic scissors with count for future draw calls, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_set_scissor_with_count().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_scissor_with_count`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_scissor_with_count`]: Self::try_set_scissor_with_count
+    #[track_caller]
+    pub unsafe fn set_scissor_with_count(&mut self, scissors: &[Scissor]) -> &mut Self {
+        unsafe { self.try_set_scissor_with_count(scissors) }.unwrap()
+    }
+
     /// Sets the dynamic scissors with count for future draw calls.
-    pub unsafe fn set_scissor_with_count(&mut self, scissors: &[Scissor]) -> Result<&mut Self> {
+    pub unsafe fn try_set_scissor_with_count(&mut self, scissors: &[Scissor]) -> Result<&mut Self> {
         Ok(unsafe { self.set_scissor_with_count_unchecked(scissors) })
     }
 
@@ -460,8 +777,27 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic stencil compare mask on one or both faces for future draw calls.
+    /// Sets the dynamic stencil compare mask on one or both faces for future draw calls, panicking
+    /// on a validation error.
+    ///
+    /// This is a shortcut for `try_set_stencil_compare_mask().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_stencil_compare_mask`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_stencil_compare_mask`]: Self::try_set_stencil_compare_mask
+    #[track_caller]
     pub unsafe fn set_stencil_compare_mask(
+        &mut self,
+        faces: StencilFaces,
+        compare_mask: u32,
+    ) -> &mut Self {
+        unsafe { self.try_set_stencil_compare_mask(faces, compare_mask) }.unwrap()
+    }
+
+    /// Sets the dynamic stencil compare mask on one or both faces for future draw calls.
+    pub unsafe fn try_set_stencil_compare_mask(
         &mut self,
         faces: StencilFaces,
         compare_mask: u32,
@@ -482,8 +818,31 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic stencil ops on one or both faces for future draw calls.
+    /// Sets the dynamic stencil ops on one or both faces for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_set_stencil_op().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_stencil_op`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_stencil_op`]: Self::try_set_stencil_op
+    #[track_caller]
     pub unsafe fn set_stencil_op(
+        &mut self,
+        faces: StencilFaces,
+        fail_op: StencilOp,
+        pass_op: StencilOp,
+        depth_fail_op: StencilOp,
+        compare_op: CompareOp,
+    ) -> &mut Self {
+        unsafe { self.try_set_stencil_op(faces, fail_op, pass_op, depth_fail_op, compare_op) }
+            .unwrap()
+    }
+
+    /// Sets the dynamic stencil ops on one or both faces for future draw calls.
+    pub unsafe fn try_set_stencil_op(
         &mut self,
         faces: StencilFaces,
         fail_op: StencilOp,
@@ -525,8 +884,27 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic stencil reference on one or both faces for future draw calls.
+    /// Sets the dynamic stencil reference on one or both faces for future draw calls, panicking on
+    /// a validation error.
+    ///
+    /// This is a shortcut for `try_set_stencil_reference().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_stencil_reference`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_stencil_reference`]: Self::try_set_stencil_reference
+    #[track_caller]
     pub unsafe fn set_stencil_reference(
+        &mut self,
+        faces: StencilFaces,
+        reference: u32,
+    ) -> &mut Self {
+        unsafe { self.try_set_stencil_reference(faces, reference) }.unwrap()
+    }
+
+    /// Sets the dynamic stencil reference on one or both faces for future draw calls.
+    pub unsafe fn try_set_stencil_reference(
         &mut self,
         faces: StencilFaces,
         reference: u32,
@@ -545,8 +923,23 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets whether dynamic stencil testing is enabled for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_set_stencil_test_enable().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_stencil_test_enable`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_stencil_test_enable`]: Self::try_set_stencil_test_enable
+    #[track_caller]
+    pub unsafe fn set_stencil_test_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_stencil_test_enable(enable) }.unwrap()
+    }
+
     /// Sets whether dynamic stencil testing is enabled for future draw calls.
-    pub unsafe fn set_stencil_test_enable(&mut self, enable: bool) -> Result<&mut Self> {
+    pub unsafe fn try_set_stencil_test_enable(&mut self, enable: bool) -> Result<&mut Self> {
         Ok(unsafe { self.set_stencil_test_enable_unchecked(enable) })
     }
 
@@ -564,8 +957,27 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic stencil write mask on one or both faces for future draw calls.
+    /// Sets the dynamic stencil write mask on one or both faces for future draw calls, panicking
+    /// on a validation error.
+    ///
+    /// This is a shortcut for `try_set_stencil_write_mask().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_stencil_write_mask`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_stencil_write_mask`]: Self::try_set_stencil_write_mask
+    #[track_caller]
     pub unsafe fn set_stencil_write_mask(
+        &mut self,
+        faces: StencilFaces,
+        write_mask: u32,
+    ) -> &mut Self {
+        unsafe { self.try_set_stencil_write_mask(faces, write_mask) }.unwrap()
+    }
+
+    /// Sets the dynamic stencil write mask on one or both faces for future draw calls.
+    pub unsafe fn try_set_stencil_write_mask(
         &mut self,
         faces: StencilFaces,
         write_mask: u32,
@@ -584,8 +996,22 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic vertex input for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_vertex_input().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_vertex_input`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_vertex_input`]: Self::try_set_vertex_input
+    #[track_caller]
+    pub unsafe fn set_vertex_input(&mut self, vertex_input_state: &VertexInputState) -> &mut Self {
+        unsafe { self.try_set_vertex_input(vertex_input_state) }.unwrap()
+    }
+
     /// Sets the dynamic vertex input for future draw calls.
-    pub unsafe fn set_vertex_input(
+    pub unsafe fn try_set_vertex_input(
         &mut self,
         vertex_input_state: &VertexInputState,
     ) -> Result<&mut Self> {
@@ -656,8 +1082,26 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic viewports for future draw calls.
+    /// Sets the dynamic viewports for future draw calls, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_set_viewport().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_viewport`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_viewport`]: Self::try_set_viewport
+    #[track_caller]
     pub unsafe fn set_viewport(
+        &mut self,
+        first_viewport: u32,
+        viewports: &[Viewport],
+    ) -> &mut Self {
+        unsafe { self.try_set_viewport(first_viewport, viewports) }.unwrap()
+    }
+
+    /// Sets the dynamic viewports for future draw calls.
+    pub unsafe fn try_set_viewport(
         &mut self,
         first_viewport: u32,
         viewports: &[Viewport],
@@ -692,8 +1136,26 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Sets the dynamic viewports with count for future draw calls, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_set_viewport_with_count().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_viewport_with_count`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_viewport_with_count`]: Self::try_set_viewport_with_count
+    #[track_caller]
+    pub unsafe fn set_viewport_with_count(&mut self, viewports: &[Viewport]) -> &mut Self {
+        unsafe { self.try_set_viewport_with_count(viewports) }.unwrap()
+    }
+
     /// Sets the dynamic viewports with count for future draw calls.
-    pub unsafe fn set_viewport_with_count(&mut self, viewports: &[Viewport]) -> Result<&mut Self> {
+    pub unsafe fn try_set_viewport_with_count(
+        &mut self,
+        viewports: &[Viewport],
+    ) -> Result<&mut Self> {
         Ok(unsafe { self.set_viewport_with_count_unchecked(viewports) })
     }
 
@@ -729,8 +1191,28 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic conservative rasterization mode for future draw calls.
+    /// Sets the dynamic conservative rasterization mode for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for
+    /// `try_set_conservative_rasterization_mode().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_conservative_rasterization_mode`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_conservative_rasterization_mode`]: Self::try_set_conservative_rasterization_mode
+    #[track_caller]
     pub unsafe fn set_conservative_rasterization_mode(
+        &mut self,
+        conservative_rasterization_mode: ConservativeRasterizationMode,
+    ) -> &mut Self {
+        unsafe { self.try_set_conservative_rasterization_mode(conservative_rasterization_mode) }
+            .unwrap()
+    }
+
+    /// Sets the dynamic conservative rasterization mode for future draw calls.
+    pub unsafe fn try_set_conservative_rasterization_mode(
         &mut self,
         conservative_rasterization_mode: ConservativeRasterizationMode,
     ) -> Result<&mut Self> {
@@ -755,8 +1237,30 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic extra primitive overestimation size for future draw calls.
+    /// Sets the dynamic extra primitive overestimation size for future draw calls, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for
+    /// `try_set_extra_primitive_overestimation_size().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_extra_primitive_overestimation_size`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_extra_primitive_overestimation_size`]: Self::try_set_extra_primitive_overestimation_size
+    #[track_caller]
     pub unsafe fn set_extra_primitive_overestimation_size(
+        &mut self,
+        extra_primitive_overestimation_size: f32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_set_extra_primitive_overestimation_size(extra_primitive_overestimation_size)
+        }
+        .unwrap()
+    }
+
+    /// Sets the dynamic extra primitive overestimation size for future draw calls.
+    pub unsafe fn try_set_extra_primitive_overestimation_size(
         &mut self,
         extra_primitive_overestimation_size: f32,
     ) -> Result<&mut Self> {
@@ -783,8 +1287,27 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Sets the dynamic fragment shading rate for future draw calls.
+    /// Sets the dynamic fragment shading rate for future draw calls, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_set_fragment_shading_rate().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_fragment_shading_rate`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_fragment_shading_rate`]: Self::try_set_fragment_shading_rate
+    #[track_caller]
     pub unsafe fn set_fragment_shading_rate(
+        &mut self,
+        fragment_size: [u32; 2],
+        combiner_ops: [FragmentShadingRateCombinerOp; 2],
+    ) -> &mut Self {
+        unsafe { self.try_set_fragment_shading_rate(fragment_size, combiner_ops) }.unwrap()
+    }
+
+    /// Sets the dynamic fragment shading rate for future draw calls.
+    pub unsafe fn try_set_fragment_shading_rate(
         &mut self,
         fragment_size: [u32; 2],
         combiner_ops: [FragmentShadingRateCombinerOp; 2],

--- a/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
@@ -16,6 +16,30 @@ use vulkano::{
 ///
 /// Dispatch commands require a compute queue, draw commands require a graphics queue.
 impl RecordingCommandBuffer<'_> {
+    /// Performs a single compute operation using a compute pipeline, panicking on a validation
+    /// error.
+    ///
+    /// A compute pipeline must have been bound using [`bind_pipeline_compute`]. Any resources used
+    /// by the compute pipeline, such as descriptor sets, must have been set beforehand.
+    ///
+    /// This is a shortcut for `try_dispatch().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_dispatch`] returns a [`ValidationError`].
+    ///
+    /// [`bind_pipeline_compute`]: Self::bind_pipeline_compute
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [`try_dispatch`]: Self::try_dispatch
+    #[track_caller]
+    pub unsafe fn dispatch(&mut self, group_counts: [u32; 3]) -> &mut Self {
+        unsafe { self.try_dispatch(group_counts) }.unwrap()
+    }
+
     /// Performs a single compute operation using a compute pipeline.
     ///
     /// A compute pipeline must have been bound using [`bind_pipeline_compute`]. Any resources used
@@ -27,7 +51,7 @@ impl RecordingCommandBuffer<'_> {
     ///
     /// [`bind_pipeline_compute`]: Self::bind_pipeline_compute
     /// [shader safety requirements]: vulkano::shader#safety
-    pub unsafe fn dispatch(&mut self, group_counts: [u32; 3]) -> Result<&mut Self> {
+    pub unsafe fn try_dispatch(&mut self, group_counts: [u32; 3]) -> Result<&mut Self> {
         Ok(unsafe { self.dispatch_unchecked(group_counts) })
     }
 
@@ -45,6 +69,37 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Performs a single compute operation using a compute pipeline, panicking on a validation
+    /// error. One dispatch is performed for the [`DispatchIndirectCommand`] struct that is read
+    /// from `buffer` starting at `offset`.
+    ///
+    /// A compute pipeline must have been bound using [`bind_pipeline_compute`]. Any resources used
+    /// by the compute pipeline, such as descriptor sets, must have been set beforehand.
+    ///
+    /// This is a shortcut for `try_dispatch_indirect().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `DispatchIndirectCommand`] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_dispatch_indirect`] returns a [`ValidationError`].
+    ///
+    /// [`bind_pipeline_compute`]: Self::bind_pipeline_compute
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `DispatchIndirectCommand`]: DispatchIndirectCommand#safety
+    /// [`try_dispatch_indirect`]: Self::try_dispatch_indirect
+    #[track_caller]
+    pub unsafe fn dispatch_indirect(
+        &mut self,
+        buffer: Id<Buffer>,
+        offset: DeviceSize,
+    ) -> &mut Self {
+        unsafe { self.try_dispatch_indirect(buffer, offset) }.unwrap()
+    }
+
     /// Performs a single compute operation using a compute pipeline. One dispatch is performed
     /// for the [`DispatchIndirectCommand`] struct that is read from `buffer` starting at `offset`.
     ///
@@ -59,7 +114,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`bind_pipeline_compute`]: Self::bind_pipeline_compute
     /// [shader safety requirements]: vulkano::shader#safety
     /// [safety requirements for `DispatchIndirectCommand`]: DispatchIndirectCommand#safety
-    pub unsafe fn dispatch_indirect(
+    pub unsafe fn try_dispatch_indirect(
         &mut self,
         buffer: Id<Buffer>,
         offset: DeviceSize,
@@ -80,6 +135,44 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Performs a single draw operation using a primitive shading graphics pipeline, panicking on
+    /// a validation error.
+    ///
+    /// The parameters specify the first vertex and the number of vertices to draw, and the first
+    /// instance and number of instances. For non-instanced drawing, specify `instance_count` as 1
+    /// and `first_instance` as 0.
+    ///
+    /// A primitive shading graphics pipeline must have been bound using
+    /// [`bind_pipeline_graphics`]. Any resources used by the graphics pipeline, such as descriptor
+    /// sets, vertex buffers and dynamic state, must have been set beforehand. If the bound
+    /// graphics pipeline uses vertex buffers, then the provided vertex and instance ranges must be
+    /// in range of the bound vertex buffers.
+    ///
+    /// This is a shortcut for `try_draw().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw`] returns a [`ValidationError`].
+    ///
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [`try_draw`]: Self::try_draw
+    #[track_caller]
+    pub unsafe fn draw(
+        &mut self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> &mut Self {
+        unsafe { self.try_draw(vertex_count, instance_count, first_vertex, first_instance) }
+            .unwrap()
+    }
+
     /// Performs a single draw operation using a primitive shading graphics pipeline.
     ///
     /// The parameters specify the first vertex and the number of vertices to draw, and the first
@@ -98,7 +191,7 @@ impl RecordingCommandBuffer<'_> {
     ///
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
-    pub unsafe fn draw(
+    pub unsafe fn try_draw(
         &mut self,
         vertex_count: u32,
         instance_count: u32,
@@ -131,6 +224,49 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Performs multiple draw operations using a primitive shading graphics pipeline, panicking on
+    /// a validation error.
+    ///
+    /// One draw is performed for each [`DrawIndirectCommand`] struct that is read from `buffer`
+    /// starting at `offset`, with the offset increasing by `stride` bytes for each successive
+    /// draw. `draw_count` draw commands are performed. The maximum number of draw commands in the
+    /// buffer is limited by the [`max_draw_indirect_count`] limit. This limit is 1 unless the
+    /// [`multi_draw_indirect`] feature has been enabled.
+    ///
+    /// A primitive shading graphics pipeline must have been bound using
+    /// [`bind_pipeline_graphics`]. Any resources used by the graphics pipeline, such as descriptor
+    /// sets, vertex buffers and dynamic state, must have been set beforehand. If the bound
+    /// graphics pipeline uses vertex buffers, then the vertex and instance ranges of each
+    /// `DrawIndirectCommand` in the indirect buffer must be in range of the bound vertex buffers.
+    ///
+    /// This is a shortcut for `try_draw_indirect().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `DrawIndirectCommand`] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw_indirect`] returns a [`ValidationError`].
+    ///
+    /// [`max_draw_indirect_count`]: vulkano::device::DeviceProperties::max_draw_indirect_count
+    /// [`multi_draw_indirect`]: vulkano::device::DeviceFeatures::multi_draw_indirect
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `DrawIndirectCommand`]: DrawIndirectCommand#safety
+    /// [`try_draw_indirect`]: Self::try_draw_indirect
+    #[track_caller]
+    pub unsafe fn draw_indirect(
+        &mut self,
+        buffer: Id<Buffer>,
+        offset: DeviceSize,
+        draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe { self.try_draw_indirect(buffer, offset, draw_count, stride) }.unwrap()
+    }
+
     /// Performs multiple draw operations using a primitive shading graphics pipeline.
     ///
     /// One draw is performed for each [`DrawIndirectCommand`] struct that is read from `buffer`
@@ -155,7 +291,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
     /// [safety requirements for `DrawIndirectCommand`]: DrawIndirectCommand#safety
-    pub unsafe fn draw_indirect(
+    pub unsafe fn try_draw_indirect(
         &mut self,
         buffer: Id<Buffer>,
         offset: DeviceSize,
@@ -180,6 +316,64 @@ impl RecordingCommandBuffer<'_> {
         };
 
         self
+    }
+
+    /// Performs multiple draw operations using a primitive shading graphics pipeline, reading the
+    /// number of draw operations from a separate buffer, panicking on a validation error.
+    ///
+    /// One draw is performed for each [`DrawIndirectCommand`] struct that is read from `buffer`
+    /// starting at `offset`, with the offset increasing by `stride` bytes for each successive
+    /// draw. The number of draws to perform is read from `count_buffer` at `count_buffer_offset`,
+    /// or specified by `max_draw_count`, whichever is lower. This number is limited by the
+    /// [`max_draw_indirect_count`] limit.
+    ///
+    /// A primitive shading graphics pipeline must have been bound using
+    /// [`bind_pipeline_graphics`]. Any resources used by the graphics pipeline, such as descriptor
+    /// sets, vertex buffers and dynamic state, must have been set beforehand. If the bound
+    /// graphics pipeline uses vertex buffers, then the vertex and instance ranges of each
+    /// `DrawIndirectCommand` in the indirect buffer must be in range of the bound vertex buffers.
+    ///
+    /// This is a shortcut for `try_draw_indirect_count().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `DrawIndirectCommand`] apply.
+    /// - The count stored in `count_buffer` must not be greater than the
+    ///   [`max_draw_indirect_count`] device limit.
+    /// - The count stored in `count_buffer` must fall within the range of `buffer` starting at
+    ///   `offset`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw_indirect_count`] returns a [`ValidationError`].
+    ///
+    /// [`max_draw_indirect_count`]: vulkano::device::DeviceProperties::max_draw_indirect_count
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `DrawIndirectCommand`]: DrawIndirectCommand#safety
+    /// [`try_draw_indirect_count`]: Self::try_draw_indirect_count
+    #[track_caller]
+    pub unsafe fn draw_indirect_count(
+        &mut self,
+        buffer: Id<Buffer>,
+        offset: DeviceSize,
+        count_buffer: Id<Buffer>,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_draw_indirect_count(
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_draw_count,
+                stride,
+            )
+        }
+        .unwrap()
     }
 
     /// Performs multiple draw operations using a primitive shading graphics pipeline, reading the
@@ -210,7 +404,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
     /// [safety requirements for `DrawIndirectCommand`]: DrawIndirectCommand#safety
-    pub unsafe fn draw_indirect_count(
+    pub unsafe fn try_draw_indirect_count(
         &mut self,
         buffer: Id<Buffer>,
         offset: DeviceSize,
@@ -271,6 +465,66 @@ impl RecordingCommandBuffer<'_> {
     }
 
     /// Performs a single draw operation using a primitive shading graphics pipeline, using an
+    /// index buffer, panicking on a validation error.
+    ///
+    /// The parameters specify the first index and the number of indices in the index buffer that
+    /// should be used, and the first instance and number of instances. For non-instanced drawing,
+    /// specify `instance_count` as 1 and `first_instance` as 0. The `vertex_offset` is a constant
+    /// value that should be added to each index in the index buffer to produce the final vertex
+    /// number to be used.
+    ///
+    /// An index buffer must have been bound using [`bind_index_buffer`], and the provided index
+    /// range must be in range of the bound index buffer.
+    ///
+    /// A primitive shading graphics pipeline must have been bound using
+    /// [`bind_pipeline_graphics`]. Any resources used by the graphics pipeline, such as descriptor
+    /// sets, vertex buffers and dynamic state, must have been set beforehand. If the bound
+    /// graphics pipeline uses vertex buffers, then the provided instance range must be in range of
+    /// the bound vertex buffers. The vertex indices in the index buffer must be in range of the
+    /// bound vertex buffers.
+    ///
+    /// This is a shortcut for `try_draw_indexed().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - Every vertex number that is retrieved from the index buffer must fall within the range of
+    ///   the bound vertex-rate vertex buffers.
+    /// - Every vertex number that is retrieved from the index buffer, if it is not the special
+    ///   primitive restart value, must be no greater than the [`max_draw_indexed_index_value`]
+    ///   device limit.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw_indexed`] returns a [`ValidationError`].
+    ///
+    /// [`bind_index_buffer`]: Self::bind_index_buffer
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [`max_draw_indexed_index_value`]: vulkano::device::DeviceProperties::max_draw_indexed_index_value
+    /// [`try_draw_indexed`]: Self::try_draw_indexed
+    #[track_caller]
+    pub unsafe fn draw_indexed(
+        &mut self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        vertex_offset: i32,
+        first_instance: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_draw_indexed(
+                index_count,
+                instance_count,
+                first_index,
+                vertex_offset,
+                first_instance,
+            )
+        }
+        .unwrap()
+    }
+
+    /// Performs a single draw operation using a primitive shading graphics pipeline, using an
     /// index buffer.
     ///
     /// The parameters specify the first index and the number of indices in the index buffer that
@@ -302,7 +556,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
     /// [`max_draw_indexed_index_value`]: vulkano::device::DeviceProperties::max_draw_indexed_index_value
-    pub unsafe fn draw_indexed(
+    pub unsafe fn try_draw_indexed(
         &mut self,
         index_count: u32,
         instance_count: u32,
@@ -345,6 +599,55 @@ impl RecordingCommandBuffer<'_> {
     }
 
     /// Performs multiple draw operations using a primitive shading graphics pipeline, using an
+    /// index buffer, panicking on a validation error.
+    ///
+    /// One draw is performed for each [`DrawIndexedIndirectCommand`] struct that is read from
+    /// `buffer` starting at `offset`, with the offset increasing by `stride` bytes with each
+    /// successive draw. `draw_count` draw commands are performed. The maximum number of draw
+    /// commands in the buffer is limited by the [`max_draw_indirect_count`] limit. This limit is 1
+    /// unless the [`multi_draw_indirect`] feature has been enabled.
+    ///
+    /// An index buffer must have been bound using [`bind_index_buffer`], and the index ranges of
+    /// each `DrawIndexedIndirectCommand` in the indirect buffer must be in range of the bound
+    /// index buffer.
+    ///
+    /// A primitive shading graphics pipeline must have been bound using
+    /// [`bind_pipeline_graphics`]. Any resources used by the graphics pipeline, such as descriptor
+    /// sets, vertex buffers and dynamic state, must have been set beforehand. If the bound
+    /// graphics pipeline uses vertex buffers, then the instance ranges of each
+    /// `DrawIndexedIndirectCommand` in the indirect buffer must be in range of the bound vertex
+    /// buffers.
+    ///
+    /// This is a shortcut for `try_draw_indexed_indirect().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `DrawIndexedIndirectCommand`] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw_indexed_indirect`] returns a [`ValidationError`].
+    ///
+    /// [`max_draw_indirect_count`]: vulkano::device::DeviceProperties::max_draw_indirect_count
+    /// [`multi_draw_indirect`]: vulkano::device::DeviceFeatures::multi_draw_indirect
+    /// [`bind_index_buffer`]: Self::bind_index_buffer
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `DrawIndexedIndirectCommand`]: DrawIndexedIndirectCommand#safety
+    /// [`try_draw_indexed_indirect`]: Self::try_draw_indexed_indirect
+    #[track_caller]
+    pub unsafe fn draw_indexed_indirect(
+        &mut self,
+        buffer: Id<Buffer>,
+        offset: DeviceSize,
+        draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe { self.try_draw_indexed_indirect(buffer, offset, draw_count, stride) }.unwrap()
+    }
+
+    /// Performs multiple draw operations using a primitive shading graphics pipeline, using an
     /// index buffer.
     ///
     /// One draw is performed for each [`DrawIndexedIndirectCommand`] struct that is read from
@@ -375,7 +678,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
     /// [safety requirements for `DrawIndexedIndirectCommand`]: DrawIndexedIndirectCommand#safety
-    pub unsafe fn draw_indexed_indirect(
+    pub unsafe fn try_draw_indexed_indirect(
         &mut self,
         buffer: Id<Buffer>,
         offset: DeviceSize,
@@ -406,6 +709,70 @@ impl RecordingCommandBuffer<'_> {
         };
 
         self
+    }
+
+    /// Performs multiple draw operations using a primitive shading graphics pipeline, using an
+    /// index buffer, and reading the number of draw operations from a separate buffer, panicking
+    /// on a validation error.
+    ///
+    /// One draw is performed for each [`DrawIndexedIndirectCommand`] struct that is read from
+    /// `buffer` starting at `offset`, with the offset increasing by `stride` bytes for each
+    /// successive draw. The number of draws to perform is read from `count_buffer` at
+    /// `count_buffer_offset`, or specified by `max_draw_count`, whichever is lower. This number is
+    /// limited by the [`max_draw_indirect_count`] limit.
+    ///
+    /// An index buffer must have been bound using [`bind_index_buffer`], and the index ranges of
+    /// each `DrawIndexedIndirectCommand` in the indirect buffer must be in range of the bound
+    /// index buffer.
+    ///
+    /// A primitive shading graphics pipeline must have been bound using
+    /// [`bind_pipeline_graphics`]. Any resources used by the graphics pipeline, such as descriptor
+    /// sets, vertex buffers and dynamic state, must have been set beforehand. If the bound
+    /// graphics pipeline uses vertex buffers, then the instance ranges of each
+    /// `DrawIndexedIndirectCommand` in the indirect buffer must be in range of the bound vertex
+    /// buffers.
+    ///
+    /// This is a shortcut for `try_draw_indexed_indirect_count().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `DrawIndexedIndirectCommand`] apply.
+    /// - The count stored in `count_buffer` must not be greater than the
+    ///   [`max_draw_indirect_count`] device limit.
+    /// - The count stored in `count_buffer` must fall within the range of `buffer`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw_indexed_indirect_count`] returns a [`ValidationError`].
+    ///
+    /// [`max_draw_indirect_count`]: vulkano::device::DeviceProperties::max_draw_indirect_count
+    /// [`bind_index_buffer`]: Self::bind_index_buffer
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `DrawIndexedIndirectCommand`]: DrawIndexedIndirectCommand#safety
+    /// [`try_draw_indexed_indirect_count`]: Self::try_draw_indexed_indirect_count
+    #[track_caller]
+    pub unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        buffer: Id<Buffer>,
+        offset: DeviceSize,
+        count_buffer: Id<Buffer>,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_draw_indexed_indirect_count(
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_draw_count,
+                stride,
+            )
+        }
+        .unwrap()
     }
 
     /// Performs multiple draw operations using a primitive shading graphics pipeline, using an
@@ -441,7 +808,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
     /// [safety requirements for `DrawIndexedIndirectCommand`]: DrawIndexedIndirectCommand#safety
-    pub unsafe fn draw_indexed_indirect_count(
+    pub unsafe fn try_draw_indexed_indirect_count(
         &mut self,
         buffer: Id<Buffer>,
         offset: DeviceSize,
@@ -503,6 +870,31 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Perform a single draw operation using a mesh shading graphics pipeline, panicking on a
+    /// validation error.
+    ///
+    /// A mesh shading graphics pipeline must have been bound using [`bind_pipeline_graphics`]. Any
+    /// resources used by the graphics pipeline, such as descriptor sets and dynamic state, must
+    /// have been set beforehand.
+    ///
+    /// This is a shortcut for `try_draw_mesh_tasks().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw_mesh_tasks`] returns a [`ValidationError`].
+    ///
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [`try_draw_mesh_tasks`]: Self::try_draw_mesh_tasks
+    #[track_caller]
+    pub unsafe fn draw_mesh_tasks(&mut self, group_counts: [u32; 3]) -> &mut Self {
+        unsafe { self.try_draw_mesh_tasks(group_counts) }.unwrap()
+    }
+
     /// Perform a single draw operation using a mesh shading graphics pipeline.
     ///
     /// A mesh shading graphics pipeline must have been bound using [`bind_pipeline_graphics`]. Any
@@ -515,7 +907,7 @@ impl RecordingCommandBuffer<'_> {
     ///
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
-    pub unsafe fn draw_mesh_tasks(&mut self, group_counts: [u32; 3]) -> Result<&mut Self> {
+    pub unsafe fn try_draw_mesh_tasks(&mut self, group_counts: [u32; 3]) -> Result<&mut Self> {
         Ok(unsafe { self.draw_mesh_tasks_unchecked(group_counts) })
     }
 
@@ -531,6 +923,47 @@ impl RecordingCommandBuffer<'_> {
         };
 
         self
+    }
+
+    /// Perform multiple draw operations using a mesh shading graphics pipeline, panicking on a
+    /// validation error.
+    ///
+    /// One draw is performed for each [`DrawMeshTasksIndirectCommand`] struct that is read from
+    /// `buffer` starting at `offset`, with the offset increasing by `stride` bytes for each
+    /// successive draw. `draw_count` draw commands are performed. The maximum number of draw
+    /// commands in the buffer is limited by the [`max_draw_indirect_count`] limit. This limit is 1
+    /// unless the [`multi_draw_indirect`] feature has been enabled.
+    ///
+    /// A mesh shading graphics pipeline must have been bound using [`bind_pipeline_graphics`]. Any
+    /// resources used by the graphics pipeline, such as descriptor sets and dynamic state, must
+    /// have been set beforehand.
+    ///
+    /// This is a shortcut for `try_draw_mesh_tasks_indirect().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `DrawMeshTasksIndirectCommand`] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw_mesh_tasks_indirect`] returns a [`ValidationError`].
+    ///
+    /// [`max_draw_indirect_count`]: vulkano::device::DeviceProperties::max_draw_indirect_count
+    /// [`multi_draw_indirect`]: vulkano::device::DeviceFeatures::multi_draw_indirect
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `DrawMeshTasksIndirectCommand`]: DrawMeshTasksIndirectCommand#safety
+    /// [`try_draw_mesh_tasks_indirect`]: Self::try_draw_mesh_tasks_indirect
+    #[track_caller]
+    pub unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        buffer: Id<Buffer>,
+        offset: DeviceSize,
+        draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe { self.try_draw_mesh_tasks_indirect(buffer, offset, draw_count, stride) }.unwrap()
     }
 
     /// Perform multiple draw operations using a mesh shading graphics pipeline.
@@ -555,7 +988,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
     /// [safety requirements for `DrawMeshTasksIndirectCommand`]: DrawMeshTasksIndirectCommand#safety
-    pub unsafe fn draw_mesh_tasks_indirect(
+    pub unsafe fn try_draw_mesh_tasks_indirect(
         &mut self,
         buffer: Id<Buffer>,
         offset: DeviceSize,
@@ -589,6 +1022,61 @@ impl RecordingCommandBuffer<'_> {
     }
 
     /// Performs multiple draw operations using a mesh shading graphics pipeline, reading the
+    /// number of draw operations from a separate buffer, panicking on a validation error.
+    ///
+    /// One draw is performed for each [`DrawMeshTasksIndirectCommand`] struct that is read from
+    /// `buffer` starting at `offset`, with the offset increasing by `stride` bytes after each
+    /// successive draw. The number of draws to perform is read from `count_buffer`, or specified
+    /// by `max_draw_count`, whichever is lower. This number is limited by the
+    /// [`max_draw_indirect_count`] limit.
+    ///
+    /// A mesh shading graphics pipeline must have been bound using [`bind_pipeline_graphics`]. Any
+    /// resources used by the graphics pipeline, such as descriptor sets and dynamic state, must
+    /// have been set beforehand.
+    ///
+    /// This is a shortcut for `try_draw_mesh_tasks_indirect_count().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `DrawMeshTasksIndirectCommand`] apply.
+    /// - The count stored in `count_buffer` must not be greater than the
+    ///   [`max_draw_indirect_count`] device limit.
+    /// - The count stored in `count_buffer` must fall within the range of `buffer`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_draw_mesh_tasks_indirect_count`] returns a [`ValidationError`].
+    ///
+    /// [`max_draw_indirect_count`]: vulkano::device::DeviceProperties::max_draw_indirect_count
+    /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `DrawMeshTasksIndirectCommand`]: DrawMeshTasksIndirectCommand#safety
+    /// [`try_draw_mesh_tasks_indirect_count`]: Self::try_draw_mesh_tasks_indirect_count
+    #[track_caller]
+    pub unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        buffer: Id<Buffer>,
+        offset: DeviceSize,
+        count_buffer: Id<Buffer>,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_draw_mesh_tasks_indirect_count(
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_draw_count,
+                stride,
+            )
+        }
+        .unwrap()
+    }
+
+    /// Performs multiple draw operations using a mesh shading graphics pipeline, reading the
     /// number of draw operations from a separate buffer.
     ///
     /// One draw is performed for each [`DrawMeshTasksIndirectCommand`] struct that is read from
@@ -613,7 +1101,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`bind_pipeline_graphics`]: Self::bind_pipeline_graphics
     /// [shader safety requirements]: vulkano::shader#safety
     /// [safety requirements for `DrawMeshTasksIndirectCommand`]: DrawMeshTasksIndirectCommand#safety
-    pub unsafe fn draw_mesh_tasks_indirect_count(
+    pub unsafe fn try_draw_mesh_tasks_indirect_count(
         &mut self,
         buffer: Id<Buffer>,
         offset: DeviceSize,
@@ -662,6 +1150,35 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
+    /// Performs a single ray tracing operation using a ray tracing pipeline, panicking on a
+    /// validation error.
+    ///
+    /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
+    /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
+    /// beforehand.
+    ///
+    /// This is a shortcut for `try_trace_rays().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_trace_rays`] returns a [`ValidationError`].
+    ///
+    /// [`bind_pipeline_ray_tracing`]: Self::bind_pipeline_ray_tracing
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [`try_trace_rays`]: Self::try_trace_rays
+    #[track_caller]
+    pub unsafe fn trace_rays(
+        &mut self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        dimensions: [u32; 3],
+    ) -> &mut Self {
+        unsafe { self.try_trace_rays(shader_binding_table_addresses, dimensions) }.unwrap()
+    }
+
     /// Performs a single ray tracing operation using a ray tracing pipeline.
     ///
     /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
@@ -674,7 +1191,7 @@ impl RecordingCommandBuffer<'_> {
     ///
     /// [`bind_pipeline_ray_tracing`]: Self::bind_pipeline_ray_tracing
     /// [shader safety requirements]: vulkano::shader#safety
-    pub unsafe fn trace_rays(
+    pub unsafe fn try_trace_rays(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         dimensions: [u32; 3],

--- a/vulkano-taskgraph/src/command_buffer/commands/render_pass.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/render_pass.rs
@@ -5,6 +5,33 @@ use vulkano::command_buffer::{ClearAttachment, ClearRect};
 ///
 /// These commands require a graphics queue.
 impl RecordingCommandBuffer<'_> {
+    /// Clears specific regions of specific attachments of the framebuffer, panicking on a
+    /// validation error.
+    ///
+    /// `attachments` specify the types of attachments and their clear values. `rects` specify the
+    /// regions to clear.
+    ///
+    /// If the render pass instance this is recorded in uses multiview then
+    /// [`ClearRect::base_array_layer`] must be zero and [`ClearRect::layer_count`] must be one.
+    ///
+    /// The rectangle area must be inside the render area ranges.
+    ///
+    /// This is a shortcut for `try_clear_attachments().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_clear_attachments`] returns a [`ValidationError`].
+    ///
+    /// [`try_clear_attachments`]: Self::try_clear_attachments
+    #[track_caller]
+    pub unsafe fn clear_attachments(
+        &mut self,
+        attachments: &[ClearAttachment],
+        rects: &[ClearRect],
+    ) -> &mut Self {
+        unsafe { self.try_clear_attachments(attachments, rects) }.unwrap()
+    }
+
     /// Clears specific regions of specific attachments of the framebuffer.
     ///
     /// `attachments` specify the types of attachments and their clear values. `rects` specify the
@@ -14,7 +41,7 @@ impl RecordingCommandBuffer<'_> {
     /// [`ClearRect::base_array_layer`] must be zero and [`ClearRect::layer_count`] must be one.
     ///
     /// The rectangle area must be inside the render area ranges.
-    pub unsafe fn clear_attachments(
+    pub unsafe fn try_clear_attachments(
         &mut self,
         attachments: &[ClearAttachment],
         rects: &[ClearRect],

--- a/vulkano-taskgraph/src/command_buffer/commands/sync.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/sync.rs
@@ -14,7 +14,12 @@ use vulkano::{
 
 /// # Commands to synchronize resource accesses
 impl RecordingCommandBuffer<'_> {
-    pub unsafe fn pipeline_barrier(
+    #[track_caller]
+    pub unsafe fn pipeline_barrier(&mut self, dependency_info: &DependencyInfo<'_>) -> &mut Self {
+        unsafe { self.try_pipeline_barrier(dependency_info) }.unwrap()
+    }
+
+    pub unsafe fn try_pipeline_barrier(
         &mut self,
         dependency_info: &DependencyInfo<'_>,
     ) -> Result<&mut Self> {

--- a/vulkano-taskgraph/src/descriptor_set.rs
+++ b/vulkano-taskgraph/src/descriptor_set.rs
@@ -99,12 +99,12 @@ impl BindlessContext {
         }
     }
 
-    pub(crate) fn new(
+    pub(crate) fn try_new(
         resources: &Arc<ResourceStorage>,
         create_info: &BindlessContextCreateInfo<'_>,
     ) -> Result<Self, Validated<VulkanError>> {
         let global_set_layout =
-            GlobalDescriptorSet::create_layout(resources, create_info.global_set)?;
+            GlobalDescriptorSet::try_create_layout(resources, create_info.global_set)?;
 
         let global_set = GlobalDescriptorSet::new(resources, &global_set_layout)?;
 
@@ -136,6 +136,37 @@ impl BindlessContext {
 
     /// Creates a new bindless pipeline layout from the union of the push constant requirements of
     /// each stage in `stages` for push constant ranges and the [global descriptor set layout] and
+    /// optionally the [local descriptor set layout] for set layouts, panicking on a validation
+    /// error.
+    ///
+    /// All pipelines that you bind must have been created with a layout created like this or with
+    /// a compatible layout for the bindless system to be able to bind its descriptor sets.
+    ///
+    /// It is recommended that you share the same pipeline layout object with as many pipelines as
+    /// possible in order to reduce the amount of descriptor set (re)binding that is needed.
+    ///
+    /// This is a shortcut for `try_pipeline_layout_from_stages().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_pipeline_layout_from_stages`] returns a [`ValidationError`].
+    ///
+    /// [global descriptor set layout]: Self::global_set_layout
+    /// [local descriptor set layout]: Self::local_set_layout
+    /// [`try_pipeline_layout_from_stages`]: Self::try_pipeline_layout_from_stages
+    #[track_caller]
+    pub fn pipeline_layout_from_stages(
+        &self,
+        stages: &[PipelineShaderStageCreateInfo<'_>],
+    ) -> Result<Arc<PipelineLayout>, VulkanError> {
+        match self.try_pipeline_layout_from_stages(stages) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new bindless pipeline layout from the union of the push constant requirements of
+    /// each stage in `stages` for push constant ranges and the [global descriptor set layout] and
     /// optionally the [local descriptor set layout] for set layouts.
     ///
     /// All pipelines that you bind must have been created with a layout created like this or with
@@ -146,7 +177,7 @@ impl BindlessContext {
     ///
     /// [global descriptor set layout]: Self::global_set_layout
     /// [local descriptor set layout]: Self::local_set_layout
-    pub fn pipeline_layout_from_stages(
+    pub fn try_pipeline_layout_from_stages(
         &self,
         stages: &[PipelineShaderStageCreateInfo<'_>],
     ) -> Result<Arc<PipelineLayout>, Validated<VulkanError>> {
@@ -156,7 +187,7 @@ impl BindlessContext {
             set_layouts.push(local_set_layout);
         }
 
-        PipelineLayout::new(
+        PipelineLayout::try_new(
             self.device(),
             &PipelineLayoutCreateInfo {
                 set_layouts: &set_layouts,
@@ -267,7 +298,7 @@ impl GlobalDescriptorSet {
         let device = resources.device();
 
         let allocator = Arc::new(GlobalDescriptorSetAllocator::new(device));
-        let inner = RawDescriptorSet::new(&allocator, layout, 0).map_err(Validated::unwrap)?;
+        let inner = RawDescriptorSet::new(&allocator, layout, 0)?;
 
         let hyaline_collector = resources.hyaline_collector();
 
@@ -322,7 +353,7 @@ impl GlobalDescriptorSet {
         })
     }
 
-    fn create_layout(
+    fn try_create_layout(
         resources: &Arc<ResourceStorage>,
         create_info: &GlobalDescriptorSetCreateInfo<'_>,
     ) -> Result<Arc<DescriptorSetLayout>, Validated<VulkanError>> {
@@ -393,7 +424,18 @@ impl GlobalDescriptorSet {
         &self.inner
     }
 
+    #[track_caller]
     pub fn create_sampler(
+        &self,
+        create_info: &SamplerCreateInfo<'_>,
+    ) -> Result<SamplerId, VulkanError> {
+        match self.try_create_sampler(create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    pub fn try_create_sampler(
         &self,
         create_info: &SamplerCreateInfo<'_>,
     ) -> Result<SamplerId, Validated<VulkanError>> {
@@ -402,7 +444,20 @@ impl GlobalDescriptorSet {
         Ok(self.add_sampler(sampler))
     }
 
+    #[track_caller]
     pub fn create_sampled_image(
+        &self,
+        image_id: Id<Image>,
+        create_info: &ImageViewCreateInfo<'_>,
+        image_layout: ImageLayout,
+    ) -> Result<SampledImageId, VulkanError> {
+        match self.try_create_sampled_image(image_id, create_info, image_layout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    pub fn try_create_sampled_image(
         &self,
         image_id: Id<Image>,
         create_info: &ImageViewCreateInfo<'_>,
@@ -414,7 +469,20 @@ impl GlobalDescriptorSet {
         Ok(self.add_sampled_image(image_view, image_layout))
     }
 
+    #[track_caller]
     pub fn create_storage_image(
+        &self,
+        image_id: Id<Image>,
+        create_info: &ImageViewCreateInfo<'_>,
+        image_layout: ImageLayout,
+    ) -> Result<StorageImageId, VulkanError> {
+        match self.try_create_storage_image(image_id, create_info, image_layout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    pub fn try_create_storage_image(
         &self,
         image_id: Id<Image>,
         create_info: &ImageViewCreateInfo<'_>,
@@ -426,7 +494,20 @@ impl GlobalDescriptorSet {
         Ok(self.add_storage_image(image_view, image_layout))
     }
 
+    #[track_caller]
     pub fn create_storage_buffer(
+        &self,
+        buffer_id: Id<Buffer>,
+        offset: DeviceSize,
+        size: Option<DeviceSize>,
+    ) -> Result<StorageBufferId, VulkanError> {
+        match self.try_create_storage_buffer(buffer_id, offset, size) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    pub fn try_create_storage_buffer(
         &self,
         buffer_id: Id<Buffer>,
         offset: DeviceSize,
@@ -977,7 +1058,7 @@ impl GlobalDescriptorSetAllocator {
 }
 
 unsafe impl DescriptorSetAllocator for GlobalDescriptorSetAllocator {
-    fn allocate(
+    fn try_allocate(
         &self,
         layout: &Arc<DescriptorSetLayout>,
         _variable_count: u32,
@@ -988,7 +1069,7 @@ unsafe impl DescriptorSetAllocator for GlobalDescriptorSetAllocator {
             .map(|binding| (binding.descriptor_type, binding.descriptor_count))
             .collect::<Vec<_>>();
 
-        let pool = Arc::new(DescriptorPool::new(
+        let pool = Arc::new(DescriptorPool::try_new(
             layout.device(),
             &DescriptorPoolCreateInfo {
                 flags: DescriptorPoolCreateFlags::UPDATE_AFTER_BIND,
@@ -1000,7 +1081,7 @@ unsafe impl DescriptorSetAllocator for GlobalDescriptorSetAllocator {
 
         let allocate_info = DescriptorSetAllocateInfo::new(layout);
 
-        let inner = unsafe { pool.allocate_descriptor_sets(slice::from_ref(&allocate_info)) }?
+        let inner = unsafe { pool.try_allocate_descriptor_sets(slice::from_ref(&allocate_info)) }?
             .next()
             .unwrap();
 
@@ -1009,6 +1090,14 @@ unsafe impl DescriptorSetAllocator for GlobalDescriptorSetAllocator {
             pool,
             handle: AllocationHandle::null(),
         })
+    }
+
+    unsafe fn allocate_unchecked(
+        &self,
+        _layout: &Arc<DescriptorSetLayout>,
+        _variable_descriptor_count: u32,
+    ) -> Result<DescriptorSetAlloc, VulkanError> {
+        unimplemented!()
     }
 
     unsafe fn deallocate(&self, _allocation: DescriptorSetAlloc) {}
@@ -1037,7 +1126,7 @@ impl LocalDescriptorSet {
         subpass_index: usize,
     ) -> Result<Arc<Self>, VulkanError> {
         let allocator = resources.descriptor_set_allocator();
-        let inner = RawDescriptorSet::new(allocator, layout, 0).map_err(Validated::unwrap)?;
+        let inner = RawDescriptorSet::new(allocator, layout, 0)?;
 
         let render_pass = framebuffer.render_pass();
         let subpass_description = &render_pass.subpasses()[subpass_index];

--- a/vulkano-taskgraph/src/graph/compile.rs
+++ b/vulkano-taskgraph/src/graph/compile.rs
@@ -1386,7 +1386,7 @@ fn create_render_pass(
         }
     }
 
-    let render_pass = RenderPass::new(
+    let render_pass = RenderPass::try_new(
         resources.physical_resources.device(),
         &RenderPassCreateInfo {
             attachments: &attachments,

--- a/vulkano-taskgraph/src/graph/execute.rs
+++ b/vulkano-taskgraph/src/graph/execute.rs
@@ -44,6 +44,43 @@ use vulkano::{
 };
 
 impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
+    /// Executes the next frame of the [flight] given by `flight_id`, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_execute().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - There must be no other task graphs executing that access any of the same subresources as
+    ///   `self`.
+    /// - A subresource in flight must not be accessed in more than one frame in flight.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_execute`] returns a [`ValidationError`].
+    /// - Panics if `resource_map` doesn't map the virtual resources of `self` exhaustively.
+    /// - Panics if `self.flight_id()` is invalid.
+    /// - Panics if another thread is already executing a task graph using the flight.
+    /// - Panics if another thread is already executing a task graph using any of the swapchains
+    ///   used by the task graph.
+    /// - Panics if any swapchain used by the task graph has already been recreated or removed.
+    /// - Panics if the oldest frame of the flight wasn't [waited] on.
+    ///
+    /// [`try_execute`]: Self::try_execute
+    /// [waited]: crate::resource::Flight::wait
+    #[track_caller]
+    pub unsafe fn execute(
+        &self,
+        resource_map: ResourceMap<'_>,
+        world: &W,
+        pre_present_notify: impl FnOnce(),
+    ) -> Result<(), ExecuteError> {
+        match unsafe { self.try_execute(resource_map, world, pre_present_notify) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Executes the next frame of the [flight] given by `flight_id`.
     ///
     /// # Safety
@@ -64,12 +101,12 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
     ///
     /// [waited]: crate::resource::Flight::wait
     #[track_caller]
-    pub unsafe fn execute(
+    pub unsafe fn try_execute(
         &self,
         resource_map: ResourceMap<'_>,
         world: &W,
         pre_present_notify: impl FnOnce(),
-    ) -> Result {
+    ) -> Result<(), Validated<ExecuteError>> {
         assert!(ptr::eq(
             resource_map.virtual_resources,
             &self.graph.resources,
@@ -80,7 +117,7 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
 
         let flight = resource_map
             .physical_resources
-            .flight_protected(flight_id, &resource_map.guard)
+            .try_flight_protected(flight_id, &resource_map.guard)
             .expect("invalid flight ID");
 
         let _flight_lock_guard = flight.try_lock().unwrap_or_else(|| {
@@ -105,7 +142,7 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
         let mut current_fence = flight.current_fence().write();
 
         // SAFETY: We checked that the fence has been signaled.
-        unsafe { current_fence.reset_unchecked() }?;
+        unsafe { current_fence.reset_unchecked() }.map_err(ExecuteError::VulkanError)?;
 
         unsafe { self.invalidate_mapped_memory_ranges(&resource_map) }?;
 
@@ -192,7 +229,7 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
     unsafe fn collect_swapchains(&self, resource_map: &ResourceMap<'_>) -> Result {
         for &swapchain_id in &self.swapchains {
             let swapchain_state = unsafe { resource_map.swapchain_unchecked(swapchain_id) };
-            unsafe { swapchain_state.collect() }?;
+            unsafe { swapchain_state.collect() }.map_err(ExecuteError::VulkanError)?;
         }
 
         Ok(())
@@ -210,10 +247,10 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
             }
 
             if let Err(error) = unsafe { swapchain_state.acquire_next_image() } {
-                return Err(ExecuteError::Swapchain {
+                return Err(Validated::Error(ExecuteError::Swapchain {
                     swapchain_id,
                     error,
-                });
+                }));
             }
         }
 
@@ -261,7 +298,8 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
                 )
             }
             .result()
-            .map_err(VulkanError::from)?;
+            .map_err(VulkanError::from)
+            .map_err(ExecuteError::VulkanError)?;
         }
 
         Ok(())
@@ -589,7 +627,8 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
                 )
             }
             .result()
-            .map_err(VulkanError::from)?;
+            .map_err(VulkanError::from)
+            .map_err(ExecuteError::VulkanError)?;
         }
 
         Ok(())
@@ -654,7 +693,7 @@ impl<W: ?Sized + 'static> ExecutableTaskGraph<W> {
             }
         }
 
-        res
+        res.map_err(Validated::Error)
     }
 
     unsafe fn update_resource_state(
@@ -774,7 +813,7 @@ unsafe fn create_framebuffers(
                     _ => unreachable!(),
                 };
 
-                ImageView::new(
+                ImageView::try_new(
                     image,
                     &ImageViewCreateInfo {
                         format: attachment.format,
@@ -793,9 +832,10 @@ unsafe fn create_framebuffers(
                 // FIXME:
                 .map_err(Validated::unwrap)
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ExecuteError::VulkanError)?;
 
-        let framebuffer = Framebuffer::new(
+        let framebuffer = Framebuffer::try_new(
             render_pass,
             &FramebufferCreateInfo {
                 attachments: &attachments.iter().collect::<Vec<_>>(),
@@ -803,7 +843,8 @@ unsafe fn create_framebuffers(
             },
         )
         // FIXME:
-        .map_err(Validated::unwrap)?;
+        .map_err(Validated::unwrap)
+        .map_err(ExecuteError::VulkanError)?;
 
         framebuffers.push(framebuffer);
 
@@ -1092,7 +1133,7 @@ impl<'a, W: ?Sized + 'static> ExecuteState2<'a, W> {
         };
 
         unsafe { task.execute(&mut current_command_buffer, &mut context, self.world) }
-            .map_err(|error| ExecuteError::Task { node_index, error })?;
+            .map_err(|err| err.map(|error| ExecuteError::Task { node_index, error }))?;
 
         if !self.command_buffers.is_empty() {
             unsafe { self.flush_current_command_buffer() }?;
@@ -1201,7 +1242,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState2<'a, W> {
                 framebuffer,
                 0,
             )
-        }?;
+        }
+        .map_err(ExecuteError::VulkanError)?;
 
         // FIXME:
         let mut render_area_vk = vk::Rect2D::default();
@@ -1250,7 +1292,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState2<'a, W> {
                 framebuffer,
                 self.current_subpass_index,
             )
-        }?;
+        }
+        .map_err(ExecuteError::VulkanError)?;
 
         let fns = self.executable.device().fns();
         unsafe {
@@ -1317,7 +1360,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState2<'a, W> {
         stage_mask: PipelineStages,
     ) -> Result {
         let swapchain_state = unsafe { self.resource_map.swapchain_unchecked(swapchain_id) };
-        let semaphore_vk = unsafe { swapchain_state.init_pre_present_semaphore() }?;
+        let semaphore_vk = unsafe { swapchain_state.init_pre_present_semaphore() }
+            .map_err(ExecuteError::VulkanError)?;
 
         self.current_per_submit.signal_semaphore_infos_vk.push(
             vk::SemaphoreSubmitInfo::default()
@@ -1345,7 +1389,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState2<'a, W> {
         stage_mask: PipelineStages,
     ) -> Result {
         let swapchain_state = unsafe { self.resource_map.swapchain_unchecked(swapchain_id) };
-        let semaphore_vk = unsafe { swapchain_state.init_present_semaphore() }?;
+        let semaphore_vk = unsafe { swapchain_state.init_present_semaphore() }
+            .map_err(ExecuteError::VulkanError)?;
 
         self.current_per_submit.signal_semaphore_infos_vk.push(
             vk::SemaphoreSubmitInfo::default()
@@ -1404,18 +1449,21 @@ impl<'a, W: ?Sized + 'static> ExecuteState2<'a, W> {
             vk::Fence::null()
         };
 
-        submission.queue.with(|_guard| {
-            unsafe {
-                (self.queue_submit2)(
-                    submission.queue.handle(),
-                    submit_infos_vk.len() as u32,
-                    submit_infos_vk.as_ptr(),
-                    fence_handle,
-                )
-            }
-            .result()
-            .map_err(VulkanError::from)
-        })?;
+        submission
+            .queue
+            .with(|_guard| {
+                unsafe {
+                    (self.queue_submit2)(
+                        submission.queue.handle(),
+                        submit_infos_vk.len() as u32,
+                        submit_infos_vk.as_ptr(),
+                        fence_handle,
+                    )
+                }
+                .result()
+                .map_err(VulkanError::from)
+            })
+            .map_err(ExecuteError::VulkanError)?;
 
         drop(submit_infos_vk);
         self.per_submits.clear();
@@ -1427,7 +1475,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState2<'a, W> {
 
     unsafe fn flush_current_command_buffer(&mut self) -> Result {
         let current_command_buffer = self.current_command_buffer.take().unwrap();
-        let command_buffer = unsafe { current_command_buffer.end() }?;
+        let command_buffer =
+            unsafe { current_command_buffer.end() }.map_err(ExecuteError::VulkanError)?;
         self.current_per_submit
             .command_buffer_infos_vk
             .push(vk::CommandBufferSubmitInfo::default().command_buffer(command_buffer.handle()));
@@ -1705,7 +1754,7 @@ impl<'a, W: ?Sized + 'static> ExecuteState<'a, W> {
         };
 
         unsafe { task.execute(&mut current_command_buffer, &mut context, self.world) }
-            .map_err(|error| ExecuteError::Task { node_index, error })?;
+            .map_err(|err| err.map(|error| ExecuteError::Task { node_index, error }))?;
 
         if !self.command_buffers.is_empty() {
             unsafe { self.flush_current_command_buffer() }?;
@@ -1817,7 +1866,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState<'a, W> {
                 framebuffer,
                 0,
             )
-        }?;
+        }
+        .map_err(ExecuteError::VulkanError)?;
 
         // FIXME:
         let mut render_area_vk = vk::Rect2D::default();
@@ -1866,7 +1916,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState<'a, W> {
                 framebuffer,
                 self.current_subpass_index,
             )
-        }?;
+        }
+        .map_err(ExecuteError::VulkanError)?;
 
         let fns = self.executable.device().fns();
         unsafe {
@@ -1931,7 +1982,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState<'a, W> {
         _stage_mask: PipelineStages,
     ) -> Result {
         let swapchain_state = unsafe { self.resource_map.swapchain_unchecked(swapchain_id) };
-        let semaphore_vk = unsafe { swapchain_state.init_pre_present_semaphore() }?;
+        let semaphore_vk = unsafe { swapchain_state.init_pre_present_semaphore() }
+            .map_err(ExecuteError::VulkanError)?;
 
         self.current_per_submit
             .signal_semaphores_vk
@@ -1958,7 +2010,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState<'a, W> {
         _stage_mask: PipelineStages,
     ) -> Result {
         let swapchain_state = unsafe { self.resource_map.swapchain_unchecked(swapchain_id) };
-        let semaphore_vk = unsafe { swapchain_state.init_present_semaphore() }?;
+        let semaphore_vk = unsafe { swapchain_state.init_present_semaphore() }
+            .map_err(ExecuteError::VulkanError)?;
 
         self.current_per_submit
             .signal_semaphores_vk
@@ -2032,18 +2085,21 @@ impl<'a, W: ?Sized + 'static> ExecuteState<'a, W> {
             vk::Fence::null()
         };
 
-        submission.queue.with(|_guard| {
-            unsafe {
-                (self.queue_submit)(
-                    submission.queue.handle(),
-                    submit_infos_vk.len() as u32,
-                    submit_infos_vk.as_ptr(),
-                    fence_vk,
-                )
-            }
-            .result()
-            .map_err(VulkanError::from)
-        })?;
+        submission
+            .queue
+            .with(|_guard| {
+                unsafe {
+                    (self.queue_submit)(
+                        submission.queue.handle(),
+                        submit_infos_vk.len() as u32,
+                        submit_infos_vk.as_ptr(),
+                        fence_vk,
+                    )
+                }
+                .result()
+                .map_err(VulkanError::from)
+            })
+            .map_err(ExecuteError::VulkanError)?;
 
         drop(submit_infos_vk);
         self.per_submits.clear();
@@ -2055,7 +2111,8 @@ impl<'a, W: ?Sized + 'static> ExecuteState<'a, W> {
 
     unsafe fn flush_current_command_buffer(&mut self) -> Result {
         let current_command_buffer = self.current_command_buffer.take().unwrap();
-        let command_buffer = unsafe { current_command_buffer.end() }?;
+        let command_buffer =
+            unsafe { current_command_buffer.end() }.map_err(ExecuteError::VulkanError)?;
         self.current_per_submit
             .command_buffers_vk
             .push(command_buffer.handle());
@@ -2076,10 +2133,10 @@ use current_submission;
 macro_rules! current_command_buffer {
     ($state:expr) => {{
         if $state.current_command_buffer.is_none() {
-            $state.current_command_buffer = Some(create_command_buffer(
-                $state.resource_map,
-                &current_submission!($state).queue,
-            )?);
+            $state.current_command_buffer = Some(
+                create_command_buffer($state.resource_map, &current_submission!($state).queue)
+                    .map_err(ExecuteError::VulkanError)?,
+            );
         }
 
         $state.current_command_buffer.as_mut().unwrap()
@@ -2106,9 +2163,6 @@ fn create_command_buffer(
             },
         )
     }
-    // This can't panic because we know that the queue family index is active on the device,
-    // otherwise we wouldn't have a reference to the `Queue`.
-    .map_err(Validated::unwrap)
 }
 
 unsafe fn framebuffer_index(resource_map: &ResourceMap<'_>, swapchains: &[Id<Swapchain>]) -> usize {
@@ -2448,17 +2502,19 @@ impl<'a> ResourceMap<'a> {
                 ObjectType::Buffer => {
                     let physical_id = unsafe { physical_id.parametrize() };
 
-                    <*const _>::cast(physical_resources.buffer_protected(physical_id, &guard)?)
+                    <*const _>::cast(physical_resources.try_buffer_protected(physical_id, &guard)?)
                 }
                 ObjectType::Image => {
                     let physical_id = unsafe { physical_id.parametrize() };
 
-                    <*const _>::cast(physical_resources.image_protected(physical_id, &guard)?)
+                    <*const _>::cast(physical_resources.try_image_protected(physical_id, &guard)?)
                 }
                 ObjectType::Swapchain => {
                     let physical_id = unsafe { physical_id.parametrize() };
 
-                    <*const _>::cast(physical_resources.swapchain_protected(physical_id, &guard)?)
+                    <*const _>::cast(
+                        physical_resources.try_swapchain_protected(physical_id, &guard)?,
+                    )
                 }
                 _ => unreachable!(),
             };
@@ -2502,7 +2558,7 @@ impl<'a> ResourceMap<'a> {
 
         let state = self
             .physical_resources
-            .buffer_protected(physical_id, &self.guard)?;
+            .try_buffer_protected(physical_id, &self.guard)?;
 
         assert_eq!(
             state.buffer().sharing().is_exclusive(),
@@ -2583,7 +2639,7 @@ impl<'a> ResourceMap<'a> {
 
         let state = self
             .physical_resources
-            .image_protected(physical_id, &self.guard)?;
+            .try_image_protected(physical_id, &self.guard)?;
 
         assert_eq!(
             state.image().sharing().is_exclusive(),
@@ -2657,7 +2713,7 @@ impl<'a> ResourceMap<'a> {
 
         let state = self
             .physical_resources
-            .swapchain_protected(physical_id, &self.guard)?;
+            .try_swapchain_protected(physical_id, &self.guard)?;
 
         assert_eq!(
             state.swapchain().image_sharing().is_exclusive(),
@@ -2876,7 +2932,7 @@ macro_rules! resource_map {
     };
 }
 
-type Result<T = (), E = ExecuteError> = ::std::result::Result<T, E>;
+type Result<T = (), E = Validated<ExecuteError>> = ::std::result::Result<T, E>;
 
 /// Error that can happen when [executing] an [`ExecutableTaskGraph`].
 ///
@@ -2894,9 +2950,9 @@ pub enum ExecuteError {
     VulkanError(VulkanError),
 }
 
-impl From<VulkanError> for ExecuteError {
-    fn from(err: VulkanError) -> Self {
-        Self::VulkanError(err)
+impl From<ExecuteError> for Validated<ExecuteError> {
+    fn from(err: ExecuteError) -> Self {
+        Self::Error(err)
     }
 }
 

--- a/vulkano-taskgraph/src/graph/mod.rs
+++ b/vulkano-taskgraph/src/graph/mod.rs
@@ -426,7 +426,7 @@ impl Resources {
         physical_id: Id<Buffer>,
     ) -> Result<Id<Buffer>, InvalidSlotError> {
         let physical_resources = self.physical_resources.clone();
-        let buffer_state = physical_resources.buffer(physical_id)?;
+        let buffer_state = physical_resources.try_buffer(physical_id)?;
         let buffer = buffer_state.buffer();
         let virtual_id = self.add_buffer(&BufferCreateInfo {
             sharing: buffer.sharing(),
@@ -443,7 +443,7 @@ impl Resources {
         physical_id: Id<Image>,
     ) -> Result<Id<Image>, InvalidSlotError> {
         let physical_resources = self.physical_resources.clone();
-        let image_state = physical_resources.image(physical_id)?;
+        let image_state = physical_resources.try_image(physical_id)?;
         let image = image_state.image();
         let virtual_id = self.add_image(&ImageCreateInfo {
             sharing: image.sharing(),
@@ -460,7 +460,7 @@ impl Resources {
         id: Id<Swapchain>,
     ) -> Result<Id<Swapchain>, InvalidSlotError> {
         let physical_resources = self.physical_resources.clone();
-        let swapchain_state = physical_resources.swapchain(id)?;
+        let swapchain_state = physical_resources.try_swapchain(id)?;
         let swapchain = swapchain_state.swapchain();
         let virtual_id = self.add_swapchain(&SwapchainCreateInfo {
             image_sharing: swapchain.image_sharing(),

--- a/vulkano-taskgraph/src/lib.rs
+++ b/vulkano-taskgraph/src/lib.rs
@@ -31,7 +31,7 @@ use vulkano::{
     image::Image,
     render_pass::Framebuffer,
     swapchain::Swapchain,
-    DeviceSize, ValidationError,
+    DeviceSize, Validated, ValidationError,
 };
 
 pub mod collector;
@@ -256,9 +256,24 @@ pub struct TaskContext<'a> {
 }
 
 impl<'a> TaskContext<'a> {
-    /// Returns the buffer corresponding to `id`, or returns an error if it isn't present.
+    /// Returns the buffer corresponding to `id`, panicking on an invalid slot error.
+    ///
+    /// This is a shortcut for `try_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_buffer`] returns an [`InvalidSlotError`].
+    ///
+    /// [`try_buffer`]: Self::try_buffer
     #[inline]
-    pub fn buffer(&self, id: Id<Buffer>) -> TaskResult<&'a BufferState> {
+    #[track_caller]
+    pub fn buffer(&self, id: Id<Buffer>) -> &'a BufferState {
+        self.try_buffer(id).unwrap()
+    }
+
+    /// Returns the buffer corresponding to `id`.
+    #[inline]
+    pub fn try_buffer(&self, id: Id<Buffer>) -> Result<&'a BufferState, InvalidSlotError> {
         if id.is_virtual() {
             // SAFETY: The caller of `Task::execute` must ensure that `self.resource_map` maps the
             // virtual IDs of the graph exhaustively.
@@ -267,17 +282,33 @@ impl<'a> TaskContext<'a> {
             let resources = self.resource_map.resources();
             let guard = self.resource_map.guard();
 
-            Ok(resources.buffer_protected(id, guard)?)
+            Ok(resources.try_buffer_protected(id, guard)?)
         }
     }
 
-    /// Returns the image corresponding to `id`, or returns an error if it isn't present.
+    /// Returns the image corresponding to `id`, panicking on an invalid slot error.
+    ///
+    /// This is a shortcut for `try_image().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_image`] returns an [`InvalidSlotError`].
+    /// - Panics if `id` refers to a swapchain image.
+    ///
+    /// [`try_image`]: Self::try_image
+    #[inline]
+    #[track_caller]
+    pub fn image(&self, id: Id<Image>) -> &'a ImageState {
+        self.try_image(id).unwrap()
+    }
+
+    /// Returns the image corresponding to `id`.
     ///
     /// # Panics
     ///
     /// - Panics if `id` refers to a swapchain image.
     #[inline]
-    pub fn image(&self, id: Id<Image>) -> TaskResult<&'a ImageState> {
+    pub fn try_image(&self, id: Id<Image>) -> Result<&'a ImageState, InvalidSlotError> {
         assert_ne!(id.object_type(), ObjectType::Swapchain);
 
         if id.is_virtual() {
@@ -288,13 +319,28 @@ impl<'a> TaskContext<'a> {
             let resources = self.resource_map.resources();
             let guard = self.resource_map.guard();
 
-            Ok(resources.image_protected(id, guard)?)
+            Ok(resources.try_image_protected(id, guard)?)
         }
+    }
+
+    /// Returns the swapchain corresponding to `id`, panicking on an invalid slot error.
+    ///
+    /// This is a shortcut for `try_swapchain().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_swapchain`] returns an [`InvalidSlotError`].
+    ///
+    /// [`try_swapchain`]: Self::try_swapchain
+    #[inline]
+    #[track_caller]
+    pub fn swapchain(&self, id: Id<Swapchain>) -> &'a SwapchainState {
+        self.try_swapchain(id).unwrap()
     }
 
     /// Returns the swapchain corresponding to `id`, or returns an error if it isn't present.
     #[inline]
-    pub fn swapchain(&self, id: Id<Swapchain>) -> TaskResult<&'a SwapchainState> {
+    pub fn try_swapchain(&self, id: Id<Swapchain>) -> Result<&'a SwapchainState, InvalidSlotError> {
         if id.is_virtual() {
             // SAFETY: The caller of `Task::execute` must ensure that `self.resource_map` maps the
             // virtual IDs of the graph exhaustively.
@@ -303,7 +349,7 @@ impl<'a> TaskContext<'a> {
             let resources = self.resource_map.resources();
             let guard = self.resource_map.guard();
 
-            Ok(resources.swapchain_protected(id, guard)?)
+            Ok(resources.try_swapchain_protected(id, guard)?)
         }
     }
 
@@ -318,6 +364,36 @@ impl<'a> TaskContext<'a> {
     #[must_use]
     pub fn current_frame_index(&self) -> u32 {
         self.current_frame_index
+    }
+
+    /// Tries to get read access to a portion of the buffer corresponding to `id`, panicking on a
+    /// validation error or task error.
+    ///
+    /// If host read access for the buffer is not accounted for in the [task graph's host access
+    /// set], this method will return an error.
+    ///
+    /// If the memory backing the buffer is not managed by vulkano (i.e. the buffer was created
+    /// by [`RawBuffer::assume_bound`]), then it can't be read using this method and an error will
+    /// be returned.
+    ///
+    /// This is a shortcut for `try_read_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_read_buffer`] returns a [`ValidationError`] or [`TaskError`].
+    /// - Panics if the alignment of `T` is greater than 64.
+    /// - Panics if [`Subbuffer::slice`] with the given `range` panics.
+    /// - Panics if [`Subbuffer::reinterpret`] to the given `T` panics.
+    ///
+    /// [`RawBuffer::assume_bound`]: vulkano::buffer::sys::RawBuffer::assume_bound
+    /// [`try_read_buffer`]: Self::try_read_buffer
+    #[track_caller]
+    pub fn read_buffer<T: BufferContents + ?Sized>(
+        &self,
+        id: Id<Buffer>,
+        range: impl RangeBounds<DeviceSize>,
+    ) -> &T {
+        self.try_read_buffer(id, range).unwrap()
     }
 
     /// Tries to get read access to a portion of the buffer corresponding to `id`.
@@ -336,18 +412,18 @@ impl<'a> TaskContext<'a> {
     /// - Panics if [`Subbuffer::reinterpret`] to the given `T` panics.
     ///
     /// [`RawBuffer::assume_bound`]: vulkano::buffer::sys::RawBuffer::assume_bound
-    pub fn read_buffer<T: BufferContents + ?Sized>(
+    pub fn try_read_buffer<T: BufferContents + ?Sized>(
         &self,
         id: Id<Buffer>,
         range: impl RangeBounds<DeviceSize>,
-    ) -> TaskResult<&T> {
+    ) -> Result<&T, Validated<TaskError>> {
         self.validate_read_buffer(id)?;
 
         // SAFETY: We checked that the task has read access to the buffer above, which also
         // includes the guarantee that no other tasks can be writing the subbuffer on neither the
         // host nor the device. The same task cannot obtain another mutable reference to the buffer
         // because `TaskContext::write_buffer` requires a mutable reference.
-        unsafe { self.read_buffer_unchecked(id, range) }
+        Ok(unsafe { self.read_buffer_unchecked(id, range) }?)
     }
 
     fn validate_read_buffer(&self, id: Id<Buffer>) -> Result<(), Box<ValidationError>> {
@@ -390,10 +466,13 @@ impl<'a> TaskContext<'a> {
         &self,
         id: Id<Buffer>,
         range: impl RangeBounds<DeviceSize>,
-    ) -> TaskResult<&T> {
+    ) -> Result<&T, TaskError> {
         assert!(T::LAYOUT.alignment().as_devicesize() <= 64);
 
-        let buffer = self.buffer(id)?.buffer();
+        let buffer = self
+            .try_buffer(id)
+            .map_err(TaskError::InvalidSlot)?
+            .buffer();
         let subbuffer = Subbuffer::from(buffer.clone())
             .slice(range)
             .reinterpret::<T>();
@@ -409,11 +488,16 @@ impl<'a> TaskContext<'a> {
             _ => unreachable!(),
         };
 
-        unsafe { allocation.mapped_slice_unchecked(..) }.map_err(|err| match err {
-            vulkano::sync::HostAccessError::NotHostMapped => HostAccessError::NotHostMapped,
-            vulkano::sync::HostAccessError::OutOfMappedRange => HostAccessError::OutOfMappedRange,
-            _ => unreachable!(),
-        })?;
+        match unsafe { allocation.mapped_slice_unchecked(..) } {
+            Ok(_) => {}
+            Err(vulkano::sync::HostAccessError::NotHostMapped) => {
+                return Err(TaskError::HostAccess(HostAccessError::NotHostMapped));
+            }
+            Err(vulkano::sync::HostAccessError::OutOfMappedRange) => {
+                return Err(TaskError::HostAccess(HostAccessError::OutOfMappedRange));
+            }
+            Err(_) => unreachable!(),
+        }
 
         let mapped_slice = subbuffer.mapped_slice().unwrap();
 
@@ -422,6 +506,36 @@ impl<'a> TaskContext<'a> {
         let data = unsafe { &*data_ptr };
 
         Ok(data)
+    }
+
+    /// Tries to get write access to a portion of the buffer corresponding to `id`, panicking on a
+    /// validation error or task error.
+    ///
+    /// If host write access for the buffer is not accounted for in the [task graph's host access
+    /// set], this method will return an error.
+    ///
+    /// If the memory backing the buffer is not managed by vulkano (i.e. the buffer was created
+    /// by [`RawBuffer::assume_bound`]), then it can't be written using this method and an error
+    /// will be returned.
+    ///
+    /// This is a shortcut for `try_write_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_write_buffer`] returns a [`ValidationError`] or [`TaskError`].
+    /// - Panics if the alignment of `T` is greater than 64.
+    /// - Panics if [`Subbuffer::slice`] with the given `range` panics.
+    /// - Panics if [`Subbuffer::reinterpret`] to the given `T` panics.
+    ///
+    /// [`RawBuffer::assume_bound`]: vulkano::buffer::sys::RawBuffer::assume_bound
+    /// [`try_write_buffer`]: Self::try_write_buffer
+    #[track_caller]
+    pub fn write_buffer<T: BufferContents + ?Sized>(
+        &mut self,
+        id: Id<Buffer>,
+        range: impl RangeBounds<DeviceSize>,
+    ) -> &mut T {
+        self.try_write_buffer(id, range).unwrap()
     }
 
     /// Tries to get write access to a portion of the buffer corresponding to `id`.
@@ -440,18 +554,18 @@ impl<'a> TaskContext<'a> {
     /// - Panics if [`Subbuffer::reinterpret`] to the given `T` panics.
     ///
     /// [`RawBuffer::assume_bound`]: vulkano::buffer::sys::RawBuffer::assume_bound
-    pub fn write_buffer<T: BufferContents + ?Sized>(
+    pub fn try_write_buffer<T: BufferContents + ?Sized>(
         &mut self,
         id: Id<Buffer>,
         range: impl RangeBounds<DeviceSize>,
-    ) -> TaskResult<&mut T> {
+    ) -> Result<&mut T, Validated<TaskError>> {
         self.validate_write_buffer(id)?;
 
         // SAFETY: We checked that the task has write access to the buffer above, which also
         // includes the guarantee that no other tasks can be accessing the buffer on neither the
         // host nor the device. The same task cannot obtain another mutable reference to the buffer
         // because `TaskContext::write_buffer` requires a mutable reference.
-        unsafe { self.write_buffer_unchecked(id, range) }
+        Ok(unsafe { self.write_buffer_unchecked(id, range) }?)
     }
 
     fn validate_write_buffer(&self, id: Id<Buffer>) -> Result<(), Box<ValidationError>> {
@@ -494,10 +608,13 @@ impl<'a> TaskContext<'a> {
         &mut self,
         id: Id<Buffer>,
         range: impl RangeBounds<DeviceSize>,
-    ) -> TaskResult<&mut T> {
+    ) -> Result<&mut T, TaskError> {
         assert!(T::LAYOUT.alignment().as_devicesize() <= 64);
 
-        let buffer = self.buffer(id)?.buffer();
+        let buffer = self
+            .try_buffer(id)
+            .map_err(TaskError::InvalidSlot)?
+            .buffer();
         let subbuffer = Subbuffer::from(buffer.clone())
             .slice(range)
             .reinterpret::<T>();
@@ -513,11 +630,16 @@ impl<'a> TaskContext<'a> {
             _ => unreachable!(),
         };
 
-        unsafe { allocation.mapped_slice_unchecked(..) }.map_err(|err| match err {
-            vulkano::sync::HostAccessError::NotHostMapped => HostAccessError::NotHostMapped,
-            vulkano::sync::HostAccessError::OutOfMappedRange => HostAccessError::OutOfMappedRange,
-            _ => unreachable!(),
-        })?;
+        match unsafe { allocation.mapped_slice_unchecked(..) } {
+            Ok(_) => {}
+            Err(vulkano::sync::HostAccessError::NotHostMapped) => {
+                return Err(TaskError::HostAccess(HostAccessError::NotHostMapped));
+            }
+            Err(vulkano::sync::HostAccessError::OutOfMappedRange) => {
+                return Err(TaskError::HostAccess(HostAccessError::OutOfMappedRange));
+            }
+            Err(_) => unreachable!(),
+        }
 
         let mapped_slice = subbuffer.mapped_slice().unwrap();
 
@@ -604,31 +726,24 @@ impl ClearValues<'_> {
 }
 
 /// The type of result returned by a task.
-pub type TaskResult<T = (), E = TaskError> = ::std::result::Result<T, E>;
+pub type TaskResult<T = (), E = Validated<TaskError>> = ::std::result::Result<T, E>;
 
 /// Error that can happen inside a task.
 #[derive(Debug)]
 pub enum TaskError {
     InvalidSlot(InvalidSlotError),
     HostAccess(HostAccessError),
-    ValidationError(Box<ValidationError>),
 }
 
-impl From<InvalidSlotError> for TaskError {
+impl From<InvalidSlotError> for Validated<TaskError> {
     fn from(err: InvalidSlotError) -> Self {
-        Self::InvalidSlot(err)
+        Self::Error(TaskError::InvalidSlot(err))
     }
 }
 
-impl From<HostAccessError> for TaskError {
-    fn from(err: HostAccessError) -> Self {
-        Self::HostAccess(err)
-    }
-}
-
-impl From<Box<ValidationError>> for TaskError {
-    fn from(err: Box<ValidationError>) -> Self {
-        Self::ValidationError(err)
+impl From<TaskError> for Validated<TaskError> {
+    fn from(err: TaskError) -> Self {
+        Self::Error(err)
     }
 }
 
@@ -637,7 +752,6 @@ impl fmt::Display for TaskError {
         let msg = match self {
             Self::InvalidSlot(_) => "invalid slot",
             Self::HostAccess(_) => "a host access error occurred",
-            Self::ValidationError(_) => "a validation error occurred",
         };
 
         f.write_str(msg)
@@ -649,7 +763,6 @@ impl Error for TaskError {
         match self {
             Self::InvalidSlot(err) => Some(err),
             Self::HostAccess(err) => Some(err),
-            Self::ValidationError(err) => Some(err),
         }
     }
 }

--- a/vulkano-taskgraph/src/resource/mod.rs
+++ b/vulkano-taskgraph/src/resource/mod.rs
@@ -87,12 +87,33 @@ struct SwapchainGarbage {
 }
 
 impl Resources {
+    /// Creates a new `Resources` collection, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    /// - Panics if `device` already has a `Resources` collection associated with it.
+    ///
+    /// [`try_new`]: Self::try_new
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &ResourcesCreateInfo<'_>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `Resources` collection.
     ///
     /// # Panics
     ///
     /// - Panics if `device` already has a `Resources` collection associated with it.
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &ResourcesCreateInfo<'_>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
@@ -155,7 +176,7 @@ impl Resources {
             hyaline_collector,
         });
         let bindless_context = bindless_context
-            .map(|bindless_info| BindlessContext::new(&storage, bindless_info))
+            .map(|bindless_info| BindlessContext::try_new(&storage, bindless_info))
             .transpose()?;
 
         Ok(Arc::new(Resources {
@@ -192,6 +213,33 @@ impl Resources {
         self.bindless_context.as_ref()
     }
 
+    /// Creates a new buffer and adds it to the collection, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_create_buffer().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_create_buffer`] returns a [`ValidationError`].
+    /// - Panics if `create_info.size` is not zero.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error when [`try_create_buffer`] returns a [`VulkanError`].
+    ///
+    /// [`try_create_buffer`]: Self::try_create_buffer
+    #[track_caller]
+    pub fn create_buffer(
+        &self,
+        create_info: &BufferCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+        layout: DeviceLayout,
+    ) -> Result<Id<Buffer>, AllocateBufferError> {
+        match self.try_create_buffer(create_info, allocation_info, layout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new buffer and adds it to the collection.
     ///
     /// # Panics
@@ -200,14 +248,14 @@ impl Resources {
     ///
     /// # Errors
     ///
-    /// - Returns an error when [`Buffer::new`] returns an error.
-    pub fn create_buffer(
+    /// - Returns an error when [`Buffer::try_new`] returns an error.
+    pub fn try_create_buffer(
         &self,
         create_info: &BufferCreateInfo<'_>,
         allocation_info: &AllocationCreateInfo<'_>,
         layout: DeviceLayout,
     ) -> Result<Id<Buffer>, Validated<AllocateBufferError>> {
-        let buffer = Buffer::new(
+        let buffer = Buffer::try_new(
             &self.storage.memory_allocator,
             create_info,
             allocation_info,
@@ -218,20 +266,73 @@ impl Resources {
         Ok(unsafe { self.add_buffer_unchecked(buffer) })
     }
 
-    /// Creates a new image and adds it to the collection.
+    /// Creates a new image and adds it to the collection, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_create_image().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_create_image`] returns a [`ValidationError`].
     ///
     /// # Errors
     ///
-    /// - Returns an error when [`Image::new`] returns an error.
+    /// - Returns an error when [`try_create_image`] returns a [`VulkanError`].
+    ///
+    /// [`try_create_image`]: Self::try_create_image
+    #[track_caller]
     pub fn create_image(
         &self,
         create_info: &ImageCreateInfo<'_>,
         allocation_info: &AllocationCreateInfo<'_>,
+    ) -> Result<Id<Image>, AllocateImageError> {
+        match self.try_create_image(create_info, allocation_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new image and adds it to the collection.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error when [`Image::try_new`] returns an error.
+    pub fn try_create_image(
+        &self,
+        create_info: &ImageCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
     ) -> Result<Id<Image>, Validated<AllocateImageError>> {
-        let image = Image::new(&self.storage.memory_allocator, create_info, allocation_info)?;
+        let image = Image::try_new(&self.storage.memory_allocator, create_info, allocation_info)?;
 
         // SAFETY: We just created the image.
         Ok(unsafe { self.add_image_unchecked(image) })
+    }
+
+    /// Creates a swapchain and adds it to the collection, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_create_swapchain().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_create_swapchain`] returns a [`ValidationError`].
+    /// - Panics if the instance of `surface` is not the same as that of `self.device()`.
+    /// - Panics if `create_info.min_image_count` is not greater than or equal to the number of
+    ///   [frames] of the flight corresponding to `flight_id`.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error when [`try_create_swapchain`] returns a [`VulkanError`].
+    ///
+    /// [`try_create_swapchain`]: Self::try_create_swapchain
+    #[track_caller]
+    pub fn create_swapchain(
+        self: &Arc<Self>,
+        surface: &Arc<Surface>,
+        create_info: &SwapchainCreateInfo<'_>,
+    ) -> Result<Id<Swapchain>, VulkanError> {
+        match self.try_create_swapchain(surface, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
     }
 
     /// Creates a swapchain and adds it to the collection.
@@ -244,8 +345,8 @@ impl Resources {
     ///
     /// # Errors
     ///
-    /// - Returns an error when [`Swapchain::new`] returns an error.
-    pub fn create_swapchain(
+    /// - Returns an error when [`Swapchain::try_new`] returns an error.
+    pub fn try_create_swapchain(
         self: &Arc<Self>,
         surface: &Arc<Surface>,
         create_info: &SwapchainCreateInfo<'_>,
@@ -414,6 +515,34 @@ impl Resources {
     }
 
     /// Calls [`Swapchain::recreate`] on the swapchain corresponding to `id` and adds the new
+    /// swapchain to the collection, panicking on a validation error. The old swapchain will be
+    /// cleaned up as soon as possible.
+    ///
+    /// This is a shortcut for `try_recreate_swapchain().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_recreate_swapchain`] returns a [`ValidationError`].
+    /// - Panics if [`try_recreate_swapchain`] panics.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error when [`try_recreate_swapchain`] returns a [`VulkanError`].
+    ///
+    /// [`try_recreate_swapchain`]: Self::try_recreate_swapchain
+    #[track_caller]
+    pub fn recreate_swapchain(
+        &self,
+        id: Id<Swapchain>,
+        f: impl for<'a> FnOnce(&SwapchainCreateInfo<'a>) -> SwapchainCreateInfo<'a>,
+    ) -> Result<Id<Swapchain>, VulkanError> {
+        match self.try_recreate_swapchain(id, f) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Calls [`Swapchain::recreate`] on the swapchain corresponding to `id` and adds the new
     /// swapchain to the collection. The old swapchain will be cleaned up as soon as possible.
     ///
     /// # Panics
@@ -427,7 +556,7 @@ impl Resources {
     ///
     /// - Returns an error when [`Swapchain::recreate`] returns an error.
     #[track_caller]
-    pub fn recreate_swapchain(
+    pub fn try_recreate_swapchain(
         &self,
         id: Id<Swapchain>,
         f: impl for<'a> FnOnce(&SwapchainCreateInfo<'a>) -> SwapchainCreateInfo<'a>,
@@ -455,7 +584,7 @@ impl Resources {
         Ok(unsafe { new_id.parametrize() })
     }
 
-    pub(crate) fn invalidate_buffer<'a>(
+    pub(crate) fn try_invalidate_buffer<'a>(
         &'a self,
         id: Id<Buffer>,
         guard: &'a hyaline::Guard<'_>,
@@ -469,7 +598,7 @@ impl Resources {
         Ok(state)
     }
 
-    pub(crate) fn invalidate_image<'a>(
+    pub(crate) fn try_invalidate_image<'a>(
         &'a self,
         id: Id<Image>,
         guard: &'a hyaline::Guard<'_>,
@@ -483,7 +612,7 @@ impl Resources {
         Ok(state)
     }
 
-    pub(crate) fn invalidate_swapchain<'a>(
+    pub(crate) fn try_invalidate_swapchain<'a>(
         &'a self,
         id: Id<Swapchain>,
         guard: &'a hyaline::Guard<'_>,
@@ -520,6 +649,29 @@ impl Resources {
         };
     }
 
+    /// Removes the swapchain corresponding to `id` from the collection, panicking on an invalid
+    /// slot error.
+    ///
+    /// Note that if there are any pending present operations then the swapchain cannot be
+    /// collected until it's certain that the presentation engine is no longer using the swapchain
+    /// or any of its old swapchains. The only way to guarantee that is by calling [`wait_idle`]
+    /// after removing the swapchain.
+    ///
+    /// This is a shortcut for `try_remove_swapchain().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_remove_swapchain`] returns an [`InvalidSlotError`].
+    /// - Panics if a task graph using the swapchain is being executed.
+    /// - Panics if the swapchain has already been recreated or removed.
+    ///
+    /// [`wait_idle`]: Self::wait_idle
+    /// [`try_remove_swapchain`]: Self::try_remove_swapchain
+    #[track_caller]
+    pub fn remove_swapchain(&self, id: Id<Swapchain>) -> Ref<'_, SwapchainState> {
+        self.try_remove_swapchain(id).unwrap()
+    }
+
     /// Removes the swapchain corresponding to `id` from the collection.
     ///
     /// Note that if there are any pending present operations then the swapchain cannot be
@@ -534,7 +686,7 @@ impl Resources {
     ///
     /// [`wait_idle`]: Self::wait_idle
     #[track_caller]
-    pub fn remove_swapchain(&self, id: Id<Swapchain>) -> Result<Ref<'_, SwapchainState>> {
+    pub fn try_remove_swapchain(&self, id: Id<Swapchain>) -> Result<Ref<'_, SwapchainState>> {
         let guard = self.storage.pin();
 
         let state = self
@@ -551,13 +703,28 @@ impl Resources {
         Ok(Ref::new(state, guard))
     }
 
+    /// Returns the buffer corresponding to `id`, panicking on an invalid slot error.
+    ///
+    /// This is a shortcut for `try_buffer().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_buffer`] returns an [`InvalidSlotError`].
+    ///
+    /// [`try_buffer`]: Self::try_buffer
+    #[inline]
+    #[track_caller]
+    pub fn buffer(&self, id: Id<Buffer>) -> Ref<'_, BufferState> {
+        self.try_buffer(id).unwrap()
+    }
+
     /// Returns the buffer corresponding to `id`.
     #[inline]
-    pub fn buffer(&self, id: Id<Buffer>) -> Result<Ref<'_, BufferState>> {
+    pub fn try_buffer(&self, id: Id<Buffer>) -> Result<Ref<'_, BufferState>> {
         self.storage.buffer(id)
     }
 
-    pub(crate) fn buffer_protected<'a>(
+    pub(crate) fn try_buffer_protected<'a>(
         &'a self,
         id: Id<Buffer>,
         guard: &'a hyaline::Guard<'a>,
@@ -574,13 +741,28 @@ impl Resources {
         unsafe { self.storage.buffer_unchecked_protected(id, guard) }
     }
 
+    /// Returns the image corresponding to `id`, panicking on an invalid slot error.
+    ///
+    /// This is a shortcut for `try_image().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_image`] returns an [`InvalidSlotError`].
+    ///
+    /// [`try_image`]: Self::try_image
+    #[inline]
+    #[track_caller]
+    pub fn image(&self, id: Id<Image>) -> Ref<'_, ImageState> {
+        self.try_image(id).unwrap()
+    }
+
     /// Returns the image corresponding to `id`.
     #[inline]
-    pub fn image(&self, id: Id<Image>) -> Result<Ref<'_, ImageState>> {
+    pub fn try_image(&self, id: Id<Image>) -> Result<Ref<'_, ImageState>> {
         self.storage.image(id)
     }
 
-    pub(crate) fn image_protected<'a>(
+    pub(crate) fn try_image_protected<'a>(
         &'a self,
         id: Id<Image>,
         guard: &'a hyaline::Guard<'a>,
@@ -597,13 +779,28 @@ impl Resources {
         unsafe { self.storage.image_unchecked_protected(id, guard) }
     }
 
+    /// Returns the swapchain corresponding to `id`, panicking on an invalid slot error.
+    ///
+    /// This is a shortcut for `try_swapchain().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_swapchain`] returns an [`InvalidSlotError`].
+    ///
+    /// [`try_swapchain`]: Self::try_swapchain
+    #[inline]
+    #[track_caller]
+    pub fn swapchain(&self, id: Id<Swapchain>) -> Ref<'_, SwapchainState> {
+        self.try_swapchain(id).unwrap()
+    }
+
     /// Returns the swapchain corresponding to `id`.
     #[inline]
-    pub fn swapchain(&self, id: Id<Swapchain>) -> Result<Ref<'_, SwapchainState>> {
+    pub fn try_swapchain(&self, id: Id<Swapchain>) -> Result<Ref<'_, SwapchainState>> {
         self.storage.swapchain(id)
     }
 
-    pub(crate) fn swapchain_protected<'a>(
+    pub(crate) fn try_swapchain_protected<'a>(
         &'a self,
         id: Id<Swapchain>,
         guard: &'a hyaline::Guard<'a>,
@@ -622,11 +819,17 @@ impl Resources {
 
     /// Returns the [flight] corresponding to `id`.
     #[inline]
-    pub fn flight(&self, id: Id<Flight>) -> Result<Ref<'_, Flight>> {
+    pub fn flight(&self, id: Id<Flight>) -> Ref<'_, Flight> {
+        self.try_flight(id).unwrap()
+    }
+
+    /// Returns the [flight] corresponding to `id`.
+    #[inline]
+    pub fn try_flight(&self, id: Id<Flight>) -> Result<Ref<'_, Flight>> {
         self.storage.flight(id)
     }
 
-    pub(crate) fn flight_protected<'a>(
+    pub(crate) fn try_flight_protected<'a>(
         &'a self,
         id: Id<Flight>,
         guard: &'a hyaline::Guard<'a>,

--- a/vulkano-taskgraph/src/resource/state.rs
+++ b/vulkano-taskgraph/src/resource/state.rs
@@ -32,7 +32,7 @@ use vulkano::{
         fence::{Fence, FenceCreateFlags, FenceCreateInfo},
         semaphore::Semaphore,
     },
-    Validated, VulkanError, VulkanObject,
+    VulkanError, VulkanObject,
 };
 
 #[derive(Debug)]
@@ -232,6 +232,9 @@ impl SwapchainState {
         let semaphore = sync_state.allocate_semaphore()?;
         let fence = sync_state.allocate_fence()?;
 
+        // This should not panic because our swapchain lock prevents using a swapchain after it has
+        // been recreated. However, this will panic if the user circumvents that by calling
+        // `Swapchain::recreate` themself. The user is not supposed to do that.
         let res = unsafe {
             self.swapchain.acquire_next_image(&AcquireNextImageInfo {
                 semaphore: Some(&semaphore),
@@ -240,10 +243,7 @@ impl SwapchainState {
             })
         };
 
-        // This should not panic because our swapchain lock prevents using a swapchain after it has
-        // been recreated. However, this will panic if the user circumvents that by calling
-        // `Swapchain::recreate` themself. The user is not supposed to do that.
-        match res.map_err(Validated::unwrap) {
+        match res {
             Ok(AcquiredImage { image_index, .. }) => {
                 assert!(sync_state.current_acquire_semaphore.is_none());
                 assert!(sync_state.current_acquire_fence.is_none());
@@ -411,7 +411,7 @@ impl SwapchainState {
                 continue;
             };
 
-            if !fence.is_signaled()? {
+            if !unsafe { fence.is_signaled_unchecked() }? {
                 // We can't be certain that the present operation is done yet. Unlike when it comes
                 // to acquires, we do know the order of presents because we're in control of them.
                 // The order the Presentation Engine gets the presents is the same as that of our
@@ -595,7 +595,9 @@ impl SwapchainState {
         if has_present_operations {
             // We can't remove the old swapchain until we know that there are no pending present
             // operations, so we only invalidate it for now.
-            resources.invalidate_swapchain(swapchain_id, guard).unwrap();
+            resources
+                .try_invalidate_swapchain(swapchain_id, guard)
+                .unwrap();
 
             let has_garbage = sync_state
                 .garbage_queue
@@ -735,7 +737,9 @@ impl SwapchainState {
         if has_present_operations {
             // We can't remove the old swapchain until we know that there are no pending present
             // operations, so we only invalidate it for now.
-            resources.invalidate_swapchain(swapchain_id, guard).unwrap();
+            resources
+                .try_invalidate_swapchain(swapchain_id, guard)
+                .unwrap();
 
             garbage.swapchains.push(swapchain_id);
         } else {
@@ -1017,11 +1021,13 @@ impl Flight {
             return Ok(());
         }
 
+        let frame_count = NonZero::<u64>::from(self.frame_count);
+
         // The `frame_count` bias cancels out under the modulus; however, the `1` bias doesn't, so
         // we subtract it to get the same index as would be computed using the unbiased `frame`.
-        self.fences[((biased_frame - 1) % NonZero::<u64>::from(self.frame_count)) as usize]
-            .read()
-            .wait(timeout)?;
+        let fence = &self.fences[((biased_frame - 1) % frame_count) as usize];
+
+        unsafe { fence.read().wait_unchecked(timeout) }?;
 
         // SAFETY: We waited for the frame.
         if unsafe { self.update_biased_complete_frame(biased_frame) }.is_ok() {

--- a/vulkano/src/acceleration_structure.rs
+++ b/vulkano/src/acceleration_structure.rs
@@ -110,6 +110,35 @@ pub struct AccelerationStructure {
 }
 
 impl AccelerationStructure {
+    /// Creates a new `AccelerationStructure`, panicking on a validation error.
+    ///
+    /// The [`acceleration_structure`] feature must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `create_info.buffer` (and any subbuffer it overlaps with) must not be accessed while it
+    ///   is bound to the acceleration structure.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`acceleration_structure`]: crate::device::DeviceFeatures::acceleration_structure
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub unsafe fn new(
+        device: &Arc<Device>,
+        create_info: &AccelerationStructureCreateInfo<'_>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_new(device, create_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `AccelerationStructure`.
     ///
     /// The [`acceleration_structure`] feature must be enabled on the device.
@@ -121,7 +150,7 @@ impl AccelerationStructure {
     ///
     /// [`acceleration_structure`]: crate::device::DeviceFeatures::acceleration_structure
     #[inline]
-    pub unsafe fn new(
+    pub unsafe fn try_new(
         device: &Arc<Device>,
         create_info: &AccelerationStructureCreateInfo<'_>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {

--- a/vulkano/src/buffer/allocator.rs
+++ b/vulkano/src/buffer/allocator.rs
@@ -92,7 +92,7 @@ impl<S> BufferAllocator<S> {
     }
 
     fn allocate_buffer(&self) -> Result<Arc<Buffer>, MemoryAllocatorError> {
-        Buffer::new(
+        Buffer::try_new(
             &self.memory_allocator,
             &BufferCreateInfo {
                 usage: self.buffer_usage,
@@ -698,7 +698,7 @@ where
     }
 
     fn create_arena(&self) -> Result<Arc<Buffer>, MemoryAllocatorError> {
-        Buffer::new(
+        Buffer::try_new(
             &self.memory_allocator,
             &BufferCreateInfo {
                 usage: self.buffer_usage,

--- a/vulkano/src/buffer/mod.rs
+++ b/vulkano/src/buffer/mod.rs
@@ -324,7 +324,7 @@ impl Buffer {
         T: BufferContents,
     {
         let layout = T::LAYOUT.unwrap_sized();
-        let buffer = Subbuffer::new(Buffer::new(
+        let buffer = Subbuffer::new(Buffer::try_new(
             allocator,
             create_info,
             allocation_info,
@@ -370,7 +370,7 @@ impl Buffer {
         T: BufferContents + ?Sized,
     {
         let layout = T::LAYOUT.layout_for_len(len).unwrap();
-        let buffer = Subbuffer::new(Buffer::new(
+        let buffer = Subbuffer::new(Buffer::try_new(
             allocator,
             create_info,
             allocation_info,
@@ -380,17 +380,24 @@ impl Buffer {
         Ok(unsafe { buffer.reinterpret_unchecked() })
     }
 
-    /// Creates a new uninitialized `Buffer` with the given `layout`.
+    /// Creates a new uninitialized `Buffer` with the given `layout`, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
     ///
     /// # Panics
     ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
     /// - Panics if `create_info.size` is not zero.
+    ///
+    /// [`try_new`]: Self::try_new
+    #[track_caller]
     pub fn new(
         allocator: &Arc<impl MemoryAllocator + ?Sized>,
         create_info: &BufferCreateInfo<'_>,
         allocation_info: &AllocationCreateInfo<'_>,
         layout: DeviceLayout,
-    ) -> Result<Arc<Self>, Validated<AllocateBufferError>> {
+    ) -> Result<Arc<Self>, AllocateBufferError> {
         Self::new_inner(
             allocator.clone().as_dyn(),
             create_info,
@@ -399,7 +406,38 @@ impl Buffer {
         )
     }
 
-    pub(crate) fn new_inner(
+    fn new_inner(
+        allocator: Arc<dyn MemoryAllocator>,
+        create_info: &BufferCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+        layout: DeviceLayout,
+    ) -> Result<Arc<Self>, AllocateBufferError> {
+        match Self::try_new_inner(allocator, create_info, allocation_info, layout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new uninitialized `Buffer` with the given `layout`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `create_info.size` is not zero.
+    pub fn try_new(
+        allocator: &Arc<impl MemoryAllocator + ?Sized>,
+        create_info: &BufferCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+        layout: DeviceLayout,
+    ) -> Result<Arc<Self>, Validated<AllocateBufferError>> {
+        Self::try_new_inner(
+            allocator.clone().as_dyn(),
+            create_info,
+            allocation_info,
+            layout,
+        )
+    }
+
+    pub(crate) fn try_new_inner(
         allocator: Arc<dyn MemoryAllocator>,
         create_info: &BufferCreateInfo<'_>,
         allocation_info: &AllocationCreateInfo<'_>,
@@ -420,28 +458,90 @@ impl Buffer {
             ..*create_info
         };
 
-        let raw_buffer =
-            RawBuffer::new(allocator.device(), &create_info).map_err(|err| match err {
-                Validated::Error(err) => Validated::Error(AllocateBufferError::CreateBuffer(err)),
-                Validated::ValidationError(err) => err.into(),
-            })?;
+        let raw_buffer = RawBuffer::try_new(allocator.device(), &create_info)
+            .map_err(|err| err.map(AllocateBufferError::CreateBuffer))?;
         let mut requirements = *raw_buffer.memory_requirements();
         requirements.layout = requirements.layout.align_to(layout.alignment()).unwrap();
 
         let allocation = allocator
-            .allocate(
+            .try_allocate(
                 &requirements,
                 AllocationType::Linear,
                 allocation_info,
                 Some(DedicatedAllocation::Buffer(&raw_buffer)),
             )
-            .map_err(AllocateBufferError::AllocateMemory)?;
+            .map_err(|err| err.map(AllocateBufferError::AllocateMemory))?;
         let allocation = unsafe { ResourceMemory::from_allocation_inner(allocator, allocation) };
 
-        let buffer = raw_buffer.bind_memory(allocation).map_err(|(err, _, _)| {
-            err.map(AllocateBufferError::BindMemory)
-                .map_validation(|err| err.add_context("RawBuffer::bind_memory"))
-        })?;
+        let buffer = raw_buffer
+            .try_bind_memory(allocation)
+            .map_err(|(err, _, _)| {
+                err.map(AllocateBufferError::BindMemory)
+                    .map_validation(|err| err.add_context("RawBuffer::bind_memory"))
+            })?;
+
+        Ok(Arc::new(buffer))
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn new_unchecked(
+        allocator: &Arc<impl MemoryAllocator + ?Sized>,
+        create_info: &BufferCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+        layout: DeviceLayout,
+    ) -> Result<Arc<Self>, AllocateBufferError> {
+        unsafe {
+            Self::new_unchecked_inner(
+                allocator.clone().as_dyn(),
+                create_info,
+                allocation_info,
+                layout,
+            )
+        }
+    }
+
+    unsafe fn new_unchecked_inner(
+        allocator: Arc<dyn MemoryAllocator>,
+        create_info: &BufferCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+        layout: DeviceLayout,
+    ) -> Result<Arc<Self>, AllocateBufferError> {
+        assert!(!create_info
+            .flags
+            .contains(BufferCreateFlags::SPARSE_BINDING));
+
+        assert_eq!(
+            create_info.size, 0,
+            "`Buffer::new*` functions set the `create_info.size` field themselves, you should not \
+             set it yourself"
+        );
+
+        let create_info = BufferCreateInfo {
+            size: layout.size(),
+            ..*create_info
+        };
+
+        // SAFETY: Enforced by the caller.
+        let raw_buffer = unsafe { RawBuffer::new_unchecked(allocator.device(), &create_info) }
+            .map_err(AllocateBufferError::CreateBuffer)?;
+        let mut requirements = *raw_buffer.memory_requirements();
+        requirements.layout = requirements.layout.align_to(layout.alignment()).unwrap();
+
+        // SAFETY: Enforced by the caller.
+        let allocation = unsafe {
+            allocator.allocate_unchecked(
+                &requirements,
+                AllocationType::Linear,
+                allocation_info,
+                Some(DedicatedAllocation::Buffer(&raw_buffer)),
+            )
+        }
+        .map_err(AllocateBufferError::AllocateMemory)?;
+        let allocation = unsafe { ResourceMemory::from_allocation_inner(allocator, allocation) };
+
+        // SAFETY: Enforced by the caller.
+        let buffer = unsafe { raw_buffer.bind_memory_unchecked(allocation) }
+            .map_err(|(err, _, _)| AllocateBufferError::BindMemory(err))?;
 
         Ok(Arc::new(buffer))
     }
@@ -498,9 +598,23 @@ impl Buffer {
         self.inner.external_memory_handle_types()
     }
 
+    /// Returns the device address for this buffer, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_device_address().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_device_address`] returns a [`ValidationError`].
+    ///
+    /// [`try_device_address`]: Self::try_device_address
+    #[track_caller]
+    pub fn device_address(&self) -> NonZero<DeviceAddress> {
+        self.try_device_address().unwrap()
+    }
+
     /// Returns the device address for this buffer.
     // TODO: Caching?
-    pub fn device_address(&self) -> Result<NonZero<DeviceAddress>, Box<ValidationError>> {
+    pub fn try_device_address(&self) -> Result<NonZero<DeviceAddress>, Box<ValidationError>> {
         self.validate_device_address()?;
 
         Ok(unsafe { self.device_address_unchecked() })

--- a/vulkano/src/buffer/subbuffer.rs
+++ b/vulkano/src/buffer/subbuffer.rs
@@ -131,7 +131,7 @@ impl<T: ?Sized> Subbuffer<T> {
 
     /// Returns the device address for this subbuffer.
     pub fn device_address(&self) -> Result<NonZero<DeviceAddress>, Box<ValidationError>> {
-        self.buffer().device_address().map(|ptr| {
+        self.buffer().try_device_address().map(|ptr| {
             // SAFETY: The original address came from the Vulkan implementation, and allocation
             // sizes are guaranteed to not exceed `DeviceLayout::MAX_SIZE`, so the offset better be
             // in range.
@@ -1281,7 +1281,7 @@ mod tests {
 
         // Allocate some junk in the same block as the buffer.
         let _junk = allocator
-            .allocate(
+            .try_allocate(
                 &MemoryRequirements {
                     layout: DeviceLayout::from_size_alignment(17, 1).unwrap(),
                     ..requirements
@@ -1293,7 +1293,7 @@ mod tests {
             .unwrap();
 
         let allocation = allocator
-            .allocate(
+            .try_allocate(
                 &requirements,
                 AllocationType::Linear,
                 &AllocationCreateInfo::default(),

--- a/vulkano/src/buffer/sys.rs
+++ b/vulkano/src/buffer/sys.rs
@@ -43,16 +43,42 @@ pub struct RawBuffer {
 }
 
 impl RawBuffer {
+    /// Creates a new `RawBuffer`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    /// - Panics if `create_info.sharing` is [`Concurrent`] with less than 2 items.
+    /// - Panics if `create_info.size` is zero.
+    /// - Panics if `create_info.usage` is empty.
+    ///
+    /// [`try_new`]: Self::try_new
+    /// [`Concurrent`]: Sharing::Concurrent
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &BufferCreateInfo<'_>,
+    ) -> Result<Self, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `RawBuffer`.
     ///
     /// # Panics
     ///
-    /// - Panics if `create_info.sharing` is [`Concurrent`](Sharing::Concurrent) with less than 2
-    ///   items.
+    /// - Panics if `create_info.sharing` is [`Concurrent`] with less than 2 items.
     /// - Panics if `create_info.size` is zero.
     /// - Panics if `create_info.usage` is empty.
+    ///
+    /// [`Concurrent`]: Sharing::Concurrent
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &BufferCreateInfo<'_>,
     ) -> Result<Self, Validated<VulkanError>> {
@@ -251,9 +277,30 @@ impl RawBuffer {
         )
     }
 
+    /// Binds device memory to this buffer, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_bind_memory().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_bind_memory`] returns a [`ValidationError`].
+    ///
+    /// [`try_bind_memory`]: Self::try_bind_memory
+    #[inline]
+    #[track_caller]
+    pub fn bind_memory(
+        self,
+        allocation: ResourceMemory,
+    ) -> Result<Buffer, (VulkanError, RawBuffer, ResourceMemory)> {
+        match self.try_bind_memory(allocation) {
+            Ok(buffer) => Ok(buffer),
+            Err((err, this, allocation)) => Err((err.unwrap(), this, allocation)),
+        }
+    }
+
     /// Binds device memory to this buffer.
     #[inline]
-    pub fn bind_memory(
+    pub fn try_bind_memory(
         self,
         allocation: ResourceMemory,
     ) -> Result<Buffer, (Validated<VulkanError>, RawBuffer, ResourceMemory)> {
@@ -990,7 +1037,7 @@ mod tests {
     fn create_empty_buffer() {
         let (device, _) = gfx_dev_and_queue!();
 
-        RawBuffer::new(
+        RawBuffer::try_new(
             &device,
             &BufferCreateInfo {
                 size: 0,

--- a/vulkano/src/buffer/view.rs
+++ b/vulkano/src/buffer/view.rs
@@ -65,9 +65,30 @@ pub struct BufferView {
 }
 
 impl BufferView {
-    /// Creates a new `BufferView`.
+    /// Creates a new `BufferView`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns an error.
+    ///
+    /// [`try_new`]: Self::try_new
     #[inline]
+    #[track_caller]
     pub fn new(
+        subbuffer: &Subbuffer<impl ?Sized>,
+        create_info: &BufferViewCreateInfo<'_>,
+    ) -> Result<Arc<BufferView>, VulkanError> {
+        match Self::try_new(subbuffer, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new `BufferView`, returning an error on failure.
+    #[inline]
+    pub fn try_new(
         subbuffer: &Subbuffer<impl ?Sized>,
         create_info: &BufferViewCreateInfo<'_>,
     ) -> Result<Arc<BufferView>, Validated<VulkanError>> {
@@ -554,7 +575,7 @@ mod tests {
         )
         .unwrap();
 
-        match BufferView::new(
+        match BufferView::try_new(
             &buffer,
             &BufferViewCreateInfo {
                 format: Format::R8G8B8A8_UNORM,
@@ -583,7 +604,7 @@ mod tests {
         .unwrap();
 
         // TODO: what if R64G64B64A64_SFLOAT is supported?
-        match BufferView::new(
+        match BufferView::try_new(
             &buffer,
             &BufferViewCreateInfo {
                 format: Format::R64G64B64A64_SFLOAT,

--- a/vulkano/src/command_buffer/allocator.rs
+++ b/vulkano/src/command_buffer/allocator.rs
@@ -57,11 +57,37 @@ const MAX_POOLS: usize = 32;
 /// different thread than it was allocated from.
 pub unsafe trait CommandBufferAllocator: DeviceOwned + Send + Sync + 'static {
     /// Allocates a command buffer.
-    fn allocate(
+    fn try_allocate(
         &self,
         queue_family_index: u32,
         level: CommandBufferLevel,
     ) -> Result<CommandBufferAlloc, Validated<VulkanError>>;
+
+    /// Allocates a command buffer without doing any checks.
+    ///
+    /// <div class="vulkano-alert-caution">
+    ///
+    /// > Caution
+    /// >
+    /// > You should only call this when necessary. Humans are famously bad at guessing what needs
+    /// > to be optimized, so **the only way** to know is by profiling. Have you profiled to make
+    /// > sure that this actually makes a difference? In 99% of cases (not an exaggeration),
+    /// > calling the unchecked version of one of our functions/methods makes absolutely no
+    /// > difference, so make sure first.
+    ///
+    /// </div>
+    ///
+    /// # Safety
+    ///
+    /// - If calling [`try_allocate`] with the same arguments would return a [`ValidationError`],
+    ///   calling this method is *undefined behavior*!
+    ///
+    /// [`try_allocate`]: Self::try_allocate
+    unsafe fn allocate_unchecked(
+        &self,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+    ) -> Result<CommandBufferAlloc, VulkanError>;
 
     /// Deallocates the given `allocation`.
     ///
@@ -258,29 +284,16 @@ impl StandardCommandBufferAllocator {
 
 unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
     #[inline]
-    fn allocate(
+    fn try_allocate(
         &self,
         queue_family_index: u32,
         level: CommandBufferLevel,
     ) -> Result<CommandBufferAlloc, Validated<VulkanError>> {
-        if !self
-            .device
-            .active_queue_family_indices()
-            .contains(&queue_family_index)
-        {
-            Err(Box::new(ValidationError {
-                context: "queue_family_index".into(),
-                problem: "is not active on the device".into(),
-                vuids: &["VUID-vkCreateCommandPool-queueFamilyIndex-01937"],
-                ..Default::default()
-            }))?;
-        }
-
         let entry_ptr = self.entry(queue_family_index);
         let entry = unsafe { &mut *entry_ptr };
 
         if entry.is_none() {
-            *entry = Some(Entry::new(
+            *entry = Some(Entry::try_new(
                 &self.device,
                 queue_family_index,
                 &self.buffer_count,
@@ -290,7 +303,34 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
 
         let entry = entry.as_mut().unwrap();
 
-        Ok(entry.allocate(queue_family_index, level, &self.buffer_count)?)
+        entry.try_allocate(queue_family_index, level, &self.buffer_count)
+    }
+
+    #[inline]
+    unsafe fn allocate_unchecked(
+        &self,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+    ) -> Result<CommandBufferAlloc, VulkanError> {
+        let entry_ptr = self.entry(queue_family_index);
+        let entry = unsafe { &mut *entry_ptr };
+
+        if entry.is_none() {
+            // SAFETY: Enforced by the caller.
+            *entry = Some(unsafe {
+                Entry::new_unchecked(
+                    &self.device,
+                    queue_family_index,
+                    &self.buffer_count,
+                    Arc::new(ArrayQueue::new(MAX_POOLS)),
+                )
+            }?);
+        }
+
+        let entry = entry.as_mut().unwrap();
+
+        // SAFETY: Enforced by the caller.
+        unsafe { entry.allocate_unchecked(queue_family_index, level, &self.buffer_count) }
     }
 
     #[inline]
@@ -340,12 +380,21 @@ unsafe impl CommandBufferAllocator for StandardCommandBufferAllocator {
 
 unsafe impl<T: CommandBufferAllocator + ?Sized> CommandBufferAllocator for Arc<T> {
     #[inline]
-    fn allocate(
+    fn try_allocate(
         &self,
         queue_family_index: u32,
         level: CommandBufferLevel,
     ) -> Result<CommandBufferAlloc, Validated<VulkanError>> {
-        (**self).allocate(queue_family_index, level)
+        (**self).try_allocate(queue_family_index, level)
+    }
+
+    #[inline]
+    unsafe fn allocate_unchecked(
+        &self,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+    ) -> Result<CommandBufferAlloc, VulkanError> {
+        unsafe { (**self).allocate_unchecked(queue_family_index, level) }
     }
 
     #[inline]
@@ -382,20 +431,100 @@ struct Entry {
 unsafe impl Send for Entry {}
 
 impl Entry {
-    fn new(
+    fn try_new(
+        device: &Arc<Device>,
+        queue_family_index: u32,
+        buffer_count: &[usize; 2],
+        pool_reserve: Arc<ArrayQueue<Arc<Pool>>>,
+    ) -> Result<Self, Validated<VulkanError>> {
+        Ok(Entry {
+            pool: Pool::try_new(device, queue_family_index, buffer_count, &pool_reserve)?,
+            allocations: [0; 2],
+            pool_reserve,
+        })
+    }
+
+    unsafe fn new_unchecked(
         device: &Arc<Device>,
         queue_family_index: u32,
         buffer_count: &[usize; 2],
         pool_reserve: Arc<ArrayQueue<Arc<Pool>>>,
     ) -> Result<Self, VulkanError> {
         Ok(Entry {
-            pool: Pool::new(device, queue_family_index, buffer_count, &pool_reserve)?,
+            // SAFETY: Enforced by the caller.
+            pool: unsafe {
+                Pool::new_unchecked(device, queue_family_index, buffer_count, &pool_reserve)
+            }?,
             allocations: [0; 2],
             pool_reserve,
         })
     }
 
-    fn allocate(
+    fn try_allocate(
+        &mut self,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+        buffer_count: &[usize; 2],
+    ) -> Result<CommandBufferAlloc, Validated<VulkanError>> {
+        if self.allocations[level as usize] >= buffer_count[level as usize] {
+            // This can happen if there's only ever one allocation alive at any point in time. In
+            // that case, when deallocating the last command buffer before reaching `buffer_count`,
+            // there will be 2 references to the pool (one here and one in the allocation) and so
+            // the pool won't be returned to the reserve when deallocating. However, since there
+            // are no other allocations alive, there would be no other allocations that could
+            // return it to the reserve. To avoid dropping the pool unnecessarily, we simply
+            // continue using it. In the case where there are other references, we drop ours, at
+            // which point an allocation still holding a reference will be able to put the pool
+            // into the reserve when deallocated.
+            //
+            // TODO: This can still run into the A/B/A problem causing the pool to be dropped.
+            if Arc::strong_count(&self.pool) == 1 {
+                // SAFETY: We checked that the pool has a single strong reference above, meaning
+                // that all the allocations we gave out must have been deallocated.
+                unsafe { self.pool.inner.try_reset(CommandPoolResetFlags::empty()) }?;
+
+                self.allocations = [0; 2];
+            } else {
+                if let Some(pool) = self.pool_reserve.pop() {
+                    // SAFETY: We checked that the pool has a single strong reference when
+                    // deallocating, meaning that all the allocations we gave out must have been
+                    // deallocated.
+                    unsafe { pool.inner.try_reset(CommandPoolResetFlags::empty()) }?;
+
+                    self.pool = pool;
+                    self.allocations = [0; 2];
+                } else {
+                    *self = Entry::try_new(
+                        self.pool.inner.device(),
+                        queue_family_index,
+                        buffer_count,
+                        self.pool_reserve.clone(),
+                    )?;
+                }
+            }
+        }
+
+        let Some(buffer_reserve) = self.pool.buffer_reserve[level as usize].as_ref() else {
+            return Err(Validated::ValidationError(Box::new(ValidationError {
+                problem: format!(
+                    "attempted to allocate a command buffer with level `{level:?}`, but the \
+                    command buffer pool for that level was configured to be empty",
+                )
+                .into(),
+                ..Default::default()
+            })));
+        };
+
+        self.allocations[level as usize] += 1;
+
+        Ok(CommandBufferAlloc {
+            inner: buffer_reserve.pop().unwrap(),
+            pool: self.pool.inner.clone(),
+            handle: AllocationHandle::from_ptr(Arc::into_raw(self.pool.clone()) as _),
+        })
+    }
+
+    unsafe fn allocate_unchecked(
         &mut self,
         queue_family_index: u32,
         level: CommandBufferLevel,
@@ -433,24 +562,23 @@ impl Entry {
                     self.pool = pool;
                     self.allocations = [0; 2];
                 } else {
-                    *self = Entry::new(
-                        self.pool.inner.device(),
-                        queue_family_index,
-                        buffer_count,
-                        self.pool_reserve.clone(),
-                    )?;
+                    // SAFETY: Enforced by the caller.
+                    *self = unsafe {
+                        Entry::new_unchecked(
+                            self.pool.inner.device(),
+                            queue_family_index,
+                            buffer_count,
+                            self.pool_reserve.clone(),
+                        )
+                    }?;
                 }
             }
         }
 
-        let buffer_reserve = self.pool.buffer_reserve[level as usize]
-            .as_ref()
-            .unwrap_or_else(|| {
-                panic!(
-                    "attempted to allocate a command buffer with level `{level:?}`, but the \
-                    command buffer pool for that level was configured to be empty",
-                )
-            });
+        let buffer_reserve = self.pool.buffer_reserve[level as usize].as_ref();
+
+        // SAFETY: Enforced by the caller.
+        let buffer_reserve = unsafe { buffer_reserve.unwrap_unchecked() };
 
         self.allocations[level as usize] += 1;
 
@@ -466,10 +594,8 @@ impl Entry {
         flags: CommandPoolResetFlags,
     ) -> Result<(), Validated<ResetCommandPoolError>> {
         if let Some(pool) = Arc::get_mut(&mut self.pool) {
-            unsafe { pool.inner.reset(flags) }.map_err(|err| match err {
-                Validated::Error(err) => Validated::Error(ResetCommandPoolError::VulkanError(err)),
-                Validated::ValidationError(err) => err.into(),
-            })?;
+            unsafe { pool.inner.try_reset(flags) }
+                .map_err(|err| err.map(ResetCommandPoolError::VulkanError))?;
 
             self.allocations = [0; 2];
 
@@ -491,20 +617,19 @@ struct Pool {
 }
 
 impl Pool {
-    fn new(
+    fn try_new(
         device: &Arc<Device>,
         queue_family_index: u32,
         buffer_counts: &[usize; 2],
         pool_reserve: &Arc<ArrayQueue<Arc<Self>>>,
-    ) -> Result<Arc<Self>, VulkanError> {
-        let inner = CommandPool::new(
+    ) -> Result<Arc<Self>, Validated<VulkanError>> {
+        let inner = CommandPool::try_new(
             device,
             &CommandPoolCreateInfo {
                 queue_family_index,
                 ..Default::default()
             },
-        )
-        .map_err(Validated::unwrap)?;
+        )?;
 
         let levels = [CommandBufferLevel::Primary, CommandBufferLevel::Secondary];
         let mut buffer_reserve = [None, None];
@@ -516,11 +641,60 @@ impl Pool {
 
             let pool = ArrayQueue::new(buffer_count);
 
-            for allocation in inner.allocate_command_buffers(&CommandBufferAllocateInfo {
+            let allocate_info = CommandBufferAllocateInfo {
                 level,
                 command_buffer_count: buffer_count.try_into().unwrap(),
                 ..Default::default()
-            })? {
+            };
+
+            for allocation in inner.try_allocate_command_buffers(&allocate_info)? {
+                let _ = pool.push(allocation);
+            }
+
+            buffer_reserve[level as usize] = Some(pool);
+        }
+
+        Ok(Arc::new(Pool {
+            inner: Arc::new(inner),
+            buffer_reserve,
+            pool_reserve: Arc::downgrade(pool_reserve),
+        }))
+    }
+
+    unsafe fn new_unchecked(
+        device: &Arc<Device>,
+        queue_family_index: u32,
+        buffer_counts: &[usize; 2],
+        pool_reserve: &Arc<ArrayQueue<Arc<Self>>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        // SAFETY: Enforced by the caller.
+        let inner = unsafe {
+            CommandPool::new_unchecked(
+                device,
+                &CommandPoolCreateInfo {
+                    queue_family_index,
+                    ..Default::default()
+                },
+            )
+        }?;
+
+        let levels = [CommandBufferLevel::Primary, CommandBufferLevel::Secondary];
+        let mut buffer_reserve = [None, None];
+
+        for (level, &buffer_count) in levels.into_iter().zip(buffer_counts) {
+            if buffer_count == 0 {
+                continue;
+            }
+
+            let pool = ArrayQueue::new(buffer_count);
+
+            let allocate_info = CommandBufferAllocateInfo {
+                level,
+                command_buffer_count: buffer_count.try_into().unwrap(),
+                ..Default::default()
+            };
+
+            for allocation in unsafe { inner.allocate_command_buffers_unchecked(&allocate_info) }? {
                 let _ = pool.push(allocation);
             }
 

--- a/vulkano/src/command_buffer/auto/builder.rs
+++ b/vulkano/src/command_buffer/auto/builder.rs
@@ -383,7 +383,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                     };
 
                     #[cfg(debug_assertions)]
-                    unsafe { self.inner.pipeline_barrier(&dependency_info_raw) }
+                    unsafe { self.inner.try_pipeline_barrier(&dependency_info_raw) }
                         .expect("bug in Vulkano");
 
                     #[cfg(not(debug_assertions))]
@@ -452,7 +452,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 };
 
                 #[cfg(debug_assertions)]
-                unsafe { self.inner.pipeline_barrier(&dependency_info_raw) }
+                unsafe { self.inner.try_pipeline_barrier(&dependency_info_raw) }
                     .expect("bug in Vulkano");
 
                 #[cfg(not(debug_assertions))]

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -20,7 +20,17 @@ use std::sync::Arc;
 
 impl RecordingCommandBuffer {
     #[inline]
+    #[track_caller]
     pub unsafe fn build_acceleration_structure(
+        &mut self,
+        info: &AccelerationStructureBuildGeometryInfo,
+        build_range_infos: &[AccelerationStructureBuildRangeInfo],
+    ) -> &mut Self {
+        unsafe { self.try_build_acceleration_structure(info, build_range_infos) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_build_acceleration_structure(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
         build_range_infos: &[AccelerationStructureBuildRangeInfo],
@@ -795,7 +805,27 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn build_acceleration_structure_indirect(
+        &mut self,
+        info: &AccelerationStructureBuildGeometryInfo,
+        indirect_buffer: &Subbuffer<[u8]>,
+        stride: u32,
+        max_primitive_counts: &[u32],
+    ) -> &mut Self {
+        unsafe {
+            self.try_build_acceleration_structure_indirect(
+                info,
+                indirect_buffer,
+                stride,
+                max_primitive_counts,
+            )
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_build_acceleration_structure_indirect(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
         indirect_buffer: &Subbuffer<[u8]>,
@@ -1422,7 +1452,16 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn copy_acceleration_structure(
+        &mut self,
+        info: &CopyAccelerationStructureInfo,
+    ) -> &mut Self {
+        unsafe { self.try_copy_acceleration_structure(info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_copy_acceleration_structure(
         &mut self,
         info: &CopyAccelerationStructureInfo,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1472,7 +1511,16 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn copy_acceleration_structure_to_memory(
+        &mut self,
+        info: &CopyAccelerationStructureToMemoryInfo,
+    ) -> &mut Self {
+        unsafe { self.try_copy_acceleration_structure_to_memory(info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_copy_acceleration_structure_to_memory(
         &mut self,
         info: &CopyAccelerationStructureToMemoryInfo,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1531,7 +1579,16 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn copy_memory_to_acceleration_structure(
+        &mut self,
+        info: &CopyMemoryToAccelerationStructureInfo,
+    ) -> &mut Self {
+        unsafe { self.try_copy_memory_to_acceleration_structure(info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_copy_memory_to_acceleration_structure(
         &mut self,
         info: &CopyMemoryToAccelerationStructureInfo,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1590,7 +1647,25 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn write_acceleration_structures_properties(
+        &mut self,
+        acceleration_structures: &[Arc<AccelerationStructure>],
+        query_pool: &QueryPool,
+        first_query: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_write_acceleration_structures_properties(
+                acceleration_structures,
+                query_pool,
+                first_query,
+            )
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_write_acceleration_structures_properties(
         &mut self,
         acceleration_structures: &[Arc<AccelerationStructure>],
         query_pool: &QueryPool,

--- a/vulkano/src/command_buffer/commands/bind_push.rs
+++ b/vulkano/src/command_buffer/commands/bind_push.rs
@@ -20,7 +20,29 @@ use std::{cmp::min, ffi::c_void, ptr};
 
 impl RecordingCommandBuffer {
     #[inline]
+    #[track_caller]
     pub unsafe fn bind_descriptor_sets(
+        &mut self,
+        pipeline_bind_point: PipelineBindPoint,
+        layout: &PipelineLayout,
+        first_set: u32,
+        descriptor_sets: &[&RawDescriptorSet],
+        dynamic_offsets: &[u32],
+    ) -> &mut Self {
+        unsafe {
+            self.try_bind_descriptor_sets(
+                pipeline_bind_point,
+                layout,
+                first_set,
+                descriptor_sets,
+                dynamic_offsets,
+            )
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_bind_descriptor_sets(
         &mut self,
         pipeline_bind_point: PipelineBindPoint,
         layout: &PipelineLayout,
@@ -306,7 +328,19 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn bind_index_buffer(
+        &mut self,
+        buffer: &Buffer,
+        offset: DeviceSize,
+        size: Option<DeviceSize>,
+        index_type: IndexType,
+    ) -> &mut Self {
+        unsafe { self.try_bind_index_buffer(buffer, offset, size, index_type) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_bind_index_buffer(
         &mut self,
         buffer: &Buffer,
         offset: DeviceSize,
@@ -431,7 +465,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn bind_pipeline_compute(
+    #[track_caller]
+    pub unsafe fn bind_pipeline_compute(&mut self, pipeline: &ComputePipeline) -> &mut Self {
+        unsafe { self.try_bind_pipeline_compute(pipeline) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_bind_pipeline_compute(
         &mut self,
         pipeline: &ComputePipeline,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -482,7 +522,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn bind_pipeline_graphics(
+    #[track_caller]
+    pub unsafe fn bind_pipeline_graphics(&mut self, pipeline: &GraphicsPipeline) -> &mut Self {
+        unsafe { self.try_bind_pipeline_graphics(pipeline) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_bind_pipeline_graphics(
         &mut self,
         pipeline: &GraphicsPipeline,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -532,11 +578,17 @@ impl RecordingCommandBuffer {
         self
     }
 
-    pub unsafe fn bind_pipeline_ray_tracing(
+    #[track_caller]
+    pub unsafe fn bind_pipeline_ray_tracing(&mut self, pipeline: &RayTracingPipeline) -> &mut Self {
+        unsafe { self.try_bind_pipeline_ray_tracing(pipeline) }.unwrap()
+    }
+
+    pub unsafe fn try_bind_pipeline_ray_tracing(
         &mut self,
         pipeline: &RayTracingPipeline,
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_bind_pipeline_ray_tracing(pipeline)?;
+
         Ok(unsafe { self.bind_pipeline_ray_tracing_unchecked(pipeline) })
     }
 
@@ -584,7 +636,21 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn bind_vertex_buffers(
+        &mut self,
+        first_binding: u32,
+        buffers: &[&Buffer],
+        offsets: &[DeviceSize],
+        sizes: &[DeviceSize],
+        strides: &[DeviceSize],
+    ) -> &mut Self {
+        unsafe { self.try_bind_vertex_buffers(first_binding, buffers, offsets, sizes, strides) }
+            .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_bind_vertex_buffers(
         &mut self,
         first_binding: u32,
         buffers: &[&Buffer],
@@ -783,7 +849,18 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn push_constants(
+        &mut self,
+        layout: &PipelineLayout,
+        offset: u32,
+        values: &(impl BufferContents + ?Sized),
+    ) -> &mut Self {
+        unsafe { self.try_push_constants(layout, offset, values) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_push_constants(
         &mut self,
         layout: &PipelineLayout,
         offset: u32,
@@ -955,7 +1032,22 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn push_descriptor_set(
+        &mut self,
+        pipeline_bind_point: PipelineBindPoint,
+        pipeline: &PipelineLayout,
+        set: u32,
+        descriptor_writes: &[WriteDescriptorSet<'_>],
+    ) -> &mut Self {
+        unsafe {
+            self.try_push_descriptor_set(pipeline_bind_point, pipeline, set, descriptor_writes)
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_push_descriptor_set(
         &mut self,
         pipeline_bind_point: PipelineBindPoint,
         pipeline: &PipelineLayout,

--- a/vulkano/src/command_buffer/commands/clear.rs
+++ b/vulkano/src/command_buffer/commands/clear.rs
@@ -12,7 +12,13 @@ use std::ffi::c_void;
 
 impl RecordingCommandBuffer {
     #[inline]
-    pub unsafe fn clear_color_image(
+    #[track_caller]
+    pub unsafe fn clear_color_image(&mut self, clear_info: &ClearColorImageInfo<'_>) -> &mut Self {
+        unsafe { self.try_clear_color_image(clear_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_clear_color_image(
         &mut self,
         clear_info: &ClearColorImageInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -70,7 +76,16 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn clear_depth_stencil_image(
+        &mut self,
+        clear_info: &ClearDepthStencilImageInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_clear_depth_stencil_image(clear_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_clear_depth_stencil_image(
         &mut self,
         clear_info: &ClearDepthStencilImageInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -128,7 +143,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn fill_buffer(
+    #[track_caller]
+    pub unsafe fn fill_buffer(&mut self, fill_info: &FillBufferInfo<'_>) -> &mut Self {
+        unsafe { self.try_fill_buffer(fill_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_fill_buffer(
         &mut self,
         fill_info: &FillBufferInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -198,7 +219,18 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn update_buffer(
+        &mut self,
+        dst_buffer: &Buffer,
+        dst_offset: DeviceSize,
+        data: &(impl BufferContents + ?Sized),
+    ) -> &mut Self {
+        unsafe { self.try_update_buffer(dst_buffer, dst_offset, data) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_update_buffer(
         &mut self,
         dst_buffer: &Buffer,
         dst_offset: DeviceSize,

--- a/vulkano/src/command_buffer/commands/copy.rs
+++ b/vulkano/src/command_buffer/commands/copy.rs
@@ -15,7 +15,13 @@ use std::cmp::{max, min};
 
 impl RecordingCommandBuffer {
     #[inline]
-    pub unsafe fn copy_buffer(
+    #[track_caller]
+    pub unsafe fn copy_buffer(&mut self, copy_buffer_info: &CopyBufferInfo<'_>) -> &mut Self {
+        unsafe { self.try_copy_buffer(copy_buffer_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_copy_buffer(
         &mut self,
         copy_buffer_info: &CopyBufferInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -94,7 +100,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn copy_image(
+    #[track_caller]
+    pub unsafe fn copy_image(&mut self, copy_image_info: &CopyImageInfo<'_>) -> &mut Self {
+        unsafe { self.try_copy_image(copy_image_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_copy_image(
         &mut self,
         copy_image_info: &CopyImageInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -447,6 +459,14 @@ impl RecordingCommandBuffer {
     pub unsafe fn copy_buffer_to_image(
         &mut self,
         copy_buffer_to_image_info: &CopyBufferToImageInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_copy_buffer_to_image(copy_buffer_to_image_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_copy_buffer_to_image(
+        &mut self,
+        copy_buffer_to_image_info: &CopyBufferToImageInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_copy_buffer_to_image(copy_buffer_to_image_info)?;
 
@@ -720,7 +740,16 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn copy_image_to_buffer(
+        &mut self,
+        copy_image_to_buffer_info: &CopyImageToBufferInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_copy_image_to_buffer(copy_image_to_buffer_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_copy_image_to_buffer(
         &mut self,
         copy_image_to_buffer_info: &CopyImageToBufferInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -975,7 +1004,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn blit_image(
+    #[track_caller]
+    pub unsafe fn blit_image(&mut self, blit_image_info: &BlitImageInfo<'_>) -> &mut Self {
+        unsafe { self.try_blit_image(blit_image_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_blit_image(
         &mut self,
         blit_image_info: &BlitImageInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1057,7 +1092,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn resolve_image(
+    #[track_caller]
+    pub unsafe fn resolve_image(&mut self, resolve_image_info: &ResolveImageInfo<'_>) -> &mut Self {
+        unsafe { self.try_resolve_image(resolve_image_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_resolve_image(
         &mut self,
         resolve_image_info: &ResolveImageInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {

--- a/vulkano/src/command_buffer/commands/debug.rs
+++ b/vulkano/src/command_buffer/commands/debug.rs
@@ -7,7 +7,13 @@ use crate::{
 
 impl RecordingCommandBuffer {
     #[inline]
-    pub unsafe fn begin_debug_utils_label(
+    #[track_caller]
+    pub unsafe fn begin_debug_utils_label(&mut self, label_info: &DebugUtilsLabel) -> &mut Self {
+        unsafe { self.try_begin_debug_utils_label(label_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_begin_debug_utils_label(
         &mut self,
         label_info: &DebugUtilsLabel,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -68,7 +74,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn end_debug_utils_label(&mut self) -> Result<&mut Self, Box<ValidationError>> {
+    #[track_caller]
+    pub unsafe fn end_debug_utils_label(&mut self) -> &mut Self {
+        unsafe { self.try_end_debug_utils_label() }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_end_debug_utils_label(&mut self) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_end_debug_utils_label()?;
 
         Ok(unsafe { self.end_debug_utils_label_unchecked() })
@@ -115,7 +127,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn insert_debug_utils_label(
+    #[track_caller]
+    pub unsafe fn insert_debug_utils_label(&mut self, label_info: &DebugUtilsLabel) -> &mut Self {
+        unsafe { self.try_insert_debug_utils_label(label_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_insert_debug_utils_label(
         &mut self,
         label_info: &DebugUtilsLabel,
     ) -> Result<&mut Self, Box<ValidationError>> {

--- a/vulkano/src/command_buffer/commands/dynamic_state.rs
+++ b/vulkano/src/command_buffer/commands/dynamic_state.rs
@@ -17,7 +17,13 @@ use smallvec::SmallVec;
 
 impl RecordingCommandBuffer {
     #[inline]
-    pub unsafe fn set_blend_constants(
+    #[track_caller]
+    pub unsafe fn set_blend_constants(&mut self, constants: [f32; 4]) -> &mut Self {
+        unsafe { self.try_set_blend_constants(constants) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_blend_constants(
         &mut self,
         constants: [f32; 4],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -56,7 +62,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_color_write_enable(
+    #[track_caller]
+    pub unsafe fn set_color_write_enable(&mut self, enables: &[bool]) -> &mut Self {
+        unsafe { self.try_set_color_write_enable(enables) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_color_write_enable(
         &mut self,
         enables: &[bool],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -121,7 +133,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_cull_mode(
+    #[track_caller]
+    pub unsafe fn set_cull_mode(&mut self, cull_mode: CullMode) -> &mut Self {
+        unsafe { self.try_set_cull_mode(cull_mode) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_cull_mode(
         &mut self,
         cull_mode: CullMode,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -188,7 +206,18 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_depth_bias(
+        &mut self,
+        constant_factor: f32,
+        clamp: f32,
+        slope_factor: f32,
+    ) -> &mut Self {
+        unsafe { self.try_set_depth_bias(constant_factor, clamp, slope_factor) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_depth_bias(
         &mut self,
         constant_factor: f32,
         clamp: f32,
@@ -249,7 +278,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_depth_bias_enable(
+    #[track_caller]
+    pub unsafe fn set_depth_bias_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_depth_bias_enable(enable) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_depth_bias_enable(
         &mut self,
         enable: bool,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -309,7 +344,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_depth_bounds(
+        &mut self,
+        min_depth_bounds: f32,
+        max_depth_bounds: f32,
+    ) -> &mut Self {
+        unsafe { self.try_set_depth_bounds(min_depth_bounds, max_depth_bounds) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_depth_bounds(
         &mut self,
         min_depth_bounds: f32,
         max_depth_bounds: f32,
@@ -384,7 +429,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_depth_bounds_test_enable(
+    #[track_caller]
+    pub unsafe fn set_depth_bounds_test_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_depth_bounds_test_enable(enable) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_depth_bounds_test_enable(
         &mut self,
         enable: bool,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -446,7 +497,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_depth_compare_op(
+    #[track_caller]
+    pub unsafe fn set_depth_compare_op(&mut self, compare_op: CompareOp) -> &mut Self {
+        unsafe { self.try_set_depth_compare_op(compare_op) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_depth_compare_op(
         &mut self,
         compare_op: CompareOp,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -513,7 +570,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_depth_test_enable(
+    #[track_caller]
+    pub unsafe fn set_depth_test_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_depth_test_enable(enable) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_depth_test_enable(
         &mut self,
         enable: bool,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -575,7 +638,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_depth_write_enable(
+    #[track_caller]
+    pub unsafe fn set_depth_write_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_depth_write_enable(enable) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_depth_write_enable(
         &mut self,
         enable: bool,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -635,7 +704,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_discard_rectangle(
+        &mut self,
+        first_rectangle: u32,
+        rectangles: &[Scissor],
+    ) -> &mut Self {
+        unsafe { self.try_set_discard_rectangle(first_rectangle, rectangles) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_discard_rectangle(
         &mut self,
         first_rectangle: u32,
         rectangles: &[Scissor],
@@ -716,7 +795,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_front_face(
+    #[track_caller]
+    pub unsafe fn set_front_face(&mut self, face: FrontFace) -> &mut Self {
+        unsafe { self.try_set_front_face(face) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_front_face(
         &mut self,
         face: FrontFace,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -780,7 +865,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_line_stipple(
+    #[track_caller]
+    pub unsafe fn set_line_stipple(&mut self, factor: u32, pattern: u16) -> &mut Self {
+        unsafe { self.try_set_line_stipple(factor, pattern) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_line_stipple(
         &mut self,
         factor: u32,
         pattern: u16,
@@ -841,7 +932,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_line_width(
+    #[track_caller]
+    pub unsafe fn set_line_width(&mut self, line_width: f32) -> &mut Self {
+        unsafe { self.try_set_line_width(line_width) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_line_width(
         &mut self,
         line_width: f32,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -891,7 +988,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_logic_op(
+    #[track_caller]
+    pub unsafe fn set_logic_op(&mut self, logic_op: LogicOp) -> &mut Self {
+        unsafe { self.try_set_logic_op(logic_op) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_logic_op(
         &mut self,
         logic_op: LogicOp,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -951,7 +1054,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_patch_control_points(
+    #[track_caller]
+    pub unsafe fn set_patch_control_points(&mut self, num: u32) -> &mut Self {
+        unsafe { self.try_set_patch_control_points(num) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_patch_control_points(
         &mut self,
         num: u32,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1027,7 +1136,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_primitive_restart_enable(
+    #[track_caller]
+    pub unsafe fn set_primitive_restart_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_primitive_restart_enable(enable) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_primitive_restart_enable(
         &mut self,
         enable: bool,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1089,7 +1204,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_primitive_topology(
+    #[track_caller]
+    pub unsafe fn set_primitive_topology(&mut self, topology: PrimitiveTopology) -> &mut Self {
+        unsafe { self.try_set_primitive_topology(topology) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_primitive_topology(
         &mut self,
         topology: PrimitiveTopology,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1204,7 +1325,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_rasterizer_discard_enable(
+    #[track_caller]
+    pub unsafe fn set_rasterizer_discard_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_rasterizer_discard_enable(enable) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_rasterizer_discard_enable(
         &mut self,
         enable: bool,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1266,7 +1393,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_scissor(
+    #[track_caller]
+    pub unsafe fn set_scissor(&mut self, first_scissor: u32, scissors: &[Scissor]) -> &mut Self {
+        unsafe { self.try_set_scissor(first_scissor, scissors) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_scissor(
         &mut self,
         first_scissor: u32,
         scissors: &[Scissor],
@@ -1361,7 +1494,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_scissor_with_count(
+    #[track_caller]
+    pub unsafe fn set_scissor_with_count(&mut self, scissors: &[Scissor]) -> &mut Self {
+        unsafe { self.try_set_scissor_with_count(scissors) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_scissor_with_count(
         &mut self,
         scissors: &[Scissor],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1460,7 +1599,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_stencil_compare_mask(
+        &mut self,
+        faces: StencilFaces,
+        compare_mask: u32,
+    ) -> &mut Self {
+        unsafe { self.try_set_stencil_compare_mask(faces, compare_mask) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_stencil_compare_mask(
         &mut self,
         faces: StencilFaces,
         compare_mask: u32,
@@ -1512,7 +1661,21 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_stencil_op(
+        &mut self,
+        faces: StencilFaces,
+        fail_op: StencilOp,
+        pass_op: StencilOp,
+        depth_fail_op: StencilOp,
+        compare_op: CompareOp,
+    ) -> &mut Self {
+        unsafe { self.try_set_stencil_op(faces, fail_op, pass_op, depth_fail_op, compare_op) }
+            .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_stencil_op(
         &mut self,
         faces: StencilFaces,
         fail_op: StencilOp,
@@ -1631,7 +1794,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_stencil_reference(
+        &mut self,
+        faces: StencilFaces,
+        reference: u32,
+    ) -> &mut Self {
+        unsafe { self.try_set_stencil_reference(faces, reference) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_stencil_reference(
         &mut self,
         faces: StencilFaces,
         reference: u32,
@@ -1681,7 +1854,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_stencil_test_enable(
+    #[track_caller]
+    pub unsafe fn set_stencil_test_enable(&mut self, enable: bool) -> &mut Self {
+        unsafe { self.try_set_stencil_test_enable(enable) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_stencil_test_enable(
         &mut self,
         enable: bool,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1741,7 +1920,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_stencil_write_mask(
+        &mut self,
+        faces: StencilFaces,
+        write_mask: u32,
+    ) -> &mut Self {
+        unsafe { self.try_set_stencil_write_mask(faces, write_mask) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_stencil_write_mask(
         &mut self,
         faces: StencilFaces,
         write_mask: u32,
@@ -1791,7 +1980,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_vertex_input(
+    #[track_caller]
+    pub unsafe fn set_vertex_input(&mut self, vertex_input_state: &VertexInputState) -> &mut Self {
+        unsafe { self.try_set_vertex_input(vertex_input_state) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_vertex_input(
         &mut self,
         vertex_input_state: &VertexInputState,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1879,7 +2074,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_viewport(
+        &mut self,
+        first_viewport: u32,
+        viewports: &[Viewport],
+    ) -> &mut Self {
+        unsafe { self.try_set_viewport(first_viewport, viewports) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_viewport(
         &mut self,
         first_viewport: u32,
         viewports: &[Viewport],
@@ -1974,7 +2179,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn set_viewport_with_count(
+    #[track_caller]
+    pub unsafe fn set_viewport_with_count(&mut self, viewports: &[Viewport]) -> &mut Self {
+        unsafe { self.try_set_viewport_with_count(viewports) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_viewport_with_count(
         &mut self,
         viewports: &[Viewport],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -2076,7 +2287,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_conservative_rasterization_mode(
+        &mut self,
+        conservative_rasterization_mode: ConservativeRasterizationMode,
+    ) -> &mut Self {
+        unsafe { self.try_set_conservative_rasterization_mode(conservative_rasterization_mode) }
+            .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_conservative_rasterization_mode(
         &mut self,
         conservative_rasterization_mode: ConservativeRasterizationMode,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -2142,7 +2363,19 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_extra_primitive_overestimation_size(
+        &mut self,
+        extra_primitive_overestimation_size: f32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_set_extra_primitive_overestimation_size(extra_primitive_overestimation_size)
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_extra_primitive_overestimation_size(
         &mut self,
         extra_primitive_overestimation_size: f32,
     ) -> Result<&mut Self, Box<ValidationError>> {

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -11,7 +11,13 @@ use crate::{
 
 impl RecordingCommandBuffer {
     #[inline]
-    pub unsafe fn dispatch(
+    #[track_caller]
+    pub unsafe fn dispatch(&mut self, group_counts: [u32; 3]) -> &mut Self {
+        unsafe { self.try_dispatch(group_counts) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_dispatch(
         &mut self,
         group_counts: [u32; 3],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -86,7 +92,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn dispatch_indirect(
+    #[track_caller]
+    pub unsafe fn dispatch_indirect(&mut self, buffer: &Buffer, offset: DeviceSize) -> &mut Self {
+        unsafe { self.try_dispatch_indirect(buffer, offset) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_dispatch_indirect(
         &mut self,
         buffer: &Buffer,
         offset: DeviceSize,
@@ -165,7 +177,20 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn draw(
+        &mut self,
+        vertex_count: u32,
+        instance_count: u32,
+        first_vertex: u32,
+        first_instance: u32,
+    ) -> &mut Self {
+        unsafe { self.try_draw(vertex_count, instance_count, first_vertex, first_instance) }
+            .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw(
         &mut self,
         vertex_count: u32,
         instance_count: u32,
@@ -226,7 +251,19 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn draw_indirect(
+        &mut self,
+        buffer: &Buffer,
+        offset: DeviceSize,
+        draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe { self.try_draw_indirect(buffer, offset, draw_count, stride) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw_indirect(
         &mut self,
         buffer: &Buffer,
         offset: DeviceSize,
@@ -369,7 +406,31 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn draw_indirect_count(
+        &mut self,
+        buffer: &Buffer,
+        offset: DeviceSize,
+        count_buffer: &Buffer,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_draw_indirect_count(
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_draw_count,
+                stride,
+            )
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw_indirect_count(
         &mut self,
         buffer: &Buffer,
         offset: DeviceSize,
@@ -560,7 +621,29 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn draw_indexed(
+        &mut self,
+        index_count: u32,
+        instance_count: u32,
+        first_index: u32,
+        vertex_offset: i32,
+        first_instance: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_draw_indexed(
+                index_count,
+                instance_count,
+                first_index,
+                vertex_offset,
+                first_instance,
+            )
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw_indexed(
         &mut self,
         index_count: u32,
         instance_count: u32,
@@ -637,7 +720,19 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn draw_indexed_indirect(
+        &mut self,
+        buffer: &Buffer,
+        offset: DeviceSize,
+        draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe { self.try_draw_indexed_indirect(buffer, offset, draw_count, stride) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw_indexed_indirect(
         &mut self,
         buffer: &Buffer,
         offset: DeviceSize,
@@ -786,7 +881,31 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        buffer: &Buffer,
+        offset: DeviceSize,
+        count_buffer: &Buffer,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_draw_indexed_indirect_count(
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_draw_count,
+                stride,
+            )
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw_indexed_indirect_count(
         &mut self,
         buffer: &Buffer,
         offset: DeviceSize,
@@ -979,7 +1098,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn draw_mesh_tasks(
+    #[track_caller]
+    pub unsafe fn draw_mesh_tasks(&mut self, group_counts: [u32; 3]) -> &mut Self {
+        unsafe { self.try_draw_mesh_tasks(group_counts) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw_mesh_tasks(
         &mut self,
         group_counts: [u32; 3],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -1034,7 +1159,19 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        buffer: &Buffer,
+        offset: DeviceSize,
+        draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe { self.try_draw_mesh_tasks_indirect(buffer, offset, draw_count, stride) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw_mesh_tasks_indirect(
         &mut self,
         buffer: &Buffer,
         offset: DeviceSize,
@@ -1197,7 +1334,31 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        buffer: &Buffer,
+        offset: DeviceSize,
+        count_buffer: &Buffer,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> &mut Self {
+        unsafe {
+            self.try_draw_mesh_tasks_indirect_count(
+                buffer,
+                offset,
+                count_buffer,
+                count_buffer_offset,
+                max_draw_count,
+                stride,
+            )
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_draw_mesh_tasks_indirect_count(
         &mut self,
         buffer: &Buffer,
         offset: DeviceSize,
@@ -1375,7 +1536,16 @@ impl RecordingCommandBuffer {
         self
     }
 
+    #[track_caller]
     pub unsafe fn trace_rays(
+        &mut self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        dimensions: [u32; 3],
+    ) -> &mut Self {
+        unsafe { self.try_trace_rays(shader_binding_table_addresses, dimensions) }.unwrap()
+    }
+
+    pub unsafe fn try_trace_rays(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         dimensions: [u32; 3],

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -10,7 +10,18 @@ use ash::vk;
 
 impl RecordingCommandBuffer {
     #[inline]
+    #[track_caller]
     pub unsafe fn begin_query(
+        &mut self,
+        query_pool: &QueryPool,
+        query: u32,
+        flags: QueryControlFlags,
+    ) -> &mut Self {
+        unsafe { self.try_begin_query(query_pool, query, flags) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_begin_query(
         &mut self,
         query_pool: &QueryPool,
         query: u32,
@@ -187,7 +198,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn end_query(
+    #[track_caller]
+    pub unsafe fn end_query(&mut self, query_pool: &QueryPool, query: u32) -> &mut Self {
+        unsafe { self.try_end_query(query_pool, query) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_end_query(
         &mut self,
         query_pool: &QueryPool,
         query: u32,
@@ -244,7 +261,18 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn write_timestamp(
+        &mut self,
+        query_pool: &QueryPool,
+        query: u32,
+        stage: PipelineStage,
+    ) -> &mut Self {
+        unsafe { self.try_write_timestamp(query_pool, query, stage) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_write_timestamp(
         &mut self,
         query_pool: &QueryPool,
         query: u32,
@@ -517,7 +545,32 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn copy_query_pool_results<T>(
+        &mut self,
+        query_pool: &QueryPool,
+        first_query: u32,
+        query_count: u32,
+        destination: &Subbuffer<[T]>,
+        flags: QueryResultFlags,
+    ) -> &mut Self
+    where
+        T: QueryResultElement,
+    {
+        unsafe {
+            self.try_copy_query_pool_results(
+                query_pool,
+                first_query,
+                query_count,
+                destination,
+                flags,
+            )
+        }
+        .unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_copy_query_pool_results<T>(
         &mut self,
         query_pool: &QueryPool,
         first_query: u32,
@@ -672,7 +725,18 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn reset_query_pool(
+        &mut self,
+        query_pool: &QueryPool,
+        first_query: u32,
+        query_count: u32,
+    ) -> &mut Self {
+        unsafe { self.try_reset_query_pool(query_pool, first_query, query_count) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_reset_query_pool(
         &mut self,
         query_pool: &QueryPool,
         first_query: u32,

--- a/vulkano/src/command_buffer/commands/render_pass.rs
+++ b/vulkano/src/command_buffer/commands/render_pass.rs
@@ -15,7 +15,17 @@ use smallvec::SmallVec;
 
 impl RecordingCommandBuffer {
     #[inline]
+    #[track_caller]
     pub unsafe fn begin_render_pass(
+        &mut self,
+        render_pass_begin_info: &RenderPassBeginInfo<'_>,
+        subpass_begin_info: &SubpassBeginInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_begin_render_pass(render_pass_begin_info, subpass_begin_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_begin_render_pass(
         &mut self,
         render_pass_begin_info: &RenderPassBeginInfo<'_>,
         subpass_begin_info: &SubpassBeginInfo<'_>,
@@ -412,7 +422,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn next_subpass(
+        &mut self,
+        subpass_end_info: &SubpassEndInfo<'_>,
+        subpass_begin_info: &SubpassBeginInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_next_subpass(subpass_end_info, subpass_begin_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_next_subpass(
         &mut self,
         subpass_end_info: &SubpassEndInfo<'_>,
         subpass_begin_info: &SubpassBeginInfo<'_>,
@@ -502,7 +522,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn end_render_pass(
+    #[track_caller]
+    pub unsafe fn end_render_pass(&mut self, subpass_end_info: &SubpassEndInfo<'_>) -> &mut Self {
+        unsafe { self.try_end_render_pass(subpass_end_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_end_render_pass(
         &mut self,
         subpass_end_info: &SubpassEndInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -576,7 +602,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn begin_rendering(
+    #[track_caller]
+    pub unsafe fn begin_rendering(&mut self, rendering_info: &RenderingInfo<'_>) -> &mut Self {
+        unsafe { self.try_begin_rendering(rendering_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_begin_rendering(
         &mut self,
         rendering_info: &RenderingInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -676,7 +708,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn end_rendering(&mut self) -> Result<&mut Self, Box<ValidationError>> {
+    #[track_caller]
+    pub unsafe fn end_rendering(&mut self) -> &mut Self {
+        unsafe { self.try_end_rendering() }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_end_rendering(&mut self) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_end_rendering()?;
 
         Ok(unsafe { self.end_rendering_unchecked() })
@@ -714,7 +752,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn clear_attachments(
+        &mut self,
+        attachments: &[ClearAttachment],
+        rects: &[ClearRect],
+    ) -> &mut Self {
+        unsafe { self.try_clear_attachments(attachments, rects) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_clear_attachments(
         &mut self,
         attachments: &[ClearAttachment],
         rects: &[ClearRect],

--- a/vulkano/src/command_buffer/commands/secondary.rs
+++ b/vulkano/src/command_buffer/commands/secondary.rs
@@ -11,7 +11,13 @@ use std::cmp::min;
 
 impl RecordingCommandBuffer {
     #[inline]
-    pub unsafe fn execute_commands(
+    #[track_caller]
+    pub unsafe fn execute_commands(&mut self, command_buffers: &[&CommandBuffer]) -> &mut Self {
+        unsafe { self.try_execute_commands(command_buffers) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_execute_commands(
         &mut self,
         command_buffers: &[&CommandBuffer],
     ) -> Result<&mut Self, Box<ValidationError>> {

--- a/vulkano/src/command_buffer/commands/sync.rs
+++ b/vulkano/src/command_buffer/commands/sync.rs
@@ -15,7 +15,13 @@ use smallvec::SmallVec;
 
 impl RecordingCommandBuffer {
     #[inline]
-    pub unsafe fn pipeline_barrier(
+    #[track_caller]
+    pub unsafe fn pipeline_barrier(&mut self, dependency_info: &DependencyInfo<'_>) -> &mut Self {
+        unsafe { self.try_pipeline_barrier(dependency_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_pipeline_barrier(
         &mut self,
         dependency_info: &DependencyInfo<'_>,
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -256,7 +262,17 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
+    #[track_caller]
     pub unsafe fn set_event(
+        &mut self,
+        event: &Event,
+        dependency_info: &DependencyInfo<'_>,
+    ) -> &mut Self {
+        unsafe { self.try_set_event(event, dependency_info) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_set_event(
         &mut self,
         event: &Event,
         dependency_info: &DependencyInfo<'_>,
@@ -492,7 +508,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn wait_events(
+    #[track_caller]
+    pub unsafe fn wait_events(&mut self, events: &[(&Event, &DependencyInfo<'_>)]) -> &mut Self {
+        unsafe { self.try_wait_events(events) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_wait_events(
         &mut self,
         events: &[(&Event, &DependencyInfo<'_>)],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -764,7 +786,13 @@ impl RecordingCommandBuffer {
     }
 
     #[inline]
-    pub unsafe fn reset_event(
+    #[track_caller]
+    pub unsafe fn reset_event(&mut self, event: &Event, stages: PipelineStages) -> &mut Self {
+        unsafe { self.try_reset_event(event, stages) }.unwrap()
+    }
+
+    #[inline]
+    pub unsafe fn try_reset_event(
         &mut self,
         event: &Event,
         stages: PipelineStages,

--- a/vulkano/src/command_buffer/pool.rs
+++ b/vulkano/src/command_buffer/pool.rs
@@ -39,8 +39,28 @@ pub struct CommandPool {
 }
 
 impl CommandPool {
-    /// Creates a new `CommandPool`.
+    /// Creates a new `CommandPool`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[track_caller]
     pub fn new(
+        device: &Arc<Device>,
+        create_info: &CommandPoolCreateInfo<'_>,
+    ) -> Result<CommandPool, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new `CommandPool`.
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &CommandPoolCreateInfo<'_>,
     ) -> Result<CommandPool, Validated<VulkanError>> {
@@ -128,13 +148,39 @@ impl CommandPool {
         self.queue_family_index
     }
 
+    /// Resets the pool, which resets all the command buffers that were allocated from it,
+    /// panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_reset().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - The command buffers allocated from this pool must not be in the pending state.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_reset`] returns a [`ValidationError`].
+    ///
+    /// [`try_reset`]: Self::try_reset
+    #[inline]
+    #[track_caller]
+    pub unsafe fn reset(&self, flags: CommandPoolResetFlags) -> Result<(), VulkanError> {
+        match unsafe { self.try_reset(flags) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Resets the pool, which resets all the command buffers that were allocated from it.
     ///
     /// # Safety
     ///
     /// - The command buffers allocated from this pool must not be in the pending state.
     #[inline]
-    pub unsafe fn reset(&self, flags: CommandPoolResetFlags) -> Result<(), Validated<VulkanError>> {
+    pub unsafe fn try_reset(
+        &self,
+        flags: CommandPoolResetFlags,
+    ) -> Result<(), Validated<VulkanError>> {
         self.validate_reset(flags)?;
 
         Ok(unsafe { self.reset_unchecked(flags) }?)
@@ -159,9 +205,48 @@ impl CommandPool {
         Ok(())
     }
 
+    /// Allocates command buffers, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_allocate_command_buffers().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_allocate_command_buffers`] returns a [`ValidationError`].
+    ///
+    /// [`try_allocate_command_buffers`]: Self::try_allocate_command_buffers
+    #[inline]
+    #[track_caller]
+    pub fn allocate_command_buffers(
+        &self,
+        allocate_info: &CommandBufferAllocateInfo<'_>,
+    ) -> Result<impl ExactSizeIterator<Item = CommandPoolAlloc> + use<>, VulkanError> {
+        match self.try_allocate_command_buffers(allocate_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Allocates command buffers.
     #[inline]
-    pub fn allocate_command_buffers(
+    pub fn try_allocate_command_buffers(
+        &self,
+        allocate_info: &CommandBufferAllocateInfo<'_>,
+    ) -> Result<impl ExactSizeIterator<Item = CommandPoolAlloc> + use<>, Validated<VulkanError>>
+    {
+        self.validate_allocate_command_buffers(allocate_info)?;
+
+        Ok(unsafe { self.allocate_command_buffers_unchecked(allocate_info) }?)
+    }
+
+    fn validate_allocate_command_buffers(
+        &self,
+        _allocate_info: &CommandBufferAllocateInfo<'_>,
+    ) -> Result<(), Box<ValidationError>> {
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn allocate_command_buffers_unchecked(
         &self,
         allocate_info: &CommandBufferAllocateInfo<'_>,
     ) -> Result<impl ExactSizeIterator<Item = CommandPoolAlloc> + use<>, VulkanError> {
@@ -205,13 +290,35 @@ impl CommandPool {
         }))
     }
 
+    /// Frees individual command buffers, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_free_command_buffers().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The `command_buffers` must have been allocated from this pool.
+    /// - The `command_buffers` must not be in the pending state.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_free_command_buffers`] returns a [`ValidationError`].
+    ///
+    /// [`try_free_command_buffers`]: Self::try_free_command_buffers
+    #[track_caller]
+    pub unsafe fn free_command_buffers(
+        &self,
+        command_buffers: impl IntoIterator<Item = CommandPoolAlloc>,
+    ) {
+        unsafe { self.try_free_command_buffers(command_buffers) }.unwrap()
+    }
+
     /// Frees individual command buffers.
     ///
     /// # Safety
     ///
     /// - The `command_buffers` must have been allocated from this pool.
     /// - The `command_buffers` must not be in the pending state.
-    pub unsafe fn free_command_buffers(
+    pub unsafe fn try_free_command_buffers(
         &self,
         command_buffers: impl IntoIterator<Item = CommandPoolAlloc>,
     ) -> Result<(), Box<ValidationError>> {
@@ -219,6 +326,7 @@ impl CommandPool {
         self.validate_free_command_buffers(&command_buffers)?;
 
         unsafe { self.free_command_buffers_unchecked(command_buffers) };
+
         Ok(())
     }
 
@@ -253,20 +361,44 @@ impl CommandPool {
     }
 
     /// Trims a command pool, which recycles unused internal memory from the command pool back to
+    /// the system, panicking on a validation error.
+    ///
+    /// Command buffers allocated from the pool are not affected by trimming.
+    ///
+    /// This function is supported only if the [`khr_maintenance1`] extension is enabled on the
+    /// device. Otherwise an error is returned. Since this operation is purely an optimization it
+    /// is legitimate to call this function and simply ignore any possible error.
+    ///
+    /// This is a shortcut for `try_trim().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_trim`] returns a [`ValidationError`].
+    ///
+    /// [`khr_maintenance1`]: crate::device::DeviceExtensions::khr_maintenance1
+    /// [`try_trim`]: Self::try_trim
+    #[inline]
+    #[track_caller]
+    pub fn trim(&self) {
+        self.try_trim().unwrap()
+    }
+
+    /// Trims a command pool, which recycles unused internal memory from the command pool back to
     /// the system.
     ///
     /// Command buffers allocated from the pool are not affected by trimming.
     ///
-    /// This function is supported only if the
-    /// [`khr_maintenance1`](crate::device::DeviceExtensions::khr_maintenance1) extension is
-    /// enabled on the device. Otherwise an error is returned.
-    /// Since this operation is purely an optimization it is legitimate to call this function and
-    /// simply ignore any possible error.
+    /// This function is supported only if the [`khr_maintenance1`] extension is enabled on the
+    /// device. Otherwise an error is returned. Since this operation is purely an optimization it
+    /// is legitimate to call this function and simply ignore any possible error.
+    ///
+    /// [`khr_maintenance1`]: crate::device::DeviceExtensions::khr_maintenance1
     #[inline]
-    pub fn trim(&self) -> Result<(), Box<ValidationError>> {
+    pub fn try_trim(&self) -> Result<(), Box<ValidationError>> {
         self.validate_trim()?;
 
-        unsafe { self.trim_unchecked() }
+        unsafe { self.trim_unchecked() };
+
         Ok(())
     }
 
@@ -383,11 +515,13 @@ impl CommandPoolCreateInfo<'_> {
                 .set_vuids(&["VUID-VkCommandPoolCreateInfo-flags-parameter"])
         })?;
 
-        if queue_family_index >= device.physical_device().queue_family_properties().len() as u32 {
+        if !device
+            .active_queue_family_indices()
+            .contains(&queue_family_index)
+        {
             return Err(Box::new(ValidationError {
                 context: "queue_family_index".into(),
-                problem: "is not less than the number of queue families in the physical device"
-                    .into(),
+                problem: "is not active on the device".into(),
                 vuids: &["VUID-vkCreateCommandPool-queueFamilyIndex-01937"],
                 ..Default::default()
             }));
@@ -566,7 +700,7 @@ mod tests {
     fn check_queue_family_too_high() {
         let (device, _) = gfx_dev_and_queue!();
 
-        match CommandPool::new(
+        match CommandPool::try_new(
             &device,
             &CommandPoolCreateInfo {
                 ..Default::default()

--- a/vulkano/src/command_buffer/sys.rs
+++ b/vulkano/src/command_buffer/sys.rs
@@ -30,17 +30,75 @@ pub struct RecordingCommandBuffer {
 }
 
 impl RecordingCommandBuffer {
-    /// Allocates and begins recording a new command buffer.
+    /// Allocates and begins recording a new command buffer, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
     #[inline]
+    #[track_caller]
     pub fn new(
         allocator: &Arc<impl CommandBufferAllocator + ?Sized>,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+        begin_info: &CommandBufferBeginInfo<'_>,
+    ) -> Result<Self, VulkanError> {
+        Self::new_inner(
+            allocator.clone().as_dyn(),
+            queue_family_index,
+            level,
+            begin_info,
+        )
+    }
+
+    #[inline]
+    #[track_caller]
+    fn new_inner(
+        allocator: Arc<dyn CommandBufferAllocator>,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+        begin_info: &CommandBufferBeginInfo<'_>,
+    ) -> Result<Self, VulkanError> {
+        match Self::try_new_inner(allocator, queue_family_index, level, begin_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Allocates and begins recording a new command buffer.
+    #[inline]
+    pub fn try_new(
+        allocator: &Arc<impl CommandBufferAllocator + ?Sized>,
+        queue_family_index: u32,
+        level: CommandBufferLevel,
+        begin_info: &CommandBufferBeginInfo<'_>,
+    ) -> Result<Self, Validated<VulkanError>> {
+        Self::try_new_inner(
+            allocator.clone().as_dyn(),
+            queue_family_index,
+            level,
+            begin_info,
+        )
+    }
+
+    #[inline]
+    fn try_new_inner(
+        allocator: Arc<dyn CommandBufferAllocator>,
         queue_family_index: u32,
         level: CommandBufferLevel,
         begin_info: &CommandBufferBeginInfo<'_>,
     ) -> Result<Self, Validated<VulkanError>> {
         Self::validate_new(allocator.device(), queue_family_index, level, begin_info)?;
 
-        unsafe { Self::new_unchecked(allocator, queue_family_index, level, begin_info) }
+        let allocation = allocator.try_allocate(queue_family_index, level)?;
+
+        Ok(unsafe {
+            Self::new_unchecked_inner_inner(allocator, allocation, queue_family_index, begin_info)
+        }?)
     }
 
     pub(super) fn validate_new(
@@ -75,7 +133,7 @@ impl RecordingCommandBuffer {
         queue_family_index: u32,
         level: CommandBufferLevel,
         begin_info: &CommandBufferBeginInfo<'_>,
-    ) -> Result<Self, Validated<VulkanError>> {
+    ) -> Result<Self, VulkanError> {
         unsafe {
             Self::new_unchecked_inner(
                 allocator.clone().as_dyn(),
@@ -91,9 +149,20 @@ impl RecordingCommandBuffer {
         queue_family_index: u32,
         level: CommandBufferLevel,
         begin_info: &CommandBufferBeginInfo<'_>,
-    ) -> Result<Self, Validated<VulkanError>> {
-        let allocation = allocator.allocate(queue_family_index, level)?;
+    ) -> Result<Self, VulkanError> {
+        let allocation = unsafe { allocator.allocate_unchecked(queue_family_index, level) }?;
 
+        unsafe {
+            Self::new_unchecked_inner_inner(allocator, allocation, queue_family_index, begin_info)
+        }
+    }
+
+    unsafe fn new_unchecked_inner_inner(
+        allocator: Arc<dyn CommandBufferAllocator>,
+        allocation: CommandBufferAlloc,
+        queue_family_index: u32,
+        begin_info: &CommandBufferBeginInfo<'_>,
+    ) -> Result<Self, VulkanError> {
         {
             let begin_info_fields2_vk = begin_info.to_vk_fields2();
             let mut begin_info_fields1_extensions_vk =

--- a/vulkano/src/deferred.rs
+++ b/vulkano/src/deferred.rs
@@ -26,13 +26,34 @@ pub struct DeferredOperation {
 }
 
 impl DeferredOperation {
+    /// Creates a new `DeferredOperation`, panicking on a validation error.
+    ///
+    /// The [`khr_deferred_host_operations`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`khr_deferred_host_operations`]: crate::device::DeviceExtensions::khr_deferred_host_operations
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(device: &Arc<Device>) -> Result<Arc<Self>, VulkanError> {
+        match Self::try_new(device) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `DeferredOperation`.
     ///
     /// The [`khr_deferred_host_operations`] extension must be enabled on the device.
     ///
     /// [`khr_deferred_host_operations`]: crate::device::DeviceExtensions::khr_deferred_host_operations
     #[inline]
-    pub fn new(device: &Arc<Device>) -> Result<Arc<Self>, Validated<VulkanError>> {
+    pub fn try_new(device: &Arc<Device>) -> Result<Arc<Self>, Validated<VulkanError>> {
         Self::validate_new(device)?;
 
         Ok(unsafe { Self::new_unchecked(device) }?)

--- a/vulkano/src/descriptor_set/allocator.rs
+++ b/vulkano/src/descriptor_set/allocator.rs
@@ -26,7 +26,7 @@ use std::{
     cell::UnsafeCell,
     fmt::{Debug, Error as FmtError, Formatter},
     num::NonZero,
-    ptr, slice,
+    ptr,
     sync::Arc,
 };
 use thread_local::ThreadLocal;
@@ -52,11 +52,38 @@ const MAX_POOLS: usize = 32;
 /// synchronized. The implementation should not panic as it is used while dropping descriptor sets.
 pub unsafe trait DescriptorSetAllocator: DeviceOwned + Send + Sync + 'static {
     /// Allocates a descriptor set.
-    fn allocate(
+    fn try_allocate(
         &self,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
     ) -> Result<DescriptorSetAlloc, Validated<VulkanError>>;
+
+    /// Allocates a descriptor set without doing any checks.
+    ///
+    /// <div class="vulkano-alert-caution">
+    ///
+    /// > Caution
+    /// >
+    /// > You should only call this when necessary. Humans are famously bad at guessing what needs
+    /// > to be optimized, so **the only way** to know is by profiling. Have you profiled to make
+    /// > sure that this actually makes a difference? In 99% of cases (not an exaggeration),
+    /// > calling the unchecked version of one of our functions/methods makes absolutely no
+    /// > difference, so make sure first.
+    ///
+    /// </div>
+    ///
+    /// # Safety
+    ///
+    /// - If calling [`try_allocate`] with the same arguments would return a [`ValidationError`],
+    ///   calling this method is *undefined behavior*!
+    ///
+    /// [`try_allocate`]: Self::try_allocate
+    /// [`ValidationError`]: crate::ValidationError
+    unsafe fn allocate_unchecked(
+        &self,
+        layout: &Arc<DescriptorSetLayout>,
+        variable_descriptor_count: u32,
+    ) -> Result<DescriptorSetAlloc, VulkanError>;
 
     /// Deallocates the given `allocation`.
     ///
@@ -229,7 +256,7 @@ impl StandardDescriptorSetAllocator {
 
 unsafe impl DescriptorSetAllocator for StandardDescriptorSetAllocator {
     #[inline]
-    fn allocate(
+    fn try_allocate(
         &self,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
@@ -240,9 +267,9 @@ unsafe impl DescriptorSetAllocator for StandardDescriptorSetAllocator {
         let entry_ptr = pools.get();
         let entry = unsafe { &mut *entry_ptr }.get_or_try_insert(layout.id(), || {
             if is_fixed {
-                FixedEntry::new(layout, &self.create_info).map(Entry::Fixed)
+                FixedEntry::try_new(layout, &self.create_info).map(Entry::Fixed)
             } else {
-                VariableEntry::new(
+                VariableEntry::try_new(
                     layout,
                     &self.create_info,
                     Arc::new(ArrayQueue::new(MAX_POOLS)),
@@ -252,10 +279,47 @@ unsafe impl DescriptorSetAllocator for StandardDescriptorSetAllocator {
         })?;
 
         match entry {
-            Entry::Fixed(entry) => entry.allocate(layout, &self.create_info),
+            Entry::Fixed(entry) => entry.try_allocate(layout, &self.create_info),
             Entry::Variable(entry) => {
-                entry.allocate(layout, variable_descriptor_count, &self.create_info)
+                entry.try_allocate(layout, variable_descriptor_count, &self.create_info)
             }
+        }
+    }
+
+    #[inline]
+    unsafe fn allocate_unchecked(
+        &self,
+        layout: &Arc<DescriptorSetLayout>,
+        variable_descriptor_count: u32,
+    ) -> Result<DescriptorSetAlloc, VulkanError> {
+        let is_fixed = layout.variable_descriptor_count() == 0;
+        let pools = self.pools.get_or_default();
+
+        let entry_ptr = pools.get();
+        let entry = unsafe { &mut *entry_ptr }.get_or_try_insert(layout.id(), || {
+            if is_fixed {
+                // SAFETY: Enforced by the caller.
+                unsafe { FixedEntry::new_unchecked(layout, &self.create_info) }.map(Entry::Fixed)
+            } else {
+                // SAFETY: Enforced by the caller.
+                unsafe {
+                    VariableEntry::new_unchecked(
+                        layout,
+                        &self.create_info,
+                        Arc::new(ArrayQueue::new(MAX_POOLS)),
+                    )
+                }
+                .map(Entry::Variable)
+            }
+        })?;
+
+        match entry {
+            // SAFETY: Enforced by the caller.
+            Entry::Fixed(entry) => unsafe { entry.allocate_unchecked(layout, &self.create_info) },
+            // SAFETY: Enforced by the caller.
+            Entry::Variable(entry) => unsafe {
+                entry.allocate_unchecked(layout, variable_descriptor_count, &self.create_info)
+            },
         }
     }
 
@@ -303,12 +367,21 @@ unsafe impl DescriptorSetAllocator for StandardDescriptorSetAllocator {
 
 unsafe impl<T: DescriptorSetAllocator + ?Sized> DescriptorSetAllocator for Arc<T> {
     #[inline]
-    fn allocate(
+    fn try_allocate(
         &self,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
     ) -> Result<DescriptorSetAlloc, Validated<VulkanError>> {
-        (**self).allocate(layout, variable_descriptor_count)
+        (**self).try_allocate(layout, variable_descriptor_count)
+    }
+
+    #[inline]
+    unsafe fn allocate_unchecked(
+        &self,
+        layout: &Arc<DescriptorSetLayout>,
+        variable_descriptor_count: u32,
+    ) -> Result<DescriptorSetAlloc, VulkanError> {
+        unsafe { (**self).allocate_unchecked(layout, variable_descriptor_count) }
     }
 
     #[inline]
@@ -336,11 +409,11 @@ struct FixedEntry {
 }
 
 impl FixedEntry {
-    fn new(
+    fn try_new(
         layout: &Arc<DescriptorSetLayout>,
         create_info: &StandardDescriptorSetAllocatorCreateInfo<'_>,
     ) -> Result<Self, Validated<VulkanError>> {
-        let pool = DescriptorPool::new(
+        let pool = DescriptorPool::try_new(
             layout.device(),
             &DescriptorPoolCreateInfo {
                 flags: if create_info.update_after_bind {
@@ -359,26 +432,27 @@ impl FixedEntry {
                     .collect::<Vec<_>>(),
                 ..Default::default()
             },
-        )
-        .map_err(Validated::unwrap)?;
+        )?;
 
         let allocate_infos = (0..create_info.set_count)
             .map(|_| DescriptorSetAllocateInfo::new(layout))
             .collect::<Vec<_>>();
 
-        let allocs =
-            unsafe { pool.allocate_descriptor_sets(&allocate_infos) }.map_err(|err| match err {
-                Validated::ValidationError(_) => err,
-                Validated::Error(vk_err) => match vk_err {
-                    VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory => err,
-                    // This can't happen as we don't free individual sets.
-                    VulkanError::FragmentedPool => unreachable!(),
-                    // We created the pool with an exact size.
-                    VulkanError::OutOfPoolMemory => unreachable!(),
-                    // Shouldn't ever be returned.
-                    _ => unreachable!(),
-                },
-            })?;
+        let allocs = match unsafe { pool.try_allocate_descriptor_sets(&allocate_infos) } {
+            Ok(allocs) => allocs,
+            Err(Validated::Error(err)) => match err {
+                VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory => {
+                    return Err(Validated::Error(err));
+                }
+                // This can't happen as we don't free individual sets.
+                VulkanError::FragmentedPool => unreachable!(),
+                // We created the pool with an exact size.
+                VulkanError::OutOfPoolMemory => unreachable!(),
+                // Shouldn't ever be returned.
+                _ => unreachable!(),
+            },
+            Err(Validated::ValidationError(err)) => return Err(Validated::ValidationError(err)),
+        };
 
         let reserve = ArrayQueue::new(create_info.set_count);
 
@@ -392,7 +466,54 @@ impl FixedEntry {
         })
     }
 
-    fn allocate(
+    unsafe fn new_unchecked(
+        layout: &Arc<DescriptorSetLayout>,
+        create_info: &StandardDescriptorSetAllocatorCreateInfo<'_>,
+    ) -> Result<Self, VulkanError> {
+        // SAFETY: Enforced by the caller.
+        let pool = unsafe {
+            DescriptorPool::new_unchecked(
+                layout.device(),
+                &DescriptorPoolCreateInfo {
+                    flags: if create_info.update_after_bind {
+                        DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
+                    } else {
+                        DescriptorPoolCreateFlags::empty()
+                    },
+                    max_sets: create_info.set_count as u32,
+                    pool_sizes: &layout
+                        .descriptor_counts()
+                        .iter()
+                        .map(|&(ty, count)| {
+                            assert_ne!(ty, DescriptorType::InlineUniformBlock);
+                            (ty, count * create_info.set_count as u32)
+                        })
+                        .collect::<Vec<_>>(),
+                    ..Default::default()
+                },
+            )
+        }?;
+
+        let allocate_infos = (0..create_info.set_count)
+            .map(|_| DescriptorSetAllocateInfo::new(layout))
+            .collect::<Vec<_>>();
+
+        // SAFETY: Enforced by the caller.
+        let allocs = unsafe { pool.allocate_descriptor_sets_unchecked(&allocate_infos) }?;
+
+        let reserve = ArrayQueue::new(create_info.set_count);
+
+        for alloc in allocs {
+            let _ = reserve.push(alloc);
+        }
+
+        Ok(FixedEntry {
+            pool: Arc::new(pool),
+            reserve: Arc::new(reserve),
+        })
+    }
+
+    fn try_allocate(
         &mut self,
         layout: &Arc<DescriptorSetLayout>,
         create_info: &StandardDescriptorSetAllocatorCreateInfo<'_>,
@@ -400,7 +521,28 @@ impl FixedEntry {
         let inner = if let Some(inner) = self.reserve.pop() {
             inner
         } else {
-            *self = FixedEntry::new(layout, create_info)?;
+            *self = FixedEntry::try_new(layout, create_info)?;
+
+            self.reserve.pop().unwrap()
+        };
+
+        Ok(DescriptorSetAlloc {
+            inner,
+            pool: self.pool.clone(),
+            handle: AllocationHandle::from_ptr(Arc::into_raw(self.reserve.clone()) as _),
+        })
+    }
+
+    unsafe fn allocate_unchecked(
+        &mut self,
+        layout: &Arc<DescriptorSetLayout>,
+        create_info: &StandardDescriptorSetAllocatorCreateInfo<'_>,
+    ) -> Result<DescriptorSetAlloc, VulkanError> {
+        let inner = if let Some(inner) = self.reserve.pop() {
+            inner
+        } else {
+            // SAFETY: Enforced by the caller.
+            *self = unsafe { FixedEntry::new_unchecked(layout, create_info) }?;
 
             self.reserve.pop().unwrap()
         };
@@ -422,12 +564,12 @@ struct VariableEntry {
 }
 
 impl VariableEntry {
-    fn new(
+    fn try_new(
         layout: &DescriptorSetLayout,
         create_info: &StandardDescriptorSetAllocatorCreateInfo<'_>,
         reserve: Arc<ArrayQueue<Arc<DescriptorPool>>>,
     ) -> Result<Self, Validated<VulkanError>> {
-        let pool = DescriptorPool::new(
+        let pool = DescriptorPool::try_new(
             layout.device(),
             &DescriptorPoolCreateInfo {
                 flags: if create_info.update_after_bind {
@@ -446,8 +588,7 @@ impl VariableEntry {
                     .collect::<Vec<_>>(),
                 ..Default::default()
             },
-        )
-        .map_err(Validated::unwrap)?;
+        )?;
 
         Ok(VariableEntry {
             pool: Arc::new(pool),
@@ -456,7 +597,43 @@ impl VariableEntry {
         })
     }
 
-    fn allocate(
+    unsafe fn new_unchecked(
+        layout: &DescriptorSetLayout,
+        create_info: &StandardDescriptorSetAllocatorCreateInfo<'_>,
+        reserve: Arc<ArrayQueue<Arc<DescriptorPool>>>,
+    ) -> Result<Self, VulkanError> {
+        // SAFETY: Enforced by the caller.
+        let pool = unsafe {
+            DescriptorPool::new_unchecked(
+                layout.device(),
+                &DescriptorPoolCreateInfo {
+                    flags: if create_info.update_after_bind {
+                        DescriptorPoolCreateFlags::UPDATE_AFTER_BIND
+                    } else {
+                        DescriptorPoolCreateFlags::empty()
+                    },
+                    max_sets: create_info.set_count as u32,
+                    pool_sizes: &layout
+                        .descriptor_counts()
+                        .iter()
+                        .map(|&(ty, count)| {
+                            assert_ne!(ty, DescriptorType::InlineUniformBlock);
+                            (ty, count * create_info.set_count as u32)
+                        })
+                        .collect::<Vec<_>>(),
+                    ..Default::default()
+                },
+            )
+        }?;
+
+        Ok(VariableEntry {
+            pool: Arc::new(pool),
+            reserve,
+            allocations: 0,
+        })
+    }
+
+    fn try_allocate(
         &mut self,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
@@ -478,7 +655,7 @@ impl VariableEntry {
             if Arc::strong_count(&self.pool) == 1 {
                 // SAFETY: We checked that the pool has a single strong reference above, meaning
                 // that all the allocations we gave out must have been deallocated.
-                unsafe { self.pool.reset() }?;
+                unsafe { self.pool.try_reset() }?;
 
                 self.allocations = 0;
             } else {
@@ -486,29 +663,27 @@ impl VariableEntry {
                     // SAFETY: We checked that the pool has a single strong reference when
                     // deallocating, meaning that all the allocations we gave out must have been
                     // deallocated.
-                    unsafe { pool.reset() }?;
+                    unsafe { pool.try_reset() }?;
 
                     self.pool = pool;
                     self.allocations = 0;
                 } else {
-                    *self = VariableEntry::new(layout, create_info, self.reserve.clone())?;
+                    *self = VariableEntry::try_new(layout, create_info, self.reserve.clone())?;
                 }
             }
         }
 
-        let allocate_info = DescriptorSetAllocateInfo {
+        let allocate_info = [DescriptorSetAllocateInfo {
             variable_descriptor_count,
             ..DescriptorSetAllocateInfo::new(layout)
-        };
+        }];
 
-        let mut sets = unsafe {
-            self.pool
-                .allocate_descriptor_sets(slice::from_ref(&allocate_info))
-        }
-        .map_err(|err| match err {
-            Validated::ValidationError(_) => err,
-            Validated::Error(vk_err) => match vk_err {
-                VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory => err,
+        let mut sets = match unsafe { self.pool.try_allocate_descriptor_sets(&allocate_info) } {
+            Ok(sets) => sets,
+            Err(Validated::Error(err)) => match err {
+                VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory => {
+                    return Err(Validated::Error(err));
+                }
                 // This can't happen as we don't free individual sets.
                 VulkanError::FragmentedPool => unreachable!(),
                 // We created the pool to fit the maximum variable descriptor count.
@@ -516,7 +691,68 @@ impl VariableEntry {
                 // Shouldn't ever be returned.
                 _ => unreachable!(),
             },
-        })?;
+            Err(Validated::ValidationError(err)) => return Err(Validated::ValidationError(err)),
+        };
+
+        self.allocations += 1;
+
+        Ok(DescriptorSetAlloc {
+            inner: sets.next().unwrap(),
+            pool: self.pool.clone(),
+            handle: AllocationHandle::from_ptr(Arc::into_raw(self.reserve.clone()) as _),
+        })
+    }
+
+    unsafe fn allocate_unchecked(
+        &mut self,
+        layout: &Arc<DescriptorSetLayout>,
+        variable_descriptor_count: u32,
+        create_info: &StandardDescriptorSetAllocatorCreateInfo<'_>,
+    ) -> Result<DescriptorSetAlloc, VulkanError> {
+        if self.allocations >= create_info.set_count {
+            // This can happen if there's only ever one allocation alive at any point in time. In
+            // that case, when deallocating the last set before reaching `set_count`, there will be
+            // 2 references to the pool (one here and one in the allocation) and so the pool won't
+            // be returned to the reserve when deallocating. However, since there are no other
+            // allocations alive, there would be no other allocations that could return it to the
+            // reserve. To avoid dropping the pool unnecessarily, we simply continue using it. In
+            // the case where there are other references, we drop ours, at which point an
+            // allocation still holding a reference will be able to put the pool into the reserve
+            // when deallocated. If the user created a reference themself that will most certainly
+            // lead to a memory leak.
+            //
+            // TODO: This can still run into the A/B/A problem causing the pool to be dropped.
+            if Arc::strong_count(&self.pool) == 1 {
+                // SAFETY: We checked that the pool has a single strong reference above, meaning
+                // that all the allocations we gave out must have been deallocated.
+                unsafe { self.pool.reset_unchecked() }?;
+
+                self.allocations = 0;
+            } else {
+                if let Some(pool) = self.reserve.pop() {
+                    // SAFETY: We checked that the pool has a single strong reference when
+                    // deallocating, meaning that all the allocations we gave out must have been
+                    // deallocated.
+                    unsafe { pool.reset_unchecked() }?;
+
+                    self.pool = pool;
+                    self.allocations = 0;
+                } else {
+                    // SAFETY: Enforced by the caller.
+                    *self = unsafe {
+                        VariableEntry::new_unchecked(layout, create_info, self.reserve.clone())
+                    }?;
+                }
+            }
+        }
+
+        let allocate_info = [DescriptorSetAllocateInfo {
+            variable_descriptor_count,
+            ..DescriptorSetAllocateInfo::new(layout)
+        }];
+
+        // SAFETY: Enforced by the caller.
+        let mut sets = unsafe { self.pool.allocate_descriptor_sets_unchecked(&allocate_info) }?;
 
         self.allocations += 1;
 

--- a/vulkano/src/descriptor_set/layout.rs
+++ b/vulkano/src/descriptor_set/layout.rs
@@ -48,9 +48,30 @@ self_referential! {
 }
 
 impl DescriptorSetLayout {
+    /// Creates a new `DescriptorSetLayout`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &DescriptorSetLayoutCreateInfo<'_>,
+    ) -> Result<Arc<DescriptorSetLayout>, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `DescriptorSetLayout`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &DescriptorSetLayoutCreateInfo<'_>,
     ) -> Result<Arc<DescriptorSetLayout>, Validated<VulkanError>> {

--- a/vulkano/src/descriptor_set/pool.rs
+++ b/vulkano/src/descriptor_set/pool.rs
@@ -33,9 +33,30 @@ pub struct DescriptorPool {
 }
 
 impl DescriptorPool {
+    /// Creates a new `DescriptorPool`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &DescriptorPoolCreateInfo<'_>,
+    ) -> Result<DescriptorPool, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `DescriptorPool`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &DescriptorPoolCreateInfo<'_>,
     ) -> Result<DescriptorPool, Validated<VulkanError>> {
@@ -157,6 +178,42 @@ impl DescriptorPool {
         self.max_inline_uniform_block_bindings
     }
 
+    /// Allocates descriptor sets from the pool, one for each element in `allocate_info`, panicking
+    /// on a validation error. Returns an iterator to the allocated sets, or an error.
+    ///
+    /// The `FragmentedPool` errors often can't be prevented. If the function returns this error,
+    /// you should just create a new pool.
+    ///
+    /// This is a shortcut for `try_allocate_descriptor_sets().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - When the pool is dropped, the returned descriptor sets must not be in use by either the
+    ///   host or device.
+    /// - If the device API version is less than 1.1, and the [`khr_maintenance1`] extension is not
+    ///   enabled on the device, then the length of `allocate_infos` must not be greater than the
+    ///   number of descriptor sets remaining in the pool, and the total number of descriptors of
+    ///   each type being allocated must not be greater than the number of descriptors of that type
+    ///   remaining in the pool.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_allocate_descriptor_sets`] returns a [`ValidationError`].
+    ///
+    /// [`khr_maintenance1`]: crate::device::DeviceExtensions::khr_maintenance1
+    /// [`try_allocate_descriptor_sets`]: Self::try_allocate_descriptor_sets
+    #[inline]
+    #[track_caller]
+    pub unsafe fn allocate_descriptor_sets(
+        &self,
+        allocate_infos: &[DescriptorSetAllocateInfo<'_>],
+    ) -> Result<impl ExactSizeIterator<Item = DescriptorPoolAlloc> + use<>, VulkanError> {
+        match unsafe { self.try_allocate_descriptor_sets(allocate_infos) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Allocates descriptor sets from the pool, one for each element in `allocate_info`.
     /// Returns an iterator to the allocated sets, or an error.
     ///
@@ -175,7 +232,7 @@ impl DescriptorPool {
     ///
     /// [`khr_maintenance1`]: crate::device::DeviceExtensions::khr_maintenance1
     #[inline]
-    pub unsafe fn allocate_descriptor_sets(
+    pub unsafe fn try_allocate_descriptor_sets(
         &self,
         allocate_infos: &[DescriptorSetAllocateInfo<'_>],
     ) -> Result<impl ExactSizeIterator<Item = DescriptorPoolAlloc> + use<>, Validated<VulkanError>>
@@ -305,6 +362,36 @@ impl DescriptorPool {
             ))
     }
 
+    /// Frees some descriptor sets, panicking on a validation error.
+    ///
+    /// Note that it is not mandatory to free sets. Destroying or resetting the pool destroys all
+    /// the descriptor sets.
+    ///
+    /// This is a shortcut for `try_free_descriptor_sets().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - All elements of `descriptor_sets` must have been allocated from `self`, and not freed
+    ///   previously.
+    /// - All elements of `descriptor_sets` must not be in use by the host or device.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_free_descriptor_sets`] returns a [`ValidationError`].
+    ///
+    /// [`try_free_descriptor_sets`]: Self::try_free_descriptor_sets
+    #[inline]
+    #[track_caller]
+    pub unsafe fn free_descriptor_sets(
+        &self,
+        descriptor_sets: impl IntoIterator<Item = RawDescriptorSet>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_free_descriptor_sets(descriptor_sets) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Frees some descriptor sets.
     ///
     /// Note that it is not mandatory to free sets. Destroying or resetting the pool destroys all
@@ -316,7 +403,7 @@ impl DescriptorPool {
     ///   previously.
     /// - All elements of `descriptor_sets` must not be in use by the host or device.
     #[inline]
-    pub unsafe fn free_descriptor_sets(
+    pub unsafe fn try_free_descriptor_sets(
         &self,
         descriptor_sets: impl IntoIterator<Item = RawDescriptorSet>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -364,6 +451,31 @@ impl DescriptorPool {
         Ok(())
     }
 
+    /// Resets the pool, panicking on a validation error.
+    ///
+    /// This destroys all descriptor sets and empties the pool.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - All descriptor sets that were previously allocated from `self` must not be in use by the
+    ///   host or device.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub unsafe fn reset(&self) -> Result<(), VulkanError> {
+        match unsafe { self.try_reset() } {
+            Ok(()) => Ok(()),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Resets the pool.
     ///
     /// This destroys all descriptor sets and empties the pool.
@@ -373,7 +485,18 @@ impl DescriptorPool {
     /// - All descriptor sets that were previously allocated from `self` must not be in use by the
     ///   host or device.
     #[inline]
-    pub unsafe fn reset(&self) -> Result<(), VulkanError> {
+    pub unsafe fn try_reset(&self) -> Result<(), Validated<VulkanError>> {
+        self.validate_reset()?;
+
+        Ok(unsafe { self.reset_unchecked() }?)
+    }
+
+    fn validate_reset(&self) -> Result<(), Box<ValidationError>> {
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn reset_unchecked(&self) -> Result<(), VulkanError> {
         let fns = self.device.fns();
         unsafe {
             (fns.v1_0.reset_descriptor_pool)(
@@ -773,7 +896,7 @@ mod tests {
     fn zero_max_set() {
         let (device, _) = gfx_dev_and_queue!();
 
-        DescriptorPool::new(
+        DescriptorPool::try_new(
             &device,
             &DescriptorPoolCreateInfo {
                 max_sets: 0,

--- a/vulkano/src/descriptor_set/sys.rs
+++ b/vulkano/src/descriptor_set/sys.rs
@@ -30,13 +30,22 @@ pub struct RawDescriptorSet {
 }
 
 impl RawDescriptorSet {
-    /// Allocates a new descriptor set and returns it.
+    /// Allocates a new descriptor set and returns it, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
     #[inline]
+    #[track_caller]
     pub fn new(
         allocator: &Arc<impl DescriptorSetAllocator + ?Sized>,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
-    ) -> Result<RawDescriptorSet, Validated<VulkanError>> {
+    ) -> Result<RawDescriptorSet, VulkanError> {
         Self::new_inner(
             allocator.clone().as_dyn(),
             layout,
@@ -44,13 +53,73 @@ impl RawDescriptorSet {
         )
     }
 
+    #[inline]
+    #[track_caller]
     fn new_inner(
         allocator: Arc<dyn DescriptorSetAllocator>,
         layout: &Arc<DescriptorSetLayout>,
         variable_descriptor_count: u32,
-    ) -> Result<RawDescriptorSet, Validated<VulkanError>> {
-        let allocation = allocator.allocate(layout, variable_descriptor_count)?;
+    ) -> Result<RawDescriptorSet, VulkanError> {
+        match Self::try_new_inner(allocator, layout, variable_descriptor_count) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
 
+    /// Allocates a new descriptor set and returns it.
+    #[inline]
+    pub fn try_new(
+        allocator: &Arc<impl DescriptorSetAllocator + ?Sized>,
+        layout: &Arc<DescriptorSetLayout>,
+        variable_descriptor_count: u32,
+    ) -> Result<RawDescriptorSet, Validated<VulkanError>> {
+        Self::try_new_inner(
+            allocator.clone().as_dyn(),
+            layout,
+            variable_descriptor_count,
+        )
+    }
+
+    fn try_new_inner(
+        allocator: Arc<dyn DescriptorSetAllocator>,
+        layout: &Arc<DescriptorSetLayout>,
+        variable_descriptor_count: u32,
+    ) -> Result<RawDescriptorSet, Validated<VulkanError>> {
+        let allocation = allocator.try_allocate(layout, variable_descriptor_count)?;
+
+        Ok(unsafe { Self::new_unchecked_inner_inner(allocator, allocation) }?)
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn new_unchecked(
+        allocator: &Arc<impl DescriptorSetAllocator + ?Sized>,
+        layout: &Arc<DescriptorSetLayout>,
+        variable_descriptor_count: u32,
+    ) -> Result<RawDescriptorSet, VulkanError> {
+        unsafe {
+            Self::new_unchecked_inner(
+                allocator.clone().as_dyn(),
+                layout,
+                variable_descriptor_count,
+            )
+        }
+    }
+
+    unsafe fn new_unchecked_inner(
+        allocator: Arc<dyn DescriptorSetAllocator>,
+        layout: &Arc<DescriptorSetLayout>,
+        variable_descriptor_count: u32,
+    ) -> Result<RawDescriptorSet, VulkanError> {
+        let allocation =
+            unsafe { allocator.allocate_unchecked(layout, variable_descriptor_count) }?;
+
+        unsafe { Self::new_unchecked_inner_inner(allocator, allocation) }
+    }
+
+    unsafe fn new_unchecked_inner_inner(
+        allocator: Arc<dyn DescriptorSetAllocator>,
+        allocation: DescriptorSetAlloc,
+    ) -> Result<RawDescriptorSet, VulkanError> {
         Ok(RawDescriptorSet {
             allocation: ManuallyDrop::new(allocation),
             allocator,
@@ -81,6 +150,33 @@ impl RawDescriptorSet {
         self.allocation.inner.variable_descriptor_count()
     }
 
+    /// Updates the descriptor set with new values, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_update().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The resources in `descriptor_writes` and `descriptor_copies` must be kept alive for as
+    ///   long as `self` is in use.
+    /// - The descriptor set must not be in use by the device, or be recorded to a command buffer
+    ///   as part of a bind command.
+    /// - Host access to the descriptor set must be externally synchronized.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_update`] returns a [`ValidationError`].
+    ///
+    /// [`try_update`]: Self::try_update
+    #[inline]
+    #[track_caller]
+    pub unsafe fn update(
+        &self,
+        descriptor_writes: &[WriteDescriptorSet<'_>],
+        descriptor_copies: &[CopyDescriptorSet<'_>],
+    ) {
+        unsafe { self.try_update(descriptor_writes, descriptor_copies) }.unwrap()
+    }
+
     /// Updates the descriptor set with new values.
     ///
     /// # Safety
@@ -91,7 +187,7 @@ impl RawDescriptorSet {
     ///   as part of a bind command.
     /// - Host access to the descriptor set must be externally synchronized.
     #[inline]
-    pub unsafe fn update(
+    pub unsafe fn try_update(
         &self,
         descriptor_writes: &[WriteDescriptorSet<'_>],
         descriptor_copies: &[CopyDescriptorSet<'_>],

--- a/vulkano/src/device/mod.rs
+++ b/vulkano/src/device/mod.rs
@@ -195,9 +195,36 @@ pub struct Device {
 }
 
 impl Device {
+    /// Creates a new `Device`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        physical_device: &Arc<PhysicalDevice>,
+        create_info: &DeviceCreateInfo<'_>,
+    ) -> Result<
+        (
+            Arc<Device>,
+            impl ExactSizeIterator<Item = Arc<Queue>> + use<>,
+        ),
+        VulkanError,
+    > {
+        match Self::try_new(physical_device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `Device`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         physical_device: &Arc<PhysicalDevice>,
         create_info: &DeviceCreateInfo<'_>,
     ) -> Result<
@@ -546,9 +573,32 @@ impl Device {
 
     /// For the given acceleration structure build info and primitive counts, returns the
     /// minimum size required to build the acceleration structure, and the minimum size of the
+    /// scratch buffer used during the build operation, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_acceleration_structure_build_sizes().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_acceleration_structure_build_sizes`] returns a [`ValidationError`].
+    ///
+    /// [`try_acceleration_structure_build_sizes`]: Self::try_acceleration_structure_build_sizes
+    #[inline]
+    #[track_caller]
+    pub fn acceleration_structure_build_sizes(
+        &self,
+        build_type: AccelerationStructureBuildType,
+        build_info: &AccelerationStructureBuildGeometryInfo,
+        max_primitive_counts: &[u32],
+    ) -> AccelerationStructureBuildSizesInfo {
+        self.try_acceleration_structure_build_sizes(build_type, build_info, max_primitive_counts)
+            .unwrap()
+    }
+
+    /// For the given acceleration structure build info and primitive counts, returns the
+    /// minimum size required to build the acceleration structure, and the minimum size of the
     /// scratch buffer used during the build operation.
     #[inline]
-    pub fn acceleration_structure_build_sizes(
+    pub fn try_acceleration_structure_build_sizes(
         &self,
         build_type: AccelerationStructureBuildType,
         build_info: &AccelerationStructureBuildGeometryInfo,
@@ -705,9 +755,30 @@ impl Device {
     }
 
     /// Returns whether a serialized acceleration structure with the specified version data
+    /// is compatible with this device, panicking on a validation error.
+    ///
+    /// This is a shortcut for
+    /// `try_acceleration_structure_is_compatible().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_acceleration_structure_is_compatible`] returns a [`ValidationError`].
+    ///
+    /// [`try_acceleration_structure_is_compatible`]: Self::try_acceleration_structure_is_compatible
+    #[inline]
+    #[track_caller]
+    pub fn acceleration_structure_is_compatible(
+        &self,
+        version_data: &[u8; 2 * vk::UUID_SIZE],
+    ) -> bool {
+        self.try_acceleration_structure_is_compatible(version_data)
+            .unwrap()
+    }
+
+    /// Returns whether a serialized acceleration structure with the specified version data
     /// is compatible with this device.
     #[inline]
-    pub fn acceleration_structure_is_compatible(
+    pub fn try_acceleration_structure_is_compatible(
         &self,
         version_data: &[u8; 2 * vk::UUID_SIZE],
     ) -> Result<bool, Box<ValidationError>> {
@@ -765,6 +836,36 @@ impl Device {
     }
 
     /// Returns whether a descriptor set layout with the given `create_info` could be created
+    /// on the device, and additional supported properties where relevant, panicking on a
+    /// validation error. `Some` is returned if the descriptor set layout is supported, `None` if
+    /// it is not.
+    ///
+    /// This is primarily useful for checking whether the device supports a descriptor set layout
+    /// that goes beyond the [`max_per_set_descriptors`] limit. A layout that does not exceed
+    /// that limit is guaranteed to be supported, otherwise this function can be called.
+    ///
+    /// The device API version must be at least 1.1, or the [`khr_maintenance3`] extension must
+    /// be enabled on the device.
+    ///
+    /// This is a shortcut for `try_descriptor_set_layout_support().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_descriptor_set_layout_support`] returns a [`ValidationError`].
+    ///
+    /// [`max_per_set_descriptors`]: crate::device::DeviceProperties::max_per_set_descriptors
+    /// [`khr_maintenance3`]: crate::device::DeviceExtensions::khr_maintenance3
+    /// [`try_descriptor_set_layout_support`]: Self::try_descriptor_set_layout_support
+    #[inline]
+    #[track_caller]
+    pub fn descriptor_set_layout_support(
+        &self,
+        create_info: &DescriptorSetLayoutCreateInfo<'_>,
+    ) -> Option<DescriptorSetLayoutSupport> {
+        self.try_descriptor_set_layout_support(create_info).unwrap()
+    }
+
+    /// Returns whether a descriptor set layout with the given `create_info` could be created
     /// on the device, and additional supported properties where relevant. `Some` is returned if
     /// the descriptor set layout is supported, `None` if it is not.
     ///
@@ -778,7 +879,7 @@ impl Device {
     /// [`max_per_set_descriptors`]: crate::device::DeviceProperties::max_per_set_descriptors
     /// [`khr_maintenance3`]: crate::device::DeviceExtensions::khr_maintenance3
     #[inline]
-    pub fn descriptor_set_layout_support(
+    pub fn try_descriptor_set_layout_support(
         &self,
         create_info: &DescriptorSetLayoutCreateInfo<'_>,
     ) -> Result<Option<DescriptorSetLayoutSupport>, Box<ValidationError>> {
@@ -853,6 +954,29 @@ impl Device {
     }
 
     /// Returns the memory requirements that would apply for a buffer created with the specified
+    /// `create_info`, panicking on a validation error.
+    ///
+    /// The device API version must be at least 1.3, or the [`khr_maintenance4`] extension must
+    /// be enabled on the device.
+    ///
+    /// This is a shortcut for `try_buffer_memory_requirements().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_buffer_memory_requirements`] returns a [`ValidationError`].
+    ///
+    /// [`khr_maintenance4`]: DeviceExtensions::khr_maintenance4
+    /// [`try_buffer_memory_requirements`]: Self::try_buffer_memory_requirements
+    #[inline]
+    #[track_caller]
+    pub fn buffer_memory_requirements(
+        &self,
+        create_info: &BufferCreateInfo<'_>,
+    ) -> MemoryRequirements {
+        self.try_buffer_memory_requirements(create_info).unwrap()
+    }
+
+    /// Returns the memory requirements that would apply for a buffer created with the specified
     /// `create_info`.
     ///
     /// The device API version must be at least 1.3, or the [`khr_maintenance4`] extension must
@@ -860,7 +984,7 @@ impl Device {
     ///
     /// [`khr_maintenance4`]: DeviceExtensions::khr_maintenance4
     #[inline]
-    pub fn buffer_memory_requirements(
+    pub fn try_buffer_memory_requirements(
         &self,
         create_info: &BufferCreateInfo<'_>,
     ) -> Result<MemoryRequirements, Box<ValidationError>> {
@@ -940,6 +1064,35 @@ impl Device {
     }
 
     /// Returns the memory requirements that would apply for an image created with the specified
+    /// `create_info`, panicking on a validation error.
+    ///
+    /// If `create_info.flags` contains [`ImageCreateFlags::DISJOINT`], then `plane` must specify
+    /// the plane number of the format or memory plane (depending on tiling) that memory
+    /// requirements will be returned for. Otherwise, `plane` must be `None`.
+    ///
+    /// The device API version must be at least 1.3, or the [`khr_maintenance4`] extension must
+    /// be enabled on the device.
+    ///
+    /// This is a shortcut for `try_image_memory_requirements().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_image_memory_requirements`] returns a [`ValidationError`].
+    ///
+    /// [`khr_maintenance4`]: DeviceExtensions::khr_maintenance4
+    /// [`try_image_memory_requirements`]: Self::try_image_memory_requirements
+    #[inline]
+    #[track_caller]
+    pub fn image_memory_requirements(
+        &self,
+        create_info: &ImageCreateInfo<'_>,
+        plane: Option<usize>,
+    ) -> MemoryRequirements {
+        self.try_image_memory_requirements(create_info, plane)
+            .unwrap()
+    }
+
+    /// Returns the memory requirements that would apply for an image created with the specified
     /// `create_info`.
     ///
     /// If `create_info.flags` contains [`ImageCreateFlags::DISJOINT`], then `plane` must specify
@@ -951,7 +1104,7 @@ impl Device {
     ///
     /// [`khr_maintenance4`]: DeviceExtensions::khr_maintenance4
     #[inline]
-    pub fn image_memory_requirements(
+    pub fn try_image_memory_requirements(
         &self,
         create_info: &ImageCreateInfo<'_>,
         plane: Option<usize>,
@@ -1159,17 +1312,49 @@ impl Device {
     // TODO: image_sparse_memory_requirements
 
     /// Retrieves the properties of an external file descriptor when imported as a given external
-    /// handle type.
+    /// handle type, panicking on a validation error.
     ///
-    /// An error will be returned if the
-    /// [`khr_external_memory_fd`](DeviceExtensions::khr_external_memory_fd) extension was not
-    /// enabled on the device, or if `handle_type` is [`ExternalMemoryHandleType::OpaqueFd`].
+    /// An error will be returned if the [`khr_external_memory_fd`] extension was not enabled on
+    /// the device, or if `handle_type` is [`ExternalMemoryHandleType::OpaqueFd`].
+    ///
+    /// This is a shortcut for `try_memory_fd_properties().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
     /// - `fd` must be a handle to external memory that was created outside the Vulkan API.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_memory_fd_properties`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_memory_fd`]: DeviceExtensions::khr_external_memory_fd
+    /// [`try_memory_fd_properties`]: Self::try_memory_fd_properties
     #[inline]
+    #[track_caller]
     pub unsafe fn memory_fd_properties(
+        &self,
+        handle_type: ExternalMemoryHandleType,
+        fd: RawFd,
+    ) -> Result<MemoryFdProperties, VulkanError> {
+        match unsafe { self.try_memory_fd_properties(handle_type, fd) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Retrieves the properties of an external file descriptor when imported as a given external
+    /// handle type.
+    ///
+    /// An error will be returned if the [`khr_external_memory_fd`] extension was not enabled on
+    /// the device, or if `handle_type` is [`ExternalMemoryHandleType::OpaqueFd`].
+    ///
+    /// # Safety
+    ///
+    /// - `fd` must be a handle to external memory that was created outside the Vulkan API.
+    ///
+    /// [`khr_external_memory_fd`]: DeviceExtensions::khr_external_memory_fd
+    #[inline]
+    pub unsafe fn try_memory_fd_properties(
         &self,
         handle_type: ExternalMemoryHandleType,
         fd: RawFd,
@@ -1234,6 +1419,37 @@ impl Device {
     }
 
     /// Retrieves the properties of a Windows external memory handle when imported as a given
+    /// external handle type, panicking on a validation error.
+    ///
+    /// The [`khr_external_memory_fd`] extension must be enabled on the device and `handle_type`
+    /// must not be one of the `Opaque` handle types.
+    ///
+    /// This is a shortcut for `try_memory_win32_handle_properties().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// `handle` must be a valid Windows handle to external memory.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_memory_win32_handle_properties`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_memory_fd`]: DeviceExtensions::khr_external_memory_fd
+    /// [`try_memory_win32_handle_properties`]: Self::try_memory_win32_handle_properties
+    #[inline]
+    #[track_caller]
+    pub unsafe fn memory_win32_handle_properties(
+        &self,
+        handle_type: ExternalMemoryHandleType,
+        handle: vk::HANDLE,
+    ) -> Result<MemoryWin32HandleProperties, VulkanError> {
+        match unsafe { self.try_memory_win32_handle_properties(handle_type, handle) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Retrieves the properties of a Windows external memory handle when imported as a given
     /// external handle type.
     ///
     /// The [`khr_external_memory_fd`] extension must be enabled on the device and `handle_type`
@@ -1245,7 +1461,7 @@ impl Device {
     ///
     /// [`khr_external_memory_fd`]: DeviceExtensions::khr_external_memory_fd
     #[inline]
-    pub unsafe fn memory_win32_handle_properties(
+    pub unsafe fn try_memory_win32_handle_properties(
         &self,
         handle_type: ExternalMemoryHandleType,
         handle: vk::HANDLE,
@@ -1315,18 +1531,51 @@ impl Device {
         ))
     }
 
+    /// Assigns a human-readable name to `object` for debugging purposes, panicking on a validation
+    /// error.
+    ///
+    /// The [`ext_debug_utils`] extension must be enabled on the instance.
+    ///
+    /// If `object_name` is `None`, a previously set object name is removed.
+    ///
+    /// This is a shortcut for `try_set_debug_utils_object_name().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `object` must not be used concurrently by any other Vulkan command.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_debug_utils_object_name`] returns a [`ValidationError`].
+    ///
+    /// [`ext_debug_utils`]: crate::instance::InstanceExtensions::ext_debug_utils
+    /// [`try_set_debug_utils_object_name`]: Self::try_set_debug_utils_object_name
+    #[inline]
+    #[track_caller]
+    pub unsafe fn set_debug_utils_object_name<T: VulkanObject + DeviceOwned>(
+        &self,
+        object: &T,
+        object_name: Option<&str>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_set_debug_utils_object_name(object, object_name) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Assigns a human-readable name to `object` for debugging purposes.
     ///
-    /// The [`ext_debug_utils`](crate::instance::InstanceExtensions::ext_debug_utils) extension
-    /// must be enabled on the instance.
+    /// The [`ext_debug_utils`] extension must be enabled on the instance.
     ///
     /// If `object_name` is `None`, a previously set object name is removed.
     ///
     /// # Safety
     ///
     /// - `object` must not be used concurrently by any other Vulkan command.
+    ///
+    /// [`ext_debug_utils`]: crate::instance::InstanceExtensions::ext_debug_utils
     #[inline]
-    pub unsafe fn set_debug_utils_object_name<T: VulkanObject + DeviceOwned>(
+    pub unsafe fn try_set_debug_utils_object_name<T: VulkanObject + DeviceOwned>(
         &self,
         object: &T,
         object_name: Option<&str>,
@@ -2203,7 +2452,7 @@ pub unsafe trait DeviceOwnedVulkanObject {
     unsafe fn set_debug_utils_object_name(
         &self,
         object_name: Option<&str>,
-    ) -> Result<(), Validated<VulkanError>>;
+    ) -> Result<(), VulkanError>;
 }
 
 unsafe impl<T> DeviceOwnedVulkanObject for T
@@ -2213,7 +2462,7 @@ where
     unsafe fn set_debug_utils_object_name(
         &self,
         object_name: Option<&str>,
-    ) -> Result<(), Validated<VulkanError>> {
+    ) -> Result<(), VulkanError> {
         unsafe { self.device().set_debug_utils_object_name(self, object_name) }
     }
 }
@@ -2397,7 +2646,7 @@ mod tests {
             .map(|_| 0.5)
             .collect::<Vec<_>>();
 
-        assert!(Device::new(
+        assert!(Device::try_new(
             &physical_device,
             &DeviceCreateInfo {
                 queue_create_infos: &[QueueCreateInfo {
@@ -2425,7 +2674,7 @@ mod tests {
             return;
         }
 
-        assert!(Device::new(
+        assert!(Device::try_new(
             &physical_device,
             &DeviceCreateInfo {
                 queue_create_infos: &[QueueCreateInfo {
@@ -2447,7 +2696,7 @@ mod tests {
             None => return,
         };
 
-        assert!(Device::new(
+        assert!(Device::try_new(
             &physical_device,
             &DeviceCreateInfo {
                 queue_create_infos: &[QueueCreateInfo {
@@ -2460,7 +2709,7 @@ mod tests {
         )
         .is_err());
 
-        assert!(Device::new(
+        assert!(Device::try_new(
             &physical_device,
             &DeviceCreateInfo {
                 queue_create_infos: &[QueueCreateInfo {

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -497,9 +497,28 @@ impl PhysicalDevice {
         &self.queue_family_properties
     }
 
+    /// Returns the properties of displays attached to the physical device, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_display_properties().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_display_properties`] returns a [`ValidationError`].
+    ///
+    /// [`try_display_properties`]: Self::try_display_properties
+    #[inline]
+    #[track_caller]
+    pub fn display_properties(self: &Arc<Self>) -> Result<Vec<Arc<Display>>, VulkanError> {
+        match self.try_display_properties() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns the properties of displays attached to the physical device.
     #[inline]
-    pub fn display_properties(
+    pub fn try_display_properties(
         self: &Arc<Self>,
     ) -> Result<Vec<Arc<Display>>, Validated<VulkanError>> {
         self.validate_display_properties()?;
@@ -626,9 +645,30 @@ impl PhysicalDevice {
         }
     }
 
+    /// Returns the properties of the display planes of the physical device, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_display_plane_properties().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_display_plane_properties`] returns a [`ValidationError`].
+    ///
+    /// [`try_display_plane_properties`]: Self::try_display_plane_properties
+    #[inline]
+    #[track_caller]
+    pub fn display_plane_properties(
+        self: &Arc<Self>,
+    ) -> Result<Vec<DisplayPlaneProperties>, VulkanError> {
+        match self.try_display_plane_properties() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns the properties of the display planes of the physical device.
     #[inline]
-    pub fn display_plane_properties(
+    pub fn try_display_plane_properties(
         self: &Arc<Self>,
     ) -> Result<Vec<DisplayPlaneProperties>, Validated<VulkanError>> {
         self.validate_display_plane_properties()?;
@@ -792,12 +832,40 @@ impl PhysicalDevice {
         Ok(properties_raw)
     }
 
+    /// Returns the displays that are supported for the given plane index, panicking on a
+    /// validation error.
+    ///
+    /// The index must be less than the number of elements returned by
+    /// [`display_plane_properties`].
+    ///
+    /// This is a shortcut for `try_display_plane_supported_displays().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_display_plane_supported_displays`] returns a [`ValidationError`].
+    ///
+    /// [`display_plane_properties`]: Self::display_plane_properties
+    /// [`try_display_plane_supported_displays`]: Self::try_display_plane_supported_displays
+    #[inline]
+    #[track_caller]
+    pub fn display_plane_supported_displays(
+        self: &Arc<Self>,
+        plane_index: u32,
+    ) -> Result<Vec<Arc<Display>>, VulkanError> {
+        match self.try_display_plane_supported_displays(plane_index) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns the displays that are supported for the given plane index.
     ///
     /// The index must be less than the number of elements returned by
-    /// [`display_plane_properties`](Self::display_plane_properties).
+    /// [`display_plane_properties`].
+    ///
+    /// [`display_plane_properties`]: Self::display_plane_properties
     #[inline]
-    pub fn display_plane_supported_displays(
+    pub fn try_display_plane_supported_displays(
         self: &Arc<Self>,
         plane_index: u32,
     ) -> Result<Vec<Arc<Display>>, Validated<VulkanError>> {
@@ -899,6 +967,32 @@ impl PhysicalDevice {
         Ok(displays)
     }
 
+    /// Retrieves the external memory properties supported for buffers with a given configuration,
+    /// panicking on a validation error.
+    ///
+    /// Instance API version must be at least 1.1, or the [`khr_external_memory_capabilities`]
+    /// extension must be enabled on the instance.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_external_buffer_properties().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_external_buffer_properties`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_memory_capabilities`]: crate::instance::InstanceExtensions::khr_external_memory_capabilities
+    /// [`try_external_buffer_properties`]: Self::try_external_buffer_properties
+    #[inline]
+    #[track_caller]
+    pub fn external_buffer_properties(
+        &self,
+        info: &ExternalBufferInfo<'_>,
+    ) -> ExternalBufferProperties {
+        self.try_external_buffer_properties(info).unwrap()
+    }
+
     /// Retrieves the external memory properties supported for buffers with a given configuration.
     ///
     /// Instance API version must be at least 1.1, or the [`khr_external_memory_capabilities`]
@@ -909,7 +1003,7 @@ impl PhysicalDevice {
     ///
     /// [`khr_external_memory_capabilities`]: crate::instance::InstanceExtensions::khr_external_memory_capabilities
     #[inline]
-    pub fn external_buffer_properties(
+    pub fn try_external_buffer_properties(
         &self,
         info: &ExternalBufferInfo<'_>,
     ) -> Result<ExternalBufferProperties, Box<ValidationError>> {
@@ -991,6 +1085,32 @@ impl PhysicalDevice {
     }
 
     /// Retrieves the external handle properties supported for fences with a given
+    /// configuration, panicking on a validation error.
+    ///
+    /// The instance API version must be at least 1.1, or the [`khr_external_fence_capabilities`]
+    /// extension must be enabled on the instance.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_external_fence_properties().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_external_fence_properties`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_fence_capabilities`]: crate::instance::InstanceExtensions::khr_external_fence_capabilities
+    /// [`try_external_fence_properties`]: Self::try_external_fence_properties
+    #[inline]
+    #[track_caller]
+    pub fn external_fence_properties(
+        &self,
+        info: &ExternalFenceInfo<'_>,
+    ) -> ExternalFenceProperties {
+        self.try_external_fence_properties(info).unwrap()
+    }
+
+    /// Retrieves the external handle properties supported for fences with a given
     /// configuration.
     ///
     /// The instance API version must be at least 1.1, or the [`khr_external_fence_capabilities`]
@@ -1001,7 +1121,7 @@ impl PhysicalDevice {
     ///
     /// [`khr_external_fence_capabilities`]: crate::instance::InstanceExtensions::khr_external_fence_capabilities
     #[inline]
-    pub fn external_fence_properties(
+    pub fn try_external_fence_properties(
         &self,
         info: &ExternalFenceInfo<'_>,
     ) -> Result<ExternalFenceProperties, Box<ValidationError>> {
@@ -1083,6 +1203,32 @@ impl PhysicalDevice {
     }
 
     /// Retrieves the external handle properties supported for semaphores with a given
+    /// configuration, panicking on a validation error
+    ///
+    /// The instance API version must be at least 1.1, or the
+    /// [`khr_external_semaphore_capabilities`] extension must be enabled on the instance.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_external_semaphore_properties().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_external_semaphore_properties`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_semaphore_capabilities`]: crate::instance::InstanceExtensions::khr_external_semaphore_capabilities
+    /// [`try_external_semaphore_properties`]: Self::try_external_semaphore_properties
+    #[inline]
+    #[track_caller]
+    pub fn external_semaphore_properties(
+        &self,
+        info: &ExternalSemaphoreInfo<'_>,
+    ) -> ExternalSemaphoreProperties {
+        self.try_external_semaphore_properties(info).unwrap()
+    }
+
+    /// Retrieves the external handle properties supported for semaphores with a given
     /// configuration.
     ///
     /// The instance API version must be at least 1.1, or the
@@ -1093,7 +1239,7 @@ impl PhysicalDevice {
     ///
     /// [`khr_external_semaphore_capabilities`]: crate::instance::InstanceExtensions::khr_external_semaphore_capabilities
     #[inline]
-    pub fn external_semaphore_properties(
+    pub fn try_external_semaphore_properties(
         &self,
         info: &ExternalSemaphoreInfo<'_>,
     ) -> Result<ExternalSemaphoreProperties, Box<ValidationError>> {
@@ -1175,12 +1321,31 @@ impl PhysicalDevice {
             })
     }
 
+    /// Retrieves the properties of a format when used by this physical device, panicking on a
+    /// validation error.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_format_properties().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_format_properties`] returns a [`ValidationError`].
+    ///
+    /// [`try_format_properties`]: Self::try_format_properties
+    #[inline]
+    #[track_caller]
+    pub fn format_properties(&self, format: Format) -> FormatProperties {
+        self.try_format_properties(format).unwrap()
+    }
+
     /// Retrieves the properties of a format when used by this physical device.
     ///
     /// The results of this function are cached, so that future calls with the same arguments
     /// do not need to make a call to the Vulkan API again.
     #[inline]
-    pub fn format_properties(
+    pub fn try_format_properties(
         &self,
         format: Format,
     ) -> Result<FormatProperties, Box<ValidationError>> {
@@ -1273,6 +1438,34 @@ impl PhysicalDevice {
         })
     }
 
+    /// Returns the properties supported for images with a given image configuration, panicking on
+    /// a validation error.
+    ///
+    /// `Some` is returned if the configuration is supported, `None` if it is not.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_image_format_properties().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_image_format_properties`] returns a [`ValidationError`].
+    /// - Panics if `image_format_info.format` is `None`.
+    ///
+    /// [`try_image_format_properties`]: Self::try_image_format_properties
+    #[inline]
+    #[track_caller]
+    pub fn image_format_properties(
+        &self,
+        image_format_info: &ImageFormatInfo<'_>,
+    ) -> Result<Option<ImageFormatProperties>, VulkanError> {
+        match self.try_image_format_properties(image_format_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns the properties supported for images with a given image configuration.
     ///
     /// `Some` is returned if the configuration is supported, `None` if it is not.
@@ -1284,7 +1477,7 @@ impl PhysicalDevice {
     ///
     /// - Panics if `image_format_info.format` is `None`.
     #[inline]
-    pub fn image_format_properties(
+    pub fn try_image_format_properties(
         &self,
         image_format_info: &ImageFormatInfo<'_>,
     ) -> Result<Option<ImageFormatProperties>, Validated<VulkanError>> {
@@ -1400,6 +1593,30 @@ impl PhysicalDevice {
             })
     }
 
+    /// Returns the properties of sparse images with a given image configuration, panicking on a
+    /// validation error.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_sparse_image_format_properties().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_sparse_image_format_properties`] returns a [`ValidationError`].
+    /// - Panics if `format_info.format` is `None`.
+    ///
+    /// [`try_sparse_image_format_properties`]: Self::try_sparse_image_format_properties
+    #[inline]
+    #[track_caller]
+    pub fn sparse_image_format_properties(
+        &self,
+        format_info: &SparseImageFormatInfo<'_>,
+    ) -> Vec<SparseImageFormatProperties> {
+        self.try_sparse_image_format_properties(format_info)
+            .unwrap()
+    }
+
     /// Returns the properties of sparse images with a given image configuration.
     ///
     /// The results of this function are cached, so that future calls with the same arguments
@@ -1409,7 +1626,7 @@ impl PhysicalDevice {
     ///
     /// - Panics if `format_info.format` is `None`.
     #[inline]
-    pub fn sparse_image_format_properties(
+    pub fn try_sparse_image_format_properties(
         &self,
         format_info: &SparseImageFormatInfo<'_>,
     ) -> Result<Vec<SparseImageFormatProperties>, Box<ValidationError>> {
@@ -1552,6 +1769,32 @@ impl PhysicalDevice {
             })
     }
 
+    /// Returns the capabilities that are supported by the physical device for the given surface,
+    /// panicking on a validation error.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_surface_capabilities().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_surface_capabilities`] returns a [`ValidationError`].
+    /// - Panics if the physical device and the surface don't belong to the same instance.
+    ///
+    /// [`try_surface_capabilities`]: Self::try_surface_capabilities
+    #[track_caller]
+    pub fn surface_capabilities(
+        &self,
+        surface: &Surface,
+        surface_info: &SurfaceInfo<'_>,
+    ) -> Result<SurfaceCapabilities, VulkanError> {
+        match self.try_surface_capabilities(surface, surface_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns the capabilities that are supported by the physical device for the given surface.
     ///
     /// The results of this function are cached, so that future calls with the same arguments
@@ -1560,7 +1803,7 @@ impl PhysicalDevice {
     /// # Panics
     ///
     /// - Panics if the physical device and the surface don't belong to the same instance.
-    pub fn surface_capabilities(
+    pub fn try_surface_capabilities(
         &self,
         surface: &Surface,
         surface_info: &SurfaceInfo<'_>,
@@ -1734,6 +1977,32 @@ impl PhysicalDevice {
     }
 
     /// Returns the combinations of format and color space that are supported by the physical
+    /// device for the given surface, panicking on a validation error.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_surface_formats().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_surface_formats`] returns a [`ValidationError`].
+    /// - Panics if the physical device and the surface don't belong to the same instance.
+    ///
+    /// [`try_surface_formats`]: Self::try_surface_formats
+    #[track_caller]
+    pub fn surface_formats(
+        &self,
+        surface: &Surface,
+        surface_info: &SurfaceInfo<'_>,
+    ) -> Result<Vec<(Format, ColorSpace)>, VulkanError> {
+        match self.try_surface_formats(surface, surface_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Returns the combinations of format and color space that are supported by the physical
     /// device for the given surface.
     ///
     /// The results of this function are cached, so that future calls with the same arguments
@@ -1742,7 +2011,7 @@ impl PhysicalDevice {
     /// # Panics
     ///
     /// - Panics if the physical device and the surface don't belong to the same instance.
-    pub fn surface_formats(
+    pub fn try_surface_formats(
         &self,
         surface: &Surface,
         surface_info: &SurfaceInfo<'_>,
@@ -1976,6 +2245,32 @@ impl PhysicalDevice {
             })
     }
 
+    /// Returns the present modes that are supported by the physical device for the given surface,
+    /// panicking on a validation error.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_surface_present_modes().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_surface_present_modes`] returns a [`ValidationError`].
+    /// - Panics if the physical device and the surface don't belong to the same instance.
+    ///
+    /// [`try_surface_present_modes`]: Self::try_surface_present_modes
+    #[track_caller]
+    pub fn surface_present_modes(
+        &self,
+        surface: &Surface,
+        surface_info: &SurfaceInfo<'_>,
+    ) -> Result<Vec<PresentMode>, VulkanError> {
+        match self.try_surface_present_modes(surface, surface_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns the present modes that are supported by the physical device for the given surface.
     ///
     /// The results of this function are cached, so that future calls with the same arguments
@@ -1984,7 +2279,7 @@ impl PhysicalDevice {
     /// # Panics
     ///
     /// - Panics if the physical device and the surface don't belong to the same instance.
-    pub fn surface_present_modes(
+    pub fn try_surface_present_modes(
         &self,
         surface: &Surface,
         surface_info: &SurfaceInfo<'_>,
@@ -2177,6 +2472,37 @@ impl PhysicalDevice {
         )
     }
 
+    /// Returns whether queues of the given queue family support presentation to the given surface,
+    /// panicking on a validation error.
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments do
+    /// not need to make a call to the Vulkan API again.
+    ///
+    /// See also [`presentation_support`] for determining if a queue family supports presentation
+    /// to the surface of any window of a given event loop, for instance in cases where you have no
+    /// window and hence no surface at hand to test with or when you could have multiple windows.
+    ///
+    /// This is a shortcut for `try_surface_support().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_surface_support`] returns a [`ValidationError`].
+    ///
+    /// [`presentation_support`]: Self::presentation_support
+    /// [`try_surface_support`]: Self::try_surface_support
+    #[inline]
+    #[track_caller]
+    pub fn surface_support(
+        &self,
+        queue_family_index: u32,
+        surface: &Surface,
+    ) -> Result<bool, VulkanError> {
+        match self.try_surface_support(queue_family_index, surface) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns whether queues of the given queue family support presentation to the given surface.
     ///
     /// The results of this function are cached, so that future calls with the same arguments do
@@ -2188,7 +2514,7 @@ impl PhysicalDevice {
     ///
     /// [`presentation_support`]: Self::presentation_support
     #[inline]
-    pub fn surface_support(
+    pub fn try_surface_support(
         &self,
         queue_family_index: u32,
         surface: &Surface,
@@ -2255,16 +2581,43 @@ impl PhysicalDevice {
             })
     }
 
+    /// Retrieves the properties of tools that are currently active on the physical device,
+    /// panicking on a validation error.
+    ///
+    /// These properties may change during runtime, so the result only reflects the current
+    /// situation and is not cached.
+    ///
+    /// The physical device API version must be at least 1.3, or the [`ext_tooling_info`]
+    /// extension must be supported by the physical device.
+    ///
+    /// This is a shortcut for `try_tool_properties().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_tool_properties`] returns a [`ValidationError`].
+    ///
+    /// [`ext_tooling_info`]: crate::device::DeviceExtensions::ext_tooling_info
+    /// [`try_tool_properties`]: Self::try_tool_properties
+    #[inline]
+    #[track_caller]
+    pub fn tool_properties(&self) -> Result<Vec<ToolProperties>, VulkanError> {
+        match self.try_tool_properties() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Retrieves the properties of tools that are currently active on the physical device.
     ///
     /// These properties may change during runtime, so the result only reflects the current
     /// situation and is not cached.
     ///
-    /// The physical device API version must be at least 1.3, or the
-    /// [`ext_tooling_info`](crate::device::DeviceExtensions::ext_tooling_info)
+    /// The physical device API version must be at least 1.3, or the [`ext_tooling_info`]
     /// extension must be supported by the physical device.
+    ///
+    /// [`ext_tooling_info`]: crate::device::DeviceExtensions::ext_tooling_info
     #[inline]
-    pub fn tool_properties(&self) -> Result<Vec<ToolProperties>, Validated<VulkanError>> {
+    pub fn try_tool_properties(&self) -> Result<Vec<ToolProperties>, Validated<VulkanError>> {
         self.validate_tool_properties()?;
 
         Ok(unsafe { self.tool_properties_unchecked() }?)
@@ -2347,6 +2700,40 @@ impl PhysicalDevice {
     }
 
     /// Returns whether queues of the given queue family support presentation to surfaces of
+    /// windows of the given event loop, panicking on a validation error.
+    ///
+    /// On the X11 platform, this checks if the given queue family supports presentation to
+    /// surfaces of windows created with the root visual. This means that if you create your
+    /// window(s) with a different visual, the result of this function doesn't guarantee support
+    /// for that window's surface, and you should use [`xcb_presentation_support`] or
+    /// [`xlib_presentation_support`] directly to determine support for presentation to such
+    /// surfaces.
+    ///
+    /// See also [`surface_support`] for determining if a queue family supports presentation to a
+    /// specific surface.
+    ///
+    /// This is a shortcut for `try_presentation_support().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_presentation_support`] returns a [`ValidationError`].
+    ///
+    /// [`xcb_presentation_support`]: Self::xcb_presentation_support
+    /// [`xlib_presentation_support`]: Self::xlib_presentation_support
+    /// [`surface_support`]: Self::surface_support
+    /// [`try_presentation_support`]: Self::try_presentation_support
+    #[cfg(feature = "raw_window_handle")]
+    #[track_caller]
+    pub fn presentation_support(
+        &self,
+        queue_family_index: u32,
+        event_loop: &impl HasDisplayHandle,
+    ) -> bool {
+        self.try_presentation_support(queue_family_index, event_loop)
+            .unwrap()
+    }
+
+    /// Returns whether queues of the given queue family support presentation to surfaces of
     /// windows of the given event loop.
     ///
     /// On the X11 platform, this checks if the given queue family supports presentation to
@@ -2363,7 +2750,7 @@ impl PhysicalDevice {
     /// [`xlib_presentation_support`]: Self::xlib_presentation_support
     /// [`surface_support`]: Self::surface_support
     #[cfg(feature = "raw_window_handle")]
-    pub fn presentation_support(
+    pub fn try_presentation_support(
         &self,
         queue_family_index: u32,
         event_loop: &impl HasDisplayHandle,
@@ -2379,10 +2766,13 @@ impl PhysicalDevice {
             RawDisplayHandle::AppKit(_) => true,
             RawDisplayHandle::Wayland(display) => {
                 let display = display.display.as_ptr();
-                unsafe { self.wayland_presentation_support(queue_family_index, display.cast()) }?
+
+                unsafe {
+                    self.try_wayland_presentation_support(queue_family_index, display.cast())
+                }?
             }
             RawDisplayHandle::Windows(_display) => {
-                self.win32_presentation_support(queue_family_index)?
+                self.try_win32_presentation_support(queue_family_index)?
             }
             #[cfg(all(
                 any(
@@ -2403,7 +2793,11 @@ impl PhysicalDevice {
                 let visual_id = unsafe { get_xcb_root_visual_id(connection, screen) };
 
                 unsafe {
-                    self.xcb_presentation_support(queue_family_index, connection.cast(), visual_id)
+                    self.try_xcb_presentation_support(
+                        queue_family_index,
+                        connection.cast(),
+                        visual_id,
+                    )
                 }?
             }
             #[cfg(all(
@@ -2425,7 +2819,11 @@ impl PhysicalDevice {
                 let visual_id = unsafe { get_xlib_root_visual_id(display, screen) };
 
                 unsafe {
-                    self.xlib_presentation_support(queue_family_index, display.cast(), visual_id)
+                    self.try_xlib_presentation_support(
+                        queue_family_index,
+                        display.cast(),
+                        visual_id,
+                    )
                 }?
             }
             #[cfg(all(
@@ -2454,12 +2852,35 @@ impl PhysicalDevice {
     }
 
     /// Queries whether the physical device supports presenting to Wayland surfaces from queues of
+    /// the given queue family, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_wayland_presentation_support().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - `display` must be a valid Wayland `wl_display` handle.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_wayland_presentation_support`] returns a [`ValidationError`].
+    ///
+    /// [`try_wayland_presentation_support`]: Self::try_wayland_presentation_support
+    #[track_caller]
+    pub unsafe fn wayland_presentation_support(
+        &self,
+        queue_family_index: u32,
+        display: *mut vk::wl_display,
+    ) -> bool {
+        unsafe { self.try_wayland_presentation_support(queue_family_index, display) }.unwrap()
+    }
+
+    /// Queries whether the physical device supports presenting to Wayland surfaces from queues of
     /// the given queue family.
     ///
     /// # Safety
     ///
     /// - `display` must be a valid Wayland `wl_display` handle.
-    pub unsafe fn wayland_presentation_support(
+    pub unsafe fn try_wayland_presentation_support(
         &self,
         queue_family_index: u32,
         display: *mut vk::wl_display,
@@ -2521,9 +2942,26 @@ impl PhysicalDevice {
     }
 
     /// Queries whether the physical device supports presenting to Win32 surfaces from queues of
+    /// the given queue family, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_win32_presentation_support().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_win32_presentation_support`] returns a [`ValidationError`].
+    ///
+    /// [`try_win32_presentation_support`]: Self::try_win32_presentation_support
+    #[inline]
+    #[track_caller]
+    pub fn win32_presentation_support(&self, queue_family_index: u32) -> bool {
+        self.try_win32_presentation_support(queue_family_index)
+            .unwrap()
+    }
+
+    /// Queries whether the physical device supports presenting to Win32 surfaces from queues of
     /// the given queue family.
     #[inline]
-    pub fn win32_presentation_support(
+    pub fn try_win32_presentation_support(
         &self,
         queue_family_index: u32,
     ) -> Result<bool, Box<ValidationError>> {
@@ -2576,12 +3014,37 @@ impl PhysicalDevice {
     }
 
     /// Queries whether the physical device supports presenting to XCB surfaces from queues of the
+    /// given queue family, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_xcb_presentation_support().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - `connection` must be a valid X11 `xcb_connection_t` handle.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_xcb_presentation_support`] returns a [`ValidationError`].
+    ///
+    /// [`try_xcb_presentation_support`]: Self::try_xcb_presentation_support
+    #[track_caller]
+    pub unsafe fn xcb_presentation_support(
+        &self,
+        queue_family_index: u32,
+        connection: *mut vk::xcb_connection_t,
+        visual_id: vk::xcb_visualid_t,
+    ) -> bool {
+        unsafe { self.try_xcb_presentation_support(queue_family_index, connection, visual_id) }
+            .unwrap()
+    }
+
+    /// Queries whether the physical device supports presenting to XCB surfaces from queues of the
     /// given queue family.
     ///
     /// # Safety
     ///
     /// - `connection` must be a valid X11 `xcb_connection_t` handle.
-    pub unsafe fn xcb_presentation_support(
+    pub unsafe fn try_xcb_presentation_support(
         &self,
         queue_family_index: u32,
         connection: *mut vk::xcb_connection_t,
@@ -2649,12 +3112,37 @@ impl PhysicalDevice {
     }
 
     /// Queries whether the physical device supports presenting to Xlib surfaces from queues of the
+    /// given queue family, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_xlib_presentation_support().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - `display` must be a valid Xlib `Display` handle.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_xlib_presentation_support`] returns a [`ValidationError`].
+    ///
+    /// [`try_xlib_presentation_support`]: Self::try_xlib_presentation_support
+    #[track_caller]
+    pub unsafe fn xlib_presentation_support(
+        &self,
+        queue_family_index: u32,
+        display: *mut vk::Display,
+        visual_id: vk::VisualID,
+    ) -> bool {
+        unsafe { self.try_xlib_presentation_support(queue_family_index, display, visual_id) }
+            .unwrap()
+    }
+
+    /// Queries whether the physical device supports presenting to Xlib surfaces from queues of the
     /// given queue family.
     ///
     /// # Safety
     ///
     /// - `display` must be a valid Xlib `Display` handle.
-    pub unsafe fn xlib_presentation_support(
+    pub unsafe fn try_xlib_presentation_support(
         &self,
         queue_family_index: u32,
         display: *mut vk::Display,
@@ -2722,13 +3210,37 @@ impl PhysicalDevice {
     }
 
     /// Queries whether the physical device supports presenting to DirectFB surfaces from queues of
+    /// the given queue family, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_directfb_presentation_support().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - `dfb` must be a valid DirectFB `IDirectFB` handle.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_directfb_presentation_support`] returns a [`ValidationError`].
+    ///
+    /// [`try_directfb_presentation_support`]: Self::try_directfb_presentation_support
+    #[inline]
+    #[track_caller]
+    pub unsafe fn directfb_presentation_support(
+        &self,
+        queue_family_index: u32,
+        dfb: *mut vk::IDirectFB,
+    ) -> bool {
+        unsafe { self.try_directfb_presentation_support(queue_family_index, dfb) }.unwrap()
+    }
+
+    /// Queries whether the physical device supports presenting to DirectFB surfaces from queues of
     /// the given queue family.
     ///
     /// # Safety
     ///
     /// - `dfb` must be a valid DirectFB `IDirectFB` handle.
     #[inline]
-    pub unsafe fn directfb_presentation_support(
+    pub unsafe fn try_directfb_presentation_support(
         &self,
         queue_family_index: u32,
         dfb: *mut vk::IDirectFB,
@@ -2791,12 +3303,35 @@ impl PhysicalDevice {
     }
 
     /// Queries whether the physical device supports presenting to QNX Screen surfaces from queues
+    /// of the given queue family, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_qnx_screen_presentation_support().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - `window` must be a valid QNX Screen `_screen_window` handle.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_qnx_screen_presentation_support`] returns a [`ValidationError`].
+    ///
+    /// [`try_qnx_screen_presentation_support`]: Self::try_qnx_screen_presentation_support
+    #[track_caller]
+    pub unsafe fn qnx_screen_presentation_support(
+        &self,
+        queue_family_index: u32,
+        window: *mut vk::_screen_window,
+    ) -> bool {
+        unsafe { self.try_qnx_screen_presentation_support(queue_family_index, window) }.unwrap()
+    }
+
+    /// Queries whether the physical device supports presenting to QNX Screen surfaces from queues
     /// of the given queue family.
     ///
     /// # Safety
     ///
     /// - `window` must be a valid QNX Screen `_screen_window` handle.
-    pub unsafe fn qnx_screen_presentation_support(
+    pub unsafe fn try_qnx_screen_presentation_support(
         &self,
         queue_family_index: u32,
         window: *mut vk::_screen_window,

--- a/vulkano/src/device/private_data.rs
+++ b/vulkano/src/device/private_data.rs
@@ -30,11 +30,35 @@ pub struct PrivateDataSlot {
 }
 
 impl PrivateDataSlot {
+    /// Creates a new `PrivateDataSlot`, panicking on a validation error.
+    ///
+    /// The [`private_data`] feature must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`private_data`]: crate::device::DeviceFeatures::private_data
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &PrivateDataSlotCreateInfo<'_>,
+    ) -> Result<Self, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `PrivateDataSlot`.
     ///
     /// The `private_data` feature must be enabled on the device.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &PrivateDataSlotCreateInfo<'_>,
     ) -> Result<Self, Validated<VulkanError>> {
@@ -121,11 +145,36 @@ impl PrivateDataSlot {
         }
     }
 
+    /// Sets the private data that is associated with `object` to `data`, panicking on a validation
+    /// error.
+    ///
+    /// If `self` already has data for `object`, that data is replaced with the new value.
+    ///
+    /// This is a shortcut for `try_set_private_data().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set_private_data`] returns a [`ValidationError`].
+    ///
+    /// [`try_set_private_data`]: Self::try_set_private_data
+    #[inline]
+    #[track_caller]
+    pub fn set_private_data<T: VulkanObject + DeviceOwned>(
+        &self,
+        object: &T,
+        data: u64,
+    ) -> Result<(), VulkanError> {
+        match self.try_set_private_data(object, data) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Sets the private data that is associated with `object` to `data`.
     ///
     /// If `self` already has data for `object`, that data is replaced with the new value.
     #[inline]
-    pub fn set_private_data<T: VulkanObject + DeviceOwned>(
+    pub fn try_set_private_data<T: VulkanObject + DeviceOwned>(
         &self,
         object: &T,
         data: u64,

--- a/vulkano/src/device/queue.rs
+++ b/vulkano/src/device/queue.rs
@@ -330,6 +330,52 @@ impl<'a> QueueGuard<'a> {
             .map_err(VulkanError::from)
     }
 
+    /// Bind or unbind memory to resources with sparse memory, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_bind_sparse().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// For every semaphore in the `wait_semaphores` elements of every `bind_infos` element:
+    /// - The semaphore must be kept alive while the command is being executed.
+    /// - The semaphore must be already in the signaled state, or there must be a previously
+    ///   submitted operation that will signal it.
+    /// - When the wait operation is executed, no other queue must be waiting on the same
+    ///   semaphore.
+    ///
+    /// For every element in the `buffer_binds`, `image_opaque_binds` and `image_binds`
+    /// elements of every `bind_infos` element:
+    /// - The buffers and images must be kept alive while the command is being executed.
+    /// - The memory allocations must be kept alive while they are bound to a buffer or image.
+    /// - Access to the affected regions of each buffer or image must be synchronized.
+    ///
+    /// For every semaphore in the `signal_semaphores` elements of every `bind_infos` element:
+    /// - The semaphore must be kept alive while the command is being executed.
+    /// - When the signal operation is executed, the semaphore must be in the unsignaled state.
+    ///
+    /// If `fence` is `Some`:
+    /// - The fence must be kept alive while the command is being executed.
+    /// - The fence must be unsignaled and must not be associated with any other command that is
+    ///   still executing.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_bind_sparse`] returns a [`ValidationError`].
+    ///
+    /// [`try_bind_sparse`]: Self::try_bind_sparse
+    #[inline]
+    #[track_caller]
+    pub unsafe fn bind_sparse(
+        &mut self,
+        bind_infos: &[BindSparseInfo<'_>],
+        fence: Option<&Arc<Fence>>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_bind_sparse(bind_infos, fence) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Bind or unbind memory to resources with sparse memory.
     ///
     /// # Safety
@@ -356,7 +402,7 @@ impl<'a> QueueGuard<'a> {
     /// - The fence must be unsignaled and must not be associated with any other command that is
     ///   still executing.
     #[inline]
-    pub unsafe fn bind_sparse(
+    pub unsafe fn try_bind_sparse(
         &mut self,
         bind_infos: &[BindSparseInfo<'_>],
         fence: Option<&Arc<Fence>>,
@@ -447,6 +493,48 @@ impl<'a> QueueGuard<'a> {
         .map_err(VulkanError::from)
     }
 
+    /// Queues swapchain images for presentation to the surface, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_present().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// For every semaphore in the `wait_semaphores` elements of `present_info`:
+    /// - The semaphore must be kept alive while the command is being executed.
+    /// - The semaphore must be already in the signaled state, or there must be a previously
+    ///   submitted operation that will signal it.
+    /// - When the wait operation is executed, no other queue must be waiting on the same
+    ///   semaphore.
+    ///
+    /// For every element of `present_info.swapchain_infos`:
+    /// - `swapchain` must be kept alive while the command is being executed.
+    /// - `image_index` must be an index previously acquired from the swapchain, and the present
+    ///   operation must happen-after the acquire operation.
+    /// - The swapchain image indicated by `swapchain` and `image_index` must be in the
+    ///   [`ImageLayout::PresentSrc`] layout when the presentation operation is executed.
+    /// - The swapchain image indicated by `swapchain` and `image_index` must not be accessed after
+    ///   this function is called, until it is acquired again.
+    /// - If `present_id` is `Some`, then it must be greater than any present ID previously used
+    ///   for the same swapchain.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_present`] returns a [`ValidationError`].
+    ///
+    /// [`ImageLayout::PresentSrc`]: crate::image::ImageLayout::PresentSrc
+    /// [`try_present`]: Self::try_present
+    #[inline]
+    #[track_caller]
+    pub unsafe fn present(
+        &mut self,
+        present_info: &PresentInfo,
+    ) -> Result<impl ExactSizeIterator<Item = Result<bool, VulkanError>> + use<>, VulkanError> {
+        match unsafe { self.try_present(present_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Queues swapchain images for presentation to the surface.
     ///
     /// # Safety
@@ -471,7 +559,7 @@ impl<'a> QueueGuard<'a> {
     ///
     /// [`ImageLayout::PresentSrc`]: crate::image::ImageLayout::PresentSrc
     #[inline]
-    pub unsafe fn present(
+    pub unsafe fn try_present(
         &mut self,
         present_info: &PresentInfo,
     ) -> Result<
@@ -585,6 +673,65 @@ impl<'a> QueueGuard<'a> {
         }))
     }
 
+    /// Submits command buffers to a queue to be executed, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_submit().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// For every semaphore in the `wait_semaphores` elements of every `submit_infos` element:
+    /// - The semaphore must be kept alive while the command is being executed.
+    /// - The safety requirements for semaphores, as detailed in the
+    ///   [`semaphore`](crate::sync::semaphore#Safety) module documentation, must be followed.
+    ///
+    /// For every command buffer in the `command_buffers` elements of every `submit_infos` element,
+    /// as well as any secondary command buffers recorded within it:
+    /// - The command buffer, and any resources it uses, must be kept alive while the command is
+    ///   being executed.
+    /// - Any mutable resources used by the command buffer must be in the state (image layout,
+    ///   query reset, event signal etc.) expected by the command buffer at the time it begins
+    ///   executing, and must be synchronized appropriately.
+    /// - If the command buffer's `usage` is [`CommandBufferUsage::OneTimeSubmit`], then it must
+    ///   not have been previously submitted.
+    /// - If the command buffer's `usage` is [`CommandBufferUsage::MultipleSubmit`], then it must
+    ///   not be currently submitted and not yet completed.
+    /// - If a recorded command performs a queue family transfer acquire operation, then a
+    ///   corresponding queue family transfer release operation with matching parameters must have
+    ///   been previously submitted, and must happen-before it.
+    /// - If a recorded command references an [`Event`], then that `Event` must not be referenced
+    ///   by a command that is currently executing on another queue.
+    ///
+    /// For every semaphore in the `signal_semaphores` elements of every `submit_infos` element:
+    /// - The semaphore must be kept alive while the command is being executed.
+    /// - The safety requirements for semaphores, as detailed in the
+    ///   [`semaphore`](crate::sync::semaphore#Safety) module documentation, must be followed.
+    ///
+    /// If `fence` is `Some`:
+    /// - The fence must be kept alive while the command is being executed.
+    /// - The safety requirements for fences, as detailed in the
+    ///   [`fence`](crate::sync::fence#Safety) module documentation, must be followed.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_submit`] returns a [`ValidationError`].
+    ///
+    /// [`try_submit`]: Self::try_submit
+    /// [`CommandBufferUsage::OneTimeSubmit`]: crate::command_buffer::CommandBufferUsage::OneTimeSubmit
+    /// [`CommandBufferUsage::MultipleSubmit`]: crate::command_buffer::CommandBufferUsage::MultipleSubmit
+    /// [`Event`]: crate::sync::event::Event
+    #[inline]
+    #[track_caller]
+    pub unsafe fn submit(
+        &mut self,
+        submit_infos: &[SubmitInfo<'_>],
+        fence: Option<&Arc<Fence>>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_submit(submit_infos, fence) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Submits command buffers to a queue to be executed.
     ///
     /// # Safety
@@ -625,7 +772,7 @@ impl<'a> QueueGuard<'a> {
     /// [`CommandBufferUsage::MultipleSubmit`]: crate::command_buffer::CommandBufferUsage::MultipleSubmit
     /// [`Event`]: crate::sync::event::Event
     #[inline]
-    pub unsafe fn submit(
+    pub unsafe fn try_submit(
         &mut self,
         submit_infos: &[SubmitInfo<'_>],
         fence: Option<&Arc<Fence>>,
@@ -839,13 +986,31 @@ impl<'a> QueueGuard<'a> {
         }
     }
 
+    /// Opens a queue debug label region, panicking on a validation error.
+    ///
+    /// The [`ext_debug_utils`] extension must be enabled on the instance.
+    ///
+    /// This is a shortcut for `try_begin_debug_utils_label().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_begin_debug_utils_label`] returns a [`ValidationError`].
+    ///
+    /// [`ext_debug_utils`]: crate::instance::InstanceExtensions::ext_debug_utils
+    /// [`try_begin_debug_utils_label`]: Self::try_begin_debug_utils_label
+    #[inline]
+    #[track_caller]
+    pub fn begin_debug_utils_label(&mut self, label_info: DebugUtilsLabel) {
+        self.try_begin_debug_utils_label(label_info).unwrap()
+    }
+
     /// Opens a queue debug label region.
     ///
     /// The [`ext_debug_utils`] extension must be enabled on the instance.
     ///
     /// [`ext_debug_utils`]: crate::instance::InstanceExtensions::ext_debug_utils
     #[inline]
-    pub fn begin_debug_utils_label(
+    pub fn try_begin_debug_utils_label(
         &mut self,
         label_info: DebugUtilsLabel,
     ) -> Result<(), Box<ValidationError>> {
@@ -893,17 +1058,41 @@ impl<'a> QueueGuard<'a> {
         };
     }
 
-    /// Closes a queue debug label region.
+    /// Closes a queue debug label region, panicking on a validation error.
     ///
-    /// The [`ext_debug_utils`](crate::instance::InstanceExtensions::ext_debug_utils) must be
-    /// enabled on the instance.
+    /// The [`ext_debug_utils`] must be enabled on the instance.
+    ///
+    /// This is a shortcut for `try_end_debug_utils_label().unwrap()`.
     ///
     /// # Safety
     ///
     /// - There must be an outstanding queue label region begun with `begin_debug_utils_label` in
     ///   the queue.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_end_debug_utils_label`] returns a [`ValidationError`].
+    ///
+    /// [`ext_debug_utils`]: crate::instance::InstanceExtensions::ext_debug_utils
+    /// [`try_end_debug_utils_label`]: Self::try_end_debug_utils_label
     #[inline]
-    pub unsafe fn end_debug_utils_label(&mut self) -> Result<(), Box<ValidationError>> {
+    #[track_caller]
+    pub unsafe fn end_debug_utils_label(&mut self) {
+        unsafe { self.try_end_debug_utils_label() }.unwrap()
+    }
+
+    /// Closes a queue debug label region.
+    ///
+    /// The [`ext_debug_utils`] must be enabled on the instance.
+    ///
+    /// # Safety
+    ///
+    /// - There must be an outstanding queue label region begun with `begin_debug_utils_label` in
+    ///   the queue.
+    ///
+    /// [`ext_debug_utils`]: crate::instance::InstanceExtensions::ext_debug_utils
+    #[inline]
+    pub unsafe fn try_end_debug_utils_label(&mut self) -> Result<(), Box<ValidationError>> {
         self.validate_end_debug_utils_label()?;
         unsafe { self.end_debug_utils_label_unchecked() };
 
@@ -939,12 +1128,31 @@ impl<'a> QueueGuard<'a> {
         unsafe { (fns.ext_debug_utils.queue_end_debug_utils_label_ext)(self.queue.handle) };
     }
 
+    /// Inserts a queue debug label, panicking on a validation error.
+    ///
+    /// The [`ext_debug_utils`] must be enabled on the instance.
+    ///
+    /// This is a shortcut for `try_insert_debug_utils_label().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_insert_debug_utils_label`] returns a [`ValidationError`].
+    ///
+    /// [`ext_debug_utils`]: crate::instance::InstanceExtensions::ext_debug_utils
+    /// [`try_insert_debug_utils_label`]: Self::try_insert_debug_utils_label
+    #[inline]
+    #[track_caller]
+    pub fn insert_debug_utils_label(&mut self, label_info: DebugUtilsLabel) {
+        self.try_insert_debug_utils_label(label_info).unwrap()
+    }
+
     /// Inserts a queue debug label.
     ///
-    /// The [`ext_debug_utils`](crate::instance::InstanceExtensions::ext_debug_utils) must be
-    /// enabled on the instance.
+    /// The [`ext_debug_utils`] must be enabled on the instance.
+    ///
+    /// [`ext_debug_utils`]: crate::instance::InstanceExtensions::ext_debug_utils
     #[inline]
-    pub fn insert_debug_utils_label(
+    pub fn try_insert_debug_utils_label(
         &mut self,
         label_info: DebugUtilsLabel,
     ) -> Result<(), Box<ValidationError>> {

--- a/vulkano/src/display.rs
+++ b/vulkano/src/display.rs
@@ -351,9 +351,30 @@ pub struct DisplayMode {
 }
 
 impl DisplayMode {
+    /// Creates a custom display mode, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        display: &Arc<Display>,
+        create_info: &DisplayModeCreateInfo<'_>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match Self::try_new(display, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a custom display mode.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         display: &Arc<Display>,
         create_info: &DisplayModeCreateInfo<'_>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
@@ -451,9 +472,31 @@ impl DisplayMode {
         self.refresh_rate
     }
 
+    /// Returns the capabilities of a display plane, when used with this display mode, panicking on
+    /// a validation error.
+    ///
+    /// This is a shortcut for `try_display_plane_capabilities().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_display_plane_capabilities`] returns a [`ValidationError`].
+    ///
+    /// [`try_display_plane_capabilities`]: Self::try_display_plane_capabilities
+    #[inline]
+    #[track_caller]
+    pub fn display_plane_capabilities(
+        &self,
+        plane_index: u32,
+    ) -> Result<DisplayPlaneCapabilities, VulkanError> {
+        match self.try_display_plane_capabilities(plane_index) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns the capabilities of a display plane, when used with this display mode.
     #[inline]
-    pub fn display_plane_capabilities(
+    pub fn try_display_plane_capabilities(
         &self,
         plane_index: u32,
     ) -> Result<DisplayPlaneCapabilities, Validated<VulkanError>> {

--- a/vulkano/src/image/mod.rs
+++ b/vulkano/src/image/mod.rs
@@ -141,16 +141,46 @@ pub enum ImageMemory {
 }
 
 impl Image {
-    /// Creates a new uninitialized `Image`.
+    /// Creates a new uninitialized `Image`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[track_caller]
     pub fn new(
         allocator: &Arc<impl MemoryAllocator + ?Sized>,
         create_info: &ImageCreateInfo<'_>,
         allocation_info: &AllocationCreateInfo<'_>,
-    ) -> Result<Arc<Self>, Validated<AllocateImageError>> {
+    ) -> Result<Arc<Self>, AllocateImageError> {
         Self::new_inner(allocator.clone().as_dyn(), create_info, allocation_info)
     }
 
+    #[track_caller]
     fn new_inner(
+        allocator: Arc<dyn MemoryAllocator>,
+        create_info: &ImageCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+    ) -> Result<Arc<Self>, AllocateImageError> {
+        match Self::try_new_inner(allocator, create_info, allocation_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new uninitialized `Image`.
+    pub fn try_new(
+        allocator: &Arc<impl MemoryAllocator + ?Sized>,
+        create_info: &ImageCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+    ) -> Result<Arc<Self>, Validated<AllocateImageError>> {
+        Self::try_new_inner(allocator.clone().as_dyn(), create_info, allocation_info)
+    }
+
+    fn try_new_inner(
         allocator: Arc<dyn MemoryAllocator>,
         create_info: &ImageCreateInfo<'_>,
         allocation_info: &AllocationCreateInfo<'_>,
@@ -159,28 +189,70 @@ impl Image {
         assert!(!create_info.flags.intersects(ImageCreateFlags::DISJOINT));
 
         let allocation_type = create_info.tiling.into();
-        let raw_image =
-            RawImage::new(allocator.device(), create_info).map_err(|err| match err {
-                Validated::Error(err) => Validated::Error(AllocateImageError::CreateImage(err)),
-                Validated::ValidationError(err) => err.into(),
-            })?;
+        let raw_image = RawImage::try_new(allocator.device(), create_info)
+            .map_err(|err| err.map(AllocateImageError::CreateImage))?;
         let requirements = raw_image.memory_requirements()[0];
 
         let allocation = allocator
-            .allocate(
+            .try_allocate(
                 &requirements,
                 allocation_type,
                 allocation_info,
                 Some(DedicatedAllocation::Image(&raw_image)),
             )
-            .map_err(AllocateImageError::AllocateMemory)?;
+            .map_err(|err| err.map(AllocateImageError::AllocateMemory))?;
         let allocation = unsafe { ResourceMemory::from_allocation_inner(allocator, allocation) };
 
-        // SAFETY: we just created this raw image and hasn't bound any memory to it.
-        let image = raw_image.bind_memory([allocation]).map_err(|(err, _, _)| {
-            err.map(AllocateImageError::BindMemory)
-                .map_validation(|err| err.add_context("RawImage::bind_memory"))
-        })?;
+        let image = raw_image
+            .try_bind_memory([allocation])
+            .map_err(|(err, _, _)| {
+                err.map(AllocateImageError::BindMemory)
+                    .map_validation(|err| err.add_context("RawImage::bind_memory"))
+            })?;
+
+        Ok(Arc::new(image))
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn new_unchecked(
+        allocator: &Arc<impl MemoryAllocator + ?Sized>,
+        create_info: &ImageCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+    ) -> Result<Arc<Self>, AllocateImageError> {
+        unsafe {
+            Self::new_unchecked_inner(allocator.clone().as_dyn(), create_info, allocation_info)
+        }
+    }
+
+    unsafe fn new_unchecked_inner(
+        allocator: Arc<dyn MemoryAllocator>,
+        create_info: &ImageCreateInfo<'_>,
+        allocation_info: &AllocationCreateInfo<'_>,
+    ) -> Result<Arc<Self>, AllocateImageError> {
+        // TODO: adjust the code below to make this safe
+        assert!(!create_info.flags.intersects(ImageCreateFlags::DISJOINT));
+
+        let allocation_type = create_info.tiling.into();
+        // SAFETY: Enforced by the caller.
+        let raw_image = unsafe { RawImage::new_unchecked(allocator.device(), create_info) }
+            .map_err(AllocateImageError::CreateImage)?;
+        let requirements = raw_image.memory_requirements()[0];
+
+        // SAFETY: Enforced by the caller.
+        let allocation = unsafe {
+            allocator.allocate_unchecked(
+                &requirements,
+                allocation_type,
+                allocation_info,
+                Some(DedicatedAllocation::Image(&raw_image)),
+            )
+        }
+        .map_err(AllocateImageError::AllocateMemory)?;
+        let allocation = unsafe { ResourceMemory::from_allocation_inner(allocator, allocation) };
+
+        // SAFETY: Enforced by the caller.
+        let image = unsafe { raw_image.bind_memory_unchecked([allocation]) }
+            .map_err(|(err, _, _)| AllocateImageError::BindMemory(err))?;
 
         Ok(Arc::new(image))
     }
@@ -390,6 +462,39 @@ impl Image {
         self.inner.subresource_range()
     }
 
+    /// Queries the memory layout of a single subresource of the image, panicking on a validation
+    /// error.
+    ///
+    /// Only images with linear tiling are supported, if they do not have a format with both a
+    /// depth and a stencil format. Images with optimal tiling have an opaque image layout that is
+    /// not suitable for direct memory accesses, and likewise for combined depth/stencil formats.
+    /// Multi-planar formats are supported, but you must specify one of the planes as the `aspect`,
+    /// not [`ImageAspect::Color`].
+    ///
+    /// The layout is invariant for each image. However it is not cached, as this would waste
+    /// memory in the case of non-linear-tiling images. You are encouraged to store the layout
+    /// somewhere in order to avoid calling this semi-expensive function at every single memory
+    /// access.
+    ///
+    /// This is a shortcut for `try_subresource_layout().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_subresource_layout`] returns a [`ValidationError`].
+    ///
+    /// [`try_subresource_layout`]: Self::try_subresource_layout
+    #[inline]
+    #[track_caller]
+    pub fn subresource_layout(
+        &self,
+        aspect: ImageAspect,
+        mip_level: u32,
+        array_layer: u32,
+    ) -> SubresourceLayout {
+        self.inner
+            .subresource_layout(aspect, mip_level, array_layer)
+    }
+
     /// Queries the memory layout of a single subresource of the image.
     ///
     /// Only images with linear tiling are supported, if they do not have a format with both a
@@ -403,14 +508,14 @@ impl Image {
     /// somewhere in order to avoid calling this semi-expensive function at every single memory
     /// access.
     #[inline]
-    pub fn subresource_layout(
+    pub fn try_subresource_layout(
         &self,
         aspect: ImageAspect,
         mip_level: u32,
         array_layer: u32,
     ) -> Result<SubresourceLayout, Box<ValidationError>> {
         self.inner
-            .subresource_layout(aspect, mip_level, array_layer)
+            .try_subresource_layout(aspect, mip_level, array_layer)
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]

--- a/vulkano/src/image/sampler/mod.rs
+++ b/vulkano/src/image/sampler/mod.rs
@@ -112,9 +112,30 @@ pub struct Sampler {
 }
 
 impl Sampler {
+    /// Creates a new `Sampler`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &SamplerCreateInfo<'_>,
+    ) -> Result<Arc<Sampler>, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `Sampler`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &SamplerCreateInfo<'_>,
     ) -> Result<Arc<Sampler>, Validated<VulkanError>> {
@@ -1602,7 +1623,7 @@ mod tests {
     fn min_lod_inferior() {
         let (device, _queue) = gfx_dev_and_queue!();
 
-        Sampler::new(
+        Sampler::try_new(
             &device,
             &SamplerCreateInfo {
                 mag_filter: Filter::Linear,
@@ -1621,7 +1642,7 @@ mod tests {
     fn max_anisotropy() {
         let (device, _queue) = gfx_dev_and_queue!();
 
-        Sampler::new(
+        Sampler::try_new(
             &device,
             &SamplerCreateInfo {
                 mag_filter: Filter::Linear,
@@ -1640,7 +1661,7 @@ mod tests {
     fn anisotropy_feature() {
         let (device, _queue) = gfx_dev_and_queue!();
 
-        let r = Sampler::new(
+        let r = Sampler::try_new(
             &device,
             &SamplerCreateInfo {
                 mag_filter: Filter::Linear,
@@ -1660,7 +1681,7 @@ mod tests {
     fn anisotropy_limit() {
         let (device, _queue) = gfx_dev_and_queue!(sampler_anisotropy);
 
-        let r = Sampler::new(
+        let r = Sampler::try_new(
             &device,
             &SamplerCreateInfo {
                 mag_filter: Filter::Linear,
@@ -1680,7 +1701,7 @@ mod tests {
     fn mip_lod_bias_limit() {
         let (device, _queue) = gfx_dev_and_queue!();
 
-        let r = Sampler::new(
+        let r = Sampler::try_new(
             &device,
             &SamplerCreateInfo {
                 mag_filter: Filter::Linear,
@@ -1699,7 +1720,7 @@ mod tests {
     fn sampler_mirror_clamp_to_edge_extension() {
         let (device, _queue) = gfx_dev_and_queue!();
 
-        let r = Sampler::new(
+        let r = Sampler::try_new(
             &device,
             &SamplerCreateInfo {
                 mag_filter: Filter::Linear,
@@ -1734,7 +1755,7 @@ mod tests {
     fn sampler_filter_minmax_extension() {
         let (device, _queue) = gfx_dev_and_queue!();
 
-        let r = Sampler::new(
+        let r = Sampler::try_new(
             &device,
             &SamplerCreateInfo {
                 mag_filter: Filter::Linear,

--- a/vulkano/src/image/sampler/ycbcr.rs
+++ b/vulkano/src/image/sampler/ycbcr.rs
@@ -141,12 +141,37 @@ pub struct SamplerYcbcrConversion {
 }
 
 impl SamplerYcbcrConversion {
+    /// Creates a new `SamplerYcbcrConversion`, panicking on a validation error.
+    ///
+    /// The [`sampler_ycbcr_conversion`] feature must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`sampler_ycbcr_conversion`]: crate::device::DeviceFeatures::sampler_ycbcr_conversion
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &SamplerYcbcrConversionCreateInfo<'_>,
+    ) -> Result<Arc<SamplerYcbcrConversion>, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `SamplerYcbcrConversion`.
     ///
-    /// The [`sampler_ycbcr_conversion`](crate::device::DeviceFeatures::sampler_ycbcr_conversion)
-    /// feature must be enabled on the device.
+    /// The [`sampler_ycbcr_conversion`] feature must be enabled on the device.
+    ///
+    /// [`sampler_ycbcr_conversion`]: crate::device::DeviceFeatures::sampler_ycbcr_conversion
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &SamplerYcbcrConversionCreateInfo<'_>,
     ) -> Result<Arc<SamplerYcbcrConversion>, Validated<VulkanError>> {
@@ -909,7 +934,7 @@ mod tests {
     fn feature_not_enabled() {
         let (device, _queue) = gfx_dev_and_queue!();
 
-        let r = SamplerYcbcrConversion::new(&device, &Default::default());
+        let r = SamplerYcbcrConversion::try_new(&device, &Default::default());
 
         assert!(matches!(
             r,

--- a/vulkano/src/image/sys.rs
+++ b/vulkano/src/image/sys.rs
@@ -76,9 +76,30 @@ pub struct RawImage {
 }
 
 impl RawImage {
+    /// Creates a new `RawImage`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &ImageCreateInfo<'_>,
+    ) -> Result<RawImage, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `RawImage`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &ImageCreateInfo<'_>,
     ) -> Result<RawImage, Validated<VulkanError>> {
@@ -489,6 +510,43 @@ impl RawImage {
         Ok(properties_vk.drm_format_modifier)
     }
 
+    /// Binds device memory to this image, panicking on a validation error.
+    ///
+    /// - If `self.flags()` does not contain `ImageCreateFlags::DISJOINT`, then `allocations` must
+    ///   contain exactly one element.
+    /// - If `self.flags()` contains `ImageCreateFlags::DISJOINT`, and `self.tiling()` is
+    ///   `ImageTiling::Linear` or `ImageTiling::Optimal`, then `allocations` must contain exactly
+    ///   `self.format().unwrap().planes().len()` elements.
+    /// - If `self.flags()` contains `ImageCreateFlags::DISJOINT`, and `self.tiling()` is
+    ///   `ImageTiling::DrmFormatModifier`, then `allocations` must contain exactly
+    ///   `self.drm_format_modifier().unwrap().1` elements.
+    ///
+    /// This is a shortcut for `try_bind_memory().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_bind_memory`] returns a [`ValidationError`].
+    ///
+    /// [`try_bind_memory`]: Self::try_bind_memory
+    #[track_caller]
+    pub fn bind_memory(
+        self,
+        allocations: impl IntoIterator<Item = ResourceMemory>,
+    ) -> Result<
+        Image,
+        (
+            VulkanError,
+            RawImage,
+            // TODO: add `use<>` to not capture the type of `allocations`, once allowed
+            impl ExactSizeIterator<Item = ResourceMemory>,
+        ),
+    > {
+        match self.try_bind_memory(allocations) {
+            Ok(res) => Ok(res),
+            Err((err, raw_image, allocations)) => Err((err.unwrap(), raw_image, allocations)),
+        }
+    }
+
     /// Binds device memory to this image.
     ///
     /// - If `self.flags()` does not contain `ImageCreateFlags::DISJOINT`, then `allocations` must
@@ -499,7 +557,7 @@ impl RawImage {
     /// - If `self.flags()` contains `ImageCreateFlags::DISJOINT`, and `self.tiling()` is
     ///   `ImageTiling::DrmFormatModifier`, then `allocations` must contain exactly
     ///   `self.drm_format_modifier().unwrap().1` elements.
-    pub fn bind_memory(
+    pub fn try_bind_memory(
         self,
         allocations: impl IntoIterator<Item = ResourceMemory>,
     ) -> Result<
@@ -1192,6 +1250,36 @@ impl RawImage {
         }
     }
 
+    /// Queries the memory layout of a single subresource of the image, panicking on a validation
+    /// error.
+    ///
+    /// Only images with linear tiling are supported, if they do not have a format with both a
+    /// depth and a stencil format. Images with optimal tiling have an opaque image layout that is
+    /// not suitable for direct memory accesses, and likewise for combined depth/stencil formats.
+    /// Multi-planar formats are supported, but you must specify one of the planes as the `aspect`,
+    /// not [`ImageAspect::COLOR`].
+    ///
+    /// The results of this function are cached, so that future calls with the same arguments
+    /// do not need to make a call to the Vulkan API again.
+    ///
+    /// This is a shortcut for `try_subresource_layout().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_subresource_layout`] returns a [`ValidationError`].
+    ///
+    /// [`try_subresource_layout`]: Self::try_subresource_layout
+    #[track_caller]
+    pub fn subresource_layout(
+        &self,
+        aspect: ImageAspect,
+        mip_level: u32,
+        array_layer: u32,
+    ) -> SubresourceLayout {
+        self.try_subresource_layout(aspect, mip_level, array_layer)
+            .unwrap()
+    }
+
     /// Queries the memory layout of a single subresource of the image.
     ///
     /// Only images with linear tiling are supported, if they do not have a format with both a
@@ -1202,7 +1290,7 @@ impl RawImage {
     ///
     /// The results of this function are cached, so that future calls with the same arguments
     /// do not need to make a call to the Vulkan API again.
-    pub fn subresource_layout(
+    pub fn try_subresource_layout(
         &self,
         aspect: ImageAspect,
         mip_level: u32,
@@ -3175,7 +3263,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         assert!(matches!(
-            RawImage::new(
+            RawImage::try_new(
                 &device,
                 &ImageCreateInfo {
                     image_type: ImageType::Dim2d,
@@ -3194,7 +3282,7 @@ mod tests {
     fn mipmaps_too_high() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let res = RawImage::new(
+        let res = RawImage::try_new(
             &device,
             &ImageCreateInfo {
                 image_type: ImageType::Dim2d,
@@ -3216,7 +3304,7 @@ mod tests {
     fn shader_storage_image_multisample() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let res = RawImage::new(
+        let res = RawImage::try_new(
             &device,
             &ImageCreateInfo {
                 image_type: ImageType::Dim2d,
@@ -3248,7 +3336,7 @@ mod tests {
     fn compressed_not_color_attachment() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let res = RawImage::new(
+        let res = RawImage::try_new(
             &device,
             &ImageCreateInfo {
                 image_type: ImageType::Dim2d,
@@ -3270,7 +3358,7 @@ mod tests {
         let (device, _) = gfx_dev_and_queue!();
 
         assert!(matches!(
-            RawImage::new(
+            RawImage::try_new(
                 &device,
                 &ImageCreateInfo {
                     image_type: ImageType::Dim2d,
@@ -3288,7 +3376,7 @@ mod tests {
     fn cubecompatible_dims_mismatch() {
         let (device, _) = gfx_dev_and_queue!();
 
-        let res = RawImage::new(
+        let res = RawImage::try_new(
             &device,
             &ImageCreateInfo {
                 flags: ImageCreateFlags::CUBE_COMPATIBLE,

--- a/vulkano/src/image/view.rs
+++ b/vulkano/src/image/view.rs
@@ -48,9 +48,30 @@ pub struct ImageView {
 }
 
 impl ImageView {
+    /// Creates a new `ImageView`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        image: &Arc<Image>,
+        create_info: &ImageViewCreateInfo<'_>,
+    ) -> Result<Arc<ImageView>, VulkanError> {
+        match Self::try_new(image, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `ImageView`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         image: &Arc<Image>,
         create_info: &ImageViewCreateInfo<'_>,
     ) -> Result<Arc<ImageView>, Validated<VulkanError>> {
@@ -633,12 +654,17 @@ impl ImageView {
         unsafe { Self::from_handle(image, handle, create_info) }
     }
 
-    /// Creates a default `ImageView`. Equivalent to
-    /// `ImageView::new(image, ImageViewCreateInfo::from_image(image))`.
-    pub fn new_default(image: &Arc<Image>) -> Result<Arc<ImageView>, Validated<VulkanError>> {
-        let create_info = ImageViewCreateInfo::from_image(image);
-
-        Self::new(image, &create_info)
+    /// Creates a default `ImageView`, panicking on a validation error. Equivalent to
+    /// `ImageView::new(image, &ImageViewCreateInfo::from_image(image))`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`ImageView::new`] panics.
+    ///
+    /// [`ImageView::new`]: Self::new
+    #[track_caller]
+    pub fn new_default(image: &Arc<Image>) -> Result<Arc<ImageView>, VulkanError> {
+        Self::new(image, &ImageViewCreateInfo::from_image(image))
     }
 
     /// Creates a new `ImageView` from a raw object handle.

--- a/vulkano/src/instance/debug.rs
+++ b/vulkano/src/instance/debug.rs
@@ -61,9 +61,30 @@ pub struct DebugUtilsMessenger {
 }
 
 impl DebugUtilsMessenger {
+    /// Initializes a debug callback, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        instance: &Arc<Instance>,
+        create_info: &DebugUtilsMessengerCreateInfo<'_>,
+    ) -> Result<Self, VulkanError> {
+        match Self::try_new(instance, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Initializes a debug callback.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         instance: &Arc<Instance>,
         create_info: &DebugUtilsMessengerCreateInfo<'_>,
     ) -> Result<Self, Validated<VulkanError>> {

--- a/vulkano/src/instance/mod.rs
+++ b/vulkano/src/instance/mod.rs
@@ -296,9 +296,30 @@ impl UnwindSafe for Instance {}
 impl RefUnwindSafe for Instance {}
 
 impl Instance {
+    /// Creates a new `Instance`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        library: &Arc<VulkanLibrary>,
+        create_info: &InstanceCreateInfo<'_>,
+    ) -> Result<Arc<Instance>, VulkanError> {
+        match Self::try_new(library, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `Instance`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         library: &Arc<VulkanLibrary>,
         create_info: &InstanceCreateInfo<'_>,
     ) -> Result<Arc<Instance>, Validated<VulkanError>> {
@@ -578,6 +599,41 @@ impl Instance {
         Ok(physical_devices.into_iter())
     }
 
+    /// Returns an iterator that enumerates the groups of physical devices available, panicking on
+    /// a validation error. All physical devices in a group can be used to create a single logical
+    /// device. They are guaranteed have the same [properties], and support the same [extensions]
+    /// and [features].
+    ///
+    /// Every physical device will be returned exactly once;
+    /// physical devices that are not part of any group will be returned as a group of size 1.
+    ///
+    /// The instance API version must be at least 1.1, or the [`khr_device_group_creation`]
+    /// extension must be enabled on the instance.
+    ///
+    /// This is a shortcut for `try_enumerate_physical_device_groups().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_enumerate_physical_device_groups`] returns a [`ValidationError`].
+    ///
+    /// [properties]: PhysicalDevice::properties
+    /// [extensions]: PhysicalDevice::supported_extensions
+    /// [features]: PhysicalDevice::supported_features
+    /// [`enumerate_physical_devices`]: Self::enumerate_physical_devices
+    /// [`khr_device_group_creation`]: crate::instance::InstanceExtensions::khr_device_group_creation
+    /// [`try_enumerate_physical_device_groups`]: Self::try_enumerate_physical_device_groups
+    #[inline]
+    #[track_caller]
+    pub fn enumerate_physical_device_groups(
+        self: &Arc<Self>,
+    ) -> Result<impl ExactSizeIterator<Item = PhysicalDeviceGroupProperties> + use<>, VulkanError>
+    {
+        match self.try_enumerate_physical_device_groups() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns an iterator that enumerates the groups of physical devices available. All
     /// physical devices in a group can be used to create a single logical device. They are
     /// guaranteed have the same [properties], and support the same [extensions] and [features].
@@ -594,7 +650,7 @@ impl Instance {
     /// [`enumerate_physical_devices`]: Self::enumerate_physical_devices
     /// [`khr_device_group_creation`]: crate::instance::InstanceExtensions::khr_device_group_creation
     #[inline]
-    pub fn enumerate_physical_device_groups(
+    pub fn try_enumerate_physical_device_groups(
         self: &Arc<Self>,
     ) -> Result<
         impl ExactSizeIterator<Item = PhysicalDeviceGroupProperties> + use<>,

--- a/vulkano/src/memory/allocator/mod.rs
+++ b/vulkano/src/memory/allocator/mod.rs
@@ -290,7 +290,46 @@ pub unsafe trait MemoryAllocator: DeviceOwned + Send + Sync + 'static {
     ///
     /// - `never_allocate` - If `true` then the allocator should never allocate `DeviceMemory`,
     ///   instead only suballocate from existing blocks.
-    fn allocate_from_type(
+    fn try_allocate_from_type(
+        &self,
+        memory_type_index: u32,
+        layout: DeviceLayout,
+        allocation_type: AllocationType,
+        never_allocate: bool,
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>>;
+
+    /// Allocates memory from a specific memory type without doing any checks.
+    ///
+    /// <div class="vulkano-alert-caution">
+    ///
+    /// > Caution
+    /// >
+    /// > You should only call this when necessary. Humans are famously bad at guessing what needs
+    /// > to be optimized, so **the only way** to know is by profiling. Have you profiled to make
+    /// > sure that this actually makes a difference? In 99% of cases (not an exaggeration),
+    /// > calling the unchecked version of one of our functions/methods makes absolutely no
+    /// > difference, so make sure first.
+    ///
+    /// </div>
+    ///
+    /// # Arguments
+    ///
+    /// - `memory_type_index` - The index of the memory type to allocate from.
+    ///
+    /// - `layout` - The layout of the allocation.
+    ///
+    /// - `allocation_type` - The type of resources that can be bound to the allocation.
+    ///
+    /// - `never_allocate` - If `true` then the allocator should never allocate `DeviceMemory`,
+    ///   instead only suballocate from existing blocks.
+    ///
+    /// # Safety
+    ///
+    /// - If calling [`try_allocate_from_type`] with the same arguments would return a
+    ///   [`ValidationError`], calling this method is *undefined behavior*!
+    ///
+    /// [`try_allocate_from_type`]: Self::try_allocate_from_type
+    unsafe fn allocate_from_type_unchecked(
         &self,
         memory_type_index: u32,
         layout: DeviceLayout,
@@ -331,7 +370,66 @@ pub unsafe trait MemoryAllocator: DeviceOwned + Send + Sync + 'static {
     /// [`NonLinear`]: AllocationType::NonLinear
     /// [`Unknown`]: AllocationType::Unknown
     /// [`khr_dedicated_allocation`]: crate::device::DeviceExtensions::khr_dedicated_allocation
-    fn allocate(
+    fn try_allocate(
+        &self,
+        requirements: &MemoryRequirements,
+        allocation_type: AllocationType,
+        create_info: &AllocationCreateInfo<'_>,
+        dedicated_allocation: Option<DedicatedAllocation<'_>>,
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>>;
+
+    /// Allocates memory according to requirements without doing any checks.
+    ///
+    /// <div class="vulkano-alert-caution">
+    ///
+    /// > Caution
+    /// >
+    /// > You should only call this when necessary. Humans are famously bad at guessing what needs
+    /// > to be optimized, so **the only way** to know is by profiling. Have you profiled to make
+    /// > sure that this actually makes a difference? In 99% of cases (not an exaggeration),
+    /// > calling the unchecked version of one of our functions/methods makes absolutely no
+    /// > difference, so make sure first.
+    ///
+    /// </div>
+    ///
+    /// # Arguments
+    ///
+    /// - `requirements` - Requirements of the resource you want to allocate memory for.
+    ///
+    ///   If you plan to bind this memory directly to a non-sparse resource, then this must
+    ///   correspond to the value returned by either [`RawBuffer::memory_requirements`] or
+    ///   [`RawImage::memory_requirements`] for the respective buffer or image.
+    ///
+    /// - `allocation_type` - What type of resource this allocation will be used for.
+    ///
+    ///   This should be [`Linear`] for buffers and linear images, and [`NonLinear`] for optimal
+    ///   images. You can not bind memory allocated with the [`Linear`] type to optimal images or
+    ///   bind memory allocated with the [`NonLinear`] type to buffers and linear images. You
+    ///   should never use the [`Unknown`] type unless you have to, as that can be less memory
+    ///   efficient.
+    ///
+    /// - `dedicated_allocation` - Allows a dedicated allocation to be created.
+    ///
+    ///   You should always fill this field in if you are allocating memory for a non-sparse
+    ///   resource, otherwise the allocator won't be able to create a dedicated allocation if one
+    ///   is required or recommended.
+    ///
+    ///   This argument is silently ignored (treated as `None`) if the device API version is below
+    ///   1.1 and the [`khr_dedicated_allocation`] extension is not enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - If calling [`try_allocate`] with the same arguments would return a [`ValidationError`],
+    ///   calling this method is *undefined behavior*!
+    ///
+    /// [`RawBuffer::memory_requirements`]: crate::buffer::sys::RawBuffer::memory_requirements
+    /// [`RawImage::memory_requirements`]: crate::image::sys::RawImage::memory_requirements
+    /// [`Linear`]: AllocationType::Linear
+    /// [`NonLinear`]: AllocationType::NonLinear
+    /// [`Unknown`]: AllocationType::Unknown
+    /// [`khr_dedicated_allocation`]: crate::device::DeviceExtensions::khr_dedicated_allocation
+    /// [`try_allocate`]: Self::try_allocate
+    unsafe fn allocate_unchecked(
         &self,
         requirements: &MemoryRequirements,
         allocation_type: AllocationType,
@@ -340,7 +438,36 @@ pub unsafe trait MemoryAllocator: DeviceOwned + Send + Sync + 'static {
     ) -> Result<MemoryAlloc, MemoryAllocatorError>;
 
     /// Creates an allocation with a whole device memory block dedicated to it.
-    fn allocate_dedicated(
+    fn try_allocate_dedicated(
+        &self,
+        memory_type_index: u32,
+        allocation_size: DeviceSize,
+        dedicated_allocation: Option<DedicatedAllocation<'_>>,
+        export_handle_types: ExternalMemoryHandleTypes,
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>>;
+
+    /// Creates an allocation with a whole device memory block dedicated to it without doing any
+    /// checks.
+    ///
+    /// <div class="vulkano-alert-caution">
+    ///
+    /// > Caution
+    /// >
+    /// > You should only call this when necessary. Humans are famously bad at guessing what needs
+    /// > to be optimized, so **the only way** to know is by profiling. Have you profiled to make
+    /// > sure that this actually makes a difference? In 99% of cases (not an exaggeration),
+    /// > calling the unchecked version of one of our functions/methods makes absolutely no
+    /// > difference, so make sure first.
+    ///
+    /// </div>
+    ///
+    /// # Safety
+    ///
+    /// - If calling [`try_allocate_dedicated`] with the same arguments would return a
+    ///   [`ValidationError`], calling this method is *undefined behavior*!
+    ///
+    /// [`try_allocate_dedicated`]: Self::try_allocate_dedicated
+    unsafe fn allocate_dedicated_unchecked(
         &self,
         memory_type_index: u32,
         allocation_size: DeviceSize,
@@ -796,11 +923,11 @@ impl AllocationHandle {
 #[derive(Clone, Debug)]
 pub enum MemoryAllocatorError {
     /// Allocating [`DeviceMemory`] failed.
-    AllocateDeviceMemory(Validated<VulkanError>),
+    AllocateDeviceMemory(VulkanError),
 
     /// Finding a suitable memory type failed.
     ///
-    /// This is returned from [`MemoryAllocator::allocate`] when
+    /// This is returned from [`MemoryAllocator::try_allocate`] when
     /// [`MemoryAllocator::find_memory_type_index`] returns [`None`].
     FindMemoryType,
 
@@ -1063,7 +1190,7 @@ impl<S> GenericMemoryAllocator<S> {
     }
 
     #[cold]
-    fn allocate_device_memory(
+    fn try_allocate_device_memory(
         &self,
         memory_type_index: u32,
         allocation_size: DeviceSize,
@@ -1081,6 +1208,44 @@ impl<S> GenericMemoryAllocator<S> {
                 ..Default::default()
             },
         )?;
+
+        if self.pools[memory_type_index as usize]
+            .property_flags
+            .intersects(MemoryPropertyFlags::HOST_VISIBLE)
+        {
+            // SAFETY:
+            // - We checked that the memory is host-visible.
+            // - The memory can't be mapped already, because we just allocated it.
+            // - Mapping the whole range is always valid.
+            unsafe { memory.map_unchecked(&MemoryMapInfo::default()) }?;
+        }
+
+        Ok(Arc::new(memory))
+    }
+
+    #[cold]
+    unsafe fn allocate_device_memory_unchecked(
+        &self,
+        memory_type_index: u32,
+        allocation_size: DeviceSize,
+        dedicated_allocation: Option<DedicatedAllocation<'_>>,
+        export_handle_types: ExternalMemoryHandleTypes,
+    ) -> Result<Arc<DeviceMemory>, VulkanError> {
+        // SAFETY: Enforced by the caller.
+        let mut memory = unsafe {
+            DeviceMemory::allocate_unchecked(
+                &self.device,
+                &MemoryAllocateInfo {
+                    allocation_size,
+                    memory_type_index,
+                    dedicated_allocation,
+                    export_handle_types,
+                    flags: self.flags,
+                    ..Default::default()
+                },
+                None,
+            )
+        }?;
 
         if self.pools[memory_type_index as usize]
             .property_flags
@@ -1154,7 +1319,142 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
     /// [`AllocateDeviceMemory`]: MemoryAllocatorError::AllocateDeviceMemory
     /// [`OutOfPoolMemory`]: MemoryAllocatorError::OutOfPoolMemory
     /// [`BlockSizeExceeded`]: MemoryAllocatorError::BlockSizeExceeded
-    fn allocate_from_type(
+    fn try_allocate_from_type(
+        &self,
+        memory_type_index: u32,
+        mut layout: DeviceLayout,
+        allocation_type: AllocationType,
+        never_allocate: bool,
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>> {
+        let size = layout.size();
+        let pool = &self.pools[memory_type_index as usize];
+
+        if size > pool.block_size {
+            return Err(Validated::Error(MemoryAllocatorError::BlockSizeExceeded));
+        }
+
+        layout = layout.align_to(pool.atom_size).unwrap();
+
+        let blocks = &mut *pool.blocks.lock();
+        let vec = &mut blocks.vec;
+
+        // TODO: Incremental sorting
+        vec.sort_by_key(|block| block.free_size());
+        let (Ok(idx) | Err(idx)) = vec.binary_search_by_key(&size, |block| block.free_size());
+
+        for block in &mut vec[idx..] {
+            if let Ok(allocation) =
+                block.allocate(layout, allocation_type, self.buffer_image_granularity)
+            {
+                return Ok(allocation);
+            }
+        }
+
+        if never_allocate {
+            return Err(Validated::Error(MemoryAllocatorError::OutOfPoolMemory));
+        }
+
+        // The pool doesn't have enough real estate, so we need a new block.
+        let block = {
+            let export_handle_types = if !self.export_handle_types.is_empty() {
+                self.export_handle_types[memory_type_index as usize]
+            } else {
+                ExternalMemoryHandleTypes::empty()
+            };
+            let mut i = 0;
+
+            loop {
+                let allocation_size = pool.block_size >> i;
+
+                match self.try_allocate_device_memory(
+                    memory_type_index,
+                    allocation_size,
+                    None,
+                    export_handle_types,
+                ) {
+                    Ok(device_memory) => {
+                        break DeviceMemoryBlock::new(device_memory, &blocks.block_allocator);
+                    }
+                    // Retry up to 3 times, halving the allocation size each time so long as the
+                    // resulting size is still large enough.
+                    Err(Validated::Error(
+                        VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory,
+                    )) if i < 3 && pool.block_size >> (i + 1) >= size => {
+                        i += 1;
+                    }
+                    Err(Validated::Error(err)) => {
+                        return Err(Validated::Error(
+                            MemoryAllocatorError::AllocateDeviceMemory(err),
+                        ));
+                    }
+                    Err(Validated::ValidationError(err)) => {
+                        return Err(Validated::ValidationError(err));
+                    }
+                }
+            }
+        };
+
+        vec.push(block);
+        let block = vec.last_mut().unwrap();
+
+        match block.allocate(layout, allocation_type, self.buffer_image_granularity) {
+            Ok(allocation) => Ok(allocation),
+            // This can't happen as we always allocate a block of sufficient size.
+            Err(SuballocatorError::OutOfRegionMemory) => unreachable!(),
+            // This can't happen as the block is fresher than Febreze and we're still holding an
+            // exclusive lock.
+            Err(SuballocatorError::FragmentedRegion) => unreachable!(),
+        }
+    }
+
+    /// Allocates memory from a specific memory type without doing any checks.
+    ///
+    /// <div class="vulkano-alert-caution">
+    ///
+    /// > Caution
+    /// >
+    /// > You should only call this when necessary. Humans are famously bad at guessing what needs
+    /// > to be optimized, so **the only way** to know is by profiling. Have you profiled to make
+    /// > sure that this actually makes a difference? In 99% of cases (not an exaggeration),
+    /// > calling the unchecked version of one of our functions/methods makes absolutely no
+    /// > difference, so make sure first.
+    ///
+    /// </div>
+    ///
+    /// # Arguments
+    ///
+    /// - `memory_type_index` - The index of the memory type to allocate from.
+    ///
+    /// - `layout` - The layout of the allocation.
+    ///
+    /// - `allocation_type` - The type of resources that can be bound to the allocation.
+    ///
+    /// - `never_allocate` - If `true` then the allocator should never allocate `DeviceMemory`,
+    ///   instead only suballocate from existing blocks.
+    ///
+    /// # Safety
+    ///
+    /// - If calling [`try_allocate_from_type`] with the same arguments would return a
+    ///   [`ValidationError`], calling this method is *undefined behavior*!
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `memory_type_index` is not less than the number of available memory types.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`AllocateDeviceMemory`] if allocating a new block failed.
+    /// - Returns [`OutOfPoolMemory`] if `never_allocate` is `true` and the pool doesn't have
+    ///   enough free space.
+    /// - Returns [`BlockSizeExceeded`] if `create_info.layout.size()` is greater than the block
+    ///   size corresponding to the heap that the memory type corresponding to `memory_type_index`
+    ///   resides in.
+    ///
+    /// [`try_allocate_from_type`]: Self::try_allocate_from_type
+    /// [`AllocateDeviceMemory`]: MemoryAllocatorError::AllocateDeviceMemory
+    /// [`OutOfPoolMemory`]: MemoryAllocatorError::OutOfPoolMemory
+    /// [`BlockSizeExceeded`]: MemoryAllocatorError::BlockSizeExceeded
+    unsafe fn allocate_from_type_unchecked(
         &self,
         memory_type_index: u32,
         mut layout: DeviceLayout,
@@ -1201,23 +1501,28 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
             loop {
                 let allocation_size = pool.block_size >> i;
 
-                match self.allocate_device_memory(
-                    memory_type_index,
-                    allocation_size,
-                    None,
-                    export_handle_types,
-                ) {
+                // SAFETY: Enforced by the caller.
+                match unsafe {
+                    self.allocate_device_memory_unchecked(
+                        memory_type_index,
+                        allocation_size,
+                        None,
+                        export_handle_types,
+                    )
+                } {
                     Ok(device_memory) => {
                         break DeviceMemoryBlock::new(device_memory, &blocks.block_allocator);
                     }
                     // Retry up to 3 times, halving the allocation size each time so long as the
                     // resulting size is still large enough.
-                    Err(Validated::Error(
-                        VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory,
-                    )) if i < 3 && pool.block_size >> (i + 1) >= size => {
+                    Err(VulkanError::OutOfHostMemory | VulkanError::OutOfDeviceMemory)
+                        if i < 3 && pool.block_size >> (i + 1) >= size =>
+                    {
                         i += 1;
                     }
-                    Err(err) => return Err(MemoryAllocatorError::AllocateDeviceMemory(err)),
+                    Err(err) => {
+                        return Err(MemoryAllocatorError::AllocateDeviceMemory(err));
+                    }
                 }
             }
         };
@@ -1289,7 +1594,211 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
     /// [`OutOfPoolMemory`]: MemoryAllocatorError::OutOfPoolMemory
     /// [`DedicatedAllocationRequired`]: MemoryAllocatorError::DedicatedAllocationRequired
     /// [`BlockSizeExceeded`]: MemoryAllocatorError::BlockSizeExceeded
-    fn allocate(
+    fn try_allocate(
+        &self,
+        requirements: &MemoryRequirements,
+        allocation_type: AllocationType,
+        create_info: &AllocationCreateInfo<'_>,
+        mut dedicated_allocation: Option<DedicatedAllocation<'_>>,
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>> {
+        let &MemoryRequirements {
+            layout,
+            mut memory_type_bits,
+            mut prefers_dedicated_allocation,
+            requires_dedicated_allocation,
+        } = requirements;
+
+        memory_type_bits &= self.memory_type_bits;
+        memory_type_bits &= create_info.memory_type_bits;
+
+        let &AllocationCreateInfo {
+            memory_type_filter,
+            memory_type_bits: _,
+            allocate_preference,
+            _ne: _,
+        } = create_info;
+
+        let size = layout.size();
+
+        let mut memory_type_index = self
+            .find_memory_type_index(memory_type_bits, memory_type_filter)
+            .ok_or(Validated::Error(MemoryAllocatorError::FindMemoryType))?;
+
+        if !self.dedicated_allocation && !requires_dedicated_allocation {
+            dedicated_allocation = None;
+        }
+
+        let export_handle_types = if self.export_handle_types.is_empty() {
+            ExternalMemoryHandleTypes::empty()
+        } else {
+            self.export_handle_types[memory_type_index as usize]
+        };
+
+        loop {
+            let pool = &self.pools[memory_type_index as usize];
+
+            let res = match allocate_preference {
+                MemoryAllocatePreference::Unknown => {
+                    // VUID-vkBindBufferMemory-buffer-01444
+                    // VUID-vkBindImageMemory-image-01445
+                    if requires_dedicated_allocation {
+                        self.try_allocate_dedicated(
+                            memory_type_index,
+                            size,
+                            dedicated_allocation,
+                            export_handle_types,
+                        )
+                    } else {
+                        if size > pool.block_size / 2 {
+                            prefers_dedicated_allocation = true;
+                        }
+                        if self.device.allocation_count() > self.max_allocations
+                            && size <= pool.block_size
+                        {
+                            prefers_dedicated_allocation = false;
+                        }
+
+                        if prefers_dedicated_allocation {
+                            self.try_allocate_dedicated(
+                                memory_type_index,
+                                size,
+                                dedicated_allocation,
+                                export_handle_types,
+                            )
+                            // Fall back to suballocation.
+                            .or_else(|err| {
+                                self.try_allocate_from_type(
+                                    memory_type_index,
+                                    layout,
+                                    allocation_type,
+                                    true, // A dedicated allocation already failed.
+                                )
+                                .map_err(|_| err)
+                            })
+                        } else {
+                            self.try_allocate_from_type(
+                                memory_type_index,
+                                layout,
+                                allocation_type,
+                                false,
+                            )
+                            // Fall back to dedicated allocation. It is possible that the 1/8
+                            // block size tried was greater than the allocation size, so
+                            // there's hope.
+                            .or_else(|_| {
+                                self.try_allocate_dedicated(
+                                    memory_type_index,
+                                    size,
+                                    dedicated_allocation,
+                                    export_handle_types,
+                                )
+                            })
+                        }
+                    }
+                }
+                MemoryAllocatePreference::NeverAllocate => {
+                    if requires_dedicated_allocation {
+                        return Err(Validated::Error(
+                            MemoryAllocatorError::DedicatedAllocationRequired,
+                        ));
+                    }
+
+                    self.try_allocate_from_type(memory_type_index, layout, allocation_type, true)
+                }
+                MemoryAllocatePreference::AlwaysAllocate => self.try_allocate_dedicated(
+                    memory_type_index,
+                    size,
+                    dedicated_allocation,
+                    export_handle_types,
+                ),
+            };
+
+            match res {
+                Ok(allocation) => return Ok(allocation),
+                // Try a different memory type.
+                Err(err) => {
+                    memory_type_bits &= !(1 << memory_type_index);
+                    memory_type_index = self
+                        .find_memory_type_index(memory_type_bits, memory_type_filter)
+                        .ok_or(err)?;
+                }
+            }
+        }
+    }
+
+    /// Allocates memory according to requirements without doing any checks.
+    ///
+    /// <div class="vulkano-alert-caution">
+    ///
+    /// > Caution
+    /// >
+    /// > You should only call this when necessary. Humans are famously bad at guessing what needs
+    /// > to be optimized, so **the only way** to know is by profiling. Have you profiled to make
+    /// > sure that this actually makes a difference? In 99% of cases (not an exaggeration),
+    /// > calling the unchecked version of one of our functions/methods makes absolutely no
+    /// > difference, so make sure first.
+    ///
+    /// </div>
+    ///
+    /// # Arguments
+    ///
+    /// - `requirements` - Requirements of the resource you want to allocate memory for.
+    ///
+    ///   If you plan to bind this memory directly to a non-sparse resource, then this must
+    ///   correspond to the value returned by either [`RawBuffer::memory_requirements`] or
+    ///   [`RawImage::memory_requirements`] for the respective buffer or image.
+    ///
+    /// - `allocation_type` - What type of resource this allocation will be used for.
+    ///
+    ///   This should be [`Linear`] for buffers and linear images, and [`NonLinear`] for optimal
+    ///   images. You can not bind memory allocated with the [`Linear`] type to optimal images or
+    ///   bind memory allocated with the [`NonLinear`] type to buffers and linear images. You
+    ///   should never use the [`Unknown`] type unless you have to, as that can be less memory
+    ///   efficient.
+    ///
+    /// - `dedicated_allocation` - Allows a dedicated allocation to be created.
+    ///
+    ///   You should always fill this field in if you are allocating memory for a non-sparse
+    ///   resource, otherwise the allocator won't be able to create a dedicated allocation if one
+    ///   is required or recommended.
+    ///
+    ///   This argument is silently ignored (treated as `None`) if the device API version is below
+    ///   1.1 and the [`khr_dedicated_allocation`] extension is not enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - If calling [`try_allocate`] with the same arguments would return a [`ValidationError`],
+    ///   calling this method is *undefined behavior*!
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`AllocateDeviceMemory`] if allocating a new block failed.
+    /// - Returns [`FindMemoryType`] if finding a suitable memory type failed. This can happen if
+    ///   the `create_info.requirements` correspond to those of an optimal image but
+    ///   `create_info.memory_type_filter` requires host access.
+    /// - Returns [`OutOfPoolMemory`] if `create_info.allocate_preference` is
+    ///   [`MemoryAllocatePreference::NeverAllocate`] and none of the pools of suitable memory
+    ///   types have enough free space.
+    /// - Returns [`DedicatedAllocationRequired`] if `create_info.allocate_preference` is
+    ///   [`MemoryAllocatePreference::NeverAllocate`] and
+    ///   `create_info.requirements.requires_dedicated_allocation` is `true`.
+    /// - Returns [`BlockSizeExceeded`] if `create_info.allocate_preference` is
+    ///   [`MemoryAllocatePreference::NeverAllocate`] and `create_info.requirements.size` is
+    ///   greater than the block size for all heaps of suitable memory types.
+    ///
+    /// [`RawBuffer::memory_requirements`]: crate::buffer::sys::RawBuffer::memory_requirements
+    /// [`RawImage::memory_requirements`]: crate::image::sys::RawImage::memory_requirements
+    /// [`Linear`]: AllocationType::Linear
+    /// [`NonLinear`]: AllocationType::NonLinear
+    /// [`Unknown`]: AllocationType::Unknown
+    /// [`khr_dedicated_allocation`]: crate::device::DeviceExtensions::khr_dedicated_allocation
+    /// [`try_allocate`]: Self::try_allocate
+    /// [`AllocateDeviceMemory`]: MemoryAllocatorError::AllocateDeviceMemory
+    /// [`FindMemoryType`]: MemoryAllocatorError::FindMemoryType
+    /// [`OutOfPoolMemory`]: MemoryAllocatorError::OutOfPoolMemory
+    /// [`DedicatedAllocationRequired`]: MemoryAllocatorError::DedicatedAllocationRequired
+    /// [`BlockSizeExceeded`]: MemoryAllocatorError::BlockSizeExceeded
+    unsafe fn allocate_unchecked(
         &self,
         requirements: &MemoryRequirements,
         allocation_type: AllocationType,
@@ -1337,12 +1846,15 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
                     // VUID-vkBindBufferMemory-buffer-01444
                     // VUID-vkBindImageMemory-image-01445
                     if requires_dedicated_allocation {
-                        self.allocate_dedicated(
-                            memory_type_index,
-                            size,
-                            dedicated_allocation,
-                            export_handle_types,
-                        )
+                        // SAFETY: Enforced by the caller.
+                        unsafe {
+                            self.allocate_dedicated_unchecked(
+                                memory_type_index,
+                                size,
+                                dedicated_allocation,
+                                export_handle_types,
+                            )
+                        }
                     } else {
                         if size > pool.block_size / 2 {
                             prefers_dedicated_allocation = true;
@@ -1354,39 +1866,51 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
                         }
 
                         if prefers_dedicated_allocation {
-                            self.allocate_dedicated(
-                                memory_type_index,
-                                size,
-                                dedicated_allocation,
-                                export_handle_types,
-                            )
-                            // Fall back to suballocation.
-                            .or_else(|err| {
-                                self.allocate_from_type(
-                                    memory_type_index,
-                                    layout,
-                                    allocation_type,
-                                    true, // A dedicated allocation already failed.
-                                )
-                                .map_err(|_| err)
-                            })
-                        } else {
-                            self.allocate_from_type(
-                                memory_type_index,
-                                layout,
-                                allocation_type,
-                                false,
-                            )
-                            // Fall back to dedicated allocation. It is possible that the 1/8
-                            // block size tried was greater than the allocation size, so
-                            // there's hope.
-                            .or_else(|_| {
-                                self.allocate_dedicated(
+                            // SAFETY: Enforced by the caller.
+                            unsafe {
+                                self.allocate_dedicated_unchecked(
                                     memory_type_index,
                                     size,
                                     dedicated_allocation,
                                     export_handle_types,
                                 )
+                            }
+                            // Fall back to suballocation.
+                            .or_else(|err| {
+                                // SAFETY: Enforced by the caller.
+                                unsafe {
+                                    self.allocate_from_type_unchecked(
+                                        memory_type_index,
+                                        layout,
+                                        allocation_type,
+                                        true, // A dedicated allocation already failed.
+                                    )
+                                }
+                                .map_err(|_| err)
+                            })
+                        } else {
+                            // SAFETY: Enforced by the caller.
+                            unsafe {
+                                self.allocate_from_type_unchecked(
+                                    memory_type_index,
+                                    layout,
+                                    allocation_type,
+                                    false,
+                                )
+                            }
+                            // Fall back to dedicated allocation. It is possible that the 1/8
+                            // block size tried was greater than the allocation size, so
+                            // there's hope.
+                            .or_else(|_| {
+                                // SAFETY: Enforced by the caller.
+                                unsafe {
+                                    self.allocate_dedicated_unchecked(
+                                        memory_type_index,
+                                        size,
+                                        dedicated_allocation,
+                                        export_handle_types,
+                                    )
+                                }
                             })
                         }
                     }
@@ -1396,14 +1920,23 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
                         return Err(MemoryAllocatorError::DedicatedAllocationRequired);
                     }
 
-                    self.allocate_from_type(memory_type_index, layout, allocation_type, true)
+                    unsafe {
+                        self.allocate_from_type_unchecked(
+                            memory_type_index,
+                            layout,
+                            allocation_type,
+                            true,
+                        )
+                    }
                 }
-                MemoryAllocatePreference::AlwaysAllocate => self.allocate_dedicated(
-                    memory_type_index,
-                    size,
-                    dedicated_allocation,
-                    export_handle_types,
-                ),
+                MemoryAllocatePreference::AlwaysAllocate => unsafe {
+                    self.allocate_dedicated_unchecked(
+                        memory_type_index,
+                        size,
+                        dedicated_allocation,
+                        export_handle_types,
+                    )
+                },
             };
 
             match res {
@@ -1420,21 +1953,46 @@ unsafe impl<S: Suballocator + Send + 'static> MemoryAllocator for GenericMemoryA
     }
 
     #[cold]
-    fn allocate_dedicated(
+    fn try_allocate_dedicated(
+        &self,
+        memory_type_index: u32,
+        allocation_size: DeviceSize,
+        dedicated_allocation: Option<DedicatedAllocation<'_>>,
+        export_handle_types: ExternalMemoryHandleTypes,
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>> {
+        let device_memory = self
+            .try_allocate_device_memory(
+                memory_type_index,
+                allocation_size,
+                dedicated_allocation,
+                export_handle_types,
+            )
+            .map_err(|err| err.map(MemoryAllocatorError::AllocateDeviceMemory))?;
+
+        Ok(MemoryAlloc {
+            device_memory,
+            suballocation: None,
+            allocation_handle: AllocationHandle::null(),
+        })
+    }
+
+    #[cold]
+    unsafe fn allocate_dedicated_unchecked(
         &self,
         memory_type_index: u32,
         allocation_size: DeviceSize,
         dedicated_allocation: Option<DedicatedAllocation<'_>>,
         export_handle_types: ExternalMemoryHandleTypes,
     ) -> Result<MemoryAlloc, MemoryAllocatorError> {
-        let device_memory = self
-            .allocate_device_memory(
+        let device_memory = unsafe {
+            self.allocate_device_memory_unchecked(
                 memory_type_index,
                 allocation_size,
                 dedicated_allocation,
                 export_handle_types,
             )
-            .map_err(MemoryAllocatorError::AllocateDeviceMemory)?;
+        }
+        .map_err(MemoryAllocatorError::AllocateDeviceMemory)?;
 
         Ok(MemoryAlloc {
             device_memory,
@@ -1487,24 +2045,41 @@ unsafe impl<T: MemoryAllocator + ?Sized> MemoryAllocator for Arc<T> {
         (**self).find_memory_type_index(memory_type_bits, filter)
     }
 
-    fn allocate_from_type(
+    fn try_allocate_from_type(
+        &self,
+        memory_type_index: u32,
+        layout: DeviceLayout,
+        allocation_type: AllocationType,
+        never_allocate: bool,
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>> {
+        (**self).try_allocate_from_type(memory_type_index, layout, allocation_type, never_allocate)
+    }
+
+    unsafe fn allocate_from_type_unchecked(
         &self,
         memory_type_index: u32,
         layout: DeviceLayout,
         allocation_type: AllocationType,
         never_allocate: bool,
     ) -> Result<MemoryAlloc, MemoryAllocatorError> {
-        (**self).allocate_from_type(memory_type_index, layout, allocation_type, never_allocate)
+        unsafe {
+            (**self).allocate_from_type_unchecked(
+                memory_type_index,
+                layout,
+                allocation_type,
+                never_allocate,
+            )
+        }
     }
 
-    fn allocate(
+    fn try_allocate(
         &self,
         requirements: &MemoryRequirements,
         allocation_type: AllocationType,
         create_info: &AllocationCreateInfo<'_>,
         dedicated_allocation: Option<DedicatedAllocation<'_>>,
-    ) -> Result<MemoryAlloc, MemoryAllocatorError> {
-        (**self).allocate(
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>> {
+        (**self).try_allocate(
             requirements,
             allocation_type,
             create_info,
@@ -1512,19 +2087,53 @@ unsafe impl<T: MemoryAllocator + ?Sized> MemoryAllocator for Arc<T> {
         )
     }
 
-    fn allocate_dedicated(
+    unsafe fn allocate_unchecked(
+        &self,
+        requirements: &MemoryRequirements,
+        allocation_type: AllocationType,
+        create_info: &AllocationCreateInfo<'_>,
+        dedicated_allocation: Option<DedicatedAllocation<'_>>,
+    ) -> Result<MemoryAlloc, MemoryAllocatorError> {
+        unsafe {
+            (**self).allocate_unchecked(
+                requirements,
+                allocation_type,
+                create_info,
+                dedicated_allocation,
+            )
+        }
+    }
+
+    fn try_allocate_dedicated(
+        &self,
+        memory_type_index: u32,
+        allocation_size: DeviceSize,
+        dedicated_allocation: Option<DedicatedAllocation<'_>>,
+        export_handle_types: ExternalMemoryHandleTypes,
+    ) -> Result<MemoryAlloc, Validated<MemoryAllocatorError>> {
+        (**self).try_allocate_dedicated(
+            memory_type_index,
+            allocation_size,
+            dedicated_allocation,
+            export_handle_types,
+        )
+    }
+
+    unsafe fn allocate_dedicated_unchecked(
         &self,
         memory_type_index: u32,
         allocation_size: DeviceSize,
         dedicated_allocation: Option<DedicatedAllocation<'_>>,
         export_handle_types: ExternalMemoryHandleTypes,
     ) -> Result<MemoryAlloc, MemoryAllocatorError> {
-        (**self).allocate_dedicated(
-            memory_type_index,
-            allocation_size,
-            dedicated_allocation,
-            export_handle_types,
-        )
+        unsafe {
+            (**self).allocate_dedicated_unchecked(
+                memory_type_index,
+                allocation_size,
+                dedicated_allocation,
+                export_handle_types,
+            )
+        }
     }
 
     unsafe fn deallocate(&self, allocation: MemoryAlloc) {

--- a/vulkano/src/memory/device_memory.rs
+++ b/vulkano/src/memory/device_memory.rs
@@ -62,6 +62,32 @@ pub struct DeviceMemory {
 }
 
 impl DeviceMemory {
+    /// Allocates a block of memory from the device, panicking on a validation error.
+    ///
+    /// Some platforms may have a limit on the maximum size of a single allocation. For example,
+    /// certain systems may fail to create allocations with a size greater than or equal to 4GB.
+    ///
+    /// This is a shortcut for `try_allocate().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `allocate_info.dedicated_allocation` is `Some` and the contained buffer or
+    ///   image does not belong to `device`.
+    /// - Panics if [`try_allocate`] returns a [`ValidationError`].
+    ///
+    /// [`try_allocate`]: Self::try_allocate
+    #[inline]
+    #[track_caller]
+    pub fn allocate(
+        device: &Arc<Device>,
+        allocate_info: &MemoryAllocateInfo<'_>,
+    ) -> Result<Self, VulkanError> {
+        match Self::try_allocate(device, allocate_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Allocates a block of memory from the device.
     ///
     /// Some platforms may have a limit on the maximum size of a single allocation. For example,
@@ -72,13 +98,41 @@ impl DeviceMemory {
     /// - Panics if `allocate_info.dedicated_allocation` is `Some` and the contained buffer or
     ///   image does not belong to `device`.
     #[inline]
-    pub fn allocate(
+    pub fn try_allocate(
         device: &Arc<Device>,
         allocate_info: &MemoryAllocateInfo<'_>,
     ) -> Result<Self, Validated<VulkanError>> {
         Self::validate_allocate(device, allocate_info, None)?;
 
         Ok(unsafe { Self::allocate_unchecked(device, allocate_info, None) }?)
+    }
+
+    /// Imports a block of memory from an external source, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_import().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - See the documentation of the variants of [`MemoryImportInfo`].
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `allocate_info.dedicated_allocation` is `Some` and the contained buffer or
+    ///   image does not belong to `device`.
+    /// - Panics if [`try_import`] returns a [`ValidationError`].
+    ///
+    /// [`try_import`]: Self::try_import
+    #[inline]
+    #[track_caller]
+    pub unsafe fn import(
+        device: &Arc<Device>,
+        allocate_info: &MemoryAllocateInfo<'_>,
+        import_info: &MemoryImportInfo,
+    ) -> Result<Self, VulkanError> {
+        match unsafe { Self::try_import(device, allocate_info, import_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
     }
 
     /// Imports a block of memory from an external source.
@@ -92,7 +146,7 @@ impl DeviceMemory {
     /// - Panics if `allocate_info.dedicated_allocation` is `Some` and the contained buffer or
     ///   image does not belong to `device`.
     #[inline]
-    pub unsafe fn import(
+    pub unsafe fn try_import(
         device: &Arc<Device>,
         allocate_info: &MemoryAllocateInfo<'_>,
         import_info: &MemoryImportInfo,
@@ -302,11 +356,31 @@ impl DeviceMemory {
         self.is_coherent
     }
 
+    /// Maps a range of memory to be accessed by the host, panicking on a validation error.
+    ///
+    /// `self` must not be host-mapped already and must be allocated from host-visible memory.
+    ///
+    /// This is a shortcut for `try_map().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_map`] returns a [`ValidationError`].
+    ///
+    /// [`try_map`]: Self::try_map
+    #[inline]
+    #[track_caller]
+    pub fn map(&mut self, map_info: &MemoryMapInfo<'_>) -> Result<(), VulkanError> {
+        match self.try_map(map_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Maps a range of memory to be accessed by the host.
     ///
     /// `self` must not be host-mapped already and must be allocated from host-visible memory.
     #[inline]
-    pub fn map(&mut self, map_info: &MemoryMapInfo<'_>) -> Result<(), Validated<VulkanError>> {
+    pub fn try_map(&mut self, map_info: &MemoryMapInfo<'_>) -> Result<(), Validated<VulkanError>> {
         self.validate_map(map_info, None)?;
 
         Ok(unsafe { self.map_unchecked(map_info) }?)
@@ -319,6 +393,45 @@ impl DeviceMemory {
         map_info: &MemoryMapInfo<'_>,
     ) -> Result<(), VulkanError> {
         unsafe { self.map_unchecked_inner(map_info, None) }
+    }
+
+    /// Maps a range of memory to be accessed by the host at the specified `placed_address`,
+    /// panicking on a validation error.
+    ///
+    /// Requires the [`memory_map_placed`] feature to be enabled on the device.
+    ///
+    /// `placed_address` must be aligned to the [`min_placed_memory_map_alignment`] device
+    /// property.
+    ///
+    /// `self` must not be host-mapped already and must be allocated from host-visible memory.
+    ///
+    /// This is a shortcut for `try_map_placed().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - The memory mapping specified by `placed_address` and `map_info.size` will be replaced,
+    ///   including mappings made by the Rust allocator, a library, or your application itself.
+    /// - The memory mapping specified by `placed_address` and `map_info.size` must not overlap any
+    ///   existing Vulkan memory mapping.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_map_placed`] returns a [`ValidationError`].
+    ///
+    /// [`memory_map_placed`]: crate::device::DeviceFeatures::memory_map_placed
+    /// [`min_placed_memory_map_alignment`]: crate::device::DeviceProperties::min_placed_memory_map_alignment
+    /// [`try_map_placed`]: Self::try_map_placed
+    #[inline]
+    #[track_caller]
+    pub unsafe fn map_placed(
+        &mut self,
+        map_info: &MemoryMapInfo<'_>,
+        placed_address: NonNull<c_void>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_map_placed(map_info, placed_address) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
     }
 
     /// Maps a range of memory to be accessed by the host at the specified `placed_address`.
@@ -340,7 +453,7 @@ impl DeviceMemory {
     /// [`memory_map_placed`]: crate::device::DeviceFeatures::memory_map_placed
     /// [`min_placed_memory_map_alignment`]: crate::device::DeviceProperties::min_placed_memory_map_alignment
     #[inline]
-    pub unsafe fn map_placed(
+    pub unsafe fn try_map_placed(
         &mut self,
         map_info: &MemoryMapInfo<'_>,
         placed_address: NonNull<c_void>,
@@ -462,6 +575,27 @@ impl DeviceMemory {
         Ok(())
     }
 
+    /// Unmaps the memory, panicking on a validation error. It will no longer be accessible from
+    /// the host.
+    ///
+    /// `self` must be currently host-mapped.
+    ///
+    /// This is a shortcut for `try_unmap().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_unmap`] returns a [`ValidationError`].
+    ///
+    /// [`try_unmap`]: Self::try_unmap
+    #[inline]
+    #[track_caller]
+    pub fn unmap(&mut self, unmap_info: &MemoryUnmapInfo<'_>) -> Result<(), VulkanError> {
+        match self.try_unmap(unmap_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Unmaps the memory. It will no longer be accessible from the host.
     ///
     /// `self` must be currently host-mapped.
@@ -472,7 +606,7 @@ impl DeviceMemory {
     // that's currently being read or written by the host elsewhere, requiring even more locking on
     // each host access.
     #[inline]
-    pub fn unmap(
+    pub fn try_unmap(
         &mut self,
         unmap_info: &MemoryUnmapInfo<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -522,6 +656,40 @@ impl DeviceMemory {
         Ok(())
     }
 
+    /// Invalidates the host cache for a range of mapped memory, panicking on a validation error.
+    ///
+    /// If the device memory is not [host-coherent], you must call this function before the memory
+    /// is read by the host, if the device previously wrote to the memory. It has no effect if the
+    /// memory is host-coherent.
+    ///
+    /// This is a shortcut for `try_invalidate_range().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - If there are memory writes by the device that have not been propagated into the host
+    ///   cache, then there must not be any references in Rust code to any portion of the specified
+    ///   `memory_range`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_invalidate_range`] returns a [`ValidationError`].
+    ///
+    /// [host-coherent]: MemoryPropertyFlags::HOST_COHERENT
+    /// [`map`]: Self::map
+    /// [`non_coherent_atom_size`]: crate::device::DeviceProperties::non_coherent_atom_size
+    /// [`try_invalidate_range`]: Self::try_invalidate_range
+    #[inline]
+    #[track_caller]
+    pub unsafe fn invalidate_range(
+        &self,
+        memory_range: &MappedMemoryRange<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_invalidate_range(memory_range) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Invalidates the host cache for a range of mapped memory.
     ///
     /// If the device memory is not [host-coherent], you must call this function before the memory
@@ -538,7 +706,7 @@ impl DeviceMemory {
     /// [`map`]: Self::map
     /// [`non_coherent_atom_size`]: crate::device::DeviceProperties::non_coherent_atom_size
     #[inline]
-    pub unsafe fn invalidate_range(
+    pub unsafe fn try_invalidate_range(
         &self,
         memory_range: &MappedMemoryRange<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -569,6 +737,39 @@ impl DeviceMemory {
         Ok(())
     }
 
+    /// Flushes the host cache for a range of mapped memory, panicking on a validation error.
+    ///
+    /// If the device memory is not [host-coherent], you must call this function after writing to
+    /// the memory, if the device is going to read the memory. It has no effect if the memory is
+    /// host-coherent.
+    ///
+    /// This is a shortcut for `try_flush_range().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - There must be no operations pending or executing in a device queue, that access the
+    ///   specified `memory_range`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_flush_range`] returns a [`ValidationError`].
+    ///
+    /// [host-coherent]: MemoryPropertyFlags::HOST_COHERENT
+    /// [`map`]: Self::map
+    /// [`non_coherent_atom_size`]: crate::device::DeviceProperties::non_coherent_atom_size
+    /// [`try_flush_range`]: Self::try_flush_range
+    #[inline]
+    #[track_caller]
+    pub unsafe fn flush_range(
+        &self,
+        memory_range: &MappedMemoryRange<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_flush_range(memory_range) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Flushes the host cache for a range of mapped memory.
     ///
     /// If the device memory is not [host-coherent], you must call this function after writing to
@@ -584,7 +785,7 @@ impl DeviceMemory {
     /// [`map`]: Self::map
     /// [`non_coherent_atom_size`]: crate::device::DeviceProperties::non_coherent_atom_size
     #[inline]
-    pub unsafe fn flush_range(
+    pub unsafe fn try_flush_range(
         &self,
         memory_range: &MappedMemoryRange<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -630,6 +831,29 @@ impl DeviceMemory {
     }
 
     /// Retrieves the amount of lazily-allocated memory that is currently committed to this
+    /// memory object, panicking on a validation error.
+    ///
+    /// The device may change this value at any time, and the returned value may be
+    /// already out-of-date.
+    ///
+    /// `self` must have been allocated from a memory type that has the [`LAZILY_ALLOCATED`] flag
+    /// set.
+    ///
+    /// This is a shortcut for `try_commitment().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_commitment`] returns a [`ValidationError`].
+    ///
+    /// [`LAZILY_ALLOCATED`]: MemoryPropertyFlags::LAZILY_ALLOCATED
+    /// [`try_commitment`]: Self::try_commitment
+    #[inline]
+    #[track_caller]
+    pub fn commitment(&self) -> DeviceSize {
+        self.try_commitment().unwrap()
+    }
+
+    /// Retrieves the amount of lazily-allocated memory that is currently committed to this
     /// memory object.
     ///
     /// The device may change this value at any time, and the returned value may be
@@ -640,7 +864,7 @@ impl DeviceMemory {
     ///
     /// [`LAZILY_ALLOCATED`]: MemoryPropertyFlags::LAZILY_ALLOCATED
     #[inline]
-    pub fn commitment(&self) -> Result<DeviceSize, Box<ValidationError>> {
+    pub fn try_commitment(&self) -> Result<DeviceSize, Box<ValidationError>> {
         self.validate_commitment()?;
 
         Ok(unsafe { self.commitment_unchecked() })
@@ -682,6 +906,26 @@ impl DeviceMemory {
         output
     }
 
+    /// Exports the device memory into a Unix file descriptor, panicking on a validation error. The
+    /// caller owns the returned file descriptor.
+    ///
+    /// This is a shortcut for `try_export_fd().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_export_fd`] returns a [`ValidationError`].
+    /// - Panics if the user requests an invalid handle type for this device memory object.
+    ///
+    /// [`try_export_fd`]: Self::try_export_fd
+    #[inline]
+    #[track_caller]
+    pub fn export_fd(&self, handle_type: ExternalMemoryHandleType) -> Result<RawFd, VulkanError> {
+        match self.try_export_fd(handle_type) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Exports the device memory into a Unix file descriptor. The caller owns the returned file
     /// descriptor.
     ///
@@ -689,7 +933,7 @@ impl DeviceMemory {
     ///
     /// - Panics if the user requests an invalid handle type for this device memory object.
     #[inline]
-    pub fn export_fd(
+    pub fn try_export_fd(
         &self,
         handle_type: ExternalMemoryHandleType,
     ) -> Result<RawFd, Validated<VulkanError>> {
@@ -2535,7 +2779,7 @@ mod tests {
             })
             .unwrap();
 
-        DeviceMemory::allocate(
+        DeviceMemory::try_allocate(
             &device,
             &MemoryAllocateInfo {
                 allocation_size: 0xffffffffffffffff,

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -341,6 +341,40 @@ impl ResourceMemory {
         (!memory.is_coherent()).then_some(memory.atom_size())
     }
 
+    /// Invalidates the host cache for a range of the `ResourceMemory`, panicking on a validation
+    /// error.
+    ///
+    /// If the device memory is not [host-coherent], you must call this function before the memory
+    /// is read by the host, if the device previously wrote to the memory. It has no effect if the
+    /// memory is host-coherent.
+    ///
+    /// This is a shortcut for `try_invalidate_range().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - If there are memory writes by the device that have not been propagated into the host
+    ///   cache, then there must not be any references in Rust code to any portion of the specified
+    ///   `memory_range`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_invalidate_range`] returns a [`ValidationError`].
+    ///
+    /// [host-coherent]: MemoryPropertyFlags::HOST_COHERENT
+    /// [`non_coherent_atom_size`]: crate::device::DeviceProperties::non_coherent_atom_size
+    /// [`try_invalidate_range`]: Self::try_invalidate_range
+    #[inline]
+    #[track_caller]
+    pub unsafe fn invalidate_range(
+        &self,
+        memory_range: &MappedMemoryRange<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_invalidate_range(memory_range) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Invalidates the host cache for a range of the `ResourceMemory`.
     ///
     /// If the device memory is not [host-coherent], you must call this function before the memory
@@ -356,7 +390,7 @@ impl ResourceMemory {
     /// [host-coherent]: MemoryPropertyFlags::HOST_COHERENT
     /// [`non_coherent_atom_size`]: crate::device::DeviceProperties::non_coherent_atom_size
     #[inline]
-    pub unsafe fn invalidate_range(
+    pub unsafe fn try_invalidate_range(
         &self,
         memory_range: &MappedMemoryRange<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -364,7 +398,7 @@ impl ResourceMemory {
 
         unsafe {
             self.device_memory()
-                .invalidate_range(&self.create_memory_range(memory_range))
+                .try_invalidate_range(&self.create_memory_range(memory_range))
         }
     }
 
@@ -377,6 +411,39 @@ impl ResourceMemory {
         unsafe {
             self.device_memory()
                 .invalidate_range_unchecked(&self.create_memory_range(memory_range))
+        }
+    }
+
+    /// Flushes the host cache for a range of the `ResourceMemory`, panicking on a validation
+    /// error.
+    ///
+    /// If the device memory is not [host-coherent], you must call this function after writing to
+    /// the memory, if the device is going to read the memory. It has no effect if the memory is
+    /// host-coherent.
+    ///
+    /// This is a shortcut for `try_flush_range().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - There must be no operations pending or executing in a device queue, that access any
+    ///   portion of the specified `memory_range`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_flush_range`] returns a [`ValidationError`].
+    ///
+    /// [host-coherent]: MemoryPropertyFlags::HOST_COHERENT
+    /// [`non_coherent_atom_size`]: crate::device::DeviceProperties::non_coherent_atom_size
+    /// [`try_flush_range`]: Self::try_flush_range
+    #[inline]
+    #[track_caller]
+    pub unsafe fn flush_range(
+        &self,
+        memory_range: &MappedMemoryRange<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_flush_range(memory_range) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
         }
     }
 
@@ -394,7 +461,7 @@ impl ResourceMemory {
     /// [host-coherent]: MemoryPropertyFlags::HOST_COHERENT
     /// [`non_coherent_atom_size`]: crate::device::DeviceProperties::non_coherent_atom_size
     #[inline]
-    pub unsafe fn flush_range(
+    pub unsafe fn try_flush_range(
         &self,
         memory_range: &MappedMemoryRange<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -402,7 +469,7 @@ impl ResourceMemory {
 
         unsafe {
             self.device_memory()
-                .flush_range(&self.create_memory_range(memory_range))
+                .try_flush_range(&self.create_memory_range(memory_range))
         }
     }
 

--- a/vulkano/src/pipeline/cache.rs
+++ b/vulkano/src/pipeline/cache.rs
@@ -36,12 +36,18 @@ pub struct PipelineCache {
 }
 
 impl PipelineCache {
-    /// Builds a new pipeline cache.
+    /// Builds a new pipeline cache, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
     ///
     /// # Examples
     ///
-    /// This example loads a cache from a file, if it exists.
-    /// See [`get_data`](#method.get_data) for how to store the data in a file.
+    /// This example loads a cache from a file, if it exists. See [`get_data`] for how to store the
+    /// data in a file.
     ///
     /// ```
     /// # use std::sync::Arc;
@@ -78,8 +84,24 @@ impl PipelineCache {
     /// )
     /// .unwrap();
     /// ```
+    ///
+    /// [`get_data`]: Self::get_data
+    /// [`try_new`]: Self::try_new
     #[inline]
+    #[track_caller]
     pub fn new(
+        device: &Arc<Device>,
+        create_info: &PipelineCacheCreateInfo<'_>,
+    ) -> Result<Arc<PipelineCache>, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Builds a new pipeline cache.
+    #[inline]
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &PipelineCacheCreateInfo<'_>,
     ) -> Result<Arc<PipelineCache>, Validated<VulkanError>> {
@@ -219,9 +241,15 @@ impl PipelineCache {
         Ok(data)
     }
 
-    /// Merges other pipeline caches into this one.
+    /// Merges other pipeline caches into this one, panicking on a validation error.
     ///
     /// It is `self` that is modified here. The pipeline caches passed as parameter are untouched.
+    ///
+    /// This is a shortcut for `try_merge().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_merge`] returns a [`ValidationError`].
     ///
     /// # Examples
     ///
@@ -270,8 +298,25 @@ impl PipelineCache {
     /// // Now merge the new pipeline cache into the existing one
     /// current_cache.merge([new_cache.as_ref()]).unwrap();
     /// ```
-    // FIXME: vkMergePipelineCaches is not thread safe for the destination cache
+    ///
+    /// [`try_merge`]: Self::try_merge
+    #[track_caller]
     pub fn merge<'a>(
+        &self,
+        src_caches: impl IntoIterator<Item = &'a PipelineCache>,
+    ) -> Result<(), VulkanError> {
+        match self.try_merge(src_caches) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Merges other pipeline caches into this one.
+    ///
+    /// It is `self` that is modified here. The pipeline caches passed as parameter are untouched.
+    //
+    // FIXME: vkMergePipelineCaches is not thread safe for the destination cache
+    pub fn try_merge<'a>(
         &self,
         src_caches: impl IntoIterator<Item = &'a PipelineCache>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -479,7 +524,7 @@ mod tests {
     fn merge_self_forbidden() {
         let (device, _queue) = gfx_dev_and_queue!();
         let pipeline = PipelineCache::new(&device, &Default::default()).unwrap();
-        assert!(pipeline.merge([pipeline.as_ref()]).is_err());
+        assert!(pipeline.try_merge([pipeline.as_ref()]).is_err());
     }
 
     #[test]

--- a/vulkano/src/pipeline/compute.rs
+++ b/vulkano/src/pipeline/compute.rs
@@ -51,9 +51,31 @@ pub struct ComputePipeline {
 }
 
 impl ComputePipeline {
+    /// Creates a new `ComputePipeline`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        cache: Option<&Arc<PipelineCache>>,
+        create_info: &ComputePipelineCreateInfo<'_>,
+    ) -> Result<Arc<ComputePipeline>, VulkanError> {
+        match Self::try_new(device, cache, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `ComputePipeline`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         cache: Option<&Arc<PipelineCache>>,
         create_info: &ComputePipelineCreateInfo<'_>,
@@ -495,7 +517,6 @@ mod tests {
                     .unwrap();
             module
                 .specialize(&[(83, 0x12345678i32.into())])
-                .unwrap()
                 .entry_point("main")
                 .unwrap()
         };

--- a/vulkano/src/pipeline/graphics/mod.rs
+++ b/vulkano/src/pipeline/graphics/mod.rs
@@ -178,9 +178,31 @@ pub struct GraphicsPipeline {
 }
 
 impl GraphicsPipeline {
+    /// Creates a new `GraphicsPipeline`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        cache: Option<&Arc<PipelineCache>>,
+        create_info: &GraphicsPipelineCreateInfo<'_>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match Self::try_new(device, cache, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `GraphicsPipeline`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         cache: Option<&Arc<PipelineCache>>,
         create_info: &GraphicsPipelineCreateInfo<'_>,

--- a/vulkano/src/pipeline/layout.rs
+++ b/vulkano/src/pipeline/layout.rs
@@ -90,8 +90,28 @@ pub struct PipelineLayout {
 }
 
 impl PipelineLayout {
-    /// Creates a new `PipelineLayout`.
+    /// Creates a new `PipelineLayout`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[track_caller]
     pub fn new(
+        device: &Arc<Device>,
+        create_info: &PipelineLayoutCreateInfo<'_>,
+    ) -> Result<Arc<PipelineLayout>, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new `PipelineLayout`.
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &PipelineLayoutCreateInfo<'_>,
     ) -> Result<Arc<PipelineLayout>, Validated<VulkanError>> {
@@ -140,6 +160,53 @@ impl PipelineLayout {
     }
 
     /// Creates a new `PipelineLayout` from the union of the requirements of each shader stage in
+    /// `stages`, panicking on a validation error.
+    ///
+    /// This is intended for quick prototyping or for single use layouts that do not have any
+    /// bindings in common with other shaders. For the general case, it is strongly recommended to
+    /// create pipeline layouts manually:
+    /// - When multiple pipelines share the same layout object, it is faster than if they have
+    ///   different objects, even if the objects both contain identical bindings. It is also faster
+    ///   (though a little bit less), if multiple pipeline layout objects share common descriptor
+    ///   set objects.
+    /// - Pipeline layouts only need to be a superset of what the shaders use; they don't have to
+    ///   match exactly. Creating a manual pipeline layout therefore allows you to specify layouts
+    ///   that are applicable for many shaders, as long as each one uses a subset. This allows
+    ///   further sharing.
+    /// - Creating a manual pipeline layout makes your code more robust against changes in the
+    ///   shader, in particular regarding whether a particular binding in the shader is used or not
+    ///   (see also the limitations below).
+    ///
+    /// This is a shortcut for `try_from_stages().map_err(Validated::unwrap)`.
+    ///
+    /// # Limitations
+    ///
+    /// Only bindings that are [statically used] are included in the descriptor binding
+    /// requirements, and therefore are included in the descriptor set layout. If the use of a
+    /// binding depends on input variables to the shader (buffers, images, push constants etc.)
+    /// then the shader reflection is unable to know that the binding is in use, and it will not be
+    /// included in the pipeline layout.
+    ///
+    /// Note that this corresponds to the `shader_*_array_dynamic_indexing` device features.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_stages`] returns a [`ValidationError`].
+    ///
+    /// [statically used]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#shaders-staticuse
+    /// [`try_from_stages`]: Self::try_from_stages
+    #[track_caller]
+    pub fn from_stages(
+        device: &Arc<Device>,
+        stages: &[PipelineShaderStageCreateInfo<'_>],
+    ) -> Result<Arc<PipelineLayout>, VulkanError> {
+        match Self::try_from_stages(device, stages) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new `PipelineLayout` from the union of the requirements of each shader stage in
     /// `stages`.
     ///
     /// This is intended for quick prototyping or for single use layouts that do not have any
@@ -168,7 +235,7 @@ impl PipelineLayout {
     /// Note that this corresponds to the `shader_*_array_dynamic_indexing` device features.
     ///
     /// [statically used]: https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#shaders-staticuse
-    pub fn from_stages(
+    pub fn try_from_stages(
         device: &Arc<Device>,
         stages: &[PipelineShaderStageCreateInfo<'_>],
     ) -> Result<Arc<PipelineLayout>, Validated<VulkanError>> {
@@ -236,7 +303,7 @@ impl PipelineLayout {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        Self::new(
+        Self::try_new(
             device,
             &PipelineLayoutCreateInfo {
                 set_layouts: &set_layouts.iter().collect::<Vec<_>>(),

--- a/vulkano/src/pipeline/ray_tracing.rs
+++ b/vulkano/src/pipeline/ray_tracing.rs
@@ -98,9 +98,31 @@ self_referential! {
 }
 
 impl RayTracingPipeline {
+    /// Creates a new `RayTracingPipeline`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        cache: Option<&Arc<PipelineCache>>,
+        create_info: &RayTracingPipelineCreateInfo<'_>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match Self::try_new(device, cache, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `RayTracingPipeline`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         cache: Option<&Arc<PipelineCache>>,
         create_info: &RayTracingPipelineCreateInfo<'_>,
@@ -114,7 +136,7 @@ impl RayTracingPipeline {
         device: &Arc<Device>,
         cache: Option<&PipelineCache>,
         create_info: &RayTracingPipelineCreateInfo<'_>,
-    ) -> Result<(), Validated<VulkanError>> {
+    ) -> Result<(), Box<ValidationError>> {
         if let Some(cache) = cache {
             assert_eq!(device, cache.device());
         }
@@ -271,13 +293,39 @@ impl RayTracingPipeline {
         self.flags
     }
 
+    /// Retrieves the opaque handles of shaders in the ray tracing pipeline, panicking on a
+    /// validation error.
+    ///
+    /// Handles for `group_count` groups are retrieved, starting at `first_group`. The group
+    /// indices correspond to the [`groups`] the pipeline was created with.
+    ///
+    /// This is a shortcut for `try_group_handles().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_group_handles`] returns a [`ValidationError`].
+    ///
+    /// [`groups`]: Self::groups
+    /// [`try_group_handles`]: Self::try_group_handles
+    #[track_caller]
+    pub fn group_handles(
+        &self,
+        first_group: u32,
+        group_count: u32,
+    ) -> Result<ShaderGroupHandlesData, VulkanError> {
+        match self.try_group_handles(first_group, group_count) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Retrieves the opaque handles of shaders in the ray tracing pipeline.
     ///
     /// Handles for `group_count` groups are retrieved, starting at `first_group`. The group
     /// indices correspond to the [`groups`] the pipeline was created with.
     ///
     /// [`groups`]: Self::groups
-    pub fn group_handles(
+    pub fn try_group_handles(
         &self,
         first_group: u32,
         group_count: u32,
@@ -976,15 +1024,44 @@ pub struct ShaderBindingTable {
 }
 
 impl ShaderBindingTable {
-    /// Automatically creates a shader binding table from a ray tracing pipeline.
+    /// Automatically creates a shader binding table from a ray tracing pipeline, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[track_caller]
     pub fn new(
         allocator: &Arc<impl MemoryAllocator + ?Sized>,
         ray_tracing_pipeline: &RayTracingPipeline,
-    ) -> Result<Self, Validated<VulkanError>> {
+    ) -> Result<Self, VulkanError> {
         Self::new_inner(allocator.clone().as_dyn(), ray_tracing_pipeline)
     }
 
+    #[track_caller]
     fn new_inner(
+        allocator: Arc<dyn MemoryAllocator>,
+        ray_tracing_pipeline: &RayTracingPipeline,
+    ) -> Result<Self, VulkanError> {
+        match Self::try_new_inner(allocator, ray_tracing_pipeline) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Automatically creates a shader binding table from a ray tracing pipeline.
+    pub fn try_new(
+        allocator: &Arc<impl MemoryAllocator + ?Sized>,
+        ray_tracing_pipeline: &RayTracingPipeline,
+    ) -> Result<Self, Validated<VulkanError>> {
+        Self::try_new_inner(allocator.clone().as_dyn(), ray_tracing_pipeline)
+    }
+
+    fn try_new_inner(
         allocator: Arc<dyn MemoryAllocator>,
         ray_tracing_pipeline: &RayTracingPipeline,
     ) -> Result<Self, Validated<VulkanError>> {
@@ -1090,7 +1167,7 @@ impl ShaderBindingTable {
         )
         .expect("todo: raytracing: better error type for buffer errors");
 
-        raygen.device_address = sbt_buffer.buffer().device_address().unwrap().get();
+        raygen.device_address = sbt_buffer.buffer().device_address().get();
         miss.device_address = raygen.device_address + raygen.size;
         hit.device_address = miss.device_address + miss.size;
         callable.device_address = hit.device_address + hit.size;
@@ -1143,7 +1220,7 @@ fn new_bytes_buffer_with_alignment(
     alignment: DeviceAlignment,
 ) -> Result<Subbuffer<[u8]>, Validated<AllocateBufferError>> {
     let layout = DeviceLayout::from_size_alignment(size, alignment.as_devicesize()).unwrap();
-    let buffer = Subbuffer::new(Buffer::new_inner(
+    let buffer = Subbuffer::new(Buffer::try_new_inner(
         allocator,
         create_info,
         allocation_info,

--- a/vulkano/src/query.rs
+++ b/vulkano/src/query.rs
@@ -33,9 +33,30 @@ pub struct QueryPool {
 }
 
 impl QueryPool {
+    /// Creates a new `QueryPool`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &QueryPoolCreateInfo<'_>,
+    ) -> Result<Arc<QueryPool>, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `QueryPool`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &QueryPoolCreateInfo<'_>,
     ) -> Result<Arc<QueryPool>, Validated<VulkanError>> {
@@ -144,6 +165,46 @@ impl QueryPool {
         }) + result_flags.intersects(QueryResultFlags::WITH_AVAILABILITY) as DeviceSize
     }
 
+    /// Copies the results of a range of queries to a buffer on the CPU, panicking on a validation
+    /// error.
+    ///
+    /// [`self.result_len(flags)`] elements will be written for each query in the range, plus 1
+    /// extra element per query if [`WITH_AVAILABILITY`] is enabled. The provided buffer must be
+    /// large enough to hold the data.
+    ///
+    /// `true` is returned if every result was available and written to the buffer. `false` is
+    /// returned if some results were not yet available; these will not be written to the buffer.
+    ///
+    /// See also [`copy_query_pool_results`].
+    ///
+    /// This is a shortcut for `try_get_results().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_get_results`] returns a [`ValidationError`].
+    ///
+    /// [`self.result_len(flags)`]: QueryPool::result_len
+    /// [`WITH_AVAILABILITY`]: QueryResultFlags::WITH_AVAILABILITY
+    /// [`copy_query_pool_results`]: crate::command_buffer::AutoCommandBufferBuilder::copy_query_pool_results
+    /// [`try_get_results`]: Self::try_get_results
+    #[inline]
+    #[track_caller]
+    pub fn get_results<T>(
+        &self,
+        first_query: u32,
+        query_count: u32,
+        destination: &mut [T],
+        flags: QueryResultFlags,
+    ) -> Result<bool, VulkanError>
+    where
+        T: QueryResultElement,
+    {
+        match self.try_get_results(first_query, query_count, destination, flags) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Copies the results of a range of queries to a buffer on the CPU.
     ///
     /// [`self.result_len(flags)`] elements will be written for each query in the range, plus 1
@@ -155,11 +216,11 @@ impl QueryPool {
     ///
     /// See also [`copy_query_pool_results`].
     ///
-    /// [`self.result_len()`]: QueryPool::result_len
+    /// [`self.result_len(flags)`]: QueryPool::result_len
     /// [`WITH_AVAILABILITY`]: QueryResultFlags::WITH_AVAILABILITY
     /// [`copy_query_pool_results`]: crate::command_buffer::AutoCommandBufferBuilder::copy_query_pool_results
     #[inline]
-    pub fn get_results<T>(
+    pub fn try_get_results<T>(
         &self,
         first_query: u32,
         query_count: u32,
@@ -283,6 +344,31 @@ impl QueryPool {
         }
     }
 
+    /// Resets a range of queries, panicking on a validation error.
+    ///
+    /// The [`host_query_reset`] feature must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_reset().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// For the queries indicated by `first_query` and `query_count`:
+    /// - There must be no operations pending or executing on the device.
+    /// - There must be no calls to `reset*` or `get_results*` executing concurrently on another
+    ///   thread.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_reset`] returns a [`ValidationError`].
+    ///
+    /// [`host_query_reset`]: crate::device::DeviceFeatures::host_query_reset
+    /// [`try_reset`]: Self::try_reset
+    #[inline]
+    #[track_caller]
+    pub unsafe fn reset(&self, first_query: u32, query_count: u32) {
+        unsafe { self.try_reset(first_query, query_count) }.unwrap()
+    }
+
     /// Resets a range of queries.
     ///
     /// The [`host_query_reset`] feature must be enabled on the device.
@@ -296,7 +382,7 @@ impl QueryPool {
     ///
     /// [`host_query_reset`]: crate::device::DeviceFeatures::host_query_reset
     #[inline]
-    pub unsafe fn reset(
+    pub unsafe fn try_reset(
         &self,
         first_query: u32,
         query_count: u32,
@@ -796,7 +882,7 @@ mod tests {
     fn pipeline_statistics_feature() {
         let (device, _) = gfx_dev_and_queue!();
         assert!(matches!(
-            QueryPool::new(
+            QueryPool::try_new(
                 &device,
                 &QueryPoolCreateInfo {
                     query_count: 256,

--- a/vulkano/src/render_pass/framebuffer.rs
+++ b/vulkano/src/render_pass/framebuffer.rs
@@ -49,8 +49,28 @@ pub struct Framebuffer {
 }
 
 impl Framebuffer {
-    /// Creates a new `Framebuffer`.
+    /// Creates a new `Framebuffer`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[track_caller]
     pub fn new(
+        render_pass: &Arc<RenderPass>,
+        create_info: &FramebufferCreateInfo<'_>,
+    ) -> Result<Arc<Framebuffer>, VulkanError> {
+        match Self::try_new(render_pass, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a new `Framebuffer`.
+    pub fn try_new(
         render_pass: &Arc<RenderPass>,
         create_info: &FramebufferCreateInfo<'_>,
     ) -> Result<Arc<Framebuffer>, Validated<VulkanError>> {
@@ -751,7 +771,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(Framebuffer::new(
+        assert!(Framebuffer::try_new(
             &render_pass,
             &FramebufferCreateInfo {
                 extent: [0xffffffff, 0xffffffff],
@@ -761,7 +781,7 @@ mod tests {
         )
         .is_err());
 
-        assert!(Framebuffer::new(
+        assert!(Framebuffer::try_new(
             &render_pass,
             &FramebufferCreateInfo {
                 extent: [1, 1],
@@ -810,7 +830,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(Framebuffer::new(
+        assert!(Framebuffer::try_new(
             &render_pass,
             &FramebufferCreateInfo {
                 attachments: &[&view],
@@ -910,7 +930,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(Framebuffer::new(
+        assert!(Framebuffer::try_new(
             &render_pass,
             &FramebufferCreateInfo {
                 attachments: &[&view],
@@ -981,7 +1001,7 @@ mod tests {
         )
         .unwrap();
 
-        let framebuffer = Framebuffer::new(
+        let framebuffer = Framebuffer::try_new(
             &render_pass,
             &FramebufferCreateInfo {
                 attachments: &[&a, &b],
@@ -1040,7 +1060,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(Framebuffer::new(
+        assert!(Framebuffer::try_new(
             &render_pass,
             &FramebufferCreateInfo {
                 attachments: &[&view],
@@ -1103,7 +1123,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(Framebuffer::new(
+        assert!(Framebuffer::try_new(
             &render_pass,
             &FramebufferCreateInfo {
                 attachments: &[&a, &b],
@@ -1149,6 +1169,6 @@ mod tests {
         )
         .unwrap();
 
-        assert!(Framebuffer::new(&render_pass, &FramebufferCreateInfo::default()).is_err());
+        assert!(Framebuffer::try_new(&render_pass, &FramebufferCreateInfo::default()).is_err());
     }
 }

--- a/vulkano/src/render_pass/macros.rs
+++ b/vulkano/src/render_pass/macros.rs
@@ -123,7 +123,7 @@ macro_rules! ordered_passes_renderpass {
             $(layouts[$atch_name as usize].final_layout = Some($final_layout);)?
         })*
 
-        $crate::render_pass::RenderPass::new(
+        $crate::render_pass::RenderPass::try_new(
             $device,
             &$crate::render_pass::RenderPassCreateInfo {
                 attachments: &[$(

--- a/vulkano/src/render_pass/mod.rs
+++ b/vulkano/src/render_pass/mod.rs
@@ -129,13 +129,35 @@ self_referential! {
 }
 
 impl RenderPass {
+    /// Creates a new `RenderPass`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    /// - Panics if `create_info.subpasses` is empty.
+    /// - Panics if any element of `create_info.attachments` has a `format` of `None`.
+    ///
+    /// [`try_new`]: Self::try_new
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &RenderPassCreateInfo<'_>,
+    ) -> Result<Arc<RenderPass>, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `RenderPass`.
     ///
     /// # Panics
     ///
     /// - Panics if `create_info.subpasses` is empty.
     /// - Panics if any element of `create_info.attachments` has a `format` of `None`.
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &RenderPassCreateInfo<'_>,
     ) -> Result<Arc<RenderPass>, Validated<VulkanError>> {

--- a/vulkano/src/shader/mod.rs
+++ b/vulkano/src/shader/mod.rs
@@ -458,13 +458,38 @@ pub struct ShaderModule {
 }
 
 impl ShaderModule {
+    /// Creates a new shader module, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - The SPIR-V code in `create_info.code` must be valid.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub unsafe fn new(
+        device: &Arc<Device>,
+        create_info: &ShaderModuleCreateInfo<'_>,
+    ) -> Result<Arc<ShaderModule>, VulkanError> {
+        match unsafe { Self::try_new(device, create_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new shader module.
     ///
     /// # Safety
     ///
     /// - The SPIR-V code in `create_info.code` must be valid.
     #[inline]
-    pub unsafe fn new(
+    pub unsafe fn try_new(
         device: &Arc<Device>,
         create_info: &ShaderModuleCreateInfo<'_>,
     ) -> Result<Arc<ShaderModule>, Validated<VulkanError>> {
@@ -576,7 +601,7 @@ impl ShaderModule {
         device: Arc<Device>,
         words: &[u32],
     ) -> Result<Arc<ShaderModule>, Validated<VulkanError>> {
-        unsafe { Self::new(&device, &ShaderModuleCreateInfo::new(words)) }
+        unsafe { Self::try_new(&device, &ShaderModuleCreateInfo::new(words)) }
     }
 
     /// As `from_words`, but takes a slice of bytes.
@@ -596,7 +621,7 @@ impl ShaderModule {
     ) -> Result<Arc<ShaderModule>, Validated<VulkanError>> {
         let words = spirv::bytes_to_words(bytes).unwrap();
 
-        unsafe { Self::new(&device, &ShaderModuleCreateInfo::new(&words)) }
+        unsafe { Self::try_new(&device, &ShaderModuleCreateInfo::new(&words)) }
     }
 
     /// Returns the specialization constants that are defined in the module,
@@ -609,8 +634,33 @@ impl ShaderModule {
         &self.specialization_constants
     }
 
-    /// Applies the specialization constants to the shader module,
-    /// and returns a specialized version of the module.
+    /// Applies the specialization constants to the shader module, and returns a specialized
+    /// version of the module, panicking on a validation error.
+    ///
+    /// Constants that are not given a value here will have the default value that was specified
+    /// for them in the shader code.
+    /// When provided, they must have the same type as defined in the shader (as returned by
+    /// [`specialization_constants`]).
+    ///
+    /// This is a shortcut for `try_specialize().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_specialize`] returns a [`ValidationError`].
+    ///
+    /// [`specialization_constants`]: Self::specialization_constants
+    /// [`try_specialize`]: Self::try_specialize
+    #[inline]
+    #[track_caller]
+    pub fn specialize(
+        self: &Arc<Self>,
+        specialization_info: &[(u32, SpecializationConstant)],
+    ) -> Arc<SpecializedShaderModule> {
+        self.try_specialize(specialization_info).unwrap()
+    }
+
+    /// Applies the specialization constants to the shader module, and returns a specialized
+    /// version of the module.
     ///
     /// Constants that are not given a value here will have the default value that was specified
     /// for them in the shader code.
@@ -619,11 +669,11 @@ impl ShaderModule {
     ///
     /// [`specialization_constants`]: Self::specialization_constants
     #[inline]
-    pub fn specialize(
+    pub fn try_specialize(
         self: &Arc<Self>,
         specialization_info: &[(u32, SpecializationConstant)],
     ) -> Result<Arc<SpecializedShaderModule>, Box<ValidationError>> {
-        SpecializedShaderModule::new(self, specialization_info)
+        SpecializedShaderModule::try_new(self, specialization_info)
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
@@ -975,9 +1025,28 @@ pub struct SpecializedShaderModule {
 }
 
 impl SpecializedShaderModule {
+    /// Returns `base_module` specialized with `specialization_info`, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_new().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        base_module: &Arc<ShaderModule>,
+        specialization_info: &[(u32, SpecializationConstant)],
+    ) -> Arc<Self> {
+        Self::try_new(base_module, specialization_info).unwrap()
+    }
+
     /// Returns `base_module` specialized with `specialization_info`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         base_module: &Arc<ShaderModule>,
         specialization_info: &[(u32, SpecializationConstant)],
     ) -> Result<Arc<Self>, Box<ValidationError>> {

--- a/vulkano/src/swapchain/acquire_present.rs
+++ b/vulkano/src/swapchain/acquire_present.rs
@@ -172,7 +172,7 @@ pub fn acquire_next_image(
         image_index,
         is_suboptimal,
     } = unsafe {
-        swapchain.acquire_next_image(&AcquireNextImageInfo {
+        swapchain.try_acquire_next_image(&AcquireNextImageInfo {
             timeout,
             semaphore: Some(&semaphore),
             fence: Some(&fence),
@@ -296,7 +296,7 @@ impl SwapchainAcquireFuture {
     /// You still need to join with this future for present to work
     pub fn wait(&self, timeout: Option<Duration>) -> Result<(), VulkanError> {
         match &self.fence {
-            Some(fence) => fence.wait(timeout),
+            Some(fence) => unsafe { fence.wait_unchecked(timeout) },
             None => Ok(()),
         }
     }
@@ -1319,5 +1319,5 @@ pub fn wait_for_present(
     present_id: u64,
     timeout: Option<Duration>,
 ) -> Result<bool, Validated<VulkanError>> {
-    swapchain.wait_for_present(present_id.try_into().unwrap(), timeout)
+    swapchain.try_wait_for_present(present_id.try_into().unwrap(), timeout)
 }

--- a/vulkano/src/swapchain/mod.rs
+++ b/vulkano/src/swapchain/mod.rs
@@ -424,6 +424,34 @@ struct ImageEntry {
 }
 
 impl Swapchain {
+    /// Creates a new `Swapchain`, panicking on a validation error.
+    ///
+    /// This function returns the swapchain plus a list of the images that belong to the
+    /// swapchain. The order in which the images are returned is important for the
+    /// `acquire_next_image` and `present` functions.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    /// - Panics if the device and the surface don't belong to the same instance.
+    /// - Panics if `create_info.usage` is empty.
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        surface: &Arc<Surface>,
+        create_info: &SwapchainCreateInfo<'_>,
+    ) -> Result<(Arc<Swapchain>, Vec<Arc<Image>>), VulkanError> {
+        match Self::try_new(device, surface, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `Swapchain`.
     ///
     /// This function returns the swapchain plus a list of the images that belong to the
@@ -435,7 +463,7 @@ impl Swapchain {
     /// - Panics if the device and the surface don't belong to the same instance.
     /// - Panics if `create_info.usage` is empty.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         surface: &Arc<Surface>,
         create_info: &SwapchainCreateInfo<'_>,
@@ -458,6 +486,29 @@ impl Swapchain {
         unsafe { Self::from_handle(device, handle, image_handles, surface, create_info) }
     }
 
+    /// Creates a new swapchain from this one, panicking on a validation error.
+    ///
+    /// Use this when a swapchain has become invalidated, such as due to window resizes.
+    ///
+    /// This is a shortcut for `try_recreate().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_recreate`] returns a [`ValidationError`].
+    /// - Panics if `create_info.usage` is empty.
+    ///
+    /// [`try_recreate`]: Self::try_recreate
+    #[track_caller]
+    pub fn recreate(
+        self: &Arc<Self>,
+        create_info: &SwapchainCreateInfo<'_>,
+    ) -> Result<(Arc<Swapchain>, Vec<Arc<Image>>), VulkanError> {
+        match Self::try_recreate(self, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new swapchain from this one.
     ///
     /// Use this when a swapchain has become invalidated, such as due to window resizes.
@@ -465,7 +516,7 @@ impl Swapchain {
     /// # Panics
     ///
     /// - Panics if `create_info.usage` is empty.
-    pub fn recreate(
+    pub fn try_recreate(
         self: &Arc<Self>,
         create_info: &SwapchainCreateInfo<'_>,
     ) -> Result<(Arc<Swapchain>, Vec<Arc<Image>>), Validated<VulkanError>> {
@@ -1300,6 +1351,52 @@ impl Swapchain {
         self.full_screen_exclusive
     }
 
+    /// Acquires temporary ownership of a swapchain image, panicking on a validation error.
+    ///
+    /// The function returns the index of the image in the array of images that was returned
+    /// when creating the swapchain. The image will not be available immediately after the function
+    /// returns successfully.
+    ///
+    /// When the image becomes available, a semaphore or fence will be signaled. The image can then
+    /// be accessed by the host or device. After this, the image must be *presented* back to the
+    /// swapchain, using the [`present`] queue command.
+    ///
+    /// This is a shortcut for `try_acquire_next_image().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `self` must be kept alive until either `acquire_info.semaphore` or `acquire_info.fence`
+    ///   is signaled.
+    /// - If all images from `self` are currently acquired, and have not been presented yet, then
+    ///   `acquire_info.timeout` must not be `None`.
+    ///
+    /// If `acquire_info.semaphore` is `Some`:
+    /// - The semaphore must be kept alive until it is signaled.
+    /// - When the signal operation is executed, the semaphore must be in the unsignaled state.
+    ///
+    /// If `acquire_info.fence` is `Some`:
+    /// - The fence must be kept alive until it is signaled.
+    /// - The fence must be unsignaled and must not be associated with any other command that is
+    ///   still executing.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_acquire_next_image`] returns a [`ValidationError`].
+    ///
+    /// [`present`]: crate::device::QueueGuard::present
+    /// [`try_acquire_next_image`]: Self::try_acquire_next_image
+    #[inline]
+    #[track_caller]
+    pub unsafe fn acquire_next_image(
+        &self,
+        acquire_info: &AcquireNextImageInfo<'_>,
+    ) -> Result<AcquiredImage, VulkanError> {
+        match unsafe { self.try_acquire_next_image(acquire_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Acquires temporary ownership of a swapchain image.
     ///
     /// The function returns the index of the image in the array of images that was returned
@@ -1328,7 +1425,7 @@ impl Swapchain {
     ///
     /// [`present`]: crate::device::QueueGuard::present
     #[inline]
-    pub unsafe fn acquire_next_image(
+    pub unsafe fn try_acquire_next_image(
         &self,
         acquire_info: &AcquireNextImageInfo<'_>,
     ) -> Result<AcquiredImage, Validated<VulkanError>> {
@@ -1423,6 +1520,36 @@ impl Swapchain {
         })
     }
 
+    /// Waits for a swapchain image with a specific present ID to be presented to the user,
+    /// panicking on a validation error.
+    ///
+    /// For this to work, you must set [`SwapchainPresentInfo::present_id`] to `Some` when
+    /// presenting. This function will then wait until the swapchain image with the specified ID is
+    /// presented.
+    ///
+    /// Returns whether the presentation was suboptimal. This has the same meaning as in
+    /// [`AcquiredImage::is_suboptimal`].
+    ///
+    /// This is a shortcut for `try_wait_for_present().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_wait_for_present`] returns a [`ValidationError`].
+    ///
+    /// [`try_wait_for_present`]: Self::try_wait_for_present
+    #[inline]
+    #[track_caller]
+    pub fn wait_for_present(
+        &self,
+        present_id: NonZero<u64>,
+        timeout: Option<Duration>,
+    ) -> Result<bool, VulkanError> {
+        match self.try_wait_for_present(present_id, timeout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Waits for a swapchain image with a specific present ID to be presented to the user.
     ///
     /// For this to work, you must set [`SwapchainPresentInfo::present_id`] to `Some` when
@@ -1432,7 +1559,7 @@ impl Swapchain {
     /// Returns whether the presentation was suboptimal. This has the same meaning as in
     /// [`AcquiredImage::is_suboptimal`].
     #[inline]
-    pub fn wait_for_present(
+    pub fn try_wait_for_present(
         &self,
         present_id: NonZero<u64>,
         timeout: Option<Duration>,
@@ -1517,6 +1644,30 @@ impl Swapchain {
         }
     }
 
+    /// Acquires full-screen exclusivity, panicking on a validation error.
+    ///
+    /// The swapchain must have been created with [`FullScreenExclusive::ApplicationControlled`],
+    /// and must not already hold full-screen exclusivity. Full-screen exclusivity is held until
+    /// either the `release_full_screen_exclusive` is called, or if any of the the other
+    /// `Swapchain` functions return `FullScreenExclusiveLost`.
+    ///
+    /// This is a shortcut for
+    /// `try_acquire_full_screen_exclusive_mode().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_acquire_full_screen_exclusive_mode`] returns a [`ValidationError`].
+    ///
+    /// [`try_acquire_full_screen_exclusive_mode`]: Self::try_acquire_full_screen_exclusive_mode
+    #[inline]
+    #[track_caller]
+    pub fn acquire_full_screen_exclusive_mode(&self) -> Result<(), VulkanError> {
+        match self.try_acquire_full_screen_exclusive_mode() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Acquires full-screen exclusivity.
     ///
     /// The swapchain must have been created with [`FullScreenExclusive::ApplicationControlled`],
@@ -1524,7 +1675,7 @@ impl Swapchain {
     /// either the `release_full_screen_exclusive` is called, or if any of the the other
     /// `Swapchain` functions return `FullScreenExclusiveLost`.
     #[inline]
-    pub fn acquire_full_screen_exclusive_mode(&self) -> Result<(), Validated<VulkanError>> {
+    pub fn try_acquire_full_screen_exclusive_mode(&self) -> Result<(), Validated<VulkanError>> {
         self.validate_acquire_full_screen_exclusive_mode()?;
 
         Ok(unsafe { self.acquire_full_screen_exclusive_mode_unchecked() }?)
@@ -1581,12 +1732,34 @@ impl Swapchain {
         Ok(())
     }
 
+    /// Releases full-screen exclusivity, panicking on a validation error.
+    ///
+    /// The swapchain must have been created with [`FullScreenExclusive::ApplicationControlled`],
+    /// and must currently hold full-screen exclusivity.
+    ///
+    /// This is a shortcut for
+    /// `try_release_full_screen_exclusive_mode().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_release_full_screen_exclusive_mode`] returns a [`ValidationError`].
+    ///
+    /// [`try_release_full_screen_exclusive_mode`]: Self::try_release_full_screen_exclusive_mode
+    #[inline]
+    #[track_caller]
+    pub fn release_full_screen_exclusive_mode(&self) -> Result<(), VulkanError> {
+        match self.try_release_full_screen_exclusive_mode() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Releases full-screen exclusivity.
     ///
     /// The swapchain must have been created with [`FullScreenExclusive::ApplicationControlled`],
     /// and must currently hold full-screen exclusivity.
     #[inline]
-    pub fn release_full_screen_exclusive_mode(&self) -> Result<(), Validated<VulkanError>> {
+    pub fn try_release_full_screen_exclusive_mode(&self) -> Result<(), Validated<VulkanError>> {
         self.validate_release_full_screen_exclusive_mode()?;
 
         Ok(unsafe { self.release_full_screen_exclusive_mode_unchecked() }?)

--- a/vulkano/src/swapchain/surface.rs
+++ b/vulkano/src/swapchain/surface.rs
@@ -15,7 +15,8 @@ use crate::{
 use ash::vk;
 #[cfg(feature = "raw_window_handle")]
 use raw_window_handle::{
-    HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle, RawWindowHandle,
+    DisplayHandle, HandleError, HasDisplayHandle, HasWindowHandle, RawDisplayHandle,
+    RawWindowHandle, WindowHandle,
 };
 use smallvec::SmallVec;
 use std::{
@@ -52,16 +53,47 @@ pub struct Surface {
 
 impl Surface {
     /// Returns the instance extensions required to create a surface from a window of the given
+    /// event loop, panicking on a handle error.
+    ///
+    /// This is a shortcut for `try_required_extensions().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_required_extensions`] returns a [`HandleError`].
+    ///
+    /// [`try_required_extensions`]: Self::try_required_extensions
+    #[cfg(feature = "raw_window_handle")]
+    #[track_caller]
+    pub fn required_extensions(event_loop: &impl HasDisplayHandle) -> InstanceExtensions {
+        Self::required_extensions_inner(event_loop.display_handle())
+    }
+
+    #[cfg(feature = "raw_window_handle")]
+    #[track_caller]
+    fn required_extensions_inner(
+        display_handle: Result<DisplayHandle<'_>, HandleError>,
+    ) -> InstanceExtensions {
+        Self::try_required_extensions_inner(display_handle).unwrap()
+    }
+
+    /// Returns the instance extensions required to create a surface from a window of the given
     /// event loop.
     #[cfg(feature = "raw_window_handle")]
-    pub fn required_extensions(
+    pub fn try_required_extensions(
         event_loop: &impl HasDisplayHandle,
+    ) -> Result<InstanceExtensions, HandleError> {
+        Self::try_required_extensions_inner(event_loop.display_handle())
+    }
+
+    #[cfg(feature = "raw_window_handle")]
+    fn try_required_extensions_inner(
+        display_handle: Result<DisplayHandle<'_>, HandleError>,
     ) -> Result<InstanceExtensions, HandleError> {
         let mut extensions = InstanceExtensions {
             khr_surface: true,
             ..InstanceExtensions::empty()
         };
-        match event_loop.display_handle()?.as_raw() {
+        match display_handle?.as_raw() {
             RawDisplayHandle::Android(_) => extensions.khr_android_surface = true,
             RawDisplayHandle::AppKit(_) => extensions.ext_metal_surface = true,
             RawDisplayHandle::UiKit(_) => extensions.ext_metal_surface = true,
@@ -75,16 +107,109 @@ impl Surface {
         Ok(extensions)
     }
 
-    /// Creates a new `Surface` from the given `window`.
+    /// Creates a new `Surface` from the given `window`, panicking on a validation error or handle
+    /// error.
+    ///
+    /// This is a shortcut for
+    /// `try_from_window().map_err(Validated::unwrap).map_err(FromWindowError::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_window`] returns a [`ValidationError`] or [`HandleError`].
+    ///
+    /// [`try_from_window`]: Self::try_from_window
     #[cfg(feature = "raw_window_handle")]
+    #[track_caller]
     pub fn from_window(
         instance: &Arc<Instance>,
         window: &Arc<impl HasWindowHandle + HasDisplayHandle + Any + Send + Sync>,
-    ) -> Result<Arc<Self>, FromWindowError> {
-        let mut surface = unsafe { Self::from_window_ref(instance, window) }?;
-        Arc::get_mut(&mut surface).unwrap().object = Some(window.clone());
+    ) -> Result<Arc<Self>, VulkanError> {
+        Self::from_window_inner(
+            instance,
+            window.clone(),
+            window.window_handle(),
+            window.display_handle(),
+        )
+    }
+
+    #[cfg(feature = "raw_window_handle")]
+    #[track_caller]
+    fn from_window_inner(
+        instance: &Arc<Instance>,
+        window: Arc<dyn Any + Send + Sync>,
+        window_handle: Result<WindowHandle<'_>, HandleError>,
+        display_handle: Result<DisplayHandle<'_>, HandleError>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match Self::try_from_window_inner(instance, window, window_handle, display_handle) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap().unwrap()),
+        }
+    }
+
+    /// Creates a new `Surface` from the given `window`.
+    #[cfg(feature = "raw_window_handle")]
+    pub fn try_from_window(
+        instance: &Arc<Instance>,
+        window: &Arc<impl HasWindowHandle + HasDisplayHandle + Any + Send + Sync>,
+    ) -> Result<Arc<Self>, Validated<FromWindowError>> {
+        let window_handle = window.window_handle();
+        let display_handle = window.display_handle();
+
+        Self::try_from_window_inner(instance, window.clone(), window_handle, display_handle)
+    }
+
+    #[cfg(feature = "raw_window_handle")]
+    fn try_from_window_inner(
+        instance: &Arc<Instance>,
+        window: Arc<dyn Any + Send + Sync>,
+        window_handle: Result<WindowHandle<'_>, HandleError>,
+        display_handle: Result<DisplayHandle<'_>, HandleError>,
+    ) -> Result<Arc<Self>, Validated<FromWindowError>> {
+        let mut surface =
+            unsafe { Self::try_from_window_ref_inner(instance, window_handle, display_handle) }?;
+        Arc::get_mut(&mut surface).unwrap().object = Some(window);
 
         Ok(surface)
+    }
+
+    /// Creates a new `Surface` from the given `window` without ensuring that the window outlives
+    /// the surface, panicking on a validation error or handle error.
+    ///
+    /// This is a shortcut for
+    /// `try_from_window_ref().map_err(Validated::unwrap).map_err(FromHandleError::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - The given `window` must outlive the created surface.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_window_ref`] returns a [`ValidationError`] or [`HandleError`].
+    ///
+    /// [`try_from_window_ref`]: Self::try_from_window_ref
+    #[cfg(feature = "raw_window_handle")]
+    #[track_caller]
+    pub unsafe fn from_window_ref(
+        instance: &Arc<Instance>,
+        window: &(impl HasWindowHandle + HasDisplayHandle),
+    ) -> Result<Arc<Self>, VulkanError> {
+        let window_handle = window.window_handle();
+        let display_handle = window.display_handle();
+
+        unsafe { Self::from_window_ref_inner(instance, window_handle, display_handle) }
+    }
+
+    #[cfg(feature = "raw_window_handle")]
+    #[track_caller]
+    unsafe fn from_window_ref_inner(
+        instance: &Arc<Instance>,
+        window_handle: Result<WindowHandle<'_>, HandleError>,
+        display_handle: Result<DisplayHandle<'_>, HandleError>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_window_ref_inner(instance, window_handle, display_handle) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap().unwrap()),
+        }
     }
 
     /// Creates a new `Surface` from the given `window` without ensuring that the window outlives
@@ -94,37 +219,49 @@ impl Surface {
     ///
     /// - The given `window` must outlive the created surface.
     #[cfg(feature = "raw_window_handle")]
-    pub unsafe fn from_window_ref(
+    pub unsafe fn try_from_window_ref(
         instance: &Arc<Instance>,
         window: &(impl HasWindowHandle + HasDisplayHandle),
-    ) -> Result<Arc<Self>, FromWindowError> {
-        let window_handle = window
-            .window_handle()
-            .map_err(FromWindowError::RetrieveHandle)?;
-        let display_handle = window
-            .display_handle()
-            .map_err(FromWindowError::RetrieveHandle)?;
+    ) -> Result<Arc<Self>, Validated<FromWindowError>> {
+        let window_handle = window.window_handle();
+        let display_handle = window.display_handle();
+
+        unsafe { Self::try_from_window_ref_inner(instance, window_handle, display_handle) }
+    }
+
+    #[cfg(feature = "raw_window_handle")]
+    unsafe fn try_from_window_ref_inner(
+        instance: &Arc<Instance>,
+        window_handle: Result<WindowHandle<'_>, HandleError>,
+        display_handle: Result<DisplayHandle<'_>, HandleError>,
+    ) -> Result<Arc<Self>, Validated<FromWindowError>> {
+        let window_handle = window_handle
+            .map_err(FromWindowError::RetrieveHandle)
+            .map_err(Validated::Error)?;
+        let display_handle = display_handle
+            .map_err(FromWindowError::RetrieveHandle)
+            .map_err(Validated::Error)?;
 
         match (window_handle.as_raw(), display_handle.as_raw()) {
             (RawWindowHandle::AndroidNdk(window), RawDisplayHandle::Android(_display)) => unsafe {
-                Self::from_android(instance, window.a_native_window.as_ptr().cast(), None)
+                Self::try_from_android(instance, window.a_native_window.as_ptr().cast(), None)
             },
             #[cfg(target_vendor = "apple")]
             (RawWindowHandle::AppKit(handle), _) => {
                 let layer = unsafe { raw_window_metal::Layer::from_ns_view(handle.ns_view) };
 
                 // Vulkan retains the CAMetalLayer, so no need to retain it past this invocation
-                unsafe { Self::from_metal(instance, layer.as_ptr().as_ptr(), None) }
+                unsafe { Self::try_from_metal(instance, layer.as_ptr().as_ptr(), None) }
             }
             #[cfg(target_vendor = "apple")]
             (RawWindowHandle::UiKit(handle), _) => {
                 let layer = unsafe { raw_window_metal::Layer::from_ui_view(handle.ui_view) };
 
                 // Vulkan retains the CAMetalLayer, so no need to retain it past this invocation
-                unsafe { Self::from_metal(instance, layer.as_ptr().as_ptr(), None) }
+                unsafe { Self::try_from_metal(instance, layer.as_ptr().as_ptr(), None) }
             }
             (RawWindowHandle::Wayland(window), RawDisplayHandle::Wayland(display)) => unsafe {
-                Self::from_wayland(
+                Self::try_from_wayland(
                     instance,
                     display.display.as_ptr().cast(),
                     window.surface.as_ptr().cast(),
@@ -132,7 +269,7 @@ impl Surface {
                 )
             },
             (RawWindowHandle::Win32(window), RawDisplayHandle::Windows(_display)) => unsafe {
-                Self::from_win32(
+                Self::try_from_win32(
                     instance,
                     window.hinstance.unwrap().get() as vk::HINSTANCE,
                     window.hwnd.get() as vk::HWND,
@@ -140,7 +277,7 @@ impl Surface {
                 )
             },
             (RawWindowHandle::Xcb(window), RawDisplayHandle::Xcb(display)) => unsafe {
-                Self::from_xcb(
+                Self::try_from_xcb(
                     instance,
                     display.connection.unwrap().as_ptr().cast(),
                     window.window.get() as vk::xcb_window_t,
@@ -148,7 +285,7 @@ impl Surface {
                 )
             },
             (RawWindowHandle::Xlib(window), RawDisplayHandle::Xlib(display)) => unsafe {
-                Self::from_xlib(
+                Self::try_from_xlib(
                     instance,
                     display.display.unwrap().as_ptr().cast(),
                     window.window as vk::Window,
@@ -156,11 +293,11 @@ impl Surface {
                 )
             },
             _ => unimplemented!(
-                "the window was created with a windowing API that is not supported \
-                by Vulkan/Vulkano"
+                "the window was created with a windowing API that is not supported by \
+                Vulkan/vulkano",
             ),
         }
-        .map_err(FromWindowError::CreateSurface)
+        .map_err(|err| err.map(FromWindowError::CreateSurface))
     }
 
     /// Creates a `Surface` from a raw handle.
@@ -189,12 +326,36 @@ impl Surface {
         }
     }
 
+    /// Creates a `Surface` with no backing window or display, panicking on a validation error.
+    ///
+    /// Presenting to a headless surface does nothing, so this is mostly useless in itself.
+    /// However, it may be useful for testing, and it is available for future extensions to layer
+    /// on top of.
+    ///
+    /// This is a shortcut for `try_headless().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_headless`] returns a [`ValidationError`].
+    ///
+    /// [`try_headless`]: Self::try_headless
+    #[track_caller]
+    pub fn headless(
+        instance: &Arc<Instance>,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match Self::try_headless(instance, object) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` with no backing window or display.
     ///
     /// Presenting to a headless surface does nothing, so this is mostly useless in itself.
-    /// However, it may be useful for testing, and it is available for future extensions to
-    /// layer on top of.
-    pub fn headless(
+    /// However, it may be useful for testing, and it is available for future extensions to layer
+    /// on top of.
+    pub fn try_headless(
         instance: &Arc<Instance>,
         object: Option<Arc<dyn Any + Send + Sync>>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
@@ -245,9 +406,31 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from a `DisplayMode` and display plane, panicking on a validation
+    /// error.
+    ///
+    /// This is a shortcut for `try_from_display_plane().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_display_plane`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_display_plane`]: Self::try_from_display_plane
+    #[inline]
+    #[track_caller]
+    pub fn from_display_plane(
+        display_mode: &Arc<DisplayMode>,
+        create_info: &DisplaySurfaceCreateInfo<'_>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match Self::try_from_display_plane(display_mode, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from a `DisplayMode` and display plane.
     #[inline]
-    pub fn from_display_plane(
+    pub fn try_from_display_plane(
         display_mode: &Arc<DisplayMode>,
         create_info: &DisplaySurfaceCreateInfo<'_>,
     ) -> Result<Arc<Self>, Validated<VulkanError>> {
@@ -396,6 +579,33 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from an Android window, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_from_android().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `window` must be a valid Android `ANativeWindow` handle.
+    /// - The object referred to by `window` must outlive the created `Surface`. The `object`
+    ///   parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_android`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_android`]: Self::try_from_android
+    #[track_caller]
+    pub unsafe fn from_android(
+        instance: &Arc<Instance>,
+        window: *mut vk::ANativeWindow,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_android(instance, window, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from an Android window.
     ///
     /// # Safety
@@ -403,7 +613,7 @@ impl Surface {
     /// - `window` must be a valid Android `ANativeWindow` handle.
     /// - The object referred to by `window` must outlive the created `Surface`. The `object`
     ///   parameter can be used to ensure this.
-    pub unsafe fn from_android(
+    pub unsafe fn try_from_android(
         instance: &Arc<Instance>,
         window: *mut vk::ANativeWindow,
         object: Option<Arc<dyn Any + Send + Sync>>,
@@ -463,6 +673,35 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from a DirectFB surface, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_from_directfb().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `dfb` must be a valid DirectFB `IDirectFB` handle.
+    /// - `surface` must be a valid DirectFB `IDirectFBSurface` handle.
+    /// - The object referred to by `dfb` and `surface` must outlive the created `Surface`. The
+    ///   `object` parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_directfb`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_directfb`]: Self::try_from_directfb
+    #[track_caller]
+    pub unsafe fn from_directfb(
+        instance: &Arc<Instance>,
+        dfb: *mut vk::IDirectFB,
+        surface: *mut vk::IDirectFBSurface,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_directfb(instance, dfb, surface, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from a DirectFB surface.
     ///
     /// # Safety
@@ -471,7 +710,7 @@ impl Surface {
     /// - `surface` must be a valid DirectFB `IDirectFBSurface` handle.
     /// - The object referred to by `dfb` and `surface` must outlive the created `Surface`. The
     ///   `object` parameter can be used to ensure this.
-    pub unsafe fn from_directfb(
+    pub unsafe fn try_from_directfb(
         instance: &Arc<Instance>,
         dfb: *mut vk::IDirectFB,
         surface: *mut vk::IDirectFBSurface,
@@ -538,6 +777,33 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from an Fuchsia ImagePipe, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_from_fuchsia_image_pipe().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `image_pipe_handle` must be a valid Fuchsia `zx_handle_t` handle.
+    /// - The object referred to by `image_pipe_handle` must outlive the created `Surface`. The
+    ///   `object` parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_fuchsia_image_pipe`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_fuchsia_image_pipe`]: Self::try_from_fuchsia_image_pipe
+    #[track_caller]
+    pub unsafe fn from_fuchsia_image_pipe(
+        instance: &Arc<Instance>,
+        image_pipe_handle: vk::zx_handle_t,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_fuchsia_image_pipe(instance, image_pipe_handle, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from an Fuchsia ImagePipe.
     ///
     /// # Safety
@@ -545,7 +811,7 @@ impl Surface {
     /// - `image_pipe_handle` must be a valid Fuchsia `zx_handle_t` handle.
     /// - The object referred to by `image_pipe_handle` must outlive the created `Surface`. The
     ///   `object` parameter can be used to ensure this.
-    pub unsafe fn from_fuchsia_image_pipe(
+    pub unsafe fn try_from_fuchsia_image_pipe(
         instance: &Arc<Instance>,
         image_pipe_handle: vk::zx_handle_t,
         object: Option<Arc<dyn Any + Send + Sync>>,
@@ -610,6 +876,34 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from a Google Games Platform stream descriptor, panicking on a
+    /// validation error.
+    ///
+    /// This is a shortcut for `try_from_ggp_stream_descriptor().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `stream_descriptor` must be a valid Google Games Platform `GgpStreamDescriptor` handle.
+    /// - The object referred to by `stream_descriptor` must outlive the created `Surface`. The
+    ///   `object` parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_ggp_stream_descriptor`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_ggp_stream_descriptor`]: Self::try_from_ggp_stream_descriptor
+    #[track_caller]
+    pub unsafe fn from_ggp_stream_descriptor(
+        instance: &Arc<Instance>,
+        stream_descriptor: vk::GgpStreamDescriptor,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_ggp_stream_descriptor(instance, stream_descriptor, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from a Google Games Platform stream descriptor.
     ///
     /// # Safety
@@ -617,7 +911,7 @@ impl Surface {
     /// - `stream_descriptor` must be a valid Google Games Platform `GgpStreamDescriptor` handle.
     /// - The object referred to by `stream_descriptor` must outlive the created `Surface`. The
     ///   `object` parameter can be used to ensure this.
-    pub unsafe fn from_ggp_stream_descriptor(
+    pub unsafe fn try_from_ggp_stream_descriptor(
         instance: &Arc<Instance>,
         stream_descriptor: vk::GgpStreamDescriptor,
         object: Option<Arc<dyn Any + Send + Sync>>,
@@ -680,6 +974,34 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from an iOS `UIView`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_from_ios().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `metal_layer` must be a valid `IOSMetalLayer` handle.
+    /// - The object referred to by `metal_layer` must outlive the created `Surface`. The `object`
+    ///   parameter can be used to ensure this.
+    /// - The `UIView` must be backed by a `CALayer` instance of type `CAMetalLayer`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_ios`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_ios`]: Self::try_from_ios
+    #[track_caller]
+    pub unsafe fn from_ios(
+        instance: &Arc<Instance>,
+        view: *const c_void,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_ios(instance, view, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from an iOS `UIView`.
     ///
     /// # Safety
@@ -688,7 +1010,7 @@ impl Surface {
     /// - The object referred to by `metal_layer` must outlive the created `Surface`. The `object`
     ///   parameter can be used to ensure this.
     /// - The `UIView` must be backed by a `CALayer` instance of type `CAMetalLayer`.
-    pub unsafe fn from_ios(
+    pub unsafe fn try_from_ios(
         instance: &Arc<Instance>,
         view: *const c_void,
         object: Option<Arc<dyn Any + Send + Sync>>,
@@ -751,6 +1073,34 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from a MacOS `NSView`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_from_mac_os().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `view` must be a valid `CAMetalLayer` or `NSView` handle.
+    /// - The object referred to by `view` must outlive the created `Surface`. The `object`
+    ///   parameter can be used to ensure this.
+    /// - The `NSView` must be backed by a `CALayer` instance of type `CAMetalLayer`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_mac_os`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_mac_os`]: Self::try_from_mac_os
+    #[track_caller]
+    pub unsafe fn from_mac_os(
+        instance: &Arc<Instance>,
+        view: *const c_void,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_mac_os(instance, view, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from a MacOS `NSView`.
     ///
     /// # Safety
@@ -759,7 +1109,7 @@ impl Surface {
     /// - The object referred to by `view` must outlive the created `Surface`. The `object`
     ///   parameter can be used to ensure this.
     /// - The `NSView` must be backed by a `CALayer` instance of type `CAMetalLayer`.
-    pub unsafe fn from_mac_os(
+    pub unsafe fn try_from_mac_os(
         instance: &Arc<Instance>,
         view: *const c_void,
         object: Option<Arc<dyn Any + Send + Sync>>,
@@ -822,6 +1172,37 @@ impl Surface {
         }))
     }
 
+    /// Create a `Surface` from a [`CAMetalLayer`], panicking on a validation error.
+    ///
+    /// If you want to create this from a `NSView` or `UIView`, it is recommended that you use the
+    /// `raw-window-metal` crate to get access to a layer without overwriting the view's layer.
+    ///
+    /// This is a shortcut for `try_from_metal().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `layer` must point to a valid, initialized, non-NULL `CAMetalLayer`.
+    /// - The surface will retain the layer internally, so you do not need to keep the source from
+    ///   where this came from alive.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_metal`] returns a [`ValidationError`].
+    ///
+    /// [`CAMetalLayer`]: https://developer.apple.com/documentation/quartzcore/cametallayer
+    /// [`try_from_metal`]: Self::try_from_metal
+    #[track_caller]
+    pub unsafe fn from_metal(
+        instance: &Arc<Instance>,
+        layer: *const vk::CAMetalLayer,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_metal(instance, layer, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Create a `Surface` from a [`CAMetalLayer`].
     ///
     /// If you want to create this from a `NSView` or `UIView`, it is
@@ -836,7 +1217,7 @@ impl Surface {
     ///
     /// The surface will retain the layer internally, so you do not need to
     /// keep the source from where this came from alive.
-    pub unsafe fn from_metal(
+    pub unsafe fn try_from_metal(
         instance: &Arc<Instance>,
         layer: *const vk::CAMetalLayer,
         object: Option<Arc<dyn Any + Send + Sync>>,
@@ -895,6 +1276,35 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from a QNX Screen window, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_from_qnx_screen().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `context` must be a valid QNX Screen `_screen_context` handle.
+    /// - `window` must be a valid QNX Screen `_screen_window` handle.
+    /// - The object referred to by `window` must outlive the created `Surface`. The `object`
+    ///   parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_qnx_screen`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_qnx_screen`]: Self::try_from_qnx_screen
+    #[track_caller]
+    pub unsafe fn from_qnx_screen(
+        instance: &Arc<Instance>,
+        context: *mut vk::_screen_context,
+        window: *mut vk::_screen_window,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_qnx_screen(instance, context, window, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from a QNX Screen window.
     ///
     /// # Safety
@@ -903,7 +1313,7 @@ impl Surface {
     /// - `window` must be a valid QNX Screen `_screen_window` handle.
     /// - The object referred to by `window` must outlive the created `Surface`. The `object`
     ///   parameter can be used to ensure this.
-    pub unsafe fn from_qnx_screen(
+    pub unsafe fn try_from_qnx_screen(
         instance: &Arc<Instance>,
         context: *mut vk::_screen_context,
         window: *mut vk::_screen_window,
@@ -972,14 +1382,41 @@ impl Surface {
         }))
     }
 
-    /// Creates a `Surface` from a `code:nn::code:vi::code:Layer`.
+    /// Creates a `Surface` from a `nn::vi::Layer`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_from_vi().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
     /// - `window` must be a valid `nn::vi::NativeWindowHandle` handle.
     /// - The object referred to by `window` must outlive the created `Surface`. The `object`
     ///   parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_vi`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_vi`]: Self::try_from_vi
+    #[track_caller]
     pub unsafe fn from_vi(
+        instance: &Arc<Instance>,
+        window: *mut c_void,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_vi(instance, window, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Creates a `Surface` from a `nn::vi::Layer`.
+    ///
+    /// # Safety
+    ///
+    /// - `window` must be a valid `nn::vi::NativeWindowHandle` handle.
+    /// - The object referred to by `window` must outlive the created `Surface`. The `object`
+    ///   parameter can be used to ensure this.
+    pub unsafe fn try_from_vi(
         instance: &Arc<Instance>,
         window: *mut c_void,
         object: Option<Arc<dyn Any + Send + Sync>>,
@@ -1039,6 +1476,37 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from a Wayland window, panicking on a validation error.
+    ///
+    /// The window's dimensions will be set to the size of the swapchain.
+    ///
+    /// This is a shortcut for `try_from_wayland().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `display` must be a valid Wayland `wl_display` handle.
+    /// - `surface` must be a valid Wayland `wl_surface` handle.
+    /// - The objects referred to by `display` and `surface` must outlive the created `Surface`.
+    ///   The `object` parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_wayland`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_wayland`]: Self::try_from_wayland
+    #[track_caller]
+    pub unsafe fn from_wayland(
+        instance: &Arc<Instance>,
+        display: *mut vk::wl_display,
+        surface: *mut vk::wl_surface,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_wayland(instance, display, surface, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from a Wayland window.
     ///
     /// The window's dimensions will be set to the size of the swapchain.
@@ -1049,7 +1517,7 @@ impl Surface {
     /// - `surface` must be a valid Wayland `wl_surface` handle.
     /// - The objects referred to by `display` and `surface` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_wayland(
+    pub unsafe fn try_from_wayland(
         instance: &Arc<Instance>,
         display: *mut vk::wl_display,
         surface: *mut vk::wl_surface,
@@ -1116,6 +1584,37 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from a Win32 window, panicking on a validation error.
+    ///
+    /// The surface's min, max and current extent will always match the window's dimensions.
+    ///
+    /// This is a shortcut for `try_from_win32().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `hinstance` must be a valid Win32 `HINSTANCE` handle.
+    /// - `hwnd` must be a valid Win32 `HWND` handle.
+    /// - The objects referred to by `hwnd` and `hinstance` must outlive the created `Surface`. The
+    ///   `object` parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_win32`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_win32`]: Self::try_from_win32
+    #[track_caller]
+    pub unsafe fn from_win32(
+        instance: &Arc<Instance>,
+        hinstance: vk::HINSTANCE,
+        hwnd: vk::HWND,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_win32(instance, hinstance, hwnd, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from a Win32 window.
     ///
     /// The surface's min, max and current extent will always match the window's dimensions.
@@ -1126,7 +1625,7 @@ impl Surface {
     /// - `hwnd` must be a valid Win32 `HWND` handle.
     /// - The objects referred to by `hwnd` and `hinstance` must outlive the created `Surface`. The
     ///   `object` parameter can be used to ensure this.
-    pub unsafe fn from_win32(
+    pub unsafe fn try_from_win32(
         instance: &Arc<Instance>,
         hinstance: vk::HINSTANCE,
         hwnd: vk::HWND,
@@ -1193,6 +1692,37 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from an XCB window, panicking on a validation error.
+    ///
+    /// The surface's min, max and current extent will always match the window's dimensions.
+    ///
+    /// This is a shortcut for `try_from_xcb().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `connection` must be a valid X11 `xcb_connection_t` handle.
+    /// - `window` must be a valid X11 `xcb_window_t` handle.
+    /// - The objects referred to by `connection` and `window` must outlive the created `Surface`.
+    ///   The `object` parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_xcb`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_xcb`]: Self::try_from_xcb
+    #[track_caller]
+    pub unsafe fn from_xcb(
+        instance: &Arc<Instance>,
+        connection: *mut vk::xcb_connection_t,
+        window: vk::xcb_window_t,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_xcb(instance, connection, window, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from an XCB window.
     ///
     /// The surface's min, max and current extent will always match the window's dimensions.
@@ -1203,7 +1733,7 @@ impl Surface {
     /// - `window` must be a valid X11 `xcb_window_t` handle.
     /// - The objects referred to by `connection` and `window` must outlive the created `Surface`.
     ///   The `object` parameter can be used to ensure this.
-    pub unsafe fn from_xcb(
+    pub unsafe fn try_from_xcb(
         instance: &Arc<Instance>,
         connection: *mut vk::xcb_connection_t,
         window: vk::xcb_window_t,
@@ -1270,6 +1800,37 @@ impl Surface {
         }))
     }
 
+    /// Creates a `Surface` from an Xlib window, panicking on a validation error.
+    ///
+    /// The surface's min, max and current extent will always match the window's dimensions.
+    ///
+    /// This is a shortcut for `try_from_xlib().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - `display` must be a valid Xlib `Display` handle.
+    /// - `window` must be a valid Xlib `Window` handle.
+    /// - The objects referred to by `display` and `window` must outlive the created `Surface`. The
+    ///   `object` parameter can be used to ensure this.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_from_xlib`] returns a [`ValidationError`].
+    ///
+    /// [`try_from_xlib`]: Self::try_from_xlib
+    #[track_caller]
+    pub unsafe fn from_xlib(
+        instance: &Arc<Instance>,
+        display: *mut vk::Display,
+        window: vk::Window,
+        object: Option<Arc<dyn Any + Send + Sync>>,
+    ) -> Result<Arc<Self>, VulkanError> {
+        match unsafe { Self::try_from_xlib(instance, display, window, object) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a `Surface` from an Xlib window.
     ///
     /// The surface's min, max and current extent will always match the window's dimensions.
@@ -1280,7 +1841,7 @@ impl Surface {
     /// - `window` must be a valid Xlib `Window` handle.
     /// - The objects referred to by `display` and `window` must outlive the created `Surface`. The
     ///   `object` parameter can be used to ensure this.
-    pub unsafe fn from_xlib(
+    pub unsafe fn try_from_xlib(
         instance: &Arc<Instance>,
         display: *mut vk::Display,
         window: vk::Window,
@@ -2568,7 +3129,22 @@ pub enum FromWindowError {
     /// Retrieving the window or display handle failed.
     RetrieveHandle(HandleError),
     /// Creating the surface failed.
-    CreateSurface(Validated<VulkanError>),
+    CreateSurface(VulkanError),
+}
+
+#[cfg(feature = "raw_window_handle")]
+impl FromWindowError {
+    /// Returns the inner `CreateSurface` value, or panics if it contains `RetrieveHandle`.
+    #[inline(always)]
+    #[track_caller]
+    pub fn unwrap(self) -> VulkanError {
+        match self {
+            Self::RetrieveHandle(err) => {
+                panic!("called `FromWindowError::unwrap` on a `RetrieveHandle` value: {err:?}");
+            }
+            Self::CreateSurface(err) => err,
+        }
+    }
 }
 
 #[cfg(feature = "raw_window_handle")]
@@ -2603,7 +3179,7 @@ mod tests {
     #[test]
     fn khr_win32_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_win32(&instance, 0, 0, None) } {
+        match unsafe { Surface::try_from_win32(&instance, 0, 0, None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,
@@ -2621,7 +3197,7 @@ mod tests {
     #[test]
     fn khr_xcb_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_xcb(&instance, ptr::null_mut(), 0, None) } {
+        match unsafe { Surface::try_from_xcb(&instance, ptr::null_mut(), 0, None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,
@@ -2639,7 +3215,7 @@ mod tests {
     #[test]
     fn khr_xlib_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_xlib(&instance, ptr::null_mut(), 0, None) } {
+        match unsafe { Surface::try_from_xlib(&instance, ptr::null_mut(), 0, None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,
@@ -2657,7 +3233,9 @@ mod tests {
     #[test]
     fn khr_wayland_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_wayland(&instance, ptr::null_mut(), ptr::null_mut(), None) } {
+        match unsafe {
+            Surface::try_from_wayland(&instance, ptr::null_mut(), ptr::null_mut(), None)
+        } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,
@@ -2675,7 +3253,7 @@ mod tests {
     #[test]
     fn khr_android_surface_ext_missing() {
         let instance = instance!();
-        match unsafe { Surface::from_android(&instance, ptr::null_mut(), None) } {
+        match unsafe { Surface::try_from_android(&instance, ptr::null_mut(), None) } {
             Err(Validated::ValidationError(err))
                 if matches!(
                     *err,

--- a/vulkano/src/sync/event.rs
+++ b/vulkano/src/sync/event.rs
@@ -41,15 +41,39 @@ pub struct Event {
 }
 
 impl Event {
+    /// Creates a new `Event`, panicking on a validation error.
+    ///
+    /// On [portability subset] devices, the [`events`] feature must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [portability subset]: crate::instance#portability-subset-devices-and-the-enumerate_portability-flag
+    /// [`events`]: crate::device::DeviceFeatures::events
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &EventCreateInfo<'_>,
+    ) -> Result<Event, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `Event`.
     ///
-    /// On [portability
-    /// subset](crate::instance#portability-subset-devices-and-the-enumerate_portability-flag)
-    /// devices, the
-    /// [`events`](crate::device::DeviceFeatures::events)
-    /// feature must be enabled on the device.
+    /// On [portability subset] devices, the [`events`] feature must be enabled on the device.
+    ///
+    /// [portability subset]: crate::instance#portability-subset-devices-and-the-enumerate_portability-flag
+    /// [`events`]: crate::device::DeviceFeatures::events
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &EventCreateInfo<'_>,
     ) -> Result<Event, Validated<VulkanError>> {
@@ -174,9 +198,27 @@ impl Event {
         self.flags
     }
 
+    /// Returns true if the event is signaled, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_is_signaled().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_is_signaled`] returns a [`ValidationError`].
+    ///
+    /// [`try_is_signaled`]: Self::try_is_signaled
+    #[inline]
+    #[track_caller]
+    pub fn is_signaled(&self) -> Result<bool, VulkanError> {
+        match self.try_is_signaled() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns true if the event is signaled.
     #[inline]
-    pub fn is_signaled(&self) -> Result<bool, Validated<VulkanError>> {
+    pub fn try_is_signaled(&self) -> Result<bool, Validated<VulkanError>> {
         self.validate_is_signaled()?;
 
         Ok(unsafe { self.is_signaled_unchecked() }?)
@@ -198,10 +240,29 @@ impl Event {
         }
     }
 
+    /// Changes the `Event` to the signaled state, panicking on a validation error.
+    ///
+    /// If a command buffer is waiting on this event, it is then unblocked.
+    ///
+    /// This is a shortcut for `try_set().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_set`] returns a [`ValidationError`].
+    ///
+    /// [`try_set`]: Self::try_set
+    #[track_caller]
+    pub fn set(&mut self) -> Result<(), VulkanError> {
+        match self.try_set() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Changes the `Event` to the signaled state.
     ///
     /// If a command buffer is waiting on this event, it is then unblocked.
-    pub fn set(&mut self) -> Result<(), Validated<VulkanError>> {
+    pub fn try_set(&mut self) -> Result<(), Validated<VulkanError>> {
         self.validate_set()?;
 
         Ok(unsafe { self.set_unchecked() }?)
@@ -221,6 +282,30 @@ impl Event {
         Ok(())
     }
 
+    /// Changes the `Event` to the unsignaled state, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_reset().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - There must be an execution dependency between `reset` and the execution of any
+    ///   [`wait_events`] command that includes this event in its `events` parameter.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_reset`] returns a [`ValidationError`].
+    ///
+    /// [`try_reset`]: Self::try_reset
+    /// [`wait_events`]: crate::command_buffer::RecordingCommandBuffer::wait_events
+    #[inline]
+    #[track_caller]
+    pub unsafe fn reset(&mut self) -> Result<(), VulkanError> {
+        match unsafe { self.try_reset() } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Changes the `Event` to the unsignaled state.
     ///
     /// # Safety
@@ -230,7 +315,7 @@ impl Event {
     ///
     /// [`wait_events`]: crate::command_buffer::RecordingCommandBuffer::wait_events
     #[inline]
-    pub unsafe fn reset(&mut self) -> Result<(), Validated<VulkanError>> {
+    pub unsafe fn try_reset(&mut self) -> Result<(), Validated<VulkanError>> {
         self.validate_reset()?;
 
         Ok(unsafe { self.reset_unchecked() }?)

--- a/vulkano/src/sync/fence.rs
+++ b/vulkano/src/sync/fence.rs
@@ -61,9 +61,30 @@ pub struct Fence {
 }
 
 impl Fence {
+    /// Creates a new `Fence`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &FenceCreateInfo<'_>,
+    ) -> Result<Fence, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `Fence`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &FenceCreateInfo<'_>,
     ) -> Result<Fence, Validated<VulkanError>> {
@@ -193,9 +214,39 @@ impl Fence {
         self.export_handle_types
     }
 
+    /// Returns true if the fence is signaled, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_is_signaled().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_is_signaled`] returns a [`ValidationError`].
+    ///
+    /// [`try_is_signaled`]: Self::try_is_signaled
+    #[inline]
+    #[track_caller]
+    pub fn is_signaled(&self) -> Result<bool, VulkanError> {
+        match self.try_is_signaled() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Returns true if the fence is signaled.
     #[inline]
-    pub fn is_signaled(&self) -> Result<bool, VulkanError> {
+    pub fn try_is_signaled(&self) -> Result<bool, Validated<VulkanError>> {
+        self.validate_is_signaled()?;
+
+        Ok(unsafe { self.is_signaled_unchecked() }?)
+    }
+
+    fn validate_is_signaled(&self) -> Result<(), Box<ValidationError>> {
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    #[inline]
+    pub unsafe fn is_signaled_unchecked(&self) -> Result<bool, VulkanError> {
         let fns = self.device.fns();
         let result = unsafe { (fns.v1_0.get_fence_status)(self.device.handle(), self.handle) };
         match result {
@@ -205,10 +256,42 @@ impl Fence {
         }
     }
 
-    /// Waits until the fence is signaled, or at least until the timeout duration has elapsed.
+    /// Waits until the fence is signaled, or at least until the timeout duration has elapsed,
+    /// panicking on a validation error.
     ///
     /// If you pass a duration of 0, then the function will return without blocking.
+    ///
+    /// This is a shortcut for `try_wait().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_wait`] returns a [`ValidationError`].
+    ///
+    /// [`try_wait`]: Self::try_wait
+    #[track_caller]
     pub fn wait(&self, timeout: Option<Duration>) -> Result<(), VulkanError> {
+        match self.try_wait(timeout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Waits until the fence is signaled, or at least until the timeout duration has elapsed,
+    /// returning an error on failure.
+    ///
+    /// If you pass a duration of 0, then the function will return without blocking.
+    pub fn try_wait(&self, timeout: Option<Duration>) -> Result<(), Validated<VulkanError>> {
+        self.validate_wait(timeout)?;
+
+        Ok(unsafe { self.wait_unchecked(timeout) }?)
+    }
+
+    fn validate_wait(&self, _timeout: Option<Duration>) -> Result<(), Box<ValidationError>> {
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn wait_unchecked(&self, timeout: Option<Duration>) -> Result<(), VulkanError> {
         let timeout_ns = timeout.map_or(u64::MAX, |timeout| {
             timeout
                 .as_secs()
@@ -227,21 +310,39 @@ impl Fence {
         }
     }
 
-    /// Waits for multiple fences at once.
+    /// Waits for many fences at once, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_wait_many().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_wait_many`] returns a [`ValidationError`].
+    /// - Panics if not all fences belong to the same device.
+    ///
+    /// [`try_wait_many`]: Self::try_wait_many
+    #[track_caller]
+    pub fn wait_many(fences: &[&Fence], timeout: Option<Duration>) -> Result<(), VulkanError> {
+        match Self::try_wait_many(fences, timeout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Waits for many fences at once.
     ///
     /// # Panics
     ///
     /// - Panics if not all fences belong to the same device.
-    pub fn multi_wait(
+    pub fn try_wait_many(
         fences: &[&Fence],
         timeout: Option<Duration>,
     ) -> Result<(), Validated<VulkanError>> {
-        Self::validate_multi_wait(fences, timeout)?;
+        Self::validate_wait_many(fences, timeout)?;
 
-        Ok(unsafe { Self::multi_wait_unchecked(fences, timeout) }?)
+        Ok(unsafe { Self::wait_many_unchecked(fences, timeout) }?)
     }
 
-    fn validate_multi_wait(
+    fn validate_wait_many(
         fences: &[&Fence],
         _timeout: Option<Duration>,
     ) -> Result<(), Box<ValidationError>> {
@@ -260,7 +361,7 @@ impl Fence {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn multi_wait_unchecked(
+    pub unsafe fn wait_many_unchecked(
         fences: &[&Fence],
         timeout: Option<Duration>,
     ) -> Result<(), VulkanError> {
@@ -306,13 +407,35 @@ impl Fence {
         }
     }
 
+    /// Resets the fence, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_reset().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - The fence must not be in use by the device.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_reset`] returns a [`ValidationError`].
+    ///
+    /// [`try_reset`]: Self::try_reset
+    #[inline]
+    #[track_caller]
+    pub unsafe fn reset(&self) -> Result<(), VulkanError> {
+        match unsafe { self.try_reset() } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Resets the fence.
     ///
     /// # Safety
     ///
     /// - The fence must not be in use by the device.
     #[inline]
-    pub unsafe fn reset(&self) -> Result<(), Validated<VulkanError>> {
+    pub unsafe fn try_reset(&self) -> Result<(), Validated<VulkanError>> {
         self.validate_reset()?;
 
         Ok(unsafe { self.reset_unchecked() }?)
@@ -332,18 +455,39 @@ impl Fence {
         Ok(())
     }
 
-    /// Resets multiple fences at once.
+    /// Resets many fences at once, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_reset_many().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
     /// - The elements of `fences` must not be in use by the device.
-    pub unsafe fn multi_reset(fences: &[&Fence]) -> Result<(), Validated<VulkanError>> {
-        Self::validate_multi_reset(fences)?;
-
-        Ok(unsafe { Self::multi_reset_unchecked(fences) }?)
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_reset_many`] returns a [`ValidationError`].
+    ///
+    /// [`try_reset_many`]: Self::try_reset_many
+    #[track_caller]
+    pub unsafe fn reset_many(fences: &[&Fence]) -> Result<(), VulkanError> {
+        match unsafe { Self::try_reset_many(fences) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
     }
 
-    fn validate_multi_reset(fences: &[&Fence]) -> Result<(), Box<ValidationError>> {
+    /// Resets many fences at once.
+    ///
+    /// # Safety
+    ///
+    /// - The elements of `fences` must not be in use by the device.
+    pub unsafe fn try_reset_many(fences: &[&Fence]) -> Result<(), Validated<VulkanError>> {
+        Self::validate_reset_many(fences)?;
+
+        Ok(unsafe { Self::reset_many_unchecked(fences) }?)
+    }
+
+    fn validate_reset_many(fences: &[&Fence]) -> Result<(), Box<ValidationError>> {
         if fences.is_empty() {
             return Ok(());
         }
@@ -359,7 +503,7 @@ impl Fence {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn multi_reset_unchecked(fences: &[&Fence]) -> Result<(), VulkanError> {
+    pub unsafe fn reset_many_unchecked(fences: &[&Fence]) -> Result<(), VulkanError> {
         if fences.is_empty() {
             return Ok(());
         }
@@ -377,11 +521,12 @@ impl Fence {
         Ok(())
     }
 
-    /// Exports the fence into a POSIX file descriptor. The caller owns the returned file
-    /// descriptor.
+    /// Exports the fence into a POSIX file descriptor, panicking on a validation error. The caller
+    /// owns the returned file descriptor.
     ///
-    /// The [`khr_external_fence_fd`](crate::device::DeviceExtensions::khr_external_fence_fd)
-    /// extension must be enabled on the device.
+    /// The [`khr_external_fence_fd`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_export_fd().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
@@ -390,8 +535,41 @@ impl Fence {
     /// - The fence must not currently have an imported payload from a swapchain acquire operation.
     /// - If the fence has an imported payload, its handle type must allow re-exporting as
     ///   `handle_type`, as returned by [`PhysicalDevice::external_fence_properties`].
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_export_fd`] returns an error.
+    ///
+    /// [`khr_external_fence_fd`]: crate::device::DeviceExtensions::khr_external_fence_fd
+    /// [`try_export_fd`]: Self::try_export_fd
     #[inline]
+    #[track_caller]
     pub unsafe fn export_fd(
+        &self,
+        handle_type: ExternalFenceHandleType,
+    ) -> Result<RawFd, VulkanError> {
+        match unsafe { self.try_export_fd(handle_type) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Exports the fence into a POSIX file descriptor. The caller owns the returned file
+    /// descriptor.
+    ///
+    /// The [`khr_external_fence_fd`] extension must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - If `handle_type` has copy transference, then the fence must be signaled, or a signal
+    ///   operation on the fence must be pending.
+    /// - The fence must not currently have an imported payload from a swapchain acquire operation.
+    /// - If the fence has an imported payload, its handle type must allow re-exporting as
+    ///   `handle_type`, as returned by [`PhysicalDevice::external_fence_properties`].
+    ///
+    /// [`khr_external_fence_fd`]: crate::device::DeviceExtensions::khr_external_fence_fd
+    #[inline]
+    pub unsafe fn try_export_fd(
         &self,
         handle_type: ExternalFenceHandleType,
     ) -> Result<RawFd, Validated<VulkanError>> {
@@ -471,10 +649,11 @@ impl Fence {
         Ok(fd)
     }
 
-    /// Exports the fence into a Win32 handle.
+    /// Exports the fence into a Win32 handle, panicking on a validation error.
     ///
-    /// The [`khr_external_fence_win32`](crate::device::DeviceExtensions::khr_external_fence_win32)
-    /// extension must be enabled on the device.
+    /// The [`khr_external_fence_win32`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_export_win32_handle().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
@@ -485,8 +664,42 @@ impl Fence {
     ///   `handle_type`, as returned by [`PhysicalDevice::external_fence_properties`].
     /// - If `handle_type` is `ExternalFenceHandleType::OpaqueWin32`, then a handle of this type
     ///   must not have been already exported from this fence.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_export_win32_handle`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_fence_win32`]: crate::device::DeviceExtensions::khr_external_fence_win32
+    /// [`try_export_win32_handle`]: Self::try_export_win32_handle
     #[inline]
+    #[track_caller]
     pub fn export_win32_handle(
+        &self,
+        handle_type: ExternalFenceHandleType,
+    ) -> Result<vk::HANDLE, VulkanError> {
+        match self.try_export_win32_handle(handle_type) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Exports the fence into a Win32 handle.
+    ///
+    /// The [`khr_external_fence_win32`] extension must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - If `handle_type` has copy transference, then the fence must be signaled, or a signal
+    ///   operation on the fence must be pending.
+    /// - The fence must not currently have an imported payload from a swapchain acquire operation.
+    /// - If the fence has an imported payload, its handle type must allow re-exporting as
+    ///   `handle_type`, as returned by [`PhysicalDevice::external_fence_properties`].
+    /// - If `handle_type` is `ExternalFenceHandleType::OpaqueWin32`, then a handle of this type
+    ///   must not have been already exported from this fence.
+    ///
+    /// [`khr_external_fence_win32`]: crate::device::DeviceExtensions::khr_external_fence_win32
+    #[inline]
+    pub fn try_export_win32_handle(
         &self,
         handle_type: ExternalFenceHandleType,
     ) -> Result<vk::HANDLE, Validated<VulkanError>> {
@@ -565,10 +778,11 @@ impl Fence {
         Ok(handle)
     }
 
-    /// Imports a fence from a POSIX file descriptor.
+    /// Imports a fence from a POSIX file descriptor, panicking on a validation error.
     ///
-    /// The [`khr_external_fence_fd`](crate::device::DeviceExtensions::khr_external_fence_fd)
-    /// extension must be enabled on the device.
+    /// The [`khr_external_fence_fd`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_import_fd().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
@@ -576,8 +790,39 @@ impl Fence {
     /// - If in `import_fence_fd_info`, `handle_type` is `ExternalHandleType::OpaqueFd`, then `fd`
     ///   must represent a fence that was exported from Vulkan or a compatible API, with a driver
     ///   and device UUID equal to those of the device that owns `self`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_import_fd`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_fence_fd`]: crate::device::DeviceExtensions::khr_external_fence_fd
+    /// [`try_import_fd`]: Self::try_import_fd
     #[inline]
+    #[track_caller]
     pub unsafe fn import_fd(
+        &self,
+        import_fence_fd_info: &ImportFenceFdInfo<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_import_fd(import_fence_fd_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Imports a fence from a POSIX file descriptor.
+    ///
+    /// The [`khr_external_fence_fd`] extension must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - The fence must not be in use by the device.
+    /// - If in `import_fence_fd_info`, `handle_type` is `ExternalHandleType::OpaqueFd`, then `fd`
+    ///   must represent a fence that was exported from Vulkan or a compatible API, with a driver
+    ///   and device UUID equal to those of the device that owns `self`.
+    ///
+    /// [`khr_external_fence_fd`]: crate::device::DeviceExtensions::khr_external_fence_fd
+    #[inline]
+    pub unsafe fn try_import_fd(
         &self,
         import_fence_fd_info: &ImportFenceFdInfo<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -621,10 +866,11 @@ impl Fence {
         Ok(())
     }
 
-    /// Imports a fence from a Win32 handle.
+    /// Imports a fence from a Win32 handle, panicking on a validation error.
     ///
-    /// The [`khr_external_fence_win32`](crate::device::DeviceExtensions::khr_external_fence_win32)
-    /// extension must be enabled on the device.
+    /// The [`khr_external_fence_win32`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_import_win32_handle().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
@@ -632,8 +878,39 @@ impl Fence {
     /// - In `import_fence_win32_handle_info`, `handle` must represent a fence that was exported
     ///   from Vulkan or a compatible API, with a driver and device UUID equal to those of the
     ///   device that owns `self`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_import_win32_handle`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_fence_win32`]: crate::device::DeviceExtensions::khr_external_fence_win32
+    /// [`try_import_win32_handle`]: Self::try_import_win32_handle
     #[inline]
+    #[track_caller]
     pub unsafe fn import_win32_handle(
+        &self,
+        import_fence_win32_handle_info: &ImportFenceWin32HandleInfo<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_import_win32_handle(import_fence_win32_handle_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Imports a fence from a Win32 handle.
+    ///
+    /// The [`khr_external_fence_win32`] extension must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - The fence must not be in use by the device.
+    /// - In `import_fence_win32_handle_info`, `handle` must represent a fence that was exported
+    ///   from Vulkan or a compatible API, with a driver and device UUID equal to those of the
+    ///   device that owns `self`.
+    ///
+    /// [`khr_external_fence_win32`]: crate::device::DeviceExtensions::khr_external_fence_win32
+    #[inline]
+    pub unsafe fn try_import_win32_handle(
         &self,
         import_fence_win32_handle_info: &ImportFenceWin32HandleInfo<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -689,7 +966,7 @@ impl Fence {
         // engine can choose to run some other tasks between probing this one.
 
         // Check if we are done without blocking
-        match self.is_signaled() {
+        match unsafe { self.is_signaled_unchecked() } {
             Err(e) => return Poll::Ready(Err(e)),
             Ok(signaled) => {
                 if signaled {
@@ -1367,7 +1644,7 @@ mod tests {
             )
             .unwrap();
 
-            let _ = Fence::multi_wait(&[&fence1, &fence2], Some(Duration::new(0, 10)));
+            let _ = Fence::wait_many(&[&fence1, &fence2], Some(Duration::new(0, 10)));
         });
     }
 
@@ -1394,7 +1671,7 @@ mod tests {
             )
             .unwrap();
 
-            let _ = unsafe { Fence::multi_reset(&[&fence1, &fence2]) };
+            let _ = unsafe { Fence::reset_many(&[&fence1, &fence2]) };
         });
     }
 

--- a/vulkano/src/sync/future/fence_signal.rs
+++ b/vulkano/src/sync/future/fence_signal.rs
@@ -136,7 +136,7 @@ where
         match &*state {
             FenceSignalFutureState::Pending(_, fence)
             | FenceSignalFutureState::PartiallyFlushed(_, fence)
-            | FenceSignalFutureState::Flushed(_, fence) => fence.is_signaled(),
+            | FenceSignalFutureState::Flushed(_, fence) => unsafe { fence.is_signaled_unchecked() },
             FenceSignalFutureState::Cleaned => Ok(true),
             FenceSignalFutureState::Poisoned => unreachable!(),
         }
@@ -157,7 +157,7 @@ where
 
         match replace(&mut *state, FenceSignalFutureState::Cleaned) {
             FenceSignalFutureState::Flushed(previous, fence) => {
-                fence.wait(timeout)?;
+                unsafe { fence.wait_unchecked(timeout) }?;
                 unsafe { previous.signal_finished() };
                 Ok(())
             }
@@ -178,7 +178,7 @@ where
 
         match *state {
             FenceSignalFutureState::Flushed(ref mut prev, ref fence) => {
-                if fence.wait(Some(Duration::from_secs(0))).is_ok() {
+                if unsafe { fence.wait_unchecked(Some(Duration::from_secs(0))) }.is_ok() {
                     unsafe { prev.signal_finished() };
                     *state = FenceSignalFutureState::Cleaned;
                 } else {
@@ -397,7 +397,7 @@ where
         match &*state {
             FenceSignalFutureState::Flushed(_, fence) => match self.behavior {
                 FenceSignalFutureBehavior::Block { timeout } => {
-                    fence.wait(timeout)?;
+                    unsafe { fence.wait_unchecked(timeout) }?;
                 }
                 FenceSignalFutureBehavior::Continue => (),
             },

--- a/vulkano/src/sync/semaphore.rs
+++ b/vulkano/src/sync/semaphore.rs
@@ -94,9 +94,30 @@ pub struct Semaphore {
 }
 
 impl Semaphore {
+    /// Creates a new `Semaphore`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_new().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_new`] returns a [`ValidationError`].
+    ///
+    /// [`try_new`]: Self::try_new
+    #[inline]
+    #[track_caller]
+    pub fn new(
+        device: &Arc<Device>,
+        create_info: &SemaphoreCreateInfo<'_>,
+    ) -> Result<Semaphore, VulkanError> {
+        match Self::try_new(device, create_info) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Creates a new `Semaphore`.
     #[inline]
-    pub fn new(
+    pub fn try_new(
         device: &Arc<Device>,
         create_info: &SemaphoreCreateInfo<'_>,
     ) -> Result<Semaphore, Validated<VulkanError>> {
@@ -218,12 +239,34 @@ impl Semaphore {
         self.export_handle_types
     }
 
+    /// If `self` is a timeline semaphore, returns the current counter value of the semaphore,
+    /// panicking on a validation error.
+    ///
+    /// The returned value may be immediately out of date, if a signal operation on the semaphore
+    /// is pending on the device.
+    ///
+    /// This is a shortcut for `try_counter_value().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_counter_value`] returns a [`ValidationError`].
+    ///
+    /// [`try_counter_value`]: Self::try_counter_value
+    #[inline]
+    #[track_caller]
+    pub fn counter_value(&self) -> Result<u64, VulkanError> {
+        match self.try_counter_value() {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// If `self` is a timeline semaphore, returns the current counter value of the semaphore.
     ///
     /// The returned value may be immediately out of date, if a signal operation on the semaphore
     /// is pending on the device.
     #[inline]
-    pub fn counter_value(&self) -> Result<u64, Validated<VulkanError>> {
+    pub fn try_counter_value(&self) -> Result<u64, Validated<VulkanError>> {
         self.validate_counter_value()?;
 
         Ok(unsafe { self.counter_value_unchecked() }?)
@@ -275,6 +318,30 @@ impl Semaphore {
     }
 
     /// If `self` is a timeline semaphore, performs a signal operation on the semaphore, setting
+    /// the new counter value to `value`, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_signal().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - The safety requirements for semaphores, as detailed in the module documentation, must be
+    ///   followed.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_signal`] returns a [`ValidationError`].
+    ///
+    /// [`try_signal`]: Self::try_signal
+    #[inline]
+    #[track_caller]
+    pub unsafe fn signal(&self, signal_info: &SemaphoreSignalInfo<'_>) -> Result<(), VulkanError> {
+        match unsafe { self.try_signal(signal_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// If `self` is a timeline semaphore, performs a signal operation on the semaphore, setting
     /// the new counter value to `value`.
     ///
     /// # Safety
@@ -282,7 +349,7 @@ impl Semaphore {
     /// - The safety requirements for semaphores, as detailed in the module documentation, must be
     ///   followed.
     #[inline]
-    pub unsafe fn signal(
+    pub unsafe fn try_signal(
         &self,
         signal_info: &SemaphoreSignalInfo<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -338,9 +405,33 @@ impl Semaphore {
     }
 
     /// If `self` is a timeline semaphore, performs a wait operation on the semaphore, blocking
+    /// until the counter value is equal to or greater than `wait_info.value`, panicking on
+    /// a validation error.
+    ///
+    /// This is a shortcut for `try_wait().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_wait`] returns a [`ValidationError`].
+    ///
+    /// [`try_wait`]: Self::try_wait
+    #[inline]
+    #[track_caller]
+    pub fn wait(
+        &self,
+        wait_info: &SemaphoreWaitInfo<'_>,
+        timeout: Option<Duration>,
+    ) -> Result<(), VulkanError> {
+        match self.try_wait(wait_info, timeout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// If `self` is a timeline semaphore, performs a wait operation on the semaphore, blocking
     /// until the counter value is equal to or greater than `wait_info.value`.
     #[inline]
-    pub fn wait(
+    pub fn try_wait(
         &self,
         wait_info: &SemaphoreWaitInfo<'_>,
         timeout: Option<Duration>,
@@ -416,23 +507,45 @@ impl Semaphore {
         .map_err(VulkanError::from)
     }
 
-    /// Waits for multiple timeline semaphores at once.
+    /// Waits for many timeline semaphores at once, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_wait_many().map_err(Validated::unwrap)`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_wait_many`] returns a [`ValidationError`].
+    /// - Panics if not all semaphores belong to the same device.
+    ///
+    /// [`try_wait_many`]: Self::try_wait_many
+    #[inline]
+    #[track_caller]
+    pub fn wait_many(
+        wait_info: &SemaphoreWaitManyInfo<'_>,
+        timeout: Option<Duration>,
+    ) -> Result<(), VulkanError> {
+        match Self::try_wait_many(wait_info, timeout) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Waits for many timeline semaphores at once.
     ///
     /// # Panics
     ///
     /// - Panics if not all semaphores belong to the same device.
     #[inline]
-    pub fn wait_multiple(
-        wait_info: &SemaphoreWaitMultipleInfo<'_>,
+    pub fn try_wait_many(
+        wait_info: &SemaphoreWaitManyInfo<'_>,
         timeout: Option<Duration>,
     ) -> Result<(), Validated<VulkanError>> {
-        Self::validate_wait_multiple(wait_info, timeout)?;
+        Self::validate_wait_many(wait_info, timeout)?;
 
-        Ok(unsafe { Self::wait_multiple_unchecked(wait_info, timeout) }?)
+        Ok(unsafe { Self::wait_many_unchecked(wait_info, timeout) }?)
     }
 
-    fn validate_wait_multiple(
-        wait_info: &SemaphoreWaitMultipleInfo<'_>,
+    fn validate_wait_many(
+        wait_info: &SemaphoreWaitManyInfo<'_>,
         timeout: Option<Duration>,
     ) -> Result<(), Box<ValidationError>> {
         if let Some(timeout) = timeout {
@@ -458,8 +571,8 @@ impl Semaphore {
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
-    pub unsafe fn wait_multiple_unchecked(
-        wait_info: &SemaphoreWaitMultipleInfo<'_>,
+    pub unsafe fn wait_many_unchecked(
+        wait_info: &SemaphoreWaitManyInfo<'_>,
         timeout: Option<Duration>,
     ) -> Result<(), VulkanError> {
         if wait_info.semaphores.is_empty() {
@@ -497,6 +610,37 @@ impl Semaphore {
         .map_err(VulkanError::from)
     }
 
+    /// Exports the semaphore into a POSIX file descriptor, panicking on a validation error. The
+    /// caller owns the returned file descriptor.
+    ///
+    /// This is a shortcut for `try_export_fd().map_err(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - If `handle_type` has copy transference, then the semaphore must be signaled, or a signal
+    ///   operation on the semaphore must be pending, and no wait operations must be pending.
+    /// - The semaphore must not currently have an imported payload from a swapchain acquire
+    ///   operation.
+    /// - If the semaphore has an imported payload, its handle type must allow re-exporting as
+    ///   `handle_type`, as returned by [`PhysicalDevice::external_semaphore_properties`].
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_export_fd`] returns a [`ValidationError`].
+    ///
+    /// [`try_export_fd`]: Self::try_export_fd
+    #[inline]
+    #[track_caller]
+    pub unsafe fn export_fd(
+        &self,
+        handle_type: ExternalSemaphoreHandleType,
+    ) -> Result<RawFd, VulkanError> {
+        match unsafe { self.try_export_fd(handle_type) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Exports the semaphore into a POSIX file descriptor. The caller owns the returned file
     /// descriptor.
     ///
@@ -509,7 +653,7 @@ impl Semaphore {
     /// - If the semaphore has an imported payload, its handle type must allow re-exporting as
     ///   `handle_type`, as returned by [`PhysicalDevice::external_semaphore_properties`].
     #[inline]
-    pub unsafe fn export_fd(
+    pub unsafe fn try_export_fd(
         &self,
         handle_type: ExternalSemaphoreHandleType,
     ) -> Result<RawFd, Validated<VulkanError>> {
@@ -599,10 +743,11 @@ impl Semaphore {
         Ok(fd)
     }
 
-    /// Exports the semaphore into a Win32 handle.
+    /// Exports the semaphore into a Win32 handle, panicking on a validation error.
     ///
-    /// The [`khr_external_semaphore_win32`](crate::device::DeviceExtensions::khr_external_semaphore_win32)
-    /// extension must be enabled on the device.
+    /// The [`khr_external_semaphore_win32`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_export_win32_handle().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
@@ -615,8 +760,44 @@ impl Semaphore {
     /// - If `handle_type` is `ExternalSemaphoreHandleType::OpaqueWin32` or
     ///   `ExternalSemaphoreHandleType::D3D12Fence`, then a handle of this type must not have been
     ///   already exported from this semaphore.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_export_win32_handle`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_semaphore_win32`]: crate::device::DeviceExtensions::khr_external_semaphore_win32
+    /// [`try_export_win32_handle`]: Self::try_export_win32_handle
     #[inline]
+    #[track_caller]
     pub fn export_win32_handle(
+        &self,
+        handle_type: ExternalSemaphoreHandleType,
+    ) -> Result<vk::HANDLE, VulkanError> {
+        match self.try_export_win32_handle(handle_type) {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Exports the semaphore into a Win32 handle.
+    ///
+    /// The [`khr_external_semaphore_win32`] extension must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - If `handle_type` has copy transference, then the semaphore must be signaled, or a signal
+    ///   operation on the semaphore must be pending, and no wait operations must be pending.
+    /// - The semaphore must not currently have an imported payload from a swapchain acquire
+    ///   operation.
+    /// - If the semaphore has an imported payload, its handle type must allow re-exporting as
+    ///   `handle_type`, as returned by [`PhysicalDevice::external_semaphore_properties`].
+    /// - If `handle_type` is `ExternalSemaphoreHandleType::OpaqueWin32` or
+    ///   `ExternalSemaphoreHandleType::D3D12Fence`, then a handle of this type must not have been
+    ///   already exported from this semaphore.
+    ///
+    /// [`khr_external_semaphore_win32`]: crate::device::DeviceExtensions::khr_external_semaphore_win32
+    #[inline]
+    pub fn try_export_win32_handle(
         &self,
         handle_type: ExternalSemaphoreHandleType,
     ) -> Result<vk::HANDLE, Validated<VulkanError>> {
@@ -703,6 +884,36 @@ impl Semaphore {
         Ok(handle)
     }
 
+    /// Exports the semaphore into a Zircon event handle, panicking on a validation error.
+    ///
+    /// This is a shortcut for `try_export_zircon_handle().map_error(Validated::unwrap)`.
+    ///
+    /// # Safety
+    ///
+    /// - If `handle_type` has copy transference, then the semaphore must be signaled, or a signal
+    ///   operation on the semaphore must be pending, and no wait operations must be pending.
+    /// - The semaphore must not currently have an imported payload from a swapchain acquire
+    ///   operation.
+    /// - If the semaphore has an imported payload, its handle type must allow re-exporting as
+    ///   `handle_type`, as returned by [`PhysicalDevice::external_semaphore_properties`].
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_export_zircon_handle`] returns a [`ValidationError`].
+    ///
+    /// [`try_export_zircon_handle`]: Self::try_export_zircon_handle
+    #[inline]
+    #[track_caller]
+    pub unsafe fn export_zircon_handle(
+        &self,
+        handle_type: ExternalSemaphoreHandleType,
+    ) -> Result<vk::zx_handle_t, VulkanError> {
+        match unsafe { self.try_export_zircon_handle(handle_type) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
     /// Exports the semaphore into a Zircon event handle.
     ///
     /// # Safety
@@ -714,7 +925,7 @@ impl Semaphore {
     /// - If the semaphore has an imported payload, its handle type must allow re-exporting as
     ///   `handle_type`, as returned by [`PhysicalDevice::external_semaphore_properties`].
     #[inline]
-    pub unsafe fn export_zircon_handle(
+    pub unsafe fn try_export_zircon_handle(
         &self,
         handle_type: ExternalSemaphoreHandleType,
     ) -> Result<vk::zx_handle_t, Validated<VulkanError>> {
@@ -798,10 +1009,11 @@ impl Semaphore {
         Ok(handle)
     }
 
-    /// Imports a semaphore from a POSIX file descriptor.
+    /// Imports a semaphore from a POSIX file descriptor, panicking on a validation error.
     ///
-    /// The [`khr_external_semaphore_fd`](crate::device::DeviceExtensions::khr_external_semaphore_fd)
-    /// extension must be enabled on the device.
+    /// The [`khr_external_semaphore_fd`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_import_fd().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
@@ -809,8 +1021,39 @@ impl Semaphore {
     /// - If in `import_semaphore_fd_info`, `handle_type` is `ExternalHandleType::OpaqueFd`, then
     ///   `fd` must represent a binary semaphore that was exported from Vulkan or a compatible API,
     ///   with a driver and device UUID equal to those of the device that owns `self`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_import_fd`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_semaphore_fd`]: crate::device::DeviceExtensions::khr_external_semaphore_fd
+    /// [`try_import_fd`]: Self::try_import_fd
     #[inline]
+    #[track_caller]
     pub unsafe fn import_fd(
+        &self,
+        import_semaphore_fd_info: &ImportSemaphoreFdInfo<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_import_fd(import_semaphore_fd_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Imports a semaphore from a POSIX file descriptor.
+    ///
+    /// The [`khr_external_semaphore_fd`] extension must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - The semaphore must not be in use by the device.
+    /// - If in `import_semaphore_fd_info`, `handle_type` is `ExternalHandleType::OpaqueFd`, then
+    ///   `fd` must represent a binary semaphore that was exported from Vulkan or a compatible API,
+    ///   with a driver and device UUID equal to those of the device that owns `self`.
+    ///
+    /// [`khr_external_semaphore_fd`]: crate::device::DeviceExtensions::khr_external_semaphore_fd
+    #[inline]
+    pub unsafe fn try_import_fd(
         &self,
         import_semaphore_fd_info: &ImportSemaphoreFdInfo<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -876,10 +1119,11 @@ impl Semaphore {
         Ok(())
     }
 
-    /// Imports a semaphore from a Win32 handle.
+    /// Imports a semaphore from a Win32 handle, panicking on a validation error.
     ///
-    /// The [`khr_external_semaphore_win32`](crate::device::DeviceExtensions::khr_external_semaphore_win32)
-    /// extension must be enabled on the device.
+    /// The [`khr_external_semaphore_win32`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_import_win32_handle().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
@@ -887,8 +1131,39 @@ impl Semaphore {
     /// - In `import_semaphore_win32_handle_info`, `handle` must represent a binary semaphore that
     ///   was exported from Vulkan or a compatible API, with a driver and device UUID equal to
     ///   those of the device that owns `self`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_import_win32_handle`] returns a [`ValidationError`].
+    ///
+    /// [`khr_external_semaphore_win32`]: crate::device::DeviceExtensions::khr_external_semaphore_win32
+    /// [`try_import_win32_handle`]: Self::try_import_win32_handle
     #[inline]
+    #[track_caller]
     pub unsafe fn import_win32_handle(
+        &self,
+        import_semaphore_win32_handle_info: &ImportSemaphoreWin32HandleInfo<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_import_win32_handle(import_semaphore_win32_handle_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Imports a semaphore from a Win32 handle.
+    ///
+    /// The [`khr_external_semaphore_win32`] extension must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - The semaphore must not be in use by the device.
+    /// - In `import_semaphore_win32_handle_info`, `handle` must represent a binary semaphore that
+    ///   was exported from Vulkan or a compatible API, with a driver and device UUID equal to
+    ///   those of the device that owns `self`.
+    ///
+    /// [`khr_external_semaphore_win32`]: crate::device::DeviceExtensions::khr_external_semaphore_win32
+    #[inline]
+    pub unsafe fn try_import_win32_handle(
         &self,
         import_semaphore_win32_handle_info: &ImportSemaphoreWin32HandleInfo<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -959,18 +1234,49 @@ impl Semaphore {
         Ok(())
     }
 
-    /// Imports a semaphore from a Zircon event handle.
+    /// Imports a semaphore from a Zircon event handle, panicking on a validation error.
     ///
-    /// The [`fuchsia_external_semaphore`](crate::device::DeviceExtensions::fuchsia_external_semaphore)
-    /// extension must be enabled on the device.
+    /// The [`fuchsia_external_semaphore`] extension must be enabled on the device.
+    ///
+    /// This is a shortcut for `try_import_zircon_handle().map_err(Validated::unwrap)`.
     ///
     /// # Safety
     ///
     /// - The semaphore must not be in use by the device.
     /// - In `import_semaphore_zircon_handle_info`, `zircon_handle` must have `ZX_RIGHTS_BASIC` and
     ///   `ZX_RIGHTS_SIGNAL`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_import_zircon_handle`] returns a [`ValidationError`].
+    ///
+    /// [`fuchsia_external_semaphore`]: crate::device::DeviceExtensions::fuchsia_external_semaphore
+    /// [`try_import_zircon_handle`]: Self::try_import_zircon_handle
     #[inline]
+    #[track_caller]
     pub unsafe fn import_zircon_handle(
+        &self,
+        import_semaphore_zircon_handle_info: &ImportSemaphoreZirconHandleInfo<'_>,
+    ) -> Result<(), VulkanError> {
+        match unsafe { self.try_import_zircon_handle(import_semaphore_zircon_handle_info) } {
+            Ok(res) => Ok(res),
+            Err(err) => Err(err.unwrap()),
+        }
+    }
+
+    /// Imports a semaphore from a Zircon event handle.
+    ///
+    /// The [`fuchsia_external_semaphore`] extension must be enabled on the device.
+    ///
+    /// # Safety
+    ///
+    /// - The semaphore must not be in use by the device.
+    /// - In `import_semaphore_zircon_handle_info`, `zircon_handle` must have `ZX_RIGHTS_BASIC` and
+    ///   `ZX_RIGHTS_SIGNAL`.
+    ///
+    /// [`fuchsia_external_semaphore`]: crate::device::DeviceExtensions::fuchsia_external_semaphore
+    #[inline]
+    pub unsafe fn try_import_zircon_handle(
         &self,
         import_semaphore_zircon_handle_info: &ImportSemaphoreZirconHandleInfo<'_>,
     ) -> Result<(), Validated<VulkanError>> {
@@ -1454,9 +1760,9 @@ impl<'a> SemaphoreWaitInfo<'a> {
     }
 }
 
-/// Parameters to wait for multiple timeline semaphores.
+/// Parameters to wait for many timeline semaphores.
 #[derive(Clone, Debug)]
-pub struct SemaphoreWaitMultipleInfo<'a> {
+pub struct SemaphoreWaitManyInfo<'a> {
     /// Additional properties of the wait operation.
     ///
     /// The default value is empty.
@@ -1470,15 +1776,15 @@ pub struct SemaphoreWaitMultipleInfo<'a> {
     pub _ne: crate::NonExhaustive<'a>,
 }
 
-impl Default for SemaphoreWaitMultipleInfo<'_> {
+impl Default for SemaphoreWaitManyInfo<'_> {
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> SemaphoreWaitMultipleInfo<'a> {
-    /// Returns a default `SemaphoreWaitMultipleInfo`.
+impl<'a> SemaphoreWaitManyInfo<'a> {
+    /// Returns a default `SemaphoreWaitManyInfo`.
     #[inline]
     pub const fn new() -> Self {
         Self {
@@ -1515,14 +1821,14 @@ impl<'a> SemaphoreWaitMultipleInfo<'a> {
 
     pub(crate) fn to_vk(
         &self,
-        fields1_vk: &'a SemaphoreWaitMultipleInfoFields1Vk,
+        fields1_vk: &'a SemaphoreWaitManyInfoFields1Vk,
     ) -> vk::SemaphoreWaitInfo<'a> {
         let &Self {
             flags,
             semaphores: _,
             _ne: _,
         } = self;
-        let SemaphoreWaitMultipleInfoFields1Vk {
+        let SemaphoreWaitManyInfoFields1Vk {
             semaphores_vk,
             values_vk,
         } = fields1_vk;
@@ -1533,8 +1839,8 @@ impl<'a> SemaphoreWaitMultipleInfo<'a> {
             .values(values_vk)
     }
 
-    pub(crate) fn to_vk_fields1(&self) -> SemaphoreWaitMultipleInfoFields1Vk {
-        let &SemaphoreWaitMultipleInfo { semaphores, .. } = self;
+    pub(crate) fn to_vk_fields1(&self) -> SemaphoreWaitManyInfoFields1Vk {
+        let &SemaphoreWaitManyInfo { semaphores, .. } = self;
 
         let mut semaphores_vk: SmallVec<[_; 8]> = SmallVec::with_capacity(semaphores.len());
         let mut values_vk: SmallVec<[_; 8]> = SmallVec::with_capacity(semaphores.len());
@@ -1550,14 +1856,14 @@ impl<'a> SemaphoreWaitMultipleInfo<'a> {
             values_vk.push(value);
         }
 
-        SemaphoreWaitMultipleInfoFields1Vk {
+        SemaphoreWaitManyInfoFields1Vk {
             semaphores_vk,
             values_vk,
         }
     }
 }
 
-pub(crate) struct SemaphoreWaitMultipleInfoFields1Vk {
+pub(crate) struct SemaphoreWaitManyInfoFields1Vk {
     semaphores_vk: SmallVec<[vk::Semaphore; 8]>,
     values_vk: SmallVec<[u64; 8]>,
 }
@@ -2219,7 +2525,7 @@ mod tests {
             Err(_) => return,
         };
 
-        let (device, _) = match Device::new(
+        let (device, _) = match Device::try_new(
             &physical_device,
             &DeviceCreateInfo {
                 queue_create_infos: &[QueueCreateInfo {


### PR DESCRIPTION
This adds a panicking version to every function that unwraps anything other than a `VulkanError`. This is because you always want to unwrap e.g., `ValidationError`s, but the `VulkanError`s should be handled. The old function names now unwrap everything except a `VulkanError`. The old behavior is preserved with the other function variant that has the same name prefixed with `try_` for those that truly need it.

I also added a `try_` variant to some methods that previously didn't return a `ValidationError` because there's nothing to validate, at least *yet*. Also, I finally made `RecordingCommandBuffer::new_unchecked` not return a `ValidationError` (which was solely because the allocator would return one) and added such a `new_unchecked` to `Buffer`, `Image` and `RawDescriptorSet` too. The `load` functions generated by vulkano-shaders had to be adjusted too, and while doing so, I marked them `unsafe` like they always should have been.

Changelog:
```markdown
### Breaking changes
Changes to errors:
- Functions that used to return anything other than `VulkanError` on error now unwrap everything except a `VulkanError`. The old behavior is preserved with the same function name prefixed with `try_` for those that truly need it. This fixes the sea of `.unwrap()`s, or even worse `.map_err(Validated::unwrap)`, that more often than not litter a vulkano application.

Changes to memory allocation:
- `MemoryAllocator`'s `allocate_from_type`, `allocate` and `allocate_dedicated` methods were renamed to `try_allocate_from_type`, `try_allocate` and `try_allocate_dedicated`, respectively, for consistency with the new inherent methods and associated functions.
- `MemoryAllocator` has the new required methods `allocate_from_type_unchecked`, `allocate_unchecked` and `allocated_dedicated_unchecked` to fix the issue that `Buffer::new` and `Image::new` would have had of returning a `Validated<VulkanError>` despite being unchecked.

Changes to command buffer allocation:
- `CommandBufferAllocator`'s `allocate` method was renamed to `try_allocate` for consistency with the new inherent methods and associated functions.
- `CommandBufferAllocator` has the new required method `allocate_unchecked` to fix the issue of `RecordingCommandBuffer::new_unchecked` returning a `Validated<VulkanError>` despite being unchecked.

Changes to descriptor set allocation:
- `DescriptorSetAllocator`'s `allocate` method was renamed to `try_allocate` for consistency with the new inherent methods and associated functions.
- `DescriptorSetAllocator` has the new required method `allocate_unchecked` to fix the issue that `RawDescriptorSet::new_unchecked` would have had of returning a `Validated<VulkanError>` despite being unchecked.

Changes to vulkano-shaders:
- The `shader!` macro now generates unsafe functions. These have always been unsafe because they delegate to the unsafe `ShaderModule::new`, but marked incorrectly. This fixes a long-standing soundness issue.
```