### PR TITLE
Remove subbuffer from `RecordingCommandBuffer`

### DIFF
--- a/vulkano/src/command_buffer/auto/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/auto/commands/acceleration_structure.rs
@@ -7,7 +7,7 @@ use crate::{
         BuildAccelerationStructureMode, CopyAccelerationStructureInfo,
         CopyAccelerationStructureToMemoryInfo, CopyMemoryToAccelerationStructureInfo,
     },
-    buffer::Subbuffer,
+    buffer::{BufferUsage, Subbuffer},
     command_buffer::{
         auto::{Resource, ResourceUseRef2},
         sys::RecordingCommandBuffer,
@@ -17,6 +17,7 @@ use crate::{
     sync::PipelineStageAccessFlags,
     ValidationError,
 };
+use ash::vk::DeviceSize;
 use smallvec::SmallVec;
 use std::sync::Arc;
 
@@ -212,9 +213,11 @@ impl<L> AutoCommandBufferBuilder<L> {
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> Result<(), Box<ValidationError>> {
+        let indirect_buffer = indirect_buffer.buffer();
+
         self.inner.validate_build_acceleration_structure_indirect(
             info,
-            indirect_buffer.buffer(),
+            indirect_buffer.device_address(),
             stride,
             max_primitive_counts,
         )?;
@@ -226,6 +229,27 @@ impl<L> AutoCommandBufferBuilder<L> {
                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-renderpass"],
                 ..Default::default()
             }));
+        }
+
+        if info.geometries.len() as DeviceSize * stride as DeviceSize > indirect_buffer.size() {
+            return Err(Box::new(ValidationError {
+                 problem: "`info.geometries.len()` * `stride` is greater than the size of \
+                     `indirect_buffer`".into(),
+                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03646"],
+                 ..Default::default()
+             }));
+        }
+
+        if !indirect_buffer
+            .usage()
+            .intersects(BufferUsage::INDIRECT_BUFFER)
+        {
+            return Err(Box::new(ValidationError {
+                 context: "indirect_buffer".into(),
+                 problem: "the buffer was not created with the `BufferUsage::INDIRECT_BUFFER` usage".into(),
+                 vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03647"],
+                 ..Default::default()
+             }));
         }
 
         Ok(())
@@ -250,7 +274,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 unsafe {
                     out.build_acceleration_structure_indirect_unchecked(
                         &info,
-                        indirect_buffer.buffer(),
+                        indirect_buffer.buffer().device_address(),
                         stride,
                         &max_primitive_counts,
                     )

--- a/vulkano/src/command_buffer/auto/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/auto/commands/acceleration_structure.rs
@@ -215,7 +215,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<(), Box<ValidationError>> {
         self.inner.validate_build_acceleration_structure_indirect(
             info,
-            indirect_buffer.device_address()?,
+            indirect_buffer.device_address()?.get(),
             stride,
             max_primitive_counts,
         )?;
@@ -273,7 +273,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 unsafe {
                     out.build_acceleration_structure_indirect_unchecked(
                         &info,
-                        indirect_buffer.device_address().unwrap(),
+                        indirect_buffer.device_address().unwrap().get(),
                         stride,
                         &max_primitive_counts,
                     )

--- a/vulkano/src/command_buffer/auto/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/auto/commands/acceleration_structure.rs
@@ -214,7 +214,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<(), Box<ValidationError>> {
         self.inner.validate_build_acceleration_structure_indirect(
             info,
-            indirect_buffer,
+            indirect_buffer.buffer(),
             stride,
             max_primitive_counts,
         )?;
@@ -250,7 +250,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 unsafe {
                     out.build_acceleration_structure_indirect_unchecked(
                         &info,
-                        &indirect_buffer,
+                        indirect_buffer.buffer(),
                         stride,
                         &max_primitive_counts,
                     )

--- a/vulkano/src/command_buffer/auto/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/auto/commands/acceleration_structure.rs
@@ -213,11 +213,9 @@ impl<L> AutoCommandBufferBuilder<L> {
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> Result<(), Box<ValidationError>> {
-        let indirect_buffer = indirect_buffer.buffer();
-
         self.inner.validate_build_acceleration_structure_indirect(
             info,
-            indirect_buffer.device_address(),
+            indirect_buffer.device_address()?,
             stride,
             max_primitive_counts,
         )?;
@@ -241,6 +239,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         }
 
         if !indirect_buffer
+            .buffer()
             .usage()
             .intersects(BufferUsage::INDIRECT_BUFFER)
         {
@@ -274,7 +273,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 unsafe {
                     out.build_acceleration_structure_indirect_unchecked(
                         &info,
-                        indirect_buffer.buffer().device_address(),
+                        indirect_buffer.device_address().unwrap(),
                         stride,
                         &max_primitive_counts,
                     )

--- a/vulkano/src/command_buffer/auto/commands/query.rs
+++ b/vulkano/src/command_buffer/auto/commands/query.rs
@@ -9,6 +9,7 @@ use crate::{
     sync::{PipelineStage, PipelineStageAccessFlags},
     ValidationError,
 };
+use ash::vk::DeviceSize;
 use std::{ops::Range, sync::Arc};
 
 /// # Commands related to queries.
@@ -271,18 +272,21 @@ impl<L> AutoCommandBufferBuilder<L> {
         &self,
         query_pool: &QueryPool,
         queries: Range<u32>,
-        destination: &Subbuffer<[T]>,
+        dst: &Subbuffer<[T]>,
         flags: QueryResultFlags,
     ) -> Result<(), Box<ValidationError>>
     where
         T: QueryResultElement,
     {
+        let stride = query_pool.result_len(flags) * size_of::<T>() as DeviceSize;
+
         self.inner.validate_copy_query_pool_results::<T>(
             query_pool,
             queries.start,
             queries.end - queries.start,
-            destination.buffer(),
-            destination.offset(),
+            dst.buffer(),
+            dst.offset(),
+            stride,
             flags,
         )?;
 
@@ -308,6 +312,8 @@ impl<L> AutoCommandBufferBuilder<L> {
     where
         T: QueryResultElement,
     {
+        let stride = query_pool.result_len(flags) * size_of::<T>() as DeviceSize;
+
         self.add_command(
             "copy_query_pool_results",
             [(
@@ -328,6 +334,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                         queries.end - queries.start,
                         destination.buffer(),
                         destination.offset(),
+                        stride,
                         flags,
                     )
                 };

--- a/vulkano/src/command_buffer/auto/commands/query.rs
+++ b/vulkano/src/command_buffer/auto/commands/query.rs
@@ -277,11 +277,12 @@ impl<L> AutoCommandBufferBuilder<L> {
     where
         T: QueryResultElement,
     {
-        self.inner.validate_copy_query_pool_results(
+        self.inner.validate_copy_query_pool_results::<T>(
             query_pool,
             queries.start,
             queries.end - queries.start,
-            destination,
+            destination.buffer(),
+            destination.offset(),
             flags,
         )?;
 
@@ -321,11 +322,12 @@ impl<L> AutoCommandBufferBuilder<L> {
             .collect(),
             move |out: &mut RecordingCommandBuffer| {
                 unsafe {
-                    out.copy_query_pool_results_unchecked(
+                    out.copy_query_pool_results_unchecked::<T>(
                         &query_pool,
                         queries.start,
                         queries.end - queries.start,
-                        &destination,
+                        destination.buffer(),
+                        destination.offset(),
                         flags,
                     )
                 };

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -9,14 +9,15 @@ use crate::{
         CopyAccelerationStructureToMemoryInfo, CopyMemoryToAccelerationStructureInfo,
         TransformMatrix,
     },
-    buffer::{Buffer, BufferUsage},
+    buffer::BufferUsage,
     command_buffer::sys::RecordingCommandBuffer,
     device::{DeviceOwned, QueueFlags},
     query::{QueryPool, QueryType},
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
+use ash::vk::DeviceAddress;
 use smallvec::SmallVec;
-use std::sync::Arc;
+use std::{num::NonZero, sync::Arc};
 
 impl RecordingCommandBuffer {
     #[inline]
@@ -809,14 +810,14 @@ impl RecordingCommandBuffer {
     pub unsafe fn build_acceleration_structure_indirect(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_buffer: &Arc<Buffer>,
+        indirect_device_address: NonZero<DeviceAddress>,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> &mut Self {
         unsafe {
             self.try_build_acceleration_structure_indirect(
                 info,
-                indirect_buffer,
+                indirect_device_address,
                 stride,
                 max_primitive_counts,
             )
@@ -828,13 +829,13 @@ impl RecordingCommandBuffer {
     pub unsafe fn try_build_acceleration_structure_indirect(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_buffer: &Arc<Buffer>,
+        indirect_device_address: NonZero<DeviceAddress>,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.validate_build_acceleration_structure_indirect(
             info,
-            indirect_buffer,
+            indirect_device_address,
             stride,
             max_primitive_counts,
         )?;
@@ -842,7 +843,7 @@ impl RecordingCommandBuffer {
         Ok(unsafe {
             self.build_acceleration_structure_indirect_unchecked(
                 info,
-                indirect_buffer,
+                indirect_device_address,
                 stride,
                 max_primitive_counts,
             )
@@ -852,7 +853,7 @@ impl RecordingCommandBuffer {
     pub(crate) fn validate_build_acceleration_structure_indirect(
         &self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_buffer: &Arc<Buffer>,
+        indirect_device_address: NonZero<DeviceAddress>,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> Result<(), Box<ValidationError>> {
@@ -1370,28 +1371,7 @@ impl RecordingCommandBuffer {
             }
         }
 
-        if geometries.len() as DeviceSize * stride as DeviceSize > indirect_buffer.size() {
-            return Err(Box::new(ValidationError {
-                problem: "`info.geometries.len()` * `stride` is greater than the size of \
-                    `indirect_buffer`".into(),
-                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03646"],
-                ..Default::default()
-            }));
-        }
-
-        if !indirect_buffer
-            .usage()
-            .intersects(BufferUsage::INDIRECT_BUFFER)
-        {
-            return Err(Box::new(ValidationError {
-                context: "indirect_buffer".into(),
-                problem: "the buffer was not created with the `BufferUsage::INDIRECT_BUFFER` usage".into(),
-                vuids: &["VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03647"],
-                ..Default::default()
-            }));
-        }
-
-        if !indirect_buffer.device_address().get().is_multiple_of(4) {
+        if !indirect_device_address.get().is_multiple_of(4) {
             return Err(Box::new(ValidationError {
                 context: "indirect_buffer".into(),
                 problem: "the buffer's device address is not a multiple of 4".into(),
@@ -1422,7 +1402,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn build_acceleration_structure_indirect_unchecked(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_buffer: &Arc<Buffer>,
+        indirect_device_address: NonZero<DeviceAddress>,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> &mut Self {
@@ -1436,7 +1416,7 @@ impl RecordingCommandBuffer {
                 self.handle(),
                 1,
                 &info_vk,
-                &indirect_buffer.device_address().get(),
+                &indirect_device_address.get(),
                 &stride,
                 &max_primitive_counts.as_ptr(),
             )

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -9,7 +9,7 @@ use crate::{
         CopyAccelerationStructureToMemoryInfo, CopyMemoryToAccelerationStructureInfo,
         TransformMatrix,
     },
-    buffer::{BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferUsage},
     command_buffer::sys::RecordingCommandBuffer,
     device::{DeviceOwned, QueueFlags},
     query::{QueryPool, QueryType},
@@ -809,7 +809,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn build_acceleration_structure_indirect(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_buffer: &Subbuffer<[u8]>,
+        indirect_buffer: &Arc<Buffer>,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> &mut Self {
@@ -828,7 +828,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn try_build_acceleration_structure_indirect(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_buffer: &Subbuffer<[u8]>,
+        indirect_buffer: &Arc<Buffer>,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -852,7 +852,7 @@ impl RecordingCommandBuffer {
     pub(crate) fn validate_build_acceleration_structure_indirect(
         &self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_buffer: &Subbuffer<[u8]>,
+        indirect_buffer: &Arc<Buffer>,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> Result<(), Box<ValidationError>> {
@@ -1380,7 +1380,6 @@ impl RecordingCommandBuffer {
         }
 
         if !indirect_buffer
-            .buffer()
             .usage()
             .intersects(BufferUsage::INDIRECT_BUFFER)
         {
@@ -1392,12 +1391,7 @@ impl RecordingCommandBuffer {
             }));
         }
 
-        if !indirect_buffer
-            .device_address()
-            .unwrap()
-            .get()
-            .is_multiple_of(4)
-        {
+        if !indirect_buffer.device_address().get().is_multiple_of(4) {
             return Err(Box::new(ValidationError {
                 context: "indirect_buffer".into(),
                 problem: "the buffer's device address is not a multiple of 4".into(),
@@ -1428,7 +1422,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn build_acceleration_structure_indirect_unchecked(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_buffer: &Subbuffer<[u8]>,
+        indirect_buffer: &Arc<Buffer>,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> &mut Self {
@@ -1442,7 +1436,7 @@ impl RecordingCommandBuffer {
                 self.handle(),
                 1,
                 &info_vk,
-                &indirect_buffer.device_address().unwrap().get(),
+                &indirect_buffer.device_address().get(),
                 &stride,
                 &max_primitive_counts.as_ptr(),
             )

--- a/vulkano/src/command_buffer/commands/acceleration_structure.rs
+++ b/vulkano/src/command_buffer/commands/acceleration_structure.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use ash::vk::DeviceAddress;
 use smallvec::SmallVec;
-use std::{num::NonZero, sync::Arc};
+use std::sync::Arc;
 
 impl RecordingCommandBuffer {
     #[inline]
@@ -810,7 +810,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn build_acceleration_structure_indirect(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_device_address: NonZero<DeviceAddress>,
+        indirect_device_address: DeviceAddress,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> &mut Self {
@@ -829,7 +829,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn try_build_acceleration_structure_indirect(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_device_address: NonZero<DeviceAddress>,
+        indirect_device_address: DeviceAddress,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> Result<&mut Self, Box<ValidationError>> {
@@ -853,7 +853,7 @@ impl RecordingCommandBuffer {
     pub(crate) fn validate_build_acceleration_structure_indirect(
         &self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_device_address: NonZero<DeviceAddress>,
+        indirect_device_address: DeviceAddress,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> Result<(), Box<ValidationError>> {
@@ -1371,7 +1371,7 @@ impl RecordingCommandBuffer {
             }
         }
 
-        if !indirect_device_address.get().is_multiple_of(4) {
+        if !indirect_device_address.is_multiple_of(4) {
             return Err(Box::new(ValidationError {
                 context: "indirect_buffer".into(),
                 problem: "the buffer's device address is not a multiple of 4".into(),
@@ -1402,7 +1402,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn build_acceleration_structure_indirect_unchecked(
         &mut self,
         info: &AccelerationStructureBuildGeometryInfo,
-        indirect_device_address: NonZero<DeviceAddress>,
+        indirect_device_address: DeviceAddress,
         stride: u32,
         max_primitive_counts: &[u32],
     ) -> &mut Self {
@@ -1416,7 +1416,7 @@ impl RecordingCommandBuffer {
                 self.handle(),
                 1,
                 &info_vk,
-                &indirect_device_address.get(),
+                &indirect_device_address,
                 &stride,
                 &max_primitive_counts.as_ptr(),
             )

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -644,9 +644,26 @@ impl RecordingCommandBuffer {
         assert_eq!(device, dst_buffer.device());
         assert_eq!(device, query_pool.device());
 
-        // VUID-vkCmdCopyQueryPoolResults-flags-00822
-        // VUID-vkCmdCopyQueryPoolResults-flags-00823
-        debug_assert!(dst_offset.is_multiple_of(size_of::<T>() as DeviceSize));
+        if dst_offset >= dst_buffer.size() {
+            return Err(Box::new(ValidationError {
+                context: "dst_offset".into(),
+                problem: "is greater than or equal to `dst_buffer.size()`".into(),
+                vuids: &["VUID-vkCmdCopyQueryPoolResults-dstOffset-00819"],
+                ..Default::default()
+            }));
+        }
+
+        if !dst_offset.is_multiple_of(size_of::<T>() as DeviceSize) {
+            return Err(Box::new(ValidationError {
+                context: "dst_offset".into(),
+                problem: "is not a multiple of the result type's size".into(),
+                vuids: &[
+                    "VUID-vkCmdCopyQueryPoolResults-flags-00822",
+                    "VUID-vkCmdCopyQueryPoolResults-flags-00823",
+                ],
+                ..Default::default()
+            }));
+        }
 
         if !first_query
             .checked_add(query_count)
@@ -666,7 +683,7 @@ impl RecordingCommandBuffer {
         let per_query_len = query_pool.result_len(flags);
         let required_len = per_query_len * query_count as DeviceSize;
 
-        if dst_buffer.size() < required_len {
+        if (dst_buffer.size() - dst_offset) / (size_of::<T>() as DeviceSize) < required_len {
             return Err(Box::new(ValidationError {
                 problem: "`dst_buffer` is smaller than the size required to write the results"
                     .into(),
@@ -699,15 +716,15 @@ impl RecordingCommandBuffer {
         if query_count > 1 {
             if stride == 0 {
                 return Err(Box::new(ValidationError {
-                    problem: "`query_count` is greater than 1 but `stride` is zero".into(),
+                    problem: "`query_count` is greater than 1, but `stride` is zero".into(),
                     vuids: &["VUID-vkCmdCopyQueryPoolResults-queryCount-09438"],
                     ..Default::default()
                 }));
             }
 
-            if !stride.is_multiple_of(std::mem::size_of::<T>() as DeviceSize) {
+            if !stride.is_multiple_of(size_of::<T>() as DeviceSize) {
                 return Err(Box::new(ValidationError {
-                    problem: "`query_count` is greater than 1 but `stride` is not a multiple of \
+                    problem: "`query_count` is greater than 1, but `stride` is not a multiple of \
                         the result type's size"
                         .into(),
                     vuids: &[

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -706,7 +706,7 @@ impl RecordingCommandBuffer {
                 }));
             }
 
-            if stride.is_multiple_of(std::mem::size_of::<T>() as DeviceSize) {
+            if !stride.is_multiple_of(std::mem::size_of::<T>() as DeviceSize) {
                 return Err(Box::new(ValidationError {
                     context: "stride".into(),
                     problem: "is not a multiple of the result type's size".into(),

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -699,8 +699,7 @@ impl RecordingCommandBuffer {
         if query_count > 1 {
             if stride == 0 {
                 return Err(Box::new(ValidationError {
-                    context: "stride".into(),
-                    problem: "is zero".into(),
+                    problem: "`query_count` is greater than 1 but `stride` is zero".into(),
                     vuids: &["VUID-vkCmdCopyQueryPoolResults-queryCount-09438"],
                     ..Default::default()
                 }));
@@ -708,8 +707,9 @@ impl RecordingCommandBuffer {
 
             if !stride.is_multiple_of(std::mem::size_of::<T>() as DeviceSize) {
                 return Err(Box::new(ValidationError {
-                    context: "stride".into(),
-                    problem: "is not a multiple of the result type's size".into(),
+                    problem: "`query_count` is greater than 1 but `stride` is not a multiple of \
+                        the result type's size"
+                        .into(),
                     vuids: &[
                         "VUID-vkCmdCopyQueryPoolResults-queryCount-12254",
                         "VUID-vkCmdCopyQueryPoolResults-queryCount-12255",

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -552,8 +552,9 @@ impl RecordingCommandBuffer {
         query_pool: &QueryPool,
         first_query: u32,
         query_count: u32,
-        destination: &Arc<Buffer>,
-        destination_offset: DeviceSize,
+        dst_buffer: &Arc<Buffer>,
+        dst_offset: DeviceSize,
+        stride: DeviceSize,
         flags: QueryResultFlags,
     ) -> &mut Self
     where
@@ -564,8 +565,9 @@ impl RecordingCommandBuffer {
                 query_pool,
                 first_query,
                 query_count,
-                destination,
-                destination_offset,
+                dst_buffer,
+                dst_offset,
+                stride,
                 flags,
             )
         }
@@ -578,8 +580,9 @@ impl RecordingCommandBuffer {
         query_pool: &QueryPool,
         first_query: u32,
         query_count: u32,
-        destination: &Arc<Buffer>,
-        destination_offset: DeviceSize,
+        dst_buffer: &Arc<Buffer>,
+        dst_offset: DeviceSize,
+        stride: DeviceSize,
         flags: QueryResultFlags,
     ) -> Result<&mut Self, Box<ValidationError>>
     where
@@ -589,8 +592,9 @@ impl RecordingCommandBuffer {
             query_pool,
             first_query,
             query_count,
-            destination,
-            destination_offset,
+            dst_buffer,
+            dst_offset,
+            stride,
             flags,
         )?;
 
@@ -599,8 +603,9 @@ impl RecordingCommandBuffer {
                 query_pool,
                 first_query,
                 query_count,
-                destination,
-                destination_offset,
+                dst_buffer,
+                dst_offset,
+                stride,
                 flags,
             )
         })
@@ -611,8 +616,9 @@ impl RecordingCommandBuffer {
         query_pool: &QueryPool,
         first_query: u32,
         query_count: u32,
-        destination: &Arc<Buffer>,
-        destination_offset: DeviceSize,
+        dst_buffer: &Arc<Buffer>,
+        dst_offset: DeviceSize,
+        stride: DeviceSize,
         flags: QueryResultFlags,
     ) -> Result<(), Box<ValidationError>>
     where
@@ -635,12 +641,12 @@ impl RecordingCommandBuffer {
         let device = self.device();
 
         // VUID-vkCmdCopyQueryPoolResults-commonparent
-        assert_eq!(device, destination.device());
+        assert_eq!(device, dst_buffer.device());
         assert_eq!(device, query_pool.device());
 
         // VUID-vkCmdCopyQueryPoolResults-flags-00822
         // VUID-vkCmdCopyQueryPoolResults-flags-00823
-        debug_assert!(destination_offset.is_multiple_of(size_of::<T>() as DeviceSize));
+        debug_assert!(dst_offset.is_multiple_of(size_of::<T>() as DeviceSize));
 
         if !first_query
             .checked_add(query_count)
@@ -660,18 +666,18 @@ impl RecordingCommandBuffer {
         let per_query_len = query_pool.result_len(flags);
         let required_len = per_query_len * query_count as DeviceSize;
 
-        if destination.size() < required_len {
+        if dst_buffer.size() < required_len {
             return Err(Box::new(ValidationError {
-                problem: "`destination` is smaller than the size required to write the results"
+                problem: "`dst_buffer` is smaller than the size required to write the results"
                     .into(),
                 vuids: &["VUID-vkCmdCopyQueryPoolResults-dstBuffer-00824"],
                 ..Default::default()
             }));
         }
 
-        if !destination.usage().intersects(BufferUsage::TRANSFER_DST) {
+        if !dst_buffer.usage().intersects(BufferUsage::TRANSFER_DST) {
             return Err(Box::new(ValidationError {
-                context: "destination.usage()".into(),
+                context: "dst_buffer.usage()".into(),
                 problem: "does not contain `BufferUsage::TRANSFER_DST`".into(),
                 vuids: &["VUID-vkCmdCopyQueryPoolResults-dstBuffer-00825"],
                 ..Default::default()
@@ -690,6 +696,29 @@ impl RecordingCommandBuffer {
             }));
         }
 
+        if query_count > 1 {
+            if stride == 0 {
+                return Err(Box::new(ValidationError {
+                    context: "stride".into(),
+                    problem: "is zero".into(),
+                    vuids: &["VUID-vkCmdCopyQueryPoolResults-queryCount-09438"],
+                    ..Default::default()
+                }));
+            }
+
+            if stride.is_multiple_of(std::mem::size_of::<T>() as DeviceSize) {
+                return Err(Box::new(ValidationError {
+                    context: "stride".into(),
+                    problem: "is not a multiple of the result type's size".into(),
+                    vuids: &[
+                        "VUID-vkCmdCopyQueryPoolResults-queryCount-12254",
+                        "VUID-vkCmdCopyQueryPoolResults-queryCount-12255",
+                    ],
+                    ..Default::default()
+                }));
+            }
+        }
+
         Ok(())
     }
 
@@ -699,16 +728,14 @@ impl RecordingCommandBuffer {
         query_pool: &QueryPool,
         first_query: u32,
         query_count: u32,
-        destination: &Arc<Buffer>,
-        destination_offset: DeviceSize,
+        dst_buffer: &Arc<Buffer>,
+        dst_offset: DeviceSize,
+        stride: DeviceSize,
         flags: QueryResultFlags,
     ) -> &mut Self
     where
         T: QueryResultElement,
     {
-        let per_query_len = query_pool.result_len(flags);
-        let stride = per_query_len * size_of::<T>() as DeviceSize;
-
         let fns = self.device().fns();
         unsafe {
             (fns.v1_0.cmd_copy_query_pool_results)(
@@ -716,8 +743,8 @@ impl RecordingCommandBuffer {
                 query_pool.handle(),
                 first_query,
                 query_count,
-                destination.handle(),
-                destination_offset,
+                dst_buffer.handle(),
+                dst_offset,
                 stride,
                 vk::QueryResultFlags::from(flags) | T::FLAG,
             )

--- a/vulkano/src/command_buffer/commands/query.rs
+++ b/vulkano/src/command_buffer/commands/query.rs
@@ -1,5 +1,5 @@
 use crate::{
-    buffer::{BufferUsage, Subbuffer},
+    buffer::{Buffer, BufferUsage},
     command_buffer::sys::RecordingCommandBuffer,
     device::{DeviceOwned, QueueFlags},
     query::{QueryControlFlags, QueryPool, QueryResultElement, QueryResultFlags, QueryType},
@@ -7,6 +7,7 @@ use crate::{
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanObject,
 };
 use ash::vk;
+use std::sync::Arc;
 
 impl RecordingCommandBuffer {
     #[inline]
@@ -551,18 +552,20 @@ impl RecordingCommandBuffer {
         query_pool: &QueryPool,
         first_query: u32,
         query_count: u32,
-        destination: &Subbuffer<[T]>,
+        destination: &Arc<Buffer>,
+        destination_offset: DeviceSize,
         flags: QueryResultFlags,
     ) -> &mut Self
     where
         T: QueryResultElement,
     {
         unsafe {
-            self.try_copy_query_pool_results(
+            self.try_copy_query_pool_results::<T>(
                 query_pool,
                 first_query,
                 query_count,
                 destination,
+                destination_offset,
                 flags,
             )
         }
@@ -575,26 +578,29 @@ impl RecordingCommandBuffer {
         query_pool: &QueryPool,
         first_query: u32,
         query_count: u32,
-        destination: &Subbuffer<[T]>,
+        destination: &Arc<Buffer>,
+        destination_offset: DeviceSize,
         flags: QueryResultFlags,
     ) -> Result<&mut Self, Box<ValidationError>>
     where
         T: QueryResultElement,
     {
-        self.validate_copy_query_pool_results(
+        self.validate_copy_query_pool_results::<T>(
             query_pool,
             first_query,
             query_count,
             destination,
+            destination_offset,
             flags,
         )?;
 
         Ok(unsafe {
-            self.copy_query_pool_results_unchecked(
+            self.copy_query_pool_results_unchecked::<T>(
                 query_pool,
                 first_query,
                 query_count,
                 destination,
+                destination_offset,
                 flags,
             )
         })
@@ -605,7 +611,8 @@ impl RecordingCommandBuffer {
         query_pool: &QueryPool,
         first_query: u32,
         query_count: u32,
-        destination: &Subbuffer<[T]>,
+        destination: &Arc<Buffer>,
+        destination_offset: DeviceSize,
         flags: QueryResultFlags,
     ) -> Result<(), Box<ValidationError>>
     where
@@ -628,14 +635,12 @@ impl RecordingCommandBuffer {
         let device = self.device();
 
         // VUID-vkCmdCopyQueryPoolResults-commonparent
-        assert_eq!(device, destination.buffer().device());
+        assert_eq!(device, destination.device());
         assert_eq!(device, query_pool.device());
 
         // VUID-vkCmdCopyQueryPoolResults-flags-00822
         // VUID-vkCmdCopyQueryPoolResults-flags-00823
-        debug_assert!(destination
-            .offset()
-            .is_multiple_of(size_of::<T>() as DeviceSize));
+        debug_assert!(destination_offset.is_multiple_of(size_of::<T>() as DeviceSize));
 
         if !first_query
             .checked_add(query_count)
@@ -655,7 +660,7 @@ impl RecordingCommandBuffer {
         let per_query_len = query_pool.result_len(flags);
         let required_len = per_query_len * query_count as DeviceSize;
 
-        if destination.len() < required_len {
+        if destination.size() < required_len {
             return Err(Box::new(ValidationError {
                 problem: "`destination` is smaller than the size required to write the results"
                     .into(),
@@ -664,11 +669,7 @@ impl RecordingCommandBuffer {
             }));
         }
 
-        if !destination
-            .buffer()
-            .usage()
-            .intersects(BufferUsage::TRANSFER_DST)
-        {
+        if !destination.usage().intersects(BufferUsage::TRANSFER_DST) {
             return Err(Box::new(ValidationError {
                 context: "destination.usage()".into(),
                 problem: "does not contain `BufferUsage::TRANSFER_DST`".into(),
@@ -698,7 +699,8 @@ impl RecordingCommandBuffer {
         query_pool: &QueryPool,
         first_query: u32,
         query_count: u32,
-        destination: &Subbuffer<[T]>,
+        destination: &Arc<Buffer>,
+        destination_offset: DeviceSize,
         flags: QueryResultFlags,
     ) -> &mut Self
     where
@@ -714,8 +716,8 @@ impl RecordingCommandBuffer {
                 query_pool.handle(),
                 first_query,
                 query_count,
-                destination.buffer().handle(),
-                destination.offset(),
+                destination.handle(),
+                destination_offset,
                 stride,
                 vk::QueryResultFlags::from(flags) | T::FLAG,
             )


### PR DESCRIPTION
Removed `Subbuffer` from `RecordingCommandBuffer`.

Changelog:

```markdown
### Breaking changes

Changes to `RecordingCommandBuffer`:
- `build_acceleration_structure_indirect`, `try_build_acceleration_structure_indirect`, `validate_build_acceleration_structure_indirect` and `build_acceleration_structure_indirect_unchecked` use an `&Arc<Buffer>` as input instead of `&Subbuffer<[u8]>`.
- `copy_query_pool_results`, `try_copy_query_pool_results`, `validate_copy_query_pool_results` and `copy_query_pool_results_unchecked` use an `&Arc<Buffer>` and `offset` instead of `&Subbuffer<[u8]>`.
```
