### PR TITLE
Fix `BuddyAllocator` region offset not having to be aligned to `BuddyAllocator::MIN_NODE_SIZE`

### DIFF
--- a/vulkano/src/memory/allocator/suballocator/buddy.rs
+++ b/vulkano/src/memory/allocator/suballocator/buddy.rs
@@ -92,13 +92,17 @@ unsafe impl Suballocator for BuddyAllocator {
     ///
     /// # Panics
     ///
-    /// - Panics if `region.size` is not a power of two.
-    /// - Panics if `region.size` is not in the range \[16B,&nbsp;32GiB\].
+    /// - Panics if `region.offset()` is not a multiple of 16.
+    /// - Panics if `region.size()` is not a power of two.
+    /// - Panics if `region.size()` is not in the range \[16B,&nbsp;32GiB\].
     ///
     /// [region]: Suballocator#regions
     fn new(region: Region) -> Self {
         const EMPTY_FREE_LIST: Vec<NonNull<SuballocationTreeNode>> = Vec::new();
 
+        assert!(region
+            .offset()
+            .is_multiple_of(BuddyAllocator::MIN_NODE_SIZE));
         assert!(region.size().is_power_of_two());
         assert!(region.size() >= BuddyAllocator::MIN_NODE_SIZE);
 


### PR DESCRIPTION
#2807 added this as part of a comment:

> The division can't discard any bits because offsets and sizes are aligned to `BuddyAllocator::MIN_NODE_SIZE`.

However, that's not true. There was no validation to ensure that a region's offset is aligned to `BuddyAllocator::MIN_NODE_SIZE`, which means that the offsets could have had bits set in those alignment bits, and those would be discarded.